### PR TITLE
[CWS] fix revive TODOs in `pkg/security/secl`

### DIFF
--- a/pkg/security/secl/compiler/ast/secl_test.go
+++ b/pkg/security/secl/compiler/ast/secl_test.go
@@ -21,7 +21,7 @@ func parseMacro(macro string) (*Macro, error) {
 	return pc.ParseMacro(macro)
 }
 
-func print(t *testing.T, i interface{}) {
+func printJSON(t *testing.T, i interface{}) {
 	b, err := json.MarshalIndent(i, "", "  ")
 	if err != nil {
 		t.Error(err)
@@ -43,7 +43,7 @@ func TestCompareNumbers(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestCompareSimpleIdent(t *testing.T) {
@@ -52,7 +52,7 @@ func TestCompareSimpleIdent(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestCompareCompositeIdent(t *testing.T) {
@@ -61,7 +61,7 @@ func TestCompareCompositeIdent(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestCompareString(t *testing.T) {
@@ -70,7 +70,7 @@ func TestCompareString(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestCompareComplex(t *testing.T) {
@@ -79,7 +79,7 @@ func TestCompareComplex(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestRegister(t *testing.T) {
@@ -88,7 +88,7 @@ func TestRegister(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestIntAnd(t *testing.T) {
@@ -97,7 +97,7 @@ func TestIntAnd(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestBoolAnd(t *testing.T) {
@@ -106,7 +106,7 @@ func TestBoolAnd(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestInArrayString(t *testing.T) {
@@ -115,7 +115,7 @@ func TestInArrayString(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestInArrayInteger(t *testing.T) {
@@ -124,7 +124,7 @@ func TestInArrayInteger(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestMacroList(t *testing.T) {
@@ -133,7 +133,7 @@ func TestMacroList(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, macro)
+	printJSON(t, macro)
 }
 
 func TestMacroPrimary(t *testing.T) {
@@ -142,7 +142,7 @@ func TestMacroPrimary(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, macro)
+	printJSON(t, macro)
 }
 
 func TestMacroExpression(t *testing.T) {
@@ -151,7 +151,7 @@ func TestMacroExpression(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, macro)
+	printJSON(t, macro)
 }
 
 func TestMultiline(t *testing.T) {
@@ -186,7 +186,7 @@ func TestPattern(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestArrayPattern(t *testing.T) {
@@ -195,7 +195,7 @@ func TestArrayPattern(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestRegexp(t *testing.T) {
@@ -204,14 +204,14 @@ func TestRegexp(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 
 	rule, err = parseRule(`process.name == r"^((?:[A-Za-z\d+]{4})*(?:[A-Za-z\d+]{3}=|[A-Za-z\d+]{2}==)\.)*(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z1-9])$" `)
 	if err != nil {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestArrayRegexp(t *testing.T) {
@@ -220,7 +220,7 @@ func TestArrayRegexp(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestDuration(t *testing.T) {
@@ -229,7 +229,7 @@ func TestDuration(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestNumberVariable(t *testing.T) {
@@ -238,7 +238,7 @@ func TestNumberVariable(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestIPv4(t *testing.T) {
@@ -247,7 +247,7 @@ func TestIPv4(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestIPv4Raw(t *testing.T) {
@@ -256,7 +256,7 @@ func TestIPv4Raw(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestIPv6Localhost(t *testing.T) {
@@ -265,7 +265,7 @@ func TestIPv6Localhost(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestIPv6(t *testing.T) {
@@ -274,7 +274,7 @@ func TestIPv6(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestIPv6Short(t *testing.T) {
@@ -283,7 +283,7 @@ func TestIPv6Short(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestIPArray(t *testing.T) {
@@ -292,7 +292,7 @@ func TestIPArray(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestIPv4CIDR(t *testing.T) {
@@ -301,7 +301,7 @@ func TestIPv4CIDR(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestIPv6CIDR(t *testing.T) {
@@ -310,7 +310,7 @@ func TestIPv6CIDR(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestCIDRArray(t *testing.T) {
@@ -319,7 +319,7 @@ func TestCIDRArray(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestIPAndCIDRArray(t *testing.T) {
@@ -328,7 +328,7 @@ func TestIPAndCIDRArray(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestCIDRMatches(t *testing.T) {
@@ -337,7 +337,7 @@ func TestCIDRMatches(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }
 
 func TestCIDRArrayMatches(t *testing.T) {
@@ -346,5 +346,5 @@ func TestCIDRArrayMatches(t *testing.T) {
 		t.Error(err)
 	}
 
-	print(t, rule)
+	printJSON(t, rule)
 }

--- a/pkg/security/secl/compiler/ast/secl_test.go
+++ b/pkg/security/secl/compiler/ast/secl_test.go
@@ -21,7 +21,6 @@ func parseMacro(macro string) (*Macro, error) {
 	return pc.ParseMacro(macro)
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
 func print(t *testing.T, i interface{}) {
 	b, err := json.MarshalIndent(i, "", "  ")
 	if err != nil {

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -54,8 +54,7 @@ func parseRule(expr string, model Model, opts *Opts) (*Rule, error) {
 	return rule, nil
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
-func eval(t *testing.T, event *testEvent, expr string) (bool, *ast.Rule, error) {
+func eval(_ *testing.T, event *testEvent, expr string) (bool, *ast.Rule, error) {
 	model := &testModel{}
 
 	ctx := NewContext(event)

--- a/pkg/security/secl/compiler/eval/evaluators.go
+++ b/pkg/security/secl/compiler/eval/evaluators.go
@@ -195,9 +195,7 @@ func (s *StringValuesEvaluator) Eval(ctx *Context) interface{} {
 }
 
 // IsDeterministicFor returns whether the evaluator is partial
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (s *StringValuesEvaluator) IsDeterministicFor(field Field) bool {
+func (s *StringValuesEvaluator) IsDeterministicFor(_ Field) bool {
 	return s.isDeterministic
 }
 
@@ -364,9 +362,7 @@ func (s *CIDRValuesEvaluator) Eval(ctx *Context) interface{} {
 }
 
 // IsDeterministicFor returns whether the evaluator is partial
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (s *CIDRValuesEvaluator) IsDeterministicFor(field Field) bool {
+func (s *CIDRValuesEvaluator) IsDeterministicFor(_ Field) bool {
 	return s.isDeterministic
 }
 

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -166,8 +166,7 @@ func (m *testModel) GetIterator(field Field) (Iterator, error) {
 	return nil, &ErrIteratorNotSupported{Field: field}
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, error) {
+func (m *testModel) GetEvaluator(field Field, _ RegisterID) (Evaluator, error) {
 	switch field {
 
 	case "network.ip":

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -44,9 +44,7 @@ func (v *Variable) Set(ctx *Context, value interface{}) error {
 }
 
 // Append a value to the variable
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (v *Variable) Append(ctx *Context, value interface{}) error {
+func (v *Variable) Append(_ *Context, _ interface{}) error {
 	return errAppendNotSupported
 }
 
@@ -204,17 +202,13 @@ type MutableIntVariable struct {
 }
 
 // Set the variable with the specified value
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *MutableIntVariable) Set(ctx *Context, value interface{}) error {
+func (m *MutableIntVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(int)
 	return nil
 }
 
 // Append a value to the integer
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *MutableIntVariable) Append(ctx *Context, value interface{}) error {
+func (m *MutableIntVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case int:
 		m.Value += value
@@ -253,17 +247,13 @@ func (m *MutableBoolVariable) GetEvaluator() interface{} {
 }
 
 // Set the variable with the specified value
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *MutableBoolVariable) Set(ctx *Context, value interface{}) error {
+func (m *MutableBoolVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(bool)
 	return nil
 }
 
 // Append a value to the boolean
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *MutableBoolVariable) Append(ctx *Context, value interface{}) error {
+func (m *MutableBoolVariable) Append(_ *Context, _ interface{}) error {
 	return errAppendNotSupported
 }
 
@@ -288,9 +278,7 @@ func (m *MutableStringVariable) GetEvaluator() interface{} {
 }
 
 // Append a value to the string
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *MutableStringVariable) Append(ctx *Context, value interface{}) error {
+func (m *MutableStringVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case string:
 		m.Value += value
@@ -301,9 +289,7 @@ func (m *MutableStringVariable) Append(ctx *Context, value interface{}) error {
 }
 
 // Set the variable with the specified value
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *MutableStringVariable) Set(ctx *Context, value interface{}) error {
+func (m *MutableStringVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(string)
 	return nil
 }
@@ -319,9 +305,7 @@ type MutableStringArrayVariable struct {
 }
 
 // Set the variable with the specified value
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *MutableStringArrayVariable) Set(ctx *Context, values interface{}) error {
+func (m *MutableStringArrayVariable) Set(_ *Context, values interface{}) error {
 	if s, ok := values.(string); ok {
 		values = []string{s}
 	}
@@ -334,9 +318,7 @@ func (m *MutableStringArrayVariable) Set(ctx *Context, values interface{}) error
 }
 
 // Append a value to the array
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *MutableStringArrayVariable) Append(ctx *Context, value interface{}) error {
+func (m *MutableStringArrayVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case string:
 		m.AppendScalarValue(value)
@@ -370,9 +352,7 @@ type MutableIntArrayVariable struct {
 }
 
 // Set the variable with the specified value
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *MutableIntArrayVariable) Set(ctx *Context, values interface{}) error {
+func (m *MutableIntArrayVariable) Set(_ *Context, values interface{}) error {
 	if i, ok := values.(int); ok {
 		values = []int{i}
 	}
@@ -381,9 +361,7 @@ func (m *MutableIntArrayVariable) Set(ctx *Context, values interface{}) error {
 }
 
 // Append a value to the array
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *MutableIntArrayVariable) Append(ctx *Context, value interface{}) error {
+func (m *MutableIntArrayVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case int:
 		m.Values = append(m.Values, value)
@@ -421,9 +399,7 @@ type Scoper func(ctx *Context) ScopedVariable
 type GlobalVariables struct{}
 
 // GetVariable returns new variable of the type of the specified value
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (v *GlobalVariables) GetVariable(name string, value interface{}) (VariableValue, error) {
+func (v *GlobalVariables) GetVariable(_ string, value interface{}) (VariableValue, error) {
 	switch value := value.(type) {
 	case bool:
 		return NewMutableBoolVariable(), nil

--- a/pkg/security/secl/log/logger.go
+++ b/pkg/security/secl/log/logger.go
@@ -24,27 +24,19 @@ type Logger interface {
 type NullLogger struct{}
 
 // Tracef is used to print a trace level log
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (l NullLogger) Tracef(format string, params ...interface{}) {
+func (l NullLogger) Tracef(_ string, _ ...interface{}) {
 }
 
 // Debugf is used to print a trace level log
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (l NullLogger) Debugf(format string, params ...interface{}) {
+func (l NullLogger) Debugf(_ string, _ ...interface{}) {
 }
 
 // Errorf is used to print an error
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (l NullLogger) Errorf(format string, params ...interface{}) {
+func (l NullLogger) Errorf(_ string, _ ...interface{}) {
 }
 
 // Infof is used to print an info
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (l NullLogger) Infof(format string, params ...interface{}) {
+func (l NullLogger) Infof(_ string, _ ...interface{}) {
 }
 
 // IsTracing is used to check if TraceF would actually log

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -579,22 +579,16 @@ type BaseExtraFieldHandlers interface {
 }
 
 // ResolveProcessCacheEntry stub implementation
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (dfh *DefaultFieldHandlers) ResolveProcessCacheEntry(ev *Event) (*ProcessCacheEntry, bool) {
+func (dfh *DefaultFieldHandlers) ResolveProcessCacheEntry(_ *Event) (*ProcessCacheEntry, bool) {
 	return nil, false
 }
 
 // ResolveContainerContext stub implementation
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (dfh *DefaultFieldHandlers) ResolveContainerContext(ev *Event) (*ContainerContext, bool) {
+func (dfh *DefaultFieldHandlers) ResolveContainerContext(_ *Event) (*ContainerContext, bool) {
 	return nil, false
 }
 
 // GetProcessService stub implementation
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (dfh *DefaultFieldHandlers) GetProcessService(ev *Event) string {
+func (dfh *DefaultFieldHandlers) GetProcessService(_ *Event) string {
 	return ""
 }

--- a/pkg/security/secl/model/model_test.go
+++ b/pkg/security/secl/model/model_test.go
@@ -134,9 +134,8 @@ func TestSetFieldValue(t *testing.T) {
 			if err != nil {
 				if errors.As(err, &readOnlyError) {
 					continue
-				} else {
-					t.Error(err)
 				}
+				t.Error(err)
 			}
 			value, err := event.GetFieldValue(field)
 			if err != nil {
@@ -162,9 +161,8 @@ func TestSetFieldValue(t *testing.T) {
 			if err != nil {
 				if errors.As(err, &readOnlyError) {
 					continue
-				} else {
-					t.Error(err)
 				}
+				t.Error(err)
 			}
 			value, err := event.GetFieldValue(field)
 			if err != nil {

--- a/pkg/security/secl/model/model_test.go
+++ b/pkg/security/secl/model/model_test.go
@@ -134,7 +134,7 @@ func TestSetFieldValue(t *testing.T) {
 			if err != nil {
 				if errors.As(err, &readOnlyError) {
 					continue
-				} else { //nolint:revive // TODO(SEC) Fix revive linter
+				} else {
 					t.Error(err)
 				}
 			}
@@ -162,7 +162,7 @@ func TestSetFieldValue(t *testing.T) {
 			if err != nil {
 				if errors.As(err, &readOnlyError) {
 					continue
-				} else { //nolint:revive // TODO(SEC) Fix revive linter
+				} else {
 					t.Error(err)
 				}
 			}

--- a/pkg/security/secl/model/utils.go
+++ b/pkg/security/secl/model/utils.go
@@ -22,10 +22,10 @@ func SliceToArray(src []byte, dst []byte) {
 // UnmarshalStringArray extract array of string for array of byte
 func UnmarshalStringArray(data []byte) ([]string, error) {
 	var result []string
-	len := uint32(len(data))
+	length := uint32(len(data))
 
-	for i := uint32(0); i < len; {
-		if i+4 >= len {
+	for i := uint32(0); i < length; {
+		if i+4 >= length {
 			return result, ErrStringArrayOverflow
 		}
 		// size of arg
@@ -35,9 +35,9 @@ func UnmarshalStringArray(data []byte) ([]string, error) {
 		}
 		i += 4
 
-		if i+n > len {
+		if i+n > length {
 			// truncated
-			arg := NullTerminatedString(data[i:len])
+			arg := NullTerminatedString(data[i:length])
 			return append(result, arg), ErrStringArrayOverflow
 		}
 

--- a/pkg/security/secl/model/utils.go
+++ b/pkg/security/secl/model/utils.go
@@ -22,7 +22,6 @@ func SliceToArray(src []byte, dst []byte) {
 // UnmarshalStringArray extract array of string for array of byte
 func UnmarshalStringArray(data []byte) ([]string, error) {
 	var result []string
-	//nolint:revive // TODO(SEC) Fix revive linter
 	len := uint32(len(data))
 
 	for i := uint32(0); i < len; {

--- a/pkg/security/secl/rules/collected_events_regular.go
+++ b/pkg/security/secl/rules/collected_events_regular.go
@@ -15,9 +15,7 @@ type EventCollector struct {
 }
 
 // CollectEvent collects event
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (ec *EventCollector) CollectEvent(rs *RuleSet, event eval.Event, result bool) {
+func (ec *EventCollector) CollectEvent(_ *RuleSet, _ eval.Event, _ bool) {
 	// no-op
 }
 

--- a/pkg/security/secl/rules/policy_loader_test.go
+++ b/pkg/security/secl/rules/policy_loader_test.go
@@ -471,7 +471,7 @@ func (d dummyDirProvider) LoadPolicies(_ []MacroFilter, _ []RuleFilter) ([]*Poli
 	return d.dummyLoadPoliciesFunc()
 }
 
-func (dummyDirProvider) SetOnNewPoliciesReadyCb(f func()) {} //nolint:revive // TODO fix revive unused-parameter
+func (dummyDirProvider) SetOnNewPoliciesReadyCb(_ func()) {}
 
 func (dummyDirProvider) Start() {}
 
@@ -491,7 +491,7 @@ func (d dummyRCProvider) LoadPolicies(_ []MacroFilter, _ []RuleFilter) ([]*Polic
 	return d.dummyLoadPoliciesFunc()
 }
 
-func (dummyRCProvider) SetOnNewPoliciesReadyCb(f func()) {} //nolint:revive // TODO fix revive unused-parameter
+func (dummyRCProvider) SetOnNewPoliciesReadyCb(_ func()) {}
 
 func (dummyRCProvider) Start() {}
 

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -39,13 +39,11 @@ func (rs *RuleSet) setRuleSetTagValue(value eval.RuleSetTagValue) error {
 	return nil
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
-func (f *testHandler) RuleMatch(rule *Rule, event eval.Event) bool {
+func (f *testHandler) RuleMatch(_ *Rule, _ eval.Event) bool {
 	return true
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
-func (f *testHandler) EventDiscarderFound(rs *RuleSet, event eval.Event, field string, eventType eval.EventType) {
+func (f *testHandler) EventDiscarderFound(_ *RuleSet, event eval.Event, field string, _ eval.EventType) {
 	values, ok := f.filters[event.GetType()]
 	if !ok {
 		values = make(testFieldValues)


### PR DESCRIPTION
### What does this PR do?

Fixes the revive TODOs:
- mostly removing unused parameters
- changing function & variable names when it conflicts with built-in (print, len)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
