### PR TITLE
Add agent release management team to .ddqa config

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -262,3 +262,14 @@ jira_statuses = [
 ]
 github_team = "apm-onboarding"
 github_labels = ["team/apm-onboarding"]
+
+[teams."Agent Release Management"]
+jira_project = "AGNTR"
+jira_issue_type = "Task"
+jira_statuses = [
+  "To Do",
+  "In Progress",
+  "Done",
+]
+github_team = "agent-release-management"
+github_labels = ["team/agent-release-management "]

--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -272,4 +272,4 @@ jira_statuses = [
   "Done",
 ]
 github_team = "agent-release-management"
-github_labels = ["team/agent-release-management "]
+github_labels = ["team/agent-release-management"]


### PR DESCRIPTION
### What does this PR do?

This PR adds agent-release-management team to .ddqa config file so QA cards can be generated properly during Agent releases.

### Motivation

Agent QA consistency.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
