### PR TITLE
dogstatsd/uds: make sure we always close both the listener and connec…

### DIFF
--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -153,9 +153,12 @@ func (l *UDSListener) handleConnection(conn *net.UnixConn, closeFunc CloseFuncti
 		tlmListenerID = ""
 	}
 
+	packetsBufferSize := l.config.GetInt("dogstatsd_packet_buffer_size")
+	flushTimeout := l.config.GetDuration("dogstatsd_packet_buffer_flush_timeout")
+
 	packetsBuffer := packets.NewBuffer(
-		uint(l.config.GetInt("dogstatsd_packet_buffer_size")),
-		l.config.GetDuration("dogstatsd_packet_buffer_flush_timeout"),
+		uint(packetsBufferSize),
+		flushTimeout,
 		l.packetOut,
 		tlmListenerID,
 	)

--- a/comp/dogstatsd/listeners/uds_common_test.go
+++ b/comp/dogstatsd/listeners/uds_common_test.go
@@ -50,7 +50,7 @@ func testFileExistsNewUDSListener(t *testing.T, socketPath string, cfg map[strin
 	assert.Nil(t, err)
 	defer os.Remove(socketPath)
 	config := fulfillDepsWithConfig(t, cfg)
-	_, err := listenerFactory(nil, newPacketPoolManagerUDS(config), config)
+	_, err = listenerFactory(nil, newPacketPoolManagerUDS(config), config)
 	assert.Error(t, err)
 }
 

--- a/comp/dogstatsd/listeners/uds_common_test.go
+++ b/comp/dogstatsd/listeners/uds_common_test.go
@@ -50,8 +50,9 @@ func testFileExistsNewUDSListener(t *testing.T, socketPath string, cfg map[strin
 	assert.Nil(t, err)
 	defer os.Remove(socketPath)
 	config := fulfillDepsWithConfig(t, cfg)
-	_, err = listenerFactory(nil, newPacketPoolManagerUDS(config), config)
+	s, err := listenerFactory(nil, newPacketPoolManagerUDS(config), config)
 	assert.Error(t, err)
+	s.Stop()
 }
 
 func testSocketExistsNewUSDListener(t *testing.T, socketPath string, cfg map[string]interface{}, listenerFactory udsListenerFactory) {
@@ -72,6 +73,7 @@ func testWorkingNewUDSListener(t *testing.T, socketPath string, cfg map[string]i
 	fi, err := os.Stat(socketPath)
 	require.Nil(t, err)
 	assert.Equal(t, "Srwx-w--w-", fi.Mode().String())
+	s.Stop()
 }
 
 func testNewUDSListener(t *testing.T, listenerFactory udsListenerFactory, transport string) {
@@ -166,4 +168,6 @@ func testUDSReceive(t *testing.T, listenerFactory udsListenerFactory, transport 
 		assert.FailNow(t, "Timeout on receive channel")
 	}
 
+	conn.Close()
+	s.Stop()
 }

--- a/comp/dogstatsd/listeners/uds_common_test.go
+++ b/comp/dogstatsd/listeners/uds_common_test.go
@@ -50,9 +50,8 @@ func testFileExistsNewUDSListener(t *testing.T, socketPath string, cfg map[strin
 	assert.Nil(t, err)
 	defer os.Remove(socketPath)
 	config := fulfillDepsWithConfig(t, cfg)
-	s, err := listenerFactory(nil, newPacketPoolManagerUDS(config), config)
+	_, err := listenerFactory(nil, newPacketPoolManagerUDS(config), config)
 	assert.Error(t, err)
-	s.Stop()
 }
 
 func testSocketExistsNewUSDListener(t *testing.T, socketPath string, cfg map[string]interface{}, listenerFactory udsListenerFactory) {


### PR DESCRIPTION
…tions during the tests

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

dogstatsd/uds: make sure we always close both the listener and connection during the tests. Ohterwise
some objects / goroutines might still be running after we finish the test.

### Motivation

https://datadoghq.atlassian.net/browse/AMLII-1225

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
