### PR TITLE
[usm] Fix read hpack int bug

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -157,6 +157,7 @@ static __always_inline void update_path_size_telemetry(http2_telemetry_t *http2_
 // dynamic table, and will skip headers that are not path headers.
 static __always_inline bool parse_field_literal(struct __sk_buff *skb, skb_info_t *skb_info, http2_header_t *headers_to_process, __u64 index, __u64 global_dynamic_counter, __u8 *interesting_headers_counter, http2_telemetry_t *http2_tel) {
     __u64 str_len = 0;
+    // String length supposed to be represented with at least 7 bits representation -https://datatracker.ietf.org/doc/html/rfc7541#section-5.2
     if (!read_hpack_int(skb, skb_info, MAX_7_BITS, &str_len)) {
         return false;
     }
@@ -165,6 +166,7 @@ static __always_inline bool parse_field_literal(struct __sk_buff *skb, skb_info_
     if (index == 0) {
         skb_info->data_off += str_len;
         str_len = 0;
+        // String length supposed to be represented with at least 7 bits representation -https://datatracker.ietf.org/doc/html/rfc7541#section-5.2
         if (!read_hpack_int(skb, skb_info, MAX_7_BITS, &str_len)) {
             return false;
         }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -157,7 +157,7 @@ static __always_inline void update_path_size_telemetry(http2_telemetry_t *http2_
 // dynamic table, and will skip headers that are not path headers.
 static __always_inline bool parse_field_literal(struct __sk_buff *skb, skb_info_t *skb_info, http2_header_t *headers_to_process, __u64 index, __u64 global_dynamic_counter, __u8 *interesting_headers_counter, http2_telemetry_t *http2_tel) {
     __u64 str_len = 0;
-    if (!read_hpack_int(skb, skb_info, MAX_6_BITS, &str_len)) {
+    if (!read_hpack_int(skb, skb_info, MAX_7_BITS, &str_len)) {
         return false;
     }
 
@@ -165,7 +165,7 @@ static __always_inline bool parse_field_literal(struct __sk_buff *skb, skb_info_
     if (index == 0) {
         skb_info->data_off += str_len;
         str_len = 0;
-        if (!read_hpack_int(skb, skb_info, MAX_6_BITS, &str_len)) {
+        if (!read_hpack_int(skb, skb_info, MAX_7_BITS, &str_len)) {
             return false;
         }
         goto end;

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -669,13 +669,13 @@ func (s *USMHTTP2Suite) TestSimpleHTTP2() {
 	startH2CServer(t)
 
 	expected := make(map[http.Key]captureRange)
-	// currently we have a bug with paths which are not Huffman encoded, therefor we are skipping them by string length 3.
+	// currently we have a bug with paths which are not Huffman encoded, therefore, we are skipping them by starting from `/aaa` (i := 3).
 	for i := 3; i < 100; i++ {
 		expected[http.Key{
 			Path:   http.Path{Content: http.Interner.GetString(fmt.Sprintf("/%s", strings.Repeat("a", i)))},
 			Method: http.MethodPost,
 		}] = captureRange{
-			lower: 0,
+			lower: 1,
 			upper: 1,
 		}
 	}
@@ -799,7 +799,7 @@ func (s *USMHTTP2Suite) TestSimpleHTTP2() {
 				if t.Failed() {
 					for key := range expected {
 						if _, ok := res[key]; !ok {
-							t.Logf("key: %v not found in res", key.Path.Content.Get())
+							t.Logf("key: %v was not found in res", key.Path.Content.Get())
 						}
 					}
 					o, err := monitor.DumpMaps("http2_in_flight")

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -888,7 +888,6 @@ func (s *USMHTTP2Suite) TestHTTP2KernelTelemetry() {
 				}
 				if telemetry.Response_seen != tt.expectedTelemetry.Response_seen {
 					return false
-
 				}
 				if telemetry.Path_exceeds_frame != tt.expectedTelemetry.Path_exceeds_frame {
 					return false
@@ -899,7 +898,7 @@ func (s *USMHTTP2Suite) TestHTTP2KernelTelemetry() {
 				if telemetry.Exceeding_max_frames_to_filter != tt.expectedTelemetry.Exceeding_max_frames_to_filter {
 					return false
 				}
-				if expectedEOSOrRST < telemetry.End_of_stream+telemetry.End_of_stream_rst {
+				if telemetry.End_of_stream+telemetry.End_of_stream_rst < expectedEOSOrRST {
 					return false
 				}
 				return reflect.DeepEqual(telemetry.Path_size_bucket, tt.expectedTelemetry.Path_size_bucket)

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -883,15 +883,27 @@ func (s *USMHTTP2Suite) TestHTTP2KernelTelemetry() {
 			assert.Eventually(t, func() bool {
 				telemetry, err = usmhttp2.Spec.Instance.(*usmhttp2.Protocol).GetHTTP2KernelTelemetry()
 				require.NoError(t, err)
-				require.Equal(t, telemetry.Request_seen, tt.expectedTelemetry.Request_seen)
-				require.Equal(t, telemetry.Response_seen, tt.expectedTelemetry.Response_seen)
-				require.Equal(t, telemetry.Path_exceeds_frame, tt.expectedTelemetry.Path_exceeds_frame)
-				require.Equal(t, telemetry.Exceeding_max_interesting_frames, tt.expectedTelemetry.Exceeding_max_interesting_frames)
-				require.Equal(t, telemetry.Exceeding_max_frames_to_filter, tt.expectedTelemetry.Exceeding_max_frames_to_filter)
-				require.GreaterOrEqual(t, telemetry.End_of_stream+telemetry.End_of_stream_rst, expectedEOSOrRST)
-				require.True(t, reflect.DeepEqual(telemetry.Path_size_bucket, tt.expectedTelemetry.Path_size_bucket))
+				if telemetry.Request_seen != tt.expectedTelemetry.Request_seen {
+					return false
+				}
+				if telemetry.Response_seen != tt.expectedTelemetry.Response_seen {
+					return false
 
-				return true
+				}
+				if telemetry.Path_exceeds_frame != tt.expectedTelemetry.Path_exceeds_frame {
+					return false
+				}
+				if telemetry.Exceeding_max_interesting_frames != tt.expectedTelemetry.Exceeding_max_interesting_frames {
+					return false
+				}
+				if telemetry.Exceeding_max_frames_to_filter != tt.expectedTelemetry.Exceeding_max_frames_to_filter {
+					return false
+				}
+				if expectedEOSOrRST < telemetry.End_of_stream+telemetry.End_of_stream_rst {
+					return false
+				}
+				return reflect.DeepEqual(telemetry.Path_size_bucket, tt.expectedTelemetry.Path_size_bucket)
+
 			}, time.Second*5, time.Millisecond*100)
 			if t.Failed() {
 				t.Logf("expected telemetry: %+v;\ngot: %+v", tt.expectedTelemetry, telemetry)

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -669,7 +669,7 @@ func (s *USMHTTP2Suite) TestSimpleHTTP2() {
 	startH2CServer(t)
 
 	expected := make(map[http.Key]captureRange)
-	// currently we have a bug with paths which are not Huffman encoded, therefor I am skipping them by string length 3.
+	// currently we have a bug with paths which are not Huffman encoded, therefor we are skipping them by string length 3.
 	for i := 3; i < 100; i++ {
 		expected[http.Key{
 			Path:   http.Path{Content: http.Interner.GetString(fmt.Sprintf("/%s", strings.Repeat("a", i)))},
@@ -802,8 +802,6 @@ func (s *USMHTTP2Suite) TestSimpleHTTP2() {
 							t.Logf("key: %v not found in res", key.Path.Content.Get())
 						}
 					}
-					//t.Logf("got: %#v\n", res)
-					//t.Logf("expcected: %#v", expected)
 					o, err := monitor.DumpMaps("http2_in_flight")
 					if err != nil {
 						t.Logf("failed dumping http2_in_flight: %s", err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix the bug in our current solution related to reading integers in the HPACK algorithm.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We have a major issue currently as we are not correctly computing string lengths. The problem originated from reading at least 6 bits in `parse_field_literal`, whereas we are required to read at least 7 bits - reference https://datatracker.ietf.org/doc/html/rfc7541#section-5.2.

The only scenario where we need to support a minimum of 6 bits in our HPACK support is when reading the index of the dynamic/static table. Otherwise, we should read at least 7 bits.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
