### PR TITLE
Add a constraints file and constrain bcrypt

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -263,6 +263,18 @@ build do
         vars: { requirements: lib_req["req_lines"] }
   end
 
+  # Constraints file for constraining transitive dependencies in those cases where there may be incompatible versions
+  constraints = []
+  if redhat_target?
+    constraints.push("bcrypt < 4.1.0")
+  end
+
+  constraints_file = windows_safe_path(project_dir, "constraints.txt")
+  block "Write constraints file" do
+    File.open(constraints_file, 'w') { |f| f << constraints.join("\n") }
+  end
+
+
   # Increasing pip max retries (default: 5 times) and pip timeout (default 15 seconds) to avoid blocking network errors
   pip_max_retries = 20
   pip_timeout = 20
@@ -273,11 +285,11 @@ build do
   command "#{python} -m pip install datadog_checks_base --no-deps --no-index --find-links=#{wheel_build_dir}"
   command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => build_env, :cwd => cwd_downloader
   command "#{python} -m pip install datadog_checks_downloader --no-deps --no-index --find-links=#{wheel_build_dir}"
-  command "#{python} -m piptools compile --generate-hashes --output-file #{compiled_reqs_file_path} #{static_reqs_out_file} " \
+  command "#{python} -m piptools compile --generate-hashes -c #{constraints_file} --output-file #{compiled_reqs_file_path} #{static_reqs_out_file} " \
           "--pip-args \"--retries #{pip_max_retries} --timeout #{pip_timeout}\"", :env => build_env
   # Pip-compiling seperately each lib that needs a custom build installation
   specific_build_env.each do |lib, env|
-    command "#{python} -m piptools compile --generate-hashes --output-file #{requirements_custom[lib]["compiled_req_file_path"]} #{requirements_custom[lib]["req_file_path"]} " \
+    command "#{python} -m piptools compile --generate-hashes -c #{constraints_file} --output-file #{requirements_custom[lib]["compiled_req_file_path"]} #{requirements_custom[lib]["req_file_path"]} " \
             "--pip-args \"--retries #{pip_max_retries} --timeout #{pip_timeout}\"", :env => env
   end
 


### PR DESCRIPTION

### What does this PR do?

Adds the use of a constraints file to the py3 definition, and uses it to limit the version of `bcrypt` used on our rpm builds.

### Motivation

The release of `bcrypt 4.1.0` broke the build because it requires at the very least rust 1.63, and we can't upgrade it due to other incompatibilities. [Example of failed build](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/376444007).

4.1.0 was yanked due to https://github.com/pyca/bcrypt/issues/677, but we expect a new update to be released at some point with the same requirement w.r.t. rust.

### Additional Notes

Using a constraints file sounds preferable here to adding it as a pinned requirement somewhere. We only want to install this dependency *iif* it's really a transitive dependency.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
