### PR TITLE
[CI/Tooling] Add the 'skipped' header on the same module line

### DIFF
--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -133,6 +133,7 @@ class GoModule:
         return f"{self.import_path}@{self.__version(agent_version)}"
 
 
+# Default Modules on which will run tests / linters. When `condition=lambda: False` is defined for a module, it will be skipped.
 DEFAULT_MODULES = {
     ".": GoModule(
         ".",

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -173,10 +173,9 @@ def test_core(
         if not skip_module_class:
             module_result = module_class(path=module.full_path())
         if not headless_mode:
-            print(f"----- Module '{module.full_path()}'")
+            skipped_header = "[Skipped]" if not module.condition() else ""
+            print(f"----- {skipped_header} Module '{module.full_path()}'")
         if not module.condition():
-            if not headless_mode:
-                print("----- Skipped")
             continue
 
         command(modules_results, module, module_result)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds the 'skipped' header on the same module line.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Before the `—-- Skipped` line was printed below the skipped modules which can be misleading for the devs as they don’t know which module is skipped (the one above or below). Example
```
----- Module '/Users/alexandre.menasria/datadog-agent/test/e2e/containers/otlp_sender'
----- Skipped
----- Module '/Users/alexandre.menasria/datadog-agent/test/new-e2e'
[WARN] Agent version cache file hasn't been loaded !
--- Setting rtloader paths to lib:/Users/alexandre.menasria/datadog-agent/dev/lib | header:/Users/alexandre.menasria/datadog-agent/dev/include | common headers:
running golangci on .
```

Is `/test/e2e/containers/otlp_sender` or `/test/new-e2e` the one to be skipped ? This can be confusing for people unused to this.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
