### PR TITLE
[process-agent] Remove the unsafe conversion and rely on Go's escape analysis to avoid allocation

### DIFF
--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -20,7 +20,6 @@ import (
 	"syscall"
 	"time"
 	"unicode"
-	"unsafe"
 
 	"go.uber.org/atomic"
 
@@ -533,7 +532,7 @@ func (p *probe) parseStatusKV(key, value []byte, sInfo *statusInfo) {
 		values := bytes.Fields(value)
 		ints := make([]int32, 0, len(values))
 		for _, v := range values {
-			if i, err := parseBytesToInt(v, 10, 32); err == nil {
+			if i, err := strconv.ParseInt(string(v), 10, 32); err == nil {
 				ints = append(ints, int32(i))
 			}
 		}
@@ -545,15 +544,15 @@ func (p *probe) parseStatusKV(key, value []byte, sInfo *statusInfo) {
 	case bytes.Equal(key, keyNSpid):
 		values := bytes.Split(value, []byte("\t"))
 		// only report process namespaced PID
-		if v, err := parseBytesToInt(values[len(values)-1], 10, 32); err == nil {
+		if v, err := strconv.ParseInt(string(values[len(values)-1]), 10, 32); err == nil {
 			sInfo.nspid = int32(v)
 		}
 	case bytes.Equal(key, keyThreads):
-		if v, err := parseBytesToInt(value, 10, 32); err == nil {
+		if v, err := strconv.ParseInt(string(value), 10, 32); err == nil {
 			sInfo.numThreads = int32(v)
 		}
 	case bytes.Equal(key, keyVoluntaryCtxtSwitches), bytes.Equal(key, keyNonvoluntaryCtxtSwitches):
-		if v, err := parseBytesToInt(value, 10, 64); err == nil {
+		if v, err := strconv.ParseInt(string(value), 10, 64); err == nil {
 			if key[0] == 'v' {
 				sInfo.ctxSwitches.Voluntary = v
 			} else {
@@ -565,25 +564,10 @@ func (p *probe) parseStatusKV(key, value []byte, sInfo *statusInfo) {
 	}
 }
 
-func parseBytesToInt(buf []byte, base int, bitSize int) (int64, error) {
-	// Safety: We are not modifying the contents of the byte slice.
-	return strconv.ParseInt(*(*string)(unsafe.Pointer(&buf)), base, bitSize)
-}
-
-func parseBytesToUint(buf []byte, base int, bitSize int) (uint64, error) {
-	// Safety: We are not modifying the contents of the byte slice.
-	return strconv.ParseUint(*(*string)(unsafe.Pointer(&buf)), base, bitSize)
-}
-
-func parseBytesToFloat(buf []byte, bitSize int) (float64, error) {
-	// Safety: We are not modifying the contents of the byte slice.
-	return strconv.ParseFloat(*(*string)(unsafe.Pointer(&buf)), bitSize)
-}
-
 func parseMemInfo(value, key []byte, memInfo *MemoryInfoStat) {
 	value = bytes.TrimSuffix(value, []byte("kB"))
 	value = bytes.TrimSpace(value)
-	if v, err := parseBytesToUint(value, 10, 64); err == nil {
+	if v, err := strconv.ParseUint(string(value), 10, 64); err == nil {
 		v *= 1024
 		switch key[3] { // Using the fourth byte to differentiate between RSS, Size, and Swap
 		case 'S': // VmRSS
@@ -634,23 +618,23 @@ func (p *probe) parseStatContent(statContent []byte, sInfo *statInfo, pid int32,
 			if !prevCharIsSpace {
 				switch spaces {
 				case 2:
-					if ppid, err := parseBytesToInt(buffer, 10, 32); err == nil {
+					if ppid, err := strconv.ParseInt(string(buffer), 10, 32); err == nil {
 						sInfo.ppid = int32(ppid)
 					}
 				case 7:
-					if flags, err := parseBytesToUint(buffer, 10, 32); err == nil {
+					if flags, err := strconv.ParseUint(string(buffer), 10, 32); err == nil {
 						sInfo.flags = uint32(flags)
 					}
 				case 12:
-					if utime, err := parseBytesToFloat(buffer, 64); err == nil {
+					if utime, err := strconv.ParseFloat(string(buffer), 64); err == nil {
 						sInfo.cpuStat.User = utime / p.clockTicks
 					}
 				case 13:
-					if stime, err := parseBytesToFloat(buffer, 64); err == nil {
+					if stime, err := strconv.ParseFloat(string(buffer), 64); err == nil {
 						sInfo.cpuStat.System = stime / p.clockTicks
 					}
 				case 20:
-					if t, err := parseBytesToUint(buffer, 10, 64); err == nil {
+					if t, err := strconv.ParseUint(string(buffer), 10, 64); err == nil {
 						ctime := (t / uint64(p.clockTicks)) + p.bootTime.Load()
 						// convert create time into milliseconds
 						sInfo.createTime = int64(ctime * 1000)


### PR DESCRIPTION
### What does this PR do?
This removes the unsafe calls to get a `[]byte` to `string` to avoid copying as the go compiler is able to optimize this away as of 1.20. This will keep the code simpler and safer to work with.

#### Example code and the Go escape analysis. (notes: code is truncated imports, etc)
```go
func convertToInt(b []byte) (int64, error) {
	val := string(b)
	return strconv.ParseInt(val, 10, 64)
}
```

The escape analysis while running go 1.19.13 shows the `[]byte` is copied when converting to a string causing heap allocation.
```sh
❯ go build -gcflags="-m -m -l" bytes.go
# command-line-arguments
./bytes.go:8:15: string(b) escapes to heap:
./bytes.go:8:15:   flow: val = &{storage for string(b)}:
./bytes.go:8:15:     from string(b) (spill) at ./bytes.go:8:15
./bytes.go:8:15:     from val := string(b) (assign) at ./bytes.go:8:6
./bytes.go:8:15:   flow: {heap} = val:
./bytes.go:8:15:     from strconv.Atoi(val) (call parameter) at ./bytes.go:9:21
./bytes.go:7:19: b does not escape
./bytes.go:8:15: string(b) escapes to heap
```

Using go 1.20 it shows that no copy occurs to convert `[]byte` to string and no heap escape happens which means allocation does not occur.
```sh
❯ go build -gcflags="-m -m -l" bytes.go
# command-line-arguments
./bytes.go:7:19: b does not escape
./bytes.go:8:16: string(b) does not escape
```

This is also demonstrated in a benchmark of the test code
```go
func BenchmarkConvertToInt(b *testing.B) {
	in := "123"
	for i := 0; i < b.N; i++ {
		_, _ = convertToInt([]byte(in))
	}
}
```
#### Results
**go v1.19.13**
```sh
BenchmarkConvertToInt-10        56966983                19.92 ns/op            3 B/op          1 allocs/op

```

**go v1.20**
```sh
BenchmarkConvertToInt-10        83684193                14.19 ns/op            0 B/op          0 allocs/op
```


#### Benchmarks 
```sh
❯ benchstat old.txt new.txt
name                old time/op    new time/op    delta
ParseStatusLine-4      836ns ±14%     838ns ±20%   ~     (p=0.912 n=10+10)
ParseStatContent-4    2.27µs ± 4%    2.26µs ± 2%   ~     (p=0.857 n=9+10)

name                old alloc/op   new alloc/op   delta
ParseStatusLine-4       296B ± 0%      296B ± 0%   ~     (all equal)
ParseStatContent-4     0.00B          0.00B        ~     (all equal)

name                old allocs/op  new allocs/op  delta
ParseStatusLine-4       6.00 ± 0%      6.00 ± 0%   ~     (all equal)
ParseStatContent-4      0.00           0.00        ~     (all equal)

```

#### Raw data (truncated from 10 runs)

###### old.txt
```
BenchmarkParseStatusLine-4       1331600               892.0 ns/op           296 B/op          6 allocs/op
BenchmarkParseStatusLine-4       1387952               830.7 ns/op           296 B/op          6 allocs/op
...
BenchmarkParseStatContent-4       517012              2364 ns/op               0 B/op          0 allocs/op
BenchmarkParseStatContent-4       508501              2302 ns/op               0 B/op          0 allocs/op
...
```

###### new.txt
```
BenchmarkParseStatusLine-4       1281456              1003 ns/op             296 B/op          6 allocs/op
BenchmarkParseStatusLine-4       1320164               834.2 ns/op           296 B/op          6 allocs/op

...
BenchmarkParseStatContent-4       508948              2286 ns/op               0 B/op          0 allocs/op
BenchmarkParseStatContent-4       498462              2293 ns/op               0 B/op          0 allocs/op
...
```

### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
