### PR TITLE
[CWS] fix new e2e cws

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -480,6 +480,7 @@
 /test/new-e2e/tests/language-detection        @DataDog/processes
 /test/new-e2e/tests/ndm                       @DataDog/network-device-monitoring
 /test/new-e2e/tests/npm                       @DataDog/Networks
+/test/new-e2e/tests/cws                       @DataDog/agent-security
 /test/new-e2e/tests/agent-platform            @DataDog/agent-platform
 /test/system/                                 @DataDog/agent-shared-components
 /test/system/dogstatsd/                       @DataDog/agent-metrics-logs

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -262,6 +262,14 @@ new-e2e-cws-dev:
   # Temporary, until we manage to stabilize those tests.
   allow_failure: true
 
+new-e2e-cws-main:
+  extends: .new_e2e_template
+  rules: !reference [.on_main_and_no_skip_e2e]
+  variables:
+    TARGETS: ./tests/cws
+  # Temporary, until we manage to stabilize those tests.
+  allow_failure: true
+
 #   ^    If you create a new job here that extends `.new_e2e_template`,
 #  /!\   do not forget to add it in the `dependencies` statement of the
 # /___\  `e2e_test_junit_upload` job in the `.gitlab/e2e_test_junit_upload.yml` file

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -259,6 +259,7 @@ new-e2e-cws-dev:
   needs: []
   variables:
     TARGETS: ./tests/cws
+    TEAM: csm-threats-agent
   # Temporary, until we manage to stabilize those tests.
   allow_failure: true
 
@@ -267,6 +268,7 @@ new-e2e-cws-main:
   rules: !reference [.on_main_and_no_skip_e2e]
   variables:
     TARGETS: ./tests/cws
+    TEAM: csm-threats-agent
   # Temporary, until we manage to stabilize those tests.
   allow_failure: true
 

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -20,6 +20,7 @@ e2e_test_junit_upload:
     - new-e2e-agent-platform-install-script-debian-dogstatsd-a7-x86_64
     - new-e2e-agent-platform-install-script-debian-heroku-agent-a7-x86_64
     - new-e2e-npm-main
+    - new-e2e-cws-main
   script:
     - set +x
     - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)

--- a/test/new-e2e/pkg/utils/e2e/client/agent.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent.go
@@ -58,11 +58,4 @@ type Agent interface {
 	// Retries every 100 ms up to timeout.
 	// Returns error on failure.
 	waitForReadyTimeout(timeout time.Duration) error
-
-	// WaitAgentLogs waits for the agent log corresponding to the pattern
-	// agent-name can be: datadog-agent, system-probe, security-agent
-	// pattern: is the log that we are looking for
-	// Retries every 500 ms up to timeout.
-	// Returns error on failure.
-	WaitAgentLogs(agentName string, pattern string) error
 }

--- a/test/new-e2e/pkg/utils/e2e/client/agent_cmd_runner.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_cmd_runner.go
@@ -7,7 +7,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -156,24 +155,5 @@ func (agent *agentCommandRunner) waitForReadyTimeout(timeout time.Duration) erro
 		}
 		return nil
 	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(interval), uint64(maxRetries)))
-	return err
-}
-
-// WaitAgentLogs waits for the agent log corresponding to the pattern
-// agent-name can be: datadog-agent, system-probe, security-agent
-// pattern: is the log that we are looking for
-// Retries every 500 ms up to timeout.
-// Returns error on failure.
-func (agent *agentCommandRunner) WaitAgentLogs(agentName string, pattern string) error {
-	err := backoff.Retry(func() error {
-		output, err := agent.executeAgentCmdWithError([]string{fmt.Sprintf("cat /var/log/datadog/%s.log", agentName)})
-		if err != nil {
-			return err
-		}
-		if strings.Contains(output, pattern) {
-			return nil
-		}
-		return errors.New("no log found")
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(500*time.Millisecond), 60))
 	return err
 }

--- a/test/new-e2e/tests/cws/config/e2e-system-probe.yaml
+++ b/test/new-e2e/tests/cws/config/e2e-system-probe.yaml
@@ -1,5 +1,4 @@
 system_probe_config:
-  enabled: true
   log_level: trace
 runtime_security_config:
   enabled: true

