### PR TITLE
Ensure service permissions gets updated on maintenance

### DIFF
--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -129,6 +129,14 @@ namespace WixSetup.Datadog
                 }
             );
 
+            // Ensures that the "change" dialog also reinstall the product.
+            project.AddAction(new SetPropertyAction("REINSTALL", "ALL")
+            {
+                Condition = Conditions.Maintenance,
+                When = When.After,
+                Step = Step.FindRelatedProducts
+            });
+
             // Conditionally include the PROCMON MSM while it is in active development to make it easier
             // to build/ship without it.
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINDOWS_DDPROCMON_DRIVER")))
@@ -402,7 +410,7 @@ namespace WixSetup.Datadog
                 StopOn = null,
                 Start = SvcStartType.auto,
                 DelayedAutoStart = true,
-                RemoveOn = SvcEvent.Uninstall_Wait,
+                RemoveOn = SvcEvent.InstallUninstall_Wait,
                 ServiceSid = ServiceSid.none,
                 FirstFailureActionType = FailureActionType.restart,
                 SecondFailureActionType = FailureActionType.restart,
@@ -437,7 +445,7 @@ namespace WixSetup.Datadog
                 // Tell MSI not to stop the services. We handle service stop manually in StopDDServices custom action.
                 StopOn = null,
                 Start = SvcStartType.demand,
-                RemoveOn = SvcEvent.Uninstall_Wait,
+                RemoveOn = SvcEvent.InstallUninstall_Wait,
                 ServiceSid = ServiceSid.none,
                 FirstFailureActionType = FailureActionType.restart,
                 SecondFailureActionType = FailureActionType.restart,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR ensures that the service permission custom actions get called when the installer runs in "change" mode.

The only difference between "repair" and "change" is that the "REINSTALL" property is set to "ALL" during "repair", so this PR sets it for both "repair" and "change".

The "ServiceInstall" is also updated to "remove" the service on install - that ensures that the permissions for previous "ddagentuser" is correctly removed.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Better installation code
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Install the Agent, check the SDDL permission with `sc.exe sdshow datadogagent` and ensure the "ddagentuser" has the correct permission.
Re-run the installer and use the "change" dialog to change the user to a different one. Use `sc.exe sdshow datadogagent` to ensure that the new user as the correct permission.

Example:
```
> sc.exe sdshow datadogagent
[SC] OpenService échec(s) 1060 :

Le service spécifié n’existe pas en tant que service installé.
> msiexec /i datadog-agent-7.99.0-1-x86_64.msi
> sc.exe qc datadogagent
[SC] QueryServiceConfig réussite(s)

SERVICE_NAME: datadogagent
        TYPE               : 10  WIN32_OWN_PROCESS
        START_TYPE         : 2   AUTO_START  (DELAYED)
        ERROR_CONTROL      : 1   NORMAL
        BINARY_PATH_NAME   : "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe"
        LOAD_ORDER_GROUP   :
        TAG                : 0
        DISPLAY_NAME       : Datadog Agent
        DEPENDENCIES       :
        SERVICE_START_NAME : .\ddagentuser
> wmic useraccount get name,sid
Name                SID
Administrateur      S-1-5-21-2624507216-3994333568-3321347143-500
ddagentuser         S-1-5-21-2624507216-3994333568-3321347143-1000
DefaultAccount      S-1-5-21-2624507216-3994333568-3321347143-503
Invité              S-1-5-21-2624507216-3994333568-3321347143-501
WDAGUtilityAccount  S-1-5-21-2624507216-3994333568-3321347143-504
> sc.exe sdshow datadogagent

D:(A;;CCLCSWRPWPDTLOCR;;;S-1-5-21-2624507216-3994333568-3321347143-1000)(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)
> msiexec /i datadog-agent-7.99.0-1-x86_64.msi
> sc.exe qc datadogagent
[SC] QueryServiceConfig réussite(s)

SERVICE_NAME: datadogagent
        TYPE               : 10  WIN32_OWN_PROCESS
        START_TYPE         : 2   AUTO_START  (DELAYED)
        ERROR_CONTROL      : 1   NORMAL
        BINARY_PATH_NAME   : "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe"
        LOAD_ORDER_GROUP   :
        TAG                : 0
        DISPLAY_NAME       : Datadog Agent
        DEPENDENCIES       :
        SERVICE_START_NAME : .\toto
> wmic useraccount get name,sid
Name                SID
Administrateur      S-1-5-21-2624507216-3994333568-3321347143-500
ddagentuser         S-1-5-21-2624507216-3994333568-3321347143-1000
DefaultAccount      S-1-5-21-2624507216-3994333568-3321347143-503
Invité              S-1-5-21-2624507216-3994333568-3321347143-501
toto                S-1-5-21-2624507216-3994333568-3321347143-1001
WDAGUtilityAccount  S-1-5-21-2624507216-3994333568-3321347143-504
> sc.exe sdshow datadogagent

D:(A;;CCLCSWRPWPDTLOCR;;;S-1-5-21-2624507216-3994333568-3321347143-1001)(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
