### PR TITLE
Updates unit in telemetry description to match reporting code

### DIFF
--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -179,7 +179,7 @@ func initTelemetry(cfg config.Reader, logger logComponent.Component) {
 		"dogstatsd",
 		"channel_latency",
 		[]string{"shard", "message_type"},
-		"Time in millisecond to push metrics to the aggregator input buffer",
+		"Time in nanosecond to push metrics to the aggregator input buffer",
 		buckets)
 
 	listeners.InitTelemetry(get("telemetry.dogstatsd.listeners_latency_buckets"))


### PR DESCRIPTION
### What does this PR do?
Updates the telemetry description for `aggregator.channel_size` to match the reporting code.

### Motivation

The [code initializing the tlm](https://github.com/DataDog/datadog-agent/blob/c8cfd6ee899beee3c6cf2a4f0e21bf3bbd77aee1/comp/dogstatsd/server/server.go#L178-L183) declares it as a value in milliseconds, but this is wrong. The [code observing values](https://github.com/DataDog/datadog-agent/blob/c8cfd6ee899beee3c6cf2a4f0e21bf3bbd77aee1/comp/dogstatsd/server/batch.go#L199) is reporting data in nanoseconds.

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
N/A

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