--- a/test/new-e2e/tests/cws/e2e_cws_test.go
+++ b/test/new-e2e/tests/cws/e2e_cws_test.go
@@ -67,7 +67,7 @@ func (a *agentSuite) SetupSuite() {
 	a.filename = fmt.Sprintf("%s/secret", a.dirname)
 	a.testID = uuid.NewString()[:4]
 	a.desc = fmt.Sprintf("e2e test rule %s", a.testID)
-	a.agentRuleName = fmt.Sprintf("e2e_agent_rule_%s", a.testID)
+	a.agentRuleName = fmt.Sprintf("new_e2e_agent_rule_%s", a.testID)
 	a.Suite.SetupSuite()
 	a.apiClient = cws.NewAPIClient()
 }

--- a/test/new-e2e/tests/cws/e2e_cws_test.go
+++ b/test/new-e2e/tests/cws/e2e_cws_test.go
@@ -115,7 +115,7 @@ func (a *agentSuite) TestOpenSignal() {
 	require.NoError(a.T(), err, "Could not get APP KEY")
 
 	a.EventuallyWithT(func(c *assert.CollectT) {
-		policies := a.Env().VM.Execute(fmt.Sprintf("DD_APP_KEY=%s DD_API_KEY=%s DD_SITE=datadoghq.com %s runtime policy download", appKey, apiKey, cws.SecurityAgentPath))
+		policies := a.Env().VM.Execute(fmt.Sprintf("DD_APP_KEY=%s DD_API_KEY=%s %s runtime policy download", appKey, apiKey, cws.SecurityAgentPath))
 		assert.NotEmpty(c, policies, "should not be empty")
 		a.policies = policies
 	}, 5*time.Minute, 10*time.Second)

--- a/test/new-e2e/tests/cws/e2e_cws_test.go
+++ b/test/new-e2e/tests/cws/e2e_cws_test.go
@@ -7,12 +7,14 @@ package cws
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -98,11 +100,11 @@ func (a *agentSuite) TestOpenSignal() {
 	assert.Equal(a.T(), isReady, true, "Agent should be ready")
 
 	// Check if system-probe has started
-	err = a.Env().Agent.WaitAgentLogs("system-probe", cws.SystemProbeStartLog)
+	err = a.waitAgentLogs("system-probe", cws.SystemProbeStartLog)
 	require.NoError(a.T(), err, "system-probe could not start")
 
 	// Check if security-agent has started
-	err = a.Env().Agent.WaitAgentLogs("security-agent", cws.SecurityStartLog)
+	err = a.waitAgentLogs("security-agent", cws.SecurityStartLog)
 	require.NoError(a.T(), err, "security-agent could not start")
 
 	// Download policies
@@ -141,7 +143,7 @@ func (a *agentSuite) TestOpenSignal() {
 	a.Env().VM.Execute(fmt.Sprintf("touch %s", a.filename))
 
 	// Check agent event
-	err = a.Env().Agent.WaitAgentLogs("security-agent", "Successfully posted payload to")
+	err = a.waitAgentLogs("security-agent", "Successfully posted payload to")
 	require.NoError(a.T(), err, "could not send payload")
 
 	// Check app signal
@@ -151,4 +153,18 @@ func (a *agentSuite) TestOpenSignal() {
 	agentContext = signal.Attributes["agent"].(map[string]interface{})
 	assert.Contains(a.T(), agentContext["rule_id"], a.agentRuleName, "unable to find tag")
 
+}
+
+func (a *agentSuite) waitAgentLogs(agentName string, pattern string) error {
+	err := backoff.Retry(func() error {
+		output, err := a.Env().VM.ExecuteWithError(fmt.Sprintf("cat /var/log/datadog/%s.log", agentName))
+		if err != nil {
+			return err
+		}
+		if strings.Contains(output, pattern) {
+			return nil
+		}
+		return errors.New("no log found")
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(500*time.Millisecond), 60))
+	return err
 }

--- a/test/new-e2e/tests/cws/e2e_cws_test.go
+++ b/test/new-e2e/tests/cws/e2e_cws_test.go
@@ -27,7 +27,7 @@ import (
 
 type agentSuite struct {
 	e2e.Suite[e2e.AgentEnv]
-	apiClient     cws.MyAPIClient
+	apiClient     *cws.APIClient
 	signalRuleID  string
 	agentRuleID   string
 	dirname       string
@@ -48,7 +48,6 @@ var systemProbeConfig string
 var securityAgentConfig string
 
 func TestAgentSuite(t *testing.T) {
-
 	e2e.Run(t, &agentSuite{}, e2e.AgentStackDef(
 		e2e.WithVMParams(ec2params.WithName("cws-e2e-tests")),
 		e2e.WithAgentParams(
@@ -60,7 +59,6 @@ func TestAgentSuite(t *testing.T) {
 }
 
 func (a *agentSuite) SetupSuite() {
-
 	// Create temporary directory
 	tempDir := a.Env().VM.Execute("mktemp -d")
 	a.dirname = strings.TrimSuffix(tempDir, "\n")
@@ -69,10 +67,10 @@ func (a *agentSuite) SetupSuite() {
 	a.desc = fmt.Sprintf("e2e test rule %s", a.testID)
 	a.agentRuleName = fmt.Sprintf("e2e_agent_rule_%s", a.testID)
 	a.Suite.SetupSuite()
+	a.apiClient = cws.NewAPIClient()
 }
 
 func (a *agentSuite) TearDownSuite() {
-
 	if len(a.signalRuleID) != 0 {
 		a.apiClient.DeleteSignalRule(a.signalRuleID)
 	}
@@ -84,8 +82,6 @@ func (a *agentSuite) TearDownSuite() {
 }
 
 func (a *agentSuite) TestOpenSignal() {
-	a.apiClient = cws.NewAPIClient()
-
 	// Create CWS Agent rule
 	rule := fmt.Sprintf("open.file.path == \"%s\"", a.filename)
 	res, err := a.apiClient.CreateCWSAgentRule(a.agentRuleName, a.desc, rule)

--- a/test/new-e2e/tests/cws/lib/app.go
+++ b/test/new-e2e/tests/cws/lib/app.go
@@ -15,14 +15,14 @@ import (
 	"github.com/DataDog/datadog-api-client-go/api/v2/datadog"
 )
 
-// MyAPIClient represents the datadog API context
-type MyAPIClient struct {
+// APIClient represents the datadog API context
+type APIClient struct {
 	api *datadog.APIClient
 	ctx context.Context
 }
 
 // NewAPIClient initialise a client with the API and APP keys
-func NewAPIClient() MyAPIClient {
+func NewAPIClient() *APIClient {
 	apiKey, _ := runner.GetProfile().SecretStore().Get(parameters.APIKey)
 	appKey, _ := runner.GetProfile().SecretStore().Get(parameters.APPKey)
 	ctx := context.WithValue(
@@ -40,15 +40,14 @@ func NewAPIClient() MyAPIClient {
 
 	cfg := datadog.NewConfiguration()
 
-	apiClient := MyAPIClient{
+	return &APIClient{
 		api: datadog.NewAPIClient(cfg),
 		ctx: ctx,
 	}
-	return apiClient
 }
 
 // GetAppLog returns the logs corresponding to the query
-func (c MyAPIClient) GetAppLog(query string) (*datadog.LogsListResponse, error) {
+func (c *APIClient) GetAppLog(query string) (*datadog.LogsListResponse, error) {
 	sort := datadog.LOGSSORT_TIMESTAMP_ASCENDING
 
 	body := datadog.LogsListRequest{
@@ -75,7 +74,7 @@ func (c MyAPIClient) GetAppLog(query string) (*datadog.LogsListResponse, error) 
 }
 
 // GetAppSignal returns the signal corresponding to the query
-func (c MyAPIClient) GetAppSignal(query string) (*datadog.SecurityMonitoringSignalsListResponse, error) {
+func (c *APIClient) GetAppSignal(query string) (*datadog.SecurityMonitoringSignalsListResponse, error) {
 	now := time.Now().UTC()
 	queryFrom := now.Add(-15 * time.Minute)
 	sort := datadog.SECURITYMONITORINGSIGNALSSORT_TIMESTAMP_ASCENDING
@@ -105,7 +104,7 @@ func (c MyAPIClient) GetAppSignal(query string) (*datadog.SecurityMonitoringSign
 }
 
 // CreateCwsSignalRule creates a cws signal rule
-func (c MyAPIClient) CreateCwsSignalRule(name string, msg string, agentRuleID string, tags []string) (*datadog.SecurityMonitoringRuleResponse, error) {
+func (c *APIClient) CreateCwsSignalRule(name string, msg string, agentRuleID string, tags []string) (*datadog.SecurityMonitoringRuleResponse, error) {
 	if tags == nil {
 		tags = []string{}
 	}
@@ -157,8 +156,7 @@ func (c MyAPIClient) CreateCwsSignalRule(name string, msg string, agentRuleID st
 }
 
 // CreateCWSAgentRule creates a cws agent rule
-func (c MyAPIClient) CreateCWSAgentRule(name string, msg string, secl string) (*datadog.CloudWorkloadSecurityAgentRuleResponse, error) {
-
+func (c *APIClient) CreateCWSAgentRule(name string, msg string, secl string) (*datadog.CloudWorkloadSecurityAgentRuleResponse, error) {
 	body := datadog.CloudWorkloadSecurityAgentRuleCreateRequest{
 		Data: datadog.CloudWorkloadSecurityAgentRuleCreateData{
 			Attributes: datadog.CloudWorkloadSecurityAgentRuleCreateAttributes{
@@ -180,13 +178,13 @@ func (c MyAPIClient) CreateCWSAgentRule(name string, msg string, secl string) (*
 }
 
 // DeleteSignalRule deletes a signal rule
-func (c MyAPIClient) DeleteSignalRule(ruleID string) error {
+func (c *APIClient) DeleteSignalRule(ruleID string) error {
 	_, err := c.api.SecurityMonitoringApi.DeleteSecurityMonitoringRule(c.ctx, ruleID)
 	return err
 }
 
 // DeleteAgentRule deletes an agent rule
-func (c MyAPIClient) DeleteAgentRule(ruleID string) error {
+func (c *APIClient) DeleteAgentRule(ruleID string) error {
 	_, err := c.api.CloudWorkloadSecurityApi.DeleteCloudWorkloadSecurityAgentRule(c.ctx, ruleID)
 	return err
 }

--- a/test/new-e2e/tests/cws/lib/const.go
+++ b/test/new-e2e/tests/cws/lib/const.go
@@ -16,5 +16,5 @@ const (
 	SecurityAgentPath = "/opt/datadog-agent/embedded/bin/security-agent"
 
 	// PoliciesPath is the path of the default runtime security policies
-	PoliciesPath = "/etc/datadog-agent/runtime-security.d/default.policy"
+	PoliciesPath = "/etc/datadog-agent/runtime-security.d/test.policy"
 )

--- a/test/new-e2e/tests/cws/lib/logs.go
+++ b/test/new-e2e/tests/cws/lib/logs.go
@@ -15,7 +15,7 @@ import (
 )
 
 // WaitAppLogs waits for the app log corresponding to the query
-func WaitAppLogs(apiClient MyAPIClient, query string) (*datadog.LogAttributes, error) {
+func WaitAppLogs(apiClient *APIClient, query string) (*datadog.LogAttributes, error) {
 	query = fmt.Sprintf("host:cws-new-e2e-test-host %s", query)
 	var resp *datadog.LogAttributes
 	err := backoff.Retry(func() error {
@@ -33,7 +33,7 @@ func WaitAppLogs(apiClient MyAPIClient, query string) (*datadog.LogAttributes, e
 }
 
 // WaitAppSignal waits for the signal corresponding to the query
-func WaitAppSignal(apiClient MyAPIClient, query string) (*datadog.SecurityMonitoringSignalAttributes, error) {
+func WaitAppSignal(apiClient *APIClient, query string) (*datadog.SecurityMonitoringSignalAttributes, error) {
 	var resp *datadog.SecurityMonitoringSignalAttributes
 	err := backoff.Retry(func() error {
 		tmpResp, err := apiClient.GetAppSignal(query)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR cleans up and fixes the new CWS e2e tests.
The main change is the removal of`WaitAgentLogs` from the agent interface since it was not working (you cannot run `cat` as an agent subcommand)
This PR also adds the missing `CODEOWNERS` entry, and a `main` version of the CI job. Currently this job is allowed to fail, until we confirm it's not flaky and can be fully enabled in a few days.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
