### PR TITLE
[Serverless] Allow serverless proxy settings to be read from datadog.yaml and env vars

### DIFF
--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [amd64, arm64]
-        suite: [metric, log, trace, appsec]
+        suite: [metric, log, trace, appsec, proxy]
     name: ${{ matrix.suite }} on ${{ matrix.architecture }}
     steps:
       - name: Checkout datadog-agent repository

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -178,20 +178,19 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 		log.Errorf("Error happened when loading configuration from datadog.yaml for metric agent: %s", err)
 	}
 
-	// api key reading
+	// API key reading
 	// ---------------
 
 	// API key reading priority:
-	// KMS > Secrets Manager > Plaintext API key
-	// If one is set but failing, the next will be tried
+	// Plaintext > KMS > Secrets Manager
+	// If an API key is set but failing, the next will be tried
 
 	apikey.CheckForSingleAPIKey()
 
-	// Set secrets from the environment that are suffixed with
-	// KMS_ENCRYPTED or SECRET_ARN
+	// Set API key from DD_KMS_API_KEY, DD_API_KEY_KMS_ENCRYPTED, or DD_API_KEY_SECRET_ARN
 	apikey.SetSecretsFromEnv(os.Environ())
 
-	// validate that an apikey has been set, either by the env var, read from KMS or Secrets Manager.
+	// Validate that an API key has been set, either by DD_API_KEY or read from KMS or Secrets Manager
 	// ---------------------------
 	if !config.Datadog.IsSet("api_key") {
 		// we're not reporting the error to AWS because we don't want the function

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -178,26 +178,7 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 		log.Errorf("Error happened when loading configuration from datadog.yaml for metric agent: %s", err)
 	}
 
-	// API key reading
-	// ---------------
-
-	// API key reading priority:
-	// Plaintext > KMS > Secrets Manager
-	// If an API key is set but failing, the next will be tried
-
-	apikey.CheckForSingleAPIKey()
-
-	// Set API key from DD_KMS_API_KEY environment variable or environment variables suffixed with KMS_ENCRYPTED or SECRET_ARN
-	apikey.SetSecretsFromEnv(os.Environ())
-
-	// Validate that an API key has been set, either by DD_API_KEY or read from KMS or Secrets Manager
-	// ---------------------------
-	if !config.Datadog.IsSet("api_key") {
-		// we're not reporting the error to AWS because we don't want the function
-		// execution to be stopped. TODO(remy): discuss with AWS if there is way
-		// of reporting non-critical init errors.
-		log.Error("No API key configured")
-	}
+	apikey.HandleEnv()
 
 	logChannel := make(chan *logConfig.ChannelMessage)
 	// Channels for ColdStartCreator

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -187,7 +187,7 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 
 	apikey.CheckForSingleAPIKey()
 
-	// Set API key from DD_KMS_API_KEY, DD_API_KEY_KMS_ENCRYPTED, or DD_API_KEY_SECRET_ARN
+	// Set API key from DD_KMS_API_KEY environment variable or environment variables suffixed with KMS_ENCRYPTED or SECRET_ARN
 	apikey.SetSecretsFromEnv(os.Environ())
 
 	// Validate that an API key has been set, either by DD_API_KEY or read from KMS or Secrets Manager

