### PR TITLE
[usm] Update `http.StatKeeper.Process()` API for batch processing

### DIFF
--- a/pkg/network/protocols/events/configuration.go
+++ b/pkg/network/protocols/events/configuration.go
@@ -72,7 +72,7 @@ func setupPerfMap(proto string, m *manager.Manager) {
 	pm := &manager.PerfMap{
 		Map: manager.Map{Name: mapName},
 		PerfMapOptions: manager.PerfMapOptions{
-			PerfRingBufferSize: 16 * os.Getpagesize(),
+			PerfRingBufferSize: 64 * os.Getpagesize(),
 			Watermark:          1,
 			RecordHandler:      handler.RecordHandler,
 			LostHandler:        handler.LostHandler,

--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -166,11 +166,10 @@ func (p *protocol) DumpMaps(output *strings.Builder, mapName string, currentMap 
 }
 
 func (p *protocol) processHTTP(events []EbpfEvent) {
-	for i := range events {
-		tx := &events[i]
-		p.telemetry.Count(tx)
-		p.statkeeper.Process(tx)
-	}
+	transactions := GetTransactionSlice[EbpfEvent, *EbpfEvent](events)
+	defer transactions.Done()
+
+	p.statkeeper.Process(transactions.Data())
 }
 
 func (p *protocol) setupMapCleaner(mgr *manager.Manager) {

--- a/pkg/network/protocols/http/slice_conversion.go
+++ b/pkg/network/protocols/http/slice_conversion.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build (windows && npm) || linux_bpf
+
+package http
+
+import "sync"
+
+// GetTransactionSlice converts a slice of type []T into a slice of type
+// []Transaction (assuming that *T implements the Transaction interface).  Given
+// that this code called from the hot path of HTTP monitoring, we make use of an
+// object pool to recycle the []Transaction slices. It's the caller
+// responsibility to call the returned `func()`, once the contents of the slice
+// are used/copied.
+//
+// Note: The generic stuff is definitely more gnarly that I wished, but I
+// couldn't find a simpler way to do it. Given that we have at least 3 different
+// places using this with 3 distinct types, I thought it was worth it.
+//
+// Here's an example how you can call it:
+// Assuming you have an `events` variable of type `EbpfEvent`,
+//
+// transactions, done := GetTransactionSlice[EbpfEvent, *EbpfEvent](events)
+// ... do stuff with transactions
+// done()
+//
+// A similar example can be found in the Golang's type paramaters spec:
+// https://go.googlesource.com/proposal/+/HEAD/design/43651-type-parameters.md#pointer-method-example
+func GetTransactionSlice[V any, PV txConstraint[V]](elements []V) transactions {
+	p := transactionSlicePool.Get().(*[]Transaction)
+	result := (*p)[:0]
+	for i := range elements {
+		result = append(result, PV(&elements[i]))
+	}
+
+	return transactions{
+		ptr:  p,
+		data: result,
+	}
+}
+
+var transactionSlicePool = sync.Pool{
+	New: func() any {
+		t := make([]Transaction, 0, 512)
+		return &t
+	},
+}
+
+type transactions struct {
+	// the pointer to the slice returned by the pool
+	// we use a pointer to a slice because it avoids an allocation to the empty
+	// interface ({}interface) when `sync.Pool.Put()` is called
+	ptr *[]Transaction
+
+	// the "truncated" slice seen by the caller
+	data []Transaction
+}
+
+func (t transactions) Data() []Transaction {
+	return t.data
+}
+
+func (t transactions) Done() {
+	slice := *t.ptr
+	for i := range slice {
+		slice[i] = nil
+	}
+	transactionSlicePool.Put(t.ptr)
+}
+
+// this type constraint is only used below to generate a []Transaction from
+// multiple concrete implementations. refer to the comments above for the
+// motivation behind it
+type txConstraint[T any] interface {
+	Transaction
+	*T
+}

--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -58,16 +58,20 @@ func NewStatkeeper(c *config.Config, telemetry *Telemetry, incompleteBuffer Inco
 }
 
 // Process processes a transaction and updates the stats accordingly.
-func (h *StatKeeper) Process(tx Transaction) {
+func (h *StatKeeper) Process(transactions []Transaction) {
 	h.mux.Lock()
 	defer h.mux.Unlock()
 
-	if tx.Incomplete() {
-		h.incomplete.Add(tx)
-		return
-	}
+	for _, tx := range transactions {
+		h.telemetry.Count(tx)
 
-	h.add(tx)
+		if tx.Incomplete() {
+			h.incomplete.Add(tx)
+			continue
+		}
+
+		h.add(tx)
+	}
 }
 
 // GetAndResetAllStats returns all the stats and resets the internal state.

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -304,11 +304,10 @@ func (p *Protocol) DumpMaps(output *strings.Builder, mapName string, currentMap 
 }
 
 func (p *Protocol) processHTTP2(events []EbpfTx) {
-	for i := range events {
-		tx := &events[i]
-		p.telemetry.Count(tx)
-		p.statkeeper.Process(tx)
-	}
+	transactions := http.GetTransactionSlice[EbpfTx, *EbpfTx](events)
+	defer transactions.Done()
+
+	p.statkeeper.Process(transactions.Data())
 }
 
 func (p *Protocol) setupHTTP2InFlightMapCleaner(mgr *manager.Manager) {

--- a/pkg/network/usm/monitor_windows.go
+++ b/pkg/network/usm/monitor_windows.go
@@ -99,11 +99,9 @@ func (m *WindowsMonitor) process(transactionBatch []http.WinHttpTransaction) {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
-	for i := range transactionBatch {
-		tx := http.Transaction(&transactionBatch[i])
-		m.telemetry.Count(tx)
-		m.statkeeper.Process(tx)
-	}
+	transactions := http.GetTransactionSlice[EbpfTx, *EbpfTx](events)
+	defer transactions.Done()
+	m.statkeeper.Process(transactions.Data())
 }
 
 // GetHTTPStats returns a map of HTTP stats stored in the following format:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
