### PR TITLE
speedup junit upload job

### DIFF
--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -78,9 +78,9 @@ def split_junitxml(xml_path, codeowners, output_dir):
     return list(output_xmls), flavor
 
 
-def upload_junitxmls(output_dir, owners, flavor, xmlfile_name, process_env, additional_tags=None):
+def create_upload_junitxmls_processes(output_dir, owners, flavor, xmlfile_name, process_env, additional_tags=None):
     """
-    Upload all per-team split JUnit XMLs from given directory.
+    Spawn process to upload all per-team split JUnit XMLs from given directory.
     """
     processes = []
 
@@ -113,10 +113,7 @@ def upload_junitxmls(output_dir, owners, flavor, xmlfile_name, process_env, addi
             args.extend(additional_tags)
         args.append(junit_file_path)
         processes.append(subprocess.Popen(DATADOG_CI_COMMAND + args, bufsize=-1, env=process_env))
-    for process in processes:
-        exit_code = process.wait()
-        if exit_code != 0:
-            raise subprocess.CalledProcessError(exit_code, DATADOG_CI_COMMAND)
+    return processes
 
 
 def junit_upload_from_tgz(junit_tgz, codeowners_path=".github/CODEOWNERS"):
@@ -150,14 +147,32 @@ def junit_upload_from_tgz(junit_tgz, codeowners_path=".github/CODEOWNERS"):
         # for each unpacked xml file, split it and submit all parts
         # NOTE: recursive=True is necessary for "**" to unpack into 0-n dirs, not just 1
         xmls = 0
+        processes = []
+        tempdirs = []
         for xmlfile in glob.glob(f"{unpack_dir}/**/*.xml", recursive=True):
             if not os.path.isfile(xmlfile):
                 print(f"[WARN] Matched folder named {xmlfile}")
                 continue
             xmls += 1
-            with tempfile.TemporaryDirectory() as output_dir:
-                written_owners, flavor = split_junitxml(xmlfile, codeowners, output_dir)
-                upload_junitxmls(output_dir, written_owners, flavor, xmlfile.split("/")[-1], process_env, tags)
+            output_dir = tempfile.TemporaryDirectory()
+            written_owners, flavor = split_junitxml(xmlfile, codeowners, output_dir.name)
+            processes.extend(
+                create_upload_junitxmls_processes(
+                    output_dir.name, written_owners, flavor, xmlfile.split("/")[-1], process_env, tags
+                )
+            )
+            tempdirs.append(output_dir)
+
+        # wait for the processes created to finish
+        for process in processes:
+            exit_code = process.wait()
+            if exit_code != 0:
+                raise subprocess.CalledProcessError(exit_code, DATADOG_CI_COMMAND)
+
+        # ensure the temporary directories created for each xml files are cleaned up
+        for dir in tempdirs:
+            dir.cleanup()
+
         xmlcounts[junit_tgz] = xmls
 
     empty_tgzs = []

--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -164,14 +164,15 @@ def junit_upload_from_tgz(junit_tgz, codeowners_path=".github/CODEOWNERS"):
             tempdirs.append(output_dir)
 
         # wait for the processes created to finish
-        for process in processes:
-            exit_code = process.wait()
-            if exit_code != 0:
-                raise subprocess.CalledProcessError(exit_code, DATADOG_CI_COMMAND)
-
-        # ensure the temporary directories created for each xml files are cleaned up
-        for dir in tempdirs:
-            dir.cleanup()
+        try:
+            for process in processes:
+                exit_code = process.wait()
+                if exit_code != 0:
+                    raise subprocess.CalledProcessError(exit_code, DATADOG_CI_COMMAND)
+        finally:
+            # ensure the temporary directories created for each xml files are cleaned up
+            for dir in tempdirs:
+                dir.cleanup()
 
         xmlcounts[junit_tgz] = xmls
 


### PR DESCRIPTION
### What does this PR do?

The current junit upload jobs basically does:
```
for each tgz file from artifacts of previous jobs:
  for each xml file from this tgz: (a dozen of files):
     for each codeowner group from this xml file (1 or 2 each):
        spawn a process uploading the sub-xml file
     wait all processes from this one xml file
```

this PR moves to:
```
for each tgz file from artifacts of previous jobs:
  for each xml file from this tgz: (a dozen of files):
     for each codeowner group from this xml file (1 or 2 each):
        spawn a process uploading the sub-xml file
  wait all processes from this one tgz file
```
meaning that we spawn many more `datadog-ci` workers in parallel, speeding up the job duration by a lot.

This has a big effect because in regular pipelines we spawn more than 500 `datadog-ci` sub-processes.

This is a pretty "minimal" solution. We could be more involved and rework this whole algorithm and try to coalesce sub-xml files with the same tags (service, codeowners, etc) and pass it as a group to `datadog-ci` -> something to think about for a future improvement.

Perf benchmark:
- before: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/384951501 (p50 = 15min)
- after: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/385037801 (6min, not enough data to compute a median obviously)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
