### PR TITLE
Implemented a TLS counter and integrating it with the total_hits metric

### DIFF
--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -36,11 +36,7 @@ type Telemetry struct {
 
 	hits1XX, hits2XX, hits3XX, hits4XX, hits5XX *libtelemetry.Counter
 
-	totalHitsPlain                                                   *libtelemetry.Counter
-	totalHitsGnuTLS                                                  *libtelemetry.Counter
-	totalHitsOpenSLL                                                 *libtelemetry.Counter
-	totalHitsJavaTLS                                                 *libtelemetry.Counter
-	totalHitsGoTLS                                                   *libtelemetry.Counter
+	totalHits                                                        *TLSCounter
 	dropped                                                          *libtelemetry.Counter // this happens when statKeeper reaches capacity
 	rejected                                                         *libtelemetry.Counter // this happens when an user-defined reject-filter matches a request
 	emptyPath, unknownMethod, invalidLatency, nonPrintableCharacters *libtelemetry.Counter // this happens when the request doesn't have the expected format
@@ -65,11 +61,7 @@ func NewTelemetry(protocol string) *Telemetry {
 		aggregations: metricGroup.NewCounter("aggregations", libtelemetry.OptPrometheus),
 
 		// these metrics are also exported as statsd metrics
-		totalHitsPlain:         metricGroup.NewCounter("total_hits", "encrypted:false", libtelemetry.OptStatsd),
-		totalHitsGnuTLS:        metricGroup.NewCounter("total_hits", "encrypted:true", "tls_library:gnutls", libtelemetry.OptStatsd),
-		totalHitsOpenSLL:       metricGroup.NewCounter("total_hits", "encrypted:true", "tls_library:openssl", libtelemetry.OptStatsd),
-		totalHitsJavaTLS:       metricGroup.NewCounter("total_hits", "encrypted:true", "tls_library:java", libtelemetry.OptStatsd),
-		totalHitsGoTLS:         metricGroup.NewCounter("total_hits", "encrypted:true", "tls_library:go", libtelemetry.OptStatsd),
+		totalHits:              NewTLSCounter(metricGroup, "total_hits", libtelemetry.OptStatsd),
 		dropped:                metricGroup.NewCounter("dropped", libtelemetry.OptStatsd),
 		rejected:               metricGroup.NewCounter("rejected", libtelemetry.OptStatsd),
 		emptyPath:              metricGroup.NewCounter("malformed", "type:empty-path", libtelemetry.OptStatsd),
@@ -102,7 +94,7 @@ func (t *Telemetry) Count(tx Transaction) {
 		t.hits5XX.Add(1)
 	}
 
-	t.countOSSpecific(tx)
+	t.totalHits.Add(tx)
 }
 
 func (t *Telemetry) Log() {

--- a/pkg/network/protocols/http/tls_counter.go
+++ b/pkg/network/protocols/http/tls_counter.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build (windows && npm) || linux_bpf
+
+package http
+
+import (
+	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
+)
+
+// A TLSCounter is a TLS aware counter, it has a plain counter and a counter for each TLS library.
+type TLSCounter struct {
+	counterPlain   *libtelemetry.Counter
+	counterGnuTLS  *libtelemetry.Counter
+	counterOpenSLL *libtelemetry.Counter
+	counterJavaTLS *libtelemetry.Counter
+	counterGoTLS   *libtelemetry.Counter
+}
+
+func NewTLSCounter(metricGroup *libtelemetry.MetricGroup, metricName string, tags ...string) *TLSCounter {
+	return &TLSCounter{
+		counterPlain:   metricGroup.NewCounter(metricName, append(tags, "encrypted:false")...),
+		counterGnuTLS:  metricGroup.NewCounter(metricName, append(tags, "encrypted:true", "tls_library:gnutls")...),
+		counterOpenSLL: metricGroup.NewCounter(metricName, append(tags, "encrypted:true", "tls_library:openssl")...),
+		counterJavaTLS: metricGroup.NewCounter(metricName, append(tags, "encrypted:true", "tls_library:java")...),
+		counterGoTLS:   metricGroup.NewCounter(metricName, append(tags, "encrypted:true", "tls_library:go")...),
+	}
+}

--- a/pkg/network/protocols/http/tls_counter.go
+++ b/pkg/network/protocols/http/tls_counter.go
@@ -12,6 +12,7 @@ import (
 )
 
 // TLSCounter is a TLS aware counter, it has a plain counter and a counter for each TLS library
+// It enables the use of a single metric that increments based on the TLS library, avoiding the need for separate metrics for each TLS library
 type TLSCounter struct {
 	counterPlain   *libtelemetry.Counter
 	counterGnuTLS  *libtelemetry.Counter

--- a/pkg/network/protocols/http/tls_counter.go
+++ b/pkg/network/protocols/http/tls_counter.go
@@ -11,7 +11,7 @@ import (
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 )
 
-// A TLSCounter is a TLS aware counter, it has a plain counter and a counter for each TLS library.
+// TLSCounter is a TLS aware counter, it has a plain counter and a counter for each TLS library
 type TLSCounter struct {
 	counterPlain   *libtelemetry.Counter
 	counterGnuTLS  *libtelemetry.Counter
@@ -20,6 +20,7 @@ type TLSCounter struct {
 	counterGoTLS   *libtelemetry.Counter
 }
 
+// NewTLSCounter creates and return a new TLSCounter
 func NewTLSCounter(metricGroup *libtelemetry.MetricGroup, metricName string, tags ...string) *TLSCounter {
 	return &TLSCounter{
 		counterPlain:   metricGroup.NewCounter(metricName, append(tags, "encrypted:false")...),

--- a/pkg/network/protocols/http/tls_counter.go
+++ b/pkg/network/protocols/http/tls_counter.go
@@ -20,7 +20,7 @@ type TLSCounter struct {
 	counterGoTLS   *libtelemetry.Counter
 }
 
-// NewTLSCounter creates and return a new TLSCounter
+// NewTLSCounter creates and returns a new instance of TLSCounter
 func NewTLSCounter(metricGroup *libtelemetry.MetricGroup, metricName string, tags ...string) *TLSCounter {
 	return &TLSCounter{
 		counterPlain:   metricGroup.NewCounter(metricName, append(tags, "encrypted:false")...),

--- a/pkg/network/protocols/http/tls_counter_linux.go
+++ b/pkg/network/protocols/http/tls_counter_linux.go
@@ -7,17 +7,17 @@
 
 package http
 
-func (t *Telemetry) countOSSpecific(tx Transaction) {
+func (t *TLSCounter) Add(tx Transaction) {
 	switch tx.StaticTags() {
 	case GnuTLS:
-		t.totalHitsGnuTLS.Add(1)
+		t.counterGnuTLS.Add(1)
 	case OpenSSL:
-		t.totalHitsOpenSLL.Add(1)
+		t.counterOpenSLL.Add(1)
 	case Java:
-		t.totalHitsJavaTLS.Add(1)
+		t.counterJavaTLS.Add(1)
 	case Go:
-		t.totalHitsGoTLS.Add(1)
+		t.counterGoTLS.Add(1)
 	default:
-		t.totalHitsPlain.Add(1)
+		t.counterPlain.Add(1)
 	}
 }

--- a/pkg/network/protocols/http/tls_counter_linux.go
+++ b/pkg/network/protocols/http/tls_counter_linux.go
@@ -7,6 +7,7 @@
 
 package http
 
+// Add increments the TLS-aware counter based on the specified transaction's static tags
 func (t *TLSCounter) Add(tx Transaction) {
 	switch tx.StaticTags() {
 	case GnuTLS:

--- a/pkg/network/protocols/http/tls_counter_windows.go
+++ b/pkg/network/protocols/http/tls_counter_windows.go
@@ -7,6 +7,6 @@
 
 package http
 
-func (t *Telemetry) countOSSpecific(Transaction) {
-	t.totalHitsPlain.Add(1)
+func (t *TLSCounter) Add(tx Transaction) {
+	t.counterPlain.Add(1)
 }

--- a/pkg/network/protocols/http/tls_counter_windows.go
+++ b/pkg/network/protocols/http/tls_counter_windows.go
@@ -8,6 +8,6 @@
 package http
 
 // Add increments the plain counter since TLS support for Windows is not yet available
-func (t *TLSCounter) Add(tx Transaction) {
+func (t *TLSCounter) Add(Transaction) {
 	t.counterPlain.Add(1)
 }

--- a/pkg/network/protocols/http/tls_counter_windows.go
+++ b/pkg/network/protocols/http/tls_counter_windows.go
@@ -7,6 +7,7 @@
 
 package http
 
+// Add increments the plain counter since TLS support for Windows is not yet available
 func (t *TLSCounter) Add(tx Transaction) {
 	t.counterPlain.Add(1)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Introducing a TLS-aware counter object for USM telemetry, featuring a standard counter and individual counters for each TLS library.
Additionally, transitioning the total hits metric to utilize this newly introduced object.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This should simplify the process of making other USM metrics TLS-aware.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
