### PR TITLE
Add a notification system to the config package/comp

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -441,7 +441,7 @@ func startAgent(
 	}
 
 	// init settings that can be changed at runtime
-	if err := initRuntimeSettings(serverDebug, invAgent); err != nil {
+	if err := initRuntimeSettings(serverDebug); err != nil {
 		log.Warnf("Can't initiliaze the runtime settings: %v", err)
 	}
 

--- a/cmd/agent/subcommands/run/settings.go
+++ b/cmd/agent/subcommands/run/settings.go
@@ -8,14 +8,13 @@ package run
 import (
 	"github.com/DataDog/datadog-agent/cmd/agent/subcommands/run/internal/settings"
 	dogstatsddebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 )
 
 // initRuntimeSettings builds the map of runtime settings configurable at runtime.
-func initRuntimeSettings(serverDebug dogstatsddebug.Component, invAgent inventoryagent.Component) error {
+func initRuntimeSettings(serverDebug dogstatsddebug.Component) error {
 	// Runtime-editable settings must be registered here to dynamically populate command-line information
-	if err := commonsettings.RegisterRuntimeSetting(commonsettings.NewLogLevelRuntimeSetting(invAgent)); err != nil {
+	if err := commonsettings.RegisterRuntimeSetting(commonsettings.NewLogLevelRuntimeSetting()); err != nil {
 		return err
 	}
 	if err := commonsettings.RegisterRuntimeSetting(commonsettings.NewRuntimeMutexProfileFraction()); err != nil {

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -419,7 +419,7 @@ func start(log log.Component, config config.Component, telemetry telemetry.Compo
 
 // initRuntimeSettings builds the map of runtime Cluster Agent settings configurable at runtime.
 func initRuntimeSettings() error {
-	if err := commonsettings.RegisterRuntimeSetting(commonsettings.NewLogLevelRuntimeSetting(nil)); err != nil {
+	if err := commonsettings.RegisterRuntimeSetting(commonsettings.NewLogLevelRuntimeSetting()); err != nil {
 		return err
 	}
 

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -308,7 +308,7 @@ func RunAgent(ctx context.Context, log log.Component, config config.Component, s
 }
 
 func initRuntimeSettings() error {
-	return settings.RegisterRuntimeSetting(settings.NewLogLevelRuntimeSetting(nil))
+	return settings.RegisterRuntimeSetting(settings.NewLogLevelRuntimeSetting())
 }
 
 // StopAgent stops the API server and clean up resources

--- a/comp/metadata/inventoryagent/component.go
+++ b/comp/metadata/inventoryagent/component.go
@@ -22,8 +22,6 @@ type Component interface {
 	GetAsJSON() ([]byte, error)
 	// Get returns a copy of the agent metadata. Useful to be incorporated in the status page.
 	Get() map[string]interface{}
-	// Refresh trigger a new payload to be send while still respecting the minimal interval between two updates.
-	Refresh()
 }
 
 // Module defines the fx options for this component.

--- a/comp/metadata/inventoryagent/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagent.go
@@ -95,6 +95,8 @@ func newInventoryAgentProvider(deps dependencies) provides {
 
 	if ia.Enabled {
 		ia.initData()
+		// We want to be notified when the configuration is updated
+		deps.Config.OnUpdate(func(_ string) { ia.Refresh() })
 	}
 
 	return provides{

--- a/comp/metadata/inventoryagent/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagent_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -231,4 +232,12 @@ func TestGet(t *testing.T) {
 func TestFlareProviderFilename(t *testing.T) {
 	ia := getTestInventoryPayload(t, nil)
 	assert.Equal(t, "agent.json", ia.FlareFileName)
+}
+
+func TestConfigRefresh(t *testing.T) {
+	ia := getTestInventoryPayload(t, nil)
+
+	assert.False(t, ia.ForceRefresh)
+	pkgconfig.Datadog.Set("inventories_max_interval", 10*time.Minute, pkgconfigmodel.SourceAgentRuntime)
+	assert.True(t, ia.ForceRefresh)
 }

--- a/comp/process/apiserver/apiserver.go
+++ b/comp/process/apiserver/apiserver.go
@@ -88,7 +88,7 @@ func newApiServer(deps dependencies) Component {
 func initRuntimeSettings(logger log.Component) {
 	// NOTE: Any settings you want to register should simply be added here
 	processRuntimeSettings := []settings.RuntimeSetting{
-		settings.NewLogLevelRuntimeSetting(nil),
+		settings.NewLogLevelRuntimeSetting(),
 		settings.NewRuntimeMutexProfileFraction(),
 		settings.NewRuntimeBlockProfileRate(),
 		settings.NewProfilingGoroutines(),

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -22,6 +22,11 @@ type Proxy struct {
 	NoProxy []string `mapstructure:"no_proxy"`
 }
 
+// NotificationReceiver represents the callback type to receive notifications each time the `Set` method is called. The
+// configuration will call each NotificationReceiver registered through the 'OnUpdate' method, therefore
+// 'NotificationReceiver' should not be blocking.
+type NotificationReceiver func(key string)
+
 // Reader is a subset of Config that only allows reading of configuration
 type Reader interface {
 	Get(key string) interface{}
@@ -77,6 +82,10 @@ type Reader interface {
 
 	// Object returns Reader to config (completes config.Component interface)
 	Object() Reader
+
+	// OnUpdate adds a callback to the list receivers to be called each time a value is change in the configuration
+	// by a call to the 'Set' method. The configuration will sequentially call each receiver.
+	OnUpdate(callback NotificationReceiver)
 }
 
 // Writer is a subset of Config that only allows writing the configuration

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -63,6 +63,8 @@ type safeConfig struct {
 	envPrefix      string
 	envKeyReplacer *strings.Replacer
 
+	notificationReceivers []NotificationReceiver
+
 	// Proxy settings
 	proxiesOnce sync.Once
 	proxies     *Proxy
@@ -70,6 +72,14 @@ type safeConfig struct {
 	// configEnvVars is the set of env vars that are consulted for
 	// configuration values.
 	configEnvVars map[string]struct{}
+}
+
+// OnUpdate adds a callback to the list receivers to be called each time a value is change in the configuration
+// by a call to the 'Set' method.
+func (c *safeConfig) OnUpdate(callback NotificationReceiver) {
+	c.Lock()
+	defer c.Unlock()
+	c.notificationReceivers = append(c.notificationReceivers, callback)
 }
 
 // Set wraps Viper for concurrent access
@@ -83,6 +93,11 @@ func (c *safeConfig) Set(key string, value interface{}, source Source) {
 	defer c.Unlock()
 	c.configSources[source].Set(key, value)
 	c.mergeViperInstances(key)
+
+	// notifying all receiver about the updated setting
+	for _, receiver := range c.notificationReceivers {
+		receiver(key)
+	}
 }
 
 // SetWithoutSource sets the given value using source Unknown

--- a/pkg/config/model/viper_test.go
+++ b/pkg/config/model/viper_test.go
@@ -262,3 +262,22 @@ foo: bar
 	assert.Equal(t, SourceFile, config.GetSource("foo"))
 	assert.Equal(t, map[string]interface{}{"foo": "bar"}, config.AllSourceSettingsWithoutDefault(SourceFile))
 }
+
+func TestNotification(t *testing.T) {
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+
+	updatedKeyCB1 := []string{}
+	updatedKeyCB2 := []string{}
+
+	config.OnUpdate(func(key string) { updatedKeyCB1 = append(updatedKeyCB1, key) })
+
+	config.Set("foo", "bar", SourceFile)
+	assert.Equal(t, []string{"foo"}, updatedKeyCB1)
+
+	config.OnUpdate(func(key string) { updatedKeyCB2 = append(updatedKeyCB2, key) })
+
+	config.Set("foo", "bar2", SourceFile)
+	config.Set("foo2", "bar2", SourceFile)
+	assert.Equal(t, []string{"foo", "foo", "foo2"}, updatedKeyCB1)
+	assert.Equal(t, []string{"foo", "foo2"}, updatedKeyCB2)
+}

--- a/pkg/config/settings/runtime_setting_log_level.go
+++ b/pkg/config/settings/runtime_setting_log_level.go
@@ -6,7 +6,6 @@
 package settings
 
 import (
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	pkgconfiglogs "github.com/DataDog/datadog-agent/pkg/config/logs"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -17,16 +16,12 @@ import (
 type LogLevelRuntimeSetting struct {
 	Config    config.ReaderWriter
 	ConfigKey string
-	// invAgent is a temporary dependency until the configuration is capable of sending it's own notification upon
-	// a value being set.
-	invAgent inventoryagent.Component
 }
 
 // NewLogLevelRuntimeSetting returns a new LogLevelRuntimeSetting
-func NewLogLevelRuntimeSetting(invAgent inventoryagent.Component) *LogLevelRuntimeSetting {
+func NewLogLevelRuntimeSetting() *LogLevelRuntimeSetting {
 	return &LogLevelRuntimeSetting{
 		ConfigKey: "log_level",
-		invAgent:  invAgent,
 	}
 }
 
@@ -72,9 +67,5 @@ func (l *LogLevelRuntimeSetting) Set(v interface{}, source model.Source) error {
 		cfg = l.Config
 	}
 	cfg.Set(key, level, source)
-	// we trigger a new inventory metadata payload since the configuration was updated by the user.
-	if l.invAgent != nil {
-		l.invAgent.Refresh()
-	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Other packages/comp can now subscribe to configuration changes.

This PR contains 2 commits:
- One commit to add the notification system
- A second commit that use this system to refresh the metadata payload automatically upon configuration change.

### Describe how to test/QA your changes

Test that a configuration change trigger a new inventoryagent payload.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