--- a/go.mod
+++ b/go.mod
@@ -616,7 +616,7 @@ require (
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.8.0
 	github.com/aquasecurity/trivy v0.0.0-00010101000000-000000000000
 	github.com/aws/aws-sdk-go-v2/service/kms v1.22.2
-	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.21.6
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.23.3
 	github.com/cloudfoundry-community/go-cfclient/v2 v2.0.1-0.20230503155151-3d15366c5820
 	github.com/containerd/cgroups/v3 v3.0.2
 	github.com/containerd/typeurl/v2 v2.1.1

--- a/go.mod
+++ b/go.mod
@@ -615,8 +615,8 @@ require (
 	github.com/DataDog/go-libddwaf/v2 v2.2.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.8.0
 	github.com/aquasecurity/trivy v0.0.0-00010101000000-000000000000
-	github.com/aws/aws-sdk-go-v2/service/kms v1.22.2
-	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.23.3
+	github.com/aws/aws-sdk-go-v2/service/kms v1.26.3
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.24.0
 	github.com/cloudfoundry-community/go-cfclient/v2 v2.0.1-0.20230503155151-3d15366c5820
 	github.com/containerd/cgroups/v3 v3.0.2
 	github.com/containerd/typeurl/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.6/go.mod h1:lnc2taB
 github.com/aws/aws-sdk-go-v2/service/kms v1.22.2 h1:jwmtdM1/l1DRNy5jQrrYpsQm8zwetkgeqhAqefDr1yI=
 github.com/aws/aws-sdk-go-v2/service/kms v1.22.2/go.mod h1:aNfh11Smy55o65PB3MyKbkM8BFyFUcZmj1k+4g8eNfg=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.40.2/go.mod h1:Zjfqt7KhQK+PO1bbOsFNzKgaq7TcxzmEoDWN8lM0qzQ=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.21.6 h1:y3n83jEM6EuawrD5HZCh3eMj9RsfxniVLcXlyFMNITM=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.21.6/go.mod h1:A108ijf0IFtqhYApU+Gia80aPSAUfi9dItm+h5fWGJE=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.23.3 h1:NurfTBFmaehSiWMv5drydRWs3On0kwoBe1gWYFt+5ws=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.23.3/go.mod h1:LDD9wCQ1tvjMIWEIFPvZ8JgJsEOjded+X5jav9tD/zg=
 github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+IkPchKS7p7c2YPKwHmBOk=
 github.com/aws/aws-sdk-go-v2/service/sso v1.15.2/go.mod h1:gsL4keucRCgW+xA85ALBpRFfdSLH4kHOVSnLMSuBECo=
 github.com/aws/aws-sdk-go-v2/service/sso v1.17.3 h1:CdsSOGlFF3Pn+koXOIpTtvX7st0IuGsZ8kJqcWMlX54=

--- a/go.sum
+++ b/go.sum
@@ -346,9 +346,13 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.4/go.mod h1:aY
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.6/go.mod h1:lnc2taBsR9nTlz9meD+lhFZZ9EWY712QHrRflWpTcOA=
 github.com/aws/aws-sdk-go-v2/service/kms v1.22.2 h1:jwmtdM1/l1DRNy5jQrrYpsQm8zwetkgeqhAqefDr1yI=
 github.com/aws/aws-sdk-go-v2/service/kms v1.22.2/go.mod h1:aNfh11Smy55o65PB3MyKbkM8BFyFUcZmj1k+4g8eNfg=
+github.com/aws/aws-sdk-go-v2/service/kms v1.26.3 h1:li5dFiK1tkAFXvOC9QPWAVWqTu8ZxpIR0KzKmof6TIE=
+github.com/aws/aws-sdk-go-v2/service/kms v1.26.3/go.mod h1:N3++/sLV97B8Zliz7KRqNcojOX7iMBZWKiuit5FKtH0=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.40.2/go.mod h1:Zjfqt7KhQK+PO1bbOsFNzKgaq7TcxzmEoDWN8lM0qzQ=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.23.3 h1:NurfTBFmaehSiWMv5drydRWs3On0kwoBe1gWYFt+5ws=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.23.3/go.mod h1:LDD9wCQ1tvjMIWEIFPvZ8JgJsEOjded+X5jav9tD/zg=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.24.0 h1:nHbWXaoEhGk5JNxwinY0lSTCtmIeWJ3tO8eR3Z85jG4=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.24.0/go.mod h1:LDD9wCQ1tvjMIWEIFPvZ8JgJsEOjded+X5jav9tD/zg=
 github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+IkPchKS7p7c2YPKwHmBOk=
 github.com/aws/aws-sdk-go-v2/service/sso v1.15.2/go.mod h1:gsL4keucRCgW+xA85ALBpRFfdSLH4kHOVSnLMSuBECo=
 github.com/aws/aws-sdk-go-v2/service/sso v1.17.3 h1:CdsSOGlFF3Pn+koXOIpTtvX7st0IuGsZ8kJqcWMlX54=

--- a/go.sum
+++ b/go.sum
@@ -300,7 +300,6 @@ github.com/aws/aws-sdk-go v1.46.0 h1:Igh7W8P+sA6mXJ9yhreOSweefLapcqekhxQlY1llxcM
 github.com/aws/aws-sdk-go v1.46.0/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.17.1/go.mod h1:JLnGeGONAyi2lWXI1p0PCIOIy333JMVK1U7Hf0aRFLw=
-github.com/aws/aws-sdk-go-v2 v1.18.1/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.21.2/go.mod h1:ErQhvNuEMhJjweavOYhxVkn2RUx7kQXVATHrjKtxIpM=
 github.com/aws/aws-sdk-go-v2 v1.23.1 h1:qXaFsOOMA+HsZtX8WoCa+gJnbyW7qyFFBlPqvTSzbaI=
 github.com/aws/aws-sdk-go-v2 v1.23.1/go.mod h1:i1XDttT4rnf6vxc9AuskLc6s7XBee8rlLilKlc03uAA=
@@ -317,12 +316,10 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.13/go.mod h1:f/Ib/qYjhV2/qds
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.5 h1:KehRNiVzIfAcj6gw98zotVbb/K67taJE0fkfgM6vzqU=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.5/go.mod h1:VhnExhw6uXy9QzetvpXDolo1/hjhx4u9qukBGkuUwjs=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.25/go.mod h1:Zb29PYkf42vVYQY6pvSyJCJcFHlPIiY+YKdPtwnvMkY=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.34/go.mod h1:wZpTEecJe0Btj3IYnDx/VlUzor9wm3fJHyvLpQF0VwY=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.43/go.mod h1:auo+PiyLl0n1l8A0e8RIeR8tOzYPfZZH/JNlrJ8igTQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.4 h1:LAm3Ycm9HJfbSCd5I+wqC2S9Ej7FPrgr5CQoOljJZcE=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.4/go.mod h1:xEhvbJcyUf/31yfGSQBe01fukXwXJ0gxDp7rLfymWE0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19/go.mod h1:6Q0546uHDp421okhmmGfbxzq2hBqbXFNpi4k+Q1JnQA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.28/go.mod h1:7VRpKQQedkfIEXb4k52I7swUnZP0wohVajJMRn3vsUw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37/go.mod h1:Qe+2KtKml+FEsQF/DHmDV+xjtche/hwoF75EG4UlHW8=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.4 h1:4GV0kKZzUxiWxSVpn/9gwR0g21NF1Jsyduzo9rHgC/Q=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.4/go.mod h1:dYvTNAggxDZy6y1AF7YDwXsPuHFy/VNEpEI/2dWK9IU=
@@ -344,13 +341,9 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.37/go.mod h1:vB
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.4 h1:rdovz3rEu0vZKbzoMYPTehp0E8veoE9AyfzqCr5Eeao=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.4/go.mod h1:aYCGNjyUCUelhofxlZyj63srdxWUSsBSGg5l6MCuXuE=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.6/go.mod h1:lnc2taBsR9nTlz9meD+lhFZZ9EWY712QHrRflWpTcOA=
-github.com/aws/aws-sdk-go-v2/service/kms v1.22.2 h1:jwmtdM1/l1DRNy5jQrrYpsQm8zwetkgeqhAqefDr1yI=
-github.com/aws/aws-sdk-go-v2/service/kms v1.22.2/go.mod h1:aNfh11Smy55o65PB3MyKbkM8BFyFUcZmj1k+4g8eNfg=
 github.com/aws/aws-sdk-go-v2/service/kms v1.26.3 h1:li5dFiK1tkAFXvOC9QPWAVWqTu8ZxpIR0KzKmof6TIE=
 github.com/aws/aws-sdk-go-v2/service/kms v1.26.3/go.mod h1:N3++/sLV97B8Zliz7KRqNcojOX7iMBZWKiuit5FKtH0=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.40.2/go.mod h1:Zjfqt7KhQK+PO1bbOsFNzKgaq7TcxzmEoDWN8lM0qzQ=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.23.3 h1:NurfTBFmaehSiWMv5drydRWs3On0kwoBe1gWYFt+5ws=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.23.3/go.mod h1:LDD9wCQ1tvjMIWEIFPvZ8JgJsEOjded+X5jav9tD/zg=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.24.0 h1:nHbWXaoEhGk5JNxwinY0lSTCtmIeWJ3tO8eR3Z85jG4=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.24.0/go.mod h1:LDD9wCQ1tvjMIWEIFPvZ8JgJsEOjded+X5jav9tD/zg=
 github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+IkPchKS7p7c2YPKwHmBOk=
@@ -366,7 +359,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.25.4 h1:yEvZ4neOQ/KpUqyR+X0ycUTW/kVR
 github.com/aws/aws-sdk-go-v2/service/sts v1.25.4/go.mod h1:feTnm2Tk/pJxdX+eooEsxvlvTWBvDm6CasRZ+JOs2IY=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.13.4/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
-github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.15.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.17.0 h1:wWJD7LX6PBV6etBUwO0zElG0nWN9rUhp0WdYeHSHAaI=
 github.com/aws/smithy-go v1.17.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1797,7 +1797,7 @@ func EnvVarAreSetAndNotEqual(lhsName string, rhsName string) bool {
 
 // sanitizeAPIKeyConfig strips newlines and other control characters from a given key.
 func sanitizeAPIKeyConfig(config Config, key string) {
-	if !config.IsKnown(key) {
+	if !config.IsKnown(key) || !config.IsSet(key) {
 		return
 	}
 	config.Set(key, strings.TrimSpace(config.GetString(key)), pkgconfigmodel.SourceAgentRuntime)

--- a/pkg/serverless/apikey/api_key.go
+++ b/pkg/serverless/apikey/api_key.go
@@ -14,12 +14,13 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
-	datadogHttp "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	datadogHttp "github.com/DataDog/datadog-agent/pkg/util/http"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -184,8 +185,8 @@ func HasAPIKey() bool {
 		len(os.Getenv(apiKeyEnvVar)) > 0
 }
 
-// CheckForSingleAPIKey checks if an API key has been set in multiple places and logs a warning if so.
-func CheckForSingleAPIKey() {
+// checkForSingleAPIKey checks if an API key has been set in multiple places and logs a warning if so.
+func checkForSingleAPIKey() {
 	var apikeySetIn = []string{}
 	if len(os.Getenv(apiKeyKmsEncryptedEnvVar)) > 0 {
 		apikeySetIn = append(apikeySetIn, "KMS_ENCRYPTED")

--- a/pkg/serverless/apikey/env.go
+++ b/pkg/serverless/apikey/env.go
@@ -66,6 +66,6 @@ func getSecretEnvVars(envVars []string, kmsFunc decryptFunc, smFunc decryptFunc)
 // their API key in plaintext through environment variables.
 func SetSecretsFromEnv(envVars []string) {
 	for envKey, envVal := range getSecretEnvVars(envVars, readAPIKeyFromKMS, readAPIKeyFromSecretsManager) {
-		os.Setenv(envKey, envVal)
+		os.Setenv(envKey, strings.TrimSpace(envVal))
 	}
 }

--- a/pkg/serverless/apikey/env.go
+++ b/pkg/serverless/apikey/env.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -56,7 +57,7 @@ func getSecretEnvVars(envVars []string, kmsFunc decryptFunc, smFunc decryptFunc)
 	return decryptedEnvVars
 }
 
-// SetSecretsFromEnv - The agent is going to get any environment variables ending with _KMS_ENCRYPTED and _SECRET_ARN,
+// setSecretsFromEnv - The agent is going to get any environment variables ending with _KMS_ENCRYPTED and _SECRET_ARN,
 // get the contents of the environment variable, and query SM/KMS to retrieve the value. This allows us
 // to read arbitrarily encrypted environment variables and use the decrypted version in the extension.
 // Right now, this feature is used for dual shipping, since customers need to set DD_LOGS_CONFIGURATION
@@ -64,8 +65,32 @@ func getSecretEnvVars(envVars []string, kmsFunc decryptFunc, smFunc decryptFunc)
 // or DD_LOGS_CONFIGURATION_KMS_ENCRYPTED, which will get converted in the extension to a plaintext
 // DD_LOGS_CONFIGURATION, and will have dual shipping enabled without exposing
 // their API key in plaintext through environment variables.
-func SetSecretsFromEnv(envVars []string) {
+func setSecretsFromEnv(envVars []string) {
 	for envKey, envVal := range getSecretEnvVars(envVars, readAPIKeyFromKMS, readAPIKeyFromSecretsManager) {
 		os.Setenv(envKey, strings.TrimSpace(envVal))
+	}
+}
+
+// HandleEnv sets the API key from environment variables
+func HandleEnv() {
+	// API key reading
+	// ---------------
+
+	// API key reading priority:
+	// Plaintext > KMS > Secrets Manager
+	// If an API key is set but failing, the next will be tried
+
+	checkForSingleAPIKey()
+
+	// Set API key from DD_KMS_API_KEY environment variable or environment variables suffixed with KMS_ENCRYPTED or SECRET_ARN
+	setSecretsFromEnv(os.Environ())
+
+	// Validate that an API key has been set, either by DD_API_KEY or read from KMS or Secrets Manager
+	// ---------------------------
+	if !config.Datadog.IsSet("api_key") {
+		// we're not reporting the error to AWS because we don't want the function
+		// execution to be stopped. TODO(remy): discuss with AWS if there is way
+		// of reporting non-critical init errors.
+		log.Error("No API key configured")
 	}
 }

--- a/test/integration/serverless/datadog-proxy.yaml
+++ b/test/integration/serverless/datadog-proxy.yaml
@@ -1,0 +1,6 @@
+proxy:
+    https: "https://proxy.yaml:80"
+    http: "http://proxy.yaml:80"
+    no_proxy:
+      - "secretsmanager.eu-west-1.amazonaws.com"
+      - "kms.eu-west-1.amazonaws.com"

--- a/test/integration/serverless/log_normalize.py
+++ b/test/integration/serverless/log_normalize.py
@@ -121,10 +121,9 @@ def normalize_traces(stage, aws_account_id):
         sort_by(trace_sort_key),
     ]
 
+
 def normalize_proxy():
-    return [
-        find(r'Using proxy .*? for URL .*?\'.*?\'')
-    ]
+    return [find(r'Using proxy .*? for URL .*?\'.*?\'')]
 
 
 def normalize_appsec(stage):
@@ -194,6 +193,7 @@ def require(pattern):
         return match.group(0)
 
     return _require
+
 
 def find(pattern):
     comp = re.compile(pattern, flags=re.DOTALL)

--- a/test/integration/serverless/log_normalize.py
+++ b/test/integration/serverless/log_normalize.py
@@ -121,6 +121,11 @@ def normalize_traces(stage, aws_account_id):
         sort_by(trace_sort_key),
     ]
 
+def normalize_proxy():
+    return [
+        find(r'Using proxy .*? for URL .*?\'.*?\'')
+    ]
+
 
 def normalize_appsec(stage):
     def select__dd_appsec_json(log):
@@ -189,6 +194,17 @@ def require(pattern):
         return match.group(0)
 
     return _require
+
+def find(pattern):
+    comp = re.compile(pattern, flags=re.DOTALL)
+
+    def _find(log):
+        matches = comp.findall(log)
+        if not matches:
+            return ''
+        return '\n'.join(set(matches))
+
+    return _find
 
 
 def foreach(fn):
@@ -271,6 +287,8 @@ def get_normalizers(typ, stage, aws_account_id):
         return normalize_traces(stage, aws_account_id)
     elif typ == 'appsec':
         return normalize_appsec(stage)
+    elif typ == 'proxy':
+        return normalize_proxy()
     else:
         raise ValueError(f'invalid type "{typ}"')
 

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -243,16 +243,20 @@ cp $SERVERLESS_INTEGRATION_TESTS_DIR/src/otlpPython.py $SERVERLESS_INTEGRATION_T
 (cd ${SERVERLESS_INTEGRATION_TESTS_DIR}; npm install --no-save serverless-plugin-conditional-functions)
 serverless deploy --stage "${stage}"
 
-# deploy proxy functions with a different datadog.yaml
-mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-temp.yaml
-mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-proxy.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml
+if [ "{$RUN_SUITE_PROXY}" = true ]; then
 
-for function_name in "${proxy_functions[@]}"; do
-    serverless deploy function --stage "${stage}" --function $function_name
-done
+    # deploy proxy functions with a different datadog.yaml
+    mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-temp.yaml
+    mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-proxy.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml
 
-mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-proxy.yaml
-mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-temp.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml
+    for function_name in "${proxy_functions[@]}"; do
+        serverless deploy function --stage "${stage}" --function $function_name
+    done
+
+    mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-proxy.yaml
+    mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-temp.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml
+
+fi
 
 rm $SERVERLESS_INTEGRATION_TESTS_DIR/otlpPython.py
 

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -245,11 +245,15 @@ serverless deploy --stage "${stage}"
 
 # deploy proxy functions with a different datadog.yaml
 if [ "$RUN_SUITE_PROXY" = true ]; then
+    echo "Updating datadog.yaml for proxy tests..."
+
     mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-temp.yaml
     mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-proxy.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml
 
     for function_name in "${proxy_functions[@]}"; do
-        serverless deploy function --stage "${stage}" --function $function_name
+        if [[ "$function_name" = *-yaml-* ]]; then
+            serverless deploy function --stage "${stage}" --function $function_name
+        fi
     done
 
     mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-proxy.yaml

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -243,9 +243,8 @@ cp $SERVERLESS_INTEGRATION_TESTS_DIR/src/otlpPython.py $SERVERLESS_INTEGRATION_T
 (cd ${SERVERLESS_INTEGRATION_TESTS_DIR}; npm install --no-save serverless-plugin-conditional-functions)
 serverless deploy --stage "${stage}"
 
-if [ "{$RUN_SUITE_PROXY}" = true ]; then
-
-    # deploy proxy functions with a different datadog.yaml
+# deploy proxy functions with a different datadog.yaml
+if [ "$RUN_SUITE_PROXY" = true ]; then
     mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-temp.yaml
     mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-proxy.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml
 
@@ -255,7 +254,6 @@ if [ "{$RUN_SUITE_PROXY}" = true ]; then
 
     mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-proxy.yaml
     mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-temp.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml
-
 fi
 
 rm $SERVERLESS_INTEGRATION_TESTS_DIR/otlpPython.py

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -153,6 +153,17 @@ appsec_functions=(
     "appsec-go"
     "appsec-csharp"
 )
+proxy_functions=(
+    "proxy-env-apikey"
+    "proxy-yaml-apikey"
+    "proxy-yaml-env-apikey"
+    "proxy-env-secret"
+    "proxy-yaml-secret"
+    "proxy-yaml-env-secret"
+    "proxy-env-kms"
+    "proxy-yaml-kms"
+    "proxy-yaml-env-kms"
+)
 
 declare -a all_functions # This is an array
 if [ $# == 1 ]; then
@@ -169,14 +180,17 @@ if [ $# == 1 ]; then
         appsec)
             all_functions=("${appsec_functions[@]}")
         ;;
+        proxy)
+            all_functions=("${proxy_functions[@]}")
+        ;;
         *)
-            echo "Unknown test suite: '$1' (valid names are: metric, log, trace, appsec)"
+            echo "Unknown test suite: '$1' (valid names are: metric, log, trace, appsec, proxy)"
             exit 1
         ;;
     esac
     echo "Selected test suite '$1' contains ${#all_functions[@]} functions..."
 else
-    all_functions=("${metric_functions[@]}" "${log_functions[@]}" "${trace_functions[@]}" "${appsec_functions[@]}")
+    all_functions=("${metric_functions[@]}" "${log_functions[@]}" "${trace_functions[@]}" "${appsec_functions[@]}" "${proxy_functions[@]}")
 fi
 
 # Set feature environment for the Serverless stack to avoid deploying useless stuff...
@@ -187,6 +201,7 @@ export RUN_SUITE_LOG=false
 export RUN_SUITE_TRACE=false
 export RUN_SUITE_OTLP=false
 export RUN_SUITE_APPSEC=false
+export RUN_SUITE_PROXY=false
 for function_name in "${all_functions[@]}"; do
     case $function_name in
     metric-*)
@@ -210,6 +225,9 @@ for function_name in "${all_functions[@]}"; do
     appsec-*)
         export RUN_SUITE_APPSEC=true
     ;;
+    proxy-*)
+        export RUN_SUITE_PROXY=true
+    ;;
     *)
         echo "⚠️ Un-mapped test function: ${function_name}, the necessary components may not be deployed!"
         ;;
