### PR TITLE
Add support for private key w/ passphrase to SSH client

### DIFF
--- a/test/new-e2e/pkg/runner/configmap.go
+++ b/test/new-e2e/pkg/runner/configmap.go
@@ -109,10 +109,6 @@ func BuildStackParameters(profile Profile, scenarioConfig ConfigMap) (ConfigMap,
 	if err != nil {
 		return nil, err
 	}
-	err = SetConfigMapFromParameter(profile.ParamStore(), cm, parameters.PrivateKeyPassphrase, AWSPrivateKeyPassphrase)
-	if err != nil {
-		return nil, err
-	}
 	err = SetConfigMapFromParameter(profile.ParamStore(), cm, parameters.ExtraResourcesTags, InfraExtraResourcesTags)
 	if err != nil {
 		return nil, err
@@ -130,6 +126,11 @@ func BuildStackParameters(profile Profile, scenarioConfig ConfigMap) (ConfigMap,
 	if err != nil {
 		return nil, err
 	}
+	err = SetConfigMapFromSecret(profile.SecretStore(), cm, parameters.PrivateKeyPassphrase, AWSPrivateKeyPassphrase)
+	if err != nil {
+		return nil, err
+	}
+
 	// Merge with scenario variables
 	cm.Merge(scenarioConfig)
 

--- a/test/new-e2e/pkg/runner/configmap.go
+++ b/test/new-e2e/pkg/runner/configmap.go
@@ -36,6 +36,8 @@ const (
 	AWSPublicKeyPath = commonconfig.DDInfraConfigNamespace + ":" + infraaws.DDinfraDefaultPublicKeyPath
 	// AWSPrivateKeyPath pulumi config paramater name
 	AWSPrivateKeyPath = commonconfig.DDInfraConfigNamespace + ":" + infraaws.DDInfraDefaultPrivateKeyPath
+	// AWSPrivateKeyPassphrase pulumi config paramater name
+	AWSPrivateKeyPassphrase = commonconfig.DDInfraConfigNamespace + ":" + infraaws.DDInfraDefaultPrivateKeyPassword
 )
 
 // ConfigMap type alias to auto.ConfigMap
@@ -104,6 +106,10 @@ func BuildStackParameters(profile Profile, scenarioConfig ConfigMap) (ConfigMap,
 		return nil, err
 	}
 	err = SetConfigMapFromParameter(profile.ParamStore(), cm, parameters.PrivateKeyPath, AWSPrivateKeyPath)
+	if err != nil {
+		return nil, err
+	}
+	err = SetConfigMapFromParameter(profile.ParamStore(), cm, parameters.PrivateKeyPassphrase, AWSPrivateKeyPassphrase)
 	if err != nil {
 		return nil, err
 	}

--- a/test/new-e2e/pkg/runner/configmap.go
+++ b/test/new-e2e/pkg/runner/configmap.go
@@ -36,8 +36,8 @@ const (
 	AWSPublicKeyPath = commonconfig.DDInfraConfigNamespace + ":" + infraaws.DDinfraDefaultPublicKeyPath
 	// AWSPrivateKeyPath pulumi config paramater name
 	AWSPrivateKeyPath = commonconfig.DDInfraConfigNamespace + ":" + infraaws.DDInfraDefaultPrivateKeyPath
-	// AWSPrivateKeyPassphrase pulumi config paramater name
-	AWSPrivateKeyPassphrase = commonconfig.DDInfraConfigNamespace + ":" + infraaws.DDInfraDefaultPrivateKeyPassword
+	// AWSPrivateKeyPassword pulumi config paramater name
+	AWSPrivateKeyPassword = commonconfig.DDInfraConfigNamespace + ":" + infraaws.DDInfraDefaultPrivateKeyPassword
 )
 
 // ConfigMap type alias to auto.ConfigMap
@@ -126,7 +126,7 @@ func BuildStackParameters(profile Profile, scenarioConfig ConfigMap) (ConfigMap,
 	if err != nil {
 		return nil, err
 	}
-	err = SetConfigMapFromSecret(profile.SecretStore(), cm, parameters.PrivateKeyPassphrase, AWSPrivateKeyPassphrase)
+	err = SetConfigMapFromSecret(profile.SecretStore(), cm, parameters.PrivateKeyPassword, AWSPrivateKeyPassword)
 	if err != nil {
 		return nil, err
 	}

--- a/test/new-e2e/pkg/runner/configmap_test.go
+++ b/test/new-e2e/pkg/runner/configmap_test.go
@@ -29,14 +29,15 @@ func Test_BuildStackParameters(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, configMap)
 	assert.Equal(t, ConfigMap{
-		"ddagent:apiKey":                    auto.ConfigValue{Value: "api_key", Secret: true},
-		"ddagent:appKey":                    auto.ConfigValue{Value: "app_key", Secret: true},
-		"namespace:key/foo":                 auto.ConfigValue{Value: "42", Secret: false},
-		"ddinfra:aws/defaultKeyPairName":    auto.ConfigValue{Value: "key_pair_name", Secret: false},
-		"ddinfra:env":                       auto.ConfigValue{Value: "", Secret: false},
-		"ddinfra:extraResourcesTags":        auto.ConfigValue{Value: "extra_resources_tags", Secret: false},
-		"ddinfra:aws/defaultPublicKeyPath":  auto.ConfigValue{Value: "public_key_path", Secret: false},
-		"ddinfra:aws/defaultPrivateKeyPath": auto.ConfigValue{Value: "private_key_path", Secret: false},
-		"ddagent:pipeline_id":               auto.ConfigValue{Value: "pipeline_id", Secret: false},
+		"ddagent:apiKey":                        auto.ConfigValue{Value: "api_key", Secret: true},
+		"ddagent:appKey":                        auto.ConfigValue{Value: "app_key", Secret: true},
+		"namespace:key/foo":                     auto.ConfigValue{Value: "42", Secret: false},
+		"ddinfra:aws/defaultKeyPairName":        auto.ConfigValue{Value: "key_pair_name", Secret: false},
+		"ddinfra:env":                           auto.ConfigValue{Value: "", Secret: false},
+		"ddinfra:extraResourcesTags":            auto.ConfigValue{Value: "extra_resources_tags", Secret: false},
+		"ddinfra:aws/defaultPublicKeyPath":      auto.ConfigValue{Value: "public_key_path", Secret: false},
+		"ddinfra:aws/defaultPrivateKeyPath":     auto.ConfigValue{Value: "private_key_path", Secret: false},
+		"ddinfra:aws/defaultPrivateKeyPassword": auto.ConfigValue{Value: "private_key_passphrase", Secret: true},
+		"ddagent:pipeline_id":                   auto.ConfigValue{Value: "pipeline_id", Secret: false},
 	}, configMap)
 }

--- a/test/new-e2e/pkg/runner/configmap_test.go
+++ b/test/new-e2e/pkg/runner/configmap_test.go
@@ -37,7 +37,7 @@ func Test_BuildStackParameters(t *testing.T) {
 		"ddinfra:extraResourcesTags":            auto.ConfigValue{Value: "extra_resources_tags", Secret: false},
 		"ddinfra:aws/defaultPublicKeyPath":      auto.ConfigValue{Value: "public_key_path", Secret: false},
 		"ddinfra:aws/defaultPrivateKeyPath":     auto.ConfigValue{Value: "private_key_path", Secret: false},
-		"ddinfra:aws/defaultPrivateKeyPassword": auto.ConfigValue{Value: "private_key_passphrase", Secret: true},
+		"ddinfra:aws/defaultPrivateKeyPassword": auto.ConfigValue{Value: "private_key_password", Secret: true},
 		"ddagent:pipeline_id":                   auto.ConfigValue{Value: "pipeline_id", Secret: false},
 	}, configMap)
 }

--- a/test/new-e2e/pkg/runner/parameters/const.go
+++ b/test/new-e2e/pkg/runner/parameters/const.go
@@ -19,6 +19,8 @@ const (
 	ExtraResourcesTags StoreKey = "extra_resources_tags"
 	// KeyPairName config file parameter name
 	KeyPairName StoreKey = "key_pair_name"
+	// PrivateKeyPassphrase config file parameter name
+	PrivateKeyPassphrase StoreKey = "private_key_passphrase"
 	// PrivateKeyPath config file parameter name
 	PrivateKeyPath StoreKey = "private_key_path"
 	// Profile config file parameter name

--- a/test/new-e2e/pkg/runner/parameters/const.go
+++ b/test/new-e2e/pkg/runner/parameters/const.go
@@ -19,8 +19,8 @@ const (
 	ExtraResourcesTags StoreKey = "extra_resources_tags"
 	// KeyPairName config file parameter name
 	KeyPairName StoreKey = "key_pair_name"
-	// PrivateKeyPassphrase config file parameter name
-	PrivateKeyPassphrase StoreKey = "private_key_passphrase"
+	// PrivateKeyPassword config file parameter name
+	PrivateKeyPassword StoreKey = "private_key_password"
 	// PrivateKeyPath config file parameter name
 	PrivateKeyPath StoreKey = "private_key_path"
 	// Profile config file parameter name

--- a/test/new-e2e/pkg/runner/parameters/store_config_file.go
+++ b/test/new-e2e/pkg/runner/parameters/store_config_file.go
@@ -19,7 +19,7 @@ import (
 //     keyPairName: "totoro"
 //     publicKeyPath: "/home/totoro/.ssh/id_rsa.pub"
 //     privateKeyPath: "/home/totoro/.ssh/id_rsa"
-//     privateKeyPassphrase: "princess_mononoke"
+//     privateKeyPassword: "princess_mononoke"
 //   agent:
 //     apiKey: "00000000000000000000000000000000"=
 // stackParams:
@@ -40,12 +40,12 @@ type ConfigParams struct {
 
 // AWS instance contains AWS related parameters
 type AWS struct {
-	Account              string `yaml:"account"`
-	KeyPairName          string `yaml:"keyPairName"`
-	PublicKeyPath        string `yaml:"publicKeyPath"`
-	PrivateKeyPath       string `yaml:"privateKeyPath"`
-	PrivateKeyPassphrase string `yaml:"privateKeyPassphrase"`
-	TeamTag              string `yaml:"teamTag"`
+	Account            string `yaml:"account"`
+	KeyPairName        string `yaml:"keyPairName"`
+	PublicKeyPath      string `yaml:"publicKeyPath"`
+	PrivateKeyPath     string `yaml:"privateKeyPath"`
+	PrivateKeyPassword string `yaml:"privateKeyPassword"`
+	TeamTag            string `yaml:"teamTag"`
 }
 
 // Agent instance contains agent related parameters
@@ -109,8 +109,8 @@ func (s configFileValueStore) get(key StoreKey) (string, error) {
 		value = s.config.ConfigParams.AWS.PublicKeyPath
 	case PrivateKeyPath:
 		value = s.config.ConfigParams.AWS.PrivateKeyPath
-	case PrivateKeyPassphrase:
-		value = s.config.ConfigParams.AWS.PrivateKeyPassphrase
+	case PrivateKeyPassword:
+		value = s.config.ConfigParams.AWS.PrivateKeyPassword
 	case StackParameters:
 		value = s.stackParamsJSON
 	case Environments:

--- a/test/new-e2e/pkg/runner/parameters/store_config_file.go
+++ b/test/new-e2e/pkg/runner/parameters/store_config_file.go
@@ -38,10 +38,12 @@ type ConfigParams struct {
 
 // AWS instance contains AWS related parameters
 type AWS struct {
-	Account       string `yaml:"account"`
-	KeyPairName   string `yaml:"keyPairName"`
-	PublicKeyPath string `yaml:"publicKeyPath"`
-	TeamTag       string `yaml:"teamTag"`
+	Account              string `yaml:"account"`
+	KeyPairName          string `yaml:"keyPairName"`
+	PublicKeyPath        string `yaml:"publicKeyPath"`
+	PrivateKeyPath       string `yaml:"privateKeyPath"`
+	PrivateKeyPassphrase string `yaml:"privateKeyPassphrase"`
+	TeamTag              string `yaml:"teamTag"`
 }
 
 // Agent instance contains agent related parameters
@@ -103,6 +105,10 @@ func (s configFileValueStore) get(key StoreKey) (string, error) {
 		value = s.config.ConfigParams.AWS.KeyPairName
 	case PublicKeyPath:
 		value = s.config.ConfigParams.AWS.PublicKeyPath
+	case PrivateKeyPath:
+		value = s.config.ConfigParams.AWS.PrivateKeyPath
+	case PrivateKeyPassphrase:
+		value = s.config.ConfigParams.AWS.PrivateKeyPassphrase
 	case StackParameters:
 		value = s.stackParamsJSON
 	case Environments:

--- a/test/new-e2e/pkg/runner/parameters/store_config_file.go
+++ b/test/new-e2e/pkg/runner/parameters/store_config_file.go
@@ -18,6 +18,8 @@ import (
 //   aws:
 //     keyPairName: "totoro"
 //     publicKeyPath: "/home/totoro/.ssh/id_rsa.pub"
+//     privateKeyPath: "/home/totoro/.ssh/id_rsa"
+//     privateKeyPassphrase: "princess_mononoke"
 //   agent:
 //     apiKey: "00000000000000000000000000000000"=
 // stackParams:

--- a/test/new-e2e/pkg/utils/e2e/client/vm_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/vm_client.go
@@ -48,7 +48,7 @@ func NewVMClient(t *testing.T, connection *utils.Connection, osType componentos.
 		}
 	}
 
-	privateKeyPassphrase, err := runner.GetProfile().ParamStore().GetWithDefault(parameters.PrivateKeyPassphrase, "")
+	privateKeyPassphrase, err := runner.GetProfile().SecretStore().GetWithDefault(parameters.PrivateKeyPassphrase, "")
 	if err != nil {
 		return nil, err
 	}

--- a/test/new-e2e/pkg/utils/e2e/client/vm_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/vm_client.go
@@ -34,7 +34,7 @@ type VMClient struct {
 func NewVMClient(t *testing.T, connection *utils.Connection, osType componentos.Type) (*VMClient, error) {
 	t.Logf("connecting to remote VM at %s:%s", connection.User, connection.Host)
 
-	var privateSSHKey []byte
+	var privateSSHKey, privateKeyPassphraseBytes []byte
 
 	privateKeyPath, err := runner.GetProfile().ParamStore().GetWithDefault(parameters.PrivateKeyPath, "")
 	if err != nil {
@@ -52,12 +52,15 @@ func NewVMClient(t *testing.T, connection *utils.Connection, osType componentos.
 	if err != nil {
 		return nil, err
 	}
+	if privateKeyPassphrase != "" {
+		privateKeyPassphraseBytes = []byte(privateKeyPassphrase)
+	}
 
 	client, _, err := clients.GetSSHClient(
 		connection.User,
 		fmt.Sprintf("%s:%d", connection.Host, 22),
 		privateSSHKey,
-		[]byte(privateKeyPassphrase),
+		privateKeyPassphraseBytes,
 		2*time.Second, 5)
 	return &VMClient{
 		client: client,

--- a/test/new-e2e/pkg/utils/e2e/client/vm_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/vm_client.go
@@ -48,7 +48,7 @@ func NewVMClient(t *testing.T, connection *utils.Connection, osType componentos.
 		}
 	}
 
-	privateKeyPassphrase, err := runner.GetProfile().SecretStore().GetWithDefault(parameters.PrivateKeyPassphrase, "")
+	privateKeyPassphrase, err := runner.GetProfile().SecretStore().GetWithDefault(parameters.PrivateKeyPassword, "")
 	if err != nil {
 		return nil, err
 	}

--- a/test/new-e2e/pkg/utils/e2e/client/vm_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/vm_client.go
@@ -48,10 +48,16 @@ func NewVMClient(t *testing.T, connection *utils.Connection, osType componentos.
 		}
 	}
 
+	privateKeyPassphrase, err := runner.GetProfile().ParamStore().GetWithDefault(parameters.PrivateKeyPassphrase, "")
+	if err != nil {
+		return nil, err
+	}
+
 	client, _, err := clients.GetSSHClient(
 		connection.User,
 		fmt.Sprintf("%s:%d", connection.Host, 22),
 		privateSSHKey,
+		[]byte(privateKeyPassphrase),
 		2*time.Second, 5)
 	return &VMClient{
 		client: client,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Currently the E2E SSH client only supports either 
(a) non-passphrase protected keys, or 
(b) keys stored in the unix SSH agent.
Which means windows hosts with passphrase-protected SSH keys are not currently supported - this PR fixes that.

Additionally, adds `privateKeyPath` and `privateKeyPassword` to the supported AWS config parameters in order to make configuration a little simpler: setting these values in `test_infra_config.yaml` would now look like
```
configParams:
  aws:
    publicKeyPath: <path to public key>
    privateKeyPath:  <path to private key>
    privateKeyPassword: <private key passphrase>
```
instead of
```
configParams:
  aws:
    publicKeyPath: <path to public key>
stackParams:
  ddinfra:
    aws/defaultPrivateKeyPath: <path to private key>
    aws/defaultPrivateKeyPassword: <private key passphrase>
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

An alternate solution could be to add support for the windows SSH agent ([like this)](https://github.com/DataDog/datadog-agent/pull/21257) - however, pulumi doesn't support the use of the windows SSH agent (see the [available connection configuration options here](https://github.com/pulumi/pulumi-command/blob/75ccc1443cbdc7e62bdcd82f9c0ee29f5b6e0923/sdk/go/command/remote/pulumiTypes.go#L18-L39)), which means that currently Windows users must already specify their private key & passphrase in order for pulumi to be able to establish the initial connection to test VMs. Re-using the same authentication mechanism in the SSH client here prevents the need for ssh keys to be configured in multiple places.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
