### PR TITLE
Revert "[OTEL-1174] Include apm.trace_buffer in config_template.yaml"

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1579,12 +1579,6 @@ api_key:
   # - ns2
   # - system-ns
 
-  ## @param trace_buffer - integer - optional
-  ## @env DD_APM_TRACE_BUFFER - integer - optional
-  ## Specifies the size of trace payloads to buffer before dropping them. If unset, trace payloads are unbuffered.
-  #
-  # trace_buffer: 100
-
   {{- if .InternalProfiling -}}
   ## @param profiling - custom object - optional
   ## Enter specific configurations for internal profiling.


### PR DESCRIPTION
Reverts DataDog/datadog-agent#20664

The config was introduced in https://github.com/DataDog/datadog-agent/pull/17917 and was deliberately left undocumented. 

This is a config that users should never need to touch, and changing it will almost always result in negative effects and increasing it doesn't do what intuition would suggest (it doesn't increase the agent's ability to deal with larger payload volumes).

The config exists so that we have a knob to turn in the case of an emergency where we determine it's necessary for a customer.