@@ -224,6 +242,17 @@ cp $SERVERLESS_INTEGRATION_TESTS_DIR/src/otlpPython.py $SERVERLESS_INTEGRATION_T
 # deploy the stack
 (cd ${SERVERLESS_INTEGRATION_TESTS_DIR}; npm install --no-save serverless-plugin-conditional-functions)
 serverless deploy --stage "${stage}"
+
+# deploy proxy functions with a different datadog.yaml
+mv datadog.yaml datadog-temp.yaml
+mv datadog-proxy.yaml datadog.yaml
+
+for function_name in "${proxy_functions[@]}"; do
+    serverless deploy function --stage "${stage}" --function $function_name
+done
+
+mv datadog.yaml datadog-proxy.yaml
+mv datadog-temp.yaml datadog.yaml
 
 rm $SERVERLESS_INTEGRATION_TESTS_DIR/otlpPython.py
 
@@ -288,8 +317,8 @@ for function_name in "${all_functions[@]}"; do
             sleep 10
             continue
         fi
-        if [[ "${function_name}" = timeout-* ]]; then
-            echo "Ignoring Lambda report check count as this is a timeout example..."
+        if [[ "${function_name}" = timeout-* || "${function_name}" = proxy-* ]]; then
+            echo "Ignoring Lambda report check count as this is a timeout or proxy example..."
         else
             count=$(echo $raw_logs | grep -o 'REPORT RequestId' | wc -l)
             if [ $count -lt 2 ]; then
