### PR TITLE
cmd/trace-agent/subcommands/run: fix file path for trace-agent logger

### DIFF
--- a/cmd/trace-agent/command/command.go
+++ b/cmd/trace-agent/command/command.go
@@ -37,7 +37,7 @@ func makeCommands(globalParams *subcommands.GlobalParams) *cobra.Command {
 		return &subcommands.GlobalParams{
 			ConfPath:   globalParams.ConfPath,
 			ConfigName: globalParams.ConfigName,
-			LoggerName: "TRACE",
+			LoggerName: LoggerName,
 		}
 	}
 	commands := []*cobra.Command{

--- a/cmd/trace-agent/subcommands/run/command.go
+++ b/cmd/trace-agent/subcommands/run/command.go
@@ -12,7 +12,6 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/cmd/agent/common/path"
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands"
 	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	corelog "github.com/DataDog/datadog-agent/comp/core/log"
@@ -69,9 +68,8 @@ func runFx(ctx context.Context, cliParams *RunParams, defaultConfPath string) er
 		fx.Supply(secrets.NewEnabledParams()),
 		coreconfig.Module,
 		fx.Provide(func() corelog.Params {
-			p := corelog.ForDaemon("TRACE", "apm_config.log_file", path.DefaultLogFile)
-			return p
-		}), // fx.Supply(ctx) fails with a missing type error.
+			return corelog.ForDaemon("TRACE", "apm_config.log_file", config.DefaultLogFilePath)
+		}),
 		corelog.TraceModule,
 		// setup workloadmeta
 		collectors.GetCatalog(),

--- a/comp/core/bundle_mock.go
+++ b/comp/core/bundle_mock.go
@@ -27,14 +27,22 @@ import (
 
 // team: agent-shared-components
 
+// MakeMockBundle returns a core bundle with a customized set of fx.Option including sane defaults.
+func MakeMockBundle(logParams, logger fx.Option) fxutil.BundleOptions {
+	return fxutil.Bundle(
+		fx.Provide(func(params BundleParams) config.Params { return params.ConfigParams }),
+		config.MockModule,
+		logParams,
+		logger,
+		fx.Provide(func(params BundleParams) sysprobeconfigimpl.Params { return params.SysprobeConfigParams }),
+		sysprobeconfigimpl.MockModule,
+		telemetry.Module,
+		hostnameimpl.MockModule,
+	)
+}
+
 // MockBundle defines the mock fx options for this bundle.
-var MockBundle = fxutil.Bundle(
-	fx.Provide(func(params BundleParams) config.Params { return params.ConfigParams }),
-	config.MockModule,
-	fx.Supply(log.Params{}),
+var MockBundle = MakeMockBundle(
+	fx.Supply(func() log.Params { return log.Params{} }),
 	log.MockModule,
-	fx.Provide(func(params BundleParams) sysprobeconfigimpl.Params { return params.SysprobeConfigParams }),
-	sysprobeconfigimpl.MockModule,
-	telemetry.Module,
-	hostnameimpl.MockModule,
 )

--- a/comp/core/bundle_mock.go
+++ b/comp/core/bundle_mock.go
@@ -43,6 +43,6 @@ func MakeMockBundle(logParams, logger fx.Option) fxutil.BundleOptions {
 
 // MockBundle defines the mock fx options for this bundle.
 var MockBundle = MakeMockBundle(
-	fx.Supply(func() log.Params { return log.Params{} }),
+	fx.Supply(log.Params{}),
 	log.MockModule,
 )

--- a/comp/core/log/component.go
+++ b/comp/core/log/component.go
@@ -89,3 +89,8 @@ var TraceModule fx.Option = fxutil.Component(
 var MockModule fx.Option = fxutil.Component(
 	fx.Provide(newMockLogger),
 )
+
+// TraceMockModule defines the fx options for the mock component in its Trace variant.
+var TraceMockModule fx.Option = fxutil.Component(
+	fx.Provide(newTraceMockLogger),
+)

--- a/comp/core/log/mock.go
+++ b/comp/core/log/mock.go
@@ -7,9 +7,12 @@ package log
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/cihub/seelog"
 	"go.uber.org/fx"
 
@@ -48,4 +51,13 @@ func newMockLogger(t testing.TB, lc fx.Lifecycle) (Component, error) {
 	log.ChangeLogLevel(iface, "off")
 
 	return &logger{}, nil
+}
+
+func newTraceMockLogger(t testing.TB, lc fx.Lifecycle, params Params, cfg config.Component) (Component, error) {
+	// Make sure we are setting a default value on purpose.
+	logFilePath := params.logFileFn(cfg)
+	if logFilePath != os.Getenv("DDTEST_DEFAULT_LOG_FILE_PATH") {
+		return nil, fmt.Errorf("unexpected default log file path: %q", logFilePath)
+	}
+	return newMockLogger(t, lc)
 }


### PR DESCRIPTION
### What does this PR do?

Reverts the path for `trace-agent` logging to its original value before #19707.

### Motivation

PR #19707 changed it accidentally to `path.DefaultLogFile` that points by default to `$specific_os_path/agent.log`.

### Describe how to test/QA your changes

* Run the `trace-agent` and make sure `trace-agent.log` is created.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
