### PR TITLE
Fix Prometheus auto-discovery

### DIFF
--- a/pkg/autodiscovery/common/types/prometheus.go
+++ b/pkg/autodiscovery/common/types/prometheus.go
@@ -148,6 +148,10 @@ type InclExcl struct {
 
 // PrometheusScrapeChecksTransformer unmarshals a prometheus check.
 func PrometheusScrapeChecksTransformer(in string) ([]*PrometheusCheck, error) {
+	if in == "" {
+		return nil, nil
+	}
+
 	var promChecks []*PrometheusCheck
 	if err := json.Unmarshal([]byte(in), &promChecks); err != nil {
 		return promChecks, fmt.Errorf(`"prometheus_scrape.checks" can not be parsed: %v`, err)


### PR DESCRIPTION
### What does this PR do?

Fix Prometheus auto-discovery.

### Motivation

It has been broken by #20850.
Before this PR, `PrometheusScrapeChecksTransformer` was invoked by `viper` here: https://github.com/DataDog/datadog-agent/blob/976bbbea503e440274d3f4f4ad53959d59e44462/pkg/config/config.go#L673
So, it was called by `viper` **only** when the `prometheus_scrape.checks` parameter was explicitly set.
With the refactoring, it now always invoked, including when the parameter is left to its empty `""` default value.
This leads to the following error:
```
2023-12-08 13:48:29 UTC | CORE | ERROR | (/home/lenaic/doc/devel/DataDog/datadog-agent.not.sync/cmd/agent/common/autodiscovery.go:113 in setupAutoDiscovery) | Error while adding config provider prometheus_pods: "prometheus_scrape.checks" can not be parsed: unexpected end of JSON input
```

### Additional Notes

This regression was caught by the [`TestEKSSuite/TestPrometheus/metric___prom_gauge{kube_deployment:prometheus,kube_namespace:workload-prometheus}`](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.name%3A%22TestEKSSuite%2FTestPrometheus%2Fmetric___prom_gauge%7Bkube_deployment%3Aprometheus%2Ckube_namespace%3Aworkload-prometheus%7D%22&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=&index=citest&mode=sliding&saved-view-id=2236559&start=1700836276499&end=1702045876499&paused=false) and [`TestKindSuite/TestPrometheus/metric___prom_gauge{kube_deployment:prometheus,kube_namespace:workload-prometheus}`](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.name%3A%22TestKindSuite%2FTestPrometheus%2Fmetric___prom_gauge%7Bkube_deployment%3Aprometheus%2Ckube_namespace%3Aworkload-prometheus%7D%22&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=&index=citest&mode=sliding&saved-view-id=2236559&start=1700836258000&end=1702045858000&paused=false) new e2e tests.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Configure the agent to enable Prometheus auto-discovery with:
```yaml
prometheus_scrape:
  enabled: true
  version: 2
```

Annotate a pod exposing an OpenMetrics endpoint with:
```yaml
metadata:
  annotations:
    prometheus.io/scrape: "true"
```

Before #20850 and with this PR, check that the corresponding `openmetrics` check is properly scheduled.

After #20850 and without this PR, the `openmetrics` check wasn’t scheduled and the agent was logging:
```
2023-12-08 13:48:29 UTC | CORE | ERROR | (/home/lenaic/doc/devel/DataDog/datadog-agent.not.sync/cmd/agent/common/autodiscovery.go:113 in setupAutoDiscovery) | Error while adding config provider prometheus_pods: "prometheus_scrape.checks" can not be parsed: unexpected end of JSON input
```


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
