### PR TITLE
CWS: switch ringbuffer to `RecordGetter/RecordHandler` model

### DIFF
--- a/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
+++ b/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf/ringbuf"
 
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/eventstream"
@@ -23,6 +24,7 @@ import (
 type RingBuffer struct {
 	ringBuffer *manager.RingBuffer
 	handler    func(int, []byte)
+	recordPool *sync.Pool
 }
 
 // Init the ring buffer
@@ -33,7 +35,10 @@ func (rb *RingBuffer) Init(mgr *manager.Manager, config *config.Config) error {
 	}
 
 	rb.ringBuffer.RingBufferOptions = manager.RingBufferOptions{
-		DataHandler: rb.handleEvent,
+		RecordGetter: func() *ringbuf.Record {
+			return rb.recordPool.Get().(*ringbuf.Record)
+		},
+		RecordHandler: rb.handleEvent,
 	}
 
 	if config.EventStreamBufferSize != 0 {
@@ -51,8 +56,9 @@ func (rb *RingBuffer) Start(wg *sync.WaitGroup) error {
 // SetMonitor set the monitor
 func (rb *RingBuffer) SetMonitor(counter eventstream.LostEventCounter) {}
 
-func (rb *RingBuffer) handleEvent(CPU int, data []byte, ringBuffer *manager.RingBuffer, manager *manager.Manager) {
-	rb.handler(CPU, data)
+func (rb *RingBuffer) handleEvent(record *ringbuf.Record, ringBuffer *manager.RingBuffer, manager *manager.Manager) {
+	rb.handler(0, record.RawSample)
+	rb.recordPool.Put(record)
 }
 
 // Pause the event stream. Do nothing when using ring buffer
@@ -67,7 +73,14 @@ func (rb *RingBuffer) Resume() error {
 
 // New returns a new ring buffer based event stream.
 func New(handler func(int, []byte)) *RingBuffer {
+	recordPool := &sync.Pool{
+		New: func() interface{} {
+			return new(ringbuf.Record)
+		},
+	}
+
 	return &RingBuffer{
-		handler: handler,
+		recordPool: recordPool,
+		handler:    handler,
 	}
 }

--- a/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
+++ b/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
@@ -56,7 +56,7 @@ func (rb *RingBuffer) Start(wg *sync.WaitGroup) error {
 // SetMonitor set the monitor
 func (rb *RingBuffer) SetMonitor(counter eventstream.LostEventCounter) {}
 
-func (rb *RingBuffer) handleEvent(record *ringbuf.Record, ringBuffer *manager.RingBuffer, manager *manager.Manager) {
+func (rb *RingBuffer) handleEvent(record *ringbuf.Record, _ *manager.RingBuffer, _ *manager.Manager) {
 	rb.handler(0, record.RawSample)
 	rb.recordPool.Put(record)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

https://github.com/DataDog/ebpf-manager/commit/74c5c78ccbc6763e65e7cb16da8d2eb1630e9818 introduced this new API to the ringbuffer (already used in the perf map code path). This PR makes use of this new API

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
