### PR TITLE
[ASCII-938] Deprecate `ipc_address` in favor of `cmd_host`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -299,6 +299,7 @@
 /pkg/config/apm.go                      @DataDog/agent-apm
 /pkg/config/autodiscovery/              @Datadog/container-integrations
 /pkg/config/env                         @DataDog/container-integrations @DataDog/container-app
+/pkg/config/env/ipc_address*            @DataDog/agent-shared-components
 /pkg/config/logs                        @Datadog/agent-shared-components @Datadog/agent-platform
 /pkg/config/logs/internal/seelog/seelog_config.go          @Datadog/agent-shared-components
 /pkg/config/process*.go                 @DataDog/processes

--- a/cmd/process-agent/subcommands/status/status_test.go
+++ b/cmd/process-agent/subcommands/status/status_test.go
@@ -87,7 +87,7 @@ func TestNotRunning(t *testing.T) {
 // a connection error
 func TestError(t *testing.T) {
 	cfg := config.Mock(t)
-	cfg.SetWithoutSource("ipc_address", "8.8.8.8") // Non-local ip address will cause error in `GetIPCAddress`
+	cfg.SetWithoutSource("cmd_host", "8.8.8.8") // Non-local ip address will cause error in `GetIPCAddress`
 	_, ipcError := config.GetIPCAddress()
 
 	var errText, expectedErrText strings.Builder

--- a/comp/core/config/config_test.go
+++ b/comp/core/config/config_test.go
@@ -54,7 +54,7 @@ func TestMockConfig(t *testing.T) {
 	require.Equal(t, "https://example.com", config.GetString("dd_url"))
 
 	// but defaults are set
-	require.Equal(t, "localhost", config.GetString("ipc_address"))
+	require.Equal(t, "localhost", config.GetString("cmd_host"))
 
 	// values can also be set by the mock (config.Writer)
 	config.(Mock).Set("app_key", "newvalue", model.SourceAgentRuntime)

--- a/docs/dev/agent_api.md
+++ b/docs/dev/agent_api.md
@@ -5,7 +5,7 @@ groups:
 2. **Telemetry**: These expose some internal telemetry that is useful for profiling and debugging.
 
 ## Control API
-This API is accessible via HTTPS only and listens by default on the `localhost` interface on port `5001`. The listening interface and port can be configured using the `ipc_address` and `cmd_port` config options.
+This API is accessible via HTTPS only and listens by default on the `localhost` interface on port `5001`. The listening interface and port can be configured using the `cmd_host` and `cmd_port` config options.
 
 ### Authentication
 To avoid unprivileged users accessing the Agent control API, authentication is required and based on a generated token.
@@ -79,5 +79,3 @@ $ curl -s http://localhost:5000/debug/pprof/profile?seconds=60 > ./cpu.out
 # Not documented here
 - non-core agent endpoints (i.e., what do the security, process, and cluster agents expose)
 - GRPC endpoints
-
-

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -245,7 +245,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("syslog_pem", "")
 	config.BindEnvAndSetDefault("syslog_key", "")
 	config.BindEnvAndSetDefault("syslog_tls_verify", true)
-	config.BindEnvAndSetDefault("ipc_address", "localhost")
+	config.BindEnv("ipc_address") // deprecated: use `cmd_host` instead
+	config.BindEnvAndSetDefault("cmd_host", "localhost")
 	config.BindEnvAndSetDefault("cmd_port", 5001)
 	config.BindEnvAndSetDefault("default_integration_http_timeout", 9)
 	config.BindEnvAndSetDefault("integration_tracing", false)

--- a/pkg/config/env/ipc_address_test.go
+++ b/pkg/config/env/ipc_address_test.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package env
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+const (
+	localhostStr = "localhost"
+	localhostV4  = "127.0.0.1"
+	localhostV6  = "::1"
+)
+
+func TestGetIPCAddress(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		cfg := getConfig()
+		val, err := GetIPCAddress(cfg)
+		require.NoError(t, err)
+		require.Equal(t, localhostStr, val)
+	})
+
+	t.Run("ipc_address from file", func(t *testing.T) {
+		cfg := getConfig()
+		cfg.Set("ipc_address", localhostV4, model.SourceFile)
+		val, err := GetIPCAddress(cfg)
+		require.NoError(t, err)
+		require.Equal(t, localhostV4, val)
+	})
+
+	t.Run("ipc_address from env", func(t *testing.T) {
+		cfg := getConfig()
+		t.Setenv("DD_IPC_ADDRESS", localhostV4)
+		val, err := GetIPCAddress(cfg)
+		require.NoError(t, err)
+		require.Equal(t, localhostV4, val)
+	})
+
+	t.Run("ipc_address takes precedence over cmd_host", func(t *testing.T) {
+		cfg := getConfig()
+		cfg.Set("ipc_address", localhostV4, model.SourceFile)
+		cfg.Set("cmd_host", localhostV6, model.SourceFile)
+		val, err := GetIPCAddress(cfg)
+		require.NoError(t, err)
+		require.Equal(t, localhostV4, val)
+	})
+
+	t.Run("ipc_address takes precedence over cmd_host", func(t *testing.T) {
+		cfg := getConfig()
+		cfg.Set("cmd_host", localhostV6, model.SourceFile)
+		val, err := GetIPCAddress(cfg)
+		require.NoError(t, err)
+		require.Equal(t, localhostV6, val)
+	})
+
+	t.Run("error if not local", func(t *testing.T) {
+		cfg := getConfig()
+		cfg.Set("cmd_host", "111.111.111.111", model.SourceFile)
+		_, err := GetIPCAddress(cfg)
+		require.Error(t, err)
+	})
+}
+
+func getConfig() model.Config {
+	cfg := model.NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+	cfg.BindEnv("ipc_address")
+	cfg.BindEnvAndSetDefault("cmd_host", localhostStr)
+	return cfg
+}

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -103,7 +103,7 @@ func setupIPCAddress(t *testing.T, URL string) *config.MockConfig {
 	require.NoError(t, err)
 
 	confMock := config.Mock(t)
-	confMock.SetWithoutSource("ipc_address", host)
+	confMock.SetWithoutSource("cmd_host", host)
 	confMock.SetWithoutSource("cmd_port", port)
 	confMock.SetWithoutSource("process_config.cmd_port", port)
 

--- a/releasenotes/notes/deprecate-ipc-address-6ef3bff2e5c13c10.yaml
+++ b/releasenotes/notes/deprecate-ipc-address-6ef3bff2e5c13c10.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    The config value `ipc_address` is deprecated in favor of `cmd_host`.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Deprecate `ipc_address` in favor of `cmd_host`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Current config names for the existing API (`ipc_address`:`cmd_port`) are confusing.
As a new API server will be added to the agent soon, having clearer names for the existing one would be nice.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Check that 
- `ipc_address` can still be used (with text config and environment variable)
- `ipc_address` takes precedence over `cmd_host`
- `cmd_host` is used when `ipc_address` is not provided

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
