### PR TITLE
[CWS] fix agent rule documentation

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -16,7 +16,7 @@ Cloud Security Management Threats (CSM Threats) first evaluates activity within 
 
 
 {{< code-block lang="javascript" >}}
-<event-type>.<event-attribute> <operator> <value> <event-attribute> ...
+<event-type>.<event-attribute> <operator> <value> <event-type>.<event-attribute> ...
 
 {{< /code-block >}}
 

--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -23,7 +23,7 @@ Cloud Security Management Threats (CSM Threats) first evaluates activity within 
 Using this format, an example rule looks like this:
 
 {{< code-block lang="javascript" >}}
-open.file.path == "/etc/shadow" && file.path not in ["/usr/sbin/vipw"]
+open.file.path == "/etc/shadow" && process.file.path not in ["/usr/sbin/vipw"]
 
 {{< /code-block >}}
 
@@ -838,6 +838,7 @@ A filesystem was mounted
 | [`mount.fs_type`](#mount-fs_type-doc) | Type of the mounted file system |
 | [`mount.mountpoint.path`](#mount-mountpoint-path-doc) | Path of the mount point |
 | [`mount.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
+| [`mount.root.path`](#mount-root-path-doc) | Root path of the mount |
 | [`mount.source.path`](#mount-source-path-doc) | Source path of a bind mount |
 
 ### Event `mprotect`
@@ -2576,6 +2577,13 @@ Definition: Type of the mounted file system
 Type: string
 
 Definition: Path of the mount point
+
+
+
+### `mount.root.path` {#mount-root-path-doc}
+Type: string
+
+Definition: Root path of the mount
 
 
 

--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -16,7 +16,7 @@ Cloud Security Management Threats (CSM Threats) first evaluates activity within 
 
 
 {{< code-block lang="javascript" >}}
-<event-type>.<event-attribute> <operator> <value> <event-type>.<event-attribute> ...
+<event-type>.<event-attribute> <operator> <value> [<operator> <event-type>.<event-attribute>] ...
 
 {{< /code-block >}}
 

--- a/docs/cloud-workload-security/scripts/templates/agent_expressions.md
+++ b/docs/cloud-workload-security/scripts/templates/agent_expressions.md
@@ -17,7 +17,7 @@ Cloud Security Management Threats (CSM Threats) first evaluates activity within 
 {% raw %}
 {{< code-block lang="javascript" >}}
 {% endraw %}
-<event-type>.<event-attribute> <operator> <value> <event-type>.<event-attribute> ...
+<event-type>.<event-attribute> <operator> <value> [<operator> <event-type>.<event-attribute>] ...
 {% raw %}
 {{< /code-block >}}
 {% endraw %}

--- a/docs/cloud-workload-security/scripts/templates/agent_expressions.md
+++ b/docs/cloud-workload-security/scripts/templates/agent_expressions.md
@@ -17,7 +17,7 @@ Cloud Security Management Threats (CSM Threats) first evaluates activity within 
 {% raw %}
 {{< code-block lang="javascript" >}}
 {% endraw %}
-<event-type>.<event-attribute> <operator> <value> <event-attribute> ...
+<event-type>.<event-attribute> <operator> <value> <event-type>.<event-attribute> ...
 {% raw %}
 {{< /code-block >}}
 {% endraw %}

--- a/docs/cloud-workload-security/scripts/templates/agent_expressions.md
+++ b/docs/cloud-workload-security/scripts/templates/agent_expressions.md
@@ -26,7 +26,7 @@ Using this format, an example rule looks like this:
 {% raw %}
 {{< code-block lang="javascript" >}}
 {% endraw %}
-open.file.path == "/etc/shadow" && file.path not in ["/usr/sbin/vipw"]
+open.file.path == "/etc/shadow" && process.file.path not in ["/usr/sbin/vipw"]
 {% raw %}
 {{< /code-block >}}
 {% endraw %}


### PR DESCRIPTION
### What does this PR do?

This PR fixes an example in the CWS documentation, and re-generate it (since it was out of sync)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
