### PR TITLE
Fix non-linux build for the host metadata payload

### DIFF
--- a/comp/metadata/host/payload.go
+++ b/comp/metadata/host/payload.go
@@ -28,9 +28,9 @@ type Payload struct {
 }
 
 // SplitPayload breaks the payload into times number of pieces
-func (p *Payload) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) { //nolint:revive // TODO fix revive unusued-parameter
+func (p *Payload) SplitPayload(_ int) ([]marshaler.AbstractMarshaler, error) {
 	// Metadata payloads are analyzed as a whole, so they cannot be split
-	return nil, fmt.Errorf("V5 Payload splitting is not implemented")
+	return nil, fmt.Errorf("host Payload splitting is not implemented")
 }
 
 // MarshalJSON serialization a Payload to JSON

--- a/comp/metadata/host/payload_no_gohai.go
+++ b/comp/metadata/host/payload_no_gohai.go
@@ -8,28 +8,31 @@
 package host
 
 import (
-	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/utils"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/comp/metadata/host/utils"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 )
 
 // Payload handles the JSON unmarshalling of the metadata payload
 type Payload struct {
-	hostMetadataUtils.CommonPayload
-	hostMetadataUtils.Payload
+	utils.CommonPayload
+	utils.Payload
 	// Notice: ResourcesPayload requires gohai so it can't be included
 	// TODO: gohai alternative (or fix gohai)
 }
 
 // SplitPayload breaks the payload into times number of pieces
-func (p *Payload) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
+func (p *Payload) SplitPayload(_ int) ([]marshaler.AbstractMarshaler, error) {
 	// Metadata payloads are analyzed as a whole, so they cannot be split
-	return nil, fmt.Errorf("V5 Payload splitting is not implemented")
+	return nil, fmt.Errorf("host Payload splitting is not implemented")
 }
 
 // getPayload returns the complete metadata payload as seen in Agent v5. Note: gohai can't be used on the platforms
 // this module builds for
 func (h *host) getPayload(hostname string) *Payload {
 	return &Payload{
-		CommonPayload: *common.GetPayload(host.hostname),
-		HostPayload:   *hostMetadataUtils.GetPayload(ctx, h.config),
+		CommonPayload: *utils.GetCommonPayload(h.hostname, h.config),
+		Payload:       *utils.GetPayload(ctx, h.config),
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Fix `freebsd || netbsd || openbsd || solaris || dragonfly` build for the host metadata

### Describe how to test/QA your changes

Test the agent on one of those platform and check that metadata are sent correctly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
