### PR TITLE
[CONTINT-3410] Fix the …_pods_are_running_the_good_version e2e tests

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -218,10 +218,15 @@ func (suite *k8sSuite) TestVersion() {
 					suite.Emptyf(stderr, "Standard error of `agent version` should be empty,")
 					match := versionExtractor.FindStringSubmatch(stdout)
 					if suite.Equalf(2, len(match), "'Commit' not found in the output of `agent version`.") {
-						if len(GitCommit) == 10 && len(match[1]) == 7 {
-							suite.Equalf(GitCommit[:7], match[1], "Agent isn’t running the expected version")
-						} else {
-							suite.Equalf(GitCommit, match[1], "Agent isn’t running the expected version")
+						if suite.Greaterf(len(GitCommit), 6, "Couldn’t guess the expected version of the agent.") &&
+							suite.Greaterf(len(match[1]), 6, "Couldn’t find the version of the agent.") {
+
+							size2compare := len(GitCommit)
+							if len(match[1]) < size2compare {
+								size2compare = len(match[1])
+							}
+
+							suite.Equalf(GitCommit[:size2compare], match[1][:size2compare], "Agent isn’t running the expected version")
 						}
 					}
 				}


### PR DESCRIPTION
### What does this PR do?

Do not assume any hard-coded length of the git sha returned the `agent version` command.

### Motivation

Fix this kind of [failure](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/376862784):
```
=== FAIL: tests/containers TestKindSuite/TestVersion/Linux_agent_pods_are_running_the_good_version (0.58s)
    k8s_test.go:224: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:224
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.8.5-0.20231013065317-89920137cdfa/suite/suite.go:112
        	Error:      	Not equal: 
        	            	expected: "2abd92219c"
        	            	actual  : "2abd9221"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-2abd92219c
        	            	+2abd9221
        	Test:       	TestKindSuite/TestVersion/Linux_agent_pods_are_running_the_good_version
        	Messages:   	Agent isn’t running the expected version
```

### Additional Notes

The size of the short sha returned by `git` depends on the version of `git` as well as of the number of commits in the repository.
Here is where the git commit is computed: https://github.com/DataDog/datadog-agent/blob/8bfeaac291651dca3226a94e04034185ffa8f8d3/tasks/utils.py#L272-L276

The length of short git sha is documented in `git-config(1)`:
> If unspecified or set to "auto", an appropriate value is computed based on the approximate number of packed objects in your repository, which hopefully is enough for abbreviated object names to stay unique for some time.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Launch the e2e tests with an image that doesn’t match the version. The tests should fail. But we can check that the length of the checked version is correct.

Ex.:
```
=== FAIL: tests/containers TestEKSSuite/TestVersion/Linux_agent_pods_are_running_the_good_version (2.26s)
    k8s_test.go:229: 
                Error Trace:    /home/lenaic/doc/devel/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:229
                                                        /home/lenaic/go/pkg/mod/github.com/stretchr/testify@v1.8.5-0.20231013065317-89920137cdfa/suite/suite.go:112
                Error:          Not equal: 
                                expected: "4c67769"
                                actual  : "1790cab"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -4c67769
                                +1790cab
                Test:           TestEKSSuite/TestVersion/Linux_agent_pods_are_running_the_good_version
                Messages:       Agent isn’t running the expected version
        --- FAIL: TestEKSSuite/TestVersion/Linux_agent_pods_are_running_the_good_version (2.26s)

=== FAIL: tests/containers TestEKSSuite/TestVersion/Windows_agent_pods_are_running_the_good_version (1.88s)
    k8s_test.go:229: 
                Error Trace:    /home/lenaic/doc/devel/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:229
                                                        /home/lenaic/go/pkg/mod/github.com/stretchr/testify@v1.8.5-0.20231013065317-89920137cdfa/suite/suite.go:112
                Error:          Not equal: 
                                expected: "4c6776912a"
                                actual  : "1790cab5ca"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -4c6776912a
                                +1790cab5ca
                Test:           TestEKSSuite/TestVersion/Windows_agent_pods_are_running_the_good_version
                Messages:       Agent isn’t running the expected version
        --- FAIL: TestEKSSuite/TestVersion/Windows_agent_pods_are_running_the_good_version (1.88s)
```

Note that the version length isn’t the same for Linux and Windows agents !

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
