### PR TITLE
Change language annotation format for language detection

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments.go
@@ -10,7 +10,6 @@ package kubeapiserver
 
 import (
 	"context"
-	"regexp"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,10 +21,10 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
+	languagedetectionUtil "github.com/DataDog/datadog-agent/pkg/languagedetection/util"
+
 	ddkube "github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 )
-
-var re = regexp.MustCompile(`internal\.dd\.datadog\.com\/(init)?\.?(.+?)\.detected_langs`)
 
 // deploymentFilter filters out deployments that can't be used for unified service tagging or process language detection
 type deploymentFilter struct{}
@@ -93,7 +92,7 @@ func (p deploymentParser) Parse(obj interface{}) workloadmeta.Entity {
 
 	for annotation, languages := range deployment.Annotations {
 		// find a match
-		matches := re.FindStringSubmatch(annotation)
+		matches := languagedetectionUtil.AnnotationRegex.FindStringSubmatch(annotation)
 		if len(matches) != 3 {
 			continue
 		}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments.go
@@ -25,7 +25,7 @@ import (
 	ddkube "github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 )
 
-var re = regexp.MustCompile(`apm\.datadoghq\.com\/(init)?\.?(.+?)\.languages`)
+var re = regexp.MustCompile(`internal\.dd\.datadog\.com\/(init)?\.?(.+?)\.detected_langs`)
 
 // deploymentFilter filters out deployments that can't be used for unified service tagging or process language detection
 type deploymentFilter struct{}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments.go
@@ -91,16 +91,14 @@ func (p deploymentParser) Parse(obj interface{}) workloadmeta.Entity {
 	containerLanguages := make(map[string][]languagemodels.Language)
 
 	for annotation, languages := range deployment.Annotations {
-		// find a match
-		matches := languagedetectionUtil.AnnotationRegex.FindStringSubmatch(annotation)
-		if len(matches) != 3 {
-			continue
-		}
-		// matches[1] matches "init"
-		if matches[1] != "" {
-			updateContainerLanguageMap(initContainerLanguages, matches[2], languages)
-		} else {
-			updateContainerLanguageMap(containerLanguages, matches[2], languages)
+
+		containerName, isInitContainer := languagedetectionUtil.ExtractContainerFromAnnotationKey(annotation)
+		if containerName != "" {
+			if isInitContainer {
+				updateContainerLanguageMap(initContainerLanguages, containerName, languages)
+			} else {
+				updateContainerLanguageMap(containerLanguages, containerName, languages)
+			}
 		}
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
@@ -63,8 +63,8 @@ func TestDeploymentParser_Parse(t *testing.T) {
 						"tags.datadoghq.com/version": "version",
 					},
 					Annotations: map[string]string{
-						"internal.dd.datadog.com/nginx-cont.detected_langs":      "go,java,  python  ",
-						"internal.dd.datadog.com/init.nginx-cont.detected_langs": "go,java,  python  ",
+						"internal.dd.datadoghq.com/nginx-cont.detected_langs":      "go,java,  python  ",
+						"internal.dd.datadoghq.com/init.nginx-cont.detected_langs": "go,java,  python  ",
 					},
 				},
 			},
@@ -125,8 +125,8 @@ func TestDeploymentParser_Parse(t *testing.T) {
 						"test-label": "test-value",
 					},
 					Annotations: map[string]string{
-						"internal.dd.datadog.com/nginx-cont.detected_langs":      "go,java,  python  ",
-						"internal.dd.datadog.com/init.nginx-cont.detected_langs": "go,java,  python  ",
+						"internal.dd.datadoghq.com/nginx-cont.detected_langs":      "go,java,  python  ",
+						"internal.dd.datadoghq.com/init.nginx-cont.detected_langs": "go,java,  python  ",
 					},
 				},
 			},
@@ -191,8 +191,8 @@ func Test_DeploymentsFakeKubernetesClient(t *testing.T) {
 						Name:      "test-deployment",
 						Namespace: "test-namespace",
 						Annotations: map[string]string{"test-label": "test-value",
-							"internal.dd.datadog.com/nginx.detected_langs":      "go,java",
-							"internal.dd.datadog.com/init.redis.detected_langs": "go,python"},
+							"internal.dd.datadoghq.com/nginx.detected_langs":      "go,java",
+							"internal.dd.datadoghq.com/init.redis.detected_langs": "go,python"},
 					}},
 					metav1.CreateOptions{},
 				)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
