### PR TITLE
Restore microbenchmark runs for trace-agent

### DIFF
--- a/.gitlab/benchmarks/benchmarks.yml
+++ b/.gitlab/benchmarks/benchmarks.yml
@@ -9,16 +9,17 @@ benchmark:
   needs: ["setup_agent_version"]
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   script:
+    - export ARTIFACTS_DIR="$(pwd)/artifacts" && mkdir -p $ARTIFACTS_DIR
     - ./test/benchmarks/apm_scripts/capture-hardware-software-info.sh
     - ./test/benchmarks/apm_scripts/run-benchmarks.sh
     - ./test/benchmarks/apm_scripts/upload-results-to-s3.sh
     - ./test/benchmarks/apm_scripts/analyze-results.sh
     - ./test/benchmarks/apm_scripts/post-pr-comment.sh
   artifacts:
-    name: "reports"
+    name: "artifacts"
     when: always
     paths:
-      - reports/
+      - artifacts/
     expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"

--- a/.gitlab/benchmarks/benchmarks.yml
+++ b/.gitlab/benchmarks/benchmarks.yml
@@ -12,9 +12,9 @@ benchmark:
     - export ARTIFACTS_DIR="$(pwd)/artifacts" && mkdir -p $ARTIFACTS_DIR
     - ./test/benchmarks/apm_scripts/capture-hardware-software-info.sh
     - ./test/benchmarks/apm_scripts/run-benchmarks.sh
-    - ./test/benchmarks/apm_scripts/upload-results-to-s3.sh
     - ./test/benchmarks/apm_scripts/analyze-results.sh
-    - ./test/benchmarks/apm_scripts/post-pr-comment.sh
+    - "./test/benchmarks/apm_scripts/upload-results-to-s3.sh || :"
+    - "./test/benchmarks/apm_scripts/post-pr-comment.sh || :"
   artifacts:
     name: "artifacts"
     when: always

--- a/.gitlab/benchmarks/benchmarks.yml
+++ b/.gitlab/benchmarks/benchmarks.yml
@@ -6,6 +6,7 @@ benchmark:
   rules:
     !reference [.manual] # TODO: run this benchmark automatically when the trace-agent changes
   interruptible: true
+  needs: ["setup_agent_version"]
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   script:
     - ./test/benchmarks/apm_scripts/capture-hardware-software-info.sh

--- a/.gitlab/benchmarks/benchmarks.yml
+++ b/.gitlab/benchmarks/benchmarks.yml
@@ -1,21 +1,21 @@
 benchmark:
   stage: benchmarks
   # This base image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/relenv-microbenchmarking-platform
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/relenv-microbenchmarking-platform:trace-agent
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:trace-agent_microbenchmarks
   timeout: 1h
   rules:
     !reference [.manual] # TODO: run this benchmark automatically when the trace-agent changes
   interruptible: true
-  # tags: ["runner:apm-k8s-tweaked-metal"] # TODO: Commented out until we have the metal runners available in this repo
-  tags: ["runner:main"]
+  tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   script:
     - ./test/benchmarks/apm_scripts/capture-hardware-software-info.sh
     - ./test/benchmarks/apm_scripts/run-benchmarks.sh
-    # - ./test/benchmarks/apm_scripts/upload-results-to-s3.sh #commented out until we have merged our permissions changes
+    - ./test/benchmarks/apm_scripts/upload-results-to-s3.sh
     - ./test/benchmarks/apm_scripts/analyze-results.sh
     - ./test/benchmarks/apm_scripts/post-pr-comment.sh
   artifacts:
     name: "reports"
+    when: always
     paths:
       - reports/
     expire_in: 3 months

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -136,4 +136,4 @@ def benchmarks(ctx, bench, output="./trace-agent.benchmarks.out"):
         print("Argument --bench=<bench_regex> is required.")
         return
     with ctx.cd("./pkg/trace"):
-        ctx.run(f"go test -run=XXX -bench \"{bench}\" -benchmem -count 10 -benchtime 2s ./... | tee {output}")
+        ctx.run(f"go test -run=XXX -bench \"{bench}\" -benchmem -count 1 -benchtime 2s ./... | tee {output}")