@@ -313,8 +342,10 @@ for function_name in "${all_functions[@]}"; do
         norm_type=logs
     elif [[ " ${appsec_functions[*]} " =~ " ${function_name} " ]]; then
         norm_type=appsec
-    else
+    elif [[ " ${trace_functions[*]} " =~ " ${function_name} " ]]; then
         norm_type=traces
+    elif [[ " ${proxy_functions[*]} " =~ " ${function_name} " ]]; then
+        norm_type=proxy
     fi
     logs=$(python3 log_normalize.py --accountid ${aws_account} --type $norm_type --logs "$raw_logs" --stage $stage)
 

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -244,15 +244,15 @@ cp $SERVERLESS_INTEGRATION_TESTS_DIR/src/otlpPython.py $SERVERLESS_INTEGRATION_T
 serverless deploy --stage "${stage}"
 
 # deploy proxy functions with a different datadog.yaml
-mv datadog.yaml datadog-temp.yaml
-mv datadog-proxy.yaml datadog.yaml
+mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-temp.yaml
+mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-proxy.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml
 
 for function_name in "${proxy_functions[@]}"; do
     serverless deploy function --stage "${stage}" --function $function_name
 done
 
-mv datadog.yaml datadog-proxy.yaml
-mv datadog-temp.yaml datadog.yaml
+mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-proxy.yaml
+mv $SERVERLESS_INTEGRATION_TESTS_DIR/datadog-temp.yaml $SERVERLESS_INTEGRATION_TESTS_DIR/datadog.yaml
 
 rm $SERVERLESS_INTEGRATION_TESTS_DIR/otlpPython.py
 

