### PR TITLE
[CWS] usergroup test cleanup

### DIFF
--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -36,7 +36,7 @@ var dockerImageLibrary = map[string][]string{
 	},
 	"centos": {
 		"centos:7",
-		"public.ecr.aws/centos/centos:7",
+		"public.ecr.aws/docker/library/centos:7",
 	},
 	"alpine": {
 		"alpine",

--- a/pkg/security/tests/usergroup_test.go
+++ b/pkg/security/tests/usergroup_test.go
@@ -17,6 +17,10 @@ import (
 )
 
 func TestUserGroup(t *testing.T) {
+	if testEnvironment == DockerEnvironment {
+		t.Skip("Skip test spawning docker containers on docker")
+	}
+
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule_user",
@@ -118,11 +122,6 @@ func TestUserGroup(t *testing.T) {
 	defer test.Close()
 
 	for _, distroTest := range distroTests {
-		dockerWrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), distroTest.name)
-		if err != nil {
-			t.Skipf("Skipping user group tests: Docker not available: %s", err)
-			return
-		}
 
 		if _, err := dockerWrapper.start(); err != nil {
 			t.Fatal(err)

--- a/pkg/security/tests/usergroup_test.go
+++ b/pkg/security/tests/usergroup_test.go
@@ -122,26 +122,32 @@ func TestUserGroup(t *testing.T) {
 	defer test.Close()
 
 	for _, distroTest := range distroTests {
+		t.Run(distroTest.name, func(t *testing.T) {
+			dockerWrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), distroTest.name)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		if _, err := dockerWrapper.start(); err != nil {
-			t.Fatal(err)
-		}
-		defer dockerWrapper.stop()
+			if _, err := dockerWrapper.start(); err != nil {
+				t.Fatal(err)
+			}
+			defer dockerWrapper.stop()
 
-		for _, testCommand := range distroTest.testCommands {
-			i := 0
-			dockerWrapper.RunTest(t, distroTest.name+"-"+testCommand.name, func(t *testing.T, kind wrapperType, cmdFunc func(bin string, args, env []string) *exec.Cmd) {
-				test.WaitSignals(t, func() error {
-					return cmdFunc(testCommand.cmd[0], testCommand.cmd[1:], nil).Run()
-				}, func(event *model.Event, rule *rules.Rule) error {
-					assertTriggeredRule(t, rule, testCommand.rules[i])
-					i++
-					if i < len(testCommand.rules) {
-						return errSkipEvent
-					}
-					return nil
+			for _, testCommand := range distroTest.testCommands {
+				i := 0
+				dockerWrapper.RunTest(t, testCommand.name, func(t *testing.T, kind wrapperType, cmdFunc func(bin string, args, env []string) *exec.Cmd) {
+					test.WaitSignals(t, func() error {
+						return cmdFunc(testCommand.cmd[0], testCommand.cmd[1:], nil).Run()
+					}, func(event *model.Event, rule *rules.Rule) error {
+						assertTriggeredRule(t, rule, testCommand.rules[i])
+						i++
+						if i < len(testCommand.rules) {
+							return errSkipEvent
+						}
+						return nil
+					})
 				})
-			})
-		}
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR:
- skips the usergroup test if we are in a docker container directly (instead of doing a check after we created the module)
- moves the distribution into own `t.Run` group, allowing deferred functions to run sooner

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
