### PR TITLE
[APL-2554] fakeintake: remove `/fakeintake/routestats` endpoint

### DIFF
--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -60,7 +60,6 @@ func NewServer(options ...func(*Server)) *Server {
 	mux.HandleFunc("/", fi.handleDatadogRequest)
 	mux.HandleFunc("/fakeintake/payloads/", fi.handleGetPayloads)
 	mux.HandleFunc("/fakeintake/health/", fi.handleFakeHealth)
-	mux.HandleFunc("/fakeintake/routestats/", fi.handleGetRouteStats)
 	mux.HandleFunc("/fakeintake/flushPayloads/", fi.handleFlushPayloads)
 
 	fi.server = http.Server{
@@ -336,33 +335,5 @@ func (fi *Server) handleGetPayloads(w http.ResponseWriter, req *http.Request) {
 func (fi *Server) handleFakeHealth(w http.ResponseWriter, _ *http.Request) {
 	writeHTTPResponse(w, httpResponse{
 		statusCode: http.StatusOK,
-	})
-}
-
-func (fi *Server) handleGetRouteStats(w http.ResponseWriter, req *http.Request) {
-	log.Print("Handling getRouteStats request")
-	routes := fi.store.GetRouteStats()
-	// build response
-	resp := api.APIFakeIntakeRouteStatsGETResponse{
-		Routes: map[string]api.RouteStat{},
-	}
-	for route, count := range routes {
-		resp.Routes[route] = api.RouteStat{ID: route, Count: count}
-	}
-	jsonResp, err := json.Marshal(resp)
-	if err != nil {
-		writeHTTPResponse(w, httpResponse{
-			contentType: "text/plain",
-			statusCode:  http.StatusInternalServerError,
-			body:        []byte(err.Error()),
-		})
-		return
-	}
-
-	// send response
-	writeHTTPResponse(w, httpResponse{
-		contentType: "application/json",
-		statusCode:  http.StatusOK,
-		body:        jsonResp,
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Remove the `/fakeintake/routestats` API endpoint of the fake intake.

### Motivation

The data that this endpoint was exposing are now exposed on the OpenMetrics endpoint `/metrics` thanks to #21201.

### Additional Notes

Address this comment: https://github.com/DataDog/datadog-agent/pull/21201#discussion_r1410751499.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
