### PR TITLE
Stop adding network address not found errors in gohai warnings

### DIFF
--- a/pkg/gohai/network/network.go
+++ b/pkg/gohai/network/network.go
@@ -78,7 +78,7 @@ func ifacesToJSON(ifaces []Interface) (interface{}, []string) {
 		for key, value := range values {
 			if val, err := value.Value(); err == nil {
 				ifaceJSON[key] = val
-			} else {
+			} else if !errors.Is(err, ErrAddressNotFound) {
 				warnings = append(warnings, fmt.Sprintf("%s: %s: %v", iface.Name, key, err))
 			}
 		}
@@ -100,7 +100,7 @@ func (netInfo *Info) AsJSON() (interface{}, []string, error) {
 
 	if ipv6, err := netInfo.IPAddressV6.Value(); err == nil {
 		ret["ipaddressv6"] = ipv6
-	} else {
+	} else if !errors.Is(err, ErrAddressNotFound) {
 		warnings = append(warnings, err.Error())
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Do not add Gohai `address not found` errors to the list of generated warnings.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This is not really an error, not all network interfaces have ipv4 and ipv6 addresses, but currently it adds one log line per such "error".

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
