### PR TITLE
[wip][do not merge] macos poc for cws

### DIFF
--- a/cmd/system-probe/modules/all_darwin.go
+++ b/cmd/system-probe/modules/all_darwin.go
@@ -3,12 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !(linux || windows || darwin)
+//go:build darwin
 
-// Package modules is all the module definitions for system-probe
+//nolint:revive // TODO(EBPF) Fix revive linter
 package modules
 
-import "github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+import (
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+)
 
 // All System Probe modules should register their factories here
-var All = []module.Factory{}
+var All = []module.Factory{
+	EventMonitor,
+}

--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux || windows
+//go:build linux || windows || darwin
 
 package modules
 

--- a/cmd/system-probe/modules/eventmonitor_others.go
+++ b/cmd/system-probe/modules/eventmonitor_others.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows
+//go:build windows || darwin
 
 package modules
 

--- a/pkg/eventmonitor/eventmonitor.go
+++ b/pkg/eventmonitor/eventmonitor.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux || windows
+//go:build linux || windows || darwin
 
 // Package eventmonitor holds eventmonitor related files
 package eventmonitor

--- a/pkg/eventmonitor/eventmonitor_darwin.go
+++ b/pkg/eventmonitor/eventmonitor_darwin.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build darwin
+
+package eventmonitor
+
+import (
+	"net"
+	"os"
+)
+
+func (m *EventMonitor) getListener() (net.Listener, error) {
+	ln, err := net.Listen("unix", m.Config.SocketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = os.Chmod(m.Config.SocketPath, 0700); err != nil {
+		return nil, err
+	}
+	return ln, nil
+}
+
+func (m *EventMonitor) init() error {
+	// force socket cleanup of previous socket not cleanup
+	os.Remove(m.Config.SocketPath)
+	return nil
+}
+
+func (m *EventMonitor) cleanup() {
+	os.Remove(m.Config.SocketPath)
+}

--- a/pkg/eventmonitor/eventmonitor_other.go
+++ b/pkg/eventmonitor/eventmonitor_other.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux && !windows
+//go:build !(linux || windows || darwin)
 
 // Package eventmonitor holds eventmonitor related files
 package eventmonitor

--- a/pkg/process/events/consumer/event_copy_darwin.go
+++ b/pkg/process/events/consumer/event_copy_darwin.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build darwin
+
+package consumer
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/process/events/model"
+	smodel "github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// Copy copies the necessary fields from the event received from the event monitor
+func (p *ProcessConsumer) Copy(event *smodel.Event) any {
+	return &model.ProcessEvent{
+		EventType:      model.NewEventType(event.GetEventType().String()),
+		CollectionTime: event.GetTimestamp(),
+		Pid:            event.GetProcessPid(),
+		ContainerID:    event.GetContainerId(),
+		Ppid:           event.GetProcessPpid(),
+		UID:            event.GetProcessUid(),
+		GID:            event.GetProcessGid(),
+		Username:       event.GetProcessUser(),
+		Group:          event.GetProcessGroup(),
+		Exe:            event.GetExecFilePath(),
+		Cmdline:        event.GetProcessArgv(),
+		ExecTime:       event.GetProcessExecTime(),
+		ExitTime:       event.GetProcessExitTime(),
+		ExitCode:       event.GetExitCode(),
+	}
+}

--- a/pkg/process/events/consumer/event_copy_other.go
+++ b/pkg/process/events/consumer/event_copy_other.go
@@ -4,7 +4,7 @@
 // Copyright 2022-present Datadog, Inc.
 // Code generated - DO NOT EDIT.
 
-//go:build !linux && !windows
+//go:build !(linux || windows || darwin)
 
 package consumer
 

--- a/pkg/security/probe/field_handlers_darwin.go
+++ b/pkg/security/probe/field_handlers_darwin.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// FieldHandlers defines a field handlers
+type FieldHandlers struct {
+	// TODO(safchain) remove this when support for multiple platform with the same build tags is available
+	// keeping it can be dangerous as it can hide non implemented handlers
+	model.FakeFieldHandlers
+}

--- a/pkg/security/probe/model_darwin.go
+++ b/pkg/security/probe/model_darwin.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// NewDarwinModel returns a new model with some extra field validation
+func NewDarwinModel() *model.Model {
+	return &model.Model{
+		ExtraValidateFieldFnc: func(field eval.Field, fieldValue eval.FieldValue) error {
+			// TODO(safchain) remove this check when multiple model per platform will be supported in the SECL package
+			if !strings.HasPrefix(field, "exec.") &&
+				!strings.HasPrefix(field, "exit.") &&
+				!strings.HasPrefix(field, "process.") {
+				return fmt.Errorf("%s is not available with the Windows version", field)
+			}
+			return nil
+		},
+	}
+}
+
+// NewDarwinEvent returns a new event
+func NewDarwinEvent(fh *FieldHandlers) *model.Event {
+	event := model.NewFakeEvent()
+	event.FieldHandlers = fh
+	return event
+}

--- a/pkg/security/probe/opts_darwin.go
+++ b/pkg/security/probe/opts_darwin.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build darwin
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"github.com/DataDog/datadog-go/v5/statsd"
+)
+
+// Opts defines some probe options
+type Opts struct {
+	// StatsdClient to be used for probe stats
+	StatsdClient statsd.ClientInterface
+}
+
+func (o *Opts) normalize() {
+	if o.StatsdClient == nil {
+		o.StatsdClient = &statsd.NoOpClient{}
+	}
+}

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux || windows
+//go:build linux || windows || darwin
 
 // Package probe holds probe related files
 package probe

--- a/pkg/security/probe/probe_darwin.go
+++ b/pkg/security/probe/probe_darwin.go
@@ -1,0 +1,244 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"context"
+	json "encoding/json"
+	"errors"
+	"io"
+	"os/exec"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/serializers"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
+)
+
+// DarwinProbe defines a macOS probe
+type DarwinProbe struct {
+	probe         *Probe
+	event         *model.Event
+	resolvers     *resolvers.Resolvers
+	fieldHandlers *FieldHandlers
+	ctx           context.Context
+	cancelFnc     context.CancelFunc
+}
+
+// NewDarwinProbe returns a new darwin probe
+func NewDarwinProbe(p *Probe, config *config.Config, opts Opts) (*DarwinProbe, error) {
+	resolvers, err := resolvers.NewResolvers(config, opts.StatsdClient, p.scrubber)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancelFnc := context.WithCancel(context.Background())
+
+	return &DarwinProbe{
+		probe:         p,
+		resolvers:     resolvers,
+		fieldHandlers: &FieldHandlers{},
+		ctx:           ctx,
+		cancelFnc:     cancelFnc,
+	}, nil
+}
+
+// Setup sets up the probe
+func (dp *DarwinProbe) Setup() error { return nil }
+
+// Init initializes the probe
+func (dp *DarwinProbe) Init() error { return nil }
+
+// Start starts the probe
+func (dp *DarwinProbe) Start() error {
+	cmd := exec.Command("/usr/bin/eslogger", "exec")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(stdout)
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	go func() {
+		<-dp.ctx.Done()
+		if err := cmd.Process.Kill(); err != nil {
+			log.Errorf("error killing eslogger process: %v", err)
+		}
+		if err := cmd.Wait(); err != nil {
+			log.Errorf("error waiting for eslogger process: %v", err)
+		}
+	}()
+
+	go func() {
+		var value ESEvent
+		for {
+			err := decoder.Decode(&value)
+			if err == io.EOF {
+				break
+			}
+
+			dp.pushEvent(&value)
+		}
+	}()
+
+	return nil
+}
+
+func (dp *DarwinProbe) pushEvent(esev *ESEvent) {
+	event := dp.zeroEvent()
+	event.Type = uint32(model.ExecEventType)
+
+	pid := esev.Event.Exec.Target.AuditToken.Pid
+	ppid := esev.Event.Exec.Target.ParentAuditToken.Pid
+
+	// TODO(paulcacheux): add parent pid
+	pce, err := dp.resolvers.ProcessResolver.AddNewEntry(pid, ppid, esev.Event.Exec.Target.Executable.Path, esev.Event.Exec.Args)
+	if err != nil {
+		log.Errorf("error in resolver %v", err)
+		return
+	}
+
+	event.Exec.Process = &pce.Process
+	event.ProcessCacheEntry = pce
+	event.ProcessContext = &pce.ProcessContext
+	dp.DispatchEvent(event)
+}
+
+func (dp *DarwinProbe) zeroEvent() *model.Event {
+	dp.event.Zero()
+	dp.event.FieldHandlers = dp.fieldHandlers
+	return dp.event
+}
+
+// DispatchEvent sends an event to the probe event handler
+func (dp *DarwinProbe) DispatchEvent(event *model.Event) {
+	traceEvent("Dispatching event %s", func() ([]byte, model.EventType, error) {
+		eventJSON, err := serializers.MarshalEvent(event, nil)
+		return eventJSON, event.GetEventType(), err
+	})
+
+	// send event to wildcard handlers, like the CWS rule engine, first
+	dp.probe.sendEventToHandlers(event)
+
+	// send event to specific event handlers, like the event monitor consumers, subsequently
+	dp.probe.sendEventToConsumers(event)
+}
+
+// Stop stops the probe
+func (dp *DarwinProbe) Stop() {
+	dp.cancelFnc()
+}
+
+// SendStats sends stats to the probe statsd client
+func (dp *DarwinProbe) SendStats() error { return nil }
+
+// Snapshot collects data on the current state of the system
+func (dp *DarwinProbe) Snapshot() error {
+	return dp.resolvers.Snapshot()
+}
+
+// Close closes the probe
+func (dp *DarwinProbe) Close() error { return nil }
+
+// NewModel returns a new model
+func (dp *DarwinProbe) NewModel() *model.Model {
+	return NewDarwinModel()
+}
+
+// DumpDiscarders dumps discarders
+func (dp *DarwinProbe) DumpDiscarders() (string, error) {
+	return "", errors.New("not supported")
+}
+
+// FlushDiscarders flushes discarders
+func (dp *DarwinProbe) FlushDiscarders() error { return nil }
+
+// ApplyRuleSet applies a rule set
+func (dp *DarwinProbe) ApplyRuleSet(_ *rules.RuleSet) (*kfilters.ApplyRuleSetReport, error) {
+	return &kfilters.ApplyRuleSetReport{}, nil
+}
+
+// OnNewDiscarder is called when a new discarder is created
+func (dp *DarwinProbe) OnNewDiscarder(_ *rules.RuleSet, _ *model.Event, _ eval.Field, _ eval.EventType) {
+}
+
+// HandleActions handles actions
+func (dp *DarwinProbe) HandleActions(_ *eval.Context, _ *rules.Rule) {}
+
+// NewEvent returns a new event
+func (dp *DarwinProbe) NewEvent() *model.Event {
+	return NewDarwinEvent(dp.fieldHandlers)
+}
+
+// GetFieldHandlers returns the field handlers
+func (dp *DarwinProbe) GetFieldHandlers() model.FieldHandlers {
+	return dp.fieldHandlers
+}
+
+// DumpProcessCache dumps the process cache
+func (dp *DarwinProbe) DumpProcessCache(_ bool) (string, error) { return "", nil }
+
+// AddDiscarderPushedCallback adds a discarder pushed callback
+func (dp *DarwinProbe) AddDiscarderPushedCallback(_ DiscarderPushedCallback) {}
+
+// GetEventTags returns the event tags
+func (dp *DarwinProbe) GetEventTags(_ string) []string { return nil }
+
+// Origin returns origin
+func (p *Probe) Origin() string {
+	return ""
+}
+
+// NewProbe instantiates a new runtime security agent probe
+func NewProbe(config *config.Config, opts Opts, wmeta optional.Option[workloadmeta.Component]) (*Probe, error) {
+	opts.normalize()
+
+	p := &Probe{
+		Opts:         opts,
+		Config:       config,
+		StatsdClient: opts.StatsdClient,
+		scrubber:     newProcScrubber(config.Probe.CustomSensitiveWords),
+	}
+
+	pp, err := NewDarwinProbe(p, config, opts)
+	if err != nil {
+		return nil, err
+	}
+	p.PlatformProbe = pp
+
+	return p, nil
+}
+
+// ESEvent is the event sent by eslogger
+type ESEvent struct {
+	Event struct {
+		Exec struct {
+			Args   []string `json:"args"`
+			Target struct {
+				AuditToken struct {
+					Pid uint32 `json:"pid"`
+				} `json:"audit_token"`
+				ParentAuditToken struct {
+					Pid uint32 `json:"pid"`
+				} `json:"parent_audit_token"`
+				Executable struct {
+					Path string `json:"path"`
+				} `json:"executable"`
+			} `json:"target"`
+		} `json:"exec"`
+	} `json:"event"`
+}

--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-//go:build !linux && !windows
+//go:build !(linux || windows || darwin)
 
 package probe
 

--- a/pkg/security/probe/scrubber.go
+++ b/pkg/security/probe/scrubber.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux || windows
+//go:build linux || windows || darwin
 
 // Package probe holds probe related files
 package probe

