### PR TITLE
Set AgentType to ClusterAgent when in DCA workloademta dependencies

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -102,6 +102,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				collectors.GetCatalog(),
 				fx.Supply(workloadmeta.Params{
 					InitHelper: common.GetWorkloadmetaInit(),
+					AgentType:  workloadmeta.ClusterAgent,
 				}), // TODO(components): check what this must be for cluster-agent-cloudfoundry
 				fx.Supply(context.Background()),
 				workloadmeta.Module,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR fixes a bug in the cluster agent cmd start method. 

Currently, when we start the cluster-agent, we use dependency injection to start the `workloadmeta store`. The bug is that we miss setting the `AgentType` to `ClusterAgent` in the `Params` dependency. As a result, the `AgentType` defaults to none (more precisely, 0), and no candidates are accepted as collectors, so workloadmeta store remains empty since no collectors are started at all.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Allow collectors to start in the cluster agent.

### Additional Notes

If we don't set the `AgentType` param (which is of type `int8`) to `ClusterAgent`, it defaults to 0 (representing an empty set of targets). As a result, [this line](https://github.com/DataDog/datadog-agent/blob/07633f34180aaa8066efc40a2955780dfd82fbd9/comp/core/workloadmeta/workloadmeta.go#L63) while not allow any candidate to be started as a collector.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Deploy the cluster agent on a kubernetes cluster, and check that workloadmeta collectors are started.

