### PR TITLE
[Serverless] Reset event checker cache after each test.

### DIFF
--- a/pkg/serverless/trigger/events_test.go
+++ b/pkg/serverless/trigger/events_test.go
@@ -130,6 +130,8 @@ func TestGetEventType(t *testing.T) {
 		parsedEventType := GetEventType(jsonPayload)
 
 		assert.Equal(t, expectedEventType, parsedEventType, fmt.Sprintf("%v\n", testFile))
+
+		lastEventChecker = unknownChecker // reset event check cache
 	}
 }
 

--- a/pkg/serverless/trigger/events_test.go
+++ b/pkg/serverless/trigger/events_test.go
@@ -118,20 +118,22 @@ func TestGetEventType(t *testing.T) {
 	}
 
 	for testFile, expectedEventType := range testCases {
-		file, err := os.Open(fmt.Sprintf("%v/%v", testDir, testFile))
-		assert.NoError(t, err)
+		t.Run(testFile, func(t *testing.T) {
+			file, err := os.Open(fmt.Sprintf("%v/%v", testDir, testFile))
+			assert.NoError(t, err)
 
-		jsonData, err := io.ReadAll(file)
-		assert.NoError(t, err)
+			jsonData, err := io.ReadAll(file)
+			assert.NoError(t, err)
 
-		jsonPayload, err := Unmarshal(bytes.ToLower(jsonData))
-		assert.NoError(t, err)
+			jsonPayload, err := Unmarshal(bytes.ToLower(jsonData))
+			assert.NoError(t, err)
 
-		parsedEventType := GetEventType(jsonPayload)
+			parsedEventType := GetEventType(jsonPayload)
 
-		assert.Equal(t, expectedEventType, parsedEventType, fmt.Sprintf("%v\n", testFile))
+			assert.Equal(t, expectedEventType, parsedEventType)
 
-		lastEventChecker = unknownChecker // reset event check cache
+			lastEventChecker = unknownChecker // reset event check cache
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes flaky test `TestGetEventType`. See [CI Test Runs](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.full_name%3A%22github.com%2FDataDog%2Fdatadog-agent%2Fpkg%2Fserverless%2Ftrigger.TestGetEventType%22&colorBy=meta%5B%27_dd.ci.test_level%27%5D&colorByAttr=meta%5B%27_dd.ci.test_level%27%5D&currentTab=overview&eventStack=&index=citest&sort=time&view=spans&start=1701729796414&end=1701902596414&paused=true).

I added caching of the event type in a previous pull request but did not ensure that the cache was reset after each of these tests.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Flaky tests are bad.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