--- a/pkg/security/resolvers/process/resolver_darwin.go
+++ b/pkg/security/resolvers/process/resolver_darwin.go
@@ -1,0 +1,212 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package process holds process related files
+package process
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// Pid PID type
+type Pid = uint32
+
+// Resolver defines a resolver
+type Resolver struct {
+	sync.RWMutex
+	processes map[Pid]*model.ProcessCacheEntry
+	scrubber  *procutil.DataScrubber
+
+	processCacheEntryPool *Pool
+}
+
+// NewResolver returns a new process resolver
+func NewResolver(_ *config.Config, scrubber *procutil.DataScrubber) (*Resolver, error) {
+	p := &Resolver{
+		processes: make(map[Pid]*model.ProcessCacheEntry),
+		scrubber:  scrubber,
+	}
+
+	p.processCacheEntryPool = NewProcessCacheEntryPool(func() {})
+
+	return p, nil
+}
+
+func (p *Resolver) insertEntry(entry *model.ProcessCacheEntry) {
+	// PID collision
+	if prev := p.processes[entry.Pid]; prev != nil {
+		prev.Release()
+	}
+
+	p.processes[entry.Pid] = entry
+	entry.Retain()
+
+	parent := p.processes[entry.PPid]
+	if parent != nil {
+		entry.SetAncestor(parent)
+	} else {
+		log.Tracef("unable to find parent of %v\n", entry)
+	}
+}
+
+func (p *Resolver) deleteEntry(pid uint32, exitTime time.Time) {
+	entry, ok := p.processes[pid]
+	if !ok {
+		return
+	}
+
+	entry.Exit(exitTime)
+	delete(p.processes, entry.Pid)
+	entry.Release()
+}
+
+// DeleteEntry tries to delete an entry in the process cache
+func (p *Resolver) DeleteEntry(pid uint32, exitTime time.Time) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.deleteEntry(pid, exitTime)
+}
+
+// AddNewEntry add a new process entry to the cache
+func (p *Resolver) AddNewEntry(pid uint32, ppid uint32, file string, args []string) (*model.ProcessCacheEntry, error) {
+	e := p.processCacheEntryPool.Get()
+	e.PIDContext.Pid = pid
+	e.PPid = ppid
+
+	e.Process.Argv = args
+	e.Process.FileEvent.PathnameStr = file
+	e.Process.FileEvent.BasenameStr = filepath.Base(e.Process.FileEvent.PathnameStr)
+	e.ExecTime = time.Now()
+
+	p.insertEntry(e)
+
+	return e, nil
+}
+
+// GetEntry returns the process entry for the given pid
+func (p *Resolver) GetEntry(pid Pid) *model.ProcessCacheEntry {
+	p.Lock()
+	defer p.Unlock()
+	if e, ok := p.processes[pid]; ok {
+		return e
+	}
+	return nil
+}
+
+// Resolve returns the cache entry for the given pid
+func (p *Resolver) Resolve(pid uint32) *model.ProcessCacheEntry { //nolint:revive // TODO fix revive unused-parameter
+	return p.GetEntry(pid)
+}
+
+// GetEnvs returns the envs of the event
+func (p *Resolver) GetEnvs(pr *model.Process) []string {
+	if pr.EnvsEntry == nil {
+		return pr.Envs
+	}
+
+	keys, _ := pr.EnvsEntry.FilterEnvs(nil)
+	pr.Envs = keys
+	return pr.Envs
+}
+
+// GetEnvp returns the envs of the event with their values
+func (p *Resolver) GetEnvp(pr *model.Process) []string {
+	if pr.EnvsEntry == nil {
+		return pr.Envp
+	}
+
+	pr.Envp = pr.EnvsEntry.Values
+	return pr.Envp
+}
+
+// GetProcessCmdLineScrubbed returns the scrubbed cmdline
+func (p *Resolver) GetProcessCmdLineScrubbed(pr *model.Process) string {
+	if pr.ScrubbedCmdLineResolved {
+		return pr.CmdLine
+	}
+
+	if p.scrubber != nil && len(pr.CmdLine) > 0 {
+		// replace with the scrubbed version
+		scrubbed, _ := p.scrubber.ScrubCommand([]string{pr.CmdLine})
+		if len(scrubbed) > 0 {
+			pr.CmdLine = strings.Join(scrubbed, " ")
+		}
+	}
+
+	return pr.CmdLine
+}
+
+// SendStats sends process resolver metrics
+func (p *Resolver) SendStats() error {
+	return nil
+}
+
+// Snapshot snapshot existing processes
+func (p *Resolver) Snapshot() {
+	processes, err := utils.GetProcesses()
+	if err != nil {
+		log.Errorf("failed to list processes: %v", err)
+		return
+	}
+
+	entries := make([]*model.ProcessCacheEntry, 0, len(processes))
+
+	for _, proc := range processes {
+		fp, err := utils.GetFilledProcess(proc)
+		if err != nil {
+			log.Errorf("failed to fill process cache: %v", err)
+			continue
+		}
+
+		execPath, err := proc.Exe()
+		if err != nil {
+			log.Errorf("failed to fetch exec path: %v", err)
+			continue
+		}
+
+		pCreateTime, err := proc.CreateTime()
+		if err != nil {
+			log.Errorf("failted to fetch create time: %v", err)
+		}
+
+		e := p.processCacheEntryPool.Get()
+		e.PIDContext.Pid = Pid(fp.Pid)
+		e.PPid = Pid(fp.Ppid)
+
+		e.Process.Argv = fp.Cmdline
+		e.Process.FileEvent.PathnameStr = execPath
+		e.Process.FileEvent.BasenameStr = filepath.Base(execPath)
+		e.ExecTime = time.Unix(0, pCreateTime*int64(time.Millisecond))
+
+		entries = append(entries, e)
+	}
+
+	// make sure to insert them in the creation time order
+	sort.Slice(entries, func(i, j int) bool {
+		entryA := entries[i]
+		entryB := entries[j]
+
+		if entryA.ExecTime.Equal(entryB.ExecTime) {
+			return entries[i].Pid < entries[j].Pid
+		}
+
+		return entryA.ExecTime.Before(entryB.ExecTime)
+	})
+
+	for _, e := range entries {
+		p.insertEntry(e)
+	}
+}

--- a/pkg/security/resolvers/resolvers_darwin.go
+++ b/pkg/security/resolvers/resolvers_darwin.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package resolvers holds resolvers related files
+package resolvers
+
+import (
+	"github.com/DataDog/datadog-go/v5/statsd"
+
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
+)
+
+// Resolvers holds the list of the event attribute resolvers
+type Resolvers struct {
+	ProcessResolver *process.Resolver
+}
+
+// NewResolvers creates a new instance of Resolvers
+func NewResolvers(config *config.Config, _ statsd.ClientInterface, scrubber *procutil.DataScrubber) (*Resolvers, error) {
+	processResolver, err := process.NewResolver(config, scrubber)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvers := &Resolvers{
+		ProcessResolver: processResolver,
+	}
+	return resolvers, nil
+}
+
+// Snapshot collects data on the current state of the system
+func (r *Resolvers) Snapshot() error {
+	r.ProcessResolver.Snapshot()
+	return nil
+}

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -1078,7 +1078,7 @@ func init() {
 	flag.StringVar(&typesFile, "types-file", os.Getenv("TYPESFILE"), "Go type file to use with the model file")
 	flag.StringVar(&pkgname, "package", pkgPrefix+"/"+os.Getenv("GOPACKAGE"), "Go package name")
 	flag.StringVar(&buildTags, "tags", "unix", "build tags used for parsing")
-	flag.StringVar(&fieldAccessorsOutput, "field-accessors-output", "field_accessors_unix.go", "Generated per-field accessors output file")
-	flag.StringVar(&output, "output", "accessors_unix.go", "Go generated file")
+	flag.StringVar(&fieldAccessorsOutput, "field-accessors-output", "field_accessors_linux.go", "Generated per-field accessors output file")
+	flag.StringVar(&output, "output", "accessors_linux.go", "Go generated file")
 	flag.Parse()
 }

