### PR TITLE
APL-2320 Move Suse install script tests to new e2e

### DIFF
--- a/.gitlab/new-e2e_common/testing.yml
+++ b/.gitlab/new-e2e_common/testing.yml
@@ -9,3 +9,9 @@
     !reference [.on_kitchen_tests_a7] #TODO: Change when migration is complete to another name without 'kitchen'
   variables:
     AGENT_MAJOR_VERSION: 7
+
+.new-e2e_install_script:
+  variables:
+    TARGETS: ./tests/agent-platform/install-script
+    TEAM: agent-platform
+    EXTRA_PARAMS: --osversion $E2E_OSVERS --platform $E2E_PLATFORM --cws-supported-osversion $E2E_CWS_SUPPORTED_OSVERS --major-version $AGENT_MAJOR_VERSION --arch $E2E_ARCH --flavor $FLAVOR

--- a/.gitlab/new-e2e_testing.yml
+++ b/.gitlab/new-e2e_testing.yml
@@ -5,3 +5,4 @@
 include:
   - /.gitlab/new-e2e_testing/debian.yml
   - /.gitlab/new-e2e_testing/amazonlinux.yml
+  - /.gitlab/new-e2e_testing/suse.yml

--- a/.gitlab/new-e2e_testing/suse.yml
+++ b/.gitlab/new-e2e_testing/suse.yml
@@ -17,14 +17,6 @@
     E2E_BRANCH_OSVERS: "sles-15"
   needs: ["deploy_deb_testing-a6_x64"]
 
-.new-e2e_suse_a6_arm64:
-  variables:
-    E2E_ARCH: arm64
-    E2E_OSVERS: "sles-15"
-    E2E_CWS_SUPPORTED_OSVERS: "sles-15"
-    E2E_BRANCH_OSVERS: "sles-15"
-  needs: ["deploy_deb_testing-a6_arm64"]
-
 .new-e2e_suse_a7_x86_64:
   variables:
     E2E_ARCH: x86_64
@@ -48,17 +40,6 @@ new-e2e-agent-platform-install-script-suse-a6-x86_64:
     - .new-e2e_install_script
     - .new-e2e_os_suse
     - .new-e2e_suse_a6_x86_64
-    - .new-e2e_agent_a6
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-suse-a6-arm64:
-  stage: kitchen_testing
-  extends: 
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_suse
-    - .new-e2e_suse_a6_arm64
     - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent

--- a/.gitlab/new-e2e_testing/suse.yml
+++ b/.gitlab/new-e2e_testing/suse.yml
@@ -21,6 +21,7 @@
   variables:
     E2E_ARCH: arm64
     E2E_OSVERS: "sles-15"
+    E2E_CWS_SUPPORTED_OSVERS: "sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
   needs: ["deploy_deb_testing-a6_arm64"]
 
@@ -36,6 +37,7 @@
   variables:
     E2E_ARCH: arm64
     E2E_OSVERS: "sles-15"
+    E2E_CWS_SUPPORTED_OSVERS: "sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
   needs: ["deploy_deb_testing-a7_arm64"]
 

