### PR TITLE
USMON-617: hitsXXX counters are now TLS-aware

### DIFF
--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -35,7 +35,7 @@ type Telemetry struct {
 	// metricGroup is used here mostly for building the log message below
 	metricGroup *libtelemetry.MetricGroup
 
-	hits1XX, hits2XX, hits3XX, hits4XX, hits5XX *libtelemetry.Counter
+	hits1XX, hits2XX, hits3XX, hits4XX, hits5XX *TLSCounter
 
 	totalHits                                                        *TLSCounter
 	dropped                                                          *libtelemetry.Counter // this happens when statKeeper reaches capacity
@@ -55,11 +55,11 @@ func NewTelemetry(protocol string) *Telemetry {
 		protocol:    protocol,
 		metricGroup: metricGroup,
 
-		hits1XX:      metricGroup.NewCounter("hits", "status:1xx", libtelemetry.OptPrometheus),
-		hits2XX:      metricGroup.NewCounter("hits", "status:2xx", libtelemetry.OptPrometheus),
-		hits3XX:      metricGroup.NewCounter("hits", "status:3xx", libtelemetry.OptPrometheus),
-		hits4XX:      metricGroup.NewCounter("hits", "status:4xx", libtelemetry.OptPrometheus),
-		hits5XX:      metricGroup.NewCounter("hits", "status:5xx", libtelemetry.OptPrometheus),
+		hits1XX:      NewTLSCounter(metricGroup, "hits", "status:1xx", libtelemetry.OptPrometheus),
+		hits2XX:      NewTLSCounter(metricGroup, "hits", "status:2xx", libtelemetry.OptPrometheus),
+		hits3XX:      NewTLSCounter(metricGroup, "hits", "status:3xx", libtelemetry.OptPrometheus),
+		hits4XX:      NewTLSCounter(metricGroup, "hits", "status:4xx", libtelemetry.OptPrometheus),
+		hits5XX:      NewTLSCounter(metricGroup, "hits", "status:5xx", libtelemetry.OptPrometheus),
 		aggregations: metricGroup.NewCounter("aggregations", libtelemetry.OptPrometheus),
 
 		// these metrics are also exported as statsd metrics
@@ -86,15 +86,15 @@ func (t *Telemetry) Count(tx Transaction) {
 	statusClass := (tx.StatusCode() / 100) * 100
 	switch statusClass {
 	case 100:
-		t.hits1XX.Add(1)
+		t.hits1XX.Add(tx)
 	case 200:
-		t.hits2XX.Add(1)
+		t.hits2XX.Add(tx)
 	case 300:
-		t.hits3XX.Add(1)
+		t.hits3XX.Add(tx)
 	case 400:
-		t.hits4XX.Add(1)
+		t.hits4XX.Add(tx)
 	case 500:
-		t.hits5XX.Add(1)
+		t.hits5XX.Add(tx)
 	}
 
 	t.totalHits.Add(tx)

--- a/pkg/network/protocols/http/tls_counter.go
+++ b/pkg/network/protocols/http/tls_counter.go
@@ -24,7 +24,8 @@ type TLSCounter struct {
 // NewTLSCounter creates and returns a new instance of TLSCounter
 func NewTLSCounter(metricGroup *libtelemetry.MetricGroup, metricName string, tags ...string) *TLSCounter {
 	return &TLSCounter{
-		counterPlain:   metricGroup.NewCounter(metricName, append(tags, "encrypted:false")...),
+		// tls_library:none is a must, as prometheus metrics must have the same cardinality of tags
+		counterPlain:   metricGroup.NewCounter(metricName, append(tags, "encrypted:false", "tls_library:none")...),
 		counterGnuTLS:  metricGroup.NewCounter(metricName, append(tags, "encrypted:true", "tls_library:gnutls")...),
 		counterOpenSLL: metricGroup.NewCounter(metricName, append(tags, "encrypted:true", "tls_library:openssl")...),
 		counterJavaTLS: metricGroup.NewCounter(metricName, append(tags, "encrypted:true", "tls_library:java")...),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Transforming counters for hits in the 1XX, 2XX, 3XX, 4XX, and 5XX categories into TLS-aware counters

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We aim to label the 'hits' counters based on the TLS library
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
