### PR TITLE
add basic file operations to VM

### DIFF
--- a/test/new-e2e/examples/vm_test.go
+++ b/test/new-e2e/examples/vm_test.go
@@ -1,0 +1,134 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package examples
+
+import (
+	"flag"
+	"io/fs"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
+)
+
+var (
+	devMode = flag.Bool("devmode", false, "enable dev mode")
+)
+
+type vmSuite struct {
+	e2e.Suite[e2e.VMEnv]
+}
+
+func TestVMSuite(t *testing.T) {
+	suiteParams := make([]func(*params.Params), 0)
+	if *devMode {
+		suiteParams = append(suiteParams, params.WithDevMode())
+	}
+	e2e.Run(t, &vmSuite{},
+		e2e.EC2VMStackDef(ec2params.WithOS(ec2os.WindowsOS)),
+		suiteParams...,
+	)
+}
+
+func (v *vmSuite) TestExecute() {
+	vm := v.Env().VM
+
+	out, err := vm.ExecuteWithError("whoami")
+	v.Require().NoError(err)
+	v.Require().NotEmpty(out)
+}
+
+func (v *vmSuite) TestFileOperations() {
+	vm := v.Env().VM
+	testFilePath := "test"
+
+	v.T().Cleanup(func() {
+		_ = vm.Remove(testFilePath)
+	})
+
+	// file does not exist to start
+	exists, err := vm.FileExists(testFilePath)
+	v.Require().NoError(err)
+	v.Require().False(exists)
+
+	// Should return error when file does not exist
+	_, err = vm.ReadFile(testFilePath)
+	v.Require().ErrorIs(err, fs.ErrNotExist)
+	_, err = vm.Lstat(testFilePath)
+	v.Require().ErrorIs(err, fs.ErrNotExist)
+
+	// Write to the file
+	testContent := []byte("content")
+	bytesWritten, err := vm.WriteFile(testFilePath, testContent)
+	v.Require().NoError(err)
+	v.Require().EqualValues(len(testContent), bytesWritten)
+
+	// Writing to the file should create it
+	exists, err = vm.FileExists(testFilePath)
+	v.Require().NoError(err)
+	v.Require().True(exists)
+
+	fileInfo, err := vm.Lstat(testFilePath)
+	v.Require().NoError(err)
+	v.Require().False(fileInfo.IsDir())
+
+	// Read content back and ensure it matches
+	content, err := vm.ReadFile(testFilePath)
+	v.Require().NoError(err)
+	v.Require().Equal(testContent, content)
+
+	// Remove the file
+	err = vm.Remove(testFilePath)
+	v.Require().NoError(err)
+
+	// File should no longer exist
+	exists, err = vm.FileExists(testFilePath)
+	v.Require().NoError(err)
+	v.Require().False(exists)
+}
+
+func (v *vmSuite) TestDirectoryOperations() {
+	vm := v.Env().VM
+	testDirPath := "testDirectory"
+	testSubDirPath := "testDirectory/testSubDirectory"
+
+	v.T().Cleanup(func() {
+		_ = vm.RemoveAll(testDirPath)
+	})
+
+	// directory does not exist to start
+	exists, err := vm.FileExists(testDirPath)
+	v.Require().NoError(err)
+	v.Require().False(exists)
+
+	// Should return error when directory does not exist
+	_, err = vm.ReadDir(testDirPath)
+	v.Require().ErrorIs(err, fs.ErrNotExist)
+	_, err = vm.Lstat(testDirPath)
+	v.Require().ErrorIs(err, fs.ErrNotExist)
+
+	// Create the sub directory
+	err = vm.MkdirAll(testSubDirPath)
+	v.Require().NoError(err)
+
+	// Should create entire directory path
+	fileInfo, err := vm.Lstat(testDirPath)
+	v.Require().NoError(err)
+	v.Require().True(fileInfo.IsDir())
+	fileInfo, err = vm.Lstat(testSubDirPath)
+	v.Require().NoError(err)
+	v.Require().True(fileInfo.IsDir())
+
+	// Remove the directory
+	err = vm.RemoveAll(testDirPath)
+	v.Require().NoError(err)
+
+	// Directory should no longer exist
+	_, err = vm.Lstat(testDirPath)
+	v.Require().ErrorIs(err, fs.ErrNotExist)
+}

--- a/test/new-e2e/pkg/utils/clients/ssh.go
+++ b/test/new-e2e/pkg/utils/clients/ssh.go
@@ -6,7 +6,11 @@
 package clients
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"net"
 	"os"
 	"path"
