### PR TITLE
pkg/serverless/appsec: prevent flaky tests

### DIFF
--- a/pkg/serverless/appsec/appsec_test.go
+++ b/pkg/serverless/appsec/appsec_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func init() {
-	os.Setenv("DD_APPSEC_WAF_TIMEOUT", "2s")
+	os.Setenv("DD_APPSEC_WAF_TIMEOUT", "1m")
 }
 
 func TestNew(t *testing.T) {

--- a/pkg/serverless/appsec/appsec_test.go
+++ b/pkg/serverless/appsec/appsec_test.go
@@ -8,6 +8,7 @@ package appsec
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"testing"
 
@@ -15,6 +16,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	os.Setenv("DD_APPSEC_WAF_TIMEOUT", "2s")
+}
 
 func TestNew(t *testing.T) {
 	for _, appsecEnabled := range []bool{true, false} {
@@ -50,7 +55,6 @@ func TestMonitor(t *testing.T) {
 
 	t.Run("events-detection", func(t *testing.T) {
 		t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", "true")
-		t.Setenv("DD_APPSEC_WAF_TIMEOUT", "2s")
 		asm, err := newAppSec()
 		require.NoError(t, err)
 		defer asm.Close()
@@ -78,7 +82,6 @@ func TestMonitor(t *testing.T) {
 		t.Setenv("DD_API_SECURITY_REQUEST_SAMPLE_RATE", "1.0")
 		t.Setenv("DD_EXPERIMENTAL_API_SECURITY_ENABLED", "true")
 		t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", "true")
-		t.Setenv("DD_APPSEC_WAF_TIMEOUT", "2s")
 		asm, err := newAppSec()
 		require.NoError(t, err)
 		defer asm.Close()

--- a/pkg/serverless/appsec/httpsec/proxy_test.go
+++ b/pkg/serverless/appsec/httpsec/proxy_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func init() {
-	os.Setenv("DD_APPSEC_WAF_TIMEOUT", "2s")
+	os.Setenv("DD_APPSEC_WAF_TIMEOUT", "1m")
 }
 
 func TestProxyLifecycleProcessor(t *testing.T) {

--- a/pkg/serverless/appsec/httpsec/proxy_test.go
+++ b/pkg/serverless/appsec/httpsec/proxy_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	os.Setenv("DD_APPSEC_WAF_TIMEOUT", "2s")
+}
+
 func TestProxyLifecycleProcessor(t *testing.T) {
 	t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", "true")
 	lp, err := appsec.New()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Globally setup a large-enough WAF timeout, that was sometimes forgotten on some tests involving the WAF, and causing expected flaky tests (due to the CPU lags we experience on CIs).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Avoid flaky tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

APPSEC-12731


<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