--- a/test/integration/serverless/serverless.yml
+++ b/test/integration/serverless/serverless.yml
@@ -16,7 +16,6 @@ provider:
     apiGateway: true
   environment:
     DD_DD_URL: http://127.0.0.1:3333
-    DD_API_KEY: NO_NEED_TO_BE_VALID
     DD_LOGS_CONFIG_LOGS_DD_URL: 127.0.0.1:3333
     DD_LOGS_CONFIG_LOGS_NO_SSL: true
     DD_LOGS_INJECTION: false
@@ -46,6 +45,7 @@ package:
     - "!src/bin"
     - "!recorder-extension"
     - "!snapshots"
+    - '!datadog.yaml'
 
 custom:
   ddLayerArchitectureFlag:
@@ -75,6 +75,7 @@ functions:
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_LAMBDA_HANDLER: src/trace.simpleTest
       DD_SERVERLESS_APPSEC_ENABLED: true
       # Explicitly disable instrumentation telemetry as this causes the traces to somehow no longer be seen by the recorder.
@@ -91,6 +92,7 @@ functions:
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_LAMBDA_HANDLER: src/appSecPython.handler
       DD_SERVERLESS_APPSEC_ENABLED: true
 
@@ -107,6 +109,7 @@ functions:
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       JAVA_TOOL_OPTIONS: '-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       DD_JMXFETCH_ENABLED: false
       DD_SERVERLESS_APPSEC_ENABLED: true
@@ -124,6 +127,7 @@ functions:
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
       # AWS_LAMBDA_EXEC_WRAPPER is not applied by provided.al2 and go1.x runtimes
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_SERVERLESS_APPSEC_ENABLED: true
 
   appsec-csharp:
@@ -139,6 +143,7 @@ functions:
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:dd-trace-dotnet${self:custom.ddLayerArchitectureFlag.${env:ARCHITECTURE}}:${env:DOTNET_TRACE_LAYER_VERSION}
     environment:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_SERVERLESS_APPSEC_ENABLED: true
 
   metric-node:
@@ -149,6 +154,8 @@ functions:
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node14-x:${env:NODE_LAYER_VERSION}
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   metric-python:
     enabled: '"${env:RUN_SUITE_METRIC}" == "true"'
@@ -159,6 +166,7 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_LAMBDA_HANDLER: src/metricPython.metric
 
   metric-go:
@@ -172,6 +180,8 @@ functions:
     layers:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   metric-java:
     enabled: '"${env:RUN_SUITE_METRIC}" == "true"'
@@ -185,6 +195,7 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       JAVA_TOOL_OPTIONS: '-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       DD_JMXFETCH_ENABLED: false
 
@@ -201,6 +212,7 @@ functions:
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:dd-trace-dotnet${self:custom.ddLayerArchitectureFlag.${env:ARCHITECTURE}}:${env:DOTNET_TRACE_LAYER_VERSION}
     environment:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   metric-proxy:
     enabled: '"${env:RUN_SUITE_METRIC}" == "true"'
@@ -210,6 +222,7 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_EXPERIMENTAL_ENABLE_PROXY: true
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
 
@@ -221,6 +234,8 @@ functions:
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node14-x:${env:NODE_LAYER_VERSION}
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   error-python:
     enabled: '"${env:RUN_SUITE_ERROR}" == "true"'
@@ -231,6 +246,7 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_LAMBDA_HANDLER: src/metricPython.error
 
   error-java:
@@ -245,6 +261,7 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       JAVA_TOOL_OPTIONS: '-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       DD_JMXFETCH_ENABLED: false
 
@@ -261,6 +278,7 @@ functions:
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:dd-trace-dotnet${self:custom.ddLayerArchitectureFlag.${env:ARCHITECTURE}}:${env:DOTNET_TRACE_LAYER_VERSION}
     environment:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   error-proxy:
     enabled: '"${env:RUN_SUITE_ERROR}" == "true"'
