### PR TITLE
Revert shared components hook stop and stop AC directly in test

### DIFF
--- a/cmd/agent/subcommands/run/command_test.go
+++ b/cmd/agent/subcommands/run/command_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
@@ -20,6 +21,15 @@ import (
 )
 
 func TestCommand(t *testing.T) {
+	// FIXME: we stop AC to avoid a race condition in the test suite
+	// Calling `Command` starts the AC, and it is currently not stopped
+	// Not stopping it causes a race when running the other test of this package
+	t.Cleanup(func() {
+		if common.AC != nil {
+			common.AC.Stop()
+		}
+	})
+
 	fxutil.TestOneShotSubcommand(t,
 		Commands(newGlobalParamsTest(t)),
 		[]string{"run"},
@@ -31,6 +41,15 @@ func TestCommand(t *testing.T) {
 }
 
 func TestCommandPidfile(t *testing.T) {
+	// FIXME: we stop AC to avoid a race condition in the test suite
+	// Calling `Command` starts the AC, and it is currently not stopped
+	// Not stopping it causes a race when running the other test of this package
+	t.Cleanup(func() {
+		if common.AC != nil {
+			common.AC.Stop()
+		}
+	})
+
 	fxutil.TestOneShotSubcommand(t,
 		Commands(newGlobalParamsTest(t)),
 		[]string{"run", "--pidfile", "/pid/file"},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Revert https://github.com/DataDog/datadog-agent/pull/20911, just stop AC directly in tests to avoid the race.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
demultiplexer was stopped before AC which resulted in errors.
I did not have a clean fix at hand, the `OnStart` hook couldn't be removed, so just fixing the race in tests directly.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
