### PR TITLE
[invoke] Simplify headless mode code for inv lint-go

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import textwrap
 from pathlib import Path
+from typing import List, Union
 
 from invoke import task
 from invoke.exceptions import Exit
@@ -30,17 +31,17 @@ GOARCH_MAPPING = {
 
 def run_golangci_lint(
     ctx,
-    module_path,
-    targets,
-    rtloader_root=None,
-    build_tags=None,
-    build="test",
-    arch="x64",
-    concurrency=None,
-    timeout=None,
-    verbose=False,
-    golangci_lint_kwargs="",
-    headless_mode: bool = False,
+    module_path: str,
+    targets: Union[str, List[str]],
+    rtloader_root: str = None,
+    build_tags: str = None,
+    build: str = "test",
+    arch: str = "x64",
+    concurrency: str = None,
+    timeout: int = None,
+    verbose: bool = False,
+    golangci_lint_kwargs: str = "",
+    logger: callable = print,
 ):
     if isinstance(targets, str):
         # when this function is called from the command line, targets are passed
@@ -54,13 +55,12 @@ def run_golangci_lint(
     # Always add `test` tags while linting as test files are also linted
     tags.extend(UNIT_TEST_TAGS)
 
-    _, _, env = get_build_flags(ctx, rtloader_root=rtloader_root, headless_mode=headless_mode)
+    _, _, env = get_build_flags(ctx, rtloader_root=rtloader_root, logger=logger)
     verbosity = "-v" if verbose else ""
     # we split targets to avoid going over the memory limit from circleCI
     results = []
     for target in targets:
-        if not headless_mode:
-            print(f"running golangci on {target}")
+        logger(f"running golangci on {target}")
         concurrency_arg = "" if concurrency is None else f"--concurrency {concurrency}"
         tags_arg = " ".join(sorted(set(tags)))
         timeout_arg_value = "25m0s" if not timeout else f"{timeout}m0s"

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -796,7 +796,7 @@ def lint_go(
     logger = print
     if headless_mode:
 
-        def no_print(*args, **kwargs):
+        def no_print(*_, **__):
             pass
 
         logger = no_print

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -121,8 +121,8 @@ def get_build_flags(
     python_home_3=None,
     major_version='7',
     python_runtimes='3',
-    headless_mode=False,
     race=False,
+    logger: callable = print,
 ):
     """
     Build the common value for both ldflags and gcflags, and return an env accordingly.
@@ -172,10 +172,9 @@ def get_build_flags(
 
     # adding rtloader libs and headers to the env
     if rtloader_lib:
-        if not headless_mode:
-            print(
-                f"--- Setting rtloader paths to lib:{','.join(rtloader_lib)} | header:{rtloader_headers} | common headers:{rtloader_common_headers}"
-            )
+        logger(
+            f"--- Setting rtloader paths to lib:{','.join(rtloader_lib)} | header:{rtloader_headers} | common headers:{rtloader_common_headers}"
+        )
         env['DYLD_LIBRARY_PATH'] = os.environ.get('DYLD_LIBRARY_PATH', '') + f":{':'.join(rtloader_lib)}"  # OSX
         env['LD_LIBRARY_PATH'] = os.environ.get('LD_LIBRARY_PATH', '') + f":{':'.join(rtloader_lib)}"  # linux
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + f" -L{' -L '.join(rtloader_lib)}"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Simplify code around the `headless_mode` parameter - instead of passing the parameter to all functions and deciding whether to print or not each time a print is done, construct and pass a logger function whose behavior depends on the `headless_mode` parameter.
Add type hints.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Slightly cleaner code.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The next step would be to use a real logger instead of a lone logging function, if we need more advanced features like log levels, writing to a file, etc.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run the `inv lint-go` task with the `--headless-mode` option, check that nothing gets printed in `stdout`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