@@ -272,6 +290,7 @@ functions:
     environment:
       DD_EXPERIMENTAL_ENABLE_PROXY: true
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   timeout-node:
     enabled: '"${env:RUN_SUITE_TIMEOUT}" == "true"'
@@ -282,6 +301,8 @@ functions:
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node14-x:${env:NODE_LAYER_VERSION}
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   timeout-python:
     enabled: '"${env:RUN_SUITE_TIMEOUT}" == "true"'
@@ -293,6 +314,7 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_LAMBDA_HANDLER: src/metricPython.timeout
 
   timeout-go:
@@ -307,6 +329,8 @@ functions:
     layers:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   timeout-java:
     enabled: '"${env:RUN_SUITE_TIMEOUT}" == "true"'
@@ -321,6 +345,7 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       JAVA_TOOL_OPTIONS: '-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       DD_JMXFETCH_ENABLED: false
 
@@ -338,6 +363,7 @@ functions:
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:dd-trace-dotnet${self:custom.ddLayerArchitectureFlag.${env:ARCHITECTURE}}:${env:DOTNET_TRACE_LAYER_VERSION}
     environment:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   timeout-proxy:
     enabled: '"${env:RUN_SUITE_TIMEOUT}" == "true"'
@@ -349,25 +375,37 @@ functions:
     environment:
       DD_EXPERIMENTAL_ENABLE_PROXY: true
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   log-node:
     enabled: '"${env:RUN_SUITE_LOG}" == "true"'
     runtime: nodejs14.x
+    package:
+      individually: true
+      patterns:
+        - datadog.yaml
     handler: src/log.logTest
     layers:
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node14-x:${env:NODE_LAYER_VERSION}
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   log-python:
     enabled: '"${env:RUN_SUITE_LOG}" == "true"'
     runtime: python3.8
+    package:
+      individually: true
+      patterns:
+        - datadog.yaml
     handler: datadog_lambda.handler.handler
     layers:
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Python38${self:custom.ddLayerArchitectureFlag.${env:ARCHITECTURE}}:${env:PYTHON_LAYER_VERSION}
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_LAMBDA_HANDLER: src/logPython.log
 
   log-go:
@@ -377,10 +415,13 @@ functions:
       individually: true
       patterns:
         - src/bin/log
+        - datadog.yaml
     handler: src/bin/log
     layers:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   log-csharp:
     enabled: '"${env:RUN_SUITE_LOG}" == "true"'
@@ -389,12 +430,15 @@ functions:
     package:
       individually: true
       artifact: src/csharp-tests/bin/Release/net6.0/handler.zip
+      patterns:
+        - datadog.yaml
     layers:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:dd-trace-dotnet${self:custom.ddLayerArchitectureFlag.${env:ARCHITECTURE}}:${env:DOTNET_TRACE_LAYER_VERSION}
     environment:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   log-java:
     enabled: '"${env:RUN_SUITE_LOG}" == "true"'
@@ -403,17 +447,24 @@ functions:
     package:
       individually: true
       artifact: src/java-tests/log/target/log-dev.jar
+      patterns:
+        - datadog.yaml
     layers:
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:dd-trace-java:${env:JAVA_TRACE_LAYER_VERSION}
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       JAVA_TOOL_OPTIONS: '-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       DD_JMXFETCH_ENABLED: false
 
   log-proxy:
     enabled: '"${env:RUN_SUITE_LOG}" == "true"'
     runtime: nodejs14.x
+    package:
+      individually: true
+      patterns:
+        - datadog.yaml
     handler: src/proxyTestFunctions.log
     layers:
       - { Ref: RecorderExtensionLambdaLayer }
@@ -421,6 +472,7 @@ functions:
     environment:
       DD_EXPERIMENTAL_ENABLE_PROXY: true
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   trace-node:
     enabled: '"${env:RUN_SUITE_TRACE}" == "true"'
@@ -431,6 +483,7 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_LAMBDA_HANDLER: src/trace.simpleTest
 
   trace-python:
@@ -442,6 +495,7 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_LAMBDA_HANDLER: src/tracePython.simple_test
 
   trace-go:
@@ -455,6 +509,8 @@ functions:
     layers:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   trace-java:
     enabled: '"${env:RUN_SUITE_TRACE}" == "true"'
@@ -468,6 +524,7 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       JAVA_TOOL_OPTIONS: '-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       DD_JMXFETCH_ENABLED: false
 
@@ -484,6 +541,7 @@ functions:
       - arn:aws:lambda:${self:provider.region}:464622532012:layer:dd-trace-dotnet${self:custom.ddLayerArchitectureFlag.${env:ARCHITECTURE}}:${env:DOTNET_TRACE_LAYER_VERSION}
     environment:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   trace-proxy:
     enabled: '"${env:RUN_SUITE_TRACE}" == "true"'
@@ -495,6 +553,7 @@ functions:
     environment:
       DD_EXPERIMENTAL_ENABLE_PROXY: true
       AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
+      DD_API_KEY: NO_NEED_TO_BE_VALID
 
   otlp-python:
     enabled: '"${env:RUN_SUITE_OTLP}" == "true"'
@@ -509,7 +568,165 @@ functions:
       - arn:aws:lambda:${self:provider.region}:184161586896:layer:opentelemetry-python-0_1_0:1
     environment:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
+      DD_API_KEY: NO_NEED_TO_BE_VALID
       DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: localhost:4318
       OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4318
       OTEL_METRICS_EXPORTER: otlp
       OTEL_TRACES_EXPORTER: otlp
