### PR TITLE
[fakeintake] Add functionality to configure response overrides

### DIFF
--- a/test/fakeintake/api/api.go
+++ b/test/fakeintake/api/api.go
@@ -42,3 +42,11 @@ type RouteStat struct {
 type APIFakeIntakeRouteStatsGETResponse struct {
 	Routes map[string]RouteStat `json:"routes"`
 }
+
+// ResponseOverride is a hardcoded response for requests to the given endpoint
+type ResponseOverride struct {
+	Endpoint    string `json:"endpoint"`
+	StatusCode  int    `json:"status_code"`
+	ContentType string `json:"content_type"`
+	Body        []byte `json:"body"`
+}

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -39,6 +39,7 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -188,6 +189,28 @@ func (c *Client) GetServerHealth() error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("error code %v", resp.StatusCode)
+	}
+	return nil
+}
+
+// ConfigureOverride sets a response override on the fakeintake server
+func (c *Client) ConfigureOverride(override api.ResponseOverride) error {
+	route := fmt.Sprintf("%s/fakeintake/configure/override", c.fakeIntakeURL)
+
+	buf := new(bytes.Buffer)
+	err := json.NewEncoder(buf).Encode(override)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Post(route, "application/json", buf)
+	if err != nil {
+		return err
+	}
+
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("error code %v", resp.StatusCode)

--- a/test/fakeintake/client/client_test.go
+++ b/test/fakeintake/client/client_test.go
@@ -224,6 +224,25 @@ func TestClient(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("ConfigureOverride", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/fakeintake/configure/override" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		client := NewClient(ts.URL)
+		err := client.ConfigureOverride(api.ResponseOverride{
+			StatusCode:  http.StatusOK,
+			ContentType: "text/plain",
+			Body:        []byte("totoro"),
+		})
+		assert.NoError(t, err)
+	})
+
 	t.Run("GetLatestFlare", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write(supportFlareResponse)

--- a/test/fakeintake/server/body.go
+++ b/test/fakeintake/server/body.go
@@ -45,12 +45,12 @@ func getConnectionsResponse() []byte {
 }
 
 // getResponseFromURLPath returns the appropriate response body to HTTP request sent to 'urlPath'
-func getResponseFromURLPath(urlPath string) httpResponse {
-	var defaultResponse = httpResponse{
+func (fi *Server) getResponseFromURLPath(urlPath string) httpResponse {
+	var defaultResponse = updateResponseFromData(httpResponse{
 		statusCode:  http.StatusOK,
 		contentType: "application/json",
 		data:        errorResponseBody{Errors: []string{}},
-	}
+	})
 	responses := map[string]httpResponse{
 		"/support/flare": {
 			statusCode:  http.StatusOK,
@@ -64,8 +64,10 @@ func getResponseFromURLPath(urlPath string) httpResponse {
 		},
 	}
 
-	if _, found := responses[urlPath]; !found {
-		return defaultResponse
+	if response, found := fi.responseOverrides[urlPath]; found {
+		return response
+	} else if response, found := responses[urlPath]; found {
+		return updateResponseFromData(response)
 	}
-	return updateResponseFromData(responses[urlPath])
+	return defaultResponse
 }

--- a/test/fakeintake/server/body.go
+++ b/test/fakeintake/server/body.go
@@ -21,11 +21,8 @@ type flareResponseBody struct {
 	Error  string `json:"error,omitempty"`
 }
 
-var defaultResponse = updateResponseFromData(httpResponse{
-	statusCode:  http.StatusOK,
-	contentType: "application/json",
-	data:        errorResponseBody{Errors: []string{}},
-})
+// defaultResponse is the default response returned by the fakeintake server
+var defaultResponse httpResponse
 
 func getConnectionsResponse() []byte {
 	clStatus := &agentmodel.CollectorStatus{

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -402,14 +402,6 @@ func (fi *Server) handleGetRouteStats(w http.ResponseWriter, req *http.Request) 
 	})
 }
 
-// responseOverride is a hardcoded response for requests to the given endpoint
-type responseOverride struct {
-	Endpoint    string `json:"endpoint"`
-	StatusCode  int    `json:"status_code"`
-	ContentType string `json:"content_type"`
-	Body        []byte `json:"body"`
-}
-
 // handleConfigureOverride sets a hardcoded HTTP response for requests to a particular endpoint
 func (fi *Server) handleConfigureOverride(w http.ResponseWriter, req *http.Request) {
 	if req == nil {
@@ -430,7 +422,7 @@ func (fi *Server) handleConfigureOverride(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	var payload responseOverride
+	var payload api.ResponseOverride
 	err := json.NewDecoder(req.Body).Decode(&payload)
 	if err != nil {
 		log.Printf("Error reading body: %v", err.Error())

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -443,17 +443,22 @@ func (fi *Server) handleConfigureOverride(w http.ResponseWriter, req *http.Reque
 
 	log.Printf("Handling configureOverride request for endpoint %s", payload.Endpoint)
 
-	fi.responseOverridesMutex.Lock()
-	fi.responseOverrides[payload.Endpoint] = httpResponse{
+	fi.safeSetResponseOverride(payload.Endpoint, httpResponse{
 		statusCode:  payload.StatusCode,
 		contentType: payload.ContentType,
 		body:        payload.Body,
-	}
-	fi.responseOverridesMutex.Unlock()
+	})
 
 	writeHTTPResponse(w, httpResponse{
 		statusCode: http.StatusOK,
 	})
+}
+
+func (fi *Server) safeSetResponseOverride(endpoint string, response httpResponse) {
+	fi.responseOverridesMutex.Lock()
+	defer fi.responseOverridesMutex.Unlock()
+
+	fi.responseOverrides[endpoint] = response
 }
 
 // getResponseFromURLPath returns the HTTP response for a given URL path, or the default response if

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -35,6 +35,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+func init() {
+	defaultResponse = updateResponseFromData(httpResponse{
+		statusCode:  http.StatusOK,
+		contentType: "application/json",
+		data:        errorResponseBody{Errors: []string{}},
+	})
+}
+
 //nolint:revive // TODO(APL) Fix revive linter
 type Server struct {
 	server    http.Server

--- a/test/fakeintake/server/server_test.go
+++ b/test/fakeintake/server/server_test.go
@@ -380,7 +380,7 @@ func TestServer(t *testing.T) {
 		fi.Start()
 		defer fi.Stop()
 
-		body := responseOverride{
+		body := api.ResponseOverride{
 			Endpoint:    "/totoro",
 			StatusCode:  200,
 			ContentType: "text/plain",

--- a/test/fakeintake/server/server_test.go
+++ b/test/fakeintake/server/server_test.go
@@ -375,6 +375,23 @@ func TestServer(t *testing.T) {
 		fi.Stop()
 	})
 
+	t.Run("should respond with custom response to /support/flare", func(t *testing.T) {
+		fi := NewServer()
+		fi.Start()
+		defer fi.Stop()
+
+		request, err := http.NewRequest(
+			http.MethodPost, "/support/flare", strings.NewReader("totoro|5|tag:valid,owner:mei"))
+		require.NoError(t, err, "Error creating request")
+
+		response := httptest.NewRecorder()
+		fi.handleDatadogRequest(response, request)
+
+		assert.Equal(t, http.StatusOK, response.Code)
+		assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
+		assert.Equal(t, `{}`, response.Body.String())
+	})
+
 	t.Run("should accept response overrides", func(t *testing.T) {
 		fi := NewServer()
 		fi.Start()

--- a/test/fakeintake/server/server_test.go
+++ b/test/fakeintake/server/server_test.go
@@ -415,9 +415,29 @@ func TestServer(t *testing.T) {
 
 		expected := map[string]httpResponse{
 			"/totoro": {
-				statusCode:  200,
+				statusCode:  http.StatusOK,
 				contentType: "text/plain",
 				body:        []byte("catbus"),
+			},
+			"/support/flare": {
+				statusCode:  http.StatusOK,
+				contentType: "application/json",
+				data:        flareResponseBody{CaseID: 0, Error: ""},
+				body:        []byte("{}"),
+			},
+			"/api/v1/connections": {
+				statusCode:  http.StatusOK,
+				contentType: "application/x-protobuf",
+				data: []byte{
+					0x03, 0x00, 0x17, 0x02, 0xf7, 0x01, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x1a, 0x04, 0x08, 0x01, 0x10, 0x1e,
+				},
+				body: []byte{
+					0x03, 0x00, 0x17, 0x02, 0xf7, 0x01, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x1a, 0x04, 0x08, 0x01, 0x10, 0x1e,
+				},
 			},
 		}
 		assert.Equal(t, expected, fi.responseOverrides)


### PR DESCRIPTION
### What does this PR do?

* Add a new endpoint `/fakeintake/configure/override` to the fakeintake server to set a custom response that the intake should return for a specified endpoint.
* Add a new method to the fakeintake client to call the above endpoint.

### Motivation

The process intake currently responds to all payloads with a response to indicate whether realtime mode should be enabled for the process agent. This change allows us to enable realtime mode in an agent under test and validate its behavior.

https://datadoghq.atlassian.net/browse/APL-2200
https://datadoghq.atlassian.net/browse/PROCS-3542

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] (N/A) Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] (N/A) If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] (N/A) If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] (N/A) If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] (N/A) If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