To verify the collectors have started you can:
- Check the logs of the `cluster-agent` container of the cluster agent pod by running `kubectl logs <cluster-agent-pod> -c cluster-agent` and check that collectors have been started. For example, you should find something like: `workloadmeta collector "kubeapiserver" started successfully`
- Check that the workloadmeta store is not empty by running: `kubectl exec <cluster-agent-pod> -c cluster-agent -- agent workload-list -v`. The output should be similar to the following:
```
=== Entity kubernetes_node sources(merged):[kubeapiserver] id: gke-gke-adelhajhassa-ubuntu-container-30c272e1-pjk8 ===
----------- Entity ID -----------
Kind: kubernetes_node ID: gke-gke-adelhajhassa-ubuntu-container-30c272e1-pjk8

----------- Entity Meta -----------
Name: gke-gke-adelhajhassa-ubuntu-container-30c272e1-pjk8
Namespace: 
Annotations: csi.volume.kubernetes.io/nodeid:{"pd.csi.storage.gke.io":"projects/datadog-sandbox/zones/europe-west3-c/instances/gke-gke-adelhajhassa-ubuntu-container-30c272e1-pjk8"} node.alpha.kubernetes.io/ttl:0 node.gke.io/last-applied-node-labels:cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=2,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-netd-ready=true,cloud.google.com/gke-nodepool=ubuntu-containerd,cloud.google.com/gke-os-distribution=ubuntu,cloud.google.com/gke-provisioning=spot,cloud.google.com/gke-spot=true,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=e2,cloud.google.com/private-node=false node.gke.io/last-applied-node-taints: volumes.kubernetes.io/controller-managed-attach-detach:true container.googleapis.com/instance_id:662251133761306200 
Labels: cloud.google.com/gke-container-runtime:containerd failure-domain.beta.kubernetes.io/zone:europe-west3-c cloud.google.com/private-node:false beta.kubernetes.io/arch:amd64 beta.kubernetes.io/instance-type:e2-standard-2 cloud.google.com/gke-boot-disk:pd-balanced cloud.google.com/machine-family:e2 failure-domain.beta.kubernetes.io/region:europe-west3 cloud.google.com/gke-stack-type:IPV4 cloud.google.com/gke-netd-ready:true kubernetes.io/os:linux topology.gke.io/zone:europe-west3-c cloud.google.com/gke-os-distribution:ubuntu cloud.google.com/gke-logging-variant:DEFAULT cloud.google.com/gke-provisioning:spot topology.kubernetes.io/zone:europe-west3-c kubernetes.io/arch:amd64 cloud.google.com/gke-spot:true cloud.google.com/gke-nodepool:ubuntu-containerd node.kubernetes.io/instance-type:e2-standard-2 kubernetes.io/hostname:gke-gke-adelhajhassa-ubuntu-container-30c272e1-pjk8 topology.kubernetes.io/region:europe-west3 cloud.google.com/gke-max-pods-per-node:110 beta.kubernetes.io/os:linux cloud.google.com/gke-cpu-scaling-level:2 
===

=== Entity kubernetes_node sources(merged):[kubeapiserver] id: gke-gke-adelhajhassan-cos-containerd-91958212-frdc ===
----------- Entity ID -----------
Kind: kubernetes_node ID: gke-gke-adelhajhassan-cos-containerd-91958212-frdc

----------- Entity Meta -----------
Name: gke-gke-adelhajhassan-cos-containerd-91958212-frdc
Namespace: 
Annotations: csi.volume.kubernetes.io/nodeid:{"pd.csi.storage.gke.io":"projects/datadog-sandbox/zones/europe-west3-c/instances/gke-gke-adelhajhassan-cos-containerd-91958212-frdc"} node.alpha.kubernetes.io/ttl:0 node.gke.io/last-applied-node-labels:cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=2,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-netd-ready=true,cloud.google.com/gke-nodepool=cos-containerd,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=spot,cloud.google.com/gke-spot=true,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=e2,cloud.google.com/private-node=false node.gke.io/last-applied-node-taints: volumes.kubernetes.io/controller-managed-attach-detach:true container.googleapis.com/instance_id:6682714029032042000 
Labels: kubernetes.io/hostname:gke-gke-adelhajhassan-cos-containerd-91958212-frdc beta.kubernetes.io/instance-type:e2-standard-2 cloud.google.com/gke-netd-ready:true cloud.google.com/gke-provisioning:spot cloud.google.com/gke-cpu-scaling-level:2 cloud.google.com/gke-container-runtime:containerd kubernetes.io/os:linux beta.kubernetes.io/os:linux failure-domain.beta.kubernetes.io/region:europe-west3 kubernetes.io/arch:amd64 cloud.google.com/private-node:false topology.kubernetes.io/zone:europe-west3-c beta.kubernetes.io/arch:amd64 cloud.google.com/gke-nodepool:cos-containerd cloud.google.com/gke-stack-type:IPV4 cloud.google.com/machine-family:e2 node.kubernetes.io/instance-type:e2-standard-2 topology.gke.io/zone:europe-west3-c topology.kubernetes.io/region:europe-west3 cloud.google.com/gke-boot-disk:pd-balanced cloud.google.com/gke-spot:true cloud.google.com/gke-max-pods-per-node:110 cloud.google.com/gke-os-distribution:cos failure-domain.beta.kubernetes.io/zone:europe-west3-c cloud.google.com/gke-logging-variant:DEFAULT 
===

=== Entity kubernetes_node sources(merged):[kubeapiserver] id: gke-3ac5fc-peie ===
----------- Entity ID -----------
Kind: kubernetes_node ID: gke-3ac5fc-peie

----------- Entity Meta -----------
Name: gke-3ac5fc-peie
Namespace: 
Annotations: container.googleapis.com/instance_id:2314679456606784000 csi.volume.kubernetes.io/nodeid:{"pd.csi.storage.gke.io":"projects/datadog-sandbox/zones/europe-west3-c/instances/gke-3ac5fc-peie"} node.alpha.kubernetes.io/ttl:0 node.antrea.io/mac-address:42:01:0a:00:60:36 node.gke.io/last-applied-node-labels:cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=2,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-netd-ready=true,cloud.google.com/gke-nodepool=windows-ltsc-containerd,cloud.google.com/gke-os-distribution=windows_ltsc,cloud.google.com/gke-provisioning=spot,cloud.google.com/gke-spot=true,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/gke-windows-os-version=2019,cloud.google.com/machine-family=e2,cloud.google.com/private-node=false node.gke.io/last-applied-node-taints:node.kubernetes.io/os=windows:NoSchedule volumes.kubernetes.io/controller-managed-attach-detach:true 
Labels: cloud.google.com/gke-boot-disk:pd-balanced beta.kubernetes.io/arch:amd64 node.kubernetes.io/windows-build:10.0.17763 topology.gke.io/zone:europe-west3-c kubernetes.io/hostname:gke-3ac5fc-peie kubernetes.io/arch:amd64 cloud.google.com/private-node:false kubernetes.io/os:windows cloud.google.com/gke-container-runtime:containerd node.kubernetes.io/instance-type:e2-standard-2 cloud.google.com/gke-netd-ready:true cloud.google.com/gke-provisioning:spot failure-domain.beta.kubernetes.io/zone:europe-west3-c cloud.google.com/gke-cpu-scaling-level:2 cloud.google.com/machine-family:e2 beta.kubernetes.io/instance-type:e2-standard-2 topology.kubernetes.io/zone:europe-west3-c cloud.google.com/gke-stack-type:IPV4 cloud.google.com/gke-logging-variant:DEFAULT cloud.google.com/gke-os-distribution:windows_ltsc cloud.google.com/gke-nodepool:windows-ltsc-containerd cloud.google.com/gke-spot:true topology.kubernetes.io/region:europe-west3 beta.kubernetes.io/os:windows cloud.google.com/gke-max-pods-per-node:110 cloud.google.com/gke-windows-os-version:2019 failure-domain.beta.kubernetes.io/region:europe-west3 
===```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
