### PR TITLE
ASCII-808: Linter ensures fxutil.Run is tested using TestRun

### DIFF
--- a/cmd/otel-agent/main_test.go
+++ b/cmd/otel-agent/main_test.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build otlp
+
+package main
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestFxRun(t *testing.T) {
+	// TODO: (components) "missing type: *aggregator.AgentDemultiplexer"
+	t.SkipNow()
+	fxutil.TestOneShot(t, main)
+}

--- a/cmd/security-agent/main_windows_test.go
+++ b/cmd/security-agent/main_windows_test.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFxRun(t *testing.T) {
+	svc := service{}
+	ctx := context.Background()
+	fxutil.TestOneShot(t, func() {
+		err := svc.Run(ctx)
+		require.NoError(t, err)
+	})
+}

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/serverless/logs"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func setupTest() {
@@ -42,4 +43,8 @@ func TestTagsSetup(t *testing.T) {
 	defer metricAgent.Stop()
 	assert.Subset(t, metricAgent.GetExtraTags(), allTags)
 	assert.Subset(t, logs.GetLogsTags(), allTags)
+}
+
+func TestFxApp(t *testing.T) {
+	fxutil.TestOneShot(t, main)
 }

--- a/cmd/serverless/main_test.go
+++ b/cmd/serverless/main_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/daemon"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestDaemonStopOnTerminationSignals(t *testing.T) {
@@ -51,4 +52,8 @@ func TestDaemonStopOnTerminationSignals(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFxApp(t *testing.T) {
+	fxutil.TestOneShot(t, main)
 }

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
 	//nolint:revive // TODO(EBPF) Fix revive linter
 	_ "net/http/pprof"
 	"os"
@@ -163,46 +164,8 @@ func StartSystemProbeWithDefaults(ctxChan <-chan context.Context) (<-chan error,
 
 	// run startSystemProbe in an app, so that the log and config components get initialized
 	go func() {
-		err := fxutil.OneShot(
-			func(log log.Component, config config.Component, statsd compstatsd.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component) error {
-				defer StopSystemProbeWithDefaults()
-				err := startSystemProbe(&cliParams{GlobalParams: &command.GlobalParams{}}, log, statsd, telemetry, sysprobeconfig, rcclient)
-				if err != nil {
-					return err
-				}
-
-				// notify outer that startAgent finished
-				errChan <- err
-				// wait for context
-				ctx := <-ctxChan
-
-				// Wait for stop signal
-				select {
-				case <-signals.Stopper:
-					log.Info("Received stop command, shutting down...")
-				case <-signals.ErrorStopper:
-					_ = log.Critical("The Agent has encountered an error, shutting down...")
-				case <-ctx.Done():
-					log.Info("Received stop from service manager, shutting down...")
-				}
-
-				return nil
-			},
-			// no config file path specification in this situation
-			fx.Supply(config.NewAgentParams("", config.WithConfigMissingOK(true))),
-			fx.Supply(sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(""))),
-			fx.Supply(logimpl.ForDaemon("SYS-PROBE", "log_file", common.DefaultLogFile)),
-			rcclient.Module(),
-			config.Module(),
-			telemetry.Module(),
-			compstatsd.Module(),
-			sysprobeconfigimpl.Module(),
-			// use system-probe config instead of agent config for logging
-			fx.Provide(func(lc fx.Lifecycle, params logimpl.Params, sysprobeconfig sysprobeconfig.Component) (log.Component, error) {
-				return logimpl.NewLogger(lc, params, sysprobeconfig)
-			}),
-		)
-		// notify caller that fx.OneShot is done
+		err := runSystemProbeAsApp(ctxChan, errChan)
+		// notify caller that this is done
 		errChan <- err
 	}()
 
@@ -215,6 +178,48 @@ func StartSystemProbeWithDefaults(ctxChan <-chan context.Context) (<-chan error,
 
 	// startSystemProbe succeeded. provide errChan to caller so they can wait for fxutil.OneShot to stop
 	return errChan, nil
+}
+
+func runSystemProbeAsApp(ctxChan <-chan context.Context, errChan chan error) error {
+	return fxutil.OneShot(
+		func(log log.Component, config config.Component, statsd compstatsd.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component) error {
+			defer StopSystemProbeWithDefaults()
+			err := startSystemProbe(&cliParams{GlobalParams: &command.GlobalParams{}}, log, statsd, telemetry, sysprobeconfig, rcclient)
+			if err != nil {
+				return err
+			}
+
+			// notify outer that startAgent finished
+			errChan <- err
+			// wait for context
+			ctx := <-ctxChan
+
+			// Wait for stop signal
+			select {
+			case <-signals.Stopper:
+				log.Info("Received stop command, shutting down...")
+			case <-signals.ErrorStopper:
+				_ = log.Critical("The Agent has encountered an error, shutting down...")
+			case <-ctx.Done():
+				log.Info("Received stop from service manager, shutting down...")
+			}
+
+			return nil
+		},
+		// no config file path specification in this situation
+		fx.Supply(config.NewAgentParams("", config.WithConfigMissingOK(true))),
+		fx.Supply(sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(""))),
+		fx.Supply(logimpl.ForDaemon("SYS-PROBE", "log_file", common.DefaultLogFile)),
+		rcclient.Module(),
+		config.Module(),
+		telemetry.Module(),
+		compstatsd.Module(),
+		sysprobeconfigimpl.Module(),
+		// use system-probe config instead of agent config for logging
+		fx.Provide(func(lc fx.Lifecycle, params logimpl.Params, sysprobeconfig sysprobeconfig.Component) (log.Component, error) {
+			return logimpl.NewLogger(lc, params, sysprobeconfig)
+		}),
+	)
 }
 
 // StopSystemProbeWithDefaults is a temporary way for other packages to use stopAgent.

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -162,10 +162,10 @@ func run(log log.Component, _ config.Component, statsd compstatsd.Component, tel
 func StartSystemProbeWithDefaults(ctxChan <-chan context.Context) (<-chan error, error) {
 	errChan := make(chan error)
 
-	// run startSystemProbe in an app, so that the log and config components get initialized
+	// run startSystemProbe in the background
 	go func() {
-		err := runSystemProbeAsApp(ctxChan, errChan)
-		// notify caller that this is done
+		err := runSystemProbe(ctxChan, errChan)
+		// notify main routine that this is done, so cleanup can happen
 		errChan <- err
 	}()
 
@@ -180,7 +180,7 @@ func StartSystemProbeWithDefaults(ctxChan <-chan context.Context) (<-chan error,
 	return errChan, nil
 }
 
-func runSystemProbeAsApp(ctxChan <-chan context.Context, errChan chan error) error {
+func runSystemProbe(ctxChan <-chan context.Context, errChan chan error) error {
 	return fxutil.OneShot(
 		func(log log.Component, config config.Component, statsd compstatsd.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component) error {
 			defer StopSystemProbeWithDefaults()

--- a/cmd/system-probe/subcommands/run/command_test.go
+++ b/cmd/system-probe/subcommands/run/command_test.go
@@ -26,6 +26,6 @@ func TestStartSystemProbe(t *testing.T) {
 	fxutil.TestOneShot(t, func() {
 		ctxChan := make(<-chan context.Context)
 		errChan := make(chan error)
-		runSystemProbeAsApp(ctxChan, errChan)
+		runSystemProbe(ctxChan, errChan)
 	})
 }

--- a/cmd/system-probe/subcommands/run/command_test.go
+++ b/cmd/system-probe/subcommands/run/command_test.go
@@ -6,6 +6,7 @@
 package run
 
 import (
+	"context"
 	_ "net/http/pprof"
 	"testing"
 
@@ -19,4 +20,12 @@ func TestRunCommand(t *testing.T) {
 		[]string{"run"},
 		run,
 		func() {})
+}
+
+func TestStartSystemProbe(t *testing.T) {
+	fxutil.TestOneShot(t, func() {
+		ctxChan := make(<-chan context.Context)
+		errChan := make(chan error)
+		runSystemProbeAsApp(ctxChan, errChan)
+	})
 }

--- a/cmd/systray/command/command_test.go
+++ b/cmd/systray/command/command_test.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package command
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestFxRunCommand(t *testing.T) {
+	cmd := MakeCommand()
+	fxutil.TestRun(t, func() error {
+		return cmd.Execute()
+	})
+}

--- a/cmd/systray/command/command_test.go
+++ b/cmd/systray/command/command_test.go
@@ -1,3 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
 //go:build windows
 
 package command

--- a/cmd/trace-agent/subcommands/run/command.go
+++ b/cmd/trace-agent/subcommands/run/command.go
@@ -39,7 +39,7 @@ func MakeCommand(globalParamsGetter func() *subcommands.GlobalParams) *cobra.Com
 		Long:  `The Datadog trace-agent aggregates, samples, and forwards traces to datadog submitted by tracers loaded into your application.`,
 		RunE: func(*cobra.Command, []string) error {
 			cliParams.GlobalParams = globalParamsGetter()
-			return runTraceAgent(cliParams, cliParams.ConfPath)
+			return runTraceAgentCommand(cliParams, cliParams.ConfPath)
 		},
 	}
 
@@ -58,7 +58,7 @@ func setParamFlags(cmd *cobra.Command, cliParams *RunParams) {
 	setOSSpecificParamFlags(cmd, cliParams)
 }
 
-func runFx(ctx context.Context, cliParams *RunParams, defaultConfPath string) error {
+func runTraceAgentProcess(ctx context.Context, cliParams *RunParams, defaultConfPath string) error {
 	if cliParams.ConfPath == "" {
 		cliParams.ConfPath = defaultConfPath
 	}

--- a/cmd/trace-agent/subcommands/run/command_nix.go
+++ b/cmd/trace-agent/subcommands/run/command_nix.go
@@ -30,6 +30,6 @@ type RunParams struct {
 //nolint:revive // TODO(APM) Fix revive linter
 func setOSSpecificParamFlags(cmd *cobra.Command, cliParams *RunParams) {}
 
-func runTraceAgent(cliParams *RunParams, defaultConfPath string) error {
-	return runFx(context.Background(), cliParams, defaultConfPath)
+func runTraceAgentCommand(cliParams *RunParams, defaultConfPath string) error {
+	return runTraceAgentProcess(context.Background(), cliParams, defaultConfPath)
 }

--- a/cmd/trace-agent/subcommands/run/command_test.go
+++ b/cmd/trace-agent/subcommands/run/command_test.go
@@ -1,0 +1,18 @@
+package run
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestFxRun(t *testing.T) {
+	fxutil.TestRun(t, func() error {
+		ctx := context.Background()
+		cliParams := RunParams{GlobalParams: &subcommands.GlobalParams{}}
+		defaultConfPath := ""
+		return runFx(ctx, &cliParams, defaultConfPath)
+	})
+}

--- a/cmd/trace-agent/subcommands/run/command_test.go
+++ b/cmd/trace-agent/subcommands/run/command_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package run
 
 import (
@@ -13,6 +18,6 @@ func TestFxRun(t *testing.T) {
 		ctx := context.Background()
 		cliParams := RunParams{GlobalParams: &subcommands.GlobalParams{}}
 		defaultConfPath := ""
-		return runFx(ctx, &cliParams, defaultConfPath)
+		return runTraceAgentProcess(ctx, &cliParams, defaultConfPath)
 	})
 }

--- a/cmd/trace-agent/subcommands/run/command_windows.go
+++ b/cmd/trace-agent/subcommands/run/command_windows.go
@@ -38,12 +38,12 @@ func setOSSpecificParamFlags(cmd *cobra.Command, cliParams *RunParams) {
 		"runs the trace-agent in debug mode.")
 }
 
-func runTraceAgent(cliParams *RunParams, defaultConfPath string) error {
+func runTraceAgentCommand(cliParams *RunParams, defaultConfPath string) error {
 	if !cliParams.Foreground {
 		if servicemain.RunningAsWindowsService() {
 			servicemain.Run(&service{cliParams: cliParams, defaultConfPath: defaultConfPath})
 			return nil
 		}
 	}
-	return runFx(context.Background(), cliParams, defaultConfPath)
+	return runTraceAgentProcess(context.Background(), cliParams, defaultConfPath)
 }

--- a/cmd/trace-agent/subcommands/run/service_windows.go
+++ b/cmd/trace-agent/subcommands/run/service_windows.go
@@ -28,5 +28,5 @@ func (s *service) Init() error {
 }
 
 func (s *service) Run(ctx context.Context) error {
-	return runFx(ctx, s.cliParams, s.defaultConfPath)
+	return runTraceAgentProcess(ctx, s.cliParams, s.defaultConfPath)
 }

--- a/pkg/util/fxutil/oneshot.go
+++ b/pkg/util/fxutil/oneshot.go
@@ -11,10 +11,6 @@ import (
 	"go.uber.org/fx"
 )
 
-// oneShotTestOverride allows TestOneShotSubcommand to override the OneShot
-// function.  It is always nil in production.
-var oneShotTestOverride func(interface{}, []fx.Option) error
-
 // OneShot runs the given function in an fx.App using the supplied options.
 // The function's arguments are supplied by Fx and can be any provided type.
 // The function must return `error` or nothing.
@@ -23,8 +19,8 @@ var oneShotTestOverride func(interface{}, []fx.Option) error
 // immediately shuts down.  This is typically used for command-line tools like
 // `agent status`.
 func OneShot(oneShotFunc interface{}, opts ...fx.Option) error {
-	if oneShotTestOverride != nil {
-		return oneShotTestOverride(oneShotFunc, opts)
+	if fxAppTestOverride != nil {
+		return fxAppTestOverride(oneShotFunc, opts)
 	}
 
 	// Use a delayed Fx invocation to capture arguments for oneShotFunc during

--- a/pkg/util/fxutil/run.go
+++ b/pkg/util/fxutil/run.go
@@ -16,6 +16,10 @@ import (
 // This differs from fx.App#Run in that it returns errors instead of exiting
 // the process.
 func Run(opts ...fx.Option) error {
+	if fxAppTestOverride != nil {
+		return fxAppTestOverride(func() {}, opts)
+	}
+
 	opts = append(opts, FxLoggingOption())
 	// Temporarily increase timeout for all fxutil.Run calls until we can better characterize our
 	// start time requirements. Prepend to opts so individual calls can override the timeout.

--- a/pkg/util/fxutil/test.go
+++ b/pkg/util/fxutil/test.go
@@ -21,6 +21,10 @@ type NoDependencies struct {
 	fx.In
 }
 
+// fxAppTestOverride allows TestRunCommand and TestOneShotSubcommand to
+// override the Run and OneShot functions.  It is always nil in production.
+var fxAppTestOverride func(interface{}, []fx.Option) error
+
 // Test starts an app and returns fulfilled dependencies
 //
 // The generic return type T must conform to fx.In such
@@ -101,6 +105,24 @@ func TestStart(t testing.TB, opts fx.Option, appAssert appAssertFn, fn interface
 	appAssert(t, app)
 }
 
+// TestRun is a helper for testing code that uses fxutil.Run
+//
+// It takes a anonymous function, and sets up fx so that no actual App
+// will be constructed. Instead, it expects the given function to call
+// fxutil.Run. Then, this test verifies that all Options given to that
+// fxutil.Run call will satisfy fx's dependences by using fx.ValidateApp.
+func TestRun(t *testing.T, f func() error) {
+	var fxFakeAppRan bool
+	fxAppTestOverride = func(i interface{}, opts []fx.Option) error {
+		fxFakeAppRan = true
+		require.NoError(t, fx.ValidateApp(opts...))
+		return nil
+	}
+	defer func() { fxAppTestOverride = nil }()
+	require.NoError(t, f())
+	require.True(t, fxFakeAppRan, "fxutil.Run wasn't called")
+}
+
 // TestOneShotSubcommand is a helper for testing commands implemented with fxutil.OneShot.
 //
 // It takes an array of commands, and attaches all to a temporary top-level
@@ -125,7 +147,7 @@ func TestOneShotSubcommand(
 	verifyFn interface{}) {
 
 	var oneShotRan bool
-	oneShotTestOverride = func(oneShotFunc interface{}, opts []fx.Option) error {
+	fxAppTestOverride = func(oneShotFunc interface{}, opts []fx.Option) error {
 		oneShotRan = true
 
 		// verify that the expected oneShotFunc would have been called
@@ -149,7 +171,7 @@ func TestOneShotSubcommand(
 		defer app.RequireStart().RequireStop()
 		return nil
 	}
-	defer func() { oneShotTestOverride = nil }()
+	defer func() { fxAppTestOverride = nil }()
 
 	cmd := &cobra.Command{Use: "test"}
 	for _, c := range subcommands {
@@ -168,7 +190,7 @@ func TestOneShotSubcommand(
 // is validated with fx.ValidateApp, however.
 func TestOneShot(t *testing.T, fct func()) {
 	var oneShotRan bool
-	oneShotTestOverride = func(oneShotFunc interface{}, opts []fx.Option) error {
+	fxAppTestOverride = func(oneShotFunc interface{}, opts []fx.Option) error {
 		oneShotRan = true
 		// validate the app with the original oneShotFunc, to ensure that
 		// any types it requires are provided.
@@ -178,7 +200,7 @@ func TestOneShot(t *testing.T, fct func()) {
 					fx.Invoke(oneShotFunc))...))
 		return nil
 	}
-	defer func() { oneShotTestOverride = nil }()
+	defer func() { fxAppTestOverride = nil }()
 
 	fct()
 	require.True(t, oneShotRan, "fxutil.OneShot wasn't called")

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -374,7 +374,8 @@ def lint_fxutil_oneshot_test(_):
     for folder in folders:
         folder_path = pathlib.Path(folder)
         for file in folder_path.rglob("*.go"):
-            if str(file).endswith("_test.go") or str(file).endswith("main.go") or str(file).endswith("main_windows.go"):
+            # Don't lint test files
+            if str(file).endswith("_test.go"):
                 continue
 
             one_shot_count = file.read_text().count("fxutil.OneShot(")

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -377,24 +377,32 @@ def lint_fxutil_oneshot_test(_):
             if str(file).endswith("_test.go") or str(file).endswith("main.go") or str(file).endswith("main_windows.go"):
                 continue
 
-            # The code in this file cannot be easily tested
-            if "cmd/system-probe/subcommands/run/command.go" in str(file):
-                continue
-
             one_shot_count = file.read_text().count("fxutil.OneShot(")
-            if one_shot_count > 0:
+            run_count = file.read_text().count("fxutil.Run(")
+
+            expect_reason = 'fxutil.OneShot'
+            if one_shot_count == 0 and run_count > 0:
+                expect_reason = 'fxutil.Run'
+
+            if one_shot_count > 0 or run_count > 0:
                 test_path = file.parent.joinpath(f"{file.stem}_test.go")
                 if not test_path.exists():
-                    errors.append(f"The file {file} contains fxutil.OneShot but the file {test_path} doesn't exist.")
+                    errors.append(f"The file {file} contains {expect_reason} but the file {test_path} doesn't exist.")
                 else:
                     content = test_path.read_text()
-                    sub_cmd_count = content.count("fxutil.TestOneShotSubcommand(")
+                    test_sub_cmd_count = content.count("fxutil.TestOneShotSubcommand(")
                     test_one_shot_count = content.count("fxutil.TestOneShot(")
-                    if one_shot_count > sub_cmd_count + test_one_shot_count:
+                    test_run_count = content.count("fxutil.TestRun(")
+                    if one_shot_count > test_sub_cmd_count + test_one_shot_count:
                         errors.append(
                             f"The file {file} contains {one_shot_count} call(s) to `fxutil.OneShot`"
-                            + f"but {test_path} contains only {sub_cmd_count} call(s) to `fxutil.TestOneShotSubcommand`"
-                            + f"and {test_one_shot_count} call(s) to `fxutil.TestOneShot`"
+                            + f" but {test_path} contains only {test_sub_cmd_count} call(s) to `fxutil.TestOneShotSubcommand`"
+                            + f" and {test_one_shot_count} call(s) to `fxutil.TestOneShot`"
+                        )
+                    if run_count > test_run_count:
+                        errors.append(
+                            f"The file {file} contains {run_count} call(s) to `fxutil.Run`"
+                            + f" but {test_path} contains only {test_run_count} call(s) to `fxutil.TestRun`"
                         )
     if len(errors) > 0:
         msg = '\n'.join(errors)


### PR DESCRIPTION

### What does this PR do?

Improve the existing linter check to ensure that users of fx.Run and fx.OneShot have corresponding unit tests. These unit tests should verify that the fx dependencies are correctly fulfilled by using fx. This is done by checking for calls to fxutil.TestOneShot, fxutil.TestOneShotSubcommand, and fxutil.Run.

### Motivation

Ensure that fx.dependencies are fulfilled, preventing future breakages.

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
