### PR TITLE
[CWS/CSPM] fix secret resolution in security agent code

### DIFF
--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
@@ -73,7 +74,7 @@ func (s *service) Run(svcctx context.Context) error {
 
 	params := &cliParams{}
 	err := fxutil.OneShot(
-		func(log log.Component, config config.Component, statsd statsd.Component, sysprobeconfig sysprobeconfig.Component,
+		func(log log.Component, config config.Component, _ secrets.Component, statsd statsd.Component, sysprobeconfig sysprobeconfig.Component,
 			telemetry telemetry.Component, _ workloadmeta.Component, params *cliParams, demultiplexer demultiplexer.Component) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer start.StopAgent(cancel, log)
@@ -92,6 +93,7 @@ func (s *service) Run(svcctx context.Context) error {
 		fx.Supply(params),
 		fx.Supply(core.BundleParams{
 			ConfigParams:         config.NewSecurityAgentParams(defaultSecurityAgentConfigFilePaths),
+			SecretParams:         secrets.NewEnabledParams(),
 			SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(defaultSysProbeConfPath)),
 			LogParams:            log.ForDaemon(command.LoggerName, "security_agent.log_file", pkgconfig.DefaultSecurityAgentLogFile),
 		}),

--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
@@ -61,6 +62,7 @@ func SecurityAgentCommands(globalParams *command.GlobalParams) []*cobra.Command 
 	return commandsWrapped(func() core.BundleParams {
 		return core.BundleParams{
 			ConfigParams:         config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+			SecretParams:         secrets.NewEnabledParams(),
 			SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
 			LogParams:            log.ForOneShot(command.LoggerName, "info", true),
 		}
@@ -109,7 +111,7 @@ func commandsWrapped(bundleParamsFactory func() core.BundleParams) []*cobra.Comm
 }
 
 // RunCheck runs a check
-func RunCheck(log log.Component, config config.Component, statsd statsd.Component, checkArgs *CliParams) error {
+func RunCheck(log log.Component, config config.Component, _ secrets.Component, statsd statsd.Component, checkArgs *CliParams) error {
 	hname, err := hostname.Get(context.TODO())
 	if err != nil {
 		return err

--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -243,7 +243,7 @@ func dumpComplianceEvents(reportFile string, events []*compliance.CheckEvent) er
 	return nil
 }
 
-func reportComplianceEvents(log log.Component, config config.Component, events []*compliance.CheckEvent) error {
+func reportComplianceEvents(_ log.Component, config config.Component, events []*compliance.CheckEvent) error {
 	stopper := startstop.NewSerialStopper()
 	defer stopper.Stop()
 	runPath := config.GetString("compliance_config.run_path")

--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -58,6 +59,7 @@ func complianceEventCommand(globalParams *command.GlobalParams) *cobra.Command {
 				fx.Supply(eventArgs),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true),
 				}),
 				core.Bundle,
@@ -77,7 +79,7 @@ func complianceEventCommand(globalParams *command.GlobalParams) *cobra.Command {
 	return eventCmd
 }
 
-func eventRun(log log.Component, config config.Component, eventArgs *cliParams) error {
+func eventRun(log log.Component, config config.Component, _ secrets.Component, eventArgs *cliParams) error {
 	stopper := startstop.NewSerialStopper()
 	defer stopper.Stop()
 

--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -79,7 +79,7 @@ func complianceEventCommand(globalParams *command.GlobalParams) *cobra.Command {
 	return eventCmd
 }
 
-func eventRun(log log.Component, config config.Component, _ secrets.Component, eventArgs *cliParams) error {
+func eventRun(_ log.Component, config config.Component, _ secrets.Component, eventArgs *cliParams) error {
 	stopper := startstop.NewSerialStopper()
 	defer stopper.Stop()
 

--- a/cmd/security-agent/subcommands/config/config.go
+++ b/cmd/security-agent/subcommands/config/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
@@ -56,6 +57,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle,
 			)
@@ -74,6 +76,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					fx.Supply(cliParams),
 					fx.Supply(core.BundleParams{
 						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+						SecretParams: secrets.NewEnabledParams(),
 						LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 					core.Bundle,
 				)
@@ -93,6 +96,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					fx.Supply(cliParams),
 					fx.Supply(core.BundleParams{
 						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+						SecretParams: secrets.NewEnabledParams(),
 						LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 					core.Bundle,
 				)
@@ -112,6 +116,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					fx.Supply(cliParams),
 					fx.Supply(core.BundleParams{
 						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+						SecretParams: secrets.NewEnabledParams(),
 						LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 					core.Bundle,
 				)
@@ -133,7 +138,7 @@ func getSettingsClient(_ *cobra.Command, _ []string) (settings.Client, error) {
 	return settingshttp.NewClient(c, apiConfigURL, "security-agent"), nil
 }
 
-func showRuntimeConfiguration(log log.Component, config config.Component, params *cliParams) error {
+func showRuntimeConfiguration(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
 	c, err := params.getClient(params.command, params.args)
 	if err != nil {
 		return err
@@ -149,7 +154,7 @@ func showRuntimeConfiguration(log log.Component, config config.Component, params
 	return nil
 }
 
-func setConfigValue(log log.Component, config config.Component, params *cliParams) error {
+func setConfigValue(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
 	if len(params.args) != 2 {
 		return fmt.Errorf("exactly two parameters are required: the setting name and its value")
 	}
@@ -173,7 +178,7 @@ func setConfigValue(log log.Component, config config.Component, params *cliParam
 	return nil
 }
 
-func getConfigValue(log log.Component, config config.Component, params *cliParams) error {
+func getConfigValue(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
 	if len(params.args) != 1 {
 		return fmt.Errorf("a single setting name must be specified")
 	}
@@ -193,7 +198,7 @@ func getConfigValue(log log.Component, config config.Component, params *cliParam
 	return nil
 }
 
-func listRuntimeConfigurableValue(log log.Component, config config.Component, params *cliParams) error {
+func listRuntimeConfigurableValue(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
 	c, err := params.getClient(params.command, params.args)
 	if err != nil {
 		return err

--- a/cmd/security-agent/subcommands/config/config.go
+++ b/cmd/security-agent/subcommands/config/config.go
@@ -138,7 +138,7 @@ func getSettingsClient(_ *cobra.Command, _ []string) (settings.Client, error) {
 	return settingshttp.NewClient(c, apiConfigURL, "security-agent"), nil
 }
 
-func showRuntimeConfiguration(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
+func showRuntimeConfiguration(_ log.Component, _ config.Component, _ secrets.Component, params *cliParams) error {
 	c, err := params.getClient(params.command, params.args)
 	if err != nil {
 		return err
@@ -154,7 +154,7 @@ func showRuntimeConfiguration(log log.Component, config config.Component, _ secr
 	return nil
 }
 
-func setConfigValue(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
+func setConfigValue(_ log.Component, _ config.Component, _ secrets.Component, params *cliParams) error {
 	if len(params.args) != 2 {
 		return fmt.Errorf("exactly two parameters are required: the setting name and its value")
 	}
@@ -178,7 +178,7 @@ func setConfigValue(log log.Component, config config.Component, _ secrets.Compon
 	return nil
 }
 
-func getConfigValue(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
+func getConfigValue(_ log.Component, _ config.Component, _ secrets.Component, params *cliParams) error {
 	if len(params.args) != 1 {
 		return fmt.Errorf("a single setting name must be specified")
 	}
@@ -198,7 +198,7 @@ func getConfigValue(log log.Component, config config.Component, _ secrets.Compon
 	return nil
 }
 
-func listRuntimeConfigurableValue(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
+func listRuntimeConfigurableValue(_ log.Component, _ config.Component, _ secrets.Component, params *cliParams) error {
 	c, err := params.getClient(params.command, params.args)
 	if err != nil {
 		return err

--- a/cmd/security-agent/subcommands/flare/command.go
+++ b/cmd/security-agent/subcommands/flare/command.go
@@ -67,7 +67,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{flareCmd}
 }
 
-func requestFlare(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
+func requestFlare(_ log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
 	warnings := config.Warnings()
 	if warnings != nil && warnings.Err != nil {
 		fmt.Fprintln(color.Error, color.YellowString("Config parsing warning: %v", warnings.Err))

--- a/cmd/security-agent/subcommands/flare/command.go
+++ b/cmd/security-agent/subcommands/flare/command.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -52,6 +53,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithIgnoreErrors(true)),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle,
 			)
@@ -65,7 +67,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{flareCmd}
 }
 
-func requestFlare(log log.Component, config config.Component, params *cliParams) error {
+func requestFlare(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
 	warnings := config.Warnings()
 	if warnings != nil && warnings.Err != nil {
 		fmt.Fprintln(color.Error, color.YellowString("Config parsing warning: %v", warnings.Err))

--- a/cmd/security-agent/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/subcommands/runtime/activity_dump.go
@@ -407,7 +407,7 @@ func computeActivityDumpDiff(p1, p2 *dump.ActivityDump, states map[string]bool) 
 	}
 }
 
-func diffActivityDump(log log.Component, config config.Component, _ secrets.Component, args *activityDumpCliParams) error {
+func diffActivityDump(_ log.Component, _ config.Component, _ secrets.Component, args *activityDumpCliParams) error {
 	ad := dump.NewEmptyActivityDump(nil)
 	if err := ad.Decode(args.file); err != nil {
 		return err
@@ -458,7 +458,7 @@ func diffActivityDump(log log.Component, config config.Component, _ secrets.Comp
 	return nil
 }
 
-func generateActivityDump(log log.Component, config config.Component, _ secrets.Component, activityDumpArgs *activityDumpCliParams) error {
+func generateActivityDump(_ log.Component, _ config.Component, _ secrets.Component, activityDumpArgs *activityDumpCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -488,7 +488,7 @@ func generateActivityDump(log log.Component, config config.Component, _ secrets.
 	return nil
 }
 
-func generateEncodingFromActivityDump(log log.Component, config config.Component, _ secrets.Component, activityDumpArgs *activityDumpCliParams) error {
+func generateEncodingFromActivityDump(_ log.Component, _ config.Component, _ secrets.Component, activityDumpArgs *activityDumpCliParams) error {
 	var output *api.TranscodingRequestMessage
 
 	if activityDumpArgs.remoteRequest {
@@ -566,7 +566,7 @@ func generateEncodingFromActivityDump(log log.Component, config config.Component
 	return nil
 }
 
-func listActivityDumps(log log.Component, config config.Component, _ secrets.Component) error {
+func listActivityDumps(_ log.Component, _ config.Component, _ secrets.Component) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -614,7 +614,7 @@ func parseStorageRequest(activityDumpArgs *activityDumpCliParams) (*api.StorageR
 	}, nil
 }
 
-func stopActivityDump(log log.Component, config config.Component, _ secrets.Component, activityDumpArgs *activityDumpCliParams) error {
+func stopActivityDump(_ log.Component, _ config.Component, _ secrets.Component, activityDumpArgs *activityDumpCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)

--- a/cmd/security-agent/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/subcommands/runtime/activity_dump.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
@@ -70,6 +71,7 @@ func listCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(listActivityDumps,
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -92,6 +94,7 @@ func stopCommands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -145,6 +148,7 @@ func generateDumpCommands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -222,6 +226,7 @@ func generateEncodingCommands(globalParams *command.GlobalParams) []*cobra.Comma
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -288,6 +293,7 @@ func diffCommands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -401,7 +407,7 @@ func computeActivityDumpDiff(p1, p2 *dump.ActivityDump, states map[string]bool) 
 	}
 }
 
-func diffActivityDump(log log.Component, config config.Component, args *activityDumpCliParams) error {
+func diffActivityDump(log log.Component, config config.Component, _ secrets.Component, args *activityDumpCliParams) error {
 	ad := dump.NewEmptyActivityDump(nil)
 	if err := ad.Decode(args.file); err != nil {
 		return err
@@ -452,7 +458,7 @@ func diffActivityDump(log log.Component, config config.Component, args *activity
 	return nil
 }
 
-func generateActivityDump(log log.Component, config config.Component, activityDumpArgs *activityDumpCliParams) error {
+func generateActivityDump(log log.Component, config config.Component, _ secrets.Component, activityDumpArgs *activityDumpCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -482,7 +488,7 @@ func generateActivityDump(log log.Component, config config.Component, activityDu
 	return nil
 }
 
-func generateEncodingFromActivityDump(log log.Component, config config.Component, activityDumpArgs *activityDumpCliParams) error {
+func generateEncodingFromActivityDump(log log.Component, config config.Component, _ secrets.Component, activityDumpArgs *activityDumpCliParams) error {
 	var output *api.TranscodingRequestMessage
 
 	if activityDumpArgs.remoteRequest {
@@ -560,7 +566,7 @@ func generateEncodingFromActivityDump(log log.Component, config config.Component
 	return nil
 }
 
-func listActivityDumps(log log.Component, config config.Component) error {
+func listActivityDumps(log log.Component, config config.Component, _ secrets.Component) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -608,7 +614,7 @@ func parseStorageRequest(activityDumpArgs *activityDumpCliParams) (*api.StorageR
 	}, nil
 }
 
-func stopActivityDump(log log.Component, config config.Component, activityDumpArgs *activityDumpCliParams) error {
+func stopActivityDump(log log.Component, config config.Component, _ secrets.Component, activityDumpArgs *activityDumpCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)

--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
@@ -91,6 +92,7 @@ func evalCommands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(evalArgs),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -120,6 +122,7 @@ func commonCheckPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Co
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -140,6 +143,7 @@ func commonReloadPoliciesCommands(globalParams *command.GlobalParams) []*cobra.C
 			return fxutil.OneShot(reloadRuntimePolicies,
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -156,6 +160,7 @@ func selfTestCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(runRuntimeSelfTest,
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -185,6 +190,7 @@ func downloadPolicyCommands(globalParams *command.GlobalParams) []*cobra.Command
 				fx.Supply(downloadPolicyArgs),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -216,6 +222,7 @@ func processCacheCommands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -251,6 +258,7 @@ func networkNamespaceCommands(globalParams *command.GlobalParams) []*cobra.Comma
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -276,6 +284,7 @@ func discardersCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(dumpDiscarders,
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -291,7 +300,7 @@ func discardersCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{discardersCmd}
 }
 
-func dumpProcessCache(log log.Component, config config.Component, processCacheDumpArgs *processCacheDumpCliParams) error {
+func dumpProcessCache(log log.Component, config config.Component, _ secrets.Component, processCacheDumpArgs *processCacheDumpCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -308,7 +317,7 @@ func dumpProcessCache(log log.Component, config config.Component, processCacheDu
 	return nil
 }
 
-func dumpNetworkNamespace(log log.Component, config config.Component, dumpNetworkNamespaceArgs *dumpNetworkNamespaceCliParams) error {
+func dumpNetworkNamespace(log log.Component, config config.Component, _ secrets.Component, dumpNetworkNamespaceArgs *dumpNetworkNamespaceCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -499,7 +508,7 @@ func eventDataFromJSON(file string) (eval.Event, error) {
 	return event, nil
 }
 
-func evalRule(log log.Component, config config.Component, evalArgs *evalCliParams) error {
+func evalRule(log log.Component, config config.Component, _ secrets.Component, evalArgs *evalCliParams) error {
 	policiesDir := evalArgs.dir
 
 	// enabled all the rules
@@ -571,7 +580,7 @@ func evalRule(log log.Component, config config.Component, evalArgs *evalCliParam
 	return nil
 }
 
-func runRuntimeSelfTest(log log.Component, config config.Component) error {
+func runRuntimeSelfTest(log log.Component, config config.Component, _ secrets.Component) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -591,7 +600,7 @@ func runRuntimeSelfTest(log log.Component, config config.Component) error {
 	return nil
 }
 
-func reloadRuntimePolicies(log log.Component, config config.Component) error {
+func reloadRuntimePolicies(log log.Component, config config.Component, _ secrets.Component) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -645,7 +654,7 @@ func StartRuntimeSecurity(log log.Component, config config.Component, hostname s
 	return agent, nil
 }
 
-func downloadPolicy(log log.Component, config config.Component, downloadPolicyArgs *downloadPolicyCliParams) error {
+func downloadPolicy(log log.Component, config config.Component, _ secrets.Component, downloadPolicyArgs *downloadPolicyCliParams) error {
 	var outputFile *os.File
 
 	apiKey := config.GetString("api_key")
@@ -726,7 +735,7 @@ func downloadPolicy(log log.Component, config config.Component, downloadPolicyAr
 	return err
 }
 
-func dumpDiscarders(log log.Component, config config.Component) error {
+func dumpDiscarders(log log.Component, config config.Component, _ secrets.Component) error {
 	runtimeSecurityClient, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)

--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -152,6 +152,7 @@ func commonReloadPoliciesCommands(globalParams *command.GlobalParams) []*cobra.C
 	return []*cobra.Command{commonReloadPoliciesCmd}
 }
 
+// nolint: deadcode, unused
 func selfTestCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	selfTestCmd := &cobra.Command{
 		Use:   "self-test",
@@ -300,7 +301,8 @@ func discardersCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{discardersCmd}
 }
 
-func dumpProcessCache(log log.Component, config config.Component, _ secrets.Component, processCacheDumpArgs *processCacheDumpCliParams) error {
+// nolint: deadcode, unused
+func dumpProcessCache(_ log.Component, _ config.Component, _ secrets.Component, processCacheDumpArgs *processCacheDumpCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -317,7 +319,8 @@ func dumpProcessCache(log log.Component, config config.Component, _ secrets.Comp
 	return nil
 }
 
-func dumpNetworkNamespace(log log.Component, config config.Component, _ secrets.Component, dumpNetworkNamespaceArgs *dumpNetworkNamespaceCliParams) error {
+// nolint: deadcode, unused
+func dumpNetworkNamespace(_ log.Component, _ config.Component, _ secrets.Component, dumpNetworkNamespaceArgs *dumpNetworkNamespaceCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -354,7 +357,7 @@ func newAgentVersionFilter() (*rules.AgentVersionFilter, error) {
 	return rules.NewAgentVersionFilter(agentVersion)
 }
 
-func checkPolicies(log log.Component, config config.Component, args *checkPoliciesCliParams) error {
+func checkPolicies(_ log.Component, _ config.Component, args *checkPoliciesCliParams) error {
 	if args.evaluateAllPolicySources {
 		client, err := secagent.NewRuntimeSecurityClient()
 		if err != nil {
@@ -508,7 +511,7 @@ func eventDataFromJSON(file string) (eval.Event, error) {
 	return event, nil
 }
 
-func evalRule(log log.Component, config config.Component, _ secrets.Component, evalArgs *evalCliParams) error {
+func evalRule(_ log.Component, _ config.Component, _ secrets.Component, evalArgs *evalCliParams) error {
 	policiesDir := evalArgs.dir
 
 	// enabled all the rules
@@ -580,7 +583,8 @@ func evalRule(log log.Component, config config.Component, _ secrets.Component, e
 	return nil
 }
 
-func runRuntimeSelfTest(log log.Component, config config.Component, _ secrets.Component) error {
+// nolint: deadcode, unused
+func runRuntimeSelfTest(_ log.Component, _ config.Component, _ secrets.Component) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -600,7 +604,7 @@ func runRuntimeSelfTest(log log.Component, config config.Component, _ secrets.Co
 	return nil
 }
 
-func reloadRuntimePolicies(log log.Component, config config.Component, _ secrets.Component) error {
+func reloadRuntimePolicies(_ log.Component, _ config.Component, _ secrets.Component) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -735,7 +739,8 @@ func downloadPolicy(log log.Component, config config.Component, _ secrets.Compon
 	return err
 }
 
-func dumpDiscarders(log log.Component, config config.Component, _ secrets.Component) error {
+// nolint: deadcode, unused
+func dumpDiscarders(_ log.Component, _ config.Component, _ secrets.Component) error {
 	runtimeSecurityClient, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)

--- a/cmd/security-agent/subcommands/runtime/deprecated_commands.go
+++ b/cmd/security-agent/subcommands/runtime/deprecated_commands.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -34,6 +35,7 @@ func checkPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Command 
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -55,6 +57,7 @@ func reloadPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Command
 			return fxutil.OneShot(reloadRuntimePolicies,
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)

--- a/cmd/security-agent/subcommands/runtime/security_profile.go
+++ b/cmd/security-agent/subcommands/runtime/security_profile.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/profile"
@@ -60,6 +61,7 @@ func securityProfileShowCommands(globalParams *command.GlobalParams) []*cobra.Co
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -76,7 +78,7 @@ func securityProfileShowCommands(globalParams *command.GlobalParams) []*cobra.Co
 	return []*cobra.Command{securityProfileShowCmd}
 }
 
-func showSecurityProfile(log log.Component, config config.Component, args *securityProfileCliParams) error {
+func showSecurityProfile(log log.Component, config config.Component, _ secrets.Component, args *securityProfileCliParams) error {
 	prof, err := profile.LoadProfileFromFile(args.file)
 	if err != nil {
 		return err
@@ -105,6 +107,7 @@ func listSecurityProfileCommands(globalParams *command.GlobalParams) []*cobra.Co
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -121,7 +124,7 @@ func listSecurityProfileCommands(globalParams *command.GlobalParams) []*cobra.Co
 	return []*cobra.Command{securityProfileListCmd}
 }
 
-func listSecurityProfiles(log log.Component, config config.Component, args *securityProfileCliParams) error {
+func listSecurityProfiles(log log.Component, config config.Component, _ secrets.Component, args *securityProfileCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -204,6 +207,7 @@ func saveSecurityProfileCommands(globalParams *command.GlobalParams) []*cobra.Co
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -228,7 +232,7 @@ func saveSecurityProfileCommands(globalParams *command.GlobalParams) []*cobra.Co
 	return []*cobra.Command{securityProfileSaveCmd}
 }
 
-func saveSecurityProfile(log log.Component, config config.Component, args *securityProfileCliParams) error {
+func saveSecurityProfile(log log.Component, config config.Component, _ secrets.Component, args *securityProfileCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)

--- a/cmd/security-agent/subcommands/runtime/security_profile.go
+++ b/cmd/security-agent/subcommands/runtime/security_profile.go
@@ -78,7 +78,7 @@ func securityProfileShowCommands(globalParams *command.GlobalParams) []*cobra.Co
 	return []*cobra.Command{securityProfileShowCmd}
 }
 
-func showSecurityProfile(log log.Component, config config.Component, _ secrets.Component, args *securityProfileCliParams) error {
+func showSecurityProfile(_ log.Component, _ config.Component, _ secrets.Component, args *securityProfileCliParams) error {
 	prof, err := profile.LoadProfileFromFile(args.file)
 	if err != nil {
 		return err
@@ -124,7 +124,7 @@ func listSecurityProfileCommands(globalParams *command.GlobalParams) []*cobra.Co
 	return []*cobra.Command{securityProfileListCmd}
 }
 
-func listSecurityProfiles(log log.Component, config config.Component, _ secrets.Component, args *securityProfileCliParams) error {
+func listSecurityProfiles(_ log.Component, _ config.Component, _ secrets.Component, args *securityProfileCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -232,7 +232,7 @@ func saveSecurityProfileCommands(globalParams *command.GlobalParams) []*cobra.Co
 	return []*cobra.Command{securityProfileSaveCmd}
 }
 
-func saveSecurityProfile(log log.Component, config config.Component, _ secrets.Component, args *securityProfileCliParams) error {
+func saveSecurityProfile(_ log.Component, _ config.Component, _ secrets.Component, args *securityProfileCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
@@ -82,6 +83,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(core.BundleParams{
 					ConfigParams:         config.NewSecurityAgentParams(params.ConfigFilePaths),
 					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
+					SecretParams:         secrets.NewEnabledParams(),
 					LogParams:            log.ForDaemon(command.LoggerName, "security_agent.log_file", pkgconfig.DefaultSecurityAgentLogFile),
 				}),
 				core.Bundle,
@@ -124,7 +126,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 // TODO(components): note how workloadmeta is passed anonymously, it is still required as it is used
 // as a global. This should eventually be fixed and all workloadmeta interactions should be via the
 // injected instance.
-func start(log log.Component, config config.Component, statsd statsd.Component, sysprobeconfig sysprobeconfig.Component, telemetry telemetry.Component, _ workloadmeta.Component, demultiplexer demultiplexer.Component, params *cliParams) error {
+func start(log log.Component, config config.Component, _ secrets.Component, statsd statsd.Component, sysprobeconfig sysprobeconfig.Component, telemetry telemetry.Component, _ workloadmeta.Component, demultiplexer demultiplexer.Component, params *cliParams) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer StopAgent(cancel, log)
 

--- a/cmd/security-agent/subcommands/status/command.go
+++ b/cmd/security-agent/subcommands/status/command.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/status/render"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -46,6 +47,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle,
 			)
@@ -59,7 +61,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{statusCmd}
 }
 
-func runStatus(log log.Component, config config.Component, params *cliParams) error {
+func runStatus(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
 	fmt.Printf("Getting the status from the agent.\n")
 	var e error
 	var s string

--- a/cmd/security-agent/subcommands/status/command.go
+++ b/cmd/security-agent/subcommands/status/command.go
@@ -61,7 +61,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{statusCmd}
 }
 
-func runStatus(log log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
+func runStatus(_ log.Component, config config.Component, _ secrets.Component, params *cliParams) error {
 	fmt.Printf("Getting the status from the agent.\n")
 	var e error
 	var s string

--- a/cmd/security-agent/subcommands/version/command.go
+++ b/cmd/security-agent/subcommands/version/command.go
@@ -42,7 +42,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{versionCmd}
 }
 
-func displayVersion(log log.Component, config config.Component, _ secrets.Component) {
+func displayVersion(_ log.Component, _ config.Component, _ secrets.Component) {
 	av, _ := pkgversion.Agent()
 	meta := ""
 	if av.Meta != "" {

--- a/cmd/security-agent/subcommands/version/command.go
+++ b/cmd/security-agent/subcommands/version/command.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	pkgversion "github.com/DataDog/datadog-agent/pkg/version"
@@ -41,7 +42,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{versionCmd}
 }
 
-func displayVersion(log log.Component, config config.Component) {
+func displayVersion(log log.Component, config config.Component, _ secrets.Component) {
 	av, _ := pkgversion.Agent()
 	meta := ""
 	if av.Meta != "" {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes https://github.com/DataDog/datadog-agent/pull/20927 that broke the secret config support in the security agent
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
