### PR TITLE
[CWS] fix process ancestors args/envs serialization

### DIFF
--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1176,7 +1176,14 @@ func (p *EBPFResolver) syncCache(proc *process.Process, filledProc *utils.Filled
 		return nil, false
 	}
 
-	p.setAncestor(entry)
+	parent := p.entryCache[entry.PPid]
+	if parent != nil {
+		if parent.Equals(entry) {
+			entry.SetParentOfForkChild(parent)
+		} else {
+			entry.SetAncestor(parent)
+		}
+	}
 
 	p.insertEntry(entry, p.entryCache[pid], source)
 

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -558,8 +558,10 @@ func newCredentialsSerializer(ce *model.Credentials) *CredentialsSerializer {
 
 func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer {
 	if ps.IsNotKworker() {
-		argv, argvTruncated := e.GetProcessArgvScrubbed(), e.GetProcessArgsTruncated()
-		envs, EnvsTruncated := e.GetProcessEnvs(), e.GetProcessEnvsTruncated()
+		argv := e.FieldHandlers.ResolveProcessArgvScrubbed(e, ps)
+		argvTruncated := e.FieldHandlers.ResolveProcessArgsTruncated(e, ps)
+		envs := e.FieldHandlers.ResolveProcessEnvs(e, ps)
+		envsTruncated := e.FieldHandlers.ResolveProcessEnvsTruncated(e, ps)
 		argv0, _ := sprocess.GetProcessArgv0(ps)
 
 		psSerializer := &ProcessSerializer{
@@ -577,7 +579,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 			Args:          argv,
 			ArgsTruncated: argvTruncated,
 			Envs:          envs,
-			EnvsTruncated: EnvsTruncated,
+			EnvsTruncated: envsTruncated,
 			IsThread:      ps.IsThread,
 			IsKworker:     ps.IsKworker,
 			IsExecChild:   ps.IsExecChild,

--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -69,7 +69,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 		Pid:        ps.Pid,
 		PPid:       getUint32Pointer(&ps.PPid),
 		Executable: newFileSerializer(&ps.FileEvent, e),
-		CmdLine:    e.GetProcessCmdlineScrubbed(),
+		CmdLine:    e.FieldHandlers.ResolveProcessCmdLineScrubbed(e, ps),
 	}
 
 	if len(ps.ContainerID) != 0 {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -581,7 +581,7 @@ func validateProcessContextLineage(tb testing.TB, event *model.Event, probe *spr
 			prevPPID = ppid
 		}
 
-		// test that consecutive ancestors have deduplicated args
+		// check that parent/child ancestors have deduplicated args
 		args, ok := pce["args"].([]interface{})
 		if ok && len(args) > 0 {
 			if pid != prevPID && prevArgs != nil {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -569,7 +569,6 @@ func validateProcessContextLineage(tb testing.TB, event *model.Event, probe *spr
 			tb.Error(string(eventJSON))
 			return
 		}
-		prevPID = pid
 
 		if pid != 1 {
 			ppid, ok := pce["ppid"].(float64)
@@ -585,7 +584,7 @@ func validateProcessContextLineage(tb testing.TB, event *model.Event, probe *spr
 		// test that consecutive ancestors have deduplicated args
 		args, ok := pce["args"].([]interface{})
 		if ok && len(args) > 0 {
-			if prevArgs != nil {
+			if pid != prevPID && prevArgs != nil {
 				if reflect.DeepEqual(args, prevArgs) {
 					tb.Errorf("invalid process tree, same parent/child args (%d/%d) %+q", int(pid), int(prevPID), args)
 					tb.Error(string(eventJSON))
@@ -596,6 +595,8 @@ func validateProcessContextLineage(tb testing.TB, event *model.Event, probe *spr
 		} else {
 			prevArgs = nil
 		}
+
+		prevPID = pid
 	}
 
 	if prevPID != 1 {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR fixes the serialization of process ancestors arguments and environment variables.
Ancestors args and envs were wrongly serialized using the event process context, causing every ancestor to have the same args/envs value.

This PR also adds a dedicated check in the `validateProcessContextLineage` function to make sure this kind of regression is detected in the future.
Adding this check caused multiple tests to fail because some args/envs weren't properly deduplicated, the process resolver change adds the required deduplication step in the snapshot function to fix this.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
