### PR TITLE
Move secrets flaky test instrumentation to testMain

### DIFF
--- a/comp/core/secrets/secretsimpl/fetch_secret_test.go
+++ b/comp/core/secrets/secretsimpl/fetch_secret_test.go
@@ -34,6 +34,35 @@ func build(m *testing.M, outBin, pkg string) { //nolint:revive // TODO fix reviv
 }
 
 func TestMain(m *testing.M) {
+	// TODO: remove once the issue is resolved
+	//
+	// This test has an issue on Windows where it can block entirely and timeout after 4 minutes
+	// (while the go test timeout is 3 minutes), and in that case it doesn't print stack traces.
+	//
+	// As a workaround, we explicitly write routine stack traces in an artifact if the test
+	// is not finished after 2 minutes.
+	if _, ok := os.LookupEnv("CI_PIPELINE_ID"); ok && runtime.GOOS == "windows" {
+		done := make(chan struct{}, 1)
+		defer func() {
+			done <- struct{}{}
+		}()
+		go func() {
+			select {
+			case <-done:
+			case <-time.After(2 * time.Minute):
+				// files junit-*.tgz are automatically considered as artifacts
+				file, err := os.OpenFile(`C:\mnt\junit-TestExecCommandError.tgz`, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "could not write stack traces: %v", err)
+					return
+				}
+				defer file.Close()
+				fmt.Fprintf(file, "test will timeout, printing goroutine stack traces:\n")
+				pprof.Lookup("goroutine").WriteTo(file, 2)
+			}
+		}()
+	}
+
 	testCheckRightsStub()
 
 	if runtime.GOOS == "windows" {
@@ -84,35 +113,6 @@ func TestLimitBuffer(t *testing.T) {
 }
 
 func TestExecCommandError(t *testing.T) {
-	// TODO: remove once the issue is resolved
-	//
-	// This test has an issue on Windows where it can block entirely and timeout after 4 minutes
-	// (while the go test timeout is 3 minutes), and in that case it doesn't print stack traces.
-	//
-	// As a workaround, we explicitly write routine stack traces in an artifact if the test
-	// is not finished after 2 minutes.
-	if _, ok := os.LookupEnv("CI_PIPELINE_ID"); ok && runtime.GOOS == "windows" {
-		done := make(chan struct{}, 1)
-		defer func() {
-			done <- struct{}{}
-		}()
-		go func() {
-			select {
-			case <-done:
-			case <-time.After(2 * time.Minute):
-				// files junit-*.tgz are automatically considered as artifacts
-				file, err := os.OpenFile(`C:\mnt\junit-TestExecCommandError.tgz`, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "could not write stack traces: %v", err)
-					return
-				}
-				defer file.Close()
-				fmt.Fprintf(file, "test will timeout, printing goroutine stack traces:\n")
-				pprof.Lookup("goroutine").WriteTo(file, 2)
-			}
-		}()
-	}
-
 	inputPayload := "{\"version\": \"" + secrets.PayloadVersion + "\" , \"secrets\": [\"sec1\", \"sec2\"]}"
 
 	t.Run("Empty secretBackendCommand", func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Move instrumentation added in https://github.com/DataDog/datadog-agent/issues/21159 to the `TestMain` function, as it seems the blocking part happens outside of the actual test.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The test failed but no artifact was written.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
