### PR TITLE
[NPM-3079] Add more synchronization to DNS tests

### DIFF
--- a/pkg/network/dns/monitor_linux.go
+++ b/pkg/network/dns/monitor_linux.go
@@ -93,6 +93,10 @@ func NewReverseDNS(cfg *config.Config) (ReverseDNS, error) {
 	}, nil
 }
 
+func (m *dnsMonitor) WaitForDomain(domain string) error {
+	return m.statKeeper.WaitForDomain(domain)
+}
+
 // Start starts the monitor
 func (m *dnsMonitor) Start() error {
 	if m.p != nil {

--- a/pkg/network/dns/null.go
+++ b/pkg/network/dns/null.go
@@ -18,6 +18,11 @@ func NewNullReverseDNS() ReverseDNS {
 
 type nullReverseDNS struct{}
 
+func (d nullReverseDNS) WaitForDomain(domain string) error {
+	//TODO implement me
+	return nil
+}
+
 func (nullReverseDNS) Resolve(_ map[util.Address]struct{}) map[util.Address][]Hostname {
 	return nil
 }

--- a/pkg/network/dns/null.go
+++ b/pkg/network/dns/null.go
@@ -19,7 +19,6 @@ func NewNullReverseDNS() ReverseDNS {
 type nullReverseDNS struct{}
 
 func (d nullReverseDNS) WaitForDomain(domain string) error {
-	//TODO implement me
 	return nil
 }
 

--- a/pkg/network/dns/null.go
+++ b/pkg/network/dns/null.go
@@ -18,7 +18,7 @@ func NewNullReverseDNS() ReverseDNS {
 
 type nullReverseDNS struct{}
 
-func (d nullReverseDNS) WaitForDomain(domain string) error {
+func (d nullReverseDNS) WaitForDomain(_ string) error {
 	return nil
 }
 

--- a/pkg/network/dns/snooper.go
+++ b/pkg/network/dns/snooper.go
@@ -58,6 +58,10 @@ type socketFilterSnooper struct {
 	translation *translation
 }
 
+func (s *socketFilterSnooper) WaitForDomain(domain string) error {
+	return s.statKeeper.WaitForDomain(domain)
+}
+
 // packetSource reads raw packet data
 type packetSource interface {
 	// VisitPackets reads all new raw packets that are available, invoking the given callback for each packet.

--- a/pkg/network/dns/stats.go
+++ b/pkg/network/dns/stats.go
@@ -188,15 +188,17 @@ func (d *dnsStatKeeper) GetAndResetAllStats() StatsByKeyByNameByType {
 }
 
 func (d *dnsStatKeeper) WaitForDomain(domain string) error {
+
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
 	for {
 		select {
 		case <-time.After(waitForDomainTimeout):
 			return fmt.Errorf("domain %v did not appear within %v", domain, waitForDomainTimeout)
-		default:
+		case <-tick.C:
 			if d.hasDomain(domain) {
 				return nil
 			}
-			time.Sleep(time.Millisecond * 10)
 		}
 	}
 }

--- a/pkg/network/dns/stats.go
+++ b/pkg/network/dns/stats.go
@@ -207,7 +207,7 @@ func (d *dnsStatKeeper) hasDomain(domain string) bool {
 	d.mux.Lock()
 	defer d.mux.Unlock()
 	for _, statsByTypeByHost := range d.stats {
-		for host, _ := range statsByTypeByHost {
+		for host := range statsByTypeByHost {
 			if host.Get() == domain {
 				return true
 			}

--- a/pkg/network/dns/types.go
+++ b/pkg/network/dns/types.go
@@ -68,6 +68,11 @@ type StatsByKeyByNameByType map[Key]map[Hostname]map[QueryType]Stats
 type ReverseDNS interface {
 	Resolve(map[util.Address]struct{}) map[util.Address][]Hostname
 	GetDNSStats() StatsByKeyByNameByType
+
+	// WaitForDomain is used in tests to ensure a domain has been
+	// seen by the ReverseDNS.
+	WaitForDomain(domain string) error
+
 	Start() error
 	Close()
 }

--- a/pkg/network/filter/packet_source_linux.go
+++ b/pkg/network/filter/packet_source_linux.go
@@ -14,13 +14,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/afpacket"
 	"github.com/google/gopacket/layers"
 	"golang.org/x/net/bpf"
-
-	"github.com/DataDog/datadog-agent/pkg/network/telemetry"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )

--- a/pkg/network/filter/packet_source_linux.go
+++ b/pkg/network/filter/packet_source_linux.go
@@ -14,12 +14,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/afpacket"
 	"github.com/google/gopacket/layers"
 	"golang.org/x/net/bpf"
+
+	"github.com/DataDog/datadog-agent/pkg/network/telemetry"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1024,8 +1024,7 @@ func testDNSStats(t *testing.T, tr *Tracer, domain string, success, failure, tim
 		return err == nil || timeout != 0
 	}, 6*time.Second, 100*time.Millisecond, "Failed to get dns response")
 
-	// Allow the DNS reply to be processed in the snooper
-	time.Sleep(time.Millisecond * 500)
+	require.NoError(t, tr.reverseDNS.WaitForDomain(domain))
 
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
 	connections := getConnections(t, tr)


### PR DESCRIPTION

### What does this PR do?


We saw a few tests fail with the following error:

```
=== FAIL: pkg/network/tracer TestTracerSuite/prebuilt/TestDNSStatsWithNAT (3.76s)
    tracer_test.go:1043:
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/pkg/network/tracer/tracer_test.go:1043
        	            				/go/src/github.com/DataDog/datadog-agent/pkg/network/tracer/tracer_linux_test.go:1380
        	Error:      	Should be true
        	Test:       	TestTracerSuite/prebuilt/TestDNSStatsWithNAT

```

My theory is that the issue is that testDNSStats calls getConnections, which itself calls reverseDns#GetDNSStats().

Under the hood, reverseDNS#GetDNSStats() is polling a raw socket for DNS packets.
My theory is that reverseDNS hasn't reliably polled the latest DNS stat by the time the test calls getConnections().

This PR fixes the problem by adding a synchronization point where the test waits for the reverseDNS to see the domain. This is done a bit crudely with a test-only method that waits up to 5 seconds for the domain to show up.

Ideally we could use a better synchronization mechanism (such as waiting flushing the raw socket) but I could not find such an API.   


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation




<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
