### PR TITLE
simplify eBPF telemetry and make it thread-safe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.3.1-0.20231115110321-54ec306d83b2
 	// do not update datadog-operator to 1.2.1 because the indirect dependency github.com/DataDog/datadog-api-client-go/v2 v2.15.0 is trigger a huge Go heap memory increase.
 	github.com/DataDog/datadog-operator v1.1.0
-	github.com/DataDog/ebpf-manager v0.3.7
+	github.com/DataDog/ebpf-manager v0.3.8
 	github.com/DataDog/go-tuf v1.0.2-0.5.2
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/DataDog/datadog-go/v5 v5.3.1-0.20231115110321-54ec306d83b2 h1:E9taSkw
 github.com/DataDog/datadog-go/v5 v5.3.1-0.20231115110321-54ec306d83b2/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator v1.1.0 h1:cSZqKarzM66GR0T1pPPZVopz4oPm3ltcRyqJ/h/6eJg=
 github.com/DataDog/datadog-operator v1.1.0/go.mod h1:3aWOjI4EaE1jYVN6llOXygA9nasy70GCa1XnTIWNoCY=
-github.com/DataDog/ebpf-manager v0.3.7 h1:2QdXeAeMfd+ABfg/SBNFkM9d3bdarv+t7X189sO2nrM=
-github.com/DataDog/ebpf-manager v0.3.7/go.mod h1:ULRKNrj8WbMQG8WdkRfS46y8xrTYV2Og8HKBR3SP6uY=
+github.com/DataDog/ebpf-manager v0.3.8 h1:Y0TBoSzwe90iamiO8Zy09g/XoTLbSg9aaiSDxCg+D9w=
+github.com/DataDog/ebpf-manager v0.3.8/go.mod h1:ULRKNrj8WbMQG8WdkRfS46y8xrTYV2Og8HKBR3SP6uY=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG5603WQxNP/UX63E7k=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=

