### PR TITLE
[CWS] remove temporarily the mount device fallback

### DIFF
--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -256,6 +256,7 @@ func (mr *Resolver) lookupByMountID(mountID uint32) *model.Mount {
 	return mr.mounts[mountID]
 }
 
+/*
 func (mr *Resolver) lookupByDevice(device uint32) *model.Mount {
 	var result *model.Mount
 
@@ -271,16 +272,18 @@ func (mr *Resolver) lookupByDevice(device uint32) *model.Mount {
 
 	return result
 }
+*/
 
-func (mr *Resolver) lookupMount(mountID uint32, device uint32, allowFallbacks bool) *model.Mount {
+func (mr *Resolver) lookupMount(mountID uint32, _ uint32, allowFallbacks bool) *model.Mount {
 	if m := mr.lookupByMountID(mountID); m != nil {
 		return m
 	}
 
 	if allowFallbacks {
-		if m := mr.lookupByDevice(device); m != nil {
+		// TODO(safchain) reintroduce using a namespace aware approach
+		/*if m := mr.lookupByDevice(device); m != nil {
 			return m
-		}
+		}*/
 
 		if m := mr.getFromRedemption(mountID); m != nil {
 			return m

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -110,7 +110,7 @@ func TestMountResolver(t *testing.T) {
 				},
 			},
 		},
-		{
+		/*{
 			"insert_device",
 			args{
 				[]event{
@@ -137,7 +137,7 @@ func TestMountResolver(t *testing.T) {
 					},
 				},
 			},
-		},
+		},*/
 		{
 			"remove_overlay",
 			args{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR remove the use of the mount device fallback. This fallback should make use of the mount namespace info. Removing it for now as it causes incorrect resolution and wrong path.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
