### PR TITLE
[CWS/CSPM] fix revive lint issues in `cmd/security-agent`

### DIFF
--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -55,8 +55,7 @@ func (a *Agent) SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
-func (a *Agent) stopAgent(w http.ResponseWriter, r *http.Request) {
+func (a *Agent) stopAgent(w http.ResponseWriter, _ *http.Request) {
 	signals.Stopper <- true
 	w.Header().Set("Content-Type", "application/json")
 	j, err := json.Marshal("")
@@ -84,8 +83,7 @@ func (a *Agent) getHostname(w http.ResponseWriter, r *http.Request) {
 	w.Write(j)
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
-func (a *Agent) getStatus(w http.ResponseWriter, r *http.Request) {
+func (a *Agent) getStatus(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	s, err := status.GetStatus(false, nil)
 	if err != nil {
@@ -114,8 +112,7 @@ func (a *Agent) getStatus(w http.ResponseWriter, r *http.Request) {
 	w.Write(jsonStats)
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
-func (a *Agent) getHealth(w http.ResponseWriter, r *http.Request) {
+func (a *Agent) getHealth(w http.ResponseWriter, _ *http.Request) {
 	h := health.GetReady()
 
 	if len(h.Unhealthy) > 0 {
@@ -133,8 +130,7 @@ func (a *Agent) getHealth(w http.ResponseWriter, r *http.Request) {
 	w.Write(jsonHealth)
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
-func (a *Agent) makeFlare(w http.ResponseWriter, r *http.Request) {
+func (a *Agent) makeFlare(w http.ResponseWriter, _ *http.Request) {
 	log.Infof("Making a flare")
 	w.Header().Set("Content-Type", "application/json")
 	logFile := config.Datadog.GetString("security_agent.log_file")

--- a/cmd/security-agent/main_nix.go
+++ b/cmd/security-agent/main_nix.go
@@ -5,7 +5,7 @@
 
 //go:build !windows
 
-//nolint:revive // TODO(SEC) Fix revive linter
+// Package main implements main
 package main
 
 import (

--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -285,8 +285,7 @@ func newFakeResolver(regoInputPath string) compliance.Resolver {
 	return &fakeResolver{regoInputPath}
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
-func (r *fakeResolver) ResolveInputs(ctx context.Context, rule *compliance.Rule) (compliance.ResolvedInputs, error) {
+func (r *fakeResolver) ResolveInputs(_ context.Context, rule *compliance.Rule) (compliance.ResolvedInputs, error) {
 	var fixtures map[string]map[string]interface{}
 	data, err := os.ReadFile(r.regoInputPath)
 	if err != nil {

--- a/cmd/security-agent/subcommands/check/command_unsupported.go
+++ b/cmd/security-agent/subcommands/check/command_unsupported.go
@@ -16,15 +16,11 @@ import (
 )
 
 // SecurityAgentCommands returns security agent commands
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func SecurityAgentCommands(globalParams *command.GlobalParams) []*cobra.Command {
+func SecurityAgentCommands(_ *command.GlobalParams) []*cobra.Command {
 	return nil
 }
 
 // ClusterAgentCommands returns cluster agent commands
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func ClusterAgentCommands(bundleParams core.BundleParams) []*cobra.Command {
+func ClusterAgentCommands(_ core.BundleParams) []*cobra.Command {
 	return nil
 }

--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(SEC) Fix revive linter
+// Package compliance implements compliance related subcommands
 package compliance
 
 import (

--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -28,7 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
-//nolint:revive // TODO(SEC) Fix revive linter
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	complianceCmd := &cobra.Command{
 		Use:   "compliance",

--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
+// Commands returns the compliance commands
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	complianceCmd := &cobra.Command{
 		Use:   "compliance",

--- a/cmd/security-agent/subcommands/compliance/compliance.go
+++ b/cmd/security-agent/subcommands/compliance/compliance.go
@@ -27,7 +27,7 @@ import (
 
 // StartCompliance runs the compliance sub-agent running compliance benchmarks
 // and checks.
-func StartCompliance(log log.Component, config config.Component, sysprobeconfig sysprobeconfig.Component, hostname string, stopper startstop.Stopper, statsdClient ddgostatsd.ClientInterface, senderManager sender.SenderManager) (*compliance.Agent, error) { //nolint:revive // TODO fix revive unused-parameter
+func StartCompliance(log log.Component, config config.Component, sysprobeconfig sysprobeconfig.Component, hostname string, stopper startstop.Stopper, statsdClient ddgostatsd.ClientInterface, senderManager sender.SenderManager) (*compliance.Agent, error) {
 	enabled := config.GetBool("compliance_config.enabled")
 	runPath := config.GetString("compliance_config.run_path")
 	configDir := config.GetString("compliance_config.dir")

--- a/cmd/security-agent/subcommands/config/config_unsupported.go
+++ b/cmd/security-agent/subcommands/config/config_unsupported.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//nolint:revive // TODO(SEC) Fix revive linter
 func Commands(*command.GlobalParams) []*cobra.Command {
 	return nil
 }

--- a/cmd/security-agent/subcommands/config/config_unsupported.go
+++ b/cmd/security-agent/subcommands/config/config_unsupported.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Commands returns the config commands
 func Commands(*command.GlobalParams) []*cobra.Command {
 	return nil
 }

--- a/cmd/security-agent/subcommands/config/config_unsupported.go
+++ b/cmd/security-agent/subcommands/config/config_unsupported.go
@@ -5,7 +5,7 @@
 
 //go:build !kubeapiserver
 
-//nolint:revive // TODO(SEC) Fix revive linter
+// Package config holds config related files
 package config
 
 import (

--- a/cmd/security-agent/subcommands/flare/command.go
+++ b/cmd/security-agent/subcommands/flare/command.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(SEC) Fix revive linter
+// Package flare implements flare related subcommands
 package flare
 
 import (

--- a/cmd/security-agent/subcommands/flare/command.go
+++ b/cmd/security-agent/subcommands/flare/command.go
@@ -35,7 +35,6 @@ type cliParams struct {
 	caseID        string
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cliParams := &cliParams{
 		GlobalParams: globalParams,

--- a/cmd/security-agent/subcommands/flare/command.go
+++ b/cmd/security-agent/subcommands/flare/command.go
@@ -35,6 +35,7 @@ type cliParams struct {
 	caseID        string
 }
 
+// Commands returns the flare commands
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cliParams := &cliParams{
 		GlobalParams: globalParams,

--- a/cmd/security-agent/subcommands/runtime/command_unsupported.go
+++ b/cmd/security-agent/subcommands/runtime/command_unsupported.go
@@ -23,9 +23,7 @@ import (
 )
 
 // Commands returns the runtime security commands
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+func Commands(*command.GlobalParams) []*cobra.Command {
 	return nil
 }
 

--- a/cmd/security-agent/subcommands/runtime/command_unsupported.go
+++ b/cmd/security-agent/subcommands/runtime/command_unsupported.go
@@ -5,7 +5,7 @@
 
 //go:build !linux && !windows
 
-//nolint:revive // TODO(SEC) Fix revive linter
+// Package runtime holds runtime related files
 package runtime
 
 import (

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(SEC) Fix revive linter
+// Package start implements start related subcommands
 package start
 
 import (

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -64,7 +64,6 @@ type cliParams struct {
 	pidfilePath string
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	params := &cliParams{
 		GlobalParams: globalParams,

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -64,6 +64,7 @@ type cliParams struct {
 	pidfilePath string
 }
 
+// Commands returns the start commands
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	params := &cliParams{
 		GlobalParams: globalParams,

--- a/cmd/security-agent/subcommands/status/command.go
+++ b/cmd/security-agent/subcommands/status/command.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(SEC) Fix revive linter
+// Package status implements status related subcommands
 package status
 
 import (

--- a/cmd/security-agent/subcommands/status/command.go
+++ b/cmd/security-agent/subcommands/status/command.go
@@ -34,7 +34,6 @@ type cliParams struct {
 	file            string
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cliParams := &cliParams{
 		GlobalParams: globalParams,

--- a/cmd/security-agent/subcommands/status/command.go
+++ b/cmd/security-agent/subcommands/status/command.go
@@ -34,6 +34,7 @@ type cliParams struct {
 	file            string
 }
 
+// Commands returns the status commands
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cliParams := &cliParams{
 		GlobalParams: globalParams,

--- a/cmd/security-agent/subcommands/subcommands.go
+++ b/cmd/security-agent/subcommands/subcommands.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(SEC) Fix revive linter
+// Package subcommands implement security agent subcommands
 package subcommands
 
 import (


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR fixes the revive lint issues in `cmd/security-agent`. Mostly unused params, missing doc on packages
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
