### PR TITLE
usm: http2: Simplify static table user mode creation

### DIFF
--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -396,61 +396,21 @@ func (p *Protocol) GetStats() *protocols.ProtocolStats {
 	}
 }
 
-// The staticTableEntry represents an entry in the static table that contains an index in the table and a value.
-// The value itself contains both the key and the corresponding value in the static table.
-// For instance, index 2 in the static table has a value of method: GET, and index 3 has a value of method: POST.
-// It is not possible to save the index by the key because we need to distinguish between the values attached to the key.
-type staticTableEntry struct {
-	Index uint64
-	Value StaticTableEnumValue
-}
-
+// The following map contains a list of static table entries that are used by the http2 monitor.
+// The full list of static table entries can be found here: https://httpwg.org/specs/rfc7541.html#static.table.definition.
 var (
-	staticTableEntries = []staticTableEntry{
-		{
-			Index: 2,
-			Value: GetValue,
-		},
-		{
-			Index: 3,
-			Value: PostValue,
-		},
-		{
-			Index: 4,
-			Value: EmptyPathValue,
-		},
-		{
-			Index: 5,
-			Value: IndexPathValue,
-		},
-		{
-			Index: 8,
-			Value: K200Value,
-		},
-		{
-			Index: 9,
-			Value: K204Value,
-		},
-		{
-			Index: 10,
-			Value: K206Value,
-		},
-		{
-			Index: 11,
-			Value: K304Value,
-		},
-		{
-			Index: 12,
-			Value: K400Value,
-		},
-		{
-			Index: 13,
-			Value: K404Value,
-		},
-		{
-			Index: 14,
-			Value: K500Value,
-		},
+	staticTableEntries = map[uint64]StaticTableEnumValue{
+		2:  GetValue,
+		3:  PostValue,
+		4:  EmptyPathValue,
+		5:  IndexPathValue,
+		8:  K200Value,
+		9:  K204Value,
+		10: K206Value,
+		11: K304Value,
+		12: K400Value,
+		13: K404Value,
+		14: K500Value,
 	}
 )
 
@@ -461,8 +421,8 @@ func (p *Protocol) createStaticTable(mgr *manager.Manager) error {
 		return errors.New("http2 static table is null")
 	}
 
-	for _, entry := range staticTableEntries {
-		err := staticTable.Put(unsafe.Pointer(&entry.Index), unsafe.Pointer(&entry.Value))
+	for key, value := range staticTableEntries {
+		err := staticTable.Put(unsafe.Pointer(&key), unsafe.Pointer(&value))
 
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Simplifies the creation of http2_static_table form the user mode.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Cleaner code
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