--- a/test/benchmarks/apm_scripts/analyze-results.sh
+++ b/test/benchmarks/apm_scripts/analyze-results.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export UNCONFIDENCE_THRESHOLD=2.0
+
 benchmark_analyzer convert \
   --framework=GoBench \
   --outpath="pr.json" \
@@ -14,4 +16,3 @@ benchmark_analyzer convert \
 
 benchmark_analyzer compare pairwise --outpath $ARTIFACTS_DIR/report.md --format md-nodejs main.json pr.json
 benchmark_analyzer compare pairwise --outpath $ARTIFACTS_DIR/report_full.html --format html main.json pr.json
-

--- a/test/benchmarks/apm_scripts/analyze-results.sh
+++ b/test/benchmarks/apm_scripts/analyze-results.sh
@@ -2,16 +2,46 @@
 
 export UNCONFIDENCE_THRESHOLD=2.0
 
+CI_JOB_DATE=$(date +%s)
+CPU_MODEL=$(cat "$ARTIFACTS_DIR/lscpu.txt" | grep -Eo 'Model name: .*' | sed 's/Model name://' | awk '{$1=$1;print}')
+if [ -z "$CPU_MODEL" ]; then
+  echo "FAIL! Failed to extract CPU_MODEL from lscpu.txt"
+  exit 1
+fi
+
+COMMIT_SHA=$(git rev-parse HEAD)
+COMMIT_DATE=$(git show -s --format=%ct $COMMIT_SHA)
 benchmark_analyzer convert \
   --framework=GoBench \
   --outpath="pr.json" \
-  --extra-params="{\"trace_agent\":\"${CI_COMMIT_REF_NAME}\"}" \
+  --extra-params="{\
+    \"baseline_or_candidate\":\"candidate\", \
+    \"cpu_model\":\"$CPU_MODEL\", \
+    \"ci_job_date\":\"$CI_JOB_DATE\", \
+    \"ci_job_id\":\"$CI_JOB_ID\", \
+    \"ci_pipeline_id\":\"$CI_PIPELINE_ID\", \
+    \"git_commit_sha\":\"$COMMIT_SHA\", \
+    \"git_commit_date\":\"$COMMIT_DATE\", \
+    \"git_branch\":\"$CI_COMMIT_REF_NAME\"\
+  }" \
   "$ARTIFACTS_DIR/pr_bench.txt"
 
+git checkout main
+COMMIT_SHA=$(git rev-parse HEAD)
+COMMIT_DATE=$(git show -s --format=%ct $COMMIT_SHA)
 benchmark_analyzer convert \
   --framework=GoBench \
   --outpath="main.json" \
-  --extra-params="{\"trace_agent\":\"main\"}" \
+  --extra-params="{\
+    \"baseline_or_candidate\":\"baseline\", \
+    \"cpu_model\":\"$CPU_MODEL\", \
+    \"ci_job_date\":\"$CI_JOB_DATE\", \
+    \"ci_job_id\":\"$CI_JOB_ID\", \
+    \"ci_pipeline_id\":\"$CI_PIPELINE_ID\", \
+    \"git_commit_sha\":\"$COMMIT_SHA\", \
+    \"git_commit_date\":\"$COMMIT_DATE\", \
+    \"git_branch\":\"main\"\
+  }" \
   "$ARTIFACTS_DIR/main_bench.txt"
 
 benchmark_analyzer compare pairwise --outpath $ARTIFACTS_DIR/report.md --format md-nodejs main.json pr.json

--- a/test/benchmarks/apm_scripts/analyze-results.sh
+++ b/test/benchmarks/apm_scripts/analyze-results.sh
@@ -46,3 +46,5 @@ benchmark_analyzer convert \
 
 benchmark_analyzer compare pairwise --outpath $ARTIFACTS_DIR/report.md --format md-nodejs main.json pr.json
 benchmark_analyzer compare pairwise --outpath $ARTIFACTS_DIR/report_full.html --format html main.json pr.json
+
+git checkout "${CI_COMMIT_REF_NAME}" # (Only needed while these changes aren't merged to main)

