### PR TITLE
[CONTINT-3389] Add check_delay metric in agent telemetry

### DIFF
--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -154,7 +154,7 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats S
 	cs.m.Lock()
 	defer cs.m.Unlock()
 
-	cs.LastDelay = calculateCheckDelay(cs, t)
+	cs.LastDelay = calculateCheckDelay(time.Now(), cs, t)
 	if cs.telemetry {
 		tlmCheckDelay.Set(float64(cs.LastDelay), cs.CheckName)
 	}

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -101,6 +101,7 @@ type Stats struct {
 	LastExecutionTime        int64     // most recent run duration, provided for convenience
 	LastSuccessDate          int64     // most recent successful execution date, unix timestamp in seconds
 	LastError                string    // error that occurred in the last run, if any
+	LastErrorDate            int64     // most recent failed execution date, unix timestamp in seconds
 	LastWarnings             []string  // warnings that occurred in the last run, if any
 	UpdateTimestamp          int64     // latest update to this instance, unix timestamp in seconds
 	m                        sync.Mutex
@@ -168,6 +169,7 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats S
 			tlmRuns.Inc(cs.CheckName, runCheckFailureTag)
 		}
 		cs.LastError = err.Error()
+		cs.LastErrorDate = time.Now().Unix()
 	} else {
 		if cs.telemetry {
 			tlmRuns.Inc(cs.CheckName, runCheckSuccessTag)

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -48,6 +48,10 @@ var (
 		[]string{"check_name"}, "Histogram buckets count")
 	tlmExecutionTime = telemetry.NewGauge("checks", "execution_time",
 		[]string{"check_name"}, "Check execution time")
+	tlmCheckDelay = telemetry.NewGauge("checks",
+		"delay",
+		[]string{"check_name"},
+		"Check start time delay relative to the previous check run")
 )
 
 // SenderStats contains statistics showing the count of various types of telemetry sent by a check sender
@@ -83,6 +87,7 @@ type Stats struct {
 	CheckVersion             string
 	CheckConfigSource        string
 	CheckID                  checkid.ID
+	Interval                 time.Duration
 	TotalRuns                uint64
 	TotalErrors              uint64
 	TotalWarnings            uint64
@@ -101,7 +106,7 @@ type Stats struct {
 	LastExecutionTime        int64     // most recent run duration, provided for convenience
 	LastSuccessDate          int64     // most recent successful execution date, unix timestamp in seconds
 	LastError                string    // error that occurred in the last run, if any
-	LastErrorDate            int64     // most recent failed execution date, unix timestamp in seconds
+	LastDelay                int64     // most recent check start time delay relative to the previous check run, in seconds
 	LastWarnings             []string  // warnings that occurred in the last run, if any
 	UpdateTimestamp          int64     // latest update to this instance, unix timestamp in seconds
 	m                        sync.Mutex
@@ -115,6 +120,8 @@ type StatsCheck interface {
 	ID() checkid.ID
 	// Version returns the version of the check if available
 	Version() string
+	//Interval returns the interval time for the check
+	Interval() time.Duration
 	// ConfigSource returns the configuration source of the check
 	ConfigSource() string
 }
@@ -126,6 +133,7 @@ func NewStats(c StatsCheck) *Stats {
 		CheckName:                c.String(),
 		CheckVersion:             c.Version(),
 		CheckConfigSource:        c.ConfigSource(),
+		Interval:                 c.Interval(),
 		telemetry:                utils.IsCheckTelemetryEnabled(c.String()),
 		EventPlatformEvents:      make(map[string]int64),
 		TotalEventPlatformEvents: make(map[string]int64),
@@ -145,6 +153,11 @@ func NewStats(c StatsCheck) *Stats {
 func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats SenderStats) {
 	cs.m.Lock()
 	defer cs.m.Unlock()
+
+	cs.LastDelay = calculateCheckDelay(cs, t)
+	if cs.telemetry {
+		tlmCheckDelay.Set(float64(cs.LastDelay), cs.CheckName)
+	}
 
 	// store execution times in Milliseconds
 	tms := t.Nanoseconds() / 1e6
@@ -169,7 +182,6 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats S
 			tlmRuns.Inc(cs.CheckName, runCheckFailureTag)
 		}
 		cs.LastError = err.Error()
-		cs.LastErrorDate = time.Now().Unix()
 	} else {
 		if cs.telemetry {
 			tlmRuns.Inc(cs.CheckName, runCheckSuccessTag)

--- a/pkg/collector/check/stats/stats_test.go
+++ b/pkg/collector/check/stats/stats_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -23,13 +24,15 @@ type mockCheck struct {
 	id        checkid.ID
 	stringVal string
 	version   string
+	interval  time.Duration
 }
 
 // Mock Check interface implementation
-func (mc *mockCheck) ConfigSource() string { return mc.cfgSource }
-func (mc *mockCheck) ID() checkid.ID       { return mc.id }
-func (mc *mockCheck) String() string       { return mc.stringVal }
-func (mc *mockCheck) Version() string      { return mc.version }
+func (mc *mockCheck) ConfigSource() string    { return mc.cfgSource }
+func (mc *mockCheck) ID() checkid.ID          { return mc.id }
+func (mc *mockCheck) String() string          { return mc.stringVal }
+func (mc *mockCheck) Version() string         { return mc.version }
+func (mc *mockCheck) Interval() time.Duration { return mc.interval }
 
 func newMockCheck() StatsCheck {
 	return &mockCheck{
@@ -37,6 +40,17 @@ func newMockCheck() StatsCheck {
 		id:        "checkID",
 		stringVal: "checkString",
 		version:   "checkVersion",
+		interval:  15 * time.Second,
+	}
+}
+
+func newMockCheckWithInterval(interval time.Duration) StatsCheck {
+	return &mockCheck{
+		cfgSource: "checkConfigSrc",
+		id:        "checkID",
+		stringVal: "checkString",
+		version:   "checkVersion",
+		interval:  interval,
 	}
 }
 
@@ -60,6 +74,7 @@ func TestNewStats(t *testing.T) {
 	assert.Equal(t, stats.CheckVersion, "checkVersion")
 	assert.Equal(t, stats.CheckVersion, "checkVersion")
 	assert.Equal(t, stats.CheckConfigSource, "checkConfigSrc")
+	assert.Equal(t, stats.Interval, 15*time.Second)
 }
 
 func TestNewStatsStateTelemetryIgnoredWhenGloballyDisabled(t *testing.T) {

--- a/pkg/collector/check/stats/util.go
+++ b/pkg/collector/check/stats/util.go
@@ -7,13 +7,13 @@ package stats
 
 import "time"
 
-func calculateCheckDelay(prevRunStats *Stats, execTime time.Duration) int64 {
+func calculateCheckDelay(now time.Time, prevRunStats *Stats, execTime time.Duration) int64 {
 	if prevRunStats.UpdateTimestamp == 0 || prevRunStats.Interval == 0 {
 		return 0
 	}
 
 	previousCheckStartDate := prevRunStats.UpdateTimestamp - (prevRunStats.LastExecutionTime / 1e3)
-	currentCheckStartDate := time.Now().Unix() - int64(execTime.Seconds())
+	currentCheckStartDate := now.Unix() - int64(execTime.Seconds())
 
 	delay := currentCheckStartDate - previousCheckStartDate - int64(prevRunStats.Interval.Seconds())
 

--- a/pkg/collector/check/stats/util.go
+++ b/pkg/collector/check/stats/util.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package stats
+
+import "time"
+
+func calculateCheckDelay(prevRunStats *Stats, execTime time.Duration) int64 {
+	if prevRunStats.UpdateTimestamp == 0 || prevRunStats.Interval == 0 {
+		return 0
+	}
+
+	previousCheckStartDate := prevRunStats.UpdateTimestamp - (prevRunStats.LastExecutionTime / 1e3)
+	currentCheckStartDate := time.Now().Unix() - int64(execTime.Seconds())
+
+	delay := currentCheckStartDate - previousCheckStartDate - int64(prevRunStats.Interval.Seconds())
+
+	// delay can be negative if a check recovers from delay
+	if delay < 0 {
+		delay = 0
+	}
+
+	return delay
+}

--- a/pkg/collector/check/stats/util_test.go
+++ b/pkg/collector/check/stats/util_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package stats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newMockStats(updateTimestamp, lastExecutionTime int64, interval time.Duration) *Stats {
+	mockStatsCheck := newMockCheckWithInterval(interval)
+	mockStats := NewStats(mockStatsCheck)
+
+	mockStats.UpdateTimestamp = updateTimestamp
+	mockStats.LastExecutionTime = lastExecutionTime
+
+	return mockStats
+}
+
+func TestCalculateCheckDelay(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		prevRunStats  *Stats
+		execTime      time.Duration
+		checkInterval time.Duration
+		delay         int64
+	}{
+		{
+			name:         "First Check Run",
+			prevRunStats: newMockStats(0, 0, 15*time.Second),
+			execTime:     2 * time.Second,
+			delay:        0,
+		},
+		{
+			name:         "Long Runnig Check",
+			prevRunStats: newMockStats(0, 9999999999, 0),
+			execTime:     999999 * time.Second,
+			delay:        0,
+		},
+		{
+			name:         "Regular Running Delayed Check",
+			prevRunStats: newMockStats(time.Now().Add(-16*time.Second).Unix(), 17*1000, 15*time.Second),
+			delay:        18, // Check ran 33 seconds after the previous run started
+		},
+		{
+			name:         "Recovery from delay",
+			prevRunStats: newMockStats(time.Now().Add(-6*time.Second).Unix(), 1*1000, 15*time.Second),
+			delay:        0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.delay, calculateCheckDelay(tt.prevRunStats, tt.execTime))
+		})
+	}
+}

--- a/pkg/collector/check/stats/util_test.go
+++ b/pkg/collector/check/stats/util_test.go
@@ -23,6 +23,7 @@ func newMockStats(updateTimestamp, lastExecutionTime int64, interval time.Durati
 }
 
 func TestCalculateCheckDelay(t *testing.T) {
+	mockNow := time.Now()
 
 	tests := []struct {
 		name          string
@@ -45,19 +46,24 @@ func TestCalculateCheckDelay(t *testing.T) {
 		},
 		{
 			name:         "Regular Running Delayed Check",
-			prevRunStats: newMockStats(time.Now().Add(-16*time.Second).Unix(), 17*1000, 15*time.Second),
+			prevRunStats: newMockStats(mockNow.Add(-16*time.Second).Unix(), 17*1000, 15*time.Second),
+			delay:        18, // Check ran 33 seconds after the previous run started
+		},
+		{
+			name:         "Regular Running Delayed Check With Execution Time In Decimal Seconds ",
+			prevRunStats: newMockStats(mockNow.Add(-16*time.Second).Unix(), 17.32*1000, 15*time.Second),
 			delay:        18, // Check ran 33 seconds after the previous run started
 		},
 		{
 			name:         "Recovery from delay",
-			prevRunStats: newMockStats(time.Now().Add(-6*time.Second).Unix(), 1*1000, 15*time.Second),
+			prevRunStats: newMockStats(mockNow.Add(-6*time.Second).Unix(), 1*1000, 15*time.Second),
 			delay:        0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.delay, calculateCheckDelay(tt.prevRunStats, tt.execTime))
+			assert.Equal(t, tt.delay, calculateCheckDelay(mockNow, tt.prevRunStats, tt.execTime))
 		})
 	}
 }

--- a/pkg/collector/worker/worker.go
+++ b/pkg/collector/worker/worker.go
@@ -44,7 +44,7 @@ var checkDelay = telemetry.NewGauge(
 	"collector",
 	"check_delay",
 	[]string{"check_name"},
-	"Check Delay represents the delay in running a check in seconds.",
+	"Check delay measures time between the scheduled start time and when the check actually started.",
 )
 
 // Worker is an object that encapsulates the logic to manage a loop of processing

--- a/pkg/collector/worker/worker.go
+++ b/pkg/collector/worker/worker.go
@@ -40,6 +40,13 @@ var workerUtilization = telemetry.NewGauge(
 	"Worker utilization. It's a value between 0 and 1 that represents the share of time that the check runner worker is running checks",
 )
 
+var checkDelay = telemetry.NewGauge(
+	"collector",
+	"check_delay",
+	[]string{"check_name"},
+	"Check Delay represents the delay in running a check in seconds.",
+)
+
 // Worker is an object that encapsulates the logic to manage a loop of processing
 // checks over the provided `PendingCheckChan`
 type Worker struct {
@@ -147,6 +154,25 @@ func (w *Worker) Run() {
 		expvars.SetRunningStats(check.ID(), checkStartTime)
 
 		utilizationTracker.CheckStarted()
+
+		if checkStats, found := expvars.CheckStats(check.ID()); found {
+
+			// Calculate start time of previous execution
+			previousFinishDate := checkStats.LastSuccessDate
+			if previousFinishDate < checkStats.LastErrorDate {
+				previousFinishDate = checkStats.LastErrorDate
+			}
+
+			previousStartDate := previousFinishDate - (checkStats.LastExecutionTime / 1e3)
+
+			delay := time.Now().Unix() - previousStartDate - int64(check.Interval().Seconds())
+
+			if delay < 0 {
+				delay = 0
+			}
+
+			checkDelay.Set(float64(delay), check.String())
+		}
 
 		// Run the check
 		checkErr := check.Run()

--- a/releasenotes/notes/add_check_delay_metric-bc977ed05432a091.yaml
+++ b/releasenotes/notes/add_check_delay_metric-bc977ed05432a091.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Add `check_delay` metric in `agent` telemetry
+    Add ``check_delay`` metric in Agent telemetry

--- a/releasenotes/notes/add_check_delay_metric-bc977ed05432a091.yaml
+++ b/releasenotes/notes/add_check_delay_metric-bc977ed05432a091.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add `check_delay` metric in `agent` telemetry


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds `check_delay` metric to agent telemetry.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We need to be able to evaluate if a check is running on time based on its interval configuration (by default 15 seconds) or not because the Agent is busy with other work or because the previous check run is stuck and taking excessively long time to finish?

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- The `check_delay` metric is reported starting from the second run of the check. 
- Normally, `check_delay` will not be exposed for long running checks (checks with interval 0) since they are run only once. (Correct me if I am wrong)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
- The existing implementation tracks the check end date in seconds (unix timestamp), and the duration of the previous execution (in milliseconds). Reusing the existing implementation results in having the delay calculated on second-scale (instead of milliseconds). So an actual delay of 0.5 is reported as 0, and an actual delay of 5.9 is reported as 5. Basically this is similar to the concept of Unix timestamp, i.e. we report the number of seconds that have elapsed since the expected next check run timestamp. However, this should be fine because we are not interested in a higher precision of the delay (having higher precision is not particularly useful).

### Describe how to test/QA your changes
- When testing this PR, you should enable the check telemetry. If using helm to install, you should add the following environment variables to the `datadog` section:
```
 env:
    - name: DD_TELEMETRY_CHECKS
      value: "*"
    - name: DD_TELEMETRY_ENABLED
      value: true
```

- Deploy the agent with a configuration that causes some checks to be delayed, then check the agent telemetry by running `curl -s http://localhost:6000/telemetry` and looking for the `check_delay` metric. The value of this metric should be zero for all regular checks, and positive for other delayed checks. 

- To force a check delay, you can deploy a custom check that waits for sleeps for 20 seconds, the `check_delay` reported for such a check should be around 15 seconds.

- The output should be similar to the following (but will differ depending on which check is delayed):
```
# HELP checks__check_delay time between the scheduled start time and when the check actually started
# TYPE checks__check_delay gauge
checks__delay{check_name="cilium"} 0
checks__delay{check_name="container"} 0
checks__delay{check_name="containerd"} 0
checks__delay{check_name="cpu"} 0
checks__delay{check_name="cri"} 15
checks__delay{check_name="disk"} 0
checks__delay{check_name="docker"} 0
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
