### PR TITLE
[CI] Disable Slapr while we can't get only required reviewers

### DIFF
--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -1,31 +1,33 @@
----
-name: Slack emoji PR updates
-on:
-  pull_request_review:
-    types: [submitted]
-  pull_request:
-    types: [closed]
 
-jobs:
-  run_slapr_datadog_agent:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        channel_variables:
-          - SLACK_AGENT_PLATFORM_REVIEWS_ID
-          - SLACK_OPENTELEMETRY_ID
-          - SLACK_AGENT_METRICS_LOGS_ID
-          - SLACK_CONTAINER_INTEGRATIONS_ID
-          - SLACK_EBPF_PLATFORM_ID
-    steps:
-      - uses: DataDog/slapr@master
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          SLACK_CHANNEL_ID: "${{ secrets[matrix.channel_variables] }}"
-          SLACK_API_TOKEN: "${{ secrets.SLACK_API_TOKEN }}"
-          SLAPR_BOT_USER_ID: "${{ secrets.SLAPR_BOT_USER_ID }}"
-          SLAPR_EMOJI_REVIEW_STARTED: "review_started"
-          SLAPR_EMOJI_APPROVED: "gh-approved"
-          SLAPR_EMOJI_CHANGES_REQUESTED: "request-changes"
-          SLAPR_EMOJI_MERGED: "merged"
-          SLAPR_EMOJI_CLOSED: "closed"
+# Disable Slapr until https://github.com/DataDog/slapr/issues/45 gets fixed.
+# ---
+# name: Slack emoji PR updates
+# on:
+#   pull_request_review:
+#     types: [submitted]
+#   pull_request:
+#     types: [closed]
+
+# jobs:
+#   run_slapr_datadog_agent:
+#     runs-on: ubuntu-latest
+#     strategy:
+#       matrix:
+#         channel_variables:
+#           - SLACK_AGENT_PLATFORM_REVIEWS_ID
+#           - SLACK_OPENTELEMETRY_ID
+#           - SLACK_AGENT_METRICS_LOGS_ID
+#           - SLACK_CONTAINER_INTEGRATIONS_ID
+#           - SLACK_EBPF_PLATFORM_ID
+#     steps:
+#       - uses: DataDog/slapr@master
+#         env:
+#           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+#           SLACK_CHANNEL_ID: "${{ secrets[matrix.channel_variables] }}"
+#           SLACK_API_TOKEN: "${{ secrets.SLACK_API_TOKEN }}"
+#           SLAPR_BOT_USER_ID: "${{ secrets.SLAPR_BOT_USER_ID }}"
+#           SLAPR_EMOJI_REVIEW_STARTED: "review_started"
+#           SLAPR_EMOJI_APPROVED: "gh-approved"
+#           SLAPR_EMOJI_CHANGES_REQUESTED: "request-changes"
+#           SLAPR_EMOJI_MERGED: "merged"
+#           SLAPR_EMOJI_CLOSED: "closed"

--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -1,4 +1,3 @@
-
 # Disable Slapr until https://github.com/DataDog/slapr/issues/45 gets fixed.
 # ---
 # name: Slack emoji PR updates
@@ -7,7 +6,7 @@
 #     types: [submitted]
 #   pull_request:
 #     types: [closed]
-
+#
 # jobs:
 #   run_slapr_datadog_agent:
 #     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR disables Slapr.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

It decreases our productivity because of https://github.com/DataDog/slapr/issues/45.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
