### PR TITLE
[oracle] Activity sampling optimization (DBMON-2996)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/activity_queries.go
+++ b/pkg/collector/corechecks/oracle-dbm/activity_queries.go
@@ -150,7 +150,7 @@ WHERE
 	)
 	AND status = 'ACTIVE'`
 
-const activityQueryDirect = `SELECT /* DD_ACTIVITY_SAMPLING */
+const activityQueryDirect = `SELECT /*+ push_pred(sq) push_pred(sq_prev) */ /* DD_ACTIVITY_SAMPLING */
 s.sid,
 s.serial#,
 s.username,

--- a/releasenotes/notes/oracle-activity-samples-optimization-70b4b39291a6cd11.yaml
+++ b/releasenotes/notes/oracle-activity-samples-optimization-70b4b39291a6cd11.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improved performance of the activity sampling query on RDS and Oracle Cloud databases.


### PR DESCRIPTION
### What does this PR do?

Improving performance of the activity sampling query.

### Motivation

A customer running a busy Oracle 11 database alerted us that the activity query is running for a long time. The root cause was traced to the old optimizer, which failed to execute a crucial query transformation. We have addressed this by enforcing the transformation with hints. Although the severe issue was specific to the old, de-supported Oracle release, the optimization is proving beneficial also for newer releases.

### Additional Notes

The improvement is in orders of magnitude.

![image](https://github.com/DataDog/datadog-agent/assets/18366081/b8017615-c5cd-4c52-990b-25db59496e6e)

The change in this PR applies only to the databases hosted in cloud. The hints for self-managed databases are embedded in the view `dd_session` that has to be created during the setup.  The documentation is already updated.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Check the query execution time in query metrics.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
