### PR TITLE
[CWS] add origin of events

### DIFF
--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -205,6 +205,10 @@
           },
           "type": "array",
           "description": "The list of rules that the event matched (only valid in the context of an anomaly)"
+        },
+        "source": {
+          "type": "string",
+          "description": "Source of the event"
         }
       },
       "additionalProperties": false,

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -206,9 +206,9 @@
           "type": "array",
           "description": "The list of rules that the event matched (only valid in the context of an anomaly)"
         },
-        "source": {
+        "origin": {
           "type": "string",
-          "description": "Source of the event"
+          "description": "Origin of the event"
         }
       },
       "additionalProperties": false,

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -79,7 +79,6 @@ type Probe struct {
 
 	// internals
 	scrubber *procutil.DataScrubber
-	event    *model.Event
 
 	// Events section
 	fullAccessEventHandlers [model.MaxAllEventType][]FullAccessEventHandler
@@ -241,12 +240,6 @@ func (p *Probe) DispatchCustomEvent(rule *rules.Rule, event *events.CustomEvent)
 	for _, handler := range p.customEventHandlers[event.GetEventType()] {
 		handler.HandleCustomEvent(rule, event)
 	}
-}
-
-func (p *Probe) zeroEvent() *model.Event {
-	p.event.Zero()
-	p.event.FieldHandlers = p.PlatformProbe.GetFieldHandlers()
-	return p.event
 }
 
 // StatsPollingInterval returns the stats polling interval

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -524,7 +524,7 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 func (p *EBPFProbe) zeroEvent() *model.Event {
 	p.event.Zero()
 	p.event.FieldHandlers = p.fieldHandlers
-	p.event.Source = "ebpf"
+	p.event.Origin = "ebpf"
 	return p.event
 }
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -98,6 +98,7 @@ type EBPFProbe struct {
 	kernelVersion  *kernel.Version
 
 	// internals
+	event           *model.Event
 	monitors        *EBPFMonitors
 	profileManagers *SecurityProfileManagers
 	fieldHandlers   *EBPFFieldHandlers
@@ -520,9 +521,16 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 	return true
 }
 
+func (p *EBPFProbe) zeroEvent() *model.Event {
+	p.event.Zero()
+	p.event.FieldHandlers = p.fieldHandlers
+	p.event.Source = "ebpf"
+	return p.event
+}
+
 func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 	offset := 0
-	event := p.probe.zeroEvent()
+	event := p.zeroEvent()
 
 	dataLen := uint64(len(data))
 
@@ -1688,6 +1696,11 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts) (*EBPFProbe, e
 			eventstream.EventStreamMap: true,
 		}
 	}
+
+	p.event = p.NewEvent()
+
+	// be sure to zero the probe event before everything else
+	p.zeroEvent()
 
 	return p, nil
 }

--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -316,7 +316,7 @@ func (p *EBPFLessProbe) GetEventTags(containerID string) []string {
 func (p *EBPFLessProbe) zeroEvent() *model.Event {
 	p.event.Zero()
 	p.event.FieldHandlers = p.fieldHandlers
-	p.event.Source = "ebpfless"
+	p.event.Origin = "ebpfless"
 	return p.event
 }
 

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -35,10 +35,5 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		p.PlatformProbe = pp
 	}
 
