### PR TITLE
Linter ensures fxutil.Run is tested using TestRun

### DIFF
--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
 	//nolint:revive // TODO(EBPF) Fix revive linter
 	_ "net/http/pprof"
 	"os"
@@ -161,45 +162,8 @@ func StartSystemProbeWithDefaults(ctxChan <-chan context.Context) (<-chan error,
 
 	// run startSystemProbe in an app, so that the log and config components get initialized
 	go func() {
-		err := fxutil.OneShot(
-			func(log log.Component, config config.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component) error {
-				defer StopSystemProbeWithDefaults()
-				err := startSystemProbe(&cliParams{GlobalParams: &command.GlobalParams{}}, log, telemetry, sysprobeconfig, rcclient)
-				if err != nil {
-					return err
-				}
-
-				// notify outer that startAgent finished
-				errChan <- err
-				// wait for context
-				ctx := <-ctxChan
-
-				// Wait for stop signal
-				select {
-				case <-signals.Stopper:
-					log.Info("Received stop command, shutting down...")
-				case <-signals.ErrorStopper:
-					_ = log.Critical("The Agent has encountered an error, shutting down...")
-				case <-ctx.Done():
-					log.Info("Received stop from service manager, shutting down...")
-				}
-
-				return nil
-			},
-			// no config file path specification in this situation
-			fx.Supply(config.NewAgentParams("", config.WithConfigMissingOK(true))),
-			fx.Supply(sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(""))),
-			fx.Supply(logimpl.ForDaemon("SYS-PROBE", "log_file", common.DefaultLogFile)),
-			rcclient.Module,
-			config.Module,
-			telemetry.Module,
-			sysprobeconfigimpl.Module,
-			// use system-probe config instead of agent config for logging
-			fx.Provide(func(lc fx.Lifecycle, params logimpl.Params, sysprobeconfig sysprobeconfig.Component) (log.Component, error) {
-				return logimpl.NewLogger(lc, params, sysprobeconfig)
-			}),
-		)
-		// notify caller that fx.OneShot is done
+		err := runSystemProbeAsApp(ctxChan, errChan)
+		// notify caller that this is done
 		errChan <- err
 	}()
 
@@ -212,6 +176,47 @@ func StartSystemProbeWithDefaults(ctxChan <-chan context.Context) (<-chan error,
 
 	// startSystemProbe succeeded. provide errChan to caller so they can wait for fxutil.OneShot to stop
 	return errChan, nil
+}
+
+func runSystemProbeAsApp(ctxChan <-chan context.Context, errChan chan error) error {
+	return fxutil.OneShot(
+		func(log log.Component, config config.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component) error {
+			defer StopSystemProbeWithDefaults()
+			err := startSystemProbe(&cliParams{GlobalParams: &command.GlobalParams{}}, log, telemetry, sysprobeconfig, rcclient)
+			if err != nil {
+				return err
+			}
+
+			// notify outer that startAgent finished
+			errChan <- err
+			// wait for context
+			ctx := <-ctxChan
+
+			// Wait for stop signal
+			select {
+			case <-signals.Stopper:
+				log.Info("Received stop command, shutting down...")
+			case <-signals.ErrorStopper:
+				_ = log.Critical("The Agent has encountered an error, shutting down...")
+			case <-ctx.Done():
+				log.Info("Received stop from service manager, shutting down...")
+			}
+
+			return nil
+		},
+		// no config file path specification in this situation
+		fx.Supply(config.NewAgentParams("", config.WithConfigMissingOK(true))),
+		fx.Supply(sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(""))),
+		fx.Supply(logimpl.ForDaemon("SYS-PROBE", "log_file", common.DefaultLogFile)),
+		rcclient.Module,
+		config.Module,
+		telemetry.Module,
+		sysprobeconfigimpl.Module,
+		// use system-probe config instead of agent config for logging
+		fx.Provide(func(lc fx.Lifecycle, params logimpl.Params, sysprobeconfig sysprobeconfig.Component) (log.Component, error) {
+			return logimpl.NewLogger(lc, params, sysprobeconfig)
+		}),
+	)
 }
 
 // StopSystemProbeWithDefaults is a temporary way for other packages to use stopAgent.

