### PR TITLE
Move GetIPCAddress back to pkg/config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -303,7 +303,6 @@
 /pkg/config/apm.go                      @DataDog/agent-apm
 /pkg/config/autodiscovery/              @Datadog/container-integrations
 /pkg/config/env                         @DataDog/container-integrations @DataDog/container-app
-/pkg/config/env/ipc_address*            @DataDog/agent-shared-components
 /pkg/config/logs                        @Datadog/agent-shared-components @Datadog/agent-platform
 /pkg/config/logs/internal/seelog/seelog_config.go          @Datadog/agent-shared-components
 /pkg/config/process*.go                 @DataDog/processes

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1674,7 +1674,7 @@ func setupFipsEndpoints(config Config) error {
 		networkDevicesNetflow      = 15 // 14 is reserved for compliance (#20230)
 	)
 
-	localAddress, err := isLocalAddress(config.GetString("fips.local_address"))
+	localAddress, err := IsLocalAddress(config.GetString("fips.local_address"))
 	if err != nil {
 		return fmt.Errorf("fips.local_address: %s", err)
 	}
@@ -1862,13 +1862,6 @@ func IsCloudProviderEnabled(cloudProviderName string) bool {
 		cloudProviderFromConfig,
 		cloudProviderName)
 	return false
-}
-
-var isLocalAddress = pkgconfigenv.IsLocalAddress
-
-// GetIPCAddress returns the IPC address or an error if the address is not local
-func GetIPCAddress() (string, error) {
-	return pkgconfigenv.GetIPCAddress(Datadog)
 }
 
 // pathExists returns true if the given path exists

--- a/pkg/config/ipc_address.go
+++ b/pkg/config/ipc_address.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package env
+package config
 
 import (
 	"fmt"
@@ -38,7 +38,11 @@ func IsLocalAddress(address string) (string, error) {
 }
 
 // GetIPCAddress returns the IPC address or an error if the address is not local
-func GetIPCAddress(cfg pkgconfigmodel.Reader) (string, error) {
+func GetIPCAddress() (string, error) {
+	return getIPCAddress(Datadog)
+}
+
+func getIPCAddress(cfg pkgconfigmodel.Reader) (string, error) {
 	var key string
 	// ipc_address is deprecated in favor of cmd_host, but we still need to support it
 	// if it is set, use it, otherwise use cmd_host

--- a/pkg/config/ipc_address_test.go
+++ b/pkg/config/ipc_address_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package env
+package config
 
 import (
 	"strings"
@@ -23,7 +23,7 @@ const (
 func TestGetIPCAddress(t *testing.T) {
 	t.Run("default value", func(t *testing.T) {
 		cfg := getConfig()
-		val, err := GetIPCAddress(cfg)
+		val, err := getIPCAddress(cfg)
 		require.NoError(t, err)
 		require.Equal(t, localhostStr, val)
 	})
@@ -31,7 +31,7 @@ func TestGetIPCAddress(t *testing.T) {
 	t.Run("ipc_address from file", func(t *testing.T) {
 		cfg := getConfig()
 		cfg.Set("ipc_address", localhostV4, model.SourceFile)
-		val, err := GetIPCAddress(cfg)
+		val, err := getIPCAddress(cfg)
 		require.NoError(t, err)
 		require.Equal(t, localhostV4, val)
 	})
@@ -39,7 +39,7 @@ func TestGetIPCAddress(t *testing.T) {
 	t.Run("ipc_address from env", func(t *testing.T) {
 		cfg := getConfig()
 		t.Setenv("DD_IPC_ADDRESS", localhostV4)
-		val, err := GetIPCAddress(cfg)
+		val, err := getIPCAddress(cfg)
 		require.NoError(t, err)
 		require.Equal(t, localhostV4, val)
 	})
@@ -48,7 +48,7 @@ func TestGetIPCAddress(t *testing.T) {
 		cfg := getConfig()
 		cfg.Set("ipc_address", localhostV4, model.SourceFile)
 		cfg.Set("cmd_host", localhostV6, model.SourceFile)
-		val, err := GetIPCAddress(cfg)
+		val, err := getIPCAddress(cfg)
 		require.NoError(t, err)
 		require.Equal(t, localhostV4, val)
 	})
@@ -56,7 +56,7 @@ func TestGetIPCAddress(t *testing.T) {
 	t.Run("ipc_address takes precedence over cmd_host", func(t *testing.T) {
 		cfg := getConfig()
 		cfg.Set("cmd_host", localhostV6, model.SourceFile)
-		val, err := GetIPCAddress(cfg)
+		val, err := getIPCAddress(cfg)
 		require.NoError(t, err)
 		require.Equal(t, localhostV6, val)
 	})
@@ -64,7 +64,7 @@ func TestGetIPCAddress(t *testing.T) {
 	t.Run("error if not local", func(t *testing.T) {
 		cfg := getConfig()
 		cfg.Set("cmd_host", "111.111.111.111", model.SourceFile)
-		_, err := GetIPCAddress(cfg)
+		_, err := getIPCAddress(cfg)
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Move `GetIPCAddress` back to `pkg/config`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
It was moved in `pkg/config/env` in https://github.com/DataDog/datadog-agent/pull/20569, but should have stayed in the config package.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
No need for QA, the CI is enough.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
