### PR TITLE
Kacper murzyn/unfreeze task

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1306,6 +1306,7 @@ def unfreeze(ctx, base_directory="~/dd", major_versions="6,7", upstream="origin"
     That includes:
     - creates a release branch in datadog-agent, datadog-agent-macos, omnibus-ruby and omnibus-software repositories,
     - updates release.json on new datadog-agent branch to point to newly created release branches in nightly section
+    - updates entries in .gitlab-ci.yml which depend on local branch name
 
     Notes:
     base_directory - path to the directory where dd repos are cloned, defaults to ~/dd, but can be overwritten.

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -37,6 +37,12 @@ VERSION_RE = re.compile(r'(v)?(\d+)[.](\d+)([.](\d+))?(-devel)?(-rc\.(\d+))?')
 
 UNFREEZE_REPO_AGENT = "datadog-agent"
 UNFREEZE_REPOS = [UNFREEZE_REPO_AGENT, "omnibus-software", "omnibus-ruby", "datadog-agent-macos-build"]
+RELEASE_JSON_FIELDS_TO_UPDATE = [
+    "INTEGRATIONS_CORE_VERSION",
+    "OMNIBUS_SOFTWARE_VERSION",
+    "OMNIBUS_RUBY_VERSION",
+    "MACOS_BUILD_VERSION",
+]
 
 
 @task
@@ -1232,7 +1238,7 @@ def _get_release_json_value(key):
     return release_json
 
 
-def create_release_branch(ctx, repo, release_branch, base_directory="~/dd", upstream="origin"):
+def create_and_update_release_branch(ctx, repo, release_branch, base_directory="~/dd", upstream="origin"):
     # Perform branch out in all required repositories
     with ctx.cd(f"{base_directory}/{repo}"):
         # Step 1 - Create a local branch out from the default branch
@@ -1244,9 +1250,16 @@ def create_release_branch(ctx, repo, release_branch, base_directory="~/dd", upst
         print(color_message(f"Branching out to {release_branch}", "bold"))
         ctx.run(f"git checkout -b {release_branch}")
 
+        # Step 2 - In datadog-agent repo update base_branch and nightly builds entries
         if repo == UNFREEZE_REPO_AGENT:
             rj = _load_release_json()
+
             rj["base_branch"] = release_branch
+
+            for nightly in ["nightly", "nightly-a7"]:
+                for field in RELEASE_JSON_FIELDS_TO_UPDATE:
+                    rj[nightly][field] = f"{release_branch}"
+
             _save_release_json(rj)
             ctx.run("git add release.json")
             ok = try_git_command(ctx, f"git commit -m 'Set base_branch to {release_branch}'")
@@ -1274,13 +1287,12 @@ def create_release_branch(ctx, repo, release_branch, base_directory="~/dd", upst
 
 
 @task(help={'upstream': "Remote repository name (default 'origin')"})
-def unfreeze(ctx, base_directory="~/dd", major_versions="6,7", upstream="origin", redo=False):
+def unfreeze(ctx, base_directory="~/dd", major_versions="6,7", upstream="origin"):
     """
     Performs set of tasks required for the main branch unfreeze during the agent release cycle.
     That includes:
-    - creates a release branch in datadog-agent, omnibus-ruby and omnibus-software repositories,
-    - pushes an empty commit on the datadog-agent main branch,
-    - creates devel tags in the datadog-agent repository on the empty commit from the last step.
+    - creates a release branch in datadog-agent, datadog-agent-macos, omnibus-ruby and omnibus-software repositories,
+    - updates release.json on new datadog-agent branch to point to newly created release branches in nightly section
 
     Notes:
     base_directory - path to the directory where dd repos are cloned, defaults to ~/dd, but can be overwritten.
@@ -1300,7 +1312,6 @@ def unfreeze(ctx, base_directory="~/dd", major_versions="6,7", upstream="origin"
 
     # Strings with proper branch/tag names
     release_branch = current.branch()
-    devel_tag = str(next)
 
     # Step 0: checks
 
@@ -1317,41 +1328,8 @@ def unfreeze(ctx, base_directory="~/dd", major_versions="6,7", upstream="origin"
     ):
         raise Exit(color_message("Aborting.", "red"), code=1)
 
-    # Step 1: Create release branch
     for repo in UNFREEZE_REPOS:
-        create_release_branch(ctx, repo, release_branch, base_directory=base_directory)
-
-    print(color_message("Creating empty commit for devel tags", "bold"))
-    with ctx.cd(f"{base_directory}/datadog-agent"):
-        ctx.run("git checkout main")
-        ok = try_git_command(ctx, "git commit --allow-empty -m 'Empty commit for next release devel tags'")
-        if not ok:
-            raise Exit(
-                color_message(
-                    "Could not create commit. Please commit manually, push the commit manually to the main branch.",
-                    "red",
-                ),
-                code=1,
-            )
-
-        print(color_message("Pushing new commit", "bold"))
-        res = ctx.run(f"git push {upstream}", warn=True)
-        if res.exited is None or res.exited > 0:
-            raise Exit(
-                color_message(
-                    f"Could not push commit to the upstream '{upstream}'. Please push it manually.",
-                    "red",
-                ),
-                code=1,
-            )
-
-    # Step 3: Create tags for next version
-    print(color_message(f"Creating devel tags for agent version(s) {list_major_versions}", "bold"))
-    print(
-        color_message("If commit signing is enabled, you will have to make sure each tag gets properly signed.", "bold")
-    )
-
-    tag_version(ctx, devel_tag, tag_modules=False, push=True, force=redo)
+        create_and_update_release_branch(ctx, repo, release_branch, base_directory=base_directory, upstream=upstream)
 
 
 @task

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1261,16 +1261,6 @@ def create_and_update_release_branch(ctx, repo, release_branch, base_directory="
                     rj[nightly][field] = f"{release_branch}"
 
             _save_release_json(rj)
-            ctx.run("git add release.json")
-            ok = try_git_command(ctx, f"git commit -m 'Set base_branch to {release_branch}'")
-            if not ok:
-                raise Exit(
-                    color_message(
-                        f"Could not create commit. Please commit manually and push the commit to the {release_branch} branch.",
-                        "red",
-                    ),
-                    code=1,
-                )
 
             # Step 1.2 - In datadog-agent repo update gitlab-ci.yaml jobs
             with open(".gitlab-ci.yml", "r") as gl:
@@ -1282,6 +1272,18 @@ def create_and_update_release_branch(ctx, repo, release_branch, base_directory="
                         gl.write(line.replace("main", f"{release_branch}"))
                     else:
                         gl.write(line)
+
+            # Step 1.3 - Commit new changes
+            ctx.run("git add release.json .gitlab-ci.yml")
+            ok = try_git_command(ctx, f"git commit -m 'Update release.json and .gitlab-ci.yml with {release_branch}'")
+            if not ok:
+                raise Exit(
+                    color_message(
+                        f"Could not create commit. Please commit manually and push the commit to the {release_branch} branch.",
+                        "red",
+                    ),
+                    code=1,
+                )
 
         # Step 2 - Push newly created release branch to the remote repository
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 from datetime import date
 from time import sleep
 
+import yaml
 from invoke import Failure, task
 from invoke.exceptions import Exit
 
@@ -327,6 +328,16 @@ def _save_release_json(release_json):
     with open("release.json", "w") as release_json_stream:
         # Note, no space after the comma
         json.dump(release_json, release_json_stream, indent=4, sort_keys=False, separators=(',', ': '))
+
+
+def _load_gitlab_ci_yaml():
+    with open(".gitlab-ci.yml", "r") as gitlab_ci_stream:
+        return yaml.safe_load(gitlab_ci_stream)
+
+
+def _save_gitlab_ci_yaml(gitlab_ci):
+    with open(".gitlab-ci.yml", "w") as gitlab_ci_stream:
+        return yaml.dump(gitlab_ci, gitlab_ci_stream)
 
 
 ##
@@ -1248,10 +1259,10 @@ def create_and_update_release_branch(ctx, repo, release_branch, base_directory="
         ctx.run(f"git checkout {main_branch}")
         ctx.run("git pull")
         print(color_message(f"Branching out to {release_branch}", "bold"))
-        ctx.run(f"git checkout -b {release_branch}")
+        # ctx.run(f"git checkout -b {release_branch}")
 
-        # Step 2 - In datadog-agent repo update base_branch and nightly builds entries
         if repo == UNFREEZE_REPO_AGENT:
+            # Step 1.1 - In datadog-agent repo update base_branch and nightly builds entries
             rj = _load_release_json()
 
             rj["base_branch"] = release_branch
@@ -1261,29 +1272,37 @@ def create_and_update_release_branch(ctx, repo, release_branch, base_directory="
                     rj[nightly][field] = f"{release_branch}"
 
             _save_release_json(rj)
-            ctx.run("git add release.json")
-            ok = try_git_command(ctx, f"git commit -m 'Set base_branch to {release_branch}'")
-            if not ok:
-                raise Exit(
-                    color_message(
-                        f"Could not create commit. Please commit manually and push the commit to the {release_branch} branch.",
-                        "red",
-                    ),
-                    code=1,
-                )
+            # ctx.run("git add release.json")
+            # ok = try_git_command(ctx, f"git commit -m 'Set base_branch to {release_branch}'")
+            # if not ok:
+            #     raise Exit(
+            #         color_message(
+            #             f"Could not create commit. Please commit manually and push the commit to the {release_branch} branch.",
+            #             "red",
+            #         ),
+            #         code=1,
+            #     )
+
+            # Step 1.2 - In datadog-agent repo update gitlab_ci.yaml jobs
+            gl = _load_gitlab_ci_yaml()
+
+            gl[".on_security_agent_changes_or_manual"]["changes"]["compare_to"] = f"{release_branch}"
+            gl[".on_system_probe_changes_or_manual"]["changes"]["compare_to"] = f"{release_branch}"
+
+            _save_gitlab_ci_yaml(gl)
 
         # Step 2 - Push newly created release branch to the remote repository
 
-        print(color_message("Pushing new branch to the upstream repository", "bold"))
-        res = ctx.run(f"git push --set-upstream {upstream} {release_branch}", warn=True)
-        if res.exited is None or res.exited > 0:
-            raise Exit(
-                color_message(
-                    f"Could not push branch {release_branch} to the upstream '{upstream}'. Please push it manually.",
-                    "red",
-                ),
-                code=1,
-            )
+        # print(color_message("Pushing new branch to the upstream repository", "bold"))
+        # res = ctx.run(f"git push --set-upstream {upstream} {release_branch}", warn=True)
+        # if res.exited is None or res.exited > 0:
+        #     raise Exit(
+        #         color_message(
+        #             f"Could not push branch {release_branch} to the upstream '{upstream}'. Please push it manually.",
+        #             "red",
+        #         ),
+        #         code=1,
+        #     )
 
 
 @task(help={'upstream': "Remote repository name (default 'origin')"})
@@ -1318,8 +1337,8 @@ def unfreeze(ctx, base_directory="~/dd", major_versions="6,7", upstream="origin"
     print(color_message("Checking repository state", "bold"))
     ctx.run("git fetch")
 
-    github = GithubAPI(repository=GITHUB_REPO_NAME)
-    check_clean_branch_state(ctx, github, release_branch)
+    # github = GithubAPI(repository=GITHUB_REPO_NAME)
+    # check_clean_branch_state(ctx, github, release_branch)
 
     if not yes_no_question(
         f"This task will create new branches with the name '{release_branch}' in repositories: {', '.join(UNFREEZE_REPOS)}. Is this OK?",


### PR DESCRIPTION
### What does this PR do?

This PR updates `release.unfreeze` task in following ways:
- it removes part responsible for pushing empty commit on main branch after release branch creation, as this is not allowed (any changes to main should go through PR). I will add a second step task that handles placing devel tags.
- adds code which updates on release branch `release.json` nightly builds section to use new references,
- adds code which updates `.gitlab-ci.yml` jobs where there is a dependency on the base branch name

### Motivation

Automation of the Agent release activities.


### Describe how to test/QA your changes

Tested locally. Next real time scenario would be possible during Agent 7.51.0 release.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