--- a/cmd/system-probe/subcommands/run/command_test.go
+++ b/cmd/system-probe/subcommands/run/command_test.go
@@ -6,6 +6,7 @@
 package run
 
 import (
+	"context"
 	_ "net/http/pprof"
 	"testing"
 
@@ -19,4 +20,12 @@ func TestRunCommand(t *testing.T) {
 		[]string{"run"},
 		run,
 		func() {})
+}
+
+func TestStartSystemProbe(t *testing.T) {
+	fxutil.TestOneShot(t, func() {
+		ctxChan := make(<-chan context.Context)
+		errChan := make(chan error)
+		runSystemProbeAsApp(ctxChan, errChan)
+	})
 }

--- a/cmd/systray/command/command_test.go
+++ b/cmd/systray/command/command_test.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package command
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestFxRunCommand(t *testing.T) {
+	cmd := MakeCommand()
+	fxutil.TestRun(t, func() error {
+		return cmd.Execute()
+	})
+}

--- a/cmd/trace-agent/subcommands/run/command_test.go
+++ b/cmd/trace-agent/subcommands/run/command_test.go
@@ -1,0 +1,18 @@
+package run
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestFxRun(t *testing.T) {
+	fxutil.TestRun(t, func() error {
+		ctx := context.Background()
+		cliParams := RunParams{GlobalParams: &subcommands.GlobalParams{}}
+		defaultConfPath := ""
+		return runFx(ctx, &cliParams, defaultConfPath)
+	})
+}

--- a/pkg/util/fxutil/oneshot.go
+++ b/pkg/util/fxutil/oneshot.go
@@ -11,10 +11,6 @@ import (
 	"go.uber.org/fx"
 )
 
-// oneShotTestOverride allows TestOneShotSubcommand to override the OneShot
-// function.  It is always nil in production.
-var oneShotTestOverride func(interface{}, []fx.Option) error
-
 // OneShot runs the given function in an fx.App using the supplied options.
 // The function's arguments are supplied by Fx and can be any provided type.
 // The function must return `error` or nothing.