--- a/pkg/security/secl/model/accessors_darwin.go
+++ b/pkg/security/secl/model/accessors_darwin.go
@@ -1,0 +1,3283 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+// Code generated - DO NOT EDIT.
+
+//go:build darwin
+
+package model
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"reflect"
+)
+
+func (m *Model) GetIterator(field eval.Field) (eval.Iterator, error) {
+	switch field {
+	case "process.ancestors":
+		return &ProcessAncestorsIterator{}, nil
+	}
+	return nil, &eval.ErrIteratorNotSupported{Field: field}
+}
+func (m *Model) GetEventTypes() []eval.EventType {
+	return []eval.EventType{
+		eval.EventType("exec"),
+		eval.EventType("exit"),
+	}
+}
+func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
+	switch field {
+	case "container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "container.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "container.runtime":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerRuntime(ev, ev.BaseEvent.ContainerContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
+		}, nil
+	case "event.hostname":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveHostname(ev, &ev.BaseEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "event.origin":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.BaseEvent.Origin
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "event.os":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.BaseEvent.Os
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "event.service":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveService(ev, &ev.BaseEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "event.timestamp":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveEventTimestamp(ev, &ev.BaseEvent))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exec.args_flags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessArgsFlags(ev, ev.Exec.Process)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exec.args_options":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessArgsOptions(ev, ev.Exec.Process)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exec.argv":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessArgv(ev, ev.Exec.Process)
+			},
+			Field:  field,
+			Weight: 500 * eval.HandlerWeight,
+		}, nil
+	case "exec.cmdline":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exec.Process)
+			},
+			Field:  field,
+			Weight: 200 * eval.HandlerWeight,
+		}, nil
+	case "exec.container.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.Exec.Process.ContainerID
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exec.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exec.Process))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exec.envp":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exec.Process)
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+	case "exec.envs":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exec.Process)
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+	case "exec.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exec.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exec.file.name.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exec.Process.FileEvent))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exec.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exec.file.path.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exec.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.Exec.Process.GID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exec.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.Exec.Process.Group
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exec.pid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.Exec.Process.PIDContext.Pid)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exec.ppid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.Exec.Process.PPid)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exec.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.Exec.Process.UID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exec.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.Exec.Process.User
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exit.args_flags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessArgsFlags(ev, ev.Exit.Process)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exit.args_options":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessArgsOptions(ev, ev.Exit.Process)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exit.argv":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessArgv(ev, ev.Exit.Process)
+			},
+			Field:  field,
+			Weight: 500 * eval.HandlerWeight,
+		}, nil
+	case "exit.cause":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.Exit.Cause)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exit.cmdline":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exit.Process)
+			},
+			Field:  field,
+			Weight: 200 * eval.HandlerWeight,
+		}, nil
+	case "exit.code":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.Exit.Code)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exit.container.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.Exit.Process.ContainerID
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exit.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exit.Process))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exit.envp":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exit.Process)
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+	case "exit.envs":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exit.Process)
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+	case "exit.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exit.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exit.file.name.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exit.Process.FileEvent))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exit.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exit.file.path.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "exit.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.Exit.Process.GID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exit.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.Exit.Process.Group
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exit.pid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.Exit.Process.PIDContext.Pid)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exit.ppid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.Exit.Process.PPid)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exit.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.Exit.Process.UID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "exit.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.Exit.Process.User
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.ancestors.args_flags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				var results []string
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := ev.FieldHandlers.ResolveProcessArgsFlags(ev, &element.ProcessContext.Process)
+					results = append(results, result...)
+					value = iterator.Next()
+				}
+				ctx.StringCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.args_options":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				var results []string
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := ev.FieldHandlers.ResolveProcessArgsOptions(ev, &element.ProcessContext.Process)
+					results = append(results, result...)
+					value = iterator.Next()
+				}
+				ctx.StringCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.argv":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				var results []string
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := ev.FieldHandlers.ResolveProcessArgv(ev, &element.ProcessContext.Process)
+					results = append(results, result...)
+					value = iterator.Next()
+				}
+				ctx.StringCache[field] = results
+				return results
+			}, Field: field,
+			Weight: 500 * eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.cmdline":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				var results []string
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := ev.FieldHandlers.ResolveProcessCmdLine(ev, &element.ProcessContext.Process)
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.StringCache[field] = results
+				return results
+			}, Field: field,
+			Weight: 200 * eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.container.id":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				var results []string
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := element.ProcessContext.Process.ContainerID
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.StringCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.created_at":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ev := ctx.Event.(*Event)
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				var results []int
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, &element.ProcessContext.Process))
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.IntCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.envp":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				var results []string
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := ev.FieldHandlers.ResolveProcessEnvp(ev, &element.ProcessContext.Process)
+					results = append(results, result...)
+					value = iterator.Next()
+				}
+				ctx.StringCache[field] = results
+				return results
+			}, Field: field,
+			Weight: 100 * eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.envs":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				var results []string
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := ev.FieldHandlers.ResolveProcessEnvs(ev, &element.ProcessContext.Process)
+					results = append(results, result...)
+					value = iterator.Next()
+				}
+				ctx.StringCache[field] = results
+				return results
+			}, Field: field,
+			Weight: 100 * eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.file.name":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				var results []string
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := ev.FieldHandlers.ResolveFileBasename(ev, &element.ProcessContext.Process.FileEvent)
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.StringCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.file.name.length":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ev := ctx.Event.(*Event)
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				var results []int
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := len(ev.FieldHandlers.ResolveFileBasename(ev, &element.ProcessContext.Process.FileEvent))
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.IntCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.file.path":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				var results []string
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := ev.FieldHandlers.ResolveFilePath(ev, &element.ProcessContext.Process.FileEvent)
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.StringCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.file.path.length":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ev := ctx.Event.(*Event)
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				var results []int
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := len(ev.FieldHandlers.ResolveFilePath(ev, &element.ProcessContext.Process.FileEvent))
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.IntCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.gid":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				var results []int
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := int(element.ProcessContext.Process.GID)
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.IntCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.group":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				var results []string
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := element.ProcessContext.Process.Group
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.StringCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.pid":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				var results []int
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := int(element.ProcessContext.Process.PIDContext.Pid)
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.IntCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.ppid":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				var results []int
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := int(element.ProcessContext.Process.PPid)
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.IntCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.uid":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				var results []int
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := int(element.ProcessContext.Process.UID)
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.IntCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.ancestors.user":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				var results []string
+				iterator := &ProcessAncestorsIterator{}
+				value := iterator.Front(ctx)
+				for value != nil {
+					element := (*ProcessCacheEntry)(value)
+					result := element.ProcessContext.Process.User
+					results = append(results, result)
+					value = iterator.Next()
+				}
+				ctx.StringCache[field] = results
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+	case "process.args_flags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessArgsFlags(ev, &ev.BaseEvent.ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.args_options":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessArgsOptions(ev, &ev.BaseEvent.ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.argv":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessArgv(ev, &ev.BaseEvent.ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: 500 * eval.HandlerWeight,
+		}, nil
+	case "process.cmdline":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessCmdLine(ev, &ev.BaseEvent.ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: 200 * eval.HandlerWeight,
+		}, nil
+	case "process.container.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.BaseEvent.ProcessContext.Process.ContainerID
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.envp":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessEnvp(ev, &ev.BaseEvent.ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+	case "process.envs":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.BaseEvent.ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+	case "process.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.file.name.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.file.path.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.BaseEvent.ProcessContext.Process.GID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.BaseEvent.ProcessContext.Process.Group
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.parent.args_flags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return []string{}
+				}
+				return ev.FieldHandlers.ResolveProcessArgsFlags(ev, ev.BaseEvent.ProcessContext.Parent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.parent.args_options":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return []string{}
+				}
+				return ev.FieldHandlers.ResolveProcessArgsOptions(ev, ev.BaseEvent.ProcessContext.Parent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.parent.argv":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return []string{}
+				}
+				return ev.FieldHandlers.ResolveProcessArgv(ev, ev.BaseEvent.ProcessContext.Parent)
+			},
+			Field:  field,
+			Weight: 500 * eval.HandlerWeight,
+		}, nil
+	case "process.parent.cmdline":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.BaseEvent.ProcessContext.Parent)
+			},
+			Field:  field,
+			Weight: 200 * eval.HandlerWeight,
+		}, nil
+	case "process.parent.container.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				return ev.BaseEvent.ProcessContext.Parent.ContainerID
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.parent.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.BaseEvent.ProcessContext.Parent))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.parent.envp":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return []string{}
+				}
+				return ev.FieldHandlers.ResolveProcessEnvp(ev, ev.BaseEvent.ProcessContext.Parent)
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+	case "process.parent.envs":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return []string{}
+				}
+				return ev.FieldHandlers.ResolveProcessEnvs(ev, ev.BaseEvent.ProcessContext.Parent)
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+	case "process.parent.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.parent.file.name.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.parent.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.parent.file.path.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "process.parent.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return int(ev.BaseEvent.ProcessContext.Parent.GID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.parent.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				return ev.BaseEvent.ProcessContext.Parent.Group
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.parent.pid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return int(ev.BaseEvent.ProcessContext.Parent.PIDContext.Pid)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.parent.ppid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return int(ev.BaseEvent.ProcessContext.Parent.PPid)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.parent.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return int(ev.BaseEvent.ProcessContext.Parent.UID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.parent.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				return ev.BaseEvent.ProcessContext.Parent.User
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.pid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.BaseEvent.ProcessContext.Process.PIDContext.Pid)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.ppid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.BaseEvent.ProcessContext.Process.PPid)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.BaseEvent.ProcessContext.Process.UID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "process.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.BaseEvent.ProcessContext.Process.User
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	}
+	return nil, &eval.ErrFieldNotFound{Field: field}
+}
+func (ev *Event) GetFields() []eval.Field {
+	return []eval.Field{
+		"container.created_at",
+		"container.id",
+		"container.runtime",
+		"container.tags",
+		"event.hostname",
+		"event.origin",
+		"event.os",
+		"event.service",
+		"event.timestamp",
+		"exec.args_flags",
+		"exec.args_options",
+		"exec.argv",
+		"exec.cmdline",
+		"exec.container.id",
+		"exec.created_at",
+		"exec.envp",
+		"exec.envs",
+		"exec.file.name",
+		"exec.file.name.length",
+		"exec.file.path",
+		"exec.file.path.length",
+		"exec.gid",
+		"exec.group",
+		"exec.pid",
+		"exec.ppid",
+		"exec.uid",
+		"exec.user",
+		"exit.args_flags",
+		"exit.args_options",
+		"exit.argv",
+		"exit.cause",
+		"exit.cmdline",
+		"exit.code",
+		"exit.container.id",
+		"exit.created_at",
+		"exit.envp",
+		"exit.envs",
+		"exit.file.name",
+		"exit.file.name.length",
+		"exit.file.path",
+		"exit.file.path.length",
+		"exit.gid",
+		"exit.group",
+		"exit.pid",
+		"exit.ppid",
+		"exit.uid",
+		"exit.user",
+		"process.ancestors.args_flags",
+		"process.ancestors.args_options",
+		"process.ancestors.argv",
+		"process.ancestors.cmdline",
+		"process.ancestors.container.id",
+		"process.ancestors.created_at",
+		"process.ancestors.envp",
+		"process.ancestors.envs",
+		"process.ancestors.file.name",
+		"process.ancestors.file.name.length",
+		"process.ancestors.file.path",
+		"process.ancestors.file.path.length",
+		"process.ancestors.gid",
+		"process.ancestors.group",
+		"process.ancestors.pid",
+		"process.ancestors.ppid",
+		"process.ancestors.uid",
+		"process.ancestors.user",
+		"process.args_flags",
+		"process.args_options",
+		"process.argv",
+		"process.cmdline",
+		"process.container.id",
+		"process.created_at",
+		"process.envp",
+		"process.envs",
+		"process.file.name",
+		"process.file.name.length",
+		"process.file.path",
+		"process.file.path.length",
+		"process.gid",
+		"process.group",
+		"process.parent.args_flags",
+		"process.parent.args_options",
+		"process.parent.argv",
+		"process.parent.cmdline",
+		"process.parent.container.id",
+		"process.parent.created_at",
+		"process.parent.envp",
+		"process.parent.envs",
+		"process.parent.file.name",
+		"process.parent.file.name.length",
+		"process.parent.file.path",
+		"process.parent.file.path.length",
+		"process.parent.gid",
+		"process.parent.group",
+		"process.parent.pid",
+		"process.parent.ppid",
+		"process.parent.uid",
+		"process.parent.user",
+		"process.pid",
+		"process.ppid",
+		"process.uid",
+		"process.user",
+	}
+}
+func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
+	switch field {
+	case "container.created_at":
+		return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext)), nil
+	case "container.id":
+		return ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext), nil
+	case "container.runtime":
+		return ev.FieldHandlers.ResolveContainerRuntime(ev, ev.BaseEvent.ContainerContext), nil
+	case "container.tags":
+		return ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext), nil
+	case "event.hostname":
+		return ev.FieldHandlers.ResolveHostname(ev, &ev.BaseEvent), nil
+	case "event.origin":
+		return ev.BaseEvent.Origin, nil
+	case "event.os":
+		return ev.BaseEvent.Os, nil
+	case "event.service":
+		return ev.FieldHandlers.ResolveService(ev, &ev.BaseEvent), nil
+	case "event.timestamp":
+		return int(ev.FieldHandlers.ResolveEventTimestamp(ev, &ev.BaseEvent)), nil
+	case "exec.args_flags":
+		return ev.FieldHandlers.ResolveProcessArgsFlags(ev, ev.Exec.Process), nil
+	case "exec.args_options":
+		return ev.FieldHandlers.ResolveProcessArgsOptions(ev, ev.Exec.Process), nil
+	case "exec.argv":
+		return ev.FieldHandlers.ResolveProcessArgv(ev, ev.Exec.Process), nil
+	case "exec.cmdline":
+		return ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exec.Process), nil
+	case "exec.container.id":
+		return ev.Exec.Process.ContainerID, nil
+	case "exec.created_at":
+		return int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exec.Process)), nil
+	case "exec.envp":
+		return ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exec.Process), nil
+	case "exec.envs":
+		return ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exec.Process), nil
+	case "exec.file.name":
+		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exec.Process.FileEvent), nil
+	case "exec.file.name.length":
+		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exec.Process.FileEvent), nil
+	case "exec.file.path":
+		return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent), nil
+	case "exec.file.path.length":
+		return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent), nil
+	case "exec.gid":
+		return int(ev.Exec.Process.GID), nil
+	case "exec.group":
+		return ev.Exec.Process.Group, nil
+	case "exec.pid":
+		return int(ev.Exec.Process.PIDContext.Pid), nil
+	case "exec.ppid":
+		return int(ev.Exec.Process.PPid), nil
+	case "exec.uid":
+		return int(ev.Exec.Process.UID), nil
+	case "exec.user":
+		return ev.Exec.Process.User, nil
+	case "exit.args_flags":
+		return ev.FieldHandlers.ResolveProcessArgsFlags(ev, ev.Exit.Process), nil
+	case "exit.args_options":
+		return ev.FieldHandlers.ResolveProcessArgsOptions(ev, ev.Exit.Process), nil
+	case "exit.argv":
+		return ev.FieldHandlers.ResolveProcessArgv(ev, ev.Exit.Process), nil
+	case "exit.cause":
+		return int(ev.Exit.Cause), nil
+	case "exit.cmdline":
+		return ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exit.Process), nil
+	case "exit.code":
+		return int(ev.Exit.Code), nil
+	case "exit.container.id":
+		return ev.Exit.Process.ContainerID, nil
+	case "exit.created_at":
+		return int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exit.Process)), nil
+	case "exit.envp":
+		return ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exit.Process), nil
+	case "exit.envs":
+		return ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exit.Process), nil
+	case "exit.file.name":
+		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exit.Process.FileEvent), nil
+	case "exit.file.name.length":
+		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exit.Process.FileEvent), nil
+	case "exit.file.path":
+		return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent), nil
+	case "exit.file.path.length":
+		return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent), nil
+	case "exit.gid":
+		return int(ev.Exit.Process.GID), nil
+	case "exit.group":
+		return ev.Exit.Process.Group, nil
+	case "exit.pid":
+		return int(ev.Exit.Process.PIDContext.Pid), nil
+	case "exit.ppid":
+		return int(ev.Exit.Process.PPid), nil
+	case "exit.uid":
+		return int(ev.Exit.Process.UID), nil
+	case "exit.user":
+		return ev.Exit.Process.User, nil
+	case "process.ancestors.args_flags":
+		var values []string
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := ev.FieldHandlers.ResolveProcessArgsFlags(ev, &element.ProcessContext.Process)
+			values = append(values, result...)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.args_options":
+		var values []string
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := ev.FieldHandlers.ResolveProcessArgsOptions(ev, &element.ProcessContext.Process)
+			values = append(values, result...)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.argv":
+		var values []string
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := ev.FieldHandlers.ResolveProcessArgv(ev, &element.ProcessContext.Process)
+			values = append(values, result...)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.cmdline":
+		var values []string
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := ev.FieldHandlers.ResolveProcessCmdLine(ev, &element.ProcessContext.Process)
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.container.id":
+		var values []string
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := element.ProcessContext.Process.ContainerID
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.created_at":
+		var values []int
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, &element.ProcessContext.Process))
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.envp":
+		var values []string
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := ev.FieldHandlers.ResolveProcessEnvp(ev, &element.ProcessContext.Process)
+			values = append(values, result...)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.envs":
+		var values []string
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := ev.FieldHandlers.ResolveProcessEnvs(ev, &element.ProcessContext.Process)
+			values = append(values, result...)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.file.name":
+		var values []string
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := ev.FieldHandlers.ResolveFileBasename(ev, &element.ProcessContext.Process.FileEvent)
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.file.name.length":
+		var values []int
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := len(ev.FieldHandlers.ResolveFileBasename(ev, &element.ProcessContext.Process.FileEvent))
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.file.path":
+		var values []string
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := ev.FieldHandlers.ResolveFilePath(ev, &element.ProcessContext.Process.FileEvent)
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.file.path.length":
+		var values []int
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := len(ev.FieldHandlers.ResolveFilePath(ev, &element.ProcessContext.Process.FileEvent))
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.gid":
+		var values []int
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := int(element.ProcessContext.Process.GID)
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.group":
+		var values []string
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := element.ProcessContext.Process.Group
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.pid":
+		var values []int
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := int(element.ProcessContext.Process.PIDContext.Pid)
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.ppid":
+		var values []int
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := int(element.ProcessContext.Process.PPid)
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.uid":
+		var values []int
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := int(element.ProcessContext.Process.UID)
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.ancestors.user":
+		var values []string
+		ctx := eval.NewContext(ev)
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+			result := element.ProcessContext.Process.User
+			values = append(values, result)
+			ptr = iterator.Next()
+		}
+		return values, nil
+	case "process.args_flags":
+		return ev.FieldHandlers.ResolveProcessArgsFlags(ev, &ev.BaseEvent.ProcessContext.Process), nil
+	case "process.args_options":
+		return ev.FieldHandlers.ResolveProcessArgsOptions(ev, &ev.BaseEvent.ProcessContext.Process), nil
+	case "process.argv":
+		return ev.FieldHandlers.ResolveProcessArgv(ev, &ev.BaseEvent.ProcessContext.Process), nil
+	case "process.cmdline":
+		return ev.FieldHandlers.ResolveProcessCmdLine(ev, &ev.BaseEvent.ProcessContext.Process), nil
+	case "process.container.id":
+		return ev.BaseEvent.ProcessContext.Process.ContainerID, nil
+	case "process.created_at":
+		return int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process)), nil
+	case "process.envp":
+		return ev.FieldHandlers.ResolveProcessEnvp(ev, &ev.BaseEvent.ProcessContext.Process), nil
+	case "process.envs":
+		return ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.BaseEvent.ProcessContext.Process), nil
+	case "process.file.name":
+		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent), nil
+	case "process.file.name.length":
+		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent), nil
+	case "process.file.path":
+		return ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent), nil
+	case "process.file.path.length":
+		return ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent), nil
+	case "process.gid":
+		return int(ev.BaseEvent.ProcessContext.Process.GID), nil
+	case "process.group":
+		return ev.BaseEvent.ProcessContext.Process.Group, nil
+	case "process.parent.args_flags":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return []string{}, &eval.ErrNotSupported{Field: field}
+		}
+		return ev.FieldHandlers.ResolveProcessArgsFlags(ev, ev.BaseEvent.ProcessContext.Parent), nil
+	case "process.parent.args_options":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return []string{}, &eval.ErrNotSupported{Field: field}
+		}
+		return ev.FieldHandlers.ResolveProcessArgsOptions(ev, ev.BaseEvent.ProcessContext.Parent), nil
+	case "process.parent.argv":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return []string{}, &eval.ErrNotSupported{Field: field}
+		}
+		return ev.FieldHandlers.ResolveProcessArgv(ev, ev.BaseEvent.ProcessContext.Parent), nil
+	case "process.parent.cmdline":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return "", &eval.ErrNotSupported{Field: field}
+		}
+		return ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.BaseEvent.ProcessContext.Parent), nil
+	case "process.parent.container.id":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return "", &eval.ErrNotSupported{Field: field}
+		}
+		return ev.BaseEvent.ProcessContext.Parent.ContainerID, nil
+	case "process.parent.created_at":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return 0, &eval.ErrNotSupported{Field: field}
+		}
+		return int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.BaseEvent.ProcessContext.Parent)), nil
+	case "process.parent.envp":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return []string{}, &eval.ErrNotSupported{Field: field}
+		}
+		return ev.FieldHandlers.ResolveProcessEnvp(ev, ev.BaseEvent.ProcessContext.Parent), nil
+	case "process.parent.envs":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return []string{}, &eval.ErrNotSupported{Field: field}
+		}
+		return ev.FieldHandlers.ResolveProcessEnvs(ev, ev.BaseEvent.ProcessContext.Parent), nil
+	case "process.parent.file.name":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return "", &eval.ErrNotSupported{Field: field}
+		}
+		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent), nil
+	case "process.parent.file.name.length":
+		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent), nil
+	case "process.parent.file.path":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return "", &eval.ErrNotSupported{Field: field}
+		}
+		return ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent), nil
+	case "process.parent.file.path.length":
+		return ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent), nil
+	case "process.parent.gid":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return 0, &eval.ErrNotSupported{Field: field}
+		}
+		return int(ev.BaseEvent.ProcessContext.Parent.GID), nil
+	case "process.parent.group":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return "", &eval.ErrNotSupported{Field: field}
+		}
+		return ev.BaseEvent.ProcessContext.Parent.Group, nil
+	case "process.parent.pid":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return 0, &eval.ErrNotSupported{Field: field}
+		}
+		return int(ev.BaseEvent.ProcessContext.Parent.PIDContext.Pid), nil
+	case "process.parent.ppid":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return 0, &eval.ErrNotSupported{Field: field}
+		}
+		return int(ev.BaseEvent.ProcessContext.Parent.PPid), nil
+	case "process.parent.uid":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return 0, &eval.ErrNotSupported{Field: field}
+		}
+		return int(ev.BaseEvent.ProcessContext.Parent.UID), nil
+	case "process.parent.user":
+		if !ev.BaseEvent.ProcessContext.HasParent() {
+			return "", &eval.ErrNotSupported{Field: field}
+		}
+		return ev.BaseEvent.ProcessContext.Parent.User, nil
+	case "process.pid":
+		return int(ev.BaseEvent.ProcessContext.Process.PIDContext.Pid), nil
+	case "process.ppid":
+		return int(ev.BaseEvent.ProcessContext.Process.PPid), nil
+	case "process.uid":
+		return int(ev.BaseEvent.ProcessContext.Process.UID), nil
+	case "process.user":
+		return ev.BaseEvent.ProcessContext.Process.User, nil
+	}
+	return nil, &eval.ErrFieldNotFound{Field: field}
+}
+func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
+	switch field {
+	case "container.created_at":
+		return "*", nil
+	case "container.id":
+		return "*", nil
+	case "container.runtime":
+		return "*", nil
+	case "container.tags":
+		return "*", nil
+	case "event.hostname":
+		return "*", nil
+	case "event.origin":
+		return "*", nil
+	case "event.os":
+		return "*", nil
+	case "event.service":
+		return "*", nil
+	case "event.timestamp":
+		return "*", nil
+	case "exec.args_flags":
+		return "exec", nil
+	case "exec.args_options":
+		return "exec", nil
+	case "exec.argv":
+		return "exec", nil
+	case "exec.cmdline":
+		return "exec", nil
+	case "exec.container.id":
+		return "exec", nil
+	case "exec.created_at":
+		return "exec", nil
+	case "exec.envp":
+		return "exec", nil
+	case "exec.envs":
+		return "exec", nil
+	case "exec.file.name":
+		return "exec", nil
+	case "exec.file.name.length":
+		return "exec", nil
+	case "exec.file.path":
+		return "exec", nil
+	case "exec.file.path.length":
+		return "exec", nil
+	case "exec.gid":
+		return "exec", nil
+	case "exec.group":
+		return "exec", nil
+	case "exec.pid":
+		return "exec", nil
+	case "exec.ppid":
+		return "exec", nil
+	case "exec.uid":
+		return "exec", nil
+	case "exec.user":
+		return "exec", nil
+	case "exit.args_flags":
+		return "exit", nil
+	case "exit.args_options":
+		return "exit", nil
+	case "exit.argv":
+		return "exit", nil
+	case "exit.cause":
+		return "exit", nil
+	case "exit.cmdline":
+		return "exit", nil
+	case "exit.code":
+		return "exit", nil
+	case "exit.container.id":
+		return "exit", nil
+	case "exit.created_at":
+		return "exit", nil
+	case "exit.envp":
+		return "exit", nil
+	case "exit.envs":
+		return "exit", nil
+	case "exit.file.name":
+		return "exit", nil
+	case "exit.file.name.length":
+		return "exit", nil
+	case "exit.file.path":
+		return "exit", nil
+	case "exit.file.path.length":
+		return "exit", nil
+	case "exit.gid":
+		return "exit", nil
+	case "exit.group":
+		return "exit", nil
+	case "exit.pid":
+		return "exit", nil
+	case "exit.ppid":
+		return "exit", nil
+	case "exit.uid":
+		return "exit", nil
+	case "exit.user":
+		return "exit", nil
+	case "process.ancestors.args_flags":
+		return "*", nil
+	case "process.ancestors.args_options":
+		return "*", nil
+	case "process.ancestors.argv":
+		return "*", nil
+	case "process.ancestors.cmdline":
+		return "*", nil
+	case "process.ancestors.container.id":
+		return "*", nil
+	case "process.ancestors.created_at":
+		return "*", nil
+	case "process.ancestors.envp":
+		return "*", nil
+	case "process.ancestors.envs":
+		return "*", nil
+	case "process.ancestors.file.name":
+		return "*", nil
+	case "process.ancestors.file.name.length":
+		return "*", nil
+	case "process.ancestors.file.path":
+		return "*", nil
+	case "process.ancestors.file.path.length":
+		return "*", nil
+	case "process.ancestors.gid":
+		return "*", nil
+	case "process.ancestors.group":
+		return "*", nil
+	case "process.ancestors.pid":
+		return "*", nil
+	case "process.ancestors.ppid":
+		return "*", nil
+	case "process.ancestors.uid":
+		return "*", nil
+	case "process.ancestors.user":
+		return "*", nil
+	case "process.args_flags":
+		return "*", nil
+	case "process.args_options":
+		return "*", nil
+	case "process.argv":
+		return "*", nil
+	case "process.cmdline":
+		return "*", nil
+	case "process.container.id":
+		return "*", nil
+	case "process.created_at":
+		return "*", nil
+	case "process.envp":
+		return "*", nil
+	case "process.envs":
+		return "*", nil
+	case "process.file.name":
+		return "*", nil
+	case "process.file.name.length":
+		return "*", nil
+	case "process.file.path":
+		return "*", nil
+	case "process.file.path.length":
+		return "*", nil
+	case "process.gid":
+		return "*", nil
+	case "process.group":
+		return "*", nil
+	case "process.parent.args_flags":
+		return "*", nil
+	case "process.parent.args_options":
+		return "*", nil
+	case "process.parent.argv":
+		return "*", nil
+	case "process.parent.cmdline":
+		return "*", nil
+	case "process.parent.container.id":
+		return "*", nil
+	case "process.parent.created_at":
+		return "*", nil
+	case "process.parent.envp":
+		return "*", nil
+	case "process.parent.envs":
+		return "*", nil
+	case "process.parent.file.name":
+		return "*", nil
+	case "process.parent.file.name.length":
+		return "*", nil
+	case "process.parent.file.path":
+		return "*", nil
+	case "process.parent.file.path.length":
+		return "*", nil
+	case "process.parent.gid":
+		return "*", nil
+	case "process.parent.group":
+		return "*", nil
+	case "process.parent.pid":
+		return "*", nil
+	case "process.parent.ppid":
+		return "*", nil
+	case "process.parent.uid":
+		return "*", nil
+	case "process.parent.user":
+		return "*", nil
+	case "process.pid":
+		return "*", nil
+	case "process.ppid":
+		return "*", nil
+	case "process.uid":
+		return "*", nil
+	case "process.user":
+		return "*", nil
+	}
+	return "", &eval.ErrFieldNotFound{Field: field}
+}
+func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
+	switch field {
+	case "container.created_at":
+		return reflect.Int, nil
+	case "container.id":
+		return reflect.String, nil
+	case "container.runtime":
+		return reflect.String, nil
+	case "container.tags":
+		return reflect.String, nil
+	case "event.hostname":
+		return reflect.String, nil
+	case "event.origin":
+		return reflect.String, nil
+	case "event.os":
+		return reflect.String, nil
+	case "event.service":
+		return reflect.String, nil
+	case "event.timestamp":
+		return reflect.Int, nil
+	case "exec.args_flags":
+		return reflect.String, nil
+	case "exec.args_options":
+		return reflect.String, nil
+	case "exec.argv":
+		return reflect.String, nil
+	case "exec.cmdline":
+		return reflect.String, nil
+	case "exec.container.id":
+		return reflect.String, nil
+	case "exec.created_at":
+		return reflect.Int, nil
+	case "exec.envp":
+		return reflect.String, nil
+	case "exec.envs":
+		return reflect.String, nil
+	case "exec.file.name":
+		return reflect.String, nil
+	case "exec.file.name.length":
+		return reflect.Int, nil
+	case "exec.file.path":
+		return reflect.String, nil
+	case "exec.file.path.length":
+		return reflect.Int, nil
+	case "exec.gid":
+		return reflect.Int, nil
+	case "exec.group":
+		return reflect.String, nil
+	case "exec.pid":
+		return reflect.Int, nil
+	case "exec.ppid":
+		return reflect.Int, nil
+	case "exec.uid":
+		return reflect.Int, nil
+	case "exec.user":
+		return reflect.String, nil
+	case "exit.args_flags":
+		return reflect.String, nil
+	case "exit.args_options":
+		return reflect.String, nil
+	case "exit.argv":
+		return reflect.String, nil
+	case "exit.cause":
+		return reflect.Int, nil
+	case "exit.cmdline":
+		return reflect.String, nil
+	case "exit.code":
+		return reflect.Int, nil
+	case "exit.container.id":
+		return reflect.String, nil
+	case "exit.created_at":
+		return reflect.Int, nil
+	case "exit.envp":
+		return reflect.String, nil
+	case "exit.envs":
+		return reflect.String, nil
+	case "exit.file.name":
+		return reflect.String, nil
+	case "exit.file.name.length":
+		return reflect.Int, nil
+	case "exit.file.path":
+		return reflect.String, nil
+	case "exit.file.path.length":
+		return reflect.Int, nil
+	case "exit.gid":
+		return reflect.Int, nil
+	case "exit.group":
+		return reflect.String, nil
+	case "exit.pid":
+		return reflect.Int, nil
+	case "exit.ppid":
+		return reflect.Int, nil
+	case "exit.uid":
+		return reflect.Int, nil
+	case "exit.user":
+		return reflect.String, nil
+	case "process.ancestors.args_flags":
+		return reflect.String, nil
+	case "process.ancestors.args_options":
+		return reflect.String, nil
+	case "process.ancestors.argv":
+		return reflect.String, nil
+	case "process.ancestors.cmdline":
+		return reflect.String, nil
+	case "process.ancestors.container.id":
+		return reflect.String, nil
+	case "process.ancestors.created_at":
+		return reflect.Int, nil
+	case "process.ancestors.envp":
+		return reflect.String, nil
+	case "process.ancestors.envs":
+		return reflect.String, nil
+	case "process.ancestors.file.name":
+		return reflect.String, nil
+	case "process.ancestors.file.name.length":
+		return reflect.Int, nil
+	case "process.ancestors.file.path":
+		return reflect.String, nil
+	case "process.ancestors.file.path.length":
+		return reflect.Int, nil
+	case "process.ancestors.gid":
+		return reflect.Int, nil
+	case "process.ancestors.group":
+		return reflect.String, nil
+	case "process.ancestors.pid":
+		return reflect.Int, nil
+	case "process.ancestors.ppid":
+		return reflect.Int, nil
+	case "process.ancestors.uid":
+		return reflect.Int, nil
+	case "process.ancestors.user":
+		return reflect.String, nil
+	case "process.args_flags":
+		return reflect.String, nil
+	case "process.args_options":
+		return reflect.String, nil
+	case "process.argv":
+		return reflect.String, nil
+	case "process.cmdline":
+		return reflect.String, nil
+	case "process.container.id":
+		return reflect.String, nil
+	case "process.created_at":
+		return reflect.Int, nil
+	case "process.envp":
+		return reflect.String, nil
+	case "process.envs":
+		return reflect.String, nil
+	case "process.file.name":
+		return reflect.String, nil
+	case "process.file.name.length":
+		return reflect.Int, nil
+	case "process.file.path":
+		return reflect.String, nil
+	case "process.file.path.length":
+		return reflect.Int, nil
+	case "process.gid":
+		return reflect.Int, nil
+	case "process.group":
+		return reflect.String, nil
+	case "process.parent.args_flags":
+		return reflect.String, nil
+	case "process.parent.args_options":
+		return reflect.String, nil
+	case "process.parent.argv":
+		return reflect.String, nil
+	case "process.parent.cmdline":
+		return reflect.String, nil
+	case "process.parent.container.id":
+		return reflect.String, nil
+	case "process.parent.created_at":
+		return reflect.Int, nil
+	case "process.parent.envp":
+		return reflect.String, nil
+	case "process.parent.envs":
+		return reflect.String, nil
+	case "process.parent.file.name":
+		return reflect.String, nil
+	case "process.parent.file.name.length":
+		return reflect.Int, nil
+	case "process.parent.file.path":
+		return reflect.String, nil
+	case "process.parent.file.path.length":
+		return reflect.Int, nil
+	case "process.parent.gid":
+		return reflect.Int, nil
+	case "process.parent.group":
+		return reflect.String, nil
+	case "process.parent.pid":
+		return reflect.Int, nil
+	case "process.parent.ppid":
+		return reflect.Int, nil
+	case "process.parent.uid":
+		return reflect.Int, nil
+	case "process.parent.user":
+		return reflect.String, nil
+	case "process.pid":
+		return reflect.Int, nil
+	case "process.ppid":
+		return reflect.Int, nil
+	case "process.uid":
+		return reflect.Int, nil
+	case "process.user":
+		return reflect.String, nil
+	}
+	return reflect.Invalid, &eval.ErrFieldNotFound{Field: field}
+}
+func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
+	switch field {
+	case "container.created_at":
+		if ev.BaseEvent.ContainerContext == nil {
+			ev.BaseEvent.ContainerContext = &ContainerContext{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ContainerContext.CreatedAt"}
+		}
+		ev.BaseEvent.ContainerContext.CreatedAt = uint64(rv)
+		return nil
+	case "container.id":
+		if ev.BaseEvent.ContainerContext == nil {
+			ev.BaseEvent.ContainerContext = &ContainerContext{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ContainerContext.ContainerID"}
+		}
+		ev.BaseEvent.ContainerContext.ContainerID = ContainerID(rv)
+		return nil
+	case "container.runtime":
+		if ev.BaseEvent.ContainerContext == nil {
+			ev.BaseEvent.ContainerContext = &ContainerContext{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ContainerContext.Runtime"}
+		}
+		ev.BaseEvent.ContainerContext.Runtime = string(rv)
+		return nil
+	case "container.tags":
+		if ev.BaseEvent.ContainerContext == nil {
+			ev.BaseEvent.ContainerContext = &ContainerContext{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ContainerContext.Tags = append(ev.BaseEvent.ContainerContext.Tags, rv)
+		case []string:
+			ev.BaseEvent.ContainerContext.Tags = append(ev.BaseEvent.ContainerContext.Tags, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ContainerContext.Tags"}
+		}
+		return nil
+	case "event.hostname":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.Hostname"}
+		}
+		ev.BaseEvent.Hostname = string(rv)
+		return nil
+	case "event.origin":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.Origin"}
+		}
+		ev.BaseEvent.Origin = string(rv)
+		return nil
+	case "event.os":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.Os"}
+		}
+		ev.BaseEvent.Os = string(rv)
+		return nil
+	case "event.service":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.Service"}
+		}
+		ev.BaseEvent.Service = string(rv)
+		return nil
+	case "event.timestamp":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.TimestampRaw"}
+		}
+		ev.BaseEvent.TimestampRaw = uint64(rv)
+		return nil
+	case "exec.args_flags":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.Exec.Process.Argv = append(ev.Exec.Process.Argv, rv)
+		case []string:
+			ev.Exec.Process.Argv = append(ev.Exec.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Argv"}
+		}
+		return nil
+	case "exec.args_options":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.Exec.Process.Argv = append(ev.Exec.Process.Argv, rv)
+		case []string:
+			ev.Exec.Process.Argv = append(ev.Exec.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Argv"}
+		}
+		return nil
+	case "exec.argv":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.Exec.Process.Argv = append(ev.Exec.Process.Argv, rv)
+		case []string:
+			ev.Exec.Process.Argv = append(ev.Exec.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Argv"}
+		}
+		return nil
+	case "exec.cmdline":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.CmdLine"}
+		}
+		ev.Exec.Process.CmdLine = string(rv)
+		return nil
+	case "exec.container.id":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.ContainerID"}
+		}
+		ev.Exec.Process.ContainerID = string(rv)
+		return nil
+	case "exec.created_at":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.CreatedAt"}
+		}
+		ev.Exec.Process.CreatedAt = uint64(rv)
+		return nil
+	case "exec.envp":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.Exec.Process.Envp = append(ev.Exec.Process.Envp, rv)
+		case []string:
+			ev.Exec.Process.Envp = append(ev.Exec.Process.Envp, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Envp"}
+		}
+		return nil
+	case "exec.envs":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.Exec.Process.Envs = append(ev.Exec.Process.Envs, rv)
+		case []string:
+			ev.Exec.Process.Envs = append(ev.Exec.Process.Envs, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Envs"}
+		}
+		return nil
+	case "exec.file.name":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.BasenameStr"}
+		}
+		ev.Exec.Process.FileEvent.BasenameStr = string(rv)
+		return nil
+	case "exec.file.name.length":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "exec.file.name.length"}
+	case "exec.file.path":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.PathnameStr"}
+		}
+		ev.Exec.Process.FileEvent.PathnameStr = string(rv)
+		return nil
+	case "exec.file.path.length":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "exec.file.path.length"}
+	case "exec.gid":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.GID"}
+		}
+		ev.Exec.Process.GID = uint32(rv)
+		return nil
+	case "exec.group":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Group"}
+		}
+		ev.Exec.Process.Group = string(rv)
+		return nil
+	case "exec.pid":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.PIDContext.Pid"}
+		}
+		ev.Exec.Process.PIDContext.Pid = uint32(rv)
+		return nil
+	case "exec.ppid":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.PPid"}
+		}
+		ev.Exec.Process.PPid = uint32(rv)
+		return nil
+	case "exec.uid":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.UID"}
+		}
+		ev.Exec.Process.UID = uint32(rv)
+		return nil
+	case "exec.user":
+		if ev.Exec.Process == nil {
+			ev.Exec.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.User"}
+		}
+		ev.Exec.Process.User = string(rv)
+		return nil
+	case "exit.args_flags":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.Exit.Process.Argv = append(ev.Exit.Process.Argv, rv)
+		case []string:
+			ev.Exit.Process.Argv = append(ev.Exit.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.Argv"}
+		}
+		return nil
+	case "exit.args_options":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.Exit.Process.Argv = append(ev.Exit.Process.Argv, rv)
+		case []string:
+			ev.Exit.Process.Argv = append(ev.Exit.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.Argv"}
+		}
+		return nil
+	case "exit.argv":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.Exit.Process.Argv = append(ev.Exit.Process.Argv, rv)
+		case []string:
+			ev.Exit.Process.Argv = append(ev.Exit.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.Argv"}
+		}
+		return nil
+	case "exit.cause":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Cause"}
+		}
+		ev.Exit.Cause = uint32(rv)
+		return nil
+	case "exit.cmdline":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.CmdLine"}
+		}
+		ev.Exit.Process.CmdLine = string(rv)
+		return nil
+	case "exit.code":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Code"}
+		}
+		ev.Exit.Code = uint32(rv)
+		return nil
+	case "exit.container.id":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.ContainerID"}
+		}
+		ev.Exit.Process.ContainerID = string(rv)
+		return nil
+	case "exit.created_at":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.CreatedAt"}
+		}
+		ev.Exit.Process.CreatedAt = uint64(rv)
+		return nil
+	case "exit.envp":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.Exit.Process.Envp = append(ev.Exit.Process.Envp, rv)
+		case []string:
+			ev.Exit.Process.Envp = append(ev.Exit.Process.Envp, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.Envp"}
+		}
+		return nil
+	case "exit.envs":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.Exit.Process.Envs = append(ev.Exit.Process.Envs, rv)
+		case []string:
+			ev.Exit.Process.Envs = append(ev.Exit.Process.Envs, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.Envs"}
+		}
+		return nil
+	case "exit.file.name":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.FileEvent.BasenameStr"}
+		}
+		ev.Exit.Process.FileEvent.BasenameStr = string(rv)
+		return nil
+	case "exit.file.name.length":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "exit.file.name.length"}
+	case "exit.file.path":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.FileEvent.PathnameStr"}
+		}
+		ev.Exit.Process.FileEvent.PathnameStr = string(rv)
+		return nil
+	case "exit.file.path.length":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "exit.file.path.length"}
+	case "exit.gid":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.GID"}
+		}
+		ev.Exit.Process.GID = uint32(rv)
+		return nil
+	case "exit.group":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.Group"}
+		}
+		ev.Exit.Process.Group = string(rv)
+		return nil
+	case "exit.pid":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.PIDContext.Pid"}
+		}
+		ev.Exit.Process.PIDContext.Pid = uint32(rv)
+		return nil
+	case "exit.ppid":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.PPid"}
+		}
+		ev.Exit.Process.PPid = uint32(rv)
+		return nil
+	case "exit.uid":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.UID"}
+		}
+		ev.Exit.Process.UID = uint32(rv)
+		return nil
+	case "exit.user":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exit.Process.User"}
+		}
+		ev.Exit.Process.User = string(rv)
+		return nil
+	case "process.ancestors.args_flags":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv"}
+		}
+		return nil
+	case "process.ancestors.args_options":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv"}
+		}
+		return nil
+	case "process.ancestors.argv":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Argv"}
+		}
+		return nil
+	case "process.ancestors.cmdline":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.CmdLine"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.CmdLine = string(rv)
+		return nil
+	case "process.ancestors.container.id":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerID"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerID = string(rv)
+		return nil
+	case "process.ancestors.created_at":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.CreatedAt"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.CreatedAt = uint64(rv)
+		return nil
+	case "process.ancestors.envp":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Envp = append(ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Envp, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Envp = append(ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Envp, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Envp"}
+		}
+		return nil
+	case "process.ancestors.envs":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Envs = append(ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Envs, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Envs = append(ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Envs, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Envs"}
+		}
+		return nil
+	case "process.ancestors.file.name":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.BasenameStr"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.BasenameStr = string(rv)
+		return nil
+	case "process.ancestors.file.name.length":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "process.ancestors.file.name.length"}
+	case "process.ancestors.file.path":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PathnameStr"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PathnameStr = string(rv)
+		return nil
+	case "process.ancestors.file.path.length":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "process.ancestors.file.path.length"}
+	case "process.ancestors.gid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.GID"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.GID = uint32(rv)
+		return nil
+	case "process.ancestors.group":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Group"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Group = string(rv)
+		return nil
+	case "process.ancestors.pid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.PIDContext.Pid"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.PIDContext.Pid = uint32(rv)
+		return nil
+	case "process.ancestors.ppid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.PPid"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.PPid = uint32(rv)
+		return nil
+	case "process.ancestors.uid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UID"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UID = uint32(rv)
+		return nil
+	case "process.ancestors.user":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Ancestor == nil {
+			ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.User"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.User = string(rv)
+		return nil
+	case "process.args_flags":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Process.Argv, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.Argv"}
+		}
+		return nil
+	case "process.args_options":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Process.Argv, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.Argv"}
+		}
+		return nil
+	case "process.argv":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Process.Argv, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Process.Argv = append(ev.BaseEvent.ProcessContext.Process.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.Argv"}
+		}
+		return nil
+	case "process.cmdline":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.CmdLine"}
+		}
+		ev.BaseEvent.ProcessContext.Process.CmdLine = string(rv)
+		return nil
+	case "process.container.id":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.ContainerID"}
+		}
+		ev.BaseEvent.ProcessContext.Process.ContainerID = string(rv)
+		return nil
+	case "process.created_at":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.CreatedAt"}
+		}
+		ev.BaseEvent.ProcessContext.Process.CreatedAt = uint64(rv)
+		return nil
+	case "process.envp":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Process.Envp = append(ev.BaseEvent.ProcessContext.Process.Envp, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Process.Envp = append(ev.BaseEvent.ProcessContext.Process.Envp, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.Envp"}
+		}
+		return nil
+	case "process.envs":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Process.Envs = append(ev.BaseEvent.ProcessContext.Process.Envs, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Process.Envs = append(ev.BaseEvent.ProcessContext.Process.Envs, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.Envs"}
+		}
+		return nil
+	case "process.file.name":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.FileEvent.BasenameStr"}
+		}
+		ev.BaseEvent.ProcessContext.Process.FileEvent.BasenameStr = string(rv)
+		return nil
+	case "process.file.name.length":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "process.file.name.length"}
+	case "process.file.path":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.FileEvent.PathnameStr"}
+		}
+		ev.BaseEvent.ProcessContext.Process.FileEvent.PathnameStr = string(rv)
+		return nil
+	case "process.file.path.length":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "process.file.path.length"}
+	case "process.gid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.GID"}
+		}
+		ev.BaseEvent.ProcessContext.Process.GID = uint32(rv)
+		return nil
+	case "process.group":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.Group"}
+		}
+		ev.BaseEvent.ProcessContext.Process.Group = string(rv)
+		return nil
+	case "process.parent.args_flags":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Parent.Argv = append(ev.BaseEvent.ProcessContext.Parent.Argv, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Parent.Argv = append(ev.BaseEvent.ProcessContext.Parent.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.Argv"}
+		}
+		return nil
+	case "process.parent.args_options":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Parent.Argv = append(ev.BaseEvent.ProcessContext.Parent.Argv, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Parent.Argv = append(ev.BaseEvent.ProcessContext.Parent.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.Argv"}
+		}
+		return nil
+	case "process.parent.argv":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Parent.Argv = append(ev.BaseEvent.ProcessContext.Parent.Argv, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Parent.Argv = append(ev.BaseEvent.ProcessContext.Parent.Argv, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.Argv"}
+		}
+		return nil
+	case "process.parent.cmdline":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.CmdLine"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.CmdLine = string(rv)
+		return nil
+	case "process.parent.container.id":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.ContainerID"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.ContainerID = string(rv)
+		return nil
+	case "process.parent.created_at":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.CreatedAt"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.CreatedAt = uint64(rv)
+		return nil
+	case "process.parent.envp":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Parent.Envp = append(ev.BaseEvent.ProcessContext.Parent.Envp, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Parent.Envp = append(ev.BaseEvent.ProcessContext.Parent.Envp, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.Envp"}
+		}
+		return nil
+	case "process.parent.envs":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		switch rv := value.(type) {
+		case string:
+			ev.BaseEvent.ProcessContext.Parent.Envs = append(ev.BaseEvent.ProcessContext.Parent.Envs, rv)
+		case []string:
+			ev.BaseEvent.ProcessContext.Parent.Envs = append(ev.BaseEvent.ProcessContext.Parent.Envs, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.Envs"}
+		}
+		return nil
+	case "process.parent.file.name":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.FileEvent.BasenameStr"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.FileEvent.BasenameStr = string(rv)
+		return nil
+	case "process.parent.file.name.length":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "process.parent.file.name.length"}
+	case "process.parent.file.path":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.FileEvent.PathnameStr"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.FileEvent.PathnameStr = string(rv)
+		return nil
+	case "process.parent.file.path.length":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "process.parent.file.path.length"}
+	case "process.parent.gid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.GID"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.GID = uint32(rv)
+		return nil
+	case "process.parent.group":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.Group"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.Group = string(rv)
+		return nil
+	case "process.parent.pid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.PIDContext.Pid"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.PIDContext.Pid = uint32(rv)
+		return nil
+	case "process.parent.ppid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.PPid"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.PPid = uint32(rv)
+		return nil
+	case "process.parent.uid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.UID"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.UID = uint32(rv)
+		return nil
+	case "process.parent.user":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		if ev.BaseEvent.ProcessContext.Parent == nil {
+			ev.BaseEvent.ProcessContext.Parent = &Process{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Parent.User"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.User = string(rv)
+		return nil
+	case "process.pid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.PIDContext.Pid"}
+		}
+		ev.BaseEvent.ProcessContext.Process.PIDContext.Pid = uint32(rv)
+		return nil
+	case "process.ppid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.PPid"}
+		}
+		ev.BaseEvent.ProcessContext.Process.PPid = uint32(rv)
+		return nil
+	case "process.uid":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.UID"}
+		}
+		ev.BaseEvent.ProcessContext.Process.UID = uint32(rv)
+		return nil
+	case "process.user":
+		if ev.BaseEvent.ProcessContext == nil {
+			ev.BaseEvent.ProcessContext = &ProcessContext{}
+		}
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ProcessContext.Process.User"}
+		}
+		ev.BaseEvent.ProcessContext.Process.User = string(rv)
+		return nil
+	}
+	return &eval.ErrFieldNotFound{Field: field}
+}

