### PR TITLE
[SEC-11866] cws-instrumentation: add selftests command

### DIFF
--- a/cmd/cws-instrumentation/subcommands/selftestscmd/selftests.go
+++ b/cmd/cws-instrumentation/subcommands/selftestscmd/selftests.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package selftestscmd holds the selftests command of CWS injector
+package selftestscmd
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+type execParams struct {
+	enabled bool
+	path    string
+}
+
+type openParams struct {
+	enabled bool
+	path    string
+}
+
+type selftestsCliParams struct {
+	exec execParams
+	open openParams
+}
+
+// Command returns the commands for the selftests subcommand
+func Command() []*cobra.Command {
+	var params selftestsCliParams
+
+	selftestsCmd := &cobra.Command{
+		Use:   "selftests",
+		Short: "run selftests against the tracer",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			if params.exec.enabled {
+				err = errors.Join(err, selftestExec(&params.exec))
+			}
+			if params.open.enabled {
+				err = errors.Join(err, selftestOpen(&params.open))
+			}
+			return err
+		},
+	}
+
+	selftestsCmd.Flags().BoolVar(&params.exec.enabled, "exec", false, "run the exec selftest")
+	selftestsCmd.Flags().StringVar(&params.exec.path, "exec.path", "/usr/bin/date", "path to the file to execute")
+	selftestsCmd.Flags().BoolVar(&params.open.enabled, "open", false, "run the open selftest")
+	selftestsCmd.Flags().StringVar(&params.open.path, "open.path", "/tmp/open.test", "path to the file to open")
+
+	return []*cobra.Command{selftestsCmd}
+}
+
+func selftestExec(params *execParams) error {
+	return exec.Command(params.path).Run()
+}
+
+func selftestOpen(params *openParams) error {
+	f, createErr := os.OpenFile(params.path, os.O_CREATE|os.O_EXCL, 0400)
+	if createErr != nil {
+		f, openErr := os.Open(params.path)
+		if openErr != nil {
+			return errors.Join(createErr, openErr)
+		}
+		return f.Close()
+	}
+	return errors.Join(f.Close(), os.Remove(params.path))
+}

--- a/cmd/cws-instrumentation/subcommands/selftestscmd/selftests.go
+++ b/cmd/cws-instrumentation/subcommands/selftestscmd/selftests.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -19,6 +20,7 @@ import (
 type execParams struct {
 	enabled bool
 	path    string
+	args    string
 }
 
 type openParams struct {
@@ -52,6 +54,7 @@ func Command() []*cobra.Command {
 
 	selftestsCmd.Flags().BoolVar(&params.exec.enabled, "exec", false, "run the exec selftest")
 	selftestsCmd.Flags().StringVar(&params.exec.path, "exec.path", "/usr/bin/date", "path to the file to execute")
+	selftestsCmd.Flags().StringVar(&params.exec.args, "exec.args", "", "arguments to pass to the executable")
 	selftestsCmd.Flags().BoolVar(&params.open.enabled, "open", false, "run the open selftest")
 	selftestsCmd.Flags().StringVar(&params.open.path, "open.path", "/tmp/open.test", "path to the file to open")
 
@@ -59,6 +62,9 @@ func Command() []*cobra.Command {
 }
 
 func selftestExec(params *execParams) error {
+	if params.args != "" {
+		return exec.Command(params.path, strings.Split(params.args, " ")...).Run()
+	}
 	return exec.Command(params.path).Run()
 }
 

--- a/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
+++ b/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
@@ -11,6 +11,7 @@ package tracecmd
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/selftestscmd"
 	"github.com/DataDog/datadog-agent/pkg/security/ptracer"
 )
 
@@ -40,6 +41,8 @@ func Command() []*cobra.Command {
 
 	traceCmd.Flags().StringVar(&params.ProbeAddr, probeAddr, "localhost:5678", "system-probe eBPF less GRPC address")
 	traceCmd.Flags().BoolVar(&params.Verbose, verbose, false, "enable verbose output")
+
+	traceCmd.AddCommand(selftestscmd.Command()...)
 
 	return []*cobra.Command{traceCmd}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds a selftests command that can be used to test the cws-instrumentation tracer by tracing itself running in selftests mode.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
