### PR TITLE
Bump `test-infra-definitions`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ variables:
   # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: f25383786a1e
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: aa1982fa029c
   DATADOG_AGENT_BUILDERS: v22276738-b36b132
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -22,7 +22,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20231205124032-f25383786a1e
+	github.com/DataDog/test-infra-definitions v0.0.0-20231207152810-aa1982fa029c
 	github.com/aws/aws-sdk-go-v2 v1.23.4
 	github.com/aws/aws-sdk-go-v2/config v1.25.10
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20231205124032-f25383786a1e h1:O5PW8LRQoEFQdh/VL7VIRMyAJrm7iFLaTKajKmeNGx8=
-github.com/DataDog/test-infra-definitions v0.0.0-20231205124032-f25383786a1e/go.mod h1:UC141BOfnKPiHRjlEJQf9TnkNkhFO/LPas1MrjEn1FI=
+github.com/DataDog/test-infra-definitions v0.0.0-20231207152810-aa1982fa029c h1:g04BK2rjdooSt5AXypkUvG/kjg0sA2/FXC9nsoc00IU=
+github.com/DataDog/test-infra-definitions v0.0.0-20231207152810-aa1982fa029c/go.mod h1:UC141BOfnKPiHRjlEJQf9TnkNkhFO/LPas1MrjEn1FI=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -278,7 +278,7 @@ func (suite *ecsSuite) TestRedis() {
 				`^task_name:.*-redis-ec2$`,
 				`^task_version:[[:digit:]]+$`,
 			},
-			Message: `oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo`,
+			Message: `Accepted`,
 		},
 	})
 }

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -428,7 +428,7 @@ func (suite *k8sSuite) TestRedis() {
 				`^pod_phase:running$`,
 				`^short_image:redis$`,
 			},
-			Message: `oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo`,
+			Message: `Accepted`,
 		},
 	})
 


### PR DESCRIPTION
### What does this PR do?

* Bump `test-infra-definitions`
  * DataDog/test-infra-definitions#504 should fix all the `Test*Suite/TestCPU/*` tests.
* Assert redis logs that are produced at each new incoming connection instead of logs that are produced only once at startup. It should fix all the `Test*Suite/TestRedis/log___redis{}` tests when they are run late and that the fake intake has already cleaned the logs of the startup of the redis pod. This needs
  * DataDog/test-infra-definitions#495 for K8s
  * DataDog/test-infra-definitions#505 for ECS

### Motivation

Try to fix some `containers` new-e2e tests.

### Additional Notes

Changes: https://github.com/DataDog/test-infra-definitions/compare/f25383786a1e...aa1982fa029c

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