--- a/.gitlab/new-e2e_testing/suse.yml
+++ b/.gitlab/new-e2e_testing/suse.yml
@@ -1,0 +1,113 @@
+
+.new-e2e_os_suse:
+  variables:
+    E2E_PLATFORM: suse
+
+.new-e2e_install_script:
+  variables:
+    TARGETS: ./tests/agent-platform/install-script
+    TEAM: agent-platform
+    EXTRA_PARAMS: --osversion $E2E_OSVERS --platform $E2E_PLATFORM --cws-supported-osversion $E2E_CWS_SUPPORTED_OSVERS --major-version $AGENT_MAJOR_VERSION --arch $E2E_ARCH --flavor $FLAVOR
+
+.new-e2e_suse_a6_x86_64:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "sles-12,sles-15"
+    E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
+    E2E_BRANCH_OSVERS: "sles-15"
+  needs: ["deploy_deb_testing-a6_x64"]
+
+.new-e2e_suse_a6_arm64:
+  variables:
+    E2E_ARCH: arm64
+    E2E_OSVERS: "sles-15"
+    E2E_BRANCH_OSVERS: "sles-15"
+  needs: ["deploy_deb_testing-a6_arm64"]
+
+.new-e2e_suse_a7_x86_64:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "sles-12,sles-15"
+    E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
+    E2E_BRANCH_OSVERS: "sles-15"
+  needs: ["deploy_deb_testing-a7_x64"]
+
+.new-e2e_suse_a7_arm64:
+  variables:
+    E2E_ARCH: arm64
+    E2E_OSVERS: "sles-15"
+    E2E_BRANCH_OSVERS: "sles-15"
+  needs: ["deploy_deb_testing-a7_arm64"]
+
+new-e2e-agent-platform-install-script-suse-a6-x86_64:
+  stage: kitchen_testing
+  extends: 
+    - .new_e2e_template
+    - .new-e2e_install_script
+    - .new-e2e_os_suse
+    - .new-e2e_suse_a6_x86_64
+    - .new-e2e_agent_a6
+  variables:
+    FLAVOR: datadog-agent
+
+new-e2e-agent-platform-install-script-suse-a6-arm64:
+  stage: kitchen_testing
+  extends: 
+    - .new_e2e_template
+    - .new-e2e_install_script
+    - .new-e2e_os_suse
+    - .new-e2e_suse_a6_arm64
+    - .new-e2e_agent_a6
+  variables:
+    FLAVOR: datadog-agent
+
+new-e2e-agent-platform-install-script-suse-a7-x86_64:
+  stage: kitchen_testing
+  extends: 
+    - .new_e2e_template
+    - .new-e2e_install_script
+    - .new-e2e_os_suse
+    - .new-e2e_suse_a7_x86_64
+    - .new-e2e_agent_a7
+  rules:
+    !reference [.on_default_new-e2e_tests_a7]
+  variables:
+    FLAVOR: datadog-agent
+
+new-e2e-agent-platform-install-script-suse-a7-arm64:
+  stage: kitchen_testing
+  extends: 
+    - .new_e2e_template
+    - .new-e2e_install_script
+    - .new-e2e_os_suse
+    - .new-e2e_suse_a7_arm64
+    - .new-e2e_agent_a7
+  rules:
+    !reference [.on_all_new-e2e_tests_a7]
+  variables:
+    FLAVOR: datadog-agent
+
+new-e2e-agent-platform-install-script-suse-iot-agent-a7-x86_64:
+  stage: kitchen_testing
+  extends: 
+    - .new_e2e_template
+    - .new-e2e_install_script
+    - .new-e2e_os_suse
+    - .new-e2e_suse_a7_x86_64
+    - .new-e2e_agent_a7
+  rules:
+    !reference [.on_default_new-e2e_tests_a7]
+  variables:
+    FLAVOR: datadog-iot-agent
+
+new-e2e-agent-platform-install-script-suse-dogstatsd-a7-x86_64:
+  stage: kitchen_testing
+  extends: 
+    - .new_e2e_template
+    - .new-e2e_install_script
+    - .new-e2e_os_suse
+    - .new-e2e_suse_a7_x86_64
+    - .new-e2e_agent_a7
+  variables:
+    FLAVOR: datadog-dogstatsd
+

