### PR TITLE
[logs] add 2 headers containing timestamps in the logs HTTP requests

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -382,10 +382,8 @@ func buildURL(endpoint config.Endpoint) string {
 
 func getMessageTimestamp(messages []*message.Message) int64 {
 	timestampNanos := int64(-1)
-	for _, message := range messages {
-		if message.IngestionTimestamp > timestampNanos {
-			timestampNanos = message.IngestionTimestamp
-		}
+	if len(messages) > 0 {
+		timestampNanos = messages[len(messages)-1].IngestionTimestamp
 	}
 	return timestampNanos / int64(time.Millisecond/time.Nanosecond)
 }

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -271,9 +271,11 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 		req.Header.Set("DD-EVP-ORIGIN", string(d.origin))
 		req.Header.Set("DD-EVP-ORIGIN-VERSION", version.AgentVersion)
 	}
-	req = req.WithContext(ctx)
-
+	req.Header.Set("dd-message-timestamp", strconv.FormatInt(getMessageTimestamp(payload.Messages), 10))
 	then := time.Now()
+	req.Header.Set("dd-current-timestamp", strconv.FormatInt(then.UnixMilli(), 10))
+
+	req = req.WithContext(ctx)
 	resp, err := d.client.Do(req)
 
 	latency := time.Since(then).Milliseconds()
@@ -376,6 +378,16 @@ func buildURL(endpoint config.Endpoint) string {
 		url.Path = "/v1/input"
 	}
 	return url.String()
+}
+
+func getMessageTimestamp(messages []*message.Message) int64 {
+	timestampNanos := int64(-1)
+	for _, message := range messages {
+		if message.IngestionTimestamp > timestampNanos {
+			timestampNanos = message.IngestionTimestamp
+		}
+	}
+	return timestampNanos / int64(time.Millisecond/time.Nanosecond)
 }
 
 func prepareCheckConnectivity(endpoint config.Endpoint) (*client.DestinationsContext, *Destination) {

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -7,7 +7,9 @@ package http
 
 import (
 	"errors"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -189,6 +191,22 @@ func TestDestinationDoesntSendEmptyV2Protocol(t *testing.T) {
 	err := server.Destination.unconditionalSend(&message.Payload{Encoded: []byte("payload")})
 	assert.Nil(t, err)
 	assert.Empty(t, server.request.Header.Values("dd-protocol"))
+}
+
+func TestDestinationSendsTimestampHeaders(t *testing.T) {
+	server := NewTestServer(200)
+	defer server.httpServer.Close()
+	currentTimestamp := time.Now().UnixMilli()
+
+	err := server.Destination.unconditionalSend(&message.Payload{Messages: []*message.Message{{
+		IngestionTimestamp: 1234567890_999_999,
+	}}, Encoded: []byte("payload")})
+	assert.Nil(t, err)
+	assert.Equal(t, server.request.Header.Get("dd-message-timestamp"), "1234567890")
+
+	ddCurrentTimestamp, err := strconv.ParseInt(server.request.Header.Get("dd-current-timestamp"), 10, 64)
+	assert.Nil(t, err)
+	assert.GreaterOrEqual(t, ddCurrentTimestamp, currentTimestamp)
 }
 
 func TestDestinationConcurrentSends(t *testing.T) {

--- a/releasenotes/notes/logs-send-timestamp-45088ebe0052424c.yaml
+++ b/releasenotes/notes/logs-send-timestamp-45088ebe0052424c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add timestamps to the logs HTTP client


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds 2 new new timestamps in milliseconds:

* dd-message-timestamp: contains the max(IngestionTimestamp)
* dd-current-timestamp: contains the timestamp of the HTTP request from the agent perspective

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
