### PR TITLE
uds-stream: fix flakky tests

### DIFF
--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -55,6 +55,10 @@ type UDSListener struct {
 	transport string
 
 	dogstatsdMemBasedRateLimiter bool
+
+	packetBufferSize         uint
+	packetBufferFlushTimeout time.Duration
+	telemetryWithListenerID  bool
 }
 
 // CloseFunction is a function that closes a connection
@@ -131,6 +135,9 @@ func NewUDSListener(packetOut chan packets.Packets, sharedPacketPoolManager *pac
 		dogstatsdMemBasedRateLimiter: cfg.GetBool("dogstatsd_mem_based_rate_limiter.enabled"),
 		config:                       cfg,
 		transport:                    transport,
+		packetBufferSize:             uint(cfg.GetInt("dogstatsd_packet_buffer_size")),
+		packetBufferFlushTimeout:     cfg.GetDuration("dogstatsd_packet_buffer_flush_timeout"),
+		telemetryWithListenerID:      cfg.GetBool("dogstatsd_telemetry_enabled_listener_id"),
 	}
 
 	// Init the oob buffer pool if origin detection is enabled
@@ -149,15 +156,15 @@ func NewUDSListener(packetOut chan packets.Packets, sharedPacketPoolManager *pac
 func (l *UDSListener) handleConnection(conn *net.UnixConn, closeFunc CloseFunction) error {
 	listenerID := l.getListenerID(conn)
 	tlmListenerID := listenerID
-	telemetryWithFullListenerID := l.config.GetBool("dogstatsd_telemetry_enabled_listener_id")
+	telemetryWithFullListenerID := l.telemetryWithListenerID
 	if !telemetryWithFullListenerID {
 		// In case we don't want the full listener id, we only keep the transport.
 		tlmListenerID = "uds-" + conn.LocalAddr().Network()
 	}
 
 	packetsBuffer := packets.NewBuffer(
-		uint(l.config.GetInt("dogstatsd_packet_buffer_size")),
-		l.config.GetDuration("dogstatsd_packet_buffer_flush_timeout"),
+		l.packetBufferSize,
+		l.packetBufferFlushTimeout,
 		l.packetOut,
 		tlmListenerID,
 	)

--- a/comp/dogstatsd/listeners/uds_common_test.go
+++ b/comp/dogstatsd/listeners/uds_common_test.go
@@ -11,15 +11,17 @@ package listeners
 
 import (
 	"encoding/binary"
-	"golang.org/x/net/nettest"
 	"net"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
+	"golang.org/x/net/nettest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
 
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
 )
@@ -104,11 +106,13 @@ func testStartStopUDSListener(t *testing.T, listenerFactory udsListenerFactory, 
 	assert.NotNil(t, s)
 
 	go s.Listen()
+
 	conn, err := net.Dial(transport, socketPath)
 	assert.Nil(t, err)
 	conn.Close()
 
 	s.Stop()
+
 	_, err = net.Dial(transport, socketPath)
 	assert.NotNil(t, err)
 }

--- a/comp/dogstatsd/listeners/uds_datagram.go
+++ b/comp/dogstatsd/listeners/uds_datagram.go
@@ -76,6 +76,5 @@ func (l *UDSDatagramListener) Stop() {
 	if err != nil {
 		log.Errorf("dogstatsd-uds: error closing connection: %s", err)
 	}
-	// FIXME close all currently running connections.
 	l.UDSListener.Stop()
 }


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

- Always resolve config early, it's not supposed to change anyway
- Make sure `Listen()` has returned when `Stop()` returns

### Motivation

The tests are flaky: AMLII-1306 // AMLII-1225

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

N/A

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