+
+  proxy-env-apikey:
+    enabled: '"${env:RUN_SUITE_PROXY}" == "true"'
+    runtime: nodejs18.x
+    handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
+    layers:
+      - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node18-x:${env:NODE_LAYER_VERSION}
+      - { Ref: RecorderExtensionLambdaLayer }
+      - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
+      DD_LAMBDA_HANDLER: src/hello.lambda_handler
+      DD_LOG_LEVEL: DEBUG
+      DD_PROXY_HTTP: "http://proxy.env:80"
+      DD_PROXY_HTTPS: "https://proxy.env:80"
+
+  proxy-yaml-apikey:
+    enabled: '"${env:RUN_SUITE_PROXY}" == "true"'
+    runtime: nodejs18.x
+    package:
+      individually: true
+      patterns:
+        - datadog.yaml
+    handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
+    layers:
+      - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node18-x:${env:NODE_LAYER_VERSION}
+      - { Ref: RecorderExtensionLambdaLayer }
+      - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
+      DD_LAMBDA_HANDLER: src/hello.lambda_handler
+      DD_LOG_LEVEL: DEBUG
+
+  proxy-yaml-env-apikey:
+    enabled: '"${env:RUN_SUITE_PROXY}" == "true"'
+    runtime: nodejs18.x
+    package:
+      individually: true
+      patterns:
+        - datadog.yaml
+    handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
+    layers:
+      - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node18-x:${env:NODE_LAYER_VERSION}
+      - { Ref: RecorderExtensionLambdaLayer }
+      - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY: NO_NEED_TO_BE_VALID
+      DD_LAMBDA_HANDLER: src/hello.lambda_handler
+      DD_LOG_LEVEL: DEBUG
+      DD_PROXY_HTTP: "http://proxy.env:80"
+      DD_PROXY_HTTPS: "https://proxy.env:80"
+
+  proxy-env-secret:
+    enabled: '"${env:RUN_SUITE_PROXY}" == "true"'
+    runtime: nodejs18.x
+    handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
+    layers:
+      - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node18-x:${env:NODE_LAYER_VERSION}
+      - { Ref: RecorderExtensionLambdaLayer }
+      - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY_SECRET_ARN: arn:aws:secretsmanager:eu-west-1:425362996713:secret:integration-tests-extension-secret-MDTT46
+      DD_LAMBDA_HANDLER: src/hello.lambda_handler
+      DD_LOG_LEVEL: DEBUG
+      DD_PROXY_HTTP: "http://proxy.env:80"
+      DD_PROXY_HTTPS: "https://proxy.env:80"
+      DD_PROXY_NO_PROXY: "secretsmanager.eu-west-1.amazonaws.com"
+
+  proxy-yaml-secret:
+    enabled: '"${env:RUN_SUITE_PROXY}" == "true"'
+    runtime: nodejs18.x
+    package:
+      individually: true
+      patterns:
+        - datadog.yaml
+    handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
+    layers:
+      - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node18-x:${env:NODE_LAYER_VERSION}
+      - { Ref: RecorderExtensionLambdaLayer }
+      - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY_SECRET_ARN: arn:aws:secretsmanager:eu-west-1:425362996713:secret:integration-tests-extension-secret-MDTT46
+      DD_LAMBDA_HANDLER: src/hello.lambda_handler
+      DD_LOG_LEVEL: DEBUG
+
+  proxy-yaml-env-secret:
+    enabled: '"${env:RUN_SUITE_PROXY}" == "true"'
+    runtime: nodejs18.x
+    package:
+      individually: true
+      patterns:
+        - datadog.yaml
+    handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
+    layers:
+      - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node18-x:${env:NODE_LAYER_VERSION}
+      - { Ref: RecorderExtensionLambdaLayer }
+      - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_API_KEY_SECRET_ARN: arn:aws:secretsmanager:eu-west-1:425362996713:secret:integration-tests-extension-secret-MDTT46
+      DD_LAMBDA_HANDLER: src/hello.lambda_handler
+      DD_LOG_LEVEL: DEBUG
+      DD_PROXY_HTTP: "http://proxy.env:80"
+      DD_PROXY_HTTPS: "https://proxy.env:80"
+      DD_PROXY_NO_PROXY: "secretsmanager.eu-west-1.amazonaws.com"
+
+  proxy-env-kms:
+    enabled: '"${env:RUN_SUITE_PROXY}" == "true"'
+    runtime: nodejs18.x
+    handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
+    layers:
+      - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node18-x:${env:NODE_LAYER_VERSION}
+      - { Ref: RecorderExtensionLambdaLayer }
+      - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_KMS_API_KEY: AQICAHgsBW4nQEVAn5OIFYrKQuzjQ3LdqfR7xGqbiAChbjXogwHjsTUdDig75WssdcMQt5vcAAAAeTB3BgkqhkiG9w0BBwagajBoAgEAMGMGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMHEA6IYfLJSKfbRcyAgEQgDahdOOi2wbbnF7sGZAjXZZSywhkZKnys2YP6GQtN+tyuuj/ZS3y6jtATE4bsVTMhuiNvytc3OI=
+      DD_LAMBDA_HANDLER: src/hello.lambda_handler
+      DD_LOG_LEVEL: DEBUG
+      DD_PROXY_HTTP: "http://proxy.env:80"
+      DD_PROXY_HTTPS: "https://proxy.env:80"
+      DD_PROXY_NO_PROXY: "kms.eu-west-1.amazonaws.com"
+
+  proxy-yaml-kms:
+    enabled: '"${env:RUN_SUITE_PROXY}" == "true"'
+    runtime: nodejs18.x
+    package:
+      individually: true
+      patterns:
+        - datadog.yaml
+    handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
+    layers:
+      - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node18-x:${env:NODE_LAYER_VERSION}
+      - { Ref: RecorderExtensionLambdaLayer }
+      - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_KMS_API_KEY: AQICAHgsBW4nQEVAn5OIFYrKQuzjQ3LdqfR7xGqbiAChbjXogwHjsTUdDig75WssdcMQt5vcAAAAeTB3BgkqhkiG9w0BBwagajBoAgEAMGMGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMHEA6IYfLJSKfbRcyAgEQgDahdOOi2wbbnF7sGZAjXZZSywhkZKnys2YP6GQtN+tyuuj/ZS3y6jtATE4bsVTMhuiNvytc3OI=
+      DD_LAMBDA_HANDLER: src/hello.lambda_handler
+      DD_LOG_LEVEL: DEBUG
+
+  proxy-yaml-env-kms:
+    enabled: '"${env:RUN_SUITE_PROXY}" == "true"'
+    runtime: nodejs18.x
+    package:
+      individually: true
+      patterns:
+        - datadog.yaml
+    handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
+    layers:
+      - arn:aws:lambda:${self:provider.region}:464622532012:layer:Datadog-Node18-x:${env:NODE_LAYER_VERSION}
+      - { Ref: RecorderExtensionLambdaLayer }
+      - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
+    environment:
+      DD_KMS_API_KEY: AQICAHgsBW4nQEVAn5OIFYrKQuzjQ3LdqfR7xGqbiAChbjXogwHjsTUdDig75WssdcMQt5vcAAAAeTB3BgkqhkiG9w0BBwagajBoAgEAMGMGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMHEA6IYfLJSKfbRcyAgEQgDahdOOi2wbbnF7sGZAjXZZSywhkZKnys2YP6GQtN+tyuuj/ZS3y6jtATE4bsVTMhuiNvytc3OI=
+      DD_LAMBDA_HANDLER: src/hello.lambda_handler
+      DD_LOG_LEVEL: DEBUG
+      DD_PROXY_HTTP: "http://proxy.env:80"
+      DD_PROXY_HTTPS: "https://proxy.env:80"
+      DD_PROXY_NO_PROXY: "kms.eu-west-1.amazonaws.com"