--- a/pkg/ebpf/c/bpf_telemetry.h
+++ b/pkg/ebpf/c/bpf_telemetry.h
@@ -18,9 +18,9 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
     ({                                                                             \
         long errno_ret, errno_slot;                                                \
         errno_ret = fn(&map, args);                                                \
-        if (errno_ret < 0) {                                                       \
-            unsigned long err_telemetry_key;                                       \
-            LOAD_CONSTANT(MK_KEY(map), err_telemetry_key);                         \
+        unsigned long err_telemetry_key;                                           \
+        LOAD_CONSTANT(MK_KEY(map), err_telemetry_key);                             \
+        if (errno_ret < 0 && err_telemetry_key > 0) {                              \
             map_err_telemetry_t *entry =                                           \
                 bpf_map_lookup_elem(&map_err_telemetry_map, &err_telemetry_key);   \
             if (entry) {                                                           \

--- a/pkg/ebpf/c/bpf_telemetry.h
+++ b/pkg/ebpf/c/bpf_telemetry.h
@@ -35,7 +35,7 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
                 /* Patched instruction for 4.14+: __sync_fetch_and_add(target, 1);
                  * This patch point is placed here because the above instruction
                  * fails on the 4.4 verifier. On 4.4 this instruction is replaced
-                 * with a nop: r1 = r1 */ \
+                 * with a nop: r1 = r1 */                                          \
                 bpf_telemetry_update_patch((unsigned long)target, add);            \
             }                                                                      \
         }                                                                          \
@@ -60,9 +60,9 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
         int helper_indx = -1;                                                                   \
         long errno_slot;                                                                        \
         long errno_ret = fn(__VA_ARGS__);                                                       \
-        if (errno_ret < 0) {                                                                    \
-            unsigned long telemetry_program_id;                                                 \
-            LOAD_CONSTANT("telemetry_program_id_key", telemetry_program_id);                    \
+        unsigned long telemetry_program_id;                                                     \
+        LOAD_CONSTANT("telemetry_program_id_key", telemetry_program_id);                        \
+        if (errno_ret < 0 && telemetry_program_id > 0) {                                        \
             helper_err_telemetry_t *entry =                                                     \
                 bpf_map_lookup_elem(&helper_err_telemetry_map, &telemetry_program_id);          \
             if (entry) {                                                                        \
@@ -73,7 +73,7 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
                     /* This is duplicated below because on clang 14.0.6 the compiler
                      * concludes that this if-check will always force errno_slot in range
                      * (0, T_MAX_ERRNO-1], and removes the bounds check, causing the verifier
-                     * to trip. Duplicating this check forces clang not to omit the check */            \
+                     * to trip. Duplicating this check forces clang not to omit the check */    \
                     errno_slot &= (T_MAX_ERRNO - 1);                                            \
                 }                                                                               \
                 errno_slot &= (T_MAX_ERRNO - 1);                                                \
@@ -83,7 +83,7 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
                     /* Patched instruction for 4.14+: __sync_fetch_and_add(target, 1);
                      * This patch point is placed here because the above instruction
                      * fails on the 4.4 verifier. On 4.4 this instruction is replaced
-                     * with a nop: r1 = r1 */          \
+                     * with a nop: r1 = r1 */                                                   \
                     bpf_telemetry_update_patch((unsigned long)target, add);                     \
                 }                                                                               \
             }                                                                                   \

--- a/pkg/network/protocols/events/consumer_test.go
+++ b/pkg/network/protocols/events/consumer_test.go
@@ -164,8 +164,9 @@ func newEBPFProgram(c *config.Config) (*manager.Manager, error) {
 	}
 
 	Configure("test", m, &options)
-	m.InstructionPatcher = func(m *manager.Manager) error {
-		return bpftelemetry.PatchEBPFTelemetry(m, true, nil)
+	err = bpftelemetry.ActivateBPFTelemetry(m, nil)
+	if err != nil {
+		return nil, err
 	}
 	err = m.InitWithOptions(bc, options)
 	if err != nil {

--- a/pkg/network/protocols/events/consumer_test.go
+++ b/pkg/network/protocols/events/consumer_test.go
@@ -134,7 +134,8 @@ func newEBPFProgram(c *config.Config) (*manager.Manager, error) {
 	}
 	defer bc.Close()
 
-	m := &manager.Manager{
+	bpfTelemetry := bpftelemetry.NewEBPFTelemetry()
+	m := bpftelemetry.NewManager(&manager.Manager{
 		Probes: []*manager.Probe{
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
@@ -142,7 +143,7 @@ func newEBPFProgram(c *config.Config) (*manager.Manager, error) {
 				},
 			},
 		},
-	}
+	}, bpfTelemetry)
 	options := manager.Options{
 		RLimit: &unix.Rlimit{
 			Cur: math.MaxUint64,
@@ -163,15 +164,11 @@ func newEBPFProgram(c *config.Config) (*manager.Manager, error) {
 		},
 	}
 
-	Configure("test", m, &options)
-	err = bpftelemetry.ActivateBPFTelemetry(m, nil)
-	if err != nil {
-		return nil, err
-	}
+	Configure("test", m.Manager, &options)
 	err = m.InitWithOptions(bc, options)
 	if err != nil {
 		return nil, err
 	}
 
-	return m, nil
+	return m.Manager, nil
 }

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sys/unix"
 
@@ -326,14 +325,6 @@ func (b *EBPFTelemetry) setupMapEditors(opts *manager.Options) {
 	if b.helperErrMap != nil {
 		opts.MapEditors[probes.HelperErrTelemetryMap] = b.helperErrMap
 	}
-}
-
-func getEnabledProgramNames(m *manager.Manager) ([]string, error) {
-	progs, err := m.GetProgramSpecs()
-	if err != nil {
-		return nil, err
-	}
-	return maps.Keys(progs), nil
 }
 
 // ebpfTelemetrySupported returns whether eBPF telemetry is supported, which depends on the verifier in 4.14+

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -315,7 +315,7 @@ func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetr
 
 		options.ConstantEditors = append(options.ConstantEditors, buildMapErrTelemetryConstants(m)...)
 	} else {
-		options.ExcludedMaps = append(options.ExcludedMaps, probes.MapErrTelemetryMap, probes.HelperErrTelemetryMap)
+		// we cannot exclude the telemetry maps because on some kernels, deadcode elimination hasn't removed references
 		// leave key constants as zero, and deadcode elimination should reduce number of instructions
 	}
 	return nil

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -314,10 +314,10 @@ func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetr
 		}
 
 		options.ConstantEditors = append(options.ConstantEditors, buildMapErrTelemetryConstants(m)...)
-	} else {
-		// we cannot exclude the telemetry maps because on some kernels, deadcode elimination hasn't removed references
-		// leave key constants as zero, and deadcode elimination should reduce number of instructions
 	}
+	// we cannot exclude the telemetry maps because on some kernels, deadcode elimination hasn't removed references
+	// if telemetry not enabled: leave key constants as zero, and deadcode elimination should reduce number of instructions
+
 	return nil
 }
 

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -8,6 +8,7 @@
 package telemetry
 
 import (
+	"errors"
 	"fmt"
 	"hash"
 	"hash/fnv"
@@ -207,7 +208,7 @@ func (b *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error 
 
 		key := mapKey(h, m)
 		err := b.mapErrMap.Update(unsafe.Pointer(&key), unsafe.Pointer(z), ebpf.UpdateNoExist)
-		if err != nil {
+		if err != nil && !errors.Is(err, ebpf.ErrKeyExist) {
 			return fmt.Errorf("failed to initialize telemetry struct for map %s", m.Name)
 		}
 		b.mapKeys[m.Name] = key
@@ -224,7 +225,7 @@ func (b *EBPFTelemetry) initializeHelperErrTelemetryMap() error {
 	z := new(HelperErrTelemetry)
 	for p, key := range b.probeKeys {
 		err := b.helperErrMap.Update(unsafe.Pointer(&key), unsafe.Pointer(z), ebpf.UpdateNoExist)
-		if err != nil {
+		if err != nil && !errors.Is(err, ebpf.ErrKeyExist) {
 			return fmt.Errorf("failed to initialize telemetry struct for probe %s", p)
 		}
 	}

--- a/pkg/network/telemetry/ebpf_telemetry_testhelpers.go
+++ b/pkg/network/telemetry/ebpf_telemetry_testhelpers.go
@@ -15,10 +15,14 @@ import (
 
 // GetHelpersTelemetry returns a map of error telemetry for each ebpf program
 func (b *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
-	var val HelperErrTelemetry
 	helperTelemMap := make(map[string]interface{})
+	if b.helperErrMap == nil {
+		return helperTelemMap
+	}
+
+	var val HelperErrTelemetry
 	for probeName, k := range b.probeKeys {
-		err := b.HelperErrMap.Lookup(unsafe.Pointer(&k), unsafe.Pointer(&val))
+		err := b.helperErrMap.Lookup(unsafe.Pointer(&k), unsafe.Pointer(&val))
 		if err != nil {
 			log.Debugf("failed to get telemetry for map:key %s:%d\n", probeName, k)
 			continue
@@ -40,10 +44,14 @@ func (b *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
 
 // GetMapsTelemetry returns a map of error telemetry for each ebpf map
 func (b *EBPFTelemetry) GetMapsTelemetry() map[string]interface{} {
-	var val MapErrTelemetry
 	t := make(map[string]interface{})
+	if b.mapErrMap == nil {
+		return t
+	}
+
+	var val MapErrTelemetry
 	for m, k := range b.mapKeys {
-		err := b.MapErrMap.Lookup(unsafe.Pointer(&k), unsafe.Pointer(&val))
+		err := b.mapErrMap.Lookup(unsafe.Pointer(&k), unsafe.Pointer(&val))
 		if err != nil {
 			log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
 			continue

--- a/pkg/network/telemetry/ebpf_telemetry_testhelpers.go
+++ b/pkg/network/telemetry/ebpf_telemetry_testhelpers.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf && test
+
+package telemetry
+
+import (
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// GetHelpersTelemetry returns a map of error telemetry for each ebpf program
+func (b *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
+	var val HelperErrTelemetry
+	helperTelemMap := make(map[string]interface{})
+	for probeName, k := range b.probeKeys {
+		err := b.HelperErrMap.Lookup(unsafe.Pointer(&k), unsafe.Pointer(&val))
+		if err != nil {
+			log.Debugf("failed to get telemetry for map:key %s:%d\n", probeName, k)
+			continue
+		}
+
+		t := make(map[string]interface{})
+		for indx, helperName := range helperNames {
+			base := maxErrno * indx
+			if count := getErrCount(val.Count[base : base+maxErrno]); len(count) > 0 {
+				t[helperName] = count
+			}
+		}
+		if len(t) > 0 {
+			helperTelemMap[probeName] = t
+		}
+	}
+	return helperTelemMap
+}
+
+// GetMapsTelemetry returns a map of error telemetry for each ebpf map
+func (b *EBPFTelemetry) GetMapsTelemetry() map[string]interface{} {
+	var val MapErrTelemetry
+	t := make(map[string]interface{})
+	for m, k := range b.mapKeys {
+		err := b.MapErrMap.Lookup(unsafe.Pointer(&k), unsafe.Pointer(&val))
+		if err != nil {
+			log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
+			continue
+		}
+		if count := getErrCount(val.Count[:]); len(count) > 0 {
+			t[m] = count
+		}
+	}
+	return t
+}

--- a/pkg/network/tracer/connection/fentry/manager.go
+++ b/pkg/network/tracer/connection/fentry/manager.go
@@ -13,11 +13,11 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
-	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
+	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 )
 
-func initManager(mgr *manager.Manager, config *config.Config, closedHandler *ebpf.PerfHandler) {
+func initManager(mgr *errtelemetry.Manager, closedHandler *ebpf.PerfHandler) {
 	mgr.Maps = []*manager.Map{
 		{Name: probes.ConnMap},
 		{Name: probes.TCPStatsMap},

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -28,12 +28,12 @@ const probeUID = "net"
 var ErrorNotSupported = errors.New("fentry tracer is only supported on Fargate")
 
 // LoadTracer loads a new tracer
-func LoadTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
+func LoadTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *errtelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
 	if !fargate.IsFargateInstance() {
 		return nil, nil, ErrorNotSupported
 	}
 
-	m := &manager.Manager{}
+	m := errtelemetry.NewManager(&manager.Manager{}, bpfTelemetry)
 	err := ddebpf.LoadCOREAsset(netebpf.ModuleFileName("tracer-fentry", config.BPFDebug), func(ar bytecode.AssetReader, o manager.Options) error {
 		o.RLimit = mgrOpts.RLimit
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
@@ -45,14 +45,7 @@ func LoadTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *
 			return fmt.Errorf("invalid probe configuration: %v", err)
 		}
 
-		initManager(m, config, perfHandlerTCP)
-
-		if err := errtelemetry.ActivateBPFTelemetry(m, nil); err != nil {
-			return fmt.Errorf("could not activate ebpf telemetry: %w", err)
-		}
-
-		telemetryMapKeys := errtelemetry.BuildTelemetryKeys(m)
-		o.ConstantEditors = append(o.ConstantEditors, telemetryMapKeys...)
+		initManager(m, perfHandlerTCP)
 
 		file, err := os.Stat("/proc/self/ns/pid")
 
@@ -96,5 +89,5 @@ func LoadTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *
 		return nil, nil, err
 	}
 
-	return m, nil, nil
+	return m.Manager, nil, nil
 }

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -11,10 +11,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/ebpf"
-	"github.com/DataDog/datadog-agent/pkg/network/config"
-	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	manager "github.com/DataDog/ebpf-manager"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
+	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 )
 
 const (
@@ -68,7 +69,7 @@ var mainProbes = []probes.ProbeFuncName{
 	probes.UDPSendPageReturn,
 }
 
-func initManager(mgr *manager.Manager, config *config.Config, closedHandler *ebpf.PerfHandler, runtimeTracer bool) error {
+func initManager(mgr *errtelemetry.Manager, closedHandler *ebpf.PerfHandler, runtimeTracer bool) error {
 	mgr.Maps = []*manager.Map{
 		{Name: probes.ConnMap},
 		{Name: probes.TCPStatsMap},

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -120,7 +120,7 @@ func addBoolConst(options *manager.Options, flag bool, name string) {
 }
 
 // LoadTracer loads the co-re/prebuilt/runtime compiled network tracer, depending on config
-func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), TracerType, error) {
+func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *errtelemetry.EBPFTelemetry) (*manager.Manager, func(), TracerType, error) {
 	kprobeAttachMethod := manager.AttachKprobeWithPerfEventOpen
 	if cfg.AttachKprobesWithKprobeEventsABI {
 		kprobeAttachMethod = manager.AttachKprobeWithKprobeEvents
@@ -137,7 +137,7 @@ func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *dde
 		var m *manager.Manager
 		var closeFn func()
 		if err == nil {
-			m, closeFn, err = coreTracerLoader(cfg, mgrOpts, perfHandlerTCP)
+			m, closeFn, err = coreTracerLoader(cfg, mgrOpts, perfHandlerTCP, bpfTelemetry)
 			// if it is a verifier error, bail always regardless of
 			// whether a fallback is enabled in config
 			var ve *ebpf.VerifierError
@@ -158,7 +158,7 @@ func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *dde
 	}
 
 	if cfg.EnableRuntimeCompiler && (!cfg.EnableCORE || cfg.AllowRuntimeCompiledFallback) {
-		m, closeFn, err := rcTracerLoader(cfg, mgrOpts, perfHandlerTCP)
+		m, closeFn, err := rcTracerLoader(cfg, mgrOpts, perfHandlerTCP, bpfTelemetry)
 		if err == nil {
 			return m, closeFn, TracerTypeRuntimeCompiled, err
 		}
@@ -177,18 +177,15 @@ func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *dde
 
 	mgrOpts.ConstantEditors = append(mgrOpts.ConstantEditors, offsets...)
 
-	m, closeFn, err := prebuiltTracerLoader(cfg, mgrOpts, perfHandlerTCP)
+	m, closeFn, err := prebuiltTracerLoader(cfg, mgrOpts, perfHandlerTCP, bpfTelemetry)
 	return m, closeFn, TracerTypePrebuilt, err
 }
 
-func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer bool, config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
-	m := &manager.Manager{}
-	if err := initManager(m, config, perfHandlerTCP, runtimeTracer); err != nil {
+func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer bool, config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *errtelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
+	m := errtelemetry.NewManager(&manager.Manager{}, bpfTelemetry)
+	if err := initManager(m, perfHandlerTCP, runtimeTracer); err != nil {
 		return nil, nil, fmt.Errorf("could not initialize manager: %w", err)
 	}
-
-	telemetryMapKeys := errtelemetry.BuildTelemetryKeys(m)
-	mgrOpts.ConstantEditors = append(mgrOpts.ConstantEditors, telemetryMapKeys...)
 
 	var undefinedProbes []manager.ProbeIdentificationPair
 
@@ -224,10 +221,6 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 				EditorFlag: manager.EditType,
 			}
 		}
-	}
-
-	if err := errtelemetry.ActivateBPFTelemetry(m, undefinedProbes); err != nil {
-		return nil, nil, fmt.Errorf("could not activate ebpf telemetry: %w", err)
 	}
 
 	// Use the config to determine what kernel probes should be enabled
@@ -271,10 +264,10 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 		return nil, nil, fmt.Errorf("failed to init ebpf manager: %w", err)
 	}
 
-	return m, closeProtocolClassifierSocketFilterFn, nil
+	return m.Manager, closeProtocolClassifierSocketFilterFn, nil
 }
 
-func loadCORETracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
+func loadCORETracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *errtelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
 	var m *manager.Manager
 	var closeFn func()
 	var err error
@@ -283,24 +276,24 @@ func loadCORETracer(config *config.Config, mgrOpts manager.Options, perfHandlerT
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
 		o.ConstantEditors = mgrOpts.ConstantEditors
 		o.DefaultKprobeAttachMethod = mgrOpts.DefaultKprobeAttachMethod
-		m, closeFn, err = loadTracerFromAsset(ar, false, true, config, o, perfHandlerTCP)
+		m, closeFn, err = loadTracerFromAsset(ar, false, true, config, o, perfHandlerTCP, bpfTelemetry)
 		return err
 	})
 
 	return m, closeFn, err
 }
 
-func loadRuntimeCompiledTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
+func loadRuntimeCompiledTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *errtelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
 	buf, err := getRuntimeCompiledTracer(config)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer buf.Close()
 
-	return loadTracerFromAsset(buf, true, false, config, mgrOpts, perfHandlerTCP)
+	return loadTracerFromAsset(buf, true, false, config, mgrOpts, perfHandlerTCP, bpfTelemetry)
 }
 
-func loadPrebuiltTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
+func loadPrebuiltTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *errtelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
 	buf, err := netebpf.ReadBPFModule(config.BPFDir, config.BPFDebug)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not read bpf module: %w", err)
@@ -316,7 +309,7 @@ func loadPrebuiltTracer(config *config.Config, mgrOpts manager.Options, perfHand
 		config.CollectUDPv6Conns = false
 	}
 
-	return loadTracerFromAsset(buf, false, false, config, mgrOpts, perfHandlerTCP)
+	return loadTracerFromAsset(buf, false, false, config, mgrOpts, perfHandlerTCP, bpfTelemetry)
 }
 
 func isCORETracerSupported() error {

--- a/pkg/network/tracer/connection/kprobe/tracer_test.go
+++ b/pkg/network/tracer/connection/kprobe/tracer_test.go
@@ -17,6 +17,7 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -168,8 +169,8 @@ func testTracerFallbackCOREAndRCErr(t *testing.T) {
 	runFallbackTests(t, "CORE and RC error", true, true, tests)
 }
 
-func loaderFunc(closeFn func(), err error) func(_ *config.Config, _ manager.Options, _ *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
-	return func(_ *config.Config, _ manager.Options, _ *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
+func loaderFunc(closeFn func(), err error) func(_ *config.Config, _ manager.Options, _ *ddebpf.PerfHandler, _ *errtelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
+	return func(_ *config.Config, _ manager.Options, _ *ddebpf.PerfHandler, _ *errtelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
 		return nil, closeFn, err
 	}
 }
@@ -210,7 +211,7 @@ func runFallbackTests(t *testing.T, desc string, coreErr, rcErr bool, tests []st
 			cfg.AllowPrecompiledFallback = te.allowPrebuiltFallback
 
 			prevOffsetGuessingRun := offsetGuessingRun
-			_, closeFn, tracerType, err := LoadTracer(cfg, manager.Options{}, nil)
+			_, closeFn, tracerType, err := LoadTracer(cfg, manager.Options{}, nil, nil)
 			if te.err == nil {
 				assert.NoError(t, err, "%+v", te)
 			} else {
@@ -245,12 +246,12 @@ func TestCORETracerSupported(t *testing.T) {
 	})
 
 	coreCalled := false
-	coreTracerLoader = func(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
+	coreTracerLoader = func(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *errtelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
 		coreCalled = true
 		return nil, nil, nil
 	}
 	prebuiltCalled := false
-	prebuiltTracerLoader = func(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
+	prebuiltTracerLoader = func(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *errtelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
 		prebuiltCalled = true
 		return nil, nil, nil
 	}
@@ -264,7 +265,7 @@ func TestCORETracerSupported(t *testing.T) {
 	cfg := config.New()
 	cfg.EnableCORE = true
 	cfg.AllowRuntimeCompiledFallback = false
-	_, _, _, err = LoadTracer(cfg, manager.Options{}, nil)
+	_, _, _, err = LoadTracer(cfg, manager.Options{}, nil, nil)
 	assert.False(t, prebuiltCalled)
 	if kv < kernel.VersionCode(4, 4, 128) && platform != "centos" && platform != "redhat" {
 		assert.False(t, coreCalled)
@@ -277,7 +278,7 @@ func TestCORETracerSupported(t *testing.T) {
 	coreCalled = false
 	prebuiltCalled = false
 	cfg.AllowRuntimeCompiledFallback = true
-	_, _, _, err = LoadTracer(cfg, manager.Options{}, nil)
+	_, _, _, err = LoadTracer(cfg, manager.Options{}, nil, nil)
 	assert.NoError(t, err)
 	if kv < kernel.VersionCode(4, 4, 128) && platform != "centos" && platform != "redhat" {
 		assert.False(t, coreCalled)

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -433,13 +433,9 @@ func getManager(cfg *config.Config, buf io.ReaderAt, mapErrTelemetryMap, helperE
 		},
 	}
 
-	currKernelVersion, err := kernel.HostVersion()
+	err := nettelemetry.ActivateBPFTelemetry(mgr, nil)
 	if err != nil {
-		return nil, errors.New("failed to detect kernel version")
-	}
-	activateBPFTelemetry := currKernelVersion >= kernel.VersionCode(4, 14, 0)
-	mgr.InstructionPatcher = func(m *manager.Manager) error {
-		return nettelemetry.PatchEBPFTelemetry(m, activateBPFTelemetry, []manager.ProbeIdentificationPair{})
+		return nil, fmt.Errorf("failed to activate ebpf telemetry: %s", err)
 	}
 
 	telemetryMapKeys := nettelemetry.BuildTelemetryKeys(mgr)

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -156,8 +156,8 @@ func newTracer(cfg *config.Config) (_ *Tracer, reterr error) {
 		}
 	}()
 
-	if nettelemetry.EBPFTelemetrySupported() {
-		tr.bpfTelemetry = nettelemetry.NewEBPFTelemetry()
+	tr.bpfTelemetry = nettelemetry.NewEBPFTelemetry()
+	if tr.bpfTelemetry != nil {
 		coretelemetry.GetCompatComponent().RegisterCollector(tr.bpfTelemetry)
 	}
 
@@ -616,8 +616,6 @@ const (
 	stateStats
 	tracerStats
 	processCacheStats
-	bpfMapStats
-	bpfHelperStats
 	kafkaStats
 )
 
@@ -625,8 +623,6 @@ var allStats = []statsComp{
 	stateStats,
 	tracerStats,
 	httpStats,
-	bpfMapStats,
-	bpfHelperStats,
 }
 
 func (t *Tracer) getStats(comps ...statsComp) (map[string]interface{}, error) {
@@ -650,10 +646,6 @@ func (t *Tracer) getStats(comps ...statsComp) (map[string]interface{}, error) {
 			ret["tracer"] = tracerStats
 		case httpStats:
 			ret["universal_service_monitoring"] = t.usmMonitor.GetUSMStats()
-		case bpfMapStats:
-			ret[nettelemetry.EBPFMapTelemetryNS] = t.bpfTelemetry.GetMapsTelemetry()
-		case bpfHelperStats:
-			ret[nettelemetry.EBPFHelperTelemetryNS] = t.bpfTelemetry.GetHelpersTelemetry()
 		}
 	}
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -159,6 +159,8 @@ func newTracer(cfg *config.Config) (_ *Tracer, reterr error) {
 	tr.bpfTelemetry = nettelemetry.NewEBPFTelemetry()
 	if tr.bpfTelemetry != nil {
 		coretelemetry.GetCompatComponent().RegisterCollector(tr.bpfTelemetry)
+	} else {
+		log.Debug("eBPF telemetry not supported")
 	}
 
 	tr.ebpfTracer, err = connection.NewTracer(cfg, tr.bpfTelemetry)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config/sysctl"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	netlinktestutil "github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
-	"github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/offsetguess"
@@ -1923,11 +1922,7 @@ func (s *TracerSuite) TestGetMapsTelemetry() {
 	err := exec.Command(cmd[0], cmd[1:]...).Run()
 	require.NoError(t, err)
 
-	stats, err := tr.getStats(bpfMapStats)
-	require.NoError(t, err)
-
-	mapsTelemetry, ok := stats[telemetry.EBPFMapTelemetryNS].(map[string]interface{})
-	require.True(t, ok)
+	mapsTelemetry := tr.bpfTelemetry.GetMapsTelemetry()
 	t.Logf("EBPF Maps telemetry: %v\n", mapsTelemetry)
 
 	tcpStatsErrors, ok := mapsTelemetry[probes.TCPStatsMap].(map[string]uint64)
@@ -1981,11 +1976,7 @@ func (s *TracerSuite) TestGetHelpersTelemetry() {
 		syscall.Syscall(syscall.SYS_MUNMAP, uintptr(addr), uintptr(syscall.Getpagesize()), 0)
 	})
 
-	stats, err := tr.getStats(bpfHelperStats)
-	require.NoError(t, err)
-
-	helperTelemetry, ok := stats[telemetry.EBPFHelperTelemetryNS].(map[string]interface{})
-	require.True(t, ok)
+	helperTelemetry := tr.bpfTelemetry.GetHelpersTelemetry()
 	t.Logf("EBPF helper telemetry: %v\n", helperTelemetry)
 
 	openAtErrors, ok := helperTelemetry[expectedErrorTP].(map[string]interface{})

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -394,11 +394,13 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 		undefinedProbes = append(undefinedProbes, tc.ProbeIdentificationPair)
 	}
 
-	e.InstructionPatcher = func(m *manager.Manager) error {
-		return errtelemetry.PatchEBPFTelemetry(m, true, undefinedProbes)
+	err := errtelemetry.ActivateBPFTelemetry(e.Manager.Manager, undefinedProbes)
+	if err != nil {
+		cleanup()
+		return err
 	}
 
-	err := e.InitWithOptions(buf, options)
+	err = e.InitWithOptions(buf, options)
 	if err != nil {
 		cleanup()
 	} else {

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -389,18 +389,7 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 		}
 	}
 
-	var undefinedProbes []manager.ProbeIdentificationPair
-	for _, tc := range e.tailCallRouter {
-		undefinedProbes = append(undefinedProbes, tc.ProbeIdentificationPair)
-	}
-
-	err := errtelemetry.ActivateBPFTelemetry(e.Manager.Manager, undefinedProbes)
-	if err != nil {
-		cleanup()
-		return err
-	}
-
-	err = e.InitWithOptions(buf, options)
+	err := e.InitWithOptions(buf, options)
 	if err != nil {
 		cleanup()
 	} else {

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -79,11 +79,11 @@ func newEBPFProgram(c *config.Config, bpfTelemetry *errtelemetry.EBPFTelemetry) 
 }
 
 func (e *ebpfProgram) Init() error {
-	var err error
-
-	e.InstructionPatcher = func(m *manager.Manager) error {
-		return errtelemetry.PatchEBPFTelemetry(m, true, getAllUndefinedProbes())
+	err := errtelemetry.ActivateBPFTelemetry(e.Manager.Manager, getAllUndefinedProbes())
+	if err != nil {
+		return err
 	}
+
 	if e.cfg.EnableCORE {
 		err = e.initCORE()
 		if err == nil {

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -79,11 +79,7 @@ func newEBPFProgram(c *config.Config, bpfTelemetry *errtelemetry.EBPFTelemetry) 
 }
 
 func (e *ebpfProgram) Init() error {
-	err := errtelemetry.ActivateBPFTelemetry(e.Manager.Manager, getAllUndefinedProbes())
-	if err != nil {
-		return err
-	}
-
+	var err error
 	if e.cfg.EnableCORE {
 		err = e.initCORE()
 		if err == nil {
@@ -205,21 +201,4 @@ func getAssetName(module string, debug bool) string {
 	}
 
 	return fmt.Sprintf("%s.o", module)
-}
-
-func getAllUndefinedProbes() []manager.ProbeIdentificationPair {
-	undefined := []manager.ProbeIdentificationPair{}
-
-	if !sysOpenAt2Supported() {
-		undefined = append(undefined,
-			manager.ProbeIdentificationPair{
-				EBPFFuncName: "tracepoint__syscalls__sys_enter_openat2",
-			},
-			manager.ProbeIdentificationPair{
-				EBPFFuncName: "tracepoint__syscalls__sys_exit_openat2",
-			},
-		)
-	}
-
-	return undefined
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Simplifies the API to use eBPF telemetry and makes it thread-safe

### Motivation

- It was a bit confusing of when to call each function to setup eBPF telemetry
- There was a bug around the programs instrumented and those which had keys inserted into the telemetry map
- the `prometheus.Collector.Collect` function can be called concurrently, so it needs to be thread-safe

### Additional Notes

- You must now use the `telemetry.Manager` to setup eBPF telemetry for a `ebpf-manager.Manager`. This ensures that all the functions are called in the correct order and at the right time. It only hooks `InitWithOptions`, so it does not need to be used afterwards.
- You no longer need to provide a list of "undefined" probes. We get all the loaded programs directly from the manager.
- If telemetry is not enabled, we leave the map/program key constants as `0`. The macro code has been updated to skip even the map lookup if the constant is `0`. On kernels with deadcode elimination, this should reduce the number of instructions.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
