### PR TITLE
[ddqa] Update excluded members for @DataDog/agent-shared-components team

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -30,7 +30,10 @@ jira_statuses = [
 ]
 github_team = "agent-shared-components"
 github_labels = ["team/agent-shared-components"]
-exclude_members = ["olivielpeau", "sgnn7"]
+exclude_members = [
+  "sgnn7",
+  "truthbk",
+]
 
 [teams."Agent Platform"]
 jira_project = "APL"


### PR DESCRIPTION
### What does this PR do?

Updates ddqa `excluded_members` list

### Motivation

The membership of the team has been updated recently so the QA config is updated accordingly.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

N/A (other than waiting for next QA cycle

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
