### PR TITLE
AMLII-1326: Removes un-needed os.Setenv call for subprocess

### DIFF
--- a/pkg/compliance/evaluator_xccdf.go
+++ b/pkg/compliance/evaluator_xccdf.go
@@ -93,14 +93,15 @@ func newOSCAPIO(file string) *oscapIO {
 func (p *oscapIO) Run(ctx context.Context) error {
 	defer p.Stop()
 
+	environ := []string{}
+
 	if config.IsContainerized() {
 		hostRoot := os.Getenv("HOST_ROOT")
 		if hostRoot == "" {
 			hostRoot = "/host"
 		}
 
-		os.Setenv("OSCAP_PROBE_ROOT", hostRoot)
-		defer os.Unsetenv("OSCAP_PROBE_ROOT")
+		environ = append(environ, fmt.Sprintf("OSCAP_PROBE_ROOT=%s", hostRoot))
 	}
 
 	args := []string{}
@@ -115,6 +116,7 @@ func (p *oscapIO) Run(ctx context.Context) error {
 	}
 
 	cmd := exec.CommandContext(ctx, binPath, args...)
+	cmd.Env = append(cmd.Env, environ...)
 	cmd.Dir = filepath.Dir(p.File)
 	p.cmd = cmd
 


### PR DESCRIPTION
### What does this PR do?

Removes a call to `os.Setenv` and sets env vars for child process directly.

### Motivation
`os.Setenv` is inherently racey in go when cgo is enabled (which it is for the agent).

Working to reduce these global `os.Setenv` calls where possible.

### Additional Notes
I am relying on tests for this change, I have done some sanity checks, but I don't know how to exercise this codepath directly.
There _should_ be no functional difference assuming that only the subprocess looks at the env var `OSCAP_PROBE_ROOT`

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
