### PR TITLE
Do not log information when secrets are not enable at Configuiration time

### DIFF
--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -167,7 +167,6 @@ func (r *secretResolver) registerSecretOrigin(handle string, origin string, yaml
 // Configure initializes the executable command and other options of the secrets component
 func (r *secretResolver) Configure(command string, arguments []string, timeout, maxSize int, groupExecPerm, removeLinebreak bool) {
 	if !r.enabled {
-		log.Errorf("Agent secrets is disabled by caller")
 		return
 	}
 	r.backendCommand = command


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Multiple tests are failing in the main branch with invalid character 'e' looking for beginning of value or invalid character 'G' looking for beginning of value.

This PR makes sure that when fetching the status which doesn't have the secret component enable we do not log any line that might break our internal new-e2e tests. FYI The test parse the output of `agent status -j`

Running `./bin/agent/agent status -j -c dev/dist/datadog.yaml`

Before the change:

```
error: Agent secrets is disabled by caller
{"JMXStartupError":{"LastError":"","Timestamp":0},"JMXStatus":{"checks":{"failed_checks":null,"initialized_checks":null},"errors":0,"info":null,"timestamp":0},"NoProxyChanged":[],"NoProxyIgnoredWarningMap":[],"NoProxyUsedInFuture":[],"TransportWarnings":false,"agent_metadata":{"agent_version":"7.50.0-devel+git.768.8c628de","config_apm_dd_url":"","config_dd_url":"","config_logs_dd_url":"","config_logs_socks5_proxy_address":"","config_no_proxy":["169.254.169.254","100.100.100.200"],"config_process_dd_url":"","config_proxy_http":"","config_proxy_https":"","config_site":"","feature_apm_enabled":true,"feature_container_images_enabled":true,"feature_csm_vm_containers_enabled":false,"feature_csm_vm_hosts_enabled":false,"feature_cspm_enabled":false,"feature_cws_enabled":false,"feature_cws_network_enabled":true,"feature_cws_remote_config_enabled":true,"feature_cws_security_profiles_enabled":true,"feature_dynamic_instrumentation_enabled":false,"feature_fips_enabled":false,"feature_imdsv2_enabled":false,"feature_logs_enabled":false,"feature_networks_enabled":false,"feature_networks_http_enabled":false,"feature_networks_https_enabled":false,"feature_oom_kill_enabled":false,"feature_otlp_enabled":false,"feature_process_enabled":false,"feature_process_language_detection_enabled":false,"feature_processes_container_enabled":true,"feature_remote_configuration_enabled":true,"feature_tcp_queue_length_enabled":false,"feature_usm_enabled":false,"feature_usm_go_tls_enabled":false,"feature_usm_http2_enabled":false,"feature_usm_http_by_status_code_enabled":false,"feature_usm_istio_enabled":false,"feature_usm_java_tls_enabled":false,"feature_usm_kafka_enabled":false,"feature_windows_crash_detection_enabled":false,"flavor":"agent","hostname_source":"os","install_method_installer_version":"","install_method_tool":"undefined","install_method_tool_version":"","system_probe_core_enabled":true,"system_probe_gateway_lookup_enabled":true,"system_probe_kernel_headers_download_enabled":false,"system_probe_max_connections_per_message":600,"system_probe_prebuilt_fallback_enabled":true,"system_probe_protocol_classification_enabled":true,"system_probe_root_namespace_enabled":true,"system_probe_runtime_compilation_enabled":false,"system_probe_telemetry_enabled":true,"system_probe_track_tcp_4_connections":true,"system_probe_track_tcp_6_connections":true,"system_probe_track_udp_4_connections":true,"system_probe_track_udp_6_connections":true},"agent_start_nano":1700741933265590000,"aggregatorStats":{"ChecksHistogramBucketMetricSample":0,"ChecksMetricSample":293,"DogstatsdContexts":0,"DogstatsdContextsByMtype":{"Count":0,"Counter":0,"Distribution":0,"Gauge":0,"Histogram":0,"Historate":0,"MonotonicCount":0,"Rate":0,"Set":0},"DogstatsdMetricSample":1,"Event":1,"EventPlatformEvents":{},"EventPlatformEventsErrors":{},"EventsFlushErrors":0,"EventsFlushed":1,"Flush":{"ChecksMetricSampleFlushTime":{"FlushIndex":1,"Flushes":[2476708,2406541,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":2406541,"Name":"ChecksMetricSampleFlushTime"},"EventFlushTime":{"FlushIndex":0,"Flushes":[3157875,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":3157875,"Name":"EventFlushTime"},"MainFlushTime":{"FlushIndex":1,"Flushes":[2555625,2414458,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":2414458,"Name":"MainFlushTime"},"ManifestsTime":{"FlushIndex":-1,"Flushes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":0,"Name":"ManifestsTime"},"MetricSketchFlushTime":{"FlushIndex":-1,"Flushes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":0,"Name":"MetricSketchFlushTime"},"ServiceCheckFlushTime":{"FlushIndex":1,"Flushes":[3088792,1508291,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":1508291,"Name":"ServiceCheckFlushTime"}},"FlushCount":{"Events":{"FlushIndex":0,"Flushes":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":1,"Name":"Events"},"Manifests":{"FlushIndex":-1,"Flushes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":0,"Name":"Manifests"},"Series":{"FlushIndex":1,"Flushes":[101,115,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":115,"Name":"Series"},"ServiceChecks":{"FlushIndex":1,"Flushes":[2,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":1,"Name":"ServiceChecks"},"Sketches":{"FlushIndex":-1,"Flushes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":0,"Name":"Sketches"}},"HostnameUpdate":0,"MetricTags":{"Series":{"Above100":0,"Above90":0},"Sketches":{"Above100":0,"Above90":0}},"NumberOfFlush":2,"OrchestratorManifests":0,"OrchestratorManifestsErrors":0,"OrchestratorMetadata":0,"OrchestratorMetadataErrors":0,"SeriesFlushErrors":0,"SeriesFlushed":216,"ServiceCheck":1,"ServiceCheckFlushErrors":0,"ServiceCheckFlushed":3,"SketchesFlushErrors":0,"SketchesFlushed":0},"apmStats":{"error":"Get \"http://localhost:5012/debug/vars\": dial tcp 127.0.0.1:5012: connect: connection refused","port":5012},"autoConfigStats":{"ConfigErrors":{},"ResolveWarnings":{}},"build_arch":"arm64","checkSchedulerStats":{"LoaderErrors":{"apm":{"Core Check Loader":"Could not configure check APM Agent: Can't access the default apm binary at /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: stat /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: no such file or directory","JMX Check Loader":"check is not a jmx check, or unable to determine if it's so","Python Check Loader":"unable to import module 'apm': No module named 'apm'"},"network":{"Core Check Loader":"Check network not found in Catalog","JMX Check Loader":"check is not a jmx check, or unable to determine if it's so","Python Check Loader":"unable to import module 'network': No module named 'network'"},"process_agent":{"Core Check Loader":"Could not configure check Process Agent: Can't access the default process-agent binary at /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/embedded/bin/process-agent","JMX Check Loader":"check is not a jmx check, or unable to determine if it's so","Python Check Loader":"unable to import module 'process_agent': No module named 'process_agent'"},"winproc":{"Core Check Loader":"Check winproc not found in Catalog","JMX Check Loader":"check is not a jmx check, or unable to determine if it's so","Python Check Loader":"unable to import module 'winproc': No module named 'winproc'"}},"RunErrors":{}},"complianceChecks":{},"conf_file":"dev/dist/datadog.yaml","config":{"additional_checksd":"/opt/datadog-agent/etc/checks.d","confd_path":"/opt/datadog-agent/etc/conf.d","fips_enabled":"false","fips_local_address":"localhost","fips_port_range_start":"9803","log_file":"","log_level":"info"},"dogstatsdStats":{"EventPackets":0,"EventParseErrors":0,"MetricPackets":0,"MetricParseErrors":0,"ServiceCheckPackets":0,"ServiceCheckParseErrors":0,"UdpBytes":0,"UdpPacketReadingErrors":0,"UdpPackets":0,"UdsBytes":0,"UdsOriginDetectionErrors":0,"UdsPacketReadingErrors":0,"UdsPackets":0,"UnterminatedMetricErrors":0},"endpointsInfos":{"https://app.datadoghq.eu":["72724"]},"flavor":"agent","forwarderStats":{"APIKeyFailure":{},"APIKeyStatus":{"API key ending with 72724":"API Key valid"},"FileStorage":{"CurrentSizeInBytes":0,"DeserializeCount":0,"DeserializeErrorsCount":0,"DeserializeTransactionsCount":0,"FileSize":0,"FilesCount":0,"FilesRemovedCount":0,"PointsDroppedCount":0,"SerializeCount":0,"StartupReloadedRetryFilesCount":0},"RemovalPolicy":{"FilesFromUnknownDomainCount":0,"NewRemovalPolicyCount":0,"OutdatedFilesCount":0,"RegisteredDomainCount":0},"TransactionContainer":{"CurrentMemSizeInBytes":0,"ErrorsCount":0,"PointsDroppedCount":0,"TransactionsCount":0,"TransactionsDroppedCount":0},"Transactions":{"Cluster":0,"ClusterRole":0,"ClusterRoleBinding":0,"ConnectionEvents":{"ConnectSuccess":1,"DNSSuccess":1},"CronJob":0,"CustomResource":0,"CustomResourceDefinition":0,"DaemonSet":0,"Deployment":0,"Dropped":0,"DroppedByEndpoint":{},"Errors":0,"ErrorsByType":{"ConnectionErrors":0,"DNSErrors":0,"SentRequestErrors":0,"TLSErrors":0,"WroteRequestErrors":0},"HTTPErrors":0,"HTTPErrorsByCode":{},"HighPriorityQueueFull":0,"HorizontalPodAutoscaler":0,"Ingress":0,"InputBytesByEndpoint":{"check_run_v1":266,"intake":2267,"series_v2":3565},"InputCountByEndpoint":{"check_run_v1":2,"intake":2,"series_v2":2},"Job":0,"Namespace":0,"Node":0,"OrchestratorManifest":0,"PersistentVolume":0,"PersistentVolumeClaim":0,"Pod":0,"ReplicaSet":0,"Requeued":0,"RequeuedByEndpoint":{},"Retried":0,"RetriedByEndpoint":{},"RetryQueueSize":0,"Role":0,"RoleBinding":0,"Service":0,"ServiceAccount":0,"StatefulSet":0,"Success":6,"SuccessByEndpoint":{"check_run_v1":2,"connections":0,"container":0,"events_v2":0,"host_metadata_v2":0,"intake":2,"orchestrator":0,"process":0,"rtcontainer":0,"rtprocess":0,"series_v1":0,"series_v2":2,"services_checks_v2":0,"sketches_v1":0,"sketches_v2":0,"validate_v1":0},"SuccessBytesByEndpoint":{"check_run_v1":266,"intake":2267,"series_v2":3565},"VerticalPodAutoscaler":0}},"go_version":"go1.20.11","hostTags":[],"hostinfo":{"bootTime":1700556776,"hostId":"243ebbea-56ec-54e0-a3df-95b1bde3135f","hostname":"COMP-VQHPF4W6GY","kernelArch":"arm64","kernelVersion":"22.6.0","os":"darwin","platform":"darwin","platformFamily":"Standalone Workstation","platformVersion":"13.6.2","procs":680,"uptime":185189,"virtualizationRole":"","virtualizationSystem":""},"hostnameStats":{"errors":{"'hostname' configuration/environment":"hostname is empty","'hostname_file' configuration/environment":"'hostname_file' configuration is not enabled","aws":"not retrieving hostname from AWS: the host is not an ECS instance and other providers already retrieve non-default hostnames","azure":"azure_hostname_style is set to 'os'","container":"the agent is not containerized","fargate":"agent is not runnning on Fargate","fqdn":"'hostname_fqdn' configuration is not enabled","gce":"unable to retrieve hostname from GCE: GCE metadata API error: Get \"http://169.254.169.254/computeMetadata/v1/instance/hostname\": dial tcp 169.254.169.254:80: i/o timeout (Client.Timeout exceeded while awaiting headers)"},"provider":"os"},"inventories":{},"logsStats":{"endpoints":null,"errors":null,"integrations":null,"is_running":false,"metrics":null,"process_file_stats":null,"tailers":null,"use_http":false,"warnings":null},"metadata":{"agent-flavor":"agent","host-tags":{"system":[]},"install-method":{"installer_version":null,"tool":null,"tool_version":"undefined"},"logs":{"auto_multi_line_detection_enabled":false,"transport":""},"meta":{"ec2-hostname":"","host_aliases":[],"hostname":"COMP-VQHPF4W6GY","instance-id":"","socket-fqdn":"COMP-VQHPF4W6GY","socket-hostname":"COMP-VQHPF4W6GY","timezones":["CET"]},"network":null,"os":"darwin","otlp":{"enabled":false},"proxy-info":{"no-proxy-nonexact-match":false,"no-proxy-nonexact-match-explicitly-set":false,"proxy-behavior-changed":false},"python":"n/a","systemStats":{"cpuCores":10,"fbsdV":["","",""],"macV":["13.6.2",["","",""],"arm64"],"machine":"arm64","nixV":["","",""],"platform":"darwin","processor":"Apple M1 Max","pythonV":"n/a","winV":["","",""]}},"ntpOffset":0.028540935,"otlp":{"otlpCollectorStatus":"Not running","otlpCollectorStatusErr":"","otlpStatus":false},"pid":80099,"processAgentStatus":{"error":"Get \"http://localhost:6162/agent/status\": dial tcp 127.0.0.1:6162: connect: connection refused"},"pyLoaderStats":{"ConfigureErrors":{},"Py3Warnings":{}},"pythonInit":{"Errors":["could not initialize rtloader: error initializing string utils: No module named 'yaml'"]},"python_version":"n/a","remoteConfiguration":{"apiKeyScoped":"false","lastError":"","orgEnabled":"false"},"runnerStats":{"Checks":{"cpu":{"cpu":{"AverageExecutionTime":0,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/cpu.d/conf.yaml.default","CheckID":"cpu","CheckName":"cpu","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":0,"LastSuccessDate":1700741965,"LastWarnings":[],"MetricSamples":8,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":17,"TotalRuns":3,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741965}},"disk":{"disk":{"AverageExecutionTime":1,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/disk.d/conf.yaml.default","CheckID":"disk","CheckName":"disk","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[2,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":1,"LastSuccessDate":1700741957,"LastWarnings":[],"MetricSamples":84,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":168,"TotalRuns":2,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741957}},"file_handle":{"file_handle":{"AverageExecutionTime":0,"CheckConfigSource":"file:/Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/conf.d/file_handle.d/conf.yaml.default","CheckID":"file_handle","CheckName":"file_handle","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"open /proc/sys/fs/file-nr: no such file or directory","LastExecutionTime":0,"LastSuccessDate":0,"LastWarnings":[],"MetricSamples":0,"ServiceChecks":0,"TotalErrors":2,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":0,"TotalRuns":2,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741962}},"io":{"io":{"AverageExecutionTime":0,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/io.d/conf.yaml.default","CheckID":"io","CheckName":"io","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":1,"LastSuccessDate":1700741964,"LastWarnings":[],"MetricSamples":15,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":21,"TotalRuns":2,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741964}},"load":{"load":{"AverageExecutionTime":0,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/load.d/conf.yaml.default","CheckID":"load","CheckName":"load","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":0,"LastSuccessDate":1700741956,"LastWarnings":[],"MetricSamples":6,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":12,"TotalRuns":2,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741956}},"memory":{"memory":{"AverageExecutionTime":0,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/memory.d/conf.yaml.default","CheckID":"memory","CheckName":"memory","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":0,"LastSuccessDate":1700741963,"LastWarnings":[],"MetricSamples":11,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":22,"TotalRuns":2,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741963}},"ntp":{"ntp:3c427a42a70bbf8":{"AverageExecutionTime":122,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/ntp.d/conf.yaml.default","CheckID":"ntp:3c427a42a70bbf8","CheckName":"ntp","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[122,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":122,"LastSuccessDate":1700741937,"LastWarnings":[],"MetricSamples":1,"ServiceChecks":1,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":1,"TotalRuns":1,"TotalServiceChecks":1,"TotalWarnings":0,"UpdateTimestamp":1700741937}},"uptime":{"uptime":{"AverageExecutionTime":0,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/uptime.d/conf.yaml.default","CheckID":"uptime","CheckName":"uptime","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":0,"LastSuccessDate":1700741955,"LastWarnings":[],"MetricSamples":1,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":2,"TotalRuns":2,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741955}}},"Errors":2,"Running":{"container_image":"2023-11-23T13:18:54+01:00","container_lifecycle":"2023-11-23T13:18:54+01:00"},"RunningChecks":2,"Runs":16,"Workers":{"Count":6,"Instances":{"worker_1":{"Utilization":0.44},"worker_2":{"Utilization":0.44},"worker_3":{"Utilization":0},"worker_4":{"Utilization":0},"worker_5":{"Utilization":0},"worker_6":{"Utilization":0}}}},"time_nano":1700741969916101000,"verbose":false,"version":"7.50.0-devel+git.768.8c628de"}
```

After the change:

```
{"JMXStartupError":{"LastError":"","Timestamp":0},"JMXStatus":{"checks":{"failed_checks":null,"initialized_checks":null},"errors":0,"info":null,"timestamp":0},"NoProxyChanged":[],"NoProxyIgnoredWarningMap":[],"NoProxyUsedInFuture":[],"TransportWarnings":false,"agent_metadata":{"agent_version":"7.50.0-devel+git.768.8c628de","config_apm_dd_url":"","config_dd_url":"","config_logs_dd_url":"","config_logs_socks5_proxy_address":"","config_no_proxy":["169.254.169.254","100.100.100.200"],"config_process_dd_url":"","config_proxy_http":"","config_proxy_https":"","config_site":"","feature_apm_enabled":true,"feature_container_images_enabled":true,"feature_csm_vm_containers_enabled":false,"feature_csm_vm_hosts_enabled":false,"feature_cspm_enabled":false,"feature_cws_enabled":false,"feature_cws_network_enabled":true,"feature_cws_remote_config_enabled":true,"feature_cws_security_profiles_enabled":true,"feature_dynamic_instrumentation_enabled":false,"feature_fips_enabled":false,"feature_imdsv2_enabled":false,"feature_logs_enabled":false,"feature_networks_enabled":false,"feature_networks_http_enabled":false,"feature_networks_https_enabled":false,"feature_oom_kill_enabled":false,"feature_otlp_enabled":false,"feature_process_enabled":false,"feature_process_language_detection_enabled":false,"feature_processes_container_enabled":true,"feature_remote_configuration_enabled":true,"feature_tcp_queue_length_enabled":false,"feature_usm_enabled":false,"feature_usm_go_tls_enabled":false,"feature_usm_http2_enabled":false,"feature_usm_http_by_status_code_enabled":false,"feature_usm_istio_enabled":false,"feature_usm_java_tls_enabled":false,"feature_usm_kafka_enabled":false,"feature_windows_crash_detection_enabled":false,"flavor":"agent","hostname_source":"os","install_method_installer_version":"","install_method_tool":"undefined","install_method_tool_version":"","system_probe_core_enabled":true,"system_probe_gateway_lookup_enabled":true,"system_probe_kernel_headers_download_enabled":false,"system_probe_max_connections_per_message":600,"system_probe_prebuilt_fallback_enabled":true,"system_probe_protocol_classification_enabled":true,"system_probe_root_namespace_enabled":true,"system_probe_runtime_compilation_enabled":false,"system_probe_telemetry_enabled":true,"system_probe_track_tcp_4_connections":true,"system_probe_track_tcp_6_connections":true,"system_probe_track_udp_4_connections":true,"system_probe_track_udp_6_connections":true},"agent_start_nano":1700741813279954000,"aggregatorStats":{"ChecksHistogramBucketMetricSample":0,"ChecksMetricSample":448,"DogstatsdContexts":0,"DogstatsdContextsByMtype":{"Count":0,"Counter":0,"Distribution":0,"Gauge":0,"Histogram":0,"Historate":0,"MonotonicCount":0,"Rate":0,"Set":0},"DogstatsdMetricSample":1,"Event":1,"EventPlatformEvents":{},"EventPlatformEventsErrors":{},"EventsFlushErrors":0,"EventsFlushed":1,"Flush":{"ChecksMetricSampleFlushTime":{"FlushIndex":2,"Flushes":[2437250,4222167,8874167,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":8874167,"Name":"ChecksMetricSampleFlushTime"},"EventFlushTime":{"FlushIndex":0,"Flushes":[1646541,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":1646541,"Name":"EventFlushTime"},"MainFlushTime":{"FlushIndex":2,"Flushes":[2502125,4238750,8879834,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":8879834,"Name":"MainFlushTime"},"ManifestsTime":{"FlushIndex":-1,"Flushes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":0,"Name":"ManifestsTime"},"MetricSketchFlushTime":{"FlushIndex":-1,"Flushes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":0,"Name":"MetricSketchFlushTime"},"ServiceCheckFlushTime":{"FlushIndex":2,"Flushes":[1276458,1658375,6737167,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":6737167,"Name":"ServiceCheckFlushTime"}},"FlushCount":{"Events":{"FlushIndex":0,"Flushes":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":1,"Name":"Events"},"Manifests":{"FlushIndex":-1,"Flushes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":0,"Name":"Manifests"},"Series":{"FlushIndex":2,"Flushes":[101,115,135,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":135,"Name":"Series"},"ServiceChecks":{"FlushIndex":2,"Flushes":[2,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":1,"Name":"ServiceChecks"},"Sketches":{"FlushIndex":-1,"Flushes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LastFlush":0,"Name":"Sketches"}},"HostnameUpdate":0,"MetricTags":{"Series":{"Above100":0,"Above90":0},"Sketches":{"Above100":0,"Above90":0}},"NumberOfFlush":3,"OrchestratorManifests":0,"OrchestratorManifestsErrors":0,"OrchestratorMetadata":0,"OrchestratorMetadataErrors":0,"SeriesFlushErrors":0,"SeriesFlushed":351,"ServiceCheck":1,"ServiceCheckFlushErrors":0,"ServiceCheckFlushed":4,"SketchesFlushErrors":0,"SketchesFlushed":0},"apmStats":{"error":"Get \"http://localhost:5012/debug/vars\": dial tcp 127.0.0.1:5012: connect: connection refused","port":5012},"autoConfigStats":{"ConfigErrors":{},"ResolveWarnings":{}},"build_arch":"arm64","checkSchedulerStats":{"LoaderErrors":{"apm":{"Core Check Loader":"Could not configure check APM Agent: Can't access the default apm binary at /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: stat /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: no such file or directory","JMX Check Loader":"check is not a jmx check, or unable to determine if it's so","Python Check Loader":"unable to import module 'apm': No module named 'apm'"},"network":{"Core Check Loader":"Check network not found in Catalog","JMX Check Loader":"check is not a jmx check, or unable to determine if it's so","Python Check Loader":"unable to import module 'network': No module named 'network'"},"process_agent":{"Core Check Loader":"Could not configure check Process Agent: Can't access the default process-agent binary at /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/embedded/bin/process-agent","JMX Check Loader":"check is not a jmx check, or unable to determine if it's so","Python Check Loader":"unable to import module 'process_agent': No module named 'process_agent'"},"winproc":{"Core Check Loader":"Check winproc not found in Catalog","JMX Check Loader":"check is not a jmx check, or unable to determine if it's so","Python Check Loader":"unable to import module 'winproc': No module named 'winproc'"}},"RunErrors":{}},"complianceChecks":{},"conf_file":"dev/dist/datadog.yaml","config":{"additional_checksd":"/opt/datadog-agent/etc/checks.d","confd_path":"/opt/datadog-agent/etc/conf.d","fips_enabled":"false","fips_local_address":"localhost","fips_port_range_start":"9803","log_file":"","log_level":"info"},"dogstatsdStats":{"EventPackets":0,"EventParseErrors":0,"MetricPackets":0,"MetricParseErrors":0,"ServiceCheckPackets":0,"ServiceCheckParseErrors":0,"UdpBytes":0,"UdpPacketReadingErrors":0,"UdpPackets":0,"UdsBytes":0,"UdsOriginDetectionErrors":0,"UdsPacketReadingErrors":0,"UdsPackets":0,"UnterminatedMetricErrors":0},"endpointsInfos":{"https://app.datadoghq.eu":["72724"]},"flavor":"agent","forwarderStats":{"APIKeyFailure":{},"APIKeyStatus":{"API key ending with 72724":"API Key valid"},"FileStorage":{"CurrentSizeInBytes":0,"DeserializeCount":0,"DeserializeErrorsCount":0,"DeserializeTransactionsCount":0,"FileSize":0,"FilesCount":0,"FilesRemovedCount":0,"PointsDroppedCount":0,"SerializeCount":0,"StartupReloadedRetryFilesCount":0},"RemovalPolicy":{"FilesFromUnknownDomainCount":0,"NewRemovalPolicyCount":0,"OutdatedFilesCount":0,"RegisteredDomainCount":0},"TransactionContainer":{"CurrentMemSizeInBytes":0,"ErrorsCount":0,"PointsDroppedCount":0,"TransactionsCount":0,"TransactionsDroppedCount":0},"Transactions":{"Cluster":0,"ClusterRole":0,"ClusterRoleBinding":0,"ConnectionEvents":{"ConnectSuccess":1,"DNSSuccess":1},"CronJob":0,"CustomResource":0,"CustomResourceDefinition":0,"DaemonSet":0,"Deployment":0,"Dropped":0,"DroppedByEndpoint":{},"Errors":0,"ErrorsByType":{"ConnectionErrors":0,"DNSErrors":0,"SentRequestErrors":0,"TLSErrors":0,"WroteRequestErrors":0},"HTTPErrors":0,"HTTPErrorsByCode":{},"HighPriorityQueueFull":0,"HorizontalPodAutoscaler":0,"Ingress":0,"InputBytesByEndpoint":{"check_run_v1":389,"intake":2275,"series_v2":5822},"InputCountByEndpoint":{"check_run_v1":3,"intake":2,"series_v2":3},"Job":0,"Namespace":0,"Node":0,"OrchestratorManifest":0,"PersistentVolume":0,"PersistentVolumeClaim":0,"Pod":0,"ReplicaSet":0,"Requeued":0,"RequeuedByEndpoint":{},"Retried":0,"RetriedByEndpoint":{},"RetryQueueSize":0,"Role":0,"RoleBinding":0,"Service":0,"ServiceAccount":0,"StatefulSet":0,"Success":8,"SuccessByEndpoint":{"check_run_v1":3,"connections":0,"container":0,"events_v2":0,"host_metadata_v2":0,"intake":2,"orchestrator":0,"process":0,"rtcontainer":0,"rtprocess":0,"series_v1":0,"series_v2":3,"services_checks_v2":0,"sketches_v1":0,"sketches_v2":0,"validate_v1":0},"SuccessBytesByEndpoint":{"check_run_v1":389,"intake":2275,"series_v2":5822},"VerticalPodAutoscaler":0}},"go_version":"go1.20.11","hostTags":[],"hostinfo":{"bootTime":1700556776,"hostId":"243ebbea-56ec-54e0-a3df-95b1bde3135f","hostname":"COMP-VQHPF4W6GY","kernelArch":"arm64","kernelVersion":"22.6.0","os":"darwin","platform":"darwin","platformFamily":"Standalone Workstation","platformVersion":"13.6.2","procs":654,"uptime":185074,"virtualizationRole":"","virtualizationSystem":""},"hostnameStats":{"errors":{"'hostname' configuration/environment":"hostname is empty","'hostname_file' configuration/environment":"'hostname_file' configuration is not enabled","aws":"not retrieving hostname from AWS: the host is not an ECS instance and other providers already retrieve non-default hostnames","azure":"azure_hostname_style is set to 'os'","container":"the agent is not containerized","fargate":"agent is not runnning on Fargate","fqdn":"'hostname_fqdn' configuration is not enabled","gce":"unable to retrieve hostname from GCE: GCE metadata API error: Get \"http://169.254.169.254/computeMetadata/v1/instance/hostname\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"},"provider":"os"},"inventories":{},"logsStats":{"endpoints":null,"errors":null,"integrations":null,"is_running":false,"metrics":null,"process_file_stats":null,"tailers":null,"use_http":false,"warnings":null},"metadata":{"agent-flavor":"agent","host-tags":{"system":[]},"install-method":{"installer_version":null,"tool":null,"tool_version":"undefined"},"logs":{"auto_multi_line_detection_enabled":false,"transport":""},"meta":{"ec2-hostname":"","host_aliases":[],"hostname":"COMP-VQHPF4W6GY","instance-id":"","socket-fqdn":"COMP-VQHPF4W6GY","socket-hostname":"COMP-VQHPF4W6GY","timezones":["CET"]},"network":null,"os":"darwin","otlp":{"enabled":false},"proxy-info":{"no-proxy-nonexact-match":false,"no-proxy-nonexact-match-explicitly-set":false,"proxy-behavior-changed":false},"python":"n/a","systemStats":{"cpuCores":10,"fbsdV":["","",""],"macV":["13.6.2",["","",""],"arm64"],"machine":"arm64","nixV":["","",""],"platform":"darwin","processor":"Apple M1 Max","pythonV":"n/a","winV":["","",""]}},"ntpOffset":0.029853609500000003,"otlp":{"otlpCollectorStatus":"Not running","otlpCollectorStatusErr":"","otlpStatus":false},"pid":77224,"processAgentStatus":{"error":"Get \"http://localhost:6162/agent/status\": dial tcp 127.0.0.1:6162: connect: connection refused"},"pyLoaderStats":{"ConfigureErrors":{},"Py3Warnings":{}},"pythonInit":{"Errors":["could not initialize rtloader: error initializing string utils: No module named 'yaml'"]},"python_version":"n/a","remoteConfiguration":{"apiKeyScoped":"false","lastError":"","orgEnabled":"false"},"runnerStats":{"Checks":{"cpu":{"cpu":{"AverageExecutionTime":0,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/cpu.d/conf.yaml.default","CheckID":"cpu","CheckName":"cpu","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":0,"LastSuccessDate":1700741860,"LastWarnings":[],"MetricSamples":8,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":25,"TotalRuns":4,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741860}},"disk":{"disk":{"AverageExecutionTime":1,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/disk.d/conf.yaml.default","CheckID":"disk","CheckName":"disk","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[2,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":2,"LastSuccessDate":1700741852,"LastWarnings":[],"MetricSamples":84,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":252,"TotalRuns":3,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741852}},"file_handle":{"file_handle":{"AverageExecutionTime":0,"CheckConfigSource":"file:/Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/conf.d/file_handle.d/conf.yaml.default","CheckID":"file_handle","CheckName":"file_handle","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"open /proc/sys/fs/file-nr: no such file or directory","LastExecutionTime":1,"LastSuccessDate":0,"LastWarnings":[],"MetricSamples":0,"ServiceChecks":0,"TotalErrors":3,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":0,"TotalRuns":3,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741857}},"io":{"io":{"AverageExecutionTime":1,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/io.d/conf.yaml.default","CheckID":"io","CheckName":"io","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[0,2,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":1,"LastSuccessDate":1700741859,"LastWarnings":[],"MetricSamples":15,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":36,"TotalRuns":3,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741859}},"load":{"load":{"AverageExecutionTime":0,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/load.d/conf.yaml.default","CheckID":"load","CheckName":"load","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":0,"LastSuccessDate":1700741866,"LastWarnings":[],"MetricSamples":6,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":24,"TotalRuns":4,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741866}},"memory":{"memory":{"AverageExecutionTime":0,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/memory.d/conf.yaml.default","CheckID":"memory","CheckName":"memory","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":0,"LastSuccessDate":1700741858,"LastWarnings":[],"MetricSamples":11,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":33,"TotalRuns":3,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741858}},"ntp":{"ntp:3c427a42a70bbf8":{"AverageExecutionTime":175,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/ntp.d/conf.yaml.default","CheckID":"ntp:3c427a42a70bbf8","CheckName":"ntp","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[175,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":175,"LastSuccessDate":1700741817,"LastWarnings":[],"MetricSamples":1,"ServiceChecks":1,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":1,"TotalRuns":1,"TotalServiceChecks":1,"TotalWarnings":0,"UpdateTimestamp":1700741817}},"uptime":{"uptime":{"AverageExecutionTime":0,"CheckConfigSource":"file:/opt/datadog-agent/etc/conf.d/uptime.d/conf.yaml.default","CheckID":"uptime","CheckName":"uptime","CheckVersion":"","EventPlatformEvents":{},"Events":0,"ExecutionTimes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"HistogramBuckets":0,"LastError":"","LastExecutionTime":0,"LastSuccessDate":1700741865,"LastWarnings":[],"MetricSamples":1,"ServiceChecks":0,"TotalErrors":0,"TotalEventPlatformEvents":{},"TotalEvents":0,"TotalHistogramBuckets":0,"TotalMetricSamples":4,"TotalRuns":4,"TotalServiceChecks":0,"TotalWarnings":0,"UpdateTimestamp":1700741865}}},"Errors":3,"Running":{"container_image":"2023-11-23T13:16:54+01:00","container_lifecycle":"2023-11-23T13:16:54+01:00"},"RunningChecks":2,"Runs":25,"Workers":{"Count":6,"Instances":{"worker_1":{"Utilization":0},"worker_2":{"Utilization":0.58},"worker_3":{"Utilization":0},"worker_4":{"Utilization":0.58},"worker_5":{"Utilization":0},"worker_6":{"Utilization":0}}}},"time_nano":1700741866850460000,"verbose":false,"version":"7.50.0-devel+git.768.8c628de"}
```

We no longer see `error: Agent secrets is disabled by caller` 😄 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