--- a/test/integration/serverless/snapshots/proxy-env-apikey
+++ b/test/integration/serverless/snapshots/proxy-env-apikey
@@ -1,0 +1,1 @@
+Using proxy http://proxy.env:80 for URL 'http://127.0.0.1:3333'

--- a/test/integration/serverless/snapshots/proxy-env-kms
+++ b/test/integration/serverless/snapshots/proxy-env-kms
@@ -1,0 +1,1 @@
+Using proxy http://proxy.env:80 for URL 'http://127.0.0.1:3333'

--- a/test/integration/serverless/snapshots/proxy-env-secret
+++ b/test/integration/serverless/snapshots/proxy-env-secret
@@ -1,0 +1,1 @@
+Using proxy http://proxy.env:80 for URL 'http://127.0.0.1:3333'

--- a/test/integration/serverless/snapshots/proxy-yaml-apikey
+++ b/test/integration/serverless/snapshots/proxy-yaml-apikey
@@ -1,0 +1,1 @@
+Using proxy http://proxy.yaml:80 for URL 'http://127.0.0.1:3333'

--- a/test/integration/serverless/snapshots/proxy-yaml-env-apikey
+++ b/test/integration/serverless/snapshots/proxy-yaml-env-apikey
@@ -1,0 +1,1 @@
+Using proxy http://proxy.env:80 for URL 'http://127.0.0.1:3333'

--- a/test/integration/serverless/snapshots/proxy-yaml-env-kms
+++ b/test/integration/serverless/snapshots/proxy-yaml-env-kms
@@ -1,0 +1,1 @@
+Using proxy http://proxy.env:80 for URL 'http://127.0.0.1:3333'

--- a/test/integration/serverless/snapshots/proxy-yaml-env-secret
+++ b/test/integration/serverless/snapshots/proxy-yaml-env-secret
@@ -1,0 +1,1 @@
+Using proxy http://proxy.env:80 for URL 'http://127.0.0.1:3333'

--- a/test/integration/serverless/snapshots/proxy-yaml-kms
+++ b/test/integration/serverless/snapshots/proxy-yaml-kms
@@ -1,0 +1,1 @@
+Using proxy http://proxy.yaml:80 for URL 'http://127.0.0.1:3333'

--- a/test/integration/serverless/snapshots/proxy-yaml-secret
+++ b/test/integration/serverless/snapshots/proxy-yaml-secret
@@ -1,0 +1,1 @@
+Using proxy http://proxy.yaml:80 for URL 'http://127.0.0.1:3333'

--- a/test/integration/serverless/src/hello.js
+++ b/test/integration/serverless/src/hello.js
@@ -1,0 +1,7 @@
+exports.lambda_handler = async function (event) {
+    console.log("Logging from hello.js");
+    return {
+        statusCode: 200,
+        body: "ok",
+    };
+};


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

When a Lambda Function uses a proxy to send data to Datadog, proxy settings need to be configured before API keys are read from AWS Secrets Manager or KMS. Currently API keys are read from AWS Secrets Manager and KMS before `datadog.yaml` is loaded or proxy settings are read from environment variables, which results in the configured proxy settings not being used.

This PR changes the load order of agent settings for the Lambda Extension so settings are configured from `datadog.yaml` and environment variables before API keys are read from AWS Secrets Manager or KMS.

Summary of code changes:

* Load `datadog.yaml` before API keys are read from AWS Secrets Manager or KMS
* Bump versions for `github.com/aws/aws-sdk-go-v2/service/secretsmanager` and `github.com/aws/aws-sdk-go-v2/service/kms` due to `ResolveEndpointV2` error
* Update `config.go` to only trim spaces from API key if it's already set
* Trim spaces from API keys set from AWS Secrets Manager or KMS
* Add integration tests that validate proxy configuration set from `datadog.yaml`, environment variables, or both `datadog.yaml` and environment variables
* Add integration tests that validate proxy configuration set with a plaintext API key, and API key from Secrets Manager, or a KMS encrypted API key
* If multiple API keys sources are set they are now read in this order: `Plaintext > KMS > Secrets Manager`
  * Previously they were read in this order `KMS > Secrets Manager > Plaintext`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

https://datadoghq.atlassian.net/browse/SVLS-4071

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Follows changes in https://github.com/DataDog/datadog-agent/pull/20803

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

The API key priority changed after moving `SetSecretsFromEnv` to after the configuration load. It's possible that customers could configure Lambda functions with multiple API key sources simultaneously (ex. `DD_API_KEY` and `DD_API_KEY_SECRET_ARN`) and see a change in behavior on this version.

However this scenario is already warned against. There are also checks in CI tools like the Serverless Plugin that explicitly prevent this scenario. So while it's possible, it is unlikely. And if it does happen, it is easy to resolve by removing one of the API key sources.

https://github.com/DataDog/datadog-agent/blob/e8cc667a72e4cc331392e11a9075d9257a777534/pkg/serverless/apikey/api_key.go#L188-L206

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

* Run the Lambda Extension locally using files provided here: https://github.com/DataDog/datadog-lambda-extension/tree/main/local_tests
  * `RUNTIME=python ./local_tests/build-docker-runtime.sh`
  * `./local_tests/invoke.sh`

Configure proxy settings in `datadog.yaml` and environment variables in `Dockerfile.Python` for the following test cases:

* Proxy configured using only `datadog.yaml`
* Proxy configured using `datadog.yaml` and environment variables
* Proxy configured using only environment variables
* API key set from `DD_API_KEY`
* API key set from `DD_API_KEY_SECRET_ARN`
* API key set from `DD_KMS_API_KEY`

Validate that debug logs similar to the one below are present
`Using proxy http://proxy.env:80 for URL 'http://127.0.0.1:3333'`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
