### PR TITLE
[CWS] fix the hostname resolution of CWS/CSPM EvP paylods

### DIFF
--- a/cmd/cluster-agent/subcommands/start/compliance.go
+++ b/cmd/cluster-agent/subcommands/start/compliance.go
@@ -83,18 +83,18 @@ func startCompliance(senderManager sender.SenderManager, stopper startstop.Stopp
 	configDir := coreconfig.Datadog.GetString("compliance_config.dir")
 	checkInterval := coreconfig.Datadog.GetDuration("compliance_config.check_interval")
 
-	reporter, err := compliance.NewLogReporter(stopper, "compliance-agent", "compliance", runPath, endpoints, ctx)
+	hname, err := hostname.Get(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	reporter, err := compliance.NewLogReporter(hname, stopper, "compliance-agent", "compliance", runPath, endpoints, ctx)
 	if err != nil {
 		return err
 	}
 
 	runner := runner.NewRunner(senderManager)
 	stopper.Add(runner)
-
-	hname, err := hostname.Get(context.TODO())
-	if err != nil {
-		return err
-	}
 
 	agent := compliance.NewAgent(senderManager, compliance.AgentOptions{
 		ConfigDir:     configDir,

--- a/cmd/security-agent/subcommands/compliance/compliance.go
+++ b/cmd/security-agent/subcommands/compliance/compliance.go
@@ -44,7 +44,7 @@ func StartCompliance(log log.Component, config config.Component, sysprobeconfig 
 	}
 	stopper.Add(context)
 
-	reporter, err := compliance.NewLogReporter(stopper, "compliance-agent", "compliance", runPath, endpoints, context)
+	reporter, err := compliance.NewLogReporter(hostname, stopper, "compliance-agent", "compliance", runPath, endpoints, context)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -646,7 +646,7 @@ func StartRuntimeSecurity(log log.Component, config config.Component, hostname s
 	stopper.Add(ctx)
 
 	runPath := config.GetString("runtime_security_config.run_path")
-	reporter, err := reporter.NewCWSReporter(runPath, stopper, endpoints, ctx)
+	reporter, err := reporter.NewCWSReporter(hostname, runPath, stopper, endpoints, ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -51,7 +51,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/remote"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -241,15 +240,10 @@ func RunAgent(ctx context.Context, log log.Component, config config.Component, s
 		}
 	}()
 
-	hostnameDetected, err := utils.GetHostnameWithContext(ctx)
+	hostnameDetected, err := utils.GetHostnameWithContextAndFallback(ctx)
 	if err != nil {
-		log.Warnf("Could not resolve hostname from core-agent: %v", err)
-		hostnameDetected, err = hostname.Get(ctx)
-		if err != nil {
-			return log.Errorf("Error while getting hostname, exiting: %v", err)
-		}
+		return log.Errorf("Error while getting hostname, exiting: %v", err)
 	}
-	log.Infof("Hostname is: %s", hostnameDetected)
 	demultiplexer.AddAgentStartupTelemetry(fmt.Sprintf("%s - Datadog Security Agent", version.AgentVersion))
 
 	stopper = startstop.NewSerialStopper()

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -31,6 +31,7 @@ type Payload struct {
 // Message represents a log line sent to datadog, with its metadata
 type Message struct {
 	MessageContent
+	Hostname           string
 	Origin             *Origin
 	Status             string
 	IngestionTimestamp int64
@@ -307,6 +308,10 @@ func (m *Message) GetLatency() int64 {
 
 // GetHostname returns the hostname to applied the given log message
 func (m *Message) GetHostname() string {
+	if m.Hostname != "" {
+		return m.Hostname
+	}
+
 	if m.Lambda != nil {
 		return m.Lambda.ARN
 	}

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -482,7 +482,9 @@ func newDirectReporter(stopper startstop.Stopper) (common.RawReporter, error) {
 		log.Info(status)
 	}
 
-	reporter, err := reporter.NewCWSReporter(runPath, stopper, endpoints, destinationsCtx)
+	// we set the hostname to the empty string to take advantage of the out of the box message hostname
+	// resolution
+	reporter, err := reporter.NewCWSReporter("", runPath, stopper, endpoints, destinationsCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create direct reporter: %w", err)
 	}

--- a/pkg/security/reporter/reporter.go
+++ b/pkg/security/reporter/reporter.go
@@ -24,6 +24,7 @@ import (
 
 // RuntimeReporter represents a CWS reporter, used to send events to the intake
 type RuntimeReporter struct {
+	hostname  string
 	logSource *sources.LogSource
 	logChan   chan *message.Message
 }
@@ -34,15 +35,16 @@ func (r *RuntimeReporter) ReportRaw(content []byte, service string, tags ...stri
 	origin.SetTags(tags)
 	origin.SetService(service)
 	msg := message.NewMessage(content, origin, message.StatusInfo, time.Now().UnixNano())
+	msg.Hostname = r.hostname
 	r.logChan <- msg
 }
 
 // NewCWSReporter returns a new CWS reported based on the fields necessary to communicate with the intake
-func NewCWSReporter(runPath string, stopper startstop.Stopper, endpoints *logsconfig.Endpoints, context *client.DestinationsContext) (seccommon.RawReporter, error) {
-	return newReporter(runPath, stopper, "runtime-security-agent", "runtime-security", endpoints, context)
+func NewCWSReporter(hostname string, runPath string, stopper startstop.Stopper, endpoints *logsconfig.Endpoints, context *client.DestinationsContext) (seccommon.RawReporter, error) {
+	return newReporter(hostname, runPath, stopper, "runtime-security-agent", "runtime-security", endpoints, context)
 }
 
-func newReporter(runPath string, stopper startstop.Stopper, sourceName, sourceType string, endpoints *logsconfig.Endpoints, context *client.DestinationsContext) (seccommon.RawReporter, error) {
+func newReporter(hostname string, runPath string, stopper startstop.Stopper, sourceName, sourceType string, endpoints *logsconfig.Endpoints, context *client.DestinationsContext) (seccommon.RawReporter, error) {
 	health := health.RegisterLiveness("runtime-security")
 
 	// setup the auditor
@@ -64,6 +66,7 @@ func newReporter(runPath string, stopper startstop.Stopper, sourceName, sourceTy
 	)
 	logChan := pipelineProvider.NextPipelineChan()
 	return &RuntimeReporter{
+		hostname:  hostname,
 		logSource: logSource,
 		logChan:   logChan,
 	}, nil

--- a/releasenotes/notes/csm-events-hostname-42359b25de381a90.yaml
+++ b/releasenotes/notes/csm-events-hostname-42359b25de381a90.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    CWS/CSPM: fixes the hostname value attached to CWS and CSPM events, in some rare edge cases
-    where the security agent was not able to compute this value correctly.
+    CWS/CSPM: Fixes the hostname value attached to CWS and CSPM events, which in rare cases
+    the security agent computed incorrectly.

--- a/releasenotes/notes/csm-events-hostname-42359b25de381a90.yaml
+++ b/releasenotes/notes/csm-events-hostname-42359b25de381a90.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    CWS/CSPM: fixes the hostname value attached to CWS and CSPM events, in some rare edge cases
+    where the security agent was not able to compute this value correctly.


### PR DESCRIPTION
### What does this PR do?

Currently the `pkg/logs` machinery that we (CWS and CSPM) use fetches the hostname on its own. This is fine in the case of the core agent, but for other agents it can be the wrong way to do it. This is why for example the security agent does a gRPC call to the core agent to synchronize the correct hostname and use it from then on.

This PR introduces the needed code so that users of the logs forwarder can provide the hostname themselves, skipping the automatic resolution. This PR also uses this new code in both the CWS and CSPM forwarders.

### Motivation

Ensure the hostname attached to events is the correct one. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

This PR should improve the hostname attached to events. What needs to be QA is that the product is still working well, and that the hostname attached to events is the correct one.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