@@ -63,8 +63,8 @@ func TestDeploymentParser_Parse(t *testing.T) {
 						"tags.datadoghq.com/version": "version",
 					},
 					Annotations: map[string]string{
-						"apm.datadoghq.com/nginx-cont.languages":      "go,java,  python  ",
-						"apm.datadoghq.com/init.nginx-cont.languages": "go,java,  python  ",
+						"internal.dd.datadog.com/nginx-cont.detected_langs":      "go,java,  python  ",
+						"internal.dd.datadog.com/init.nginx-cont.detected_langs": "go,java,  python  ",
 					},
 				},
 			},
@@ -125,8 +125,8 @@ func TestDeploymentParser_Parse(t *testing.T) {
 						"test-label": "test-value",
 					},
 					Annotations: map[string]string{
-						"apm.datadoghq.com/nginx-cont.languages":      "go,java,  python  ",
-						"apm.datadoghq.com/init.nginx-cont.languages": "go,java,  python  ",
+						"internal.dd.datadog.com/nginx-cont.detected_langs":      "go,java,  python  ",
+						"internal.dd.datadog.com/init.nginx-cont.detected_langs": "go,java,  python  ",
 					},
 				},
 			},
@@ -191,8 +191,8 @@ func Test_DeploymentsFakeKubernetesClient(t *testing.T) {
 						Name:      "test-deployment",
 						Namespace: "test-namespace",
 						Annotations: map[string]string{"test-label": "test-value",
-							"apm.datadoghq.com/nginx.languages":      "go,java",
-							"apm.datadoghq.com/init.redis.languages": "go,python"},
+							"internal.dd.datadog.com/nginx.detected_langs":      "go,java",
+							"internal.dd.datadog.com/init.redis.detected_langs": "go,python"},
 					}},
 					metav1.CreateOptions{},
 				)

--- a/pkg/clusteragent/languagedetection/patcher_test.go
+++ b/pkg/clusteragent/languagedetection/patcher_test.go
@@ -289,8 +289,8 @@ func TestPatchOwner(t *testing.T) {
 				"annotations": map[string]interface{}{
 					"annotationkey1": "annotationvalue1",
 					"annotationkey2": "annotationvalue2",
-					"apm.datadoghq.com/container-1.languages": "java,python",
-					"apm.datadoghq.com/container-2.languages": "cpp",
+					"internal.dd.datadog.com/container-1.detected_langs": "java,python",
+					"internal.dd.datadog.com/container-2.detected_langs": "cpp",
 				},
 			},
 			"spec": map[string]interface{}{},
