### PR TITLE
ebpf-check: skip `NewProgramFromID` and fetch fd directly

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -214,13 +214,14 @@ func (k *Probe) getProgramStats(stats *model.EBPFStats) error {
 	var err error
 	progid := ebpf.ProgramID(0)
 	for progid, err = ebpf.ProgramGetNextID(progid); err == nil; progid, err = ebpf.ProgramGetNextID(progid) {
-		pr, err := ebpf.NewProgramFromID(progid)
+		fd, err := ProgGetFdByID(&ProgGetFdByIDAttr{ID: uint32(progid)})
 		if err != nil {
-			log.Debugf("unable to get program prog_id=%d: %s", progid, err)
+			log.Debugf("error getting program fd prog_id=%d: %s", progid, err)
 			continue
 		}
+
 		var info ProgInfo
-		if err := ProgObjInfo(uint32(pr.FD()), &info); err != nil {
+		if err := ProgObjInfo(fd, &info); err != nil {
 			log.Debugf("error getting program info prog_id=%d: %s", progid, err)
 			continue
 		}

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -219,6 +220,12 @@ func (k *Probe) getProgramStats(stats *model.EBPFStats) error {
 			log.Debugf("error getting program fd prog_id=%d: %s", progid, err)
 			continue
 		}
+		defer func() {
+			err := syscall.Close(int(fd))
+			if err != nil {
+				log.Debugf("error closing fd %d: %s", fd, err)
+			}
+		}()
 
 		var info ProgInfo
 		if err := ProgObjInfo(fd, &info); err != nil {

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/prog.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/prog.go
@@ -8,6 +8,7 @@
 package ebpfcheck
 
 import (
+	"runtime"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -34,7 +35,23 @@ func ObjGetInfoByFd(attr *ObjGetInfoByFdAttr) error {
 	if errNo != 0 {
 		return errNo
 	}
+	runtime.KeepAlive(attr)
 	return nil
+}
+
+// ProgGetFdByIDAttr corresponds to the subset of `bpf_prog_attr` needed for BPF_PROG_GET_FD_BY_ID
+type ProgGetFdByIDAttr struct {
+	ID uint32
+}
+
+// ProgGetFdByID opens a file descriptor for the eBPF program corresponding to ID in attr
+func ProgGetFdByID(attr *ProgGetFdByIDAttr) (uint32, error) {
+	fd, _, errNo := unix.Syscall(unix.SYS_BPF, uintptr(unix.BPF_PROG_GET_FD_BY_ID), uintptr(unsafe.Pointer(attr)), unsafe.Sizeof(*attr))
+	if errNo != 0 {
+		return 0, errNo
+	}
+	runtime.KeepAlive(attr)
+	return uint32(fd), nil
 }
 
 // ProgInfo corresponds to kernel C type `bpf_prog_info`


### PR DESCRIPTION
### What does this PR do?

This PR fixes/improves 2 things:
- first it fixes a fd leak: `ebpf.NewProgramFromID` opens a new fd, which was never closed. The new implementation closes the fd
- second it skips completely `ebpf.NewProgramFromID` which was allocating a lot, and never used for anything else than the fd. This PR replaces it by just the raw syscall allowing us to collect the fd directly

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