--- a/pkg/security/secl/model/accessors_linux.go
+++ b/pkg/security/secl/model/accessors_linux.go
@@ -4,7 +4,7 @@
 // Copyright 2022-present Datadog, Inc.
 // Code generated - DO NOT EDIT.
 
-//go:build unix
+//go:build linux
 
 package model
 

--- a/pkg/security/secl/model/field_accessors_darwin.go
+++ b/pkg/security/secl/model/field_accessors_darwin.go
@@ -1,0 +1,1381 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+// Code generated - DO NOT EDIT.
+
+//go:build darwin
+
+package model
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"time"
+)
+
+// GetContainerCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetContainerCreatedAt() int {
+	if ev.BaseEvent.ContainerContext == nil {
+		return 0
+	}
+	return ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext)
+}
+
+// GetContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetContainerId() string {
+	if ev.BaseEvent.ContainerContext == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext)
+}
+
+// GetContainerRuntime returns the value of the field, resolving if necessary
+func (ev *Event) GetContainerRuntime() string {
+	if ev.BaseEvent.ContainerContext == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveContainerRuntime(ev, ev.BaseEvent.ContainerContext)
+}
+
+// GetContainerTags returns the value of the field, resolving if necessary
+func (ev *Event) GetContainerTags() []string {
+	if ev.BaseEvent.ContainerContext == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext)
+}
+
+// GetEventHostname returns the value of the field, resolving if necessary
+func (ev *Event) GetEventHostname() string {
+	return ev.FieldHandlers.ResolveHostname(ev, &ev.BaseEvent)
+}
+
+// GetEventOrigin returns the value of the field, resolving if necessary
+func (ev *Event) GetEventOrigin() string {
+	return ev.BaseEvent.Origin
+}
+
+// GetEventOs returns the value of the field, resolving if necessary
+func (ev *Event) GetEventOs() string {
+	return ev.BaseEvent.Os
+}
+
+// GetEventService returns the value of the field, resolving if necessary
+func (ev *Event) GetEventService() string {
+	return ev.FieldHandlers.ResolveService(ev, &ev.BaseEvent)
+}
+
+// GetEventTimestamp returns the value of the field, resolving if necessary
+func (ev *Event) GetEventTimestamp() int {
+	return ev.FieldHandlers.ResolveEventTimestamp(ev, &ev.BaseEvent)
+}
+
+// GetExecArgsFlags returns the value of the field, resolving if necessary
+func (ev *Event) GetExecArgsFlags() []string {
+	if ev.GetEventType().String() != "exec" {
+		return []string{}
+	}
+	if ev.Exec.Process == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgsFlags(ev, ev.Exec.Process)
+}
+
+// GetExecArgsOptions returns the value of the field, resolving if necessary
+func (ev *Event) GetExecArgsOptions() []string {
+	if ev.GetEventType().String() != "exec" {
+		return []string{}
+	}
+	if ev.Exec.Process == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgsOptions(ev, ev.Exec.Process)
+}
+
+// GetExecArgv returns the value of the field, resolving if necessary
+func (ev *Event) GetExecArgv() []string {
+	if ev.GetEventType().String() != "exec" {
+		return []string{}
+	}
+	if ev.Exec.Process == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgv(ev, ev.Exec.Process)
+}
+
+// GetExecCmdline returns the value of the field, resolving if necessary
+func (ev *Event) GetExecCmdline() string {
+	if ev.GetEventType().String() != "exec" {
+		return ""
+	}
+	if ev.Exec.Process == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exec.Process)
+}
+
+// GetExecCmdlineScrubbed returns the value of the field, resolving if necessary
+func (ev *Event) GetExecCmdlineScrubbed() string {
+	if ev.GetEventType().String() != "exec" {
+		return ""
+	}
+	if ev.Exec.Process == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveProcessCmdLineScrubbed(ev, ev.Exec.Process)
+}
+
+// GetExecContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetExecContainerId() string {
+	if ev.GetEventType().String() != "exec" {
+		return ""
+	}
+	if ev.Exec.Process == nil {
+		return ""
+	}
+	return ev.Exec.Process.ContainerID
+}
+
+// GetExecCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetExecCreatedAt() int {
+	if ev.GetEventType().String() != "exec" {
+		return 0
+	}
+	if ev.Exec.Process == nil {
+		return 0
+	}
+	return ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exec.Process)
+}
+
+// GetExecEnvp returns the value of the field, resolving if necessary
+func (ev *Event) GetExecEnvp() []string {
+	if ev.GetEventType().String() != "exec" {
+		return []string{}
+	}
+	if ev.Exec.Process == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exec.Process)
+}
+
+// GetExecEnvs returns the value of the field, resolving if necessary
+func (ev *Event) GetExecEnvs() []string {
+	if ev.GetEventType().String() != "exec" {
+		return []string{}
+	}
+	if ev.Exec.Process == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exec.Process)
+}
+
+// GetExecExecTime returns the value of the field, resolving if necessary
+func (ev *Event) GetExecExecTime() time.Time {
+	if ev.GetEventType().String() != "exec" {
+		return time.Time{}
+	}
+	if ev.Exec.Process == nil {
+		return time.Time{}
+	}
+	return ev.Exec.Process.ExecTime
+}
+
+// GetExecExitTime returns the value of the field, resolving if necessary
+func (ev *Event) GetExecExitTime() time.Time {
+	if ev.GetEventType().String() != "exec" {
+		return time.Time{}
+	}
+	if ev.Exec.Process == nil {
+		return time.Time{}
+	}
+	return ev.Exec.Process.ExitTime
+}
+
+// GetExecFileName returns the value of the field, resolving if necessary
+func (ev *Event) GetExecFileName() string {
+	if ev.GetEventType().String() != "exec" {
+		return ""
+	}
+	if ev.Exec.Process == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exec.Process.FileEvent)
+}
+
+// GetExecFileNameLength returns the value of the field, resolving if necessary
+func (ev *Event) GetExecFileNameLength() int {
+	if ev.GetEventType().String() != "exec" {
+		return 0
+	}
+	if ev.Exec.Process == nil {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exec.Process.FileEvent))
+}
+
+// GetExecFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetExecFilePath() string {
+	if ev.GetEventType().String() != "exec" {
+		return ""
+	}
+	if ev.Exec.Process == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent)
+}
+
+// GetExecFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetExecFilePathLength() int {
+	if ev.GetEventType().String() != "exec" {
+		return 0
+	}
+	if ev.Exec.Process == nil {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent))
+}
+
+// GetExecGid returns the value of the field, resolving if necessary
+func (ev *Event) GetExecGid() uint32 {
+	if ev.GetEventType().String() != "exec" {
+		return uint32(0)
+	}
+	if ev.Exec.Process == nil {
+		return uint32(0)
+	}
+	return ev.Exec.Process.GID
+}
+
+// GetExecGroup returns the value of the field, resolving if necessary
+func (ev *Event) GetExecGroup() string {
+	if ev.GetEventType().String() != "exec" {
+		return ""
+	}
+	if ev.Exec.Process == nil {
+		return ""
+	}
+	return ev.Exec.Process.Group
+}
+
+// GetExecPid returns the value of the field, resolving if necessary
+func (ev *Event) GetExecPid() uint32 {
+	if ev.GetEventType().String() != "exec" {
+		return uint32(0)
+	}
+	if ev.Exec.Process == nil {
+		return uint32(0)
+	}
+	return ev.Exec.Process.PIDContext.Pid
+}
+
+// GetExecPpid returns the value of the field, resolving if necessary
+func (ev *Event) GetExecPpid() uint32 {
+	if ev.GetEventType().String() != "exec" {
+		return uint32(0)
+	}
+	if ev.Exec.Process == nil {
+		return uint32(0)
+	}
+	return ev.Exec.Process.PPid
+}
+
+// GetExecUid returns the value of the field, resolving if necessary
+func (ev *Event) GetExecUid() uint32 {
+	if ev.GetEventType().String() != "exec" {
+		return uint32(0)
+	}
+	if ev.Exec.Process == nil {
+		return uint32(0)
+	}
+	return ev.Exec.Process.UID
+}
+
+// GetExecUser returns the value of the field, resolving if necessary
+func (ev *Event) GetExecUser() string {
+	if ev.GetEventType().String() != "exec" {
+		return ""
+	}
+	if ev.Exec.Process == nil {
+		return ""
+	}
+	return ev.Exec.Process.User
+}
+
+// GetExitArgsFlags returns the value of the field, resolving if necessary
+func (ev *Event) GetExitArgsFlags() []string {
+	if ev.GetEventType().String() != "exit" {
+		return []string{}
+	}
+	if ev.Exit.Process == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgsFlags(ev, ev.Exit.Process)
+}
+
+// GetExitArgsOptions returns the value of the field, resolving if necessary
+func (ev *Event) GetExitArgsOptions() []string {
+	if ev.GetEventType().String() != "exit" {
+		return []string{}
+	}
+	if ev.Exit.Process == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgsOptions(ev, ev.Exit.Process)
+}
+
+// GetExitArgv returns the value of the field, resolving if necessary
+func (ev *Event) GetExitArgv() []string {
+	if ev.GetEventType().String() != "exit" {
+		return []string{}
+	}
+	if ev.Exit.Process == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgv(ev, ev.Exit.Process)
+}
+
+// GetExitCause returns the value of the field, resolving if necessary
+func (ev *Event) GetExitCause() uint32 {
+	if ev.GetEventType().String() != "exit" {
+		return uint32(0)
+	}
+	return ev.Exit.Cause
+}
+
+// GetExitCmdline returns the value of the field, resolving if necessary
+func (ev *Event) GetExitCmdline() string {
+	if ev.GetEventType().String() != "exit" {
+		return ""
+	}
+	if ev.Exit.Process == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exit.Process)
+}
+
+// GetExitCmdlineScrubbed returns the value of the field, resolving if necessary
+func (ev *Event) GetExitCmdlineScrubbed() string {
+	if ev.GetEventType().String() != "exit" {
+		return ""
+	}
+	if ev.Exit.Process == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveProcessCmdLineScrubbed(ev, ev.Exit.Process)
+}
+
+// GetExitCode returns the value of the field, resolving if necessary
+func (ev *Event) GetExitCode() uint32 {
+	if ev.GetEventType().String() != "exit" {
+		return uint32(0)
+	}
+	return ev.Exit.Code
+}
+
+// GetExitContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetExitContainerId() string {
+	if ev.GetEventType().String() != "exit" {
+		return ""
+	}
+	if ev.Exit.Process == nil {
+		return ""
+	}
+	return ev.Exit.Process.ContainerID
+}
+
+// GetExitCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetExitCreatedAt() int {
+	if ev.GetEventType().String() != "exit" {
+		return 0
+	}
+	if ev.Exit.Process == nil {
+		return 0
+	}
+	return ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exit.Process)
+}
+
+// GetExitEnvp returns the value of the field, resolving if necessary
+func (ev *Event) GetExitEnvp() []string {
+	if ev.GetEventType().String() != "exit" {
+		return []string{}
+	}
+	if ev.Exit.Process == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exit.Process)
+}
+
+// GetExitEnvs returns the value of the field, resolving if necessary
+func (ev *Event) GetExitEnvs() []string {
+	if ev.GetEventType().String() != "exit" {
+		return []string{}
+	}
+	if ev.Exit.Process == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exit.Process)
+}
+
+// GetExitExecTime returns the value of the field, resolving if necessary
+func (ev *Event) GetExitExecTime() time.Time {
+	if ev.GetEventType().String() != "exit" {
+		return time.Time{}
+	}
+	if ev.Exit.Process == nil {
+		return time.Time{}
+	}
+	return ev.Exit.Process.ExecTime
+}
+
+// GetExitExitTime returns the value of the field, resolving if necessary
+func (ev *Event) GetExitExitTime() time.Time {
+	if ev.GetEventType().String() != "exit" {
+		return time.Time{}
+	}
+	if ev.Exit.Process == nil {
+		return time.Time{}
+	}
+	return ev.Exit.Process.ExitTime
+}
+
+// GetExitFileName returns the value of the field, resolving if necessary
+func (ev *Event) GetExitFileName() string {
+	if ev.GetEventType().String() != "exit" {
+		return ""
+	}
+	if ev.Exit.Process == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exit.Process.FileEvent)
+}
+
+// GetExitFileNameLength returns the value of the field, resolving if necessary
+func (ev *Event) GetExitFileNameLength() int {
+	if ev.GetEventType().String() != "exit" {
+		return 0
+	}
+	if ev.Exit.Process == nil {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exit.Process.FileEvent))
+}
+
+// GetExitFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetExitFilePath() string {
+	if ev.GetEventType().String() != "exit" {
+		return ""
+	}
+	if ev.Exit.Process == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent)
+}
+
+// GetExitFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetExitFilePathLength() int {
+	if ev.GetEventType().String() != "exit" {
+		return 0
+	}
+	if ev.Exit.Process == nil {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent))
+}
+
+// GetExitGid returns the value of the field, resolving if necessary
+func (ev *Event) GetExitGid() uint32 {
+	if ev.GetEventType().String() != "exit" {
+		return uint32(0)
+	}
+	if ev.Exit.Process == nil {
+		return uint32(0)
+	}
+	return ev.Exit.Process.GID
+}
+
+// GetExitGroup returns the value of the field, resolving if necessary
+func (ev *Event) GetExitGroup() string {
+	if ev.GetEventType().String() != "exit" {
+		return ""
+	}
+	if ev.Exit.Process == nil {
+		return ""
+	}
+	return ev.Exit.Process.Group
+}
+
+// GetExitPid returns the value of the field, resolving if necessary
+func (ev *Event) GetExitPid() uint32 {
+	if ev.GetEventType().String() != "exit" {
+		return uint32(0)
+	}
+	if ev.Exit.Process == nil {
+		return uint32(0)
+	}
+	return ev.Exit.Process.PIDContext.Pid
+}
+
+// GetExitPpid returns the value of the field, resolving if necessary
+func (ev *Event) GetExitPpid() uint32 {
+	if ev.GetEventType().String() != "exit" {
+		return uint32(0)
+	}
+	if ev.Exit.Process == nil {
+		return uint32(0)
+	}
+	return ev.Exit.Process.PPid
+}
+
+// GetExitUid returns the value of the field, resolving if necessary
+func (ev *Event) GetExitUid() uint32 {
+	if ev.GetEventType().String() != "exit" {
+		return uint32(0)
+	}
+	if ev.Exit.Process == nil {
+		return uint32(0)
+	}
+	return ev.Exit.Process.UID
+}
+
+// GetExitUser returns the value of the field, resolving if necessary
+func (ev *Event) GetExitUser() string {
+	if ev.GetEventType().String() != "exit" {
+		return ""
+	}
+	if ev.Exit.Process == nil {
+		return ""
+	}
+	return ev.Exit.Process.User
+}
+
+// GetProcessAncestorsArgsFlags returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsArgsFlags() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveProcessArgsFlags(ev, &element.ProcessContext.Process)
+		values = append(values, result...)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsArgsOptions returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsArgsOptions() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveProcessArgsOptions(ev, &element.ProcessContext.Process)
+		values = append(values, result...)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsArgv returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsArgv() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveProcessArgv(ev, &element.ProcessContext.Process)
+		values = append(values, result...)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsCmdline returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsCmdline() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveProcessCmdLine(ev, &element.ProcessContext.Process)
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsCmdlineScrubbed returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsCmdlineScrubbed() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveProcessCmdLineScrubbed(ev, &element.ProcessContext.Process)
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsContainerId() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.ContainerID
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsCreatedAt() []int {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []int{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []int{}
+	}
+	var values []int
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, &element.ProcessContext.Process))
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsEnvp returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsEnvp() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveProcessEnvp(ev, &element.ProcessContext.Process)
+		values = append(values, result...)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsEnvs returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsEnvs() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveProcessEnvs(ev, &element.ProcessContext.Process)
+		values = append(values, result...)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsFileName returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsFileName() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveFileBasename(ev, &element.ProcessContext.Process.FileEvent)
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsFileNameLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsFileNameLength() []int {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []int{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []int{}
+	}
+	var values []int
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := len(ev.FieldHandlers.ResolveFileBasename(ev, &element.ProcessContext.Process.FileEvent))
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsFilePath() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveFilePath(ev, &element.ProcessContext.Process.FileEvent)
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsFilePathLength() []int {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []int{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []int{}
+	}
+	var values []int
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := len(ev.FieldHandlers.ResolveFilePath(ev, &element.ProcessContext.Process.FileEvent))
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsGid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsGid() []uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []uint32{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []uint32{}
+	}
+	var values []uint32
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.GID
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsGroup returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsGroup() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.Group
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsPid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsPid() []uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []uint32{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []uint32{}
+	}
+	var values []uint32
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.PIDContext.Pid
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsPpid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsPpid() []uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []uint32{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []uint32{}
+	}
+	var values []uint32
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.PPid
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsUid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsUid() []uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []uint32{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []uint32{}
+	}
+	var values []uint32
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.UID
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsUser returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsUser() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return []string{}
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.User
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessArgsFlags returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessArgsFlags() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgsFlags(ev, &ev.BaseEvent.ProcessContext.Process)
+}
+
+// GetProcessArgsOptions returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessArgsOptions() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgsOptions(ev, &ev.BaseEvent.ProcessContext.Process)
+}
+
+// GetProcessArgv returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessArgv() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgv(ev, &ev.BaseEvent.ProcessContext.Process)
+}
+
+// GetProcessCmdline returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessCmdline() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveProcessCmdLine(ev, &ev.BaseEvent.ProcessContext.Process)
+}
+
+// GetProcessCmdlineScrubbed returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessCmdlineScrubbed() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveProcessCmdLineScrubbed(ev, &ev.BaseEvent.ProcessContext.Process)
+}
+
+// GetProcessContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessContainerId() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	return ev.BaseEvent.ProcessContext.Process.ContainerID
+}
+
+// GetProcessCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessCreatedAt() int {
+	if ev.BaseEvent.ProcessContext == nil {
+		return 0
+	}
+	return ev.FieldHandlers.ResolveProcessCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process)
+}
+
+// GetProcessEnvp returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessEnvp() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessEnvp(ev, &ev.BaseEvent.ProcessContext.Process)
+}
+
+// GetProcessEnvs returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessEnvs() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.BaseEvent.ProcessContext.Process)
+}
+
+// GetProcessExecTime returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessExecTime() time.Time {
+	if ev.BaseEvent.ProcessContext == nil {
+		return time.Time{}
+	}
+	return ev.BaseEvent.ProcessContext.Process.ExecTime
+}
+
+// GetProcessExitTime returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessExitTime() time.Time {
+	if ev.BaseEvent.ProcessContext == nil {
+		return time.Time{}
+	}
+	return ev.BaseEvent.ProcessContext.Process.ExitTime
+}
+
+// GetProcessFileName returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessFileName() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+}
+
+// GetProcessFileNameLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessFileNameLength() int {
+	if ev.BaseEvent.ProcessContext == nil {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent))
+}
+
+// GetProcessFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessFilePath() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+}
+
+// GetProcessFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessFilePathLength() int {
+	if ev.BaseEvent.ProcessContext == nil {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent))
+}
+
+// GetProcessGid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessGid() uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return uint32(0)
+	}
+	return ev.BaseEvent.ProcessContext.Process.GID
+}
+
+// GetProcessGroup returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessGroup() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	return ev.BaseEvent.ProcessContext.Process.Group
+}
+
+// GetProcessParentArgsFlags returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentArgsFlags() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return []string{}
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgsFlags(ev, ev.BaseEvent.ProcessContext.Parent)
+}
+
+// GetProcessParentArgsOptions returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentArgsOptions() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return []string{}
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgsOptions(ev, ev.BaseEvent.ProcessContext.Parent)
+}
+
+// GetProcessParentArgv returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentArgv() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return []string{}
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessArgv(ev, ev.BaseEvent.ProcessContext.Parent)
+}
+
+// GetProcessParentCmdline returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentCmdline() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return ""
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.BaseEvent.ProcessContext.Parent)
+}
+
+// GetProcessParentCmdlineScrubbed returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentCmdlineScrubbed() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return ""
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveProcessCmdLineScrubbed(ev, ev.BaseEvent.ProcessContext.Parent)
+}
+
+// GetProcessParentContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentContainerId() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return ""
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return ""
+	}
+	return ev.BaseEvent.ProcessContext.Parent.ContainerID
+}
+
+// GetProcessParentCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentCreatedAt() int {
+	if ev.BaseEvent.ProcessContext == nil {
+		return 0
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return 0
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return 0
+	}
+	return ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.BaseEvent.ProcessContext.Parent)
+}
+
+// GetProcessParentEnvp returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentEnvp() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return []string{}
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessEnvp(ev, ev.BaseEvent.ProcessContext.Parent)
+}
+
+// GetProcessParentEnvs returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentEnvs() []string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return []string{}
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return []string{}
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return []string{}
+	}
+	return ev.FieldHandlers.ResolveProcessEnvs(ev, ev.BaseEvent.ProcessContext.Parent)
+}
+
+// GetProcessParentFileName returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentFileName() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return ""
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+}
+
+// GetProcessParentFileNameLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentFileNameLength() int {
+	if ev.BaseEvent.ProcessContext == nil {
+		return 0
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent))
+}
+
+// GetProcessParentFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentFilePath() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return ""
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+}
+
+// GetProcessParentFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentFilePathLength() int {
+	if ev.BaseEvent.ProcessContext == nil {
+		return 0
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent))
+}
+
+// GetProcessParentGid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentGid() uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return uint32(0)
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return uint32(0)
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return uint32(0)
+	}
+	return ev.BaseEvent.ProcessContext.Parent.GID
+}
+
+// GetProcessParentGroup returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentGroup() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return ""
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return ""
+	}
+	return ev.BaseEvent.ProcessContext.Parent.Group
+}
+
+// GetProcessParentPid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentPid() uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return uint32(0)
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return uint32(0)
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return uint32(0)
+	}
+	return ev.BaseEvent.ProcessContext.Parent.PIDContext.Pid
+}
+
+// GetProcessParentPpid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentPpid() uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return uint32(0)
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return uint32(0)
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return uint32(0)
+	}
+	return ev.BaseEvent.ProcessContext.Parent.PPid
+}
+
+// GetProcessParentUid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentUid() uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return uint32(0)
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return uint32(0)
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return uint32(0)
+	}
+	return ev.BaseEvent.ProcessContext.Parent.UID
+}
+
+// GetProcessParentUser returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentUser() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return ""
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return ""
+	}
+	return ev.BaseEvent.ProcessContext.Parent.User
+}
+
+// GetProcessPid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessPid() uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return uint32(0)
+	}
+	return ev.BaseEvent.ProcessContext.Process.PIDContext.Pid
+}
+
+// GetProcessPpid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessPpid() uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return uint32(0)
+	}
+	return ev.BaseEvent.ProcessContext.Process.PPid
+}
+
+// GetProcessUid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessUid() uint32 {
+	if ev.BaseEvent.ProcessContext == nil {
+		return uint32(0)
+	}
+	return ev.BaseEvent.ProcessContext.Process.UID
+}
+
+// GetProcessUser returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessUser() string {
+	if ev.BaseEvent.ProcessContext == nil {
+		return ""
+	}
+	return ev.BaseEvent.ProcessContext.Process.User
+}
+
+// GetTimestamp returns the value of the field, resolving if necessary
+func (ev *Event) GetTimestamp() time.Time {
+	return ev.FieldHandlers.ResolveEventTime(ev, &ev.BaseEvent)
+}

