### PR TITLE
New release task - RC build page update

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1397,6 +1397,7 @@ def update_build_links(_ctx, new_version):
     ATLASSIAN_PASSWORD is a token. See: https://id.atlassian.com/manage-profile/security/api-tokens
     """
     from atlassian import Confluence
+    from atlassian.confluence import ApiError
 
     BUILD_LINKS_PAGE_ID = 2889876360
 
@@ -1437,12 +1438,12 @@ def update_build_links(_ctx, new_version):
     for key in patterns:
         body = body.replace(key, patterns[key])
 
-    response = confluence.update_page(BUILD_LINKS_PAGE_ID, title, body=body)
-
-    if response.status_code != 200:
+    try:
+        confluence.update_page(BUILD_LINKS_PAGE_ID, title, body=body)
+    except ApiError as e:
         raise Exit(
             color_message(
-                f"Failed to update conluence page. Response status code - {response.status_code}",
+                f"Failed to update confluence page. Reason: {e.reason}",
                 "red",
             ),
             code=1,

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -3,6 +3,7 @@ Release helper tasks
 """
 
 import json
+import os
 import re
 import sys
 from collections import OrderedDict
@@ -34,6 +35,9 @@ from .utils import (
 # - X.Y.Z-devel
 # - vX.Y(.Z) (security-agent-policies repo)
 VERSION_RE = re.compile(r'(v)?(\d+)[.](\d+)([.](\d+))?(-devel)?(-rc\.(\d+))?')
+
+# Regex matching rc version tag format like 7.50.0-rc.1
+RC_VERSION_RE = re.compile(r'\d+[.]\d+[.]\d+-rc\.\d+')
 
 UNFREEZE_REPO_AGENT = "datadog-agent"
 UNFREEZE_REPOS = [UNFREEZE_REPO_AGENT, "omnibus-software", "omnibus-ruby", "datadog-agent-macos-build"]
@@ -1378,3 +1382,72 @@ def check_omnibus_branches(_):
         if omnibus_software_version != 'master' and not version_re.match(omnibus_software_version):
             raise Exit(code=1, message=f'omnibus-software version [{omnibus_software_version}] is not mergeable')
     return True
+
+
+@task
+def update_build_links(_ctx, new_version):
+    """
+    Updates Agent release candidates build links on https://datadoghq.atlassian.net/wiki/spaces/agent/pages/2889876360/Build+links
+
+    new_version - should be given as an Agent 7 RC version, ie. '7.50.0-rc.1' format.
+
+    Notes:
+    Attlasian credentials are required to be available as ATLASSIAN_USERNAME and ATLASSIAN_PASSWORD as environment variables.
+    ATLASSIAN_USERNAME is typically an email address.
+    ATLASSIAN_PASSWORD is a token. See: https://id.atlassian.com/manage-profile/security/api-tokens
+    """
+    from atlassian import Confluence
+
+    BUILD_LINKS_PAGE_ID = 2889876360
+
+    match = RC_VERSION_RE.match(new_version)
+    if not match:
+        raise Exit(
+            color_message(
+                f"{new_version} is not a valid Agent RC version number/tag. \nCorrect example: 7.50.0-rc.1",
+                "red",
+            ),
+            code=1,
+        )
+
+    username = os.getenv("ATLASSIAN_USERNAME")
+    password = os.getenv("ATLASSIAN_PASSWORD")
+
+    if username is None or password is None:
+        raise Exit(
+            color_message(
+                "No Atlassian credentials provided. Check --help for more details.",
+                "red",
+            ),
+            code=1,
+        )
+
+    confluence = Confluence(url="https://datadoghq.atlassian.net/", username=username, password=password)
+
+    content = confluence.get_page_by_id(page_id=BUILD_LINKS_PAGE_ID, expand="body.storage")
+
+    title = content["title"]
+    current_version = title[-11:]
+    body = content["body"]["storage"]["value"]
+
+    title = title.replace(current_version, new_version)
+
+    patterns = _create_build_links_patterns(current_version, new_version)
+
+    for key in patterns:
+        body = body.replace(key, patterns[key])
+
+    confluence.update_page(BUILD_LINKS_PAGE_ID, title, body=body)
+
+
+def _create_build_links_patterns(current_version, new_version):
+    patterns = {}
+
+    current_minor_version = current_version[1:]
+    new_minor_version = new_version[1:]
+
+    patterns[current_minor_version] = new_minor_version
+    patterns[current_minor_version.replace("rc.", "rc-")] = new_minor_version.replace("rc.", "rc-")
+    patterns[current_minor_version.replace("-rc", "~rc")] = new_minor_version.replace("-rc", "~rc")
+
+    return patterns

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1416,7 +1416,7 @@ def update_build_links(_ctx, new_version):
     if username is None or password is None:
         raise Exit(
             color_message(
-                "No Atlassian credentials provided. Check --help for more details.",
+                "No Atlassian credentials provided. Run inv --help update-build-links for more details.",
                 "red",
             ),
             code=1,
@@ -1437,7 +1437,16 @@ def update_build_links(_ctx, new_version):
     for key in patterns:
         body = body.replace(key, patterns[key])
 
-    confluence.update_page(BUILD_LINKS_PAGE_ID, title, body=body)
+    response = confluence.update_page(BUILD_LINKS_PAGE_ID, title, body=body)
+
+    if response.status_code != 200:
+        raise Exit(
+            color_message(
+                f"Failed to update conluence page. Response status code - {response.status_code}",
+                "red",
+            ),
+            code=1,
+        )
 
 
 def _create_build_links_patterns(current_version, new_version):

--- a/tasks/requirements_all_tasks.txt
+++ b/tasks/requirements_all_tasks.txt
@@ -2,3 +2,4 @@
 -r libs/requirements-github.txt
 -r libs/requirements-notifications.txt
 -r show_linters_issues/requirements.txt
+-r requirements_release_tasks.txt

--- a/tasks/requirements_release_tasks.txt
+++ b/tasks/requirements_release_tasks.txt
@@ -1,0 +1,1 @@
+atlassian-python-api==3.41.3

--- a/tasks/unit-tests/release_tests.py
+++ b/tasks/unit-tests/release_tests.py
@@ -418,5 +418,17 @@ class TestGetJMXFetchReleaseJsonInfo(unittest.TestCase):
         self.assertEqual(jmxfetch_hash, "hash7_nightly")
 
 
+class TestCreateBuildLinksPatterns(unittest.TestCase):
+    current_version = "7.50.0-rc.1"
+
+    def test_create_build_links_patterns_correct_values(self):
+        new_rc_version = "7.51.1-rc.2"
+        patterns = release._create_build_links_patterns(self.current_version, new_rc_version)
+
+        self.assertEqual(patterns[".50.0-rc.1"], ".51.1-rc.2")
+        self.assertEqual(patterns[".50.0-rc-1"], ".51.1-rc-2")
+        self.assertEqual(patterns[".50.0~rc.1"], ".51.1~rc.2")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### What does this PR do?

This PR adds `inv release.update-build-links` task, which can be used to automatically update [Agent RC build links page](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/2889876360/Build+links+-+7.50.0-rc.4)

### Motivation

Faster, easier and less error prone update of the links page.
This task can be used in the RC build pipeline to automatically update links after successful build.

### Describe how to test/QA your changes

Run `inv release.update-build-links` and pass any Agent RC tag different that currently available.
Cleanup after test.


- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
