### PR TITLE
[oracle] Bug fix for missing tags (DBMON-3210)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/init_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/init_test.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle_test
+
+package oracle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTags(t *testing.T) {
+	c, _ := newRealCheck(t, `tags:
+  - foo1:bar1
+  - foo2:bar2`)
+	err := c.Run()
+	require.NoError(t, err)
+	assert.True(t, c.initialized, "Check not initialized")
+	assert.Contains(t, c.tags, dbmsTag, "Static tag not merged")
+	assert.Contains(t, c.tags, "foo1:bar1", "Config tag not in tags")
+}

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -316,6 +316,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	c.checkInterval = float64(c.config.InitConfig.MinCollectionInterval)
 
 	tags := make([]string, len(c.config.Tags))
+	copy(tags, c.config.Tags)
 
 	tags = append(tags, fmt.Sprintf("dbms:%s", common.IntegrationName), fmt.Sprintf("ddagentversion:%s", c.agentVersion))
 	tags = append(tags, fmt.Sprintf("dbm:%t", c.dbmEnabled))
@@ -331,7 +332,10 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	if c.config.ServiceName != "" {
 		tags = append(tags, fmt.Sprintf("service:%s", c.config.ServiceName))
 	}
+	c.configTags = make([]string, len(tags))
 	copy(c.configTags, tags)
+	c.tags = make([]string, len(tags))
+	copy(c.tags, tags)
 
 	c.logPrompt = config.GetLogPrompt(c.config.InstanceConfig)
 

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics_test.go
@@ -16,5 +16,5 @@ import (
 func TestSysmetrics(t *testing.T) {
 	n, err := chk.sysMetrics()
 	assert.NoError(t, err, "failed to run sys metrics")
-	assert.Equal(t, int64(144), n)
+	assert.Equal(t, int64(92), n)
 }

--- a/releasenotes/notes/oracle-missing-tags-8e25d3d3b5041354.yaml
+++ b/releasenotes/notes/oracle-missing-tags-8e25d3d3b5041354.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Bug fix for missing tags.


### PR DESCRIPTION
### What does this PR do?

Fixing missing tags. The following tags weren't being emitted in the agent releases` 7.49` and `7.50`: `dbms`, `ddagentversion`, `dbm`, `port`, `server` and `service`. On top of that, the config tags were missing in query metrics and activity samples. (They were being emitted with the core metrics.)

### More information

![image](https://github.com/DataDog/datadog-agent/assets/18366081/7660d121-4f10-4162-83ae-5a2e7b2fe292)

![image](https://github.com/DataDog/datadog-agent/assets/18366081/d5ae2ab4-835d-429d-b8c8-467885ae20db)



### Describe how to test/QA your changes

Check if the tags mentioned above are being emitted.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
