### PR TITLE
trace-agent: add cli to capture traces

### DIFF
--- a/cmd/trace-agent/command/command.go
+++ b/cmd/trace-agent/command/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands"
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands/capture"
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands/controlsvc"
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands/info"
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands/run"
@@ -45,6 +46,7 @@ func makeCommands(globalParams *subcommands.GlobalParams) *cobra.Command {
 		run.MakeCommand(globalConfGetter),
 		info.MakeCommand(globalConfGetter),
 		version.MakeCommand("trace-agent"),
+		capture.MakeCommand(globalConfGetter),
 	}
 
 	commands = append(commands, controlsvc.Commands(globalConfGetter)...)

--- a/cmd/trace-agent/subcommands/capture/command.go
+++ b/cmd/trace-agent/subcommands/capture/command.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package capture implements the capture subcommand for the 'trace-agent' command.
 package capture
 
 import (

--- a/cmd/trace-agent/subcommands/capture/command.go
+++ b/cmd/trace-agent/subcommands/capture/command.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package capture
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands"
+	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
+	"github.com/DataDog/datadog-agent/comp/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// MakeCommand returns the capture subcommand for the 'trace-agent' command.
+func MakeCommand(globalParamsGetter func() *subcommands.GlobalParams) *cobra.Command {
+	return &cobra.Command{
+		Use:   "capture",
+		Short: "Capture live tracer payloads.",
+		Long:  `Use this to capture live tracer payloads received by the trace-agent.`,
+		RunE: func(*cobra.Command, []string) error {
+			return fxutil.OneShot(capture,
+				config.Module,
+				fx.Supply(coreconfig.NewAgentParams(globalParamsGetter().ConfPath)),
+				fx.Supply(secrets.NewEnabledParams()),
+				coreconfig.Module,
+				secretsimpl.Module,
+			)
+		},
+	}
+}
+
+func capture(config config.Component) error {
+	tracecfg := config.Object()
+	if tracecfg == nil {
+		return errors.New("cannot parse config")
+	}
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/capture", tracecfg.DebugServerPort))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(body))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/cmd/trace-agent/subcommands/capture/command_test.go
+++ b/cmd/trace-agent/subcommands/capture/command_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package capture
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCaptureCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		[]*cobra.Command{MakeCommand(func() *subcommands.GlobalParams {
+			return &subcommands.GlobalParams{}
+		})},
+		[]string{"capture"},
+		capture,
+		func() {
+			// Test no panic
+		})
+}

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -614,6 +615,20 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		c.EVPProxy.MaxPayloadSize = core.GetInt64(k)
 	}
 	c.DebugServerPort = core.GetInt("apm_config.debug.port")
+	c.Capture.Enabled = core.GetBool("apm_config.capture.enabled")
+	if k := "apm_config.capture.path"; core.IsSet(k) {
+		c.Capture.Path = core.GetString("apm_config.capture.path")
+	} else {
+		c.Capture.Path = path.Join(core.GetString("run_path"), "trace_capture")
+	}
+	if k := "apm_config.capture.duration"; core.IsSet(k) {
+		c.Capture.Duration = core.GetInt("apm_config.capture.duration")
+	}
+	if c.Capture.Duration <= 0 || c.Capture.Duration > 30 {
+		// default is 5 seconds, max is 30 seconds
+		c.Capture.Duration = 5
+	}
+
 	return nil
 }
 

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -190,6 +190,10 @@ func setupAPM(config Config) {
 		}
 		return out
 	})
+
+	config.BindEnv("apm_config.capture.enabled", "DD_APM_CAPTURE_ENABLED")
+	config.BindEnv("apm_config.capture.path", "DD_APM_CAPTURE_PATH")
+	config.BindEnv("apm_config.capture.duration", "DD_APM_CAPTURE_DURATION")
 }
 
 func parseKVList(key string) func(string) interface{} {

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -42,6 +42,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 )
 
+var capture atomic.Bool
+
 var bufferPool = sync.Pool{
 	New: func() interface{} {
 		return new(bytes.Buffer)

--- a/pkg/trace/api/debug_server.go
+++ b/pkg/trace/api/debug_server.go
@@ -16,14 +16,11 @@ import (
 	"net/http/pprof"
 	"runtime"
 	"strconv"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
-
-var capture atomic.Bool
 
 const (
 	defaultTimeout          = 5 * time.Second

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -264,6 +264,13 @@ type SymDBProxyConfig struct {
 	AdditionalEndpoints map[string][]string `json:"-"` // Never marshal this field
 }
 
+// CaptureConfig holds the configuration for the trace capture feature.
+type CaptureConfig struct {
+	Enabled  bool   `mapstructure:"enabled"`
+	Path     string `mapstructure:"path"`
+	Duration int    `mapstructure:"duration"` // in seconds
+}
+
 // AgentConfig handles the interpretation of the configuration (with default
 // behaviors) in one place. It is also a simple structure to share across all
 // the Agent components, with 100% safe and reliable values.
@@ -440,6 +447,9 @@ type AgentConfig struct {
 
 	// DebugServerPort defines the port used by the debug server
 	DebugServerPort int
+
+	// Capture holds the configuration for the trace capture feature.
+	Capture CaptureConfig
 
 	// Install Signature
 	InstallSignature InstallSignatureConfig


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add a `trace-agent capture` CLI.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Intercept live payloads coming from the tracers and dump them on disk so they can be replayed for debugging later. This is typically useful when dealing with data corruption live in production.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The tool can be extended to support filtering (e.g by language, endpoint).

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run `trace-agent capture` and find your traces dumped in `/opt/datadog-agent/run/trace_capture`

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