--- a/test/benchmarks/apm_scripts/analyze-results.sh
+++ b/test/benchmarks/apm_scripts/analyze-results.sh
@@ -1,24 +1,17 @@
 #!/usr/bin/env bash
 
-ARTIFACTS_DIR="/artifacts/${CI_JOB_ID}"
-REPORTS_DIR="$(pwd)/reports/"
-mkdir "${REPORTS_DIR}" || :
-
-source /benchmark-analyzer/.venv/bin/activate
-cd /benchmark-analyzer
-
-./benchmark_analyzer convert \
+benchmark_analyzer convert \
   --framework=GoBench \
   --outpath="pr.json" \
   --extra-params="{\"trace_agent\":\"${CI_COMMIT_REF_NAME}\"}" \
-  "${ARTIFACTS_DIR}/pr_bench.txt"
+  "$ARTIFACTS_DIR/pr_bench.txt"
 
-./benchmark_analyzer convert \
+benchmark_analyzer convert \
   --framework=GoBench \
   --outpath="main.json" \
   --extra-params="{\"trace_agent\":\"main\"}" \
-  "${ARTIFACTS_DIR}/main_bench.txt"
+  "$ARTIFACTS_DIR/main_bench.txt"
 
-./benchmark_analyzer compare pairwise --outpath ${REPORTS_DIR}/report.md --format md-nodejs main.json pr.json
-./benchmark_analyzer compare pairwise --outpath ${REPORTS_DIR}/report_full.html --format html main.json pr.json
+benchmark_analyzer compare pairwise --outpath $ARTIFACTS_DIR/report.md --format md-nodejs main.json pr.json
+benchmark_analyzer compare pairwise --outpath $ARTIFACTS_DIR/report_full.html --format html main.json pr.json
 

--- a/test/benchmarks/apm_scripts/capture-hardware-software-info.sh
+++ b/test/benchmarks/apm_scripts/capture-hardware-software-info.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-REPORTS_DIR="$(pwd)/reports/"
-mkdir "${REPORTS_DIR}" || :
-
-ARTIFACTS_DIR="/artifacts/${CI_JOB_ID}"
-mkdir -p "${ARTIFACTS_DIR}" && cd "${ARTIFACTS_DIR}"
+cd "${ARTIFACTS_DIR}"
 
 # Collect software information
 
@@ -21,7 +17,3 @@ mkdir -p "${ARTIFACTS_DIR}" && cd "${ARTIFACTS_DIR}"
 (which hwinfo && hwinfo > hwinfo-full.txt) || :
 #cpupower frequency-info > cpupower-frequency-info.txt
 #turbostat -n 1 > turbostat.txt
-
-# Save all collected information to Gitlab reports as well
-
-cp * "${REPORTS_DIR}"

--- a/test/benchmarks/apm_scripts/post-pr-comment.sh
+++ b/test/benchmarks/apm_scripts/post-pr-comment.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
 
-REPORTS_DIR="$(pwd)/reports/"
-
-cat ${REPORTS_DIR}/report.md | /usr/local/bin/pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME" --header="Benchmarks"
+cat $ARTIFACTS_DIR/report.md | pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME" --header="Benchmarks"

--- a/test/benchmarks/apm_scripts/run-benchmarks.sh
+++ b/test/benchmarks/apm_scripts/run-benchmarks.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 
-ARTIFACTS_DIR="/artifacts/${CI_JOB_ID}"
-mkdir -p "${ARTIFACTS_DIR}"
-
-inv trace-agent.benchmarks --output="${ARTIFACTS_DIR}/pr_bench.txt" --bench="BenchmarkAgentTraceProcessing$"
-
+inv trace-agent.benchmarks --output="$ARTIFACTS_DIR/pr_bench.txt" --bench="BenchmarkAgentTraceProcessing$"
 git checkout main
-inv trace-agent.benchmarks --output="${ARTIFACTS_DIR}/main_bench.txt" --bench="BenchmarkAgentTraceProcessing$"
 
