### PR TITLE
invoke: system-probe: add test-debug task

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -218,6 +218,25 @@ def get_build_flags(
     return ldflags, gcflags, env
 
 
+def get_common_test_args(build_tags, failfast):
+    return {
+        "build_tags": ",".join(build_tags),
+        "failfast": "-failfast" if failfast else "",
+    }
+
+
+def set_runtime_comp_env(env):
+    env["DD_ENABLE_RUNTIME_COMPILER"] = "true"
+    env["DD_ALLOW_PRECOMPILED_FALLBACK"] = "false"
+    env["DD_ENABLE_CO_RE"] = "false"
+
+
+def set_co_re_env(env):
+    env["DD_ENABLE_CO_RE"] = "true"
+    env["DD_ALLOW_RUNTIME_COMPILED_FALLBACK"] = "false"
+    env["DD_ALLOW_PRECOMPILED_FALLBACK"] = "false"
+
+
 def get_payload_version():
     """
     Return the Agent payload version (`x.y.z`) found in the go.mod file.

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -678,11 +678,11 @@ def test(
 def test_debug(
     ctx,
     package,
+    run,
     bundle_ebpf=False,
     runtime_compiled=False,
     co_re=False,
     skip_object_files=False,
-    run=None,
     windows=is_windows,
     failfast=False,
     kernel_release=None,
@@ -690,8 +690,6 @@ def test_debug(
     """
     Run delve on a specific system-probe test.
     """
-    if not run:
-        raise Exit(code=1, message="test name must be specified with the --run option")
 
     if os.getenv("GOPATH") is None:
         raise Exit(

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -636,12 +636,10 @@ def test(
             build_tags.append(BUNDLE_TAG)
 
     args = get_common_test_args(build_tags, failfast)
-    args["output_params"] = (f"-c -o {output_path}" if output_path else "",)
-    args["run"] = (f"-run {run}" if run else "",)
-    args["go"] = ("go",)
-    args["sudo"] = (
-        "sudo -E " if not windows and not output_path and not is_root() else "",
-    )
+    args["output_params"] = f"-c -o {output_path}" if output_path else ""
+    args["run"] = f"-run {run}" if run else ""
+    args["go"] = "go"
+    args["sudo"] = "sudo -E " if not windows and not output_path and not is_root() else ""
 
     _, _, env = get_build_flags(ctx)
     env["DD_SYSTEM_PROBE_BPF_DIR"] = EMBEDDED_SHARE_DIR

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -681,20 +681,17 @@ def test_debug(
     bundle_ebpf=False,
     runtime_compiled=False,
     co_re=False,
-    skip_linters=False,
     skip_object_files=False,
     run=None,
     windows=is_windows,
     failfast=False,
     kernel_release=None,
-    timeout=None,
 ):
     """
     Run delve on a specific system-probe test.
     """
     if not run:
-        raise Exit(
-            code=1, message="test name must be specified with the --run option")
+        raise Exit(code=1, message="test name must be specified with the --run option")
 
     if os.getenv("GOPATH") is None:
         raise Exit(
@@ -702,10 +699,6 @@ def test_debug(
             message="GOPATH is not set, if you are running tests with sudo, you may need to use the -E option to "
             "preserve your environment",
         )
-
-    if not skip_linters and not windows:
-        clang_format(ctx)
-        clang_tidy(ctx)
 
     if not skip_object_files:
         build_object_files(
@@ -741,9 +734,7 @@ def test_debug(
         env["DD_ALLOW_PRECOMPILED_FALLBACK"] = "false"
 
     args["dir"] = package
-    testto = timeout if timeout else get_test_timeout(package)
-    args["timeout"] = f"-timeout {testto}" if testto else ""
-    cmd = '{sudo}{dlv} test {dir} --build-flags="-mod=mod -v {failfast} {timeout} -tags={build_tags}" -- -test.run {run}'
+    cmd = '{sudo}{dlv} test {dir} --build-flags="-mod=mod -v {failfast} -tags={build_tags}" -- -test.run {run}'
     ctx.run(cmd.format(**args), env=env, pty=True, warn=True)
 
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -24,10 +24,10 @@ from .libs.common.utils import (
     environ,
     get_build_flags,
     get_common_test_args,
-    set_runtime_comp_env,
-    set_co_re_env,
     get_gobin,
     get_version_numeric_only,
+    set_co_re_env,
+    set_runtime_comp_env,
 )
 from .libs.ninja_syntax import NinjaWriter
 from .windows_resources import MESSAGESTRINGS_MC_PATH, arch_to_windres_target


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds the `system-probe.test-debug` task. Its goal is to help with running `delve` on a specific test, and is made to be called with the same arguments as the `system-probe.test` task, so that one can simply add the `-debug` part to re-run the test under `delve`. 

One thing to note is that the command **requires** the `--run` option to be provided. This is part of the reason being it being a separate task, and not an additional flag. The task works a bit differently too, as it won't loop through packages to test, won't call the go binary (and the arguments to delve are not the same as the `go test` command, nor report the failed packages at the end.

Usage example:
```shell
# Standard test run
 inv -e system-probe.test --skip-linters -p ./pkg/network/protocols/grpc --run 'TestGRPCScenarios'

# Debugging the same test - just add debug to the command name
 inv -e system-probe.test-debug --skip-linters -p ./pkg/network/protocols/grpc --run 'TestGRPCScenarios'
```


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