@@ -159,4 +163,133 @@ func copyFile(sftpClient *sftp.Client, src string, dst string) error {
 	}
 	return nil
 
+}
+
+// FileExists create a sftp session to and returns true if the file exists and is a regular file
+func FileExists(client *ssh.Client, path string) (bool, error) {
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return false, err
+	}
+	defer sftpClient.Close()
+
+	info, err := sftpClient.Lstat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return info.Mode().IsRegular(), nil
+}
+
+// ReadFile reads the content of the file, return bytes read and error if any
+func ReadFile(client *ssh.Client, path string) ([]byte, error) {
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return nil, err
+	}
+	defer sftpClient.Close()
+
+	f, err := sftpClient.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var content bytes.Buffer
+	_, err = io.Copy(&content, f)
+	if err != nil {
+		return content.Bytes(), err
+	}
+
+	return content.Bytes(), nil
+}
+
+// WriteFile write content to the file and returns the number of bytes written and error if any
+func WriteFile(client *ssh.Client, path string, content []byte) (int64, error) {
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return 0, err
+	}
+	defer sftpClient.Close()
+
+	f, err := sftpClient.Create(path)
+	if err != nil {
+		return 0, err
+	}
+
+	reader := bytes.NewReader(content)
+	return io.Copy(f, reader)
+}
+
+// ReadDir returns list of directory entries in path
+func ReadDir(client *ssh.Client, path string) ([]fs.DirEntry, error) {
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return nil, err
+	}
+	defer sftpClient.Close()
+
+	infos, err := sftpClient.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]fs.DirEntry, 0, len(infos))
+	for _, info := range infos {
+		entry := fs.FileInfoToDirEntry(info)
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+// Lstat returns a FileInfo structure describing path.
+// if path is a symbolic link, the FileInfo structure describes the symbolic link.
+func Lstat(client *ssh.Client, path string) (fs.FileInfo, error) {
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return nil, err
+	}
+	defer sftpClient.Close()
+
+	return sftpClient.Lstat(path)
+}
+
+// MkDirAll creates the specified directory along with any necessary parents.
+// If the path is already a directory, does nothing and returns nil.
+// Otherwise returns an error if any.
+func MkdirAll(client *ssh.Client, path string) error {
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return err
+	}
+	defer sftpClient.Close()
+
+	return sftpClient.MkdirAll(path)
+}
+
+// Remove removes the specified file or directory.
+// Returns an error if file or directory does not exist, or if the directory is not empty.
+func Remove(client *ssh.Client, path string) error {
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return err
+	}
+	defer sftpClient.Close()
+
+	return sftpClient.Remove(path)
+}
+
+// RemoveAll recursively removes all files/folders in the specified directory.
+// Returns an error if the directory does not exist.
+func RemoveAll(client *ssh.Client, path string) error {
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return err
+	}
+	defer sftpClient.Close()
+
+	return sftpClient.RemoveAll(path)
 }

--- a/test/new-e2e/pkg/utils/clients/ssh.go
+++ b/test/new-e2e/pkg/utils/clients/ssh.go
@@ -257,7 +257,7 @@ func Lstat(client *ssh.Client, path string) (fs.FileInfo, error) {
 	return sftpClient.Lstat(path)
 }
 
