### PR TITLE
[NDM] Skip bandwidth usage rate metric sample if new entry in map

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/interface_bandwidth_usage_rate.go
+++ b/pkg/collector/corechecks/snmp/internal/report/interface_bandwidth_usage_rate.go
@@ -74,5 +74,5 @@ func (ibs InterfaceBandwidthState) calculateBandwidthUsageRate(fullIndex string,
 	if ok {
 		return 0, fmt.Errorf("ifSpeed changed from %d to %d for interface ID %s, no rate emitted", state.ifSpeed, ifSpeed, interfaceID)
 	}
-	return 0, nil
+	return 0, fmt.Errorf("new entry made, no rate emitted for interface ID %s", interfaceID)
 }


### PR DESCRIPTION
### What does this PR do?

[[Slack context]](https://dd.slack.com/archives/C01C4E552HJ/p1702022205399839)


[e2e tests on snmp_listener on `integrations_core` are breaking](https://github.com/DataDog/integrations-core/actions/runs/7130391462/job/19416788282)

The error is:
```
FAILED tests/test_e2e_snmp_listener.py::test_e2e_snmp_listener - AssertionError: Needed exactly 1 candidates for 'snmp.ifBandwidthInUsage.rate', got 2
```
because 2 samples are emitted (0, then actual value) in the scenario that a new entry is made, a sample of value 0 is emitted (because no error was sent back to skip it)

This PR sends back an error with the message (new entry made, no metric should be emitted yet, emulating the rate submission type that would flush on the 2nd sample sent in)

Errors sent back by this method simply log and do not proceed to the rest of the function (sending the actual sample)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
