### PR TITLE
Fix misplaced block end in Omnibus recipe

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -321,7 +321,7 @@ build do
 
   installed_list = Array.new
   cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
-  block "Install cached wheels" do
+  block "Install integrations" do
     tasks_dir_in = windows_safe_path(Dir.pwd)
     cache_branch = (shellout! "inv release.get-release-json-value base_branch", cwd: File.expand_path('..', tasks_dir_in)).stdout.strip
     # On windows, `aws` actually executes Ruby's AWS SDK, but we want the Python one
@@ -367,10 +367,7 @@ build do
         raise "Failed to list pip installed packages"
       end
     end
-  end
 
-  block "Install integrations" do
-    # This needs to be done in a block because `checks_to_install` can only be known at build-time
     checks_to_install.each do |check|
       check_dir = File.join(project_dir, check)
       check_conf_dir = "#{conf_dir}/#{check}.d"

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -355,7 +355,7 @@ build do
 
   installed_list = Array.new
   cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
-  block "Install cached wheels" do
+  block "Install integrations" do
     tasks_dir_in = windows_safe_path(Dir.pwd)
     cache_branch = (shellout! "inv release.get-release-json-value base_branch", cwd: File.expand_path('..', tasks_dir_in)).stdout.strip
     # On windows, `aws` actually executes Ruby's AWS SDK, but we want the Python one
@@ -397,10 +397,7 @@ build do
         raise "Failed to list pip installed packages"
       end
     end
-  end
 
-  block "Install integrations" do
-    # This needs to be done in a block because `checks_to_install` can only be known at build-time
     checks_to_install.each do |check|
       check_dir = File.join(project_dir, check)
       check_conf_dir = "#{conf_dir}/#{check}.d"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix a mistake in #20933. The change was correct in the py2 recipe, not so on the py3 recipe.

### Motivation

For some reason this mistake didn't break things, I found it indirectly via #21041.

### Additional Notes

This provides further justification for unifying both py2 and py3 recipes.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Together with #20933

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
