### PR TITLE
dogstatsd: add better control on `Listen()` lifecycle

### DIFF
--- a/comp/dogstatsd/listeners/named_pipe_windows.go
+++ b/comp/dogstatsd/listeners/named_pipe_windows.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	_ "github.com/Microsoft/go-winio"
+	winio "github.com/Microsoft/go-winio"
 )
 
 var namedPipeTelemetry = newListenerTelemetry("named_pipe", "Named Pipe")

--- a/comp/dogstatsd/listeners/named_pipe_windows.go
+++ b/comp/dogstatsd/listeners/named_pipe_windows.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"go.uber.org/atomic"

--- a/comp/dogstatsd/listeners/named_pipe_windows_test.go
+++ b/comp/dogstatsd/listeners/named_pipe_windows_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Microsoft/go-winio"
+	_ "github.com/Microsoft/go-winio"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
@@ -138,7 +138,7 @@ func newNamedPipeListenerTest(t *testing.T) namedPipeListenerTest {
 		packetOut:         packetOut,
 	}
 
-	go listenerTest.Listen()
+	listenerTest.Listen()
 	return listenerTest
 }
 

--- a/comp/dogstatsd/listeners/named_pipe_windows_test.go
+++ b/comp/dogstatsd/listeners/named_pipe_windows_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/Microsoft/go-winio"
+	winio "github.com/Microsoft/go-winio"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"

--- a/comp/dogstatsd/listeners/udp.go
+++ b/comp/dogstatsd/listeners/udp.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
@@ -44,6 +45,7 @@ type UDPListener struct {
 	packetAssembler *packets.Assembler
 	buffer          []byte
 	trafficCapture  replay.Component // Currently ignored
+	listenWg        sync.WaitGroup
 }
 
 // NewUDPListener returns an idle UDP Statsd listener
