### PR TITLE
[invoke] Refactor windows_resources utility tasks

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -37,7 +37,7 @@ from .utils import (
     load_release_versions,
     timed,
 )
-from .windows_resources import build_messagetable, build_rc, versioninfo_vars
+from .windows_resources import build_windows_resources
 
 # constants
 BIN_PATH = os.path.join(".", "bin", "agent")
@@ -150,14 +150,13 @@ def build(
         if arch == "x86":
             env["GOARCH"] = "386"
 
-        build_messagetable(ctx, arch=arch)
-        vars = versioninfo_vars(ctx, major_version=major_version, python_runtimes=python_runtimes, arch=arch)
-        build_rc(
+        build_windows_resources(
             ctx,
-            "cmd/agent/windows_resources/agent.rc",
+            major_version=major_version,
+            python_runtimes=python_runtimes,
             arch=arch,
-            vars=vars,
-            out="cmd/agent/rsrc.syso",
+            rc_in_file_path="cmd/agent/windows_resources/agent.rc",
+            rc_out_file_path="cmd/agent/rsrc.syso",
         )
 
     if flavor.is_iot():

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -15,7 +15,7 @@ from .build_tags import filter_incompatible_tags, get_build_tags, get_default_bu
 from .flavor import AgentFlavor
 from .go import deps
 from .utils import REPO_PATH, bin_name, get_build_flags, get_root, get_version, load_release_versions
-from .windows_resources import build_messagetable, build_rc, versioninfo_vars
+from .windows_resources import build_windows_resources
 
 # constants
 DOGSTATSD_BIN_PATH = os.path.join(".", "bin", "dogstatsd")
@@ -54,14 +54,12 @@ def build(
         if arch == "x86":
             env["GOARCH"] = "386"
 
-        build_messagetable(ctx, arch=arch)
-        vars = versioninfo_vars(ctx, major_version=major_version, arch=arch)
-        build_rc(
+        build_windows_resources(
             ctx,
-            "cmd/dogstatsd/windows_resources/dogstatsd.rc",
+            major_version=major_version,
             arch=arch,
-            vars=vars,
-            out="cmd/dogstatsd/rsrc.syso",
+            rc_in_file_path="cmd/dogstatsd/windows_resources/dogstatsd.rc",
+            rc_out_file_path="cmd/dogstatsd/rsrc.syso",
         )
 
     if static:

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -9,7 +9,7 @@ from invoke.exceptions import Exit
 from .build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
 from .flavor import AgentFlavor
 from .utils import REPO_PATH, bin_name, get_build_flags
-from .windows_resources import build_messagetable, build_rc, versioninfo_vars
+from .windows_resources import build_windows_resources
 
 BIN_DIR = os.path.join(".", "bin", "process-agent")
 BIN_PATH = os.path.join(BIN_DIR, bin_name("process-agent"))
@@ -39,14 +39,13 @@ def build(
         if arch == "x86":
             env["GOARCH"] = "386"
 
-        build_messagetable(ctx, arch=arch)
-        vars = versioninfo_vars(ctx, major_version=major_version, python_runtimes=python_runtimes, arch=arch)
-        build_rc(
+        build_windows_resources(
             ctx,
-            "cmd/process-agent/windows_resources/process-agent.rc",
+            major_version=major_version,
+            python_runtimes=python_runtimes,
             arch=arch,
-            vars=vars,
-            out="cmd/process-agent/rsrc.syso",
+            rc_in_file_path="cmd/process-agent/windows_resources/process-agent.rc",
+            rc_out_file_path="cmd/process-agent/rsrc.syso",
         )
 
     goenv = {}

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -34,7 +34,7 @@ from .utils import (
     get_gopath,
     get_version,
 )
-from .windows_resources import build_messagetable, build_rc, versioninfo_vars
+from .windows_resources import build_windows_resources
 
 BIN_DIR = os.path.join(".", "bin")
 BIN_PATH = os.path.join(BIN_DIR, "security-agent", bin_name("security-agent"))
@@ -79,14 +79,12 @@ def build(
         if arch == "x86":
             env["GOARCH"] = "386"
 
-        build_messagetable(ctx, arch=arch)
-        vars = versioninfo_vars(ctx, major_version=major_version, arch=arch)
-        build_rc(
+        build_windows_resources(
             ctx,
-            "cmd/security-agent/windows_resources/security-agent.rc",
+            major_version=major_version,
             arch=arch,
-            vars=vars,
-            out="cmd/security-agent/rsrc.syso",
+            rc_in_file_path="cmd/security-agent/windows_resources/security-agent.rc",
+            rc_out_file_path="cmd/security-agent/rsrc.syso",
         )
 
     ldflags += ' '.join([f"-X '{main + key}={value}'" for key, value in ld_vars.items()])

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -7,7 +7,7 @@ from .build_tags import filter_incompatible_tags, get_build_tags, get_default_bu
 from .flavor import AgentFlavor
 from .go import deps
 from .utils import REPO_PATH, bin_name, get_build_flags
-from .windows_resources import build_messagetable, build_rc, versioninfo_vars
+from .windows_resources import build_windows_resources
 
 BIN_PATH = os.path.join(".", "bin", "trace-agent")
 
@@ -37,14 +37,13 @@ def build(
         if arch == "x86":
             env["GOARCH"] = "386"
 
-        build_messagetable(ctx, arch=arch)
-        vars = versioninfo_vars(ctx, major_version=major_version, python_runtimes=python_runtimes, arch=arch)
-        build_rc(
+        build_windows_resources(
             ctx,
-            "cmd/trace-agent/windows/resources/trace-agent.rc",
+            major_version=major_version,
+            python_runtimes=python_runtimes,
             arch=arch,
-            vars=vars,
-            out="cmd/trace-agent/rsrc.syso",
+            rc_in_file_path="cmd/trace-agent/windows/resources/trace-agent.rc",
+            rc_out_file_path="cmd/trace-agent/rsrc.syso",
         )
 
     build_include = (

--- a/tasks/windows_resources.py
+++ b/tasks/windows_resources.py
@@ -18,6 +18,28 @@ def arch_to_windres_target(
         raise Exception(f"Unsupported architecture: {arch}")
 
 
+def build_windows_resources(
+    ctx,
+    rc_in_file_path: str,
+    major_version: str = '7',
+    python_runtimes: str = '3',
+    arch: str = "x64",
+    rc_out_file_path: str = None,
+):
+    """
+    Build the common MESSAGETABLE shared between Agent binaries, then build the rc file for the given binary.
+    """
+    build_messagetable(ctx, arch=arch)
+    vars = versioninfo_vars(ctx, major_version=major_version, python_runtimes=python_runtimes, arch=arch)
+    build_rc(
+        ctx,
+        rc_file=rc_in_file_path,
+        arch=arch,
+        vars=vars,
+        out=rc_out_file_path,
+    )
+
+
 @task
 def build_messagetable(
     ctx,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Refactor the multiple steps to build Windows resources into one `build_windows_resources` function.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Reduce code repetition: multiple tasks had the same exact following code:
```
        build_messagetable(ctx, arch=arch)
        vars = versioninfo_vars(ctx, major_version=major_version, python_runtimes=python_runtimes, arch=arch)
        build_rc(
            ctx,
            "cmd/<agent_name>/windows_resources/<agent_name>.rc",
            arch=arch,
            vars=vars,
            out="cmd/agent/rsrc.syso",
        )
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run a pipeline, verify that the Windows builds still work.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