@@ -311,9 +311,9 @@ func TestPatchOwner(t *testing.T) {
 	assert.True(t, found)
 
 	expectedAnnotations := map[string]string{
-		"apm.datadoghq.com/container-1.languages": "cpp,java,python",
-		"apm.datadoghq.com/container-2.languages": "python,ruby",
-		"apm.datadoghq.com/container-3.languages": "cpp",
+		"internal.dd.datadog.com/container-1.detected_langs": "cpp,java,python",
+		"internal.dd.datadog.com/container-2.detected_langs": "python,ruby",
+		"internal.dd.datadog.com/container-3.detected_langs": "cpp",
 		"annotationkey1": "annotationvalue1",
 		"annotationkey2": "annotationvalue2",
 	}
@@ -427,8 +427,8 @@ func TestPatchAllOwners(t *testing.T) {
 				"annotations": map[string]interface{}{
 					"annotationkey1": "annotationvalue1",
 					"annotationkey2": "annotationvalue2",
-					"apm.datadoghq.com/container-1.languages": "java,python",
-					"apm.datadoghq.com/container-2.languages": "python",
+					"internal.dd.datadog.com/container-1.detected_langs": "java,python",
+					"internal.dd.datadog.com/container-2.detected_langs": "python",
 				},
 			},
 			"spec": map[string]interface{}{},
@@ -471,9 +471,9 @@ func TestPatchAllOwners(t *testing.T) {
 	assert.True(t, found)
 
 	expectedAnnotationsA := map[string]string{
-		"apm.datadoghq.com/container-1.languages":      "cpp,java,python",
-		"apm.datadoghq.com/container-2.languages":      "python,ruby",
-		"apm.datadoghq.com/init.container-3.languages": "cpp",
+		"internal.dd.datadog.com/container-1.detected_langs":      "cpp,java,python",
+		"internal.dd.datadog.com/container-2.detected_langs":      "python,ruby",
+		"internal.dd.datadog.com/init.container-3.detected_langs": "cpp",
 		"annotationkey1": "annotationvalue1",
 		"annotationkey2": "annotationvalue2",
 	}
@@ -489,9 +489,9 @@ func TestPatchAllOwners(t *testing.T) {
 	assert.True(t, found)
 
 	expectedAnnotationsB := map[string]string{
-		"apm.datadoghq.com/container-1.languages":      "python",
-		"apm.datadoghq.com/container-2.languages":      "golang",
-		"apm.datadoghq.com/init.container-3.languages": "cpp,java",
+		"internal.dd.datadog.com/container-1.detected_langs":      "python",
+		"internal.dd.datadog.com/container-2.detected_langs":      "golang",
+		"internal.dd.datadog.com/init.container-3.detected_langs": "cpp,java",
 	}
 
 	assert.True(t, reflect.DeepEqual(expectedAnnotationsB, annotations))

--- a/pkg/clusteragent/languagedetection/patcher_test.go
+++ b/pkg/clusteragent/languagedetection/patcher_test.go
@@ -289,8 +289,8 @@ func TestPatchOwner(t *testing.T) {
 				"annotations": map[string]interface{}{
 					"annotationkey1": "annotationvalue1",
 					"annotationkey2": "annotationvalue2",
-					"internal.dd.datadog.com/container-1.detected_langs": "java,python",
-					"internal.dd.datadog.com/container-2.detected_langs": "cpp",
+					"internal.dd.datadoghq.com/container-1.detected_langs": "java,python",
+					"internal.dd.datadoghq.com/container-2.detected_langs": "cpp",
 				},
 			},
 			"spec": map[string]interface{}{},
@@ -311,9 +311,9 @@ func TestPatchOwner(t *testing.T) {
 	assert.True(t, found)
 
 	expectedAnnotations := map[string]string{
-		"internal.dd.datadog.com/container-1.detected_langs": "cpp,java,python",
-		"internal.dd.datadog.com/container-2.detected_langs": "python,ruby",
-		"internal.dd.datadog.com/container-3.detected_langs": "cpp",
+		"internal.dd.datadoghq.com/container-1.detected_langs": "cpp,java,python",
+		"internal.dd.datadoghq.com/container-2.detected_langs": "python,ruby",
+		"internal.dd.datadoghq.com/container-3.detected_langs": "cpp",
 		"annotationkey1": "annotationvalue1",
 		"annotationkey2": "annotationvalue2",
 	}
@@ -427,8 +427,8 @@ func TestPatchAllOwners(t *testing.T) {
 				"annotations": map[string]interface{}{
 					"annotationkey1": "annotationvalue1",
 					"annotationkey2": "annotationvalue2",
-					"internal.dd.datadog.com/container-1.detected_langs": "java,python",
-					"internal.dd.datadog.com/container-2.detected_langs": "python",
+					"internal.dd.datadoghq.com/container-1.detected_langs": "java,python",
+					"internal.dd.datadoghq.com/container-2.detected_langs": "python",
 				},
 			},
 			"spec": map[string]interface{}{},
@@ -471,9 +471,9 @@ func TestPatchAllOwners(t *testing.T) {
 	assert.True(t, found)
 
 	expectedAnnotationsA := map[string]string{
-		"internal.dd.datadog.com/container-1.detected_langs":      "cpp,java,python",
-		"internal.dd.datadog.com/container-2.detected_langs":      "python,ruby",
-		"internal.dd.datadog.com/init.container-3.detected_langs": "cpp",
+		"internal.dd.datadoghq.com/container-1.detected_langs":      "cpp,java,python",
+		"internal.dd.datadoghq.com/container-2.detected_langs":      "python,ruby",
+		"internal.dd.datadoghq.com/init.container-3.detected_langs": "cpp",
 		"annotationkey1": "annotationvalue1",
 		"annotationkey2": "annotationvalue2",
 	}
@@ -489,9 +489,9 @@ func TestPatchAllOwners(t *testing.T) {
 	assert.True(t, found)
 
 	expectedAnnotationsB := map[string]string{
-		"internal.dd.datadog.com/container-1.detected_langs":      "python",
-		"internal.dd.datadog.com/container-2.detected_langs":      "golang",
-		"internal.dd.datadog.com/init.container-3.detected_langs": "cpp,java",
+		"internal.dd.datadoghq.com/container-1.detected_langs":      "python",
+		"internal.dd.datadoghq.com/container-2.detected_langs":      "golang",
+		"internal.dd.datadoghq.com/init.container-3.detected_langs": "cpp,java",
 	}
 
 	assert.True(t, reflect.DeepEqual(expectedAnnotationsB, annotations))

--- a/pkg/languagedetection/util/annotations.go
+++ b/pkg/languagedetection/util/annotations.go
@@ -6,11 +6,15 @@
 // Package util provides util type definitions and helper methods for the language detection client and handler
 package util
 
+import "regexp"
+
 const (
 
 	// AnnotationPrefix represents a prefix of the language detection annotations
-	AnnotationPrefix string = "internal.dd.datadog.com/"
+	AnnotationPrefix string = "internal.dd.datadoghq.com/"
 )
+
+var AnnotationRegex = regexp.MustCompile(`internal\.dd\.datadoghq\.com\/(init)?\.?(.+?)\.detected_langs`)
 
 // GetLanguageAnnotationKey returns the language annotation key for the specified container
 func GetLanguageAnnotationKey(containerName string) string {

--- a/pkg/languagedetection/util/annotations.go
+++ b/pkg/languagedetection/util/annotations.go
@@ -9,10 +9,10 @@ package util
 const (
 
 	// AnnotationPrefix represents a prefix of the language detection annotations
-	AnnotationPrefix string = "apm.datadoghq.com/"
+	AnnotationPrefix string = "internal.dd.datadog.com/"
 )
 
 // GetLanguageAnnotationKey returns the language annotation key for the specified container
 func GetLanguageAnnotationKey(containerName string) string {
-	return AnnotationPrefix + containerName + ".languages"
+	return AnnotationPrefix + containerName + ".detected_langs"
 }

--- a/pkg/languagedetection/util/annotations.go
+++ b/pkg/languagedetection/util/annotations.go
@@ -14,6 +14,7 @@ const (
 	AnnotationPrefix string = "internal.dd.datadoghq.com/"
 )
 
+// AnnotationRegex defines the regex pattern of language detection annotations
 var AnnotationRegex = regexp.MustCompile(`internal\.dd\.datadoghq\.com\/(init)?\.?(.+?)\.detected_langs`)
 
 // GetLanguageAnnotationKey returns the language annotation key for the specified container

--- a/pkg/languagedetection/util/annotations.go
+++ b/pkg/languagedetection/util/annotations.go
@@ -6,7 +6,9 @@
 // Package util provides util type definitions and helper methods for the language detection client and handler
 package util
 
-import "regexp"
+import (
+	"regexp"
+)
 
 const (
 
@@ -20,4 +22,19 @@ var AnnotationRegex = regexp.MustCompile(`internal\.dd\.datadoghq\.com\/(init)?\
 // GetLanguageAnnotationKey returns the language annotation key for the specified container
 func GetLanguageAnnotationKey(containerName string) string {
 	return AnnotationPrefix + containerName + ".detected_langs"
+}
+
+// ExtractContainerFromAnnotationKey extracts container name from annotation key and indicates if it is an init container
+// if the annotation key is not a language annotation it returns an empty container name
+func ExtractContainerFromAnnotationKey(annotationKey string) (string, bool) {
+	matches := AnnotationRegex.FindStringSubmatch(annotationKey)
+	if len(matches) != 3 {
+		return "", false
+	}
+
+	containerName := matches[2]
+
+	isInitContainer := matches[1] != ""
+
+	return containerName, isInitContainer
 }

--- a/pkg/languagedetection/util/annotations.go
+++ b/pkg/languagedetection/util/annotations.go
@@ -17,7 +17,7 @@ const (
 )
 
 // AnnotationRegex defines the regex pattern of language detection annotations
-var AnnotationRegex = regexp.MustCompile(`internal\.dd\.datadoghq\.com\/(init)?\.?(.+?)\.detected_langs`)
+var AnnotationRegex = regexp.MustCompile(`internal\.dd\.datadoghq\.com\/(init\.)?(.+?)\.detected_langs`)
 
 // GetLanguageAnnotationKey returns the language annotation key for the specified container
 func GetLanguageAnnotationKey(containerName string) string {

--- a/pkg/languagedetection/util/annotations_test.go
+++ b/pkg/languagedetection/util/annotations_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestGetLanguageAnnotationKey(t *testing.T) {
 	mockContainerName := "some-container-name"
-	expectedAnnotationKey := "apm.datadoghq.com/some-container-name.languages"
+	expectedAnnotationKey := "internal.dd.datadog.com/some-container-name.detected_langs"
 	actualAnnotationKey := GetLanguageAnnotationKey(mockContainerName)
 	assert.Equal(t, expectedAnnotationKey, actualAnnotationKey)
 }

--- a/pkg/languagedetection/util/annotations_test.go
+++ b/pkg/languagedetection/util/annotations_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestGetLanguageAnnotationKey(t *testing.T) {
 	mockContainerName := "some-container-name"
-	expectedAnnotationKey := "internal.dd.datadog.com/some-container-name.detected_langs"
+	expectedAnnotationKey := "internal.dd.datadoghq.com/some-container-name.detected_langs"
 	actualAnnotationKey := GetLanguageAnnotationKey(mockContainerName)
 	assert.Equal(t, expectedAnnotationKey, actualAnnotationKey)
 }

--- a/pkg/languagedetection/util/annotations_test.go
+++ b/pkg/languagedetection/util/annotations_test.go
@@ -43,6 +43,12 @@ func TestExtractContainerFromAnnotationKey(t *testing.T) {
 			containerName:   "some-container-name",
 			isInitContainer: true,
 		},
+		{
+			name:            "Language annotation for non-init container whose name starts with init",
+			annotationKey:   "internal.dd.datadoghq.com/initializer.detected_langs",
+			containerName:   "initializer",
+			isInitContainer: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/languagedetection/util/annotations_test.go
+++ b/pkg/languagedetection/util/annotations_test.go
@@ -17,3 +17,39 @@ func TestGetLanguageAnnotationKey(t *testing.T) {
 	actualAnnotationKey := GetLanguageAnnotationKey(mockContainerName)
 	assert.Equal(t, expectedAnnotationKey, actualAnnotationKey)
 }
+
+func TestExtractContainerFromAnnotationKey(t *testing.T) {
+	tests := []struct {
+		name            string
+		annotationKey   string
+		containerName   string
+		isInitContainer bool
+	}{
+		{
+			name:            "Non-matching annotation key",
+			annotationKey:   "IAmNotALanguageAnnotationKey",
+			containerName:   "",
+			isInitContainer: false,
+		},
+		{
+			name:            "Standard language annotation",
+			annotationKey:   "internal.dd.datadoghq.com/some-container-name.detected_langs",
+			containerName:   "some-container-name",
+			isInitContainer: false,
+		},
+		{
+			name:            "Language annotation for init container",
+			annotationKey:   "internal.dd.datadoghq.com/init.some-container-name.detected_langs",
+			containerName:   "some-container-name",
+			isInitContainer: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualContainerName, actualIsInit := ExtractContainerFromAnnotationKey(tt.annotationKey)
+			assert.Equal(t, tt.containerName, actualContainerName)
+			assert.Equal(t, tt.isInitContainer, actualIsInit)
+		})
+	}
+}

--- a/pkg/languagedetection/util/containerslanguages.go
+++ b/pkg/languagedetection/util/containerslanguages.go
@@ -12,7 +12,7 @@ import (
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 )
 
-var re = regexp.MustCompile(`apm\.datadoghq\.com\/(init)?\.?(.+?)\.languages`)
+var re = regexp.MustCompile(`internal\.dd\.datadog\.com\/(init)?\.?(.+?)\detected_langs`)
 
 // ContainersLanguages maps container name to language set
 type ContainersLanguages map[string]LanguageSet

--- a/pkg/languagedetection/util/containerslanguages.go
+++ b/pkg/languagedetection/util/containerslanguages.go
@@ -7,12 +7,9 @@ package util
 
 import (
 	"fmt"
-	"regexp"
 
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 )
-
-var re = regexp.MustCompile(`internal\.dd\.datadog\.com\/(init)?\.?(.+?)\detected_langs`)
 
 // ContainersLanguages maps container name to language set
 type ContainersLanguages map[string]LanguageSet
@@ -47,7 +44,7 @@ func (containerslanguages ContainersLanguages) TotalLanguages() int {
 func (containerslanguages ContainersLanguages) ParseAnnotations(annotations map[string]string) {
 	for annotation, languages := range annotations {
 		// find a match
-		matches := re.FindStringSubmatch(annotation)
+		matches := AnnotationRegex.FindStringSubmatch(annotation)
 		if len(matches) != 3 {
 			continue
 		}

--- a/pkg/languagedetection/util/containerslanguages.go
+++ b/pkg/languagedetection/util/containerslanguages.go
@@ -43,20 +43,13 @@ func (containerslanguages ContainersLanguages) TotalLanguages() int {
 // ParseAnnotations updates the containers languages based on existing language annotations
 func (containerslanguages ContainersLanguages) ParseAnnotations(annotations map[string]string) {
 	for annotation, languages := range annotations {
-		// find a match
-		matches := AnnotationRegex.FindStringSubmatch(annotation)
-		if len(matches) != 3 {
-			continue
+		containerName, isInitContainer := ExtractContainerFromAnnotationKey(annotation)
+		if containerName != "" {
+			if isInitContainer {
+				containerName = fmt.Sprintf("init.%s", containerName)
+			}
+			containerslanguages.GetOrInitializeLanguageset(containerName).Parse(languages)
 		}
-
-		containerName := matches[2]
-
-		// matches[1] matches "init"
-		if matches[1] != "" {
-			containerName = fmt.Sprintf("init.%s", containerName)
-		}
-
-		containerslanguages.GetOrInitializeLanguageset(containerName).Parse(languages)
 	}
 }
 

--- a/pkg/languagedetection/util/containerslanguages_test.go
+++ b/pkg/languagedetection/util/containerslanguages_test.go
@@ -35,11 +35,11 @@ func TestTotalLanguages(t *testing.T) {
 
 func TestParseAnnotations(t *testing.T) {
 	mockAnnotations := map[string]string{
-		"apm.datadoghq.com/cont-1.languages":      "java,cpp,python",
-		"apm.datadoghq.com/cont-2.languages":      "javascript,cpp,golang",
-		"apm.datadoghq.com/init.cont-3.languages": "python,java",
-		"annotationkey1":                          "annotationvalue1",
-		"annotationkey2":                          "annotationvalue2",
+		"internal.dd.datadog.com/cont-1.detected_langs":      "java,cpp,python",
+		"internal.dd.datadog.com/cont-2.detected_langs":      "javascript,cpp,golang",
+		"internal.dd.datadog.com/init.cont-3.detected_langs": "python,java",
+		"annotationkey1": "annotationvalue1",
+		"annotationkey2": "annotationvalue2",
 	}
 
 	containerslanguages := NewContainersLanguages()
@@ -95,9 +95,9 @@ func TestToAnnotations(t *testing.T) {
 
 	actualAnnotations := containerslanguages.ToAnnotations()
 	expectedAnnotations := map[string]string{
-		"apm.datadoghq.com/wordpress.languages":     "javascript,php",
-		"apm.datadoghq.com/server.languages":        "cpp,javascript,python",
-		"apm.datadoghq.com/init.launcher.languages": "bash,cpp",
+		"internal.dd.datadog.com/wordpress.detected_langs":     "javascript,php",
+		"internal.dd.datadog.com/server.detected_langs":        "cpp,javascript,python",
+		"internal.dd.datadog.com/init.launcher.detected_langs": "bash,cpp",
 	}
 
 	assert.Equal(t, expectedAnnotations, actualAnnotations)

--- a/pkg/languagedetection/util/containerslanguages_test.go
+++ b/pkg/languagedetection/util/containerslanguages_test.go
@@ -35,9 +35,9 @@ func TestTotalLanguages(t *testing.T) {
 
 func TestParseAnnotations(t *testing.T) {
 	mockAnnotations := map[string]string{
-		"internal.dd.datadog.com/cont-1.detected_langs":      "java,cpp,python",
-		"internal.dd.datadog.com/cont-2.detected_langs":      "javascript,cpp,golang",
-		"internal.dd.datadog.com/init.cont-3.detected_langs": "python,java",
+		"internal.dd.datadoghq.com/cont-1.detected_langs":      "java,cpp,python",
+		"internal.dd.datadoghq.com/cont-2.detected_langs":      "javascript,cpp,golang",
+		"internal.dd.datadoghq.com/init.cont-3.detected_langs": "python,java",
 		"annotationkey1": "annotationvalue1",
 		"annotationkey2": "annotationvalue2",
 	}
@@ -95,9 +95,9 @@ func TestToAnnotations(t *testing.T) {
 
 	actualAnnotations := containerslanguages.ToAnnotations()
 	expectedAnnotations := map[string]string{
-		"internal.dd.datadog.com/wordpress.detected_langs":     "javascript,php",
-		"internal.dd.datadog.com/server.detected_langs":        "cpp,javascript,python",
-		"internal.dd.datadog.com/init.launcher.detected_langs": "bash,cpp",
+		"internal.dd.datadoghq.com/wordpress.detected_langs":     "javascript,php",
+		"internal.dd.datadoghq.com/server.detected_langs":        "cpp,javascript,python",
+		"internal.dd.datadoghq.com/init.launcher.detected_langs": "bash,cpp",
 	}
 
 	assert.Equal(t, expectedAnnotations, actualAnnotations)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR change the structure of language annotations used by language detection feature from `apm.datadoghq.com/<container-name>.languages` to `internal.dd.datadoghq.com/<container-name>.detected_langs`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Make it clear to the user that these annotations indicate to languages that were internally detected automatically by the datadog agent. 

The goal is to avoid confusion with existing language annotations that can be set by the user for the SSI (single step instrumentation) feature.


### Describe how to test/QA your changes

Same testing plan as [this PR](https://github.com/DataDog/datadog-agent/pull/19636), except that the annotations should be in the format `internal.dd.datadoghq.com/<container-name>.detected_langs`

Or you can follow the following steps:
- Deploy the agent and cluster agent with process collection and language detection enabled. You can use helm with following template:
```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
  processAgent:
    enabled: true
    processCollection: true
  prometheusScrape:
    enabled: true
  env:
    - name: DD_LANGUAGE_DETECTION_ENABLED
      value: "true"
    - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
      value: "true"

clusterAgent:
  enabled: true
  replicas: 1
  admissionController:
    enabled: true
    mutateUnlabelled: true
    configMode: socket
  env:
    - name: DD_LANGUAGE_DETECTION_ENABLED
      value: "true"
    - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
      value: "true"
```
- Make sure that the cluster-agent has the correct rbac to patch deployments (you can run `kubectl edit clusterrole datadog-agent-cluster-agent` to modify the rbac of the cluster-agent by adding `patch` permission for deployment resources.
- Create a dummy java app with the following command: `kubectl create deployment javaapp --image docker.io/bdevinssureshatddog/k8s-lib-injection-app:latest`
- Check that the following annotation is added on top of the deployment `javaapp` after few seconds: `internal.dd.datadoghq.com/k8s-lib-injection-app.detected_langs: java`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
