### PR TITLE
pkg/config: update language around the trace_buffer config

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1583,9 +1583,9 @@ api_key:
   ## @env DD_APM_TRACE_BUFFER - integer - optional - default: 0
   ## 
   ## WARNING: Do not use this config. It is here for debugging and
-  ## as a temporary fix in certain load scenarios. Setting this will
-  ## result in a performance deterioration and an increase in memory
-  ## usage when the trace agent is under load. This config may be
+  ## as a temporary fix in certain load scenarios. Setting this
+  ## results in a performance deterioration and an increase in memory
+  ## usage when the Trace Agent is under load. This config may be
   ## removed in a future version.
   ## 
   ## Specifies the number of trace payloads to buffer after decoding.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1579,11 +1579,21 @@ api_key:
   # - ns2
   # - system-ns
 
-  ## @param trace_buffer - integer - optional
-  ## @env DD_APM_TRACE_BUFFER - integer - optional
-  ## Specifies the size of trace payloads to buffer before dropping them. If unset, trace payloads are unbuffered.
+  ## @param trace_buffer - integer - optional - default: 0
+  ## @env DD_APM_TRACE_BUFFER - integer - optional - default: 0
+  ## 
+  ## WARNING: Do not use this config. It is here for debugging and
+  ## as a temporary fix in certain load scenarios. Setting this will
+  ## result in a performance deterioration and an increase in memory
+  ## usage when the trace agent is under load. This config may be
+  ## removed in a future version.
+  ## 
+  ## Specifies the number of trace payloads to buffer after decoding.
+  ## Traces can be buffered when receiving traces faster than the
+  ## processor can process them.
+  ## 
   #
-  # trace_buffer: 100
+  # trace_buffer: 0
 
   {{- if .InternalProfiling -}}
   ## @param profiling - custom object - optional


### PR DESCRIPTION


### What does this PR do?

This updates the language around the trace_buffer config.

### Motivation

The trace_buffer config is not safe to use. We should document it, telling users not to use it and that it may be removed.

The config itself is only there in case we find a strange scenario where it is useful.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