-	p.event = p.PlatformProbe.NewEvent()
-
-	// be sure to zero the probe event before everything else
-	p.zeroEvent()
-
 	return p, nil
 }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -169,6 +169,7 @@ type BaseEvent struct {
 	TimestampRaw uint64         `field:"event.timestamp,handler:ResolveEventTimestamp" event:"*"` // SECLDoc[event.timestamp] Definition:`Timestamp of the event`
 	Timestamp    time.Time      `field:"timestamp,opts:getters_only,handler:ResolveEventTime"`
 	Rules        []*MatchedRule `field:"-"`
+	Source       string         `field:"-"`
 
 	// context shared with all events
 	ProcessContext         *ProcessContext        `field:"process" event:"*"`

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -169,7 +169,7 @@ type BaseEvent struct {
 	TimestampRaw uint64         `field:"event.timestamp,handler:ResolveEventTimestamp" event:"*"` // SECLDoc[event.timestamp] Definition:`Timestamp of the event`
 	Timestamp    time.Time      `field:"timestamp,opts:getters_only,handler:ResolveEventTime"`
 	Rules        []*MatchedRule `field:"-"`
-	Source       string         `field:"-"`
+	Origin       string         `field:"-"`
 
 	// context shared with all events
 	ProcessContext         *ProcessContext        `field:"process" event:"*"`

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -49,6 +49,8 @@ type EventContextSerializer struct {
 	Async bool `json:"async,omitempty"`
 	// The list of rules that the event matched (only valid in the context of an anomaly)
 	MatchedRules []MatchedRuleSerializer `json:"matched_rules,omitempty"`
+	// Source of the event
+	Source string `json:"source,omitempty"`
 }
 
 // ProcessContextSerializer serializes a process context to JSON
@@ -215,7 +217,8 @@ func NewBaseEventSerializer(event *model.Event) *BaseEventSerializer {
 
 	s := &BaseEventSerializer{
 		EventContextSerializer: EventContextSerializer{
-			Name: eventType.String(),
+			Name:   eventType.String(),
+			Source: event.Source,
 		},
 		ProcessContextSerializer: newProcessContextSerializer(pc, event),
 		Date:                     utils.NewEasyjsonTime(event.ResolveEventTime()),

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -49,8 +49,8 @@ type EventContextSerializer struct {
 	Async bool `json:"async,omitempty"`
 	// The list of rules that the event matched (only valid in the context of an anomaly)
 	MatchedRules []MatchedRuleSerializer `json:"matched_rules,omitempty"`
-	// Source of the event
-	Source string `json:"source,omitempty"`
+	// Origin of the event
+	Origin string `json:"origin,omitempty"`
 }
 
 // ProcessContextSerializer serializes a process context to JSON
@@ -218,7 +218,7 @@ func NewBaseEventSerializer(event *model.Event) *BaseEventSerializer {
 	s := &BaseEventSerializer{
 		EventContextSerializer: EventContextSerializer{
 			Name:   eventType.String(),
-			Source: event.Source,
+			Origin: event.Origin,
 		},
 		ProcessContextSerializer: newProcessContextSerializer(pc, event),
 		Date:                     utils.NewEasyjsonTime(event.ResolveEventTime()),

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -950,6 +950,8 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 				}
 				in.Delim(']')
 			}
+		case "source":
+			out.Source = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -1018,6 +1020,16 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 			}
 			out.RawByte(']')
 		}
+	}
+	if in.Source != "" {
+		const prefix string = ",\"source\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Source))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -950,8 +950,8 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 				}
 				in.Delim(']')
 			}
-		case "source":
-			out.Source = string(in.String())
+		case "origin":
+			out.Origin = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -1021,15 +1021,15 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 			out.RawByte(']')
 		}
 	}
-	if in.Source != "" {
-		const prefix string = ",\"source\":"
+	if in.Origin != "" {
+		const prefix string = ",\"origin\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
-		out.String(string(in.Source))
+		out.String(string(in.Origin))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/tests/schemas/event.json
+++ b/pkg/security/tests/schemas/event.json
@@ -18,7 +18,7 @@
                 "async": {
                     "type": "boolean"
                 },
-                "source": {
+                "origin": {
                     "type": "string"
                 }
             },

--- a/pkg/security/tests/schemas/event.json
+++ b/pkg/security/tests/schemas/event.json
@@ -17,6 +17,9 @@
                 },
                 "async": {
                     "type": "boolean"
+                },
+                "source": {
+                    "type": "string"
                 }
             },
             "required": [


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Goal is to distinguish ebpf and ebpfless events

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Generate an event from ebpf and ebpfless probes and check the source

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
