### PR TITLE
[util/containers/filter] Adds rancher/mirrored-pause exclusion

### DIFF
--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -49,6 +49,8 @@ const (
 	pauseContainerEKS = `image:(amazonaws\.com/)?eks/pause.*`
 	// rancher/pause-amd64:3.0
 	pauseContainerRancher = `image:rancher/pause.*`
+	// rancher/mirrored-pause:3.7
+	pauseContainerRancherMirrored = `image:rancher/mirrored-pause.*`
 	// - mcr.microsoft.com/k8s/core/pause-amd64
 	pauseContainerMCR = `image:mcr\.microsoft\.com(.*)/pause.*`
 	// - aksrepos.azurecr.io/mirror/pause-amd64
@@ -180,6 +182,7 @@ func GetPauseContainerFilter() (*Filter, error) {
 			pauseContainerECS,
 			pauseContainerEKS,
 			pauseContainerRancher,
+			pauseContainerRancherMirrored,
 			pauseContainerMCR,
 			pauseContainerWin,
 			pauseContainerAKS,

--- a/releasenotes/notes/rancher-exclude-mirrored-pause-627d3b6cf16bbd95.yaml
+++ b/releasenotes/notes/rancher-exclude-mirrored-pause-627d3b6cf16bbd95.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Pause containers from the Rancher image-mirror repository (``rancher/mirrored-pause.*``)  are now excluded by default for containers and metrics collection.


### PR DESCRIPTION
### What does this PR do?

* Adds rancher/mirrored-pause to the list of default excluded pause containers

### Motivation

* https://datadoghq.atlassian.net/browse/CONS-6002
* Newer Rancher versions source the main images from the Rancher image mirror repo (https://github.com/rancher/image-mirror), and the pause container is thus `rancher/mirrored-pause` : it should be excluded by default

### Describe how to test/QA your changes

* Use Rancher with docker as the runtime (for instance, using RKE 1.5.0-rc5 - https://github.com/DataDog/container-agent-envs-doc/tree/main/rancher) with the --pod-infra-container set to rancher/mirrored-pause. It is the default in `v1.26.7-rancher1-1` for instance.
* Assert there is no `container.memory.usage` metrics collected with tag `image_name:rancher/mirrored-pause`
* Assert there are no live containers using this image in the live containers page
* Modify your chart to collect pause containers https://github.com/DataDog/helm-charts/blob/fb90437a68d9e59effe6fb3e396af442a5043411/charts/datadog/values.yaml#L854 
* Assert `container.memory.usage` with tag `image_name:rancher/mirrored-pause` is now collected

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