@@ -23,8 +19,8 @@ var oneShotTestOverride func(interface{}, []fx.Option) error
 // immediately shuts down.  This is typically used for command-line tools like
 // `agent status`.
 func OneShot(oneShotFunc interface{}, opts ...fx.Option) error {
-	if oneShotTestOverride != nil {
-		return oneShotTestOverride(oneShotFunc, opts)
+	if fxAppTestOverride != nil {
+		return fxAppTestOverride(oneShotFunc, opts)
 	}
 
 	// Use a delayed Fx invocation to capture arguments for oneShotFunc during

--- a/pkg/util/fxutil/run.go
+++ b/pkg/util/fxutil/run.go
@@ -16,6 +16,10 @@ import (
 // This differs from fx.App#Run in that it returns errors instead of exiting
 // the process.
 func Run(opts ...fx.Option) error {
+	if fxAppTestOverride != nil {
+		return fxAppTestOverride(func() {}, opts)
+	}
+
 	opts = append(opts, FxLoggingOption())
 	// Temporarily increase timeout for all fxutil.Run calls until we can better characterize our
 	// start time requirements. Prepend to opts so individual calls can override the timeout.

--- a/pkg/util/fxutil/test.go
+++ b/pkg/util/fxutil/test.go
@@ -21,6 +21,10 @@ type NoDependencies struct {
 	fx.In
 }
 
+// fxAppTestOverride allows TestRunCommand and TestOneShotSubcommand to
+// override the Run and OneShot functions.  It is always nil in production.
+var fxAppTestOverride func(interface{}, []fx.Option) error
+
 // Test starts an app and returns fulfilled dependencies
 //
 // The generic return type T must conform to fx.In such
@@ -101,6 +105,24 @@ func TestStart(t testing.TB, opts fx.Option, appAssert appAssertFn, fn interface
 	appAssert(t, app)
 }
 
+// TestRun is a helper for testing code that uses fxutil.Run
+//
+// It takes a anonymous function, and sets up fx so that no actual App
+// will be constructed. Instead, it expects the given function to call
+// fxutil.Run. Then, this test verifies that all Options given to that
+// fxutil.Run call will satisfy fx's dependences by using fx.ValidateApp.
+func TestRun(t *testing.T, f func() error) {
+	var fxFakeAppRan bool
+	fxAppTestOverride = func(i interface{}, opts []fx.Option) error {
+		fxFakeAppRan = true
+		require.NoError(t, fx.ValidateApp(opts...))
+		return nil
+	}
+	defer func() { fxAppTestOverride = nil }()
+	require.NoError(t, f())
+	require.True(t, fxFakeAppRan, "fxutil.Run wasn't called")
+}
+
 // TestOneShotSubcommand is a helper for testing commands implemented with fxutil.OneShot.
 //
 // It takes an array of commands, and attaches all to a temporary top-level
@@ -125,7 +147,7 @@ func TestOneShotSubcommand(
 	verifyFn interface{}) {
 
 	var oneShotRan bool
-	oneShotTestOverride = func(oneShotFunc interface{}, opts []fx.Option) error {
+	fxAppTestOverride = func(oneShotFunc interface{}, opts []fx.Option) error {
 		oneShotRan = true
 
 		// verify that the expected oneShotFunc would have been called
@@ -149,7 +171,7 @@ func TestOneShotSubcommand(
 		defer app.RequireStart().RequireStop()
 		return nil
 	}
-	defer func() { oneShotTestOverride = nil }()
+	defer func() { fxAppTestOverride = nil }()
 
 	cmd := &cobra.Command{Use: "test"}
 	for _, c := range subcommands {
@@ -168,7 +190,7 @@ func TestOneShotSubcommand(
 // is validated with fx.ValidateApp, however.
 func TestOneShot(t *testing.T, fct func()) {
 	var oneShotRan bool
-	oneShotTestOverride = func(oneShotFunc interface{}, opts []fx.Option) error {
+	fxAppTestOverride = func(oneShotFunc interface{}, opts []fx.Option) error {
 		oneShotRan = true
 		// validate the app with the original oneShotFunc, to ensure that
 		// any types it requires are provided.
@@ -178,7 +200,7 @@ func TestOneShot(t *testing.T, fct func()) {
 					fx.Invoke(oneShotFunc))...))
 		return nil
 	}
-	defer func() { oneShotTestOverride = nil }()
+	defer func() { fxAppTestOverride = nil }()
 
 	fct()
 	require.True(t, oneShotRan, "fxutil.OneShot wasn't called")

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -379,24 +379,32 @@ def lint_fxutil_oneshot_test(_):
             if str(file).endswith("_test.go") or str(file).endswith("main.go") or str(file).endswith("main_windows.go"):
                 continue
 
-            # The code in this file cannot be easily tested
-            if "cmd/system-probe/subcommands/run/command.go" in str(file):
-                continue
-
             one_shot_count = file.read_text().count("fxutil.OneShot(")
-            if one_shot_count > 0:
+            run_count = file.read_text().count("fxutil.Run(")
+
+            expect_reason = 'fxutil.OneShot'
+            if one_shot_count == 0 and run_count > 0:
+                expect_reason = 'fxutil.Run'
+
+            if one_shot_count > 0 or run_count > 0:
                 test_path = file.parent.joinpath(f"{file.stem}_test.go")
                 if not test_path.exists():
-                    errors.append(f"The file {file} contains fxutil.OneShot but the file {test_path} doesn't exist.")
+                    errors.append(f"The file {file} contains {expect_reason} but the file {test_path} doesn't exist.")
                 else:
                     content = test_path.read_text()
-                    sub_cmd_count = content.count("fxutil.TestOneShotSubcommand(")
+                    test_sub_cmd_count = content.count("fxutil.TestOneShotSubcommand(")
                     test_one_shot_count = content.count("fxutil.TestOneShot(")
-                    if one_shot_count > sub_cmd_count + test_one_shot_count:
+                    test_run_count = content.count("fxutil.TestRun(")
+                    if one_shot_count > test_sub_cmd_count + test_one_shot_count:
                         errors.append(
                             f"The file {file} contains {one_shot_count} call(s) to `fxutil.OneShot`"
-                            + f"but {test_path} contains only {sub_cmd_count} call(s) to `fxutil.TestOneShotSubcommand`"
-                            + f"and {test_one_shot_count} call(s) to `fxutil.TestOneShot`"
+                            + f" but {test_path} contains only {test_sub_cmd_count} call(s) to `fxutil.TestOneShotSubcommand`"
+                            + f" and {test_one_shot_count} call(s) to `fxutil.TestOneShot`"
+                        )
+                    if run_count > test_run_count:
+                        errors.append(
+                            f"The file {file} contains {run_count} call(s) to `fxutil.Run`"
+                            + f" but {test_path} contains only {test_run_count} call(s) to `fxutil.TestRun`"
                         )
     if len(errors) > 0:
         msg = '\n'.join(errors)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