-// MkDirAll creates the specified directory along with any necessary parents.
+// MkdirAll creates the specified directory along with any necessary parents.
 // If the path is already a directory, does nothing and returns nil.
 // Otherwise returns an error if any.
 func MkdirAll(client *ssh.Client, path string) error {

--- a/test/new-e2e/pkg/utils/e2e/client/vm.go
+++ b/test/new-e2e/pkg/utils/e2e/client/vm.go
@@ -41,7 +41,7 @@ type VM interface {
 	// if path is a symbolic link, the FileInfo structure describes the symbolic link.
 	Lstat(path string) (fs.FileInfo, error)
 
-	// MkDirAll creates the specified directory along with any necessary parents.
+	// MkdirAll creates the specified directory along with any necessary parents.
 	// If the path is already a directory, does nothing and returns nil.
 	// Otherwise returns an error if any.
 	MkdirAll(path string) error

--- a/test/new-e2e/pkg/utils/e2e/client/vm.go
+++ b/test/new-e2e/pkg/utils/e2e/client/vm.go
@@ -6,6 +6,8 @@
 package client
 
 import (
+	"io/fs"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/executeparams"
 )
 
@@ -22,4 +24,33 @@ type VM interface {
 
 	// CopyFolder copy a folder to the remote host
 	CopyFolder(srcFolder string, dstFolder string)
+
+	// FileExists returns true if the file exists and is a regular file and returns an error if any
+	FileExists(path string) (bool, error)
+
+	// ReadFile reads the content of the file, return bytes read and error if any
+	ReadFile(path string) ([]byte, error)
+
+	// WriteFile write content to the file and returns the number of bytes written and error if any
+	WriteFile(path string, content []byte) (int64, error)
+
+	// ReadDir returns list of directory entries in path
+	ReadDir(path string) ([]fs.DirEntry, error)
+
+	// Lstat returns a FileInfo structure describing path.
+	// if path is a symbolic link, the FileInfo structure describes the symbolic link.
+	Lstat(path string) (fs.FileInfo, error)
+
+	// MkDirAll creates the specified directory along with any necessary parents.
+	// If the path is already a directory, does nothing and returns nil.
+	// Otherwise returns an error if any.
+	MkdirAll(path string) error
+
+	// Remove removes the specified file or directory.
+	// Returns an error if file or directory does not exist, or if the directory is not empty.
+	Remove(path string) error
+
+	// RemoveAll recursively removes all files/folders in the specified directory.
+	// Returns an error if the directory does not exist.
+	RemoveAll(path string) error
 }

--- a/test/new-e2e/pkg/utils/e2e/client/vm_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/vm_client.go
@@ -130,7 +130,7 @@ func (vmClient *VMClient) Lstat(path string) (fs.FileInfo, error) {
 	return clients.Lstat(vmClient.client, path)
 }
 
-// MkDirAll creates the specified directory along with any necessary parents.
+// MkdirAll creates the specified directory along with any necessary parents.
 // If the path is already a directory, does nothing and returns nil.
 // Otherwise returns an error if any.
 func (vmClient *VMClient) MkdirAll(path string) error {

--- a/test/new-e2e/pkg/utils/e2e/client/vm_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/vm_client.go
@@ -7,6 +7,7 @@ package client
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"testing"
 	"time"
@@ -101,6 +102,51 @@ func (vmClient *VMClient) CopyFile(src string, dst string) {
 func (vmClient *VMClient) CopyFolder(srcFolder string, dstFolder string) {
 	err := clients.CopyFolder(vmClient.client, srcFolder, dstFolder)
 	require.NoError(vmClient.t, err)
+}
+
+// FileExists returns true if the file exists and is a regular file and returns an error if any
+func (vmClient *VMClient) FileExists(path string) (bool, error) {
+	return clients.FileExists(vmClient.client, path)
+}
+
+// ReadFile reads the content of the file, return bytes read and error if any
+func (vmClient *VMClient) ReadFile(path string) ([]byte, error) {
+	return clients.ReadFile(vmClient.client, path)
+}
+
+// WriteFile write content to the file and returns the number of bytes written and error if any
+func (vmClient *VMClient) WriteFile(path string, content []byte) (int64, error) {
+	return clients.WriteFile(vmClient.client, path, content)
+}
+
+// ReadDir returns list of directory entries in path
+func (vmClient *VMClient) ReadDir(path string) ([]fs.DirEntry, error) {
+	return clients.ReadDir(vmClient.client, path)
+}
+
+// Lstat returns a FileInfo structure describing path.
+// if path is a symbolic link, the FileInfo structure describes the symbolic link.
+func (vmClient *VMClient) Lstat(path string) (fs.FileInfo, error) {
+	return clients.Lstat(vmClient.client, path)
+}
+
+// MkDirAll creates the specified directory along with any necessary parents.
+// If the path is already a directory, does nothing and returns nil.
+// Otherwise returns an error if any.
+func (vmClient *VMClient) MkdirAll(path string) error {
+	return clients.MkdirAll(vmClient.client, path)
+}
+
+// Remove removes the specified file or directory.
+// Returns an error if file or directory does not exist, or if the directory is not empty.
+func (vmClient *VMClient) Remove(path string) error {
+	return clients.Remove(vmClient.client, path)
+}
+
+// RemoveAll recursively removes all files/folders in the specified directory.
+// Returns an error if the directory does not exist.
+func (vmClient *VMClient) RemoveAll(path string) error {
+	return clients.RemoveAll(vmClient.client, path)
 }
 
 func (vmClient *VMClient) setEnvVariables(command string, envVar executeparams.EnvVar) string {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add basic file operations to VM. light wrapper around [sftp ](https://pkg.go.dev/github.com/pkg/sftp#section-readme)functions, using interfaces from [fs](https://pkg.go.dev/io/fs) where possible.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Needed to be able to test for file existence and read files from test VM, so added a few other basics at the same time.

https://datadoghq.atlassian.net/browse/WINA-571

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
