### PR TITLE
Export log attributes for the windows registry integration

### DIFF
--- a/comp/checks/winregistry/impl/integration_logs_registry_delegate.go
+++ b/comp/checks/winregistry/impl/integration_logs_registry_delegate.go
@@ -30,16 +30,16 @@ const (
 
 // logEvent struct defines the extra attributes that are sent along with the log message
 type logEvent struct {
-	keyPath   string `yaml:"key_path"`
-	eventType string `yaml:"event_type"`
+	KeyPath   string `yaml:"key_path"`
+	EventType string `yaml:"event_type"`
 
 	// process_id, process_name and thread_id will be coming in a future version.
 }
 
 type valueChangedLogEvent struct {
 	logEvent
-	oldValue interface{} `yaml:"old_value"`
-	newValue interface{} `yaml:"new_value"`
+	OldValue interface{} `yaml:"old_value"`
+	NewValue interface{} `yaml:"new_value"`
 }
 
 func (i *integrationLogsRegistryDelegate) sendLog(status string, payload message.BasicStructuredContent) {
@@ -83,10 +83,10 @@ func (i *integrationLogsRegistryDelegate) processValue(valueName, originalVal st
 			log = fmt.Sprintf("value %s = '%v'", keyName, val)
 		}
 		i.sendLog("info", getPayload[valueChangedLogEvent](log, func(e *valueChangedLogEvent) {
-			e.keyPath = keyName
-			e.eventType = eventType
-			e.oldValue = nil
-			e.newValue = val
+			e.KeyPath = keyName
+			e.EventType = eventType
+			e.OldValue = nil
+			e.NewValue = val
 		}))
 		i.valueMap[keyName] = val
 	} else if cachedVal != val {
@@ -97,10 +97,10 @@ func (i *integrationLogsRegistryDelegate) processValue(valueName, originalVal st
 			log = fmt.Sprintf("value %s changed from '%v' to '%v'", keyName, cachedVal, val)
 		}
 		i.sendLog("info", getPayload[valueChangedLogEvent](log, func(e *valueChangedLogEvent) {
-			e.keyPath = keyName
-			e.eventType = eventType
-			e.oldValue = cachedVal
-			e.newValue = val
+			e.KeyPath = keyName
+			e.EventType = eventType
+			e.OldValue = cachedVal
+			e.NewValue = val
 		}))
 		i.valueMap[keyName] = val
 	}
@@ -123,10 +123,10 @@ func (i *integrationLogsRegistryDelegate) onMissing(valueName string, regKeyCfg 
 	cachedVal, ok := i.valueMap[keyName]
 	if ok {
 		i.sendLog("info", getPayload[valueChangedLogEvent](fmt.Sprintf("value %s ('%v') was deleted", keyName, cachedVal), func(e *valueChangedLogEvent) {
-			e.keyPath = keyName
-			e.eventType = keyDeleted
-			e.oldValue = cachedVal
-			e.newValue = nil
+			e.KeyPath = keyName
+			e.EventType = keyDeleted
+			e.OldValue = cachedVal
+			e.NewValue = nil
 		}))
 		delete(i.valueMap, keyName)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR fixes the missing log attributes for the Windows Registry integration.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The attributes should show up in Datadog.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