--- a/pkg/security/secl/model/field_accessors_linux.go
+++ b/pkg/security/secl/model/field_accessors_linux.go
@@ -4,7 +4,7 @@
 // Copyright 2022-present Datadog, Inc.
 // Code generated - DO NOT EDIT.
 
-//go:build unix
+//go:build linux
 
 package model
 

--- a/pkg/security/secl/model/field_handlers_darwin.go
+++ b/pkg/security/secl/model/field_handlers_darwin.go
@@ -1,0 +1,161 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+// Code generated - DO NOT EDIT.
+
+//go:build darwin
+
+package model
+
+import (
+	"time"
+)
+
+// ResolveFields resolves all the fields associate to the event type. Context fields are automatically resolved.
+func (ev *Event) ResolveFields() {
+	ev.resolveFields(false)
+}
+
+// ResolveFieldsForAD resolves all the fields associate to the event type. Context fields are automatically resolved.
+func (ev *Event) ResolveFieldsForAD() {
+	ev.resolveFields(true)
+}
+func (ev *Event) resolveFields(forADs bool) {
+	// resolve context fields that are not related to any event type
+	_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext)
+	_ = ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext)
+	_ = ev.FieldHandlers.ResolveContainerRuntime(ev, ev.BaseEvent.ContainerContext)
+	if !forADs {
+		_ = ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext)
+	}
+	_ = ev.FieldHandlers.ResolveHostname(ev, &ev.BaseEvent)
+	_ = ev.FieldHandlers.ResolveService(ev, &ev.BaseEvent)
+	_ = ev.FieldHandlers.ResolveEventTimestamp(ev, &ev.BaseEvent)
+	_ = ev.FieldHandlers.ResolveProcessArgv(ev, &ev.BaseEvent.ProcessContext.Process)
+	_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, &ev.BaseEvent.ProcessContext.Process)
+	_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process)
+	_ = ev.FieldHandlers.ResolveProcessEnvp(ev, &ev.BaseEvent.ProcessContext.Process)
+	_ = ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.BaseEvent.ProcessContext.Process)
+	_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+	_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveProcessArgv(ev, ev.BaseEvent.ProcessContext.Parent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.BaseEvent.ProcessContext.Parent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.BaseEvent.ProcessContext.Parent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveProcessEnvp(ev, ev.BaseEvent.ProcessContext.Parent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveProcessEnvs(ev, ev.BaseEvent.ProcessContext.Parent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+	}
+	// resolve event specific fields
+	switch ev.GetEventType().String() {
+	case "exec":
+		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent)
+		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exec.Process.FileEvent)
+		_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exec.Process)
+		_ = ev.FieldHandlers.ResolveProcessArgv(ev, ev.Exec.Process)
+		_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exec.Process)
+		_ = ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exec.Process)
+		_ = ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exec.Process)
+	case "exit":
+		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent)
+		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exit.Process.FileEvent)
+		_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exit.Process)
+		_ = ev.FieldHandlers.ResolveProcessArgv(ev, ev.Exit.Process)
+		_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exit.Process)
+		_ = ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exit.Process)
+		_ = ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exit.Process)
+	}
+}
+
+type FieldHandlers interface {
+	ResolveContainerCreatedAt(ev *Event, e *ContainerContext) int
+	ResolveContainerID(ev *Event, e *ContainerContext) string
+	ResolveContainerRuntime(ev *Event, e *ContainerContext) string
+	ResolveContainerTags(ev *Event, e *ContainerContext) []string
+	ResolveEventTime(ev *Event, e *BaseEvent) time.Time
+	ResolveEventTimestamp(ev *Event, e *BaseEvent) int
+	ResolveFileBasename(ev *Event, e *FileEvent) string
+	ResolveFilePath(ev *Event, e *FileEvent) string
+	ResolveHostname(ev *Event, e *BaseEvent) string
+	ResolveProcessArgsFlags(ev *Event, e *Process) []string
+	ResolveProcessArgsOptions(ev *Event, e *Process) []string
+	ResolveProcessArgv(ev *Event, e *Process) []string
+	ResolveProcessCmdLine(ev *Event, e *Process) string
+	ResolveProcessCmdLineScrubbed(ev *Event, e *Process) string
+	ResolveProcessCreatedAt(ev *Event, e *Process) int
+	ResolveProcessEnvp(ev *Event, e *Process) []string
+	ResolveProcessEnvs(ev *Event, e *Process) []string
+	ResolveService(ev *Event, e *BaseEvent) string
+	// custom handlers not tied to any fields
+	ExtraFieldHandlers
+}
+type FakeFieldHandlers struct{}
+
+func (dfh *FakeFieldHandlers) ResolveContainerCreatedAt(ev *Event, e *ContainerContext) int {
+	return int(e.CreatedAt)
+}
+func (dfh *FakeFieldHandlers) ResolveContainerID(ev *Event, e *ContainerContext) string {
+	return string(e.ContainerID)
+}
+func (dfh *FakeFieldHandlers) ResolveContainerRuntime(ev *Event, e *ContainerContext) string {
+	return string(e.Runtime)
+}
+func (dfh *FakeFieldHandlers) ResolveContainerTags(ev *Event, e *ContainerContext) []string {
+	return []string(e.Tags)
+}
+func (dfh *FakeFieldHandlers) ResolveEventTime(ev *Event, e *BaseEvent) time.Time {
+	return time.Time(e.Timestamp)
+}
+func (dfh *FakeFieldHandlers) ResolveEventTimestamp(ev *Event, e *BaseEvent) int {
+	return int(e.TimestampRaw)
+}
+func (dfh *FakeFieldHandlers) ResolveFileBasename(ev *Event, e *FileEvent) string {
+	return string(e.BasenameStr)
+}
+func (dfh *FakeFieldHandlers) ResolveFilePath(ev *Event, e *FileEvent) string {
+	return string(e.PathnameStr)
+}
+func (dfh *FakeFieldHandlers) ResolveHostname(ev *Event, e *BaseEvent) string {
+	return string(e.Hostname)
+}
+func (dfh *FakeFieldHandlers) ResolveProcessArgsFlags(ev *Event, e *Process) []string {
+	return []string(e.Argv)
+}
+func (dfh *FakeFieldHandlers) ResolveProcessArgsOptions(ev *Event, e *Process) []string {
+	return []string(e.Argv)
+}
+func (dfh *FakeFieldHandlers) ResolveProcessArgv(ev *Event, e *Process) []string {
+	return []string(e.Argv)
+}
+func (dfh *FakeFieldHandlers) ResolveProcessCmdLine(ev *Event, e *Process) string {
+	return string(e.CmdLine)
+}
+func (dfh *FakeFieldHandlers) ResolveProcessCmdLineScrubbed(ev *Event, e *Process) string {
+	return string(e.CmdLineScrubbed)
+}
+func (dfh *FakeFieldHandlers) ResolveProcessCreatedAt(ev *Event, e *Process) int {
+	return int(e.CreatedAt)
+}
+func (dfh *FakeFieldHandlers) ResolveProcessEnvp(ev *Event, e *Process) []string {
+	return []string(e.Envp)
+}
+func (dfh *FakeFieldHandlers) ResolveProcessEnvs(ev *Event, e *Process) []string {
+	return []string(e.Envs)
+}
+func (dfh *FakeFieldHandlers) ResolveService(ev *Event, e *BaseEvent) string {
+	return string(e.Service)
+}

