### PR TITLE
(rc) make the agent install path configurable

### DIFF
--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -88,7 +88,7 @@ agent_deb-x64-a7-fleet:
     DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_amd64.deb'
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
-    - export INSTALL_DIR=/opt/datadog-agent/v7.test
+    - export INSTALL_DIR=/opt/datadog/agents/$RELEASE_VERSION_7
 
 agent_deb-arm64-a6:
   extends: .agent_build_common_deb

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -72,6 +72,24 @@ agent_deb-x64-a7:
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
+agent_deb-x64-a7-fleet:
+  extends: .agent_build_common_deb
+  rules:
+    !reference [.on_a7]
+  stage: package_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
+  variables:
+    AGENT_MAJOR_VERSION: 7
+    PYTHON_RUNTIMES: '3'
+    PACKAGE_ARCH: amd64
+    DESTINATION_DEB: 'datadog-agent_7_amd64.deb'
+    DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_amd64.deb'
+  before_script:
+    - export RELEASE_VERSION=$RELEASE_VERSION_7
+    - export INSTALL_DIR=/opt/datadog-agent/v7.test
+
 agent_deb-arm64-a6:
   extends: .agent_build_common_deb
   rules:

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -72,7 +72,7 @@ agent_deb-x64-a7:
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
-agent_deb-x64-a7-fleet:
+agent_deb-x64-a7-auto:
   extends: .agent_build_common_deb
   rules:
     !reference [.on_a7]

--- a/omnibus/config/projects/agent-binaries.rb
+++ b/omnibus/config/projects/agent-binaries.rb
@@ -12,17 +12,15 @@ license_file "../LICENSE"
 
 homepage 'http://www.datadoghq.com'
 
-INSTALL_DIR = ENV["INSTALL_DIR"] || '/opt/datadog-agent'
-
 if ohai['platform'] == "windows"
   # Note: this is not the final install dir, not even the default one, just a convenient
   # spaceless dir in which the agent will be built.
   # Omnibus doesn't quote the Git commands it launches unfortunately, which makes it impossible
   # to put a space here...
-  install_dir "C:"+INSTALL_DIR
+  install_dir "C:/opt/datadog-agent/"
   maintainer 'Datadog Inc.' # Windows doesn't want our e-mail address :(
 else
-  install_dir INSTALL_DIR
+  install_dir '/opt/datadog-agent'
   maintainer 'Datadog Packages <package@datadoghq.com>'
 end
 

--- a/omnibus/config/projects/agent-binaries.rb
+++ b/omnibus/config/projects/agent-binaries.rb
@@ -12,15 +12,17 @@ license_file "../LICENSE"
 
 homepage 'http://www.datadoghq.com'
 
+INSTALL_DIR = ENV["INSTALL_DIR"] || '/opt/datadog-agent'
+
 if ohai['platform'] == "windows"
   # Note: this is not the final install dir, not even the default one, just a convenient
   # spaceless dir in which the agent will be built.
   # Omnibus doesn't quote the Git commands it launches unfortunately, which makes it impossible
   # to put a space here...
-  install_dir "C:/opt/datadog-agent/"
+  install_dir "C:"+INSTALL_DIR
   maintainer 'Datadog Inc.' # Windows doesn't want our e-mail address :(
 else
-  install_dir '/opt/datadog-agent'
+  install_dir INSTALL_DIR
   maintainer 'Datadog Packages <package@datadoghq.com>'
 end
 

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -19,15 +19,15 @@ third_party_licenses "../LICENSE-3rdparty.csv"
 
 homepage 'http://www.datadoghq.com'
 
+INSTALL_DIR = ENV["INSTALL_DIR"] || '/opt/datadog-agent'
+
 if windows_target?
   # Note: this is the path used by Omnibus to build the agent, the final install
   # dir will be determined by the Windows installer. This path must not contain
   # spaces because Omnibus doesn't quote the Git commands it launches.
-  INSTALL_DIR = 'C:/opt/datadog-agent/'
+  INSTALL_DIR = 'C:'+INSTALL_DIR
   PYTHON_2_EMBEDDED_DIR = format('%s/embedded2', INSTALL_DIR)
   PYTHON_3_EMBEDDED_DIR = format('%s/embedded3', INSTALL_DIR)
-else
-  INSTALL_DIR = '/opt/datadog-agent'
 end
 
 install_dir INSTALL_DIR

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -19,15 +19,15 @@ third_party_licenses "../LICENSE-3rdparty.csv"
 
 homepage 'http://www.datadoghq.com'
 
-INSTALL_DIR = ENV["INSTALL_DIR"] || '/opt/datadog-agent'
-
 if windows_target?
   # Note: this is the path used by Omnibus to build the agent, the final install
   # dir will be determined by the Windows installer. This path must not contain
   # spaces because Omnibus doesn't quote the Git commands it launches.
-  INSTALL_DIR = 'C:'+INSTALL_DIR
+  INSTALL_DIR = 'C:/opt/datadog-agent/'
   PYTHON_2_EMBEDDED_DIR = format('%s/embedded2', INSTALL_DIR)
   PYTHON_3_EMBEDDED_DIR = format('%s/embedded3', INSTALL_DIR)
+else
+  INSTALL_DIR = ENV["INSTALL_DIR"] || '/opt/datadog-agent'
 end
 
 install_dir INSTALL_DIR


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Makes the omnibus install path configurable for the agent. This:
- Changes where the agent is installed
- Properly links ELF & SO with the correct paths

I also added a gitlab job that generates agent 7s with `/opt/datadog/agents/$RELEASE_VERSION` as the install dir.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Allows multiple runnable versions of the agent to be on disk on the same machine.


