### PR TITLE
[CI] Remove addition of `ldflags` to fix an old issue using the `-race` flag on Windows

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -609,7 +609,6 @@ def test(
         python_home_3=python_home_3,
         major_version=major_version,
         python_runtimes=python_runtimes,
-        race=race,
     )
 
     # Use stdout if no profile is set

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -122,7 +122,6 @@ def get_build_flags(
     major_version='7',
     python_runtimes='3',
     headless_mode=False,
-    race=False,
 ):
     """
     Build the common value for both ldflags and gcflags, and return an env accordingly.
@@ -216,12 +215,6 @@ def get_build_flags(
 
     if extldflags:
         ldflags += f"'-extldflags={extldflags}' "
-
-    # Needed to fix an issue when using -race + gcc 10.x on Windows
-    # https://github.com/bazelbuild/rules_go/issues/2614
-    if race:
-        if sys.platform == 'win32':
-            ldflags += " -linkmode=external"
 
     return ldflags, gcflags, env
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR removes the addition of the `-linkmode=external` ldflag fix for Windows when using the `-race` go flag.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

[Old issue post](https://github.com/bazelbuild/rules_go/issues/2614) led me to [this](https://github.com/golang/go/issues/35006) which seems to imply it's fixed for go `1.20`. Since we're using `1.20.11` as of today, this should work fine. The CI will tell !

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