--- a/pkg/security/secl/model/field_handlers_linux.go
+++ b/pkg/security/secl/model/field_handlers_linux.go
@@ -4,7 +4,7 @@
 // Copyright 2022-present Datadog, Inc.
 // Code generated - DO NOT EDIT.
 
-//go:build unix
+//go:build linux
 
 package model
 

--- a/pkg/security/secl/model/model_darwin.go
+++ b/pkg/security/secl/model/model_darwin.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:generate accessors -tags darwin -types-file model.go -output accessors_darwin.go -field-handlers field_handlers_darwin.go -field-accessors-output field_accessors_darwin.go
+
+// Package model holds model related files
+package model
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
+
+// ValidateField validates the value of a field
+func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) error {
+	if m.ExtraValidateFieldFnc != nil {
+		return m.ExtraValidateFieldFnc(field, fieldValue)
+	}
+
+	return nil
+}
+
+// Event represents an event sent from the kernel
+// genaccessors
+type Event struct {
+	BaseEvent
+
+	// process events
+	Exec ExecEvent `field:"exec" event:"exec"` // [7.27] [Process] A process was executed or forked
+	Exit ExitEvent `field:"exit" event:"exit"` // [7.38] [Process] A process was terminated
+}
+
+// FileEvent is the common file event type
+type FileEvent struct {
+	PathnameStr string `field:"path,handler:ResolveFilePath,opts:length"`     // SECLDoc[path] Definition:`File's path` Example:`exec.file.path == "c:\cmd.bat"` Description:`Matches the execution of the file located at c:\cmd.bat`
+	BasenameStr string `field:"name,handler:ResolveFileBasename,opts:length"` // SECLDoc[name] Definition:`File's basename` Example:`exec.file.name == "cmd.bat"` Description:`Matches the execution of any file named cmd.bat.`
+}
+
+// Process represents a process
+type Process struct {
+	PIDContext
+
+	UID   uint32 `field:"uid"`   // SECLDoc[uid] Definition:`UID of the process`
+	GID   uint32 `field:"gid"`   // SECLDoc[gid] Definition:`GID of the process`
+	User  string `field:"user"`  // SECLDoc[user] Definition:`User of the process` Example:`process.user == "root"` Description:`Constrain an event to be triggered by a process running as the root user.`
+	Group string `field:"group"` // SECLDoc[group] Definition:`Group of the process`
+
+	FileEvent FileEvent `field:"file"`
+
+	ContainerID string `field:"container.id"` // SECLDoc[container.id] Definition:`Container ID`
+
+	ExitTime time.Time `field:"exit_time,opts:getters_only" json:"-"`
+	ExecTime time.Time `field:"exec_time,opts:getters_only" json:"-"`
+
+	CreatedAt uint64 `field:"created_at,handler:ResolveProcessCreatedAt"` // SECLDoc[created_at] Definition:`Timestamp of the creation of the process`
+
+	PPid uint32 `field:"ppid"` // SECLDoc[ppid] Definition:`Parent process ID`
+
+	ArgsEntry *ArgsEntry `field:"-" json:"-"`
+	EnvsEntry *EnvsEntry `field:"-" json:"-"`
+
+	Argv []string `field:"argv,handler:ResolveProcessArgv,weight:500; args_flags,handler:ResolveProcessArgsFlags,opts:helper; args_options,handler:ResolveProcessArgsOptions,opts:helper"` // SECLDoc[argv] Definition:`Arguments of the process (as an array, excluding argv0)` Example:`exec.argv in ["127.0.0.1"]` Description:`Matches any process that has this IP address as one of its arguments.` SECLDoc[args_flags] Definition:`Flags in the process arguments` Example:`exec.args_flags in ["s"] && exec.args_flags in ["V"]` Description:`Matches any process with both "-s" and "-V" flags in its arguments. Also matches "-sV".` SECLDoc[args_options] Definition:`Argument of the process as options` Example:`exec.args_options in ["p=0-1024"]` Description:`Matches any process that has either "-p 0-1024" or "--p=0-1024" in its arguments.`
+
+	CmdLine         string `field:"cmdline,handler:ResolveProcessCmdLine,weight:200"` // SECLDoc[cmdline] Definition:`Command line of the process` Example:`exec.cmdline == "-sV -p 22,53,110,143,4564 198.116.0-255.1-127"` Description:`Matches any process with these exact arguments.` Example:`exec.cmdline =~ "* -F * http*"` Description:`Matches any process that has the "-F" argument anywhere before an argument starting with "http".`
+	CmdLineScrubbed string `field:"cmdline_scrubbed,handler:ResolveProcessCmdLineScrubbed,weight:500,opts:getters_only"`
+
+	Envs []string `field:"envs,handler:ResolveProcessEnvs,weight:100"` // SECLDoc[envs] Definition:`Environment variable names of the process`
+	Envp []string `field:"envp,handler:ResolveProcessEnvp,weight:100"` // SECLDoc[envp] Definition:`Environment variables of the process`                                                                                                                         // SECLDoc[envp] Definition:`Environment variables of the process`
+
+	// cache version
+	Variables               eval.Variables `field:"-" json:"-"`
+	ScrubbedCmdLineResolved bool           `field:"-" json:"-"`
+}
+
+// ExecEvent represents a exec event
+type ExecEvent struct {
+	*Process
+}
+
+// PIDContext holds the process context of an kernel event
+type PIDContext struct {
+	Pid uint32 `field:"pid"` // SECLDoc[pid] Definition:`Process ID of the process (also called thread group ID)`
+}
+
+// NetworkDeviceContext defines a network device context
+type NetworkDeviceContext struct{}
+
+// ExtraFieldHandlers handlers not hold by any field
+type ExtraFieldHandlers interface {
+	BaseExtraFieldHandlers
+}