+inv trace-agent.benchmarks --output="$ARTIFACTS_DIR/main_bench.txt" --bench="BenchmarkAgentTraceProcessing$"
 git checkout "${CI_COMMIT_REF_NAME}" # (Only needed while these changes aren't merged to main)

--- a/test/benchmarks/apm_scripts/run-benchmarks.sh
+++ b/test/benchmarks/apm_scripts/run-benchmarks.sh
@@ -4,7 +4,7 @@ set -e
 
 bench_loop_x10 () {
   for i in {1..10}; do
-    inv trace-agent.benchmarks --output="/tmp/$1" --bench="BenchmarkAgentTraceProcessing$"
+    inv trace-agent.benchmarks -count 1 -benchtime 2s --output="/tmp/$1" --bench="BenchmarkAgentTraceProcessing$"
     cat "/tmp/$1" >> "$ARTIFACTS_DIR/$1"
   done
 }

--- a/test/benchmarks/apm_scripts/run-benchmarks.sh
+++ b/test/benchmarks/apm_scripts/run-benchmarks.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 
-inv trace-agent.benchmarks --output="$ARTIFACTS_DIR/pr_bench.txt" --bench="BenchmarkAgentTraceProcessing$"
-git checkout main
+set -e
 
-inv trace-agent.benchmarks --output="$ARTIFACTS_DIR/main_bench.txt" --bench="BenchmarkAgentTraceProcessing$"
+bench_loop_x10 () {
+  for i in {1..10}; do
+    inv trace-agent.benchmarks --output="/tmp/$1" --bench="BenchmarkAgentTraceProcessing$"
+    cat "/tmp/$1" >> "$ARTIFACTS_DIR/$1"
+  done
+}
+
+bench_loop_x10 "pr_bench.txt"
+git checkout main && bench_loop_x10 "main_bench.txt"
+
 git checkout "${CI_COMMIT_REF_NAME}" # (Only needed while these changes aren't merged to main)

--- a/test/benchmarks/apm_scripts/run-benchmarks.sh
+++ b/test/benchmarks/apm_scripts/run-benchmarks.sh
@@ -4,7 +4,7 @@ set -e
 
 bench_loop_x10 () {
   for i in {1..10}; do
-    inv trace-agent.benchmarks -count 1 -benchtime 2s --output="/tmp/$1" --bench="BenchmarkAgentTraceProcessing$"
+    inv trace-agent.benchmarks --count=1 --benchtime=2s --output="/tmp/$1" --bench="BenchmarkAgentTraceProcessing$"
     cat "/tmp/$1" >> "$ARTIFACTS_DIR/$1"
   done
 }

--- a/test/benchmarks/apm_scripts/run-benchmarks.sh
+++ b/test/benchmarks/apm_scripts/run-benchmarks.sh
@@ -4,7 +4,7 @@ set -e
 
 bench_loop_x10 () {
   for i in {1..10}; do
-    inv trace-agent.benchmarks --count=1 --benchtime=2s --output="/tmp/$1" --bench="BenchmarkAgentTraceProcessing$"
+    inv trace-agent.benchmarks --output="/tmp/$1" --bench="BenchmarkAgentTraceProcessing$"
     cat "/tmp/$1" >> "$ARTIFACTS_DIR/$1"
   done
 }

--- a/test/benchmarks/apm_scripts/upload-results-to-s3.sh
+++ b/test/benchmarks/apm_scripts/upload-results-to-s3.sh
@@ -5,4 +5,4 @@ BRANCH="${CI_COMMIT_REF_NAME:-$CI_COMMIT_REF_NAME}"
 
 S3_URL=s3://relenv-benchmarking-data/${PROJECT}/${BRANCH}/${CI_JOB_ID}/
 
-aws s3 cp --recursive --acl bucket-owner-full-control /artifacts/${CI_JOB_ID}/ $S3_URL
+aws s3 cp --recursive --acl bucket-owner-full-control $ARTIFACTS_DIR $S3_URL


### PR DESCRIPTION
### What does this PR do?

Restore microbenchmark runs for trace-agent in Benchmarking Platform.

### Motivation

We can now do more performance testing. More performance testing - more confidence that quality of solutions is adequate.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
