### PR TITLE
Add CentOS 8 to KMT

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -401,7 +401,7 @@ kernel_matrix_testing_run_tests_x64:
     ARCH: "x86_64"
   parallel:
     matrix:
-      - TAG: ["ubuntu_16.04", "ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "ubuntu_23.10", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11", "debian_12", "centos_79"]
+      - TAG: ["ubuntu_16.04", "ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "ubuntu_23.10", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11", "debian_12", "centos_79", "centos_8"]
 
 kernel_matrix_testing_run_tests_arm64:
   extends:
@@ -414,7 +414,7 @@ kernel_matrix_testing_run_tests_arm64:
     ARCH: "arm64"
   parallel:
     matrix:
-      - TAG: ["ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "ubuntu_23.10", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11", "debian_12", "centos_79"]
+      - TAG: ["ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "ubuntu_23.10", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11", "debian_12", "centos_79", "centos_8"]
 
 .kernel_matrix_testing_cleanup:
   stage: kernel_matrix_testing

--- a/test/new-e2e/system-probe/config/vmconfig-arm64.json
+++ b/test/new-e2e/system-probe/config/vmconfig-arm64.json
@@ -70,6 +70,11 @@
                     "dir": "CentOS-7-aarch64-GenericCloud-2211.qcow2",
                     "tag": "centos_79",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/CentOS-7-aarch64-GenericCloud-2211.qcow2.xz"
+                },
+                {
+                    "dir": "centos-8-arm64.qcow2",
+                    "tag": "centos_8",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/centos-8/centos-8-arm64.qcow2.xz"
                 }
             ],
             "machine": "virt",

--- a/test/new-e2e/system-probe/config/vmconfig-arm64.json
+++ b/test/new-e2e/system-probe/config/vmconfig-arm64.json
@@ -67,9 +67,9 @@
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/debian-12-generic-arm64.qcow2.xz"
                 },
                 {
-                    "dir": "CentOS-7-aarch64-GenericCloud-2211.qcow2",
+                    "dir": "centos-7.9-arm64.qcow2",
                     "tag": "centos_79",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/CentOS-7-aarch64-GenericCloud-2211.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/centos-8/centos-7.9-arm64.qcow2.xz"
                 },
                 {
                     "dir": "centos-8-arm64.qcow2",

--- a/test/new-e2e/system-probe/config/vmconfig-arm64.json
+++ b/test/new-e2e/system-probe/config/vmconfig-arm64.json
@@ -69,12 +69,12 @@
                 {
                     "dir": "centos-7.9-arm64.qcow2",
                     "tag": "centos_79",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/centos-8/centos-7.9-arm64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/centos-7.9-arm64.qcow2.xz"
                 },
                 {
                     "dir": "centos-8-arm64.qcow2",
                     "tag": "centos_8",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/centos-8/centos-8-arm64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/centos-8-arm64.qcow2.xz"
                 }
             ],
             "machine": "virt",

--- a/test/new-e2e/system-probe/config/vmconfig-x64.json
+++ b/test/new-e2e/system-probe/config/vmconfig-x64.json
@@ -74,12 +74,12 @@
                 {
                     "dir": "centos-7.9-x86_64.qcow2",
                     "tag": "centos_79",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/centos-8/centos-7.9-x86_64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/centos-7.9-x86_64.qcow2.xz"
                 },
                 {
                     "dir": "centos-8-x86_64.qcow2",
                     "tag": "centos_8",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/centos-8/centos-8-x86_64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/centos-8-x86_64.qcow2.xz"
                 }
             ],
             "vcpu": [

--- a/test/new-e2e/system-probe/config/vmconfig-x64.json
+++ b/test/new-e2e/system-probe/config/vmconfig-x64.json
@@ -72,9 +72,9 @@
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/debian-12-generic-amd64.qcow2.xz"
                 },
                 {
-                    "dir": "CentOS-7-x86_64-GenericCloud-2211.qcow2",
+                    "dir": "centos-7.9-x86_64.qcow2",
                     "tag": "centos_79",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/CentOS-7-x86_64-GenericCloud-2211.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/centos-8/centos-7.9-x86_64.qcow2.xz"
                 },
                 {
                     "dir": "centos-8-x86_64.qcow2",

--- a/test/new-e2e/system-probe/config/vmconfig-x64.json
+++ b/test/new-e2e/system-probe/config/vmconfig-x64.json
@@ -75,6 +75,11 @@
                     "dir": "CentOS-7-x86_64-GenericCloud-2211.qcow2",
                     "tag": "centos_79",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/CentOS-7-x86_64-GenericCloud-2211.qcow2.xz"
+                },
+                {
+                    "dir": "centos-8-x86_64.qcow2",
+                    "tag": "centos_8",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/centos-8/centos-8-x86_64.qcow2.xz"
                 }
             ],
             "vcpu": [


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds CentOS 8 to KMT

### Motivation

Increased kernel coverage to match kitchen

### Additional Notes

Using CentOS instead of RHEL to simplify creation (not dealing with subscription)

https://datadoghq.atlassian.net/browse/EBPF-352

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
