### PR TITLE
[CONTINT-258] Dump K8s cluster state at the end of e2e tests

### DIFF
--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,8 +69,9 @@ func (suite *ecsSuite) TearDownSuite() {
 	c := color.New(color.Bold).SprintfFunc()
 	suite.T().Log(c("The data produced and asserted by these tests can be viewed on this dashboard:"))
 	c = color.New(color.Bold, color.FgBlue).SprintfFunc()
-	suite.T().Log(c("https://dddev.datadoghq.com/dashboard/mnw-tdr-jd8/e2e-tests-containers-ecs?refresh_mode=paused&tpl_var_ecs_cluster_name%%5B0%%5D=%s&from_ts=%d&to_ts=%d&live=false",
+	suite.T().Log(c("https://dddev.datadoghq.com/dashboard/mnw-tdr-jd8/e2e-tests-containers-ecs?refresh_mode=paused&tpl_var_ecs_cluster_name%%5B0%%5D=%s&tpl_var_fake_intake_task_family%%5B0%%5D=%s-fakeintake-ecs&from_ts=%d&to_ts=%d&live=false",
 		suite.ecsClusterName,
+		strings.TrimSuffix(suite.ecsClusterName, "-ecs"),
 		suite.startTime.UnixMilli(),
 		suite.endTime.UnixMilli(),
 	))

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -72,3 +72,12 @@ func (suite *eksSuite) SetupSuite() {
 
 	suite.k8sSuite.SetupSuite()
 }
+
+func (suite *eksSuite) TearDownSuite() {
+	suite.k8sSuite.TearDownSuite()
+
+	ctx := context.Background()
+	stackName, err := infra.GetStackManager().GetPulumiStackName("eks-cluster")
+	suite.Require().NoError(err)
+	suite.T().Log(dumpEKSClusterState(ctx, stackName))
+}

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -59,7 +59,8 @@ func (suite *k8sSuite) TearDownSuite() {
 	c := color.New(color.Bold).SprintfFunc()
 	suite.T().Log(c("The data produced and asserted by these tests can be viewed on this dashboard:"))
 	c = color.New(color.Bold, color.FgBlue).SprintfFunc()
-	suite.T().Log(c("https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?refresh_mode=paused&tpl_var_kube_cluster_name%%5B0%%5D=%s&from_ts=%d&to_ts=%d&live=false",
+	suite.T().Log(c("https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?refresh_mode=paused&tpl_var_kube_cluster_name%%5B0%%5D=%s&tpl_var_fake_intake_task_family%%5B0%%5D=%s-fakeintake-ecs&from_ts=%d&to_ts=%d&live=false",
+		suite.KubeClusterName,
 		suite.KubeClusterName,
 		suite.startTime.UnixMilli(),
 		suite.endTime.UnixMilli(),

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -70,3 +70,12 @@ func (suite *kindSuite) SetupSuite() {
 
 	suite.k8sSuite.SetupSuite()
 }
+
+func (suite *kindSuite) TearDownSuite() {
+	suite.k8sSuite.TearDownSuite()
+
+	ctx := context.Background()
+	stackName, err := infra.GetStackManager().GetPulumiStackName("kind-cluster")
+	suite.Require().NoError(err)
+	suite.T().Log(dumpEKSClusterState(ctx, stackName))
+}

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -77,5 +77,5 @@ func (suite *kindSuite) TearDownSuite() {
 	ctx := context.Background()
 	stackName, err := infra.GetStackManager().GetPulumiStackName("kind-cluster")
 	suite.Require().NoError(err)
-	suite.T().Log(dumpEKSClusterState(ctx, stackName))
+	suite.T().Log(dumpKindClusterState(ctx, stackName))
 }


### PR DESCRIPTION
### What does this PR do?

* Dump the Kubernetes cluster state (`kubectl get nodes,all --all-namespaces`) at the end of new `containers` end-to-end tests.
* Add the `fake_intake_task_family` parameter to the dashboards parameters for all the new fake intake widgets.

### Motivation

Provide better visibility on what happened during e2e tests.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check the GitLab job logs at the end of e2e tests.
They must contain:
* the output of `kubectl get nodes,all --all-namespaces`
* the URL to the e2e tests dashboards.
  Validate that, when clicking on this link, the fake intake widgets at the end of the dashboard are working properly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