--- a/pkg/security/secl/model/model_helpers_linux.go
+++ b/pkg/security/secl/model/model_helpers_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build unix
+//go:build linux
 
 package model
 

--- a/pkg/security/secl/model/model_linux.go
+++ b/pkg/security/secl/model/model_linux.go
@@ -3,9 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build unix
+//go:build linux
 
-//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -tags unix -types-file model.go -output accessors_unix.go -field-handlers field_handlers_unix.go -doc ../../../../docs/cloud-workload-security/secl_linux.json -field-accessors-output field_accessors_unix.go -verbose
+//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -tags linux -types-file model.go -output accessors_linux.go -field-handlers field_handlers_linux.go -doc ../../../../docs/cloud-workload-security/secl_linux.json -field-accessors-output field_accessors_linux.go -verbose
 
 // Package model holds model related files
 package model

--- a/pkg/security/secl/model/oo_symlink_linux.go
+++ b/pkg/security/secl/model/oo_symlink_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build unix
+//go:build linux
 
 // Package model holds model related files
 package model

--- a/pkg/security/secl/model/process_cache_entry_linux.go
+++ b/pkg/security/secl/model/process_cache_entry_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build unix
+//go:build linux
 
 // Package model holds model related files
 package model

--- a/pkg/security/secl/model/process_cache_entry_linux_test.go
+++ b/pkg/security/secl/model/process_cache_entry_linux_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build unix
+//go:build linux
 
 // Package model holds model related files
 package model

