### PR TITLE
usm: http2: Fixed a flaky test

### DIFF
--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -846,17 +846,18 @@ func (s *USMHTTP2Suite) TestHTTP2KernelTelemetry() {
 			// frames with EOS or RST frames, which leads into a flaking test. Therefore, we are asserting that the
 			// gotten number of EOS or RST frames is at least the number of expected EOS frames.
 			expectedEOSOrRST := tt.expectedTelemetry.End_of_stream + tt.expectedTelemetry.End_of_stream_rst
-			tt.expectedTelemetry.End_of_stream = 0
-			tt.expectedTelemetry.End_of_stream_rst = 0
 			var telemetry *usmhttp2.HTTP2Telemetry
 			assert.Eventually(t, func() bool {
 				telemetry, err = usmhttp2.Spec.Instance.(*usmhttp2.Protocol).GetHTTP2KernelTelemetry()
 				require.NoError(t, err)
 
-				sum := telemetry.End_of_stream + telemetry.End_of_stream_rst
-				telemetry.End_of_stream = 0
-				telemetry.End_of_stream_rst = 0
-				return reflect.DeepEqual(tt.expectedTelemetry, telemetry) && sum >= expectedEOSOrRST
+				return telemetry.Request_seen == tt.expectedTelemetry.Request_seen &&
+					telemetry.Response_seen == tt.expectedTelemetry.Response_seen &&
+					telemetry.Path_exceeds_frame == tt.expectedTelemetry.Path_exceeds_frame &&
+					telemetry.Exceeding_max_interesting_frames == tt.expectedTelemetry.Exceeding_max_interesting_frames &&
+					telemetry.Exceeding_max_frames_to_filter == tt.expectedTelemetry.Exceeding_max_frames_to_filter &&
+					telemetry.End_of_stream+telemetry.End_of_stream_rst >= expectedEOSOrRST &&
+					reflect.DeepEqual(telemetry.Path_size_bucket, tt.expectedTelemetry.Path_size_bucket)
 			}, time.Second*5, time.Millisecond*100)
 			if t.Failed() {
 				t.Logf("expected telemetry: %+v;\ngot: %+v", tt.expectedTelemetry, telemetry)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixing a flaky test.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We cannot predict if the client will send an RST frame or not, thus we cannot predict the number of
frames with EOS or RST frames, which leads into a flaking test. Therefore, we are asserting that the
gotten number of EOS or RST frames is at least the number of expected EOS frames.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
