### PR TITLE
usm: http2: Added initial prototype of user mode dynamic table

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -91,6 +91,12 @@ typedef struct {
 } dynamic_table_index_t;
 
 typedef struct {
+    dynamic_table_index_t key;
+    __u8 string_len;
+    char buf[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
+} dynamic_table_value_t;
+
+typedef struct {
     conn_tuple_t tup;
     __u32 stream_id;
 } http2_stream_key_t;

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -52,4 +52,10 @@ BPF_PERCPU_ARRAY_MAP(http2_ctx_heap, http2_ctx_t, 1)
  */
 BPF_ARRAY_MAP(http2_telemetry, http2_telemetry_t, 1)
 
+// A perf buffer to send http2 paths to the user mode LRU datastore.
+BPF_PERF_EVENT_ARRAY_MAP(http2_dynamic_table_perf_buffer, __u32)
+
+// This map acts as a heap for dynamic table values to be sent on the perf buffer.
+BPF_PERCPU_ARRAY_MAP(http2_dynamic_table_heap, dynamic_table_value_t, 1)
+
 #endif

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -13,6 +13,10 @@ BPF_ARRAY_MAP(http2_static_table, static_table_value_t, 15)
    conn tuple and it is value is the buffer which contains the dynamic string. */
 BPF_HASH_MAP(http2_dynamic_table, dynamic_table_index_t, dynamic_table_entry_t, 0)
 
+// The map acts as a set, to indicate if a given dynamic index (conn tuple + index) is interesting.
+// If a key exists - the index is interesting, otherwise it is not.
+BPF_HASH_MAP(http2_interesting_dynamic_table_set, dynamic_table_index_t, bool, 0)
+
 /* http2_dynamic_counter_table is a map that holding the current dynamic values amount, in order to use for the
    internal calculation of the internal index in the http2_dynamic_table, it is hold by conn_tup to support different
    clients and the value is the current counter. */

--- a/pkg/network/protocols/http2/dyanmic_table.go
+++ b/pkg/network/protocols/http2/dyanmic_table.go
@@ -1,0 +1,130 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package http2
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+
+	manager "github.com/DataDog/ebpf-manager"
+
+	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
+	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/util/intern"
+)
+
+// DynamicTable stores all interesting dynamic values captured by the kernel.
+// It is used to overcome the lack of a proper LRU datastore in the kernel, and we are not able to clear room for new
+// values, once our kernel maps are full.
+// The user mode dynamic table combines two features to achieve better memory usage:
+// - a string interner, to avoid storing the same string multiple times
+// - an LRU datastore, to evict the least recently used entries when the table is full
+//
+// The dynamic table also clear entries from the kernel map called `http2_interesting_dynamic_table_set`.
+type DynamicTable struct {
+	// dynamicTableSize is the size of the dynamic table
+	dynamicTableSize int
+	// mux is used to protect the dynamic table from concurrent access
+	mux sync.RWMutex
+	// stopChannel is used to mark our main goroutine to stop
+	stopChannel chan struct{}
+	// wg is used to wait for the dynamic table to stop
+	wg sync.WaitGroup
+	// datastore is the LRU datastore used to store the dynamic table entries
+	datastore *simplelru.LRU[http2DynamicTableIndex, *intern.StringValue]
+	// stringInternStore is the string interner used to avoid storing the same string multiple times
+	stringInternStore *intern.StringInterner
+	// kernelMap is the kernel map (`http2_interesting_dynamic_table_set`) used to store the dynamic table entries
+	kernelMap *ebpf.Map
+	// perfHandler is the perf handler used to receive new paths from the kernel
+	perfHandler *ddebpf.PerfHandler
+}
+
+// NewDynamicTable creates a new dynamic table.
+func NewDynamicTable(dynamicTableSize int) *DynamicTable {
+	return &DynamicTable{
+		dynamicTableSize:  dynamicTableSize,
+		stringInternStore: intern.NewStringInterner(),
+		perfHandler:       ddebpf.NewPerfHandler(dynamicTableSize),
+		stopChannel:       make(chan struct{}),
+	}
+}
+
+// ResolvePath resolves the path of a given index and connection tuple.
+func (dt *DynamicTable) ResolvePath(connTuple netebpf.ConnTuple, index uint64) (*intern.StringValue, bool) {
+	dt.mux.RLock()
+	defer dt.mux.RUnlock()
+
+	return dt.datastore.Get(http2DynamicTableIndex{
+		Index: index,
+		Tup:   connTuple,
+	})
+}
+
+// AddPath adds a new path to the dynamic table and the string interner.
+func (dt *DynamicTable) AddPath(key http2DynamicTableIndex, path []byte) {
+	dt.mux.Lock()
+	dt.datastore.Add(key, dt.stringInternStore.Get(path))
+	dt.mux.Unlock()
+
+	value := true
+	_ = dt.kernelMap.Update(unsafe.Pointer(&key), unsafe.Pointer(&value), 0)
+}
+
+// StartProcessingPerfHandler starts the perf handler used to receive new paths from the kernel.
+func (dt *DynamicTable) StartProcessingPerfHandler(mgr *manager.Manager) error {
+	kernelMap, ok, err := mgr.GetMap("http2_interesting_dynamic_table_set")
+	if err != nil {
+		return err
+	} else if !ok {
+		return errors.New("kernel map http2_interesting_dynamic_table_set not found")
+	}
+	dt.kernelMap = kernelMap
+
+	lru, err := simplelru.NewLRU[http2DynamicTableIndex, *intern.StringValue](dt.dynamicTableSize, func(key http2DynamicTableIndex, _ *intern.StringValue) {
+		_ = kernelMap.Delete(unsafe.Pointer(&key))
+	})
+	if err != nil {
+		return fmt.Errorf("error creating an LRU datastore for http2 dynamic table: %w", err)
+	}
+	dt.datastore = lru
+
+	dt.wg.Add(1)
+	go func() {
+		defer dt.wg.Done()
+		for {
+			select {
+			case <-dt.stopChannel:
+				return
+			case data, ok := <-dt.perfHandler.DataChannel:
+				if !ok {
+					return
+				}
+				// TODO: process path
+				data.Done()
+			case _, ok := <-dt.perfHandler.LostChannel:
+				if !ok {
+					return
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// StopProcessingPerfHandler stops the perf handler.
+func (dt *DynamicTable) StopProcessingPerfHandler() {
+	close(dt.stopChannel)
+	dt.wg.Wait()
+}

--- a/pkg/network/protocols/http2/kernel_requirements.go
+++ b/pkg/network/protocols/http2/kernel_requirements.go
@@ -16,11 +16,11 @@ import (
 var MinimumKernelVersion kernel.Version
 
 func init() {
-	MinimumKernelVersion = kernel.VersionCode(5, 2, 0)
+	MinimumKernelVersion = kernel.VersionCode(5, 4, 0)
 }
 
-// Supported We only support http2 with kernel >= 5.2.0, as the kernel implementation exceeds the instruction limit
-// on kernels prior to that. In 5.2.0 the instruction limit was bumped to 1M instead of 4K.
+// Supported We only support http2 with kernel >= 5.4.0, as the kernel implementation exceeds the instruction limit
+// on kernels prior to that. In 5.4.0 the instruction limit was bumped to 1M instead of 4K.
 func Supported() bool {
 	kversion, err := kernel.HostVersion()
 	if err != nil {

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -8,6 +8,7 @@
 package http2
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -22,25 +23,44 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
-// Path returns the URL from the request fragment captured in eBPF.
-func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
-	if tx.Stream.Path_size == 0 || int(tx.Stream.Path_size) > len(tx.Stream.Request_path) {
-		return nil, false
+// decodeHTTP2Path tries to decode (Huffman) the path from the given buffer.
+// Possible errors:
+// - If the given pathSize is 0.
+// - If the given pathSize is larger than the buffer size.
+// - If the Huffman decoding fails.
+// - If the decoded path doesn't start with a '/'.
+func decodeHTTP2Path(buf [maxHTTP2Path]byte, pathSize uint8) ([]byte, error) {
+	if pathSize == 0 {
+		return nil, errors.New("emtpy path")
+	}
+	if pathSize > maxHTTP2Path {
+		return nil, fmt.Errorf("path too long: %d", pathSize)
 	}
 
 	// trim null byte + after
-	str, err := hpack.HuffmanDecodeToString(tx.Stream.Request_path[:tx.Stream.Path_size])
+	str, err := hpack.HuffmanDecodeToString(buf[:pathSize])
 	if err != nil {
-		return nil, false
+		return nil, err
 	}
 
 	// ensure we found a '/' in the beginning of the path
-	if len(str) == 0 || str[0] != '/' {
-		return nil, false
+	if len(str) == 0 {
+		return nil, errors.New("decoded path is an empty path")
+	}
+	if str[0] != '/' {
+		return nil, fmt.Errorf("decoded path '%s' doesn't start with '/'", str)
 	}
 
-	n := copy(buffer, str)
-	// indicate if we knowingly captured the entire path
+	return []byte(str), nil
+}
+
+// Path returns the URL from the request fragment captured in eBPF.
+func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
+	res, err := decodeHTTP2Path(tx.Stream.Request_path, tx.Stream.Path_size)
+	if err != nil {
+		return nil, false
+	}
+	n := copy(buffer, res)
 	return buffer[:n], true
 }
 

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -334,7 +334,9 @@ func (p *Protocol) DumpMaps(output *strings.Builder, mapName string, currentMap 
 
 func (p *Protocol) processHTTP2(events []EbpfTx) {
 	for i := range events {
-		tx := &events[i]
+		tx := &ebpfTXWrapper{
+			EbpfTx: &events[i],
+		}
 		// TODO: Here we need to resolve the path index to the actual path
 		p.telemetry.Count(tx)
 		p.statkeeper.Process(tx)

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -27,7 +27,7 @@ type http2StreamKey C.http2_stream_key_t
 type http2Stream C.http2_stream_t
 type EbpfTx C.http2_event_t
 type HTTP2Telemetry C.http2_telemetry_t
-
+type http2DynamicTableValue C.dynamic_table_value_t
 type StaticTableEnumValue = C.static_table_value_t
 
 const (

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -59,7 +59,12 @@ type HTTP2Telemetry struct {
 	Exceeding_max_frames_to_filter   uint64
 	Path_size_bucket                 [8]uint64
 }
-
+type http2DynamicTableValue struct {
+	Key       http2DynamicTableIndex
+	Len       uint8
+	Pad_cgo_0 [7]byte
+	Buf       [160]byte
+}
 type StaticTableEnumValue = uint8
 
 const (


### PR DESCRIPTION
The new user mode dynamic table is meant to store HTTP2 paths in a LRU datastore and to associate stream with their appropriate paths/

The new module is planned to get all paths from the kernel (via perf event) and to store it in a user-mode LRU datastore, where the key is the connection tuple and the value index in the dynamic table, and the value in a pointer to string intern value. Using the string internning we're able to reduce redundant duplications and spare memory.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
