### PR TITLE
Add secret e2e tests back as has been removed by accident

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/secret_test.go
+++ b/test/new-e2e/tests/agent-subcommands/secret_test.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agentsubcommands
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type agentSecretSuite struct {
+	e2e.Suite[e2e.AgentEnv]
+}
+
+func TestAgentSecretSuite(t *testing.T) {
+	e2e.Run(t, &agentSecretSuite{}, e2e.AgentStackDef())
+}
+
+func (v *agentSecretSuite) TestAgentSecretNotEnabledByDefault() {
+	secret := v.Env().Agent.Secret()
+
+	assert.Contains(v.T(), secret, "No secret_backend_command set")
+}
+
+func (v *agentSecretSuite) TestAgentSecretChecksExecutablePermissions() {
+	v.UpdateEnv(e2e.AgentStackDef(e2e.WithAgentParams(agentparams.WithAgentConfig("secret_backend_command: /usr/bin/echo"))))
+
+	output := v.Env().Agent.Secret()
+
+	assert.Contains(v.T(), output, "=== Checking executable permissions ===")
+	assert.Contains(v.T(), output, "Executable path: /usr/bin/echo")
+	assert.Contains(v.T(), output, "Executable permissions: error: invalid executable: '/usr/bin/echo' isn't owned by this user")
+}
+
+func (v *agentSecretSuite) TestAgentSecretCorrectPermissions() {
+	secretScript := `#!/usr/bin/env sh
+printf '{"alias_secret": {"value": "a_super_secret_string"}}\n'`
+	config := `secret_backend_command: /tmp/bin/secret.sh
+host_aliases:
+  - ENC[alias_secret]`
+
+	v.UpdateEnv(e2e.AgentStackDef(e2e.WithAgentParams(agentparams.WithFile("/tmp/bin/secret.sh", secretScript, false))))
+	v.Env().VM.Execute(`sudo sh -c "chown dd-agent:dd-agent /tmp/bin/secret.sh && chmod 700 /tmp/bin/secret.sh"`)
+	v.UpdateEnv(e2e.AgentStackDef(e2e.WithAgentParams(agentparams.WithFile("/tmp/bin/secret.sh", secretScript, false), agentparams.WithAgentConfig(config))))
+
+	output := v.Env().Agent.Secret()
+
+	assert.Contains(v.T(), output, "=== Checking executable permissions ===")
+	assert.Contains(v.T(), output, "Executable path: /tmp/bin/secret.sh")
+	assert.Contains(v.T(), output, "Executable permissions: OK, the executable has the correct permissions")
+	assert.Contains(v.T(), output, "File mode: 100700")
+	assert.Contains(v.T(), output, "Owner: dd-agent")
+	assert.Contains(v.T(), output, "Group: dd-agent")
+	assert.Contains(v.T(), output, "Number of secrets decrypted: 1")
+	assert.Contains(v.T(), output, "- 'alias_secret':\n\tused in 'datadog.yaml' configuration in entry 'host_aliases'")
+	// assert we don't output the decrypted secret
+	assert.NotContains(v.T(), output, "a_super_secret_string")
+}

--- a/test/new-e2e/tests/agent-subcommands/secret_test.go
+++ b/test/new-e2e/tests/agent-subcommands/secret_test.go
@@ -57,7 +57,7 @@ host_aliases:
 	assert.Contains(v.T(), output, "File mode: 100700")
 	assert.Contains(v.T(), output, "Owner: dd-agent")
 	assert.Contains(v.T(), output, "Group: dd-agent")
-	assert.Contains(v.T(), output, "Number of secrets decrypted: 1")
+	assert.Contains(v.T(), output, "Number of secrets resolved: 1")
 	assert.Contains(v.T(), output, "- 'alias_secret':\n\tused in 'datadog.yaml' configuration in entry 'host_aliases'")
 	// assert we don't output the decrypted secret
 	assert.NotContains(v.T(), output, "a_super_secret_string")


### PR DESCRIPTION
### What does this PR do?

Add back e2e tests around secret 

### Motivation

I accidentally removed it in https://github.com/DataDog/datadog-agent/pull/21028/files 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
