### PR TITLE
[CWS] Make the ProcessCache per container in EBPFLess mode

### DIFF
--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -40,7 +40,10 @@ func (fh *EBPFLessFieldHandlers) GetProcessService(ev *model.Event) string {
 // ResolveProcessCacheEntry queries the ProcessResolver to retrieve the ProcessContext of the event
 func (fh *EBPFLessFieldHandlers) ResolveProcessCacheEntry(ev *model.Event) (*model.ProcessCacheEntry, bool) {
 	if ev.ProcessCacheEntry == nil && ev.PIDContext.Pid != 0 {
-		ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(ev.PIDContext.Pid)
+		ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(sprocess.CacheResolverKey{
+			Pid:  ev.PIDContext.Pid,
+			NSID: ev.NSID,
+		})
 	}
 
 	if ev.ProcessCacheEntry == nil {
@@ -130,7 +133,10 @@ func (fh *EBPFLessFieldHandlers) ResolveProcessEnvs(_ *model.Event, process *mod
 
 // GetProcessCacheEntry queries the ProcessResolver to retrieve the ProcessContext of the event
 func (fh *EBPFLessFieldHandlers) GetProcessCacheEntry(ev *model.Event) (*model.ProcessCacheEntry, bool) {
-	ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(ev.PIDContext.Pid)
+	ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(sprocess.CacheResolverKey{
+		Pid:  ev.PIDContext.Pid,
+		NSID: ev.NSID,
+	})
 	if ev.ProcessCacheEntry == nil {
 		ev.ProcessCacheEntry = model.GetPlaceholderProcessCacheEntry(ev.PIDContext.Pid, ev.PIDContext.Pid, false)
 		return ev.ProcessCacheEntry, false

--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -67,15 +68,16 @@ func (p *EBPFLessProbe) handleSyscallMsg(syscallMsg *ebpfless.SyscallMsg) {
 	p.seqNum++
 
 	event := p.zeroEvent()
+	event.NSID = syscallMsg.NSID
 
 	switch syscallMsg.Type {
 	case ebpfless.SyscallTypeExec:
 		event.Type = uint32(model.ExecEventType)
-		entry := p.Resolvers.ProcessResolver.AddExecEntry(syscallMsg.PID, syscallMsg.Exec.Filename, syscallMsg.Exec.Args, syscallMsg.Exec.Envs, syscallMsg.ContainerContext.ID)
+		entry := p.Resolvers.ProcessResolver.AddExecEntry(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: syscallMsg.NSID}, syscallMsg.Exec.Filename, syscallMsg.Exec.Args, syscallMsg.Exec.Envs, syscallMsg.ContainerContext.ID)
 		event.Exec.Process = &entry.Process
 	case ebpfless.SyscallTypeFork:
 		event.Type = uint32(model.ForkEventType)
-		p.Resolvers.ProcessResolver.AddForkEntry(syscallMsg.PID, syscallMsg.Fork.PPID)
+		p.Resolvers.ProcessResolver.AddForkEntry(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: syscallMsg.NSID}, syscallMsg.Fork.PPID)
 	case ebpfless.SyscallTypeOpen:
 		event.Type = uint32(model.FileOpenEventType)
 		event.Open.File.PathnameStr = syscallMsg.Open.Filename
@@ -93,7 +95,7 @@ func (p *EBPFLessProbe) handleSyscallMsg(syscallMsg *ebpfless.SyscallMsg) {
 	}
 
 	// use ProcessCacheEntry process context as process context
-	event.ProcessCacheEntry = p.Resolvers.ProcessResolver.Resolve(syscallMsg.PID)
+	event.ProcessCacheEntry = p.Resolvers.ProcessResolver.Resolve(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: syscallMsg.NSID})
 	if event.ProcessCacheEntry == nil {
 		event.ProcessCacheEntry = model.NewPlaceholderProcessCacheEntry(syscallMsg.PID, syscallMsg.PID, false)
 	}

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -75,6 +75,7 @@ type ChdirSyscallFakeMsg struct {
 // SyscallMsg defines a syscall message
 type SyscallMsg struct {
 	SeqNum           uint64
+	NSID             uint64
 	Type             SyscallType
 	PID              uint32
 	ContainerContext *ContainerContext

--- a/pkg/security/ptracer/utils.go
+++ b/pkg/security/ptracer/utils.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package ptracer holds the start command of CWS injector
+package ptracer
+
+import (
+	"bufio"
+	"bytes"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"unicode"
+
+	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
+)
+
+// Funcs mainly copied from github.com/DataDog/datadog-agent/pkg/security/utils/cgroup.go
+// in order to reduce the binary size of cws-instrumentation
+
+type controlGroup struct {
+	// id unique hierarchy ID
+	id int
+
+	// controllers are the list of cgroup controllers bound to the hierarchy
+	controllers []string
+
+	// path is the pathname of the control group to which the process
+	// belongs. It is relative to the mountpoint of the hierarchy.
+	path string
+}
+
+func getProcControlGroupsFromFile(path string) ([]controlGroup, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cgroups []controlGroup
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		t := scanner.Text()
+		parts := strings.Split(t, ":")
+		var ID int
+		ID, err = strconv.Atoi(parts[0])
+		if err != nil {
+			continue
+		}
+		c := controlGroup{
+			id:          ID,
+			controllers: strings.Split(parts[1], ","),
+			path:        parts[2],
+		}
+		cgroups = append(cgroups, c)
+	}
+	return cgroups, nil
+
+}
+
+func getContainerID(path string) string {
+	// path is in form of: /docker/580f75c027f19bf3a59de881b056829f214fc1d78961c164e8669485ef5b0dd5
+	// -> len(/docker/) = 8, +64 of container ID
+	if len(path) != 8+64 { // check length
+		return ""
+	}
+	for _, i := range path[8:] { // check that it's only numeric
+		if !unicode.IsLetter(i) && !unicode.IsDigit(i) {
+			return ""
+		}
+	}
+	return path[8:]
+}
+
+func getCurrentProcContainerID() (string, error) {
+	cgroups, err := getProcControlGroupsFromFile("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+
+	for _, cgroup := range cgroups {
+		cid := getContainerID(cgroup.path)
+		if cid != "" {
+			return cid, nil
+		}
+	}
+	return "", nil
+}
+
+func retrieveContainerIDFromProc(ctx *ebpfless.ContainerContext) error {
+	cgroup, err := getCurrentProcContainerID()
+	if err != nil {
+		return err
+	}
+	ctx.ID = cgroup
+	return nil
+}
+
+func getNSID() uint64 {
+	var stat syscall.Stat_t
+	if err := syscall.Lstat("/proc/self/ns/pid", &stat); err != nil {
+		return rand.Uint64()
+	}
+	return stat.Ino
+}

--- a/pkg/security/resolvers/process/resolver_ebpfless.go
+++ b/pkg/security/resolvers/process/resolver_ebpfless.go
@@ -26,10 +26,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
+// CacheResolverKey is used to store and retrieve processes from the cache
+type CacheResolverKey struct {
+	Pid  uint32 // Pid of the related process (namespaced)
+	NSID uint64 // NSID represents the pids namespace ID of the related container
+}
+
 // EBPFLessResolver defines a resolver
 type EBPFLessResolver struct {
 	sync.RWMutex
-	entryCache   map[uint32]*model.ProcessCacheEntry
+	entryCache   map[CacheResolverKey]*model.ProcessCacheEntry
 	opts         ResolverOpts
 	scrubber     *procutil.DataScrubber
 	statsdClient statsd.ClientInterface
@@ -43,7 +49,7 @@ type EBPFLessResolver struct {
 // NewEBPFLessResolver returns a new process resolver
 func NewEBPFLessResolver(_ *config.Config, statsdClient statsd.ClientInterface, scrubber *procutil.DataScrubber, opts *ResolverOpts) (*EBPFLessResolver, error) {
 	p := &EBPFLessResolver{
-		entryCache:   make(map[uint32]*model.ProcessCacheEntry),
+		entryCache:   make(map[CacheResolverKey]*model.ProcessCacheEntry),
 		opts:         *opts,
 		scrubber:     scrubber,
 		cacheSize:    atomic.NewInt64(0),
@@ -55,43 +61,43 @@ func NewEBPFLessResolver(_ *config.Config, statsdClient statsd.ClientInterface, 
 	return p, nil
 }
 
-func (p *EBPFLessResolver) deleteEntry(pid uint32, exitTime time.Time) {
-	entry, ok := p.entryCache[pid]
+func (p *EBPFLessResolver) deleteEntry(key CacheResolverKey, exitTime time.Time) {
+	entry, ok := p.entryCache[key]
 	if !ok {
 		return
 	}
 
 	entry.Exit(exitTime)
-	delete(p.entryCache, entry.Pid)
+	delete(p.entryCache, key)
 	entry.Release()
 }
 
 // DeleteEntry tries to delete an entry in the process cache
-func (p *EBPFLessResolver) DeleteEntry(pid uint32, exitTime time.Time) {
+func (p *EBPFLessResolver) DeleteEntry(key CacheResolverKey, exitTime time.Time) {
 	p.Lock()
 	defer p.Unlock()
 
-	p.deleteEntry(pid, exitTime)
+	p.deleteEntry(key, exitTime)
 }
 
 // AddForkEntry adds an entry to the local cache and returns the newly created entry
-func (p *EBPFLessResolver) AddForkEntry(pid uint32, ppid uint32) *model.ProcessCacheEntry {
+func (p *EBPFLessResolver) AddForkEntry(key CacheResolverKey, ppid uint32) *model.ProcessCacheEntry {
 	entry := p.processCacheEntryPool.Get()
-	entry.PIDContext.Pid = pid
+	entry.PIDContext.Pid = key.Pid
 	entry.PPid = ppid
 
 	p.Lock()
 	defer p.Unlock()
 
-	p.insertForkEntry(entry)
+	p.insertForkEntry(key, entry)
 
 	return entry
 }
 
 // AddExecEntry adds an entry to the local cache and returns the newly created entry
-func (p *EBPFLessResolver) AddExecEntry(pid uint32, file string, argv []string, envs []string, ctrID string) *model.ProcessCacheEntry {
+func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv []string, envs []string, ctrID string) *model.ProcessCacheEntry {
 	entry := p.processCacheEntryPool.Get()
-	entry.PIDContext.Pid = pid
+	entry.PIDContext.Pid = key.Pid
 
 	entry.Process.ArgsEntry = &model.ArgsEntry{Values: argv}
 	if len(argv) > 0 {
@@ -111,13 +117,13 @@ func (p *EBPFLessResolver) AddExecEntry(pid uint32, file string, argv []string, 
 	p.Lock()
 	defer p.Unlock()
 
-	p.insertExecEntry(entry)
+	p.insertExecEntry(key, entry)
 
 	return entry
 }
 
-func (p *EBPFLessResolver) insertEntry(entry, prev *model.ProcessCacheEntry) {
-	p.entryCache[entry.Pid] = entry
+func (p *EBPFLessResolver) insertEntry(key CacheResolverKey, entry, prev *model.ProcessCacheEntry) {
+	p.entryCache[key] = entry
 	entry.Retain()
 
 	if prev != nil {
@@ -127,37 +133,40 @@ func (p *EBPFLessResolver) insertEntry(entry, prev *model.ProcessCacheEntry) {
 	p.cacheSize.Inc()
 }
 
-func (p *EBPFLessResolver) insertForkEntry(entry *model.ProcessCacheEntry) {
-	prev := p.entryCache[entry.Pid]
+func (p *EBPFLessResolver) insertForkEntry(key CacheResolverKey, entry *model.ProcessCacheEntry) {
+	prev := p.entryCache[key]
 	if prev != nil {
 		// this shouldn't happen but it is better to exit the prev and let the new one replace it
 		prev.Exit(entry.ForkTime)
 	}
 
 	if entry.Pid != 1 {
-		parent := p.entryCache[entry.PPid]
+		parent := p.entryCache[CacheResolverKey{
+			Pid:  entry.PPid,
+			NSID: key.NSID,
+		}]
 		if parent != nil {
 			parent.Fork(entry)
 		}
 	}
 
-	p.insertEntry(entry, prev)
+	p.insertEntry(key, entry, prev)
 }
 
-func (p *EBPFLessResolver) insertExecEntry(entry *model.ProcessCacheEntry) {
-	prev := p.entryCache[entry.Pid]
+func (p *EBPFLessResolver) insertExecEntry(key CacheResolverKey, entry *model.ProcessCacheEntry) {
+	prev := p.entryCache[key]
 	if prev != nil {
 		prev.Exec(entry)
 	}
 
-	p.insertEntry(entry, prev)
+	p.insertEntry(key, entry, prev)
 }
 
 // Resolve returns the cache entry for the given pid
-func (p *EBPFLessResolver) Resolve(pid uint32) *model.ProcessCacheEntry {
+func (p *EBPFLessResolver) Resolve(key CacheResolverKey) *model.ProcessCacheEntry {
 	p.Lock()
 	defer p.Unlock()
-	if e, ok := p.entryCache[pid]; ok {
+	if e, ok := p.entryCache[key]; ok {
 		return e
 	}
 	return nil

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -195,6 +195,8 @@ type Event struct {
 	NetDevice        NetDeviceEvent        `field:"-" json:"-"`
 	VethPair         VethPairEvent         `field:"-" json:"-"`
 	UnshareMountNS   UnshareMountNSEvent   `field:"-" json:"-"`
+	// used for ebpfless
+	NSID uint64 `field:"-" json:"-"`
 }
 
 // SetPathResolutionError sets the Event.pathResolutionError


### PR DESCRIPTION
### What does this PR do?

It changes the key to access the process cache, from just PID, to PID + the pids namespace id coming from each containers (as they only see and send namespaced PIDs)

Also, get container ID from proc.

### Motivation

Avoid PID conflicts on EBPF less mode

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
