### PR TITLE
Add fuzzydog invoke task

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -36,6 +36,7 @@ from . import (
 from .build_tags import audit_tag_impact, print_default_build_tags
 from .components import lint_components, lint_fxutil_oneshot_test
 from .fuzz import fuzz
+from .fuzzydog import fuzzydog
 from .go import (
     check_go_version,
     check_mod_tidy,
@@ -115,6 +116,7 @@ ns.add_task(generate_config)
 ns.add_task(junit_upload)
 ns.add_task(junit_macos_repack)
 ns.add_task(fuzz)
+ns.add_task(fuzzydog)
 ns.add_task(go_fix)
 ns.add_task(build_messagetable)
 

--- a/tasks/fuzz.py
+++ b/tasks/fuzz.py
@@ -15,7 +15,7 @@ def fuzz(ctx, fuzztime="10s"):
     """
     for directory, func in search_fuzz_tests(os.getcwd()):
         with ctx.cd(directory):
-            cmd = f'go test -v . -run={func} -fuzz={func}$ -fuzztime={fuzztime}'
+            cmd = f'go test -v . -run={func}s -fuzz={func}$ -fuzztime={fuzztime}'
             ctx.run(cmd)
 
 

--- a/tasks/fuzzydog.py
+++ b/tasks/fuzzydog.py
@@ -1,0 +1,53 @@
+"""
+Helper for running fuzz targets in fuzzing CI.
+"""
+import os
+
+from invoke import task
+
+
+@task
+def fuzzydog(ctx, version, duration="600"):
+    """
+    TODO
+    """
+    cwd = os.getcwd()
+    for directory, funcs in search_fuzz_tests(cwd):
+        with ctx.cd(directory):
+            target_binary = remove_prefix(cwd, directory).replace(os.path.sep, "_")
+            bld = f'go test -c -o ./{target_binary}'
+            ctx.run(bld)
+            fzz = f'fuzzydog fuzzer create datadog-agent --duration={duration} --version={version} --binary={target_binary} --type=go-native-fuzz --team=datadog-agent'
+            ctx.run(fzz)
+            ctx.run(f'rm ./{target_binary}')
+
+def search_fuzz_tests(directory):
+    """
+    Yields (directory, [fuzz function name]) tuples.
+    """
+    for file in os.listdir(directory):
+        path = os.path.join(directory, file)
+        if os.path.isdir(path):
+            for tuple in search_fuzz_tests(path):
+                yield tuple
+        else:
+            if not file.endswith('_test.go'):
+                continue
+            with open(path) as f:
+                funcs = []
+                for line in f.readlines():
+                    if line.startswith('func Fuzz'):
+                        fuzzfunc = line[5 : line.find('(')]  # 5 is len('func ')
+                        funcs.append(fuzzfunc)
+                if funcs:
+                    yield (directory, funcs)
+
+
+def remove_prefix(prefix, directory):
+    directory = os.path.normpath(directory)
+    prefix = os.path.normpath(prefix)
+
+    if directory.startswith(prefix):
+        return directory[len(prefix)+1:]
+    else:
+        return directory

--- a/tasks/fuzzydog.py
+++ b/tasks/fuzzydog.py
@@ -17,8 +17,9 @@ def fuzzydog(ctx, version, duration="600"):
             target_binary = remove_prefix(cwd, directory).replace(os.path.sep, "_")
             bld = f'go test -c -o ./{target_binary}'
             ctx.run(bld)
-            fzz = f'fuzzydog fuzzer create datadog-agent --duration={duration} --version={version} --binary={target_binary} --type=go-native-fuzz --team=datadog-agent'
-            ctx.run(fzz)
+            for target_function in funcs:
+                fzz = f'fuzzydog fuzzer create datadog-agent --duration={duration} --version={version} --function={target_function} --type=go-native-fuzz --team=datadog-agent'
+                ctx.run(fzz)
             ctx.run(f'rm ./{target_binary}')
 
 def search_fuzz_tests(directory):


### PR DESCRIPTION
This commit introduces a task for our internal CI fuzz testing tool fuzzydog. Current progress as of this commit is minimal and is not hooked into CI. I am unsure if it's functioning.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
