### PR TITLE
[CSPM] Compliance module: improve err report and fix tests

### DIFF
--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -67,7 +67,9 @@ func (m *complianceModule) Register(router *module.Router) error {
 
 func (m *complianceModule) handleError(writer http.ResponseWriter, request *http.Request, status int, err error) {
 	_ = log.Errorf("module compliance: failed to properly handle %s request: %s", request.URL.Path, err)
+	writer.Header().Set("Content-Type", "text/plain")
 	writer.WriteHeader(status)
+	writer.Write([]byte(err.Error()))
 }
 
 func (m *complianceModule) handleScanDBConfig(writer http.ResponseWriter, request *http.Request) {
@@ -78,7 +80,7 @@ func (m *complianceModule) handleScanDBConfig(writer http.ResponseWriter, reques
 	qs := request.URL.Query()
 	pid, err := strconv.ParseInt(qs.Get("pid"), 10, 32)
 	if err != nil {
-		m.handleError(writer, request, http.StatusBadRequest, fmt.Errorf("pid query paramater is not an integer: %w", err))
+		m.handleError(writer, request, http.StatusBadRequest, fmt.Errorf("pid query parameter is not an integer: %w", err))
 		return
 	}
 

--- a/pkg/compliance/dbconfig/loader.go
+++ b/pkg/compliance/dbconfig/loader.go
@@ -89,11 +89,7 @@ func ListProcesses(ctx context.Context) map[utils.ContainerID]int32 {
 		if !ok {
 			continue
 		}
-
-		containerID, ok := utils.GetProcessContainerID(proc.Pid)
-		if !ok {
-			continue
-		}
+		containerID, _ := utils.GetProcessContainerID(proc.Pid)
 		// We dedupe our scans based on the resource type and the container
 		// ID, assuming that we will scan the same configuration for each
 		// containers running the process.
@@ -119,10 +115,7 @@ func LoadDBResourceFromPID(ctx context.Context, pid int32) (resource *DBResource
 	if !ok {
 		return
 	}
-	containerID, ok := utils.GetProcessContainerID(pid)
-	if !ok {
-		return
-	}
+	containerID, _ := utils.GetProcessContainerID(pid)
 	hostroot, ok := utils.GetProcessRootPath(pid)
 	if !ok {
 		return


### PR DESCRIPTION
### What does this PR do?

- Make the module work for processes running outside of a container
- Improve the error reporting of the compliance module by reporting the error string as part of the response body.

Also fixes and improve the tests:
- remove the symlink chmod (was failing locally for some contributors)
- check the proper result when no configuration path has been found.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
