### PR TITLE
Adds origin for new telemetry core check

### DIFF
--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -32,7 +32,7 @@ const (
 	MetricSourceWeblogic
 
 	// Core Checks
-	MetricSourceAgentTelemetry
+	MetricSourceInternal
 	MetricSourceContainer
 	MetricSourceContainerd
 	MetricSourceCri
@@ -153,8 +153,8 @@ func (ms MetricSource) String() string {
 		return "network"
 	case MetricSourceSnmp:
 		return "snmp"
-	case MetricSourceAgentTelemetry:
-		return "agent_telemetry"
+	case MetricSourceInternal:
+		return "internal"
 	default:
 		return "<unknown>"
 
@@ -219,7 +219,7 @@ func CoreCheckToMetricSource(name string) MetricSource {
 	case "snmp":
 		return MetricSourceSnmp
 	case "telemetry":
-		return MetricSourceAgentTelemetry
+		return MetricSourceInternal
 	default:
 		return MetricSourceUnknown
 	}

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -32,6 +32,7 @@ const (
 	MetricSourceWeblogic
 
 	// Core Checks
+	MetricSourceAgentTelemetry
 	MetricSourceContainer
 	MetricSourceContainerd
 	MetricSourceCri
@@ -152,6 +153,8 @@ func (ms MetricSource) String() string {
 		return "network"
 	case MetricSourceSnmp:
 		return "snmp"
+	case MetricSourceAgentTelemetry:
+		return "agent_telemetry"
 	default:
 		return "<unknown>"
 
@@ -215,6 +218,8 @@ func CoreCheckToMetricSource(name string) MetricSource {
 		return MetricSourceNetwork
 	case "snmp":
 		return MetricSourceSnmp
+	case "telemetry":
+		return MetricSourceAgentTelemetry
 	default:
 		return MetricSourceUnknown
 	}

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -344,11 +344,11 @@ func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buff
 					if err != nil {
 						return err
 					}
-					err = ps.Int32(serieMetadataOriginOriginCategory, MetricSourceToOriginCategory(serie.Source))
+					err = ps.Int32(serieMetadataOriginOriginCategory, metricSourceToOriginCategory(serie.Source))
 					if err != nil {
 						return err
 					}
-					return ps.Int32(serieMetadataOriginOriginService, MetricSourceToOriginService(serie.Source))
+					return ps.Int32(serieMetadataOriginOriginService, metricSourceToOriginService(serie.Source))
 				})
 			})
 			if err != nil {

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -34,7 +34,7 @@ func MetricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 		metrics.MetricSourceTomcat,
 		metrics.MetricSourceWeblogic,
 		// Core Checks
-		metrics.MetricSourceAgentTelemetry,
+		metrics.MetricSourceInternal,
 		metrics.MetricSourceContainer,
 		metrics.MetricSourceContainerd,
 		metrics.MetricSourceCri,
@@ -162,7 +162,7 @@ func MetricSourceToOriginService(ms metrics.MetricSource) int32 {
 		return 202
 	case metrics.MetricSourceLoad:
 		return 203
-	case metrics.MetricSourceAgentTelemetry:
+	case metrics.MetricSourceInternal:
 		return 212
 	default:
 		return 0

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -33,6 +33,8 @@ func MetricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 		metrics.MetricSourceSonarqube,
 		metrics.MetricSourceTomcat,
 		metrics.MetricSourceWeblogic,
+		// Core Checks
+		metrics.MetricSourceAgentTelemetry,
 		metrics.MetricSourceContainer,
 		metrics.MetricSourceContainerd,
 		metrics.MetricSourceCri,
@@ -160,6 +162,8 @@ func MetricSourceToOriginService(ms metrics.MetricSource) int32 {
 		return 202
 	case metrics.MetricSourceLoad:
 		return 203
+	case metrics.MetricSourceAgentTelemetry:
+		return 212
 	default:
 		return 0
 	}

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -9,8 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
-//nolint:revive // TODO(AML) Fix revive linter
-func MetricSourceToOriginCategory(ms metrics.MetricSource) int32 {
+func metricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 	// These constants map to specific fields in the 'OriginCategory' enum in origin.proto
 	switch ms {
 	case metrics.MetricSourceUnknown:
@@ -68,8 +67,7 @@ func MetricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 	}
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func MetricSourceToOriginService(ms metrics.MetricSource) int32 {
+func metricSourceToOriginService(ms metrics.MetricSource) int32 {
 	// These constants map to specific fields in the 'OriginService' enum in origin.proto
 	switch ms {
 	case metrics.MetricSourceDogstatsd:

--- a/pkg/serializer/internal/metrics/sketch_series_list.go
+++ b/pkg/serializer/internal/metrics/sketch_series_list.go
@@ -253,11 +253,11 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 					if err != nil {
 						return err
 					}
-					err = ps.Int32(sketchMetadataOriginOriginCategory, MetricSourceToOriginCategory(ss.Source))
+					err = ps.Int32(sketchMetadataOriginOriginCategory, metricSourceToOriginCategory(ss.Source))
 					if err != nil {
 						return err
 					}
-					return ps.Int32(sketchMetadataOriginOriginService, MetricSourceToOriginService(ss.Source))
+					return ps.Int32(sketchMetadataOriginOriginService, metricSourceToOriginService(ss.Source))
 				})
 			})
 			if err != nil {


### PR DESCRIPTION
### What does this PR do?
In #20681 , there was a new core check added that can submit agent internal telemetry. This PR adds proper 'origins' annotations for these metrics.

### Motivation
.

### Additional Notes
.

### Possible Drawbacks / Trade-offs
.

### Describe how to test/QA your changes
QA'd locally, can skip. Used `proxy-dumper` to validate payloads have correct metadata.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
