### PR TITLE
Update regression detector ro run with lading 0.20.1

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -18,7 +18,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.11.0
-    LADING_VERSION: 0.19.1
+    LADING_VERSION: 0.20.1-rc4
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -18,7 +18,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.11.0
-    LADING_VERSION: 0.20.1-rc4
+    LADING_VERSION: 0.20.1
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the

--- a/test/regression/cases/file_to_blackhole/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole/lading/lading.yaml
@@ -1,13 +1,14 @@
 generator:
   - file_gen:
-      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
-             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-      path_template: "/tmp/file-gen-%NNN%.log"
-      duplicates: 4 ## this multiplies bytes_per_second by 4
-      variant: "ascii"
-      bytes_per_second: "10Mb"
-      maximum_bytes_per_file: "20Mb"
-      maximum_prebuild_cache_size_bytes: "400Mb"
+      traditional:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+               59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        path_template: "/tmp/file-gen-%NNN%.log"
+        duplicates: 4 ## this multiplies bytes_per_second by 4
+        variant: "ascii"
+        bytes_per_second: "10Mb"
+        maximum_bytes_per_file: "20Mb"
+        maximum_prebuild_cache_size_bytes: "400Mb"
 
 blackhole:
   - http:


### PR DESCRIPTION
This lading release improves the shutdown regime of lading and allows for more tailoring of DogStatsD experiments. This change requires a modification to file-gen using experiments, done in this commit.

REF SMPTNG-94