### PR TITLE
Add non required vuln scanner check to agent.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,6 +43,7 @@
 /.github/workflows/serverless-benchmarks.yml        @DataDog/serverless
 /.github/workflows/serverless-binary-size.yml       @DataDog/serverless
 /.github/workflows/serverless-integration.yml       @DataDog/serverless
+/.github/workflows/serverless-vuln-scan.yml         @DataDog/serverless
 /.github/workflows/windows-*.yml                    @DataDog/windows-agent
 /.github/workflows/cws-btfhub-sync.yml              @DataDog/agent-security
 /.github/workflows/gohai.yml                        @DataDog/agent-shared-components

--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -27,7 +27,7 @@ jobs:
           path: go/src/github.com/DataDog/datadog-lambda-extension
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build extension
         run: |

--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -1,0 +1,78 @@
+name: "Serverless Vulnerability Scan"
+
+on:
+  pull_request:
+    paths:
+      - 'cmd/serverless/**'
+      - 'cmd/serverless-init/**'
+      - 'pkg/serverless/**'
+      - '.github/workflows/serverless-vuln-scan.yml'
+
+env:
+  VERSION: 1  # env var required when building extension
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout datadog-agent repository
+        uses: actions/checkout@v3
+        with:
+          path: go/src/github.com/DataDog/datadog-agent
+
+      - name: Checkout datadog-lambda-extension repository
+        uses: actions/checkout@v3
+        with:
+          repository: DataDog/datadog-lambda-extension
+          path: go/src/github.com/DataDog/datadog-lambda-extension
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build extension
+        run: |
+          cd go/src/github.com/DataDog/datadog-lambda-extension
+          ./scripts/build_binary_and_layer_dockerized.sh
+
+      - name: Scan amd64 image with trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "datadog/build-lambda-extension-amd64:${{ env.VERSION }}"
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
+
+      - name: Scan arm64 image with trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "datadog/build-lambda-extension-arm64:${{ env.VERSION }}"
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
+
+      - name: Scan amd64 image with grype
+        uses: anchore/scan-action@v3
+        with:
+          image: "datadog/build-lambda-extension-amd64:${{ env.VERSION }}"
+          only-fixed: true
+          fail-build: true
+          severity-cutoff: low
+          output-format: table
+
+      - name: Scan arm64 image with grype
+        uses: anchore/scan-action@v3
+        with:
+          image: "datadog/build-lambda-extension-arm64:${{ env.VERSION }}"
+          only-fixed: true
+          fail-build: true
+          severity-cutoff: low
+          output-format: table
+
+      - name: Scan binary files with grype
+        uses: anchore/scan-action@v3
+        with:
+          path: go/src/github.com/DataDog/datadog-lambda-extension/.layers
+          only-fixed: true
+          fail-build: true
+          severity-cutoff: low
+          output-format: table

--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout datadog-agent repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: go/src/github.com/DataDog/datadog-agent
 

--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -21,7 +21,7 @@ jobs:
           path: go/src/github.com/DataDog/datadog-agent
 
       - name: Checkout datadog-lambda-extension repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: DataDog/datadog-lambda-extension
           path: go/src/github.com/DataDog/datadog-lambda-extension


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds a non-required, non-blocking github action to test for vulnerabilities in the extension. This works using 3rd party github actions for trivy and grype.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We frequently are getting notifications from customers that we have vulnerabilities in the extension. Rather than waiting for customers to tell us, we should be being proactive.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The AWS Lambda Extension is built differently than the regular agent. The build and release scripts for it live in github.com/DataDog/datadog-lambda-extension. Therefore, running a simple dependabot vuln scan here is not enough.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