--- a/test/new-e2e/tests/agent-platform/common/pkg-manager/zypper.go
+++ b/test/new-e2e/tests/agent-platform/common/pkg-manager/zypper.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package pkgmanager
+
+import "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+
+// ZypperPackageManager is a package manager for zypper
+type ZypperPackageManager struct {
+	vmClient client.VM
+}
+
+// NewZypperPackageManager return zypper package manager
+func NewZypperPackageManager(vmClient client.VM) *ZypperPackageManager {
+	return &ZypperPackageManager{vmClient: vmClient}
+}
+
+// Remove executes remove command from zypper
+func (s *ZypperPackageManager) Remove(pkg string) (string, error) {
+	return s.vmClient.ExecuteWithError("sudo zypper remove -y " + pkg)
+}

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -62,6 +62,11 @@ func getPackageManager(vmClient e2eClient.VM) PackageManager {
 	if _, err := vmClient.ExecuteWithError("command -v yum"); err == nil {
 		return pkgmanager.NewYumPackageManager(vmClient)
 	}
+
+	if _, err := vmClient.ExecuteWithError("command -v zypper"); err == nil {
+		return pkgmanager.NewZypperPackageManager(vmClient)
+	}
+
 	return nil
 }
 

--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -71,6 +71,12 @@ func TestInstallScript(t *testing.T) {
 	vmOpts := []ec2params.Option{}
 	for _, osVers := range osVersions {
 		osVers := osVers
+
+		if platformJSON[*platform][*architecture][osVers] == "" {
+			// Fail if the image is not defined instead of silently running with default Ubuntu AMI
+			t.Fatalf("No image found for %s %s %s", *platform, *architecture, osVers)
+		}
+
 		cwsSupported := false
 		for _, cwsSupportedOs := range cwsSupportedOsVersionList {
 			if cwsSupportedOs == osVers {

--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -67,6 +67,8 @@ func TestInstallScript(t *testing.T) {
 	cwsSupportedOsVersionList := strings.Split(*cwsSupportedOsVersion, ",")
 
 	fmt.Println("Parsed platform json file: ", platformJSON)
+
+	vmOpts := []ec2params.Option{}
 	for _, osVers := range osVersions {
 		osVers := osVers
 		cwsSupported := false
@@ -76,10 +78,14 @@ func TestInstallScript(t *testing.T) {
 			}
 		}
 
+		vmOpts = append(vmOpts, ec2params.WithImageName(platformJSON[*platform][*architecture][osVers], archMapping[*architecture], osMapping[*platform]))
+		if instanceType, ok := os.LookupEnv("E2E_OVERRIDE_INSTANCE_TYPE"); ok {
+			vmOpts = append(vmOpts, ec2params.WithInstanceType(instanceType))
+		}
 		t.Run(fmt.Sprintf("test install script on %s %s %s agent %s", osVers, *architecture, *flavor, *majorVersion), func(tt *testing.T) {
 			tt.Parallel()
 			fmt.Printf("Testing %s", osVers)
-			e2e.Run(tt, &installScriptSuite{cwsSupported: cwsSupported}, e2e.EC2VMStackDef(ec2params.WithImageName(platformJSON[*platform][*architecture][osVers], archMapping[*architecture], osMapping[*platform])), params.WithStackName(fmt.Sprintf("install-script-test-%v-%v-%s-%s-%v", os.Getenv("CI_PIPELINE_ID"), osVers, *architecture, *flavor, *majorVersion)))
+			e2e.Run(tt, &installScriptSuite{cwsSupported: cwsSupported}, e2e.EC2VMStackDef(vmOpts...), params.WithStackName(fmt.Sprintf("install-script-test-%v-%v-%s-%s-%v", os.Getenv("CI_PIPELINE_ID"), osVers, *architecture, *flavor, *majorVersion)))
 		})
 	}
 }

--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -25,5 +25,14 @@
             "amazonlinux2022-5-15": "ami-0a8495f6303122235",
             "amazonlinux2023": "ami-08fc6fb8ad2e794bb"
         }
+    },
+    "suse": {
+        "x86_64": {
+            "sles-12": "ami-09e1f60648b4fb117",
+            "sles-15": "ami-08f3662e2d5b3989a"
+        },
+        "arm64": {
+            "sles-15": "ami-02f7663f03ca92749"
+        }
     }
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Move suse install script tests to new e2e
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation



<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
