### PR TITLE
make debugfs telemetry thread safe

### DIFF
--- a/pkg/ebpf/debugfs_stat_collector_linux.go
+++ b/pkg/ebpf/debugfs_stat_collector_linux.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/ebpf-manager/tracefs"
 	"github.com/prometheus/client_golang/prometheus"
@@ -20,33 +21,78 @@ import (
 
 const kProbeTelemetryName = "ebpf__probes"
 
+type profileType byte
+
+const (
+	kprobe profileType = iota
+	uprobe
+)
+
+func (p profileType) String() string {
+	switch p {
+	case kprobe:
+		return "kprobe"
+	case uprobe:
+		return "uprobe"
+	default:
+		return ""
+	}
+}
+
+func (p profileType) path() string {
+	switch p {
+	case kprobe:
+		return "kprobe_profile"
+	case uprobe:
+		return "uprobe_profile"
+	default:
+		return ""
+	}
+}
+
+type counterType byte
+
+const (
+	hits counterType = iota
+	misses
+)
+
+type eventKey struct {
+	profile profileType
+	counter counterType
+	event   string
+}
+
+// DebugFsStatCollector implements the prometheus Collector interface
+// for collecting statistics about kprobe/uprobe hits/misses from debugfs/tracefs.
 type DebugFsStatCollector struct {
+	sync.Mutex
 	hits           *prometheus.Desc
 	misses         *prometheus.Desc
-	lastProbeStats map[string]int
+	lastProbeStats map[eventKey]int
+	tracefsRoot    string
 }
 
-func NewDebugFsStatCollector() *DebugFsStatCollector {
-	return &DebugFsStatCollector{
-		hits:           prometheus.NewDesc(kProbeTelemetryName+"__hits", "Counter tracking number of probe hits", []string{"probe_name", "probe_type"}, nil),
-		misses:         prometheus.NewDesc(kProbeTelemetryName+"__misses", "Counter tracking number of probe misses", []string{"probe_name", "probe_type"}, nil),
-		lastProbeStats: make(map[string]int),
-	}
-}
-
-func (c *DebugFsStatCollector) updateProbeStats(pid int, probeType string, ch chan<- prometheus.Metric) {
-	if pid == 0 {
-		pid = myPid
-	}
+// NewDebugFsStatCollector creates a DebugFsStatCollector
+func NewDebugFsStatCollector() prometheus.Collector {
 	root, err := tracefs.Root()
 	if err != nil {
 		log.Debugf("error getting tracefs root path: %s", err)
-		return
+		return &NoopDebugFsStatCollector{}
 	}
-	profile := filepath.Join(root, probeType+"_profile")
+	return &DebugFsStatCollector{
+		hits:           prometheus.NewDesc(kProbeTelemetryName+"__hits", "Counter tracking number of probe hits", []string{"probe_name", "probe_type"}, nil),
+		misses:         prometheus.NewDesc(kProbeTelemetryName+"__misses", "Counter tracking number of probe misses", []string{"probe_name", "probe_type"}, nil),
+		lastProbeStats: make(map[eventKey]int),
+		tracefsRoot:    root,
+	}
+}
+
+func (c *DebugFsStatCollector) updateProbeStats(pid int, probeType profileType, ch chan<- prometheus.Metric) {
+	profile := filepath.Join(c.tracefsRoot, probeType.path())
 	m, err := readKprobeProfile(profile)
 	if err != nil {
-		log.Debugf("error retrieving probe stats: %s", err)
+		log.Debugf("error retrieving %s probe stats: %s", probeType.String(), err)
 		return
 	}
 	for event, st := range m {
@@ -63,17 +109,18 @@ func (c *DebugFsStatCollector) updateProbeStats(pid int, probeType string, ch ch
 			event = parts[1]
 		}
 		event = strings.ToLower(event)
-		probeTypeKey := string(probeType[0]) + "_"
-		hitsKey := "h_" + probeTypeKey + event
-		missesKey := "m_" + probeTypeKey + event
+
+		hitsKey := eventKey{probeType, hits, event}
 		hitsDelta := float64(int(st.Hits) - c.lastProbeStats[hitsKey])
 		if hitsDelta > 0 {
-			ch <- prometheus.MustNewConstMetric(c.hits, prometheus.CounterValue, hitsDelta, event, probeType)
+			ch <- prometheus.MustNewConstMetric(c.hits, prometheus.CounterValue, hitsDelta, event, probeType.String())
 		}
 		c.lastProbeStats[hitsKey] = int(st.Hits)
+
+		missesKey := eventKey{probeType, misses, event}
 		missesDelta := float64(int(st.Misses) - c.lastProbeStats[missesKey])
 		if missesDelta > 0 {
-			ch <- prometheus.MustNewConstMetric(c.misses, prometheus.CounterValue, missesDelta, event, probeType)
+			ch <- prometheus.MustNewConstMetric(c.misses, prometheus.CounterValue, missesDelta, event, probeType.String())
 		}
 		c.lastProbeStats[missesKey] = int(st.Misses)
 	}
@@ -87,6 +134,8 @@ func (c *DebugFsStatCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect returns the current state of all metrics of the collector
 func (c *DebugFsStatCollector) Collect(ch chan<- prometheus.Metric) {
-	c.updateProbeStats(0, "kprobe", ch)
-	c.updateProbeStats(0, "uprobe", ch)
+	c.Lock()
+	defer c.Unlock()
+	c.updateProbeStats(myPid, kprobe, ch)
+	c.updateProbeStats(myPid, uprobe, ch)
 }

--- a/pkg/ebpf/debugfs_stat_collector_noop.go
+++ b/pkg/ebpf/debugfs_stat_collector_noop.go
@@ -3,20 +3,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux_bpf
-
 package ebpf
 
 import "github.com/prometheus/client_golang/prometheus"
 
-type DebugFsStatCollector struct{}
-
-func NewDebugFsStatCollector() *DebugFsStatCollector {
-	return &DebugFsStatCollector{}
-}
+// NoopDebugFsStatCollector implements the prometheus Collector interface but does nothing
+type NoopDebugFsStatCollector struct{}
 
 // Describe returns all descriptions of the collector
-func (c *DebugFsStatCollector) Describe(chan<- *prometheus.Desc) {}
+func (c *NoopDebugFsStatCollector) Describe(chan<- *prometheus.Desc) {}
 
 // Collect returns the current state of all metrics of the collector
-func (c *DebugFsStatCollector) Collect(chan<- prometheus.Metric) {}
+func (c *NoopDebugFsStatCollector) Collect(chan<- prometheus.Metric) {}

--- a/pkg/ebpf/debugfs_stats_collector_nonlinux.go
+++ b/pkg/ebpf/debugfs_stats_collector_nonlinux.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux_bpf
+
+package ebpf
+
+import "github.com/prometheus/client_golang/prometheus"
+
+func NewDebugFsStatCollector() prometheus.Collector {
+	return &NoopDebugFsStatCollector{}
+}

--- a/pkg/ebpf/debugfs_stats_collector_nonlinux.go
+++ b/pkg/ebpf/debugfs_stats_collector_nonlinux.go
@@ -9,6 +9,7 @@ package ebpf
 
 import "github.com/prometheus/client_golang/prometheus"
 
+// NewDebugFsStatCollector creates a DebugFsStatCollector
 func NewDebugFsStatCollector() prometheus.Collector {
 	return &NoopDebugFsStatCollector{}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Makes debugfs collector thread-safe

### Motivation

The `Collect` function can be called concurrently. Some panics were observed in logs.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

https://datadoghq.atlassian.net/browse/EBPF-353

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
