### PR TITLE
[oracle] Correct dbm-metadata payload tags

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/metadata.go
+++ b/pkg/collector/corechecks/oracle-dbm/metadata.go
@@ -36,8 +36,6 @@ type dbInstanceEvent struct {
 }
 
 func sendDbInstanceMetadata(c *Check) error {
-	configTags := make([]string, len(c.config.Tags))
-	copy(configTags, c.config.Tags)
 	m := dbInstanceMetadata{
 		Dbm:            true,
 		ConnectionHost: config.GetConnectData(c.config.InstanceConfig),
@@ -49,7 +47,7 @@ func sendDbInstanceMetadata(c *Check) error {
 		Kind:               "database_instance",
 		CollectionInterval: c.config.InstanceConfig.DatabaseInstanceCollectionInterval,
 		DbmsVersion:        c.dbVersion,
-		Tags:               configTags,
+		Tags:               c.tags,
 		Timestamp:          float64(time.Now().UnixMilli()),
 		Metadata:           m,
 	}

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
+
 	//nolint:revive // TODO(DBM) Fix revive linter
 	_ "github.com/godror/godror"
 	go_version "github.com/hashicorp/go-version"
@@ -166,15 +167,6 @@ func (c *Check) Run() error {
 		c.connection = conn
 	}
 
-	dbInstanceIntervalExpired := checkIntervalExpired(&c.dbInstanceLastRun, 1800)
-
-	if dbInstanceIntervalExpired {
-		err := sendDbInstanceMetadata(c)
-		if err != nil {
-			return fmt.Errorf("%s failed to send db instance metadata %w", c.logPrompt, err)
-		}
-	}
-
 	metricIntervalExpired := checkIntervalExpired(&c.metricLastRun, c.config.MetricCollectionInterval)
 
 	if metricIntervalExpired {
@@ -226,6 +218,15 @@ func (c *Check) Run() error {
 			if err != nil {
 				log.Errorf("%s failed to execute custom queries %s", c.logPrompt, err)
 			}
+		}
+	}
+
+	dbInstanceIntervalExpired := checkIntervalExpired(&c.dbInstanceLastRun, 1800)
+
+	if dbInstanceIntervalExpired {
+		err := sendDbInstanceMetadata(c)
+		if err != nil {
+			return fmt.Errorf("%s failed to send db instance metadata %w", c.logPrompt, err)
 		}
 	}
 

--- a/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
+++ b/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
@@ -77,7 +77,7 @@ func isConnectionError(err error) bool {
 	if err == nil {
 		return false
 	}
-	connectionErrors := []string{"ORA-00028", "ORA-01012", "ORA-06413", "database is closed", "bad connection", "connection was aborted"}
+	connectionErrors := []string{"ORA-00028", "ORA-01012", "ORA-06413", "ORA-12514", "database is closed", "bad connection", "connection was aborted"}
 	for _, e := range connectionErrors {
 		if strings.Contains(err.Error(), e) {
 			return true

--- a/releasenotes/notes/oracle-dbm-metadata-tags-32bfbc811ef1ecec.yaml
+++ b/releasenotes/notes/oracle-dbm-metadata-tags-32bfbc811ef1ecec.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    dbm-metadata payload should have the same set of tags as events and metrics.


### PR DESCRIPTION
### What does this PR do?

`dbm-metadata` payload should have the same tags as metrics and events.

### Additional Notes

I made a false assumption that `dbm-metadata` must always be sent, also when the database is down. For this reason, the agent was only emitting tags that are read from the configuration files, not including the tags that are dynamically selected from the database. This assumption [turned out to be wrong](https://dd.slack.com/archives/C04HV5BPBU2/p1701713546761349?thread_ts=1700245708.588249&cid=C04HV5BPBU2) . Now the agent emits the full set of tags.

### Describe how to test/QA your changes

Check if the `database_version` exists in `dbm-metadata` payload.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
