### PR TITLE
[language-detection] [e2e tests] Add test to ensure env setup prior to testing functionality

### DIFF
--- a/test/new-e2e/tests/language-detection/setup_test.go
+++ b/test/new-e2e/tests/language-detection/setup_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package languagedetection
 
 import (

--- a/test/new-e2e/tests/language-detection/setup_test.go
+++ b/test/new-e2e/tests/language-detection/setup_test.go
@@ -1,0 +1,21 @@
+package languagedetection
+
+import (
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test00EnsureSetup ensures that the test environment is set up prior to running the language detection
+// tests. Because tests in testify suites always run in order, this function is named such that it
+// will run first.
+func (s *languageDetectionSuite) Test00EnsureSetup() {
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		status := s.Env().VM.Execute(("sudo datadog-agent status"))
+		assert.Contains(collect, status, "Agent start", "agent failed to return status")
+
+		wl := s.Env().VM.Execute("sudo /opt/datadog-agent/bin/agent/agent workload-list")
+		assert.NotEmpty(collect, strings.TrimSpace(wl), "agent workload-list was empty")
+	}, 5*time.Minute, 10*time.Second, "setup never completed")
+}


### PR DESCRIPTION
### What does this PR do?

Add a test that runs first and ensures the environment is set up, since this step can take much longer. See below for the impact (running locally).

Before (notice the Node.js test takes over 2 minutes):

```
--- PASS: TestLanguageDetectionSuite (182.51s)
    --- PASS: TestLanguageDetectionSuite/TestNodeDetection (131.17s)
    --- PASS: TestLanguageDetectionSuite/TestPythonDetection (9.96s)
PASS
ok  	github.com/DataDog/datadog-agent/test/new-e2e/tests/language-detection	183.689s

DONE 3 tests in 196.423s
```

After:

```
--- PASS: TestLanguageDetectionSuite (191.57s)
    --- PASS: TestLanguageDetectionSuite/Test00EnsureSetup (130.42s)
    --- PASS: TestLanguageDetectionSuite/TestNodeDetection (19.83s)
    --- PASS: TestLanguageDetectionSuite/TestPythonDetection (10.00s)
PASS
ok  	github.com/DataDog/datadog-agent/test/new-e2e/tests/language-detection	192.738s

DONE 4 tests in 204.188s
```

In CI, it seems to take even longer, causing flakes:

```
--- FAIL: TestLanguageDetectionSuite (233.57s)
    --- FAIL: TestLanguageDetectionSuite/TestNodeDetection (171.99s)
    --- PASS: TestLanguageDetectionSuite/TestPythonDetection (9.97s)
FAIL
FAIL	github.com/DataDog/datadog-agent/test/new-e2e/tests/language-detection	233.640s
```
Failing job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/382541384

### Motivation

Test flakes
https://datadoghq.atlassian.net/browse/PROCS-3545

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

CI job should pass.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
