### PR TITLE
(macrobenchmarks) Fix env var name, move common vars to template CI job

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -26,6 +26,10 @@ variables:
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true" # Important tweak for stability of benchmarks
 
+    TRACE_AGENT_CPUS: 40-41
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
+
     # Uncomment to force k8s memory limits for CI job container.
     # KUBERNETES_MEMORY_REQUEST: "4Gi"
     # KUBERNETES_MEMORY_LIMIT: "4Gi"
@@ -39,9 +43,6 @@ trace-agent-v04-2cpus-normal_load-fixed_sps:
   extends: .trace_agent_benchmarks
   variables:
     TRACE_AGENT_ENDPOINT: v04
-    TRACE_AGENT_CPUS: 40-41
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-2cpus-normal_load-fixed_sps
     SCENARIOS: >
       normal_load-10traces210spans-65ksps|
@@ -53,9 +54,6 @@ trace-agent-v04-2cpus-stress_load-fixed_sps:
   when: manual
   variables:
     TRACE_AGENT_ENDPOINT: v04
-    TRACE_AGENT_CPUS: 40-41
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-2cpus-stress_load-fixed_sps
     SCENARIOS: >
       stress_load-10traces210spans-525ksps|
@@ -66,11 +64,8 @@ trace-agent-v05-2cpus-normal_load-fixed_sps:
   extends: .trace_agent_benchmarks
   variables:
     TRACE_AGENT_ENDPOINT: v05
-    TRACE_AGENT_CPUS: 40-41
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-2cpus-normal_load-fixed_sps
-    SCENARIO: >
+    SCENARIOS: >
       normal_load-10traces210spans-65ksps|
       normal_load-500traces8617spans-65ksps|
       normal_load-3885traces3891spans-65ksps
@@ -80,9 +75,6 @@ trace-agent-v05-2cpus-stress_load-fixed_sps:
   when: manual
   variables:
     TRACE_AGENT_ENDPOINT: v05
-    TRACE_AGENT_CPUS: 40-41
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-2cpus-stress_load-fixed_sps
     SCENARIOS: >
       stress_load-10traces210spans-525ksps|


### PR DESCRIPTION
### What does this PR do?

Tidy Benchmarking Platform Gitlab CI definitions. 

### Motivation

Improve consistency of var names, reduce duplication.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
