### PR TITLE
fix revive issues for HTTP/2

### DIFF
--- a/pkg/network/protocols/http2/dummy.go
+++ b/pkg/network/protocols/http2/dummy.go
@@ -3,9 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux_bpf
-
 // On Windows/mac the package his empty, so having a dummy file to ensure the package is not invalid on Windows/mac.
-//
-//nolint:revive // TODO(USM) Fix revive linter
+
+// Package http2 provides a HTTP/2 implementation for the network package for supporting HTTP/2 and gRPC monitoring with USM.
 package http2

--- a/pkg/network/protocols/http2/kernel_requirements.go
+++ b/pkg/network/protocols/http2/kernel_requirements.go
@@ -5,7 +5,6 @@
 
 //go:build linux_bpf
 
-//nolint:revive // TODO(USM) Fix revive linter
 package http2
 
 import (

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -58,7 +58,7 @@ func (tx *EbpfTx) Incomplete() bool {
 	return tx.Stream.Request_started == 0 || tx.Stream.Response_last_seen == 0 || tx.StatusCode() == 0 || tx.Stream.Path_size == 0 || tx.Method() == http.MethodUnknown
 }
 
-//nolint:revive // TODO(USM) Fix revive linter
+// ConnTuple returns the connections tuple of the transaction.
 func (tx *EbpfTx) ConnTuple() types.ConnectionKey {
 	return types.ConnectionKey{
 		SrcIPHigh: tx.Tuple.Saddr_h,
@@ -70,7 +70,7 @@ func (tx *EbpfTx) ConnTuple() types.ConnectionKey {
 	}
 }
 
-//nolint:revive // TODO(USM) Fix revive linter
+// Method returns the HTTP method of the transaction.
 func (tx *EbpfTx) Method() http.Method {
 	switch tx.Stream.Request_method {
 	case GetValue:
@@ -82,7 +82,7 @@ func (tx *EbpfTx) Method() http.Method {
 	}
 }
 
-//nolint:revive // TODO(USM) Fix revive linter
+// StatusCode returns the HTTP status code of the transaction.
 func (tx *EbpfTx) StatusCode() uint16 {
 	switch tx.Stream.Response_status_code {
 	case uint16(K200Value):
@@ -100,43 +100,43 @@ func (tx *EbpfTx) StatusCode() uint16 {
 	}
 }
 
-//nolint:revive // TODO(USM) Fix revive linter
+// SetStatusCode sets the HTTP status code of the transaction.
 func (tx *EbpfTx) SetStatusCode(code uint16) {
 	tx.Stream.Response_status_code = code
 }
 
-//nolint:revive // TODO(USM) Fix revive linter
+// ResponseLastSeen returns the last seen response.
 func (tx *EbpfTx) ResponseLastSeen() uint64 {
 	return tx.Stream.Response_last_seen
 }
 
-//nolint:revive // TODO(USM) Fix revive linter
+// SetResponseLastSeen sets the last seen response.
 func (tx *EbpfTx) SetResponseLastSeen(lastSeen uint64) {
 	tx.Stream.Response_last_seen = lastSeen
 
 }
 
-//nolint:revive // TODO(USM) Fix revive linter
+// RequestStarted returns the timestamp of the request start.
 func (tx *EbpfTx) RequestStarted() uint64 {
 	return tx.Stream.Request_started
 }
 
-//nolint:revive // TODO(USM) Fix revive linter
+// SetRequestMethod sets the HTTP method of the transaction.
 func (tx *EbpfTx) SetRequestMethod(m http.Method) {
 	tx.Stream.Request_method = uint8(m)
 }
 
-//nolint:revive // TODO(USM) Fix revive linter
+// StaticTags returns the static tags of the transaction.
 func (tx *EbpfTx) StaticTags() uint64 {
 	return 0
 }
 
-//nolint:revive // TODO(USM) Fix revive linter
+// DynamicTags returns the dynamic tags of the transaction.
 func (tx *EbpfTx) DynamicTags() []string {
 	return nil
 }
 
-//nolint:revive // TODO(USM) Fix revive linter
+// String returns a string representation of the transaction.
 func (tx *EbpfTx) String() string {
 	var output strings.Builder
 	output.WriteString("http2.ebpfTx{")
@@ -209,6 +209,7 @@ func (t http2StreamKey) destEndpoint() string {
 	return net.JoinHostPort(t.destAddress().String(), strconv.Itoa(int(t.Tup.Dport)))
 }
 
+// String returns a string representation of the http2 stream key.
 func (t http2StreamKey) String() string {
 	return fmt.Sprintf(
 		"[%s] [%s ⇄ %s] (stream id %d)",
@@ -219,6 +220,7 @@ func (t http2StreamKey) String() string {
 	)
 }
 
+// String returns a string representation of the http2 dynamic table.
 func (t http2DynamicTableEntry) String() string {
 	if t.Len == 0 {
 		return ""

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -67,7 +67,7 @@ const (
 	telemetryMap                     = "http2_telemetry"
 )
 
-//nolint:revive // TODO(USM) Fix revive linter
+// Spec is the protocol spec for HTTP/2.
 var Spec = &protocols.ProtocolSpec{
 	Factory: newHTTP2Protocol,
 	Maps: []*manager.Map{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes revive linter warning for the package pkg/network/protocols/http2


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Pass the revive lint issues for the HTTP/2 protocol package.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
