### PR TITLE
[SEC-11864] system-probe: skip eBPF setup/cleanup when eBPF isn't required

### DIFF
--- a/cmd/system-probe/api/module/common.go
+++ b/cmd/system-probe/api/module/common.go
@@ -10,21 +10,11 @@ import (
 	"errors"
 
 	"google.golang.org/grpc"
-
-	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
 )
 
 // ErrNotEnabled is a special error type that should be returned by a Factory
 // when the associated Module is not enabled.
 var ErrNotEnabled = errors.New("module is not enabled")
-
-// Factory encapsulates the initialization of a Module
-type Factory struct {
-	Name             config.ModuleName
-	ConfigNamespaces []string
-	Fn               func(cfg *config.Config) (Module, error)
-	NeedsEBPF        func() bool
-}
 
 // Module defines the common API implemented by every System Probe Module
 type Module interface {

--- a/cmd/system-probe/api/module/common.go
+++ b/cmd/system-probe/api/module/common.go
@@ -23,6 +23,7 @@ type Factory struct {
 	Name             config.ModuleName
 	ConfigNamespaces []string
 	Fn               func(cfg *config.Config) (Module, error)
+	NeedsEBPF        func() bool
 }
 
 // Module defines the common API implemented by every System Probe Module

--- a/cmd/system-probe/api/module/factory_linux.go
+++ b/cmd/system-probe/api/module/factory_linux.go
@@ -3,16 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux_bpf && !windows
+//go:build linux
 
 package module
 
 import "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 
-func preRegister(_ *config.Config, _ []Factory) error {
-	return nil
-}
-
-func postRegister(_ *config.Config, _ []Factory) error {
-	return nil
+// Factory encapsulates the initialization of a Module
+type Factory struct {
+	Name             config.ModuleName
+	ConfigNamespaces []string
+	Fn               func(cfg *config.Config) (Module, error)
+	NeedsEBPF        func() bool
 }

--- a/cmd/system-probe/api/module/factory_others.go
+++ b/cmd/system-probe/api/module/factory_others.go
@@ -3,16 +3,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux_bpf && !windows
+//go:build !linux
 
 package module
 
 import "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 
-func preRegister(_ *config.Config, _ []Factory) error {
-	return nil
-}
-
-func postRegister(_ *config.Config, _ []Factory) error {
-	return nil
+// Factory encapsulates the initialization of a Module
+type Factory struct {
+	Name             config.ModuleName
+	ConfigNamespaces []string
+	Fn               func(cfg *config.Config) (Module, error)
 }

--- a/cmd/system-probe/api/module/loader.go
+++ b/cmd/system-probe/api/module/loader.go
@@ -65,20 +65,15 @@ func withModule(name config.ModuleName, fn func()) {
 // * Register the gRPC server;
 func Register(cfg *config.Config, httpMux *mux.Router, grpcServer *grpc.Server, factories []Factory) error {
 	var enabledModulesFactories []Factory
-	isEBPFRequired := false
-
 	for _, factory := range factories {
 		if !cfg.ModuleIsEnabled(factory.Name) {
 			log.Infof("module %s disabled", factory.Name)
 			continue
 		}
 		enabledModulesFactories = append(enabledModulesFactories, factory)
-		if factory.NeedsEBPF() {
-			isEBPFRequired = true
-		}
 	}
 
-	if err := preRegister(cfg, isEBPFRequired); err != nil {
+	if err := preRegister(cfg, enabledModulesFactories); err != nil {
 		return fmt.Errorf("error in pre-register hook: %w", err)
 	}
 
@@ -124,7 +119,7 @@ func Register(cfg *config.Config, httpMux *mux.Router, grpcServer *grpc.Server, 
 		log.Infof("module %s started", factory.Name)
 	}
 
-	if err := postRegister(cfg, isEBPFRequired); err != nil {
+	if err := postRegister(cfg, enabledModulesFactories); err != nil {
 		return fmt.Errorf("error in post-register hook: %w", err)
 	}
 

--- a/cmd/system-probe/api/module/loader_linux.go
+++ b/cmd/system-probe/api/module/loader_linux.go
@@ -12,15 +12,24 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 )
 
-func preRegister(_ *config.Config, isEBPFRequired bool) error {
-	if isEBPFRequired {
+func isEBPFRequired(factories []Factory) bool {
+	for _, f := range factories {
+		if f.NeedsEBPF() {
+			return true
+		}
+	}
+	return false
+}
+
+func preRegister(_ *config.Config, moduleFactories []Factory) error {
+	if isEBPFRequired(moduleFactories) {
 		return ebpf.Setup(ebpf.NewConfig())
 	}
 	return nil
 }
 
-func postRegister(_ *config.Config, isEBPFRequired bool) error {
-	if isEBPFRequired {
+func postRegister(_ *config.Config, moduleFactories []Factory) error {
+	if isEBPFRequired(moduleFactories) {
 		ebpf.FlushBTF()
 	}
 	return nil

--- a/cmd/system-probe/api/module/loader_linux.go
+++ b/cmd/system-probe/api/module/loader_linux.go
@@ -12,11 +12,17 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 )
 
-func preRegister(_ *config.Config) error {
+func preRegister(cfg *config.Config) error {
+	if !cfg.RequiresEBPF() {
+		return nil
+	}
 	return ebpf.Setup(ebpf.NewConfig())
 }
 
-func postRegister(_ *config.Config) error {
+func postRegister(cfg *config.Config) error {
+	if !cfg.RequiresEBPF() {
+		return nil
+	}
 	ebpf.FlushBTF()
 	return nil
 }

--- a/cmd/system-probe/api/module/loader_linux.go
+++ b/cmd/system-probe/api/module/loader_linux.go
@@ -12,17 +12,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 )
 
-func preRegister(cfg *config.Config) error {
-	if !cfg.RequiresEBPF() {
-		return nil
+func preRegister(_ *config.Config, isEBPFRequired bool) error {
+	if isEBPFRequired {
+		return ebpf.Setup(ebpf.NewConfig())
 	}
-	return ebpf.Setup(ebpf.NewConfig())
+	return nil
 }
 
-func postRegister(cfg *config.Config) error {
-	if !cfg.RequiresEBPF() {
-		return nil
+func postRegister(_ *config.Config, isEBPFRequired bool) error {
+	if isEBPFRequired {
+		ebpf.FlushBTF()
 	}
-	ebpf.FlushBTF()
 	return nil
 }

--- a/cmd/system-probe/api/module/loader_unsupported.go
+++ b/cmd/system-probe/api/module/loader_unsupported.go
@@ -9,10 +9,10 @@ package module
 
 import "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 
-func preRegister(_ *config.Config) error {
+func preRegister(_ *config.Config, _ bool) error {
 	return nil
 }
 
-func postRegister(_ *config.Config) error {
+func postRegister(_ *config.Config, _ bool) error {
 	return nil
 }

--- a/cmd/system-probe/api/module/loader_windows.go
+++ b/cmd/system-probe/api/module/loader_windows.go
@@ -13,14 +13,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func preRegister(cfg *config.Config, _ bool) error {
+func preRegister(cfg *config.Config, _ []Factory) error {
 	if err := driver.Init(cfg); err != nil {
 		return fmt.Errorf("failed to load driver subsystem: %v", err)
 	}
 	return nil
 }
 
-func postRegister(_ *config.Config, _ bool) error {
+func postRegister(_ *config.Config, _ []Factory) error {
 	if !driver.IsNeeded() {
 		// if running, shut it down
 		log.Debug("Shutting down the driver.  Upon successful initialization, it was not needed by the current configuration.")

--- a/cmd/system-probe/api/module/loader_windows.go
+++ b/cmd/system-probe/api/module/loader_windows.go
@@ -13,14 +13,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func preRegister(cfg *config.Config) error {
+func preRegister(cfg *config.Config, _ bool) error {
 	if err := driver.Init(cfg); err != nil {
 		return fmt.Errorf("failed to load driver subsystem: %v", err)
 	}
 	return nil
 }
 
-func postRegister(_ *config.Config) error {
+func postRegister(_ *config.Config, _ bool) error {
 	if !driver.IsNeeded() {
 		// if running, shut it down
 		log.Debug("Shutting down the driver.  Upon successful initialization, it was not needed by the current configuration.")

--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -37,6 +37,9 @@ var ComplianceModule = module.Factory{
 	Fn: func(cfg *config.Config) (module.Module, error) {
 		return &complianceModule{}, nil
 	},
+	NeedsEBPF: func() bool {
+		return false
+	},
 }
 
 type complianceModule struct {

--- a/cmd/system-probe/modules/crashdetect_windows.go
+++ b/cmd/system-probe/modules/crashdetect_windows.go
@@ -33,6 +33,9 @@ var WinCrashProbe = module.Factory{
 			WinCrashProbe: cp,
 		}, nil
 	},
+	NeedsEBPF: func() bool {
+		return false
+	}
 }
 
 var _ module.Module = &winCrashDetectModule{}

--- a/cmd/system-probe/modules/crashdetect_windows.go
+++ b/cmd/system-probe/modules/crashdetect_windows.go
@@ -11,12 +11,13 @@ import (
 	"fmt"
 	"net/http"
 
+	"google.golang.org/grpc"
+
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/wincrashdetect/probe"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"google.golang.org/grpc"
 )
 
 // WinCrashProbe Factory
@@ -33,9 +34,6 @@ var WinCrashProbe = module.Factory{
 			WinCrashProbe: cp,
 		}, nil
 	},
-	NeedsEBPF: func() bool {
-		return false
-	}
 }
 
 var _ module.Module = &winCrashDetectModule{}

--- a/cmd/system-probe/modules/dynamic_instrumentation.go
+++ b/cmd/system-probe/modules/dynamic_instrumentation.go
@@ -33,4 +33,7 @@ var DynamicInstrumentation = module.Factory{
 
 		return m, nil
 	},
+	NeedsEBPF: func() bool {
+		return true
+	},
 }

--- a/cmd/system-probe/modules/ebpf.go
+++ b/cmd/system-probe/modules/ebpf.go
@@ -38,6 +38,9 @@ var EBPFProbe = module.Factory{
 			lastCheck: atomic.NewInt64(0),
 		}, nil
 	},
+	NeedsEBPF: func() bool {
+		return true
+	},
 }
 
 var _ module.Module = &ebpfModule{}

--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -8,11 +8,8 @@
 package modules
 
 import (
-	"runtime"
-
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	emconfig "github.com/DataDog/datadog-agent/pkg/eventmonitor/config"
 	"github.com/DataDog/datadog-agent/pkg/network/events"
@@ -22,65 +19,59 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// EventMonitor - Event monitor Factory
-var EventMonitor = module.Factory{
-	Name:             config.EventMonitorModule,
-	ConfigNamespaces: []string{"event_monitoring_config", "runtime_security_config"},
-	Fn: func(sysProbeConfig *config.Config) (module.Module, error) {
-		emconfig := emconfig.NewConfig(sysProbeConfig)
+var eventMonitorModuleConfigNamespaces = []string{"event_monitoring_config", "runtime_security_config"}
 
-		secconfig, err := secconfig.NewConfig()
+func createEventMonitorModule(sysProbeConfig *config.Config) (module.Module, error) {
+	emconfig := emconfig.NewConfig(sysProbeConfig)
+
+	secconfig, err := secconfig.NewConfig()
+	if err != nil {
+		log.Errorf("invalid probe configuration: %v", err)
+		return nil, module.ErrNotEnabled
+	}
+
+	opts := eventmonitor.Opts{}
+	secmoduleOpts := secmodule.Opts{}
+
+	// adapt options
+	if secconfig.RuntimeSecurity.IsRuntimeEnabled() {
+		secmodule.UpdateEventMonitorOpts(&opts, secconfig)
+	} else {
+		secmodule.DisableRuntimeSecurity(secconfig)
+	}
+
+	evm, err := eventmonitor.NewEventMonitor(emconfig, secconfig, opts)
+	if err != nil {
+		log.Errorf("error initializing event monitoring module: %v", err)
+		return nil, module.ErrNotEnabled
+	}
+
+	if secconfig.RuntimeSecurity.IsRuntimeEnabled() {
+		cws, err := secmodule.NewCWSConsumer(evm, secconfig.RuntimeSecurity, secmoduleOpts)
 		if err != nil {
-			log.Errorf("invalid probe configuration: %v", err)
-			return nil, module.ErrNotEnabled
+			return nil, err
 		}
+		evm.RegisterEventConsumer(cws)
+		log.Info("event monitoring cws consumer initialized")
+	}
 
-		opts := eventmonitor.Opts{}
-		secmoduleOpts := secmodule.Opts{}
-
-		// adapt options
-		if secconfig.RuntimeSecurity.IsRuntimeEnabled() {
-			secmodule.UpdateEventMonitorOpts(&opts, secconfig)
-		} else {
-			secmodule.DisableRuntimeSecurity(secconfig)
-		}
-
-		evm, err := eventmonitor.NewEventMonitor(emconfig, secconfig, opts)
+	if emconfig.NetworkConsumerEnabled {
+		network, err := events.NewNetworkConsumer(evm)
 		if err != nil {
-			log.Errorf("error initializing event monitoring module: %v", err)
-			return nil, module.ErrNotEnabled
+			return nil, err
 		}
+		evm.RegisterEventConsumer(network)
+		log.Info("event monitoring network consumer initialized")
+	}
 
-		if secconfig.RuntimeSecurity.IsRuntimeEnabled() {
-			cws, err := secmodule.NewCWSConsumer(evm, secconfig.RuntimeSecurity, secmoduleOpts)
-			if err != nil {
-				return nil, err
-			}
-			evm.RegisterEventConsumer(cws)
-			log.Info("event monitoring cws consumer initialized")
+	if emconfig.ProcessConsumerEnabled {
+		process, err := procconsumer.NewProcessConsumer(evm)
+		if err != nil {
+			return nil, err
 		}
+		evm.RegisterEventConsumer(process)
+		log.Info("event monitoring process-agent consumer initialized")
+	}
 
-		if emconfig.NetworkConsumerEnabled {
-			network, err := events.NewNetworkConsumer(evm)
-			if err != nil {
-				return nil, err
-			}
-			evm.RegisterEventConsumer(network)
-			log.Info("event monitoring network consumer initialized")
-		}
-
-		if emconfig.ProcessConsumerEnabled {
-			process, err := procconsumer.NewProcessConsumer(evm)
-			if err != nil {
-				return nil, err
-			}
-			evm.RegisterEventConsumer(process)
-			log.Info("event monitoring process-agent consumer initialized")
-		}
-
-		return evm, err
-	},
-	NeedsEBPF: func() bool {
-		return runtime.GOOS != "windows" && !coreconfig.SystemProbe.GetBool("runtime_security_config.ebpfless.enabled")
-	},
+	return evm, err
 }

--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -8,8 +8,11 @@
 package modules
 
 import (
+	"runtime"
+
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	emconfig "github.com/DataDog/datadog-agent/pkg/eventmonitor/config"
 	"github.com/DataDog/datadog-agent/pkg/network/events"
@@ -76,5 +79,8 @@ var EventMonitor = module.Factory{
 		}
 
 		return evm, err
+	},
+	NeedsEBPF: func() bool {
+		return runtime.GOOS != "windows" && !coreconfig.SystemProbe.GetBool("runtime_security_config.ebpfless.enabled")
 	},
 }

--- a/cmd/system-probe/modules/eventmonitor_linux.go
+++ b/cmd/system-probe/modules/eventmonitor_linux.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package modules
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// EventMonitor - Event monitor Factory
+var EventMonitor = module.Factory{
+	Name:             config.EventMonitorModule,
+	ConfigNamespaces: eventMonitorModuleConfigNamespaces,
+	Fn:               createEventMonitorModule,
+	NeedsEBPF: func() bool {
+		return !coreconfig.SystemProbe.GetBool("runtime_security_config.ebpfless.enabled")
+	},
+}

--- a/cmd/system-probe/modules/eventmonitor_windows.go
+++ b/cmd/system-probe/modules/eventmonitor_windows.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package modules
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+)
+
+// EventMonitor - Event monitor Factory
+var EventMonitor = module.Factory{
+	Name:             config.EventMonitorModule,
+	ConfigNamespaces: eventMonitorModuleConfigNamespaces,
+	Fn:               createEventMonitorModule,
+}

--- a/cmd/system-probe/modules/language_detection.go
+++ b/cmd/system-probe/modules/language_detection.go
@@ -32,6 +32,9 @@ var LanguageDetectionModule = module.Factory{
 			languageDetector: privileged.NewLanguageDetector(),
 		}, nil
 	},
+	NeedsEBPF: func() bool {
+		return false
+	},
 }
 
 type languageDetectionModule struct {

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -41,40 +41,34 @@ var ErrSysprobeUnsupported = errors.New("system-probe unsupported")
 const inactivityLogDuration = 10 * time.Minute
 const inactivityRestartDuration = 20 * time.Minute
 
-// NetworkTracer is a factory for NPM's tracer
-var NetworkTracer = module.Factory{
-	Name:             config.NetworkTracerModule,
-	ConfigNamespaces: []string{"network_config", "service_monitoring_config", "data_streams_config"},
-	Fn: func(cfg *config.Config) (module.Module, error) {
-		ncfg := networkconfig.New()
+var networkTracerModuleConfigNamespaces = []string{"network_config", "service_monitoring_config", "data_streams_config"}
 
-		// Checking whether the current OS + kernel version is supported by the tracer
-		if supported, err := tracer.IsTracerSupportedByOS(ncfg.ExcludedBPFLinuxVersions); !supported {
-			return nil, fmt.Errorf("%w: %s", ErrSysprobeUnsupported, err)
-		}
+func createNetworkTracerModule(cfg *config.Config) (module.Module, error) {
+	ncfg := networkconfig.New()
 
-		if ncfg.NPMEnabled {
-			log.Info("enabling network performance monitoring (NPM)")
-		}
-		if ncfg.ServiceMonitoringEnabled {
-			log.Info("enabling universal service monitoring (USM)")
-		}
-		if ncfg.DataStreamsEnabled {
-			log.Info("enabling data streams monitoring (DSM)")
-		}
+	// Checking whether the current OS + kernel version is supported by the tracer
+	if supported, err := tracer.IsTracerSupportedByOS(ncfg.ExcludedBPFLinuxVersions); !supported {
+		return nil, fmt.Errorf("%w: %s", ErrSysprobeUnsupported, err)
+	}
 
-		t, err := tracer.NewTracer(ncfg)
+	if ncfg.NPMEnabled {
+		log.Info("enabling network performance monitoring (NPM)")
+	}
+	if ncfg.ServiceMonitoringEnabled {
+		log.Info("enabling universal service monitoring (USM)")
+	}
+	if ncfg.DataStreamsEnabled {
+		log.Info("enabling data streams monitoring (DSM)")
+	}
 
-		done := make(chan struct{})
-		if err == nil {
-			startTelemetryReporter(cfg, done)
-		}
+	t, err := tracer.NewTracer(ncfg)
 
-		return &networkTracer{tracer: t, done: done}, err
-	},
-	NeedsEBPF: func() bool {
-		return runtime.GOOS != "windows"
-	},
+	done := make(chan struct{})
+	if err == nil {
+		startTelemetryReporter(cfg, done)
+	}
+
+	return &networkTracer{tracer: t, done: done}, err
 }
 
 var _ module.Module = &networkTracer{}

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -72,6 +72,9 @@ var NetworkTracer = module.Factory{
 
 		return &networkTracer{tracer: t, done: done}, err
 	},
+	NeedsEBPF: func() bool {
+		return runtime.GOOS != "windows"
+	},
 }
 
 var _ module.Module = &networkTracer{}

--- a/cmd/system-probe/modules/network_tracer_linux.go
+++ b/cmd/system-probe/modules/network_tracer_linux.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package modules
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+)
+
+// NetworkTracer is a factory for NPM's tracer
+var NetworkTracer = module.Factory{
+	Name:             config.NetworkTracerModule,
+	ConfigNamespaces: networkTracerModuleConfigNamespaces,
+	Fn:               createNetworkTracerModule,
+	NeedsEBPF: func() bool {
+		return true
+	},
+}

--- a/cmd/system-probe/modules/network_tracer_windows.go
+++ b/cmd/system-probe/modules/network_tracer_windows.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package modules
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+)
+
+// NetworkTracer is a factory for NPM's tracer
+var NetworkTracer = module.Factory{
+	Name:             config.NetworkTracerModule,
+	ConfigNamespaces: networkTracerModuleConfigNamespaces,
+	Fn:               createNetworkTracerModule,
+}

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -38,6 +38,9 @@ var OOMKillProbe = module.Factory{
 			lastCheck: atomic.NewInt64(0),
 		}, nil
 	},
+	NeedsEBPF: func() bool {
+		return true
+	},
 }
 
 var _ module.Module = &oomKillModule{}

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+
 	//nolint:revive // TODO(PROC) Fix revive linter
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/process/encoding"
@@ -44,6 +45,9 @@ var Process = module.Factory{
 			probe:     p,
 			lastCheck: atomic.NewInt64(0),
 		}, nil
+	},
+	NeedsEBPF: func() bool {
+		return false
 	},
 }
 

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -37,6 +37,9 @@ var TCPQueueLength = module.Factory{
 			lastCheck: atomic.NewInt64(0),
 		}, nil
 	},
+	NeedsEBPF: func() bool {
+		return true
+	},
 }
 
 var _ module.Module = &tcpQueueLengthModule{}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR skips the Linux eBPF setup/cleanup when no system-probe module requires using eBPF.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The event monitor/runtime security module implemented a new way to monitor syscalls that doesn't require eBPF.
Under this setup, running system-probe without the `CAP_SYS_RESOURCE` capability will make it fail to start even though eBPF isn't required.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes


<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
