### PR TITLE
USMON-652: Addressing verifier issue on RHEL involving kernel 4.18.0-305

### DIFF
--- a/pkg/network/ebpf/c/protocols/read_into_buffer.h
+++ b/pkg/network/ebpf/c/protocols/read_into_buffer.h
@@ -36,12 +36,15 @@
         /* The maximum that we can read is (blk_size) - 1. Checking (to please the verifier) that we read no more */\
         /* than the allowed max size. */                                                                            \
         const s64 read_size = left_payload < (blk_size) - 1 ? left_payload : (blk_size) - 1;                        \
+        /* This check is essential, as certain kernel verifiers require it */                                       \
+        /* originally identified on kernel version 4.18.0-305 RHEL) */                                              \
+        const u64 read_size_unsigned = read_size > 0 ? read_size : 0;                                               \
                                                                                                                     \
         /* Calculating the absolute size from the allocated buffer, that was left empty, again to please the */     \
         /* verifier so it can be assured we are not exceeding the memory limits. */                                 \
         const s64 left_buffer = (s64)(total_size) < (s64)(i*(blk_size)) ? 0 : total_size - i*(blk_size);            \
-        if (read_size <= left_buffer) {                                                                             \
-            bpf_skb_load_bytes_with_telemetry(skb, offset, buffer, read_size);                                      \
+        if (read_size_unsigned > 0 && read_size_unsigned <= left_buffer) {                                          \
+            bpf_skb_load_bytes_with_telemetry(skb, offset, buffer, read_size_unsigned);                             \
         }                                                                                                           \
         return;                                                                                                     \
     }                                                                                                               \

--- a/pkg/network/ebpf/c/protocols/read_into_buffer.h
+++ b/pkg/network/ebpf/c/protocols/read_into_buffer.h
@@ -37,7 +37,7 @@
         /* than the allowed max size. */                                                                            \
         const s64 read_size = left_payload < (blk_size) - 1 ? left_payload : (blk_size) - 1;                        \
         /* This check is essential, as certain kernel verifiers require it */                                       \
-        /* originally identified on kernel version 4.18.0-305 RHEL) */                                              \
+        /* originally identified on kernel version 4.18.0-305 RHEL */                                               \
         const u64 read_size_unsigned = read_size > 0 ? read_size : 0;                                               \
                                                                                                                     \
         /* Calculating the absolute size from the allocated buffer, that was left empty, again to please the */     \


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR resolves a verifier issue identified on RHEL with kernel version 4.18.0-305

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

To replicate the issue, execute agent version 7.49.1 with USM enabled on RHEL 8.4 using kernel `4.18.0-305.el8.x86_64` (EC2 AMI ID is ami-02e0bb36c61bb9715). Expect a verifier error related to the `socket__classifier_entry` function. Subsequently, run version 7.51 and ensure that the verifier error does not recur.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