--- a/pkg/security/secl/model/process_cache_entry_others.go
+++ b/pkg/security/secl/model/process_cache_entry_others.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build windows || darwin
+
 package model
 
 import "time"

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux || windows
+//go:build linux || windows || darwin
 
 package serializers
 

--- a/pkg/security/serializers/serializers_darwin.go
+++ b/pkg/security/serializers/serializers_darwin.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package serializers
+
+import (
+	"encoding/json"
+
+	"github.com/DataDog/datadog-agent/pkg/security/events"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+)
+
+// FileSerializer serializes a file to JSON
+// easyjson:json
+type FileSerializer struct {
+	// File path
+	Path string `json:"path,omitempty"`
+	// File basename
+	Name string `json:"name,omitempty"`
+}
+
+// ProcessSerializer serializes a process to JSON
+type ProcessSerializer struct {
+	// Process ID
+	Pid uint32 `json:"pid,omitempty"`
+	// Parent Process ID
+	PPid *uint32 `json:"ppid,omitempty"`
+	// Exec time of the process
+	ExecTime *utils.EasyjsonTime `json:"exec_time,omitempty"`
+	// Exit time of the process
+	ExitTime *utils.EasyjsonTime `json:"exit_time,omitempty"`
+	// File information of the executable
+	Executable *FileSerializer `json:"executable,omitempty"`
+	// Container context
+	Container *ContainerContextSerializer `json:"container,omitempty"`
+	// Command line arguments
+	Args []string `json:"args,omitempty"`
+}
+
+// FileEventSerializer serializes a file event to JSON
+type FileEventSerializer struct {
+	FileSerializer
+}
+
+// NetworkDeviceSerializer serializes the network device context to JSON
+type NetworkDeviceSerializer struct{}
+
+// EventSerializer serializes an event to JSON
+type EventSerializer struct {
+	*BaseEventSerializer
+}
+
+func newFileSerializer(fe *model.FileEvent, e *model.Event, forceInode ...uint64) *FileSerializer { //nolint:revive // TODO fix revive unused-parameter
+	return &FileSerializer{
+		Path: e.FieldHandlers.ResolveFilePath(e, fe),
+		Name: e.FieldHandlers.ResolveFileBasename(e, fe),
+	}
+}
+
+func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer { //nolint:revive // TODO fix revive unused-parameter
+	psSerializer := &ProcessSerializer{
+		ExecTime: utils.NewEasyjsonTimeIfNotZero(ps.ExecTime),
+		ExitTime: utils.NewEasyjsonTimeIfNotZero(ps.ExitTime),
+
+		Pid:        ps.Pid,
+		PPid:       getUint32Pointer(&ps.PPid),
+		Executable: newFileSerializer(&ps.FileEvent, e),
+		Args:       e.FieldHandlers.ResolveProcessArgv(e, ps),
+	}
+
+	if len(ps.ContainerID) != 0 {
+		psSerializer.Container = &ContainerContextSerializer{
+			ID: ps.ContainerID,
+		}
+	}
+	return psSerializer
+}
+
+func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event) *ProcessContextSerializer {
+	if pc == nil || pc.Pid == 0 || e == nil {
+		return nil
+	}
+
+	ps := ProcessContextSerializer{
+		ProcessSerializer: newProcessSerializer(&pc.Process, e),
+	}
+
+	ctx := eval.NewContext(e)
+
+	it := &model.ProcessAncestorsIterator{}
+	ptr := it.Front(ctx)
+
+	first := true
+
+	for ptr != nil {
+		pce := (*model.ProcessCacheEntry)(ptr)
+
+		s := newProcessSerializer(&pce.Process, e)
+		ps.Ancestors = append(ps.Ancestors, s)
+
+		if first {
+			ps.Parent = s
+		}
+		first = false
+
+		ptr = it.Next()
+	}
+
+	return &ps
+}
+
+func serializeOutcome(retval int64) string { //nolint:revive // TODO fix revive unused-parameter
+	return "unknown"
+}
+
+// ToJSON returns json
+func (e *EventSerializer) ToJSON() ([]byte, error) {
+	return json.Marshal(e)
+}
+
+// MarshalEvent marshal the event
+func MarshalEvent(event *model.Event, opts *eval.Opts) ([]byte, error) {
+	s := NewEventSerializer(event, opts)
+	return json.Marshal(s)
+}
+
+// MarshalCustomEvent marshal the custom event
+func MarshalCustomEvent(event *events.CustomEvent) ([]byte, error) {
+	return json.Marshal(event)
+}
+
+// NewEventSerializer creates a new event serializer based on the event type
+func NewEventSerializer(event *model.Event, opts *eval.Opts) *EventSerializer {
+	return &EventSerializer{
+		BaseEventSerializer: NewBaseEventSerializer(event, opts),
+	}
+}

--- a/pkg/security/serializers/serializers_others.go
+++ b/pkg/security/serializers/serializers_others.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux && !windows
+//go:build !(linux || windows || darwin)
 
 // Package serializers defines functions aiming to serialize events
 package serializers

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -655,6 +655,7 @@ def cws_go_generate(ctx, verbose=False):
         ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/operators")
         if sys.platform == "linux":
             ctx.run("GOOS=windows go generate ./...")
+            ctx.run("GOOS=darwin go generate ./...")
         # Disable cross generation from windows for now. Need to fix the stringer issue.
         # elif sys.platform == "win32":
         #     ctx.run("set GOOS=linux && go generate ./...")


### PR DESCRIPTION
### What does this PR do?

This PR implements a new version of CWS in addition to the current linux-ebpf, linux-ebpfless and windows one, this time for macOS.

The main data source for macOS events is the [Apple Endpoint Security](https://developer.apple.com/documentation/endpointsecurity) framework. While some APIs are available to directly fetch and filter events, this POC is based on receiving events from `eslogger` allowing to completely skip binary signing and apple agreement processes for now.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