@@ -104,6 +106,15 @@ func (l *UDPListener) LocalAddr() string {
 
 // Listen runs the intake loop. Should be called in its own goroutine
 func (l *UDPListener) Listen() {
+	l.listenWg.Add(1)
+
+	go func() {
+		defer l.listenWg.Done()
+		l.listen()
+	}()
+}
+
+func (l *UDPListener) listen() {
 	var t1, t2 time.Time
 	log.Infof("dogstatsd-udp: starting to listen on %s", l.conn.LocalAddr())
 	for {
@@ -140,4 +151,5 @@ func (l *UDPListener) Stop() {
 	l.packetAssembler.Close()
 	l.packetsBuffer.Close()
 	l.conn.Close()
+	l.listenWg.Wait()
 }

--- a/comp/dogstatsd/listeners/udp_test.go
+++ b/comp/dogstatsd/listeners/udp_test.go
@@ -56,7 +56,7 @@ func TestStartStopUDPListener(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	go s.Listen()
+	s.Listen()
 	// Local port should be unavailable
 	address, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", port))
 	_, err = net.ListenUDP("udp", address)
@@ -89,7 +89,7 @@ func TestUDPNonLocal(t *testing.T) {
 	assert.Nil(t, err)
 	require.NotNil(t, s)
 
-	go s.Listen()
+	s.Listen()
 	defer s.Stop()
 
 	// Local port should be unavailable
@@ -116,7 +116,7 @@ func TestUDPLocalOnly(t *testing.T) {
 	assert.Nil(t, err)
 	require.NotNil(t, s)
 
-	go s.Listen()
+	s.Listen()
 	defer s.Stop()
 
 	// Local port should be unavailable
@@ -147,7 +147,7 @@ func TestUDPReceive(t *testing.T) {
 	require.NotNil(t, s)
 	assert.Nil(t, err)
 
-	go s.Listen()
+	s.Listen()
 	defer s.Stop()
 	conn, err := net.Dial("udp", fmt.Sprintf("127.0.0.1:%d", port))
 	require.NotNil(t, conn)

--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -60,7 +60,7 @@ type UDSListener struct {
 	packetBufferFlushTimeout time.Duration
 	telemetryWithListenerID  bool
 
-	listenWg sync.WaitGroup
+	listenWg *sync.WaitGroup
 }
 
 // CloseFunction is a function that closes a connection
@@ -140,6 +140,7 @@ func NewUDSListener(packetOut chan packets.Packets, sharedPacketPoolManager *pac
 		packetBufferSize:             uint(cfg.GetInt("dogstatsd_packet_buffer_size")),
 		packetBufferFlushTimeout:     cfg.GetDuration("dogstatsd_packet_buffer_flush_timeout"),
 		telemetryWithListenerID:      cfg.GetBool("dogstatsd_telemetry_enabled_listener_id"),
+		listenWg:                     &sync.WaitGroup{},
 	}
 
 	// Init the oob buffer pool if origin detection is enabled

--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -59,6 +59,8 @@ type UDSListener struct {
 	packetBufferSize         uint
 	packetBufferFlushTimeout time.Duration
 	telemetryWithListenerID  bool
+
+	listenWg sync.WaitGroup
 }
 
 // CloseFunction is a function that closes a connection
@@ -369,6 +371,7 @@ func (l *UDSListener) getListenerID(conn *net.UnixConn) string {
 // Stop closes the UDS connection and stops listening
 func (l *UDSListener) Stop() {
 	// Socket cleanup on exit is not necessary as sockets are automatically removed by go.
+	l.listenWg.Wait()
 }
 
 func (l *UDSListener) clearTelemetry(id string) {

--- a/comp/dogstatsd/listeners/uds_common_test.go
+++ b/comp/dogstatsd/listeners/uds_common_test.go
@@ -105,7 +105,7 @@ func testStartStopUDSListener(t *testing.T, listenerFactory udsListenerFactory, 
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
 
-	go s.Listen()
+	s.Listen()
 
 	conn, err := net.Dial(transport, socketPath)
 	assert.Nil(t, err)
@@ -134,7 +134,7 @@ func testUDSReceive(t *testing.T, listenerFactory udsListenerFactory, transport 
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
 
-	go s.Listen()
+	s.Listen()
 	defer s.Stop()
 	conn, err := net.Dial(transport, socketPath)
 	assert.Nil(t, err)

--- a/comp/dogstatsd/listeners/uds_datagram.go
+++ b/comp/dogstatsd/listeners/uds_datagram.go
@@ -64,6 +64,14 @@ func NewUDSDatagramListener(packetOut chan packets.Packets, sharedPacketPoolMana
 
 // Listen runs the intake loop. Should be called in its own goroutine
 func (l *UDSDatagramListener) Listen() {
+	l.listenWg.Add(1)
+	go func() {
+		defer l.listenWg.Done()
+		l.listen()
+	}()
+}
+
+func (l *UDSDatagramListener) listen() {
 	log.Infof("dogstatsd-uds: starting to listen on %s", l.conn.LocalAddr())
 	_ = l.handleConnection(l.conn, func(conn *net.UnixConn) error {
 		return conn.Close()

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -475,7 +475,7 @@ func (s *server) handleMessages() {
 	}
 
 	for _, l := range s.listeners {
-		go l.Listen()
+		l.Listen()
 	}
 
 	workersCount, _ := aggregator.GetDogStatsDWorkerAndPipelineCount()

--- a/test/integration/dogstatsd/origin_detection.go
+++ b/test/integration/dogstatsd/origin_detection.go
@@ -86,7 +86,7 @@ func testUDSOriginDetection(t *testing.T, network string) {
 
 	// Start sender container
 	t.Logf("Starting sender container %s", composeFile)
-	go s.Listen()
+	s.Listen()
 	defer s.Stop()
 
 	compose := &utils.ComposeConf{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This changes `Listen()` to start its background goroutine itself, but gives the ability to `Stop()` to wait for it to complete.

### Motivation

This allows us to make sure than `Listen()` has returned before we finish unit tests.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Unit tests should be enough, but it's worth checking that UDP and UDS listener can still start, receive metrics and stop.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
