### PR TITLE
omnibus: lmdb: allow overriding build/install environment & use common env/flags

### DIFF
--- a/omnibus/config/patches/lmdb/allow-makefile-override-vars.diff
+++ b/omnibus/config/patches/lmdb/allow-makefile-override-vars.diff
@@ -1,0 +1,22 @@
+--- a/Makefile	2023-12-06 12:09:29.871461460 +0100
++++ b/Makefile	2023-12-06 12:10:29.907352846 +0100
+@@ -18,16 +18,16 @@
+ # There may be other macros in mdb.c of interest. You should
+ # read mdb.c before changing any of them.
+ #
+-CC	= gcc
+-AR	= ar
++CC	?= gcc
++AR	?= ar
+ W	= -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized
+ THREADS = -pthread
+ OPT = -O2 -g
+ CFLAGS	= $(THREADS) $(OPT) $(W) $(XCFLAGS)
+ LDLIBS	=
+ SOLIBS	=
+ SOEXT	= .so
+-prefix	= /usr/local
++prefix	?= /usr/local
+ exec_prefix = $(prefix)
+ bindir = $(exec_prefix)/bin
+ libdir = $(exec_prefix)/lib

--- a/omnibus/config/software/lmdb.rb
+++ b/omnibus/config/software/lmdb.rb
@@ -10,11 +10,10 @@ relative_path "lmdb-LMDB_#{version}/libraries/liblmdb"
 build do
     license "OpenLDAP Public License"
     license_file "https://raw.githubusercontent.com/LMDB/lmdb/LMDB_#{version}/libraries/liblmdb/COPYRIGHT"
-    env = {
-        "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-        "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-        "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-    }
+    patch source: "allow-makefile-override-vars.diff"
+    env = with_standard_compiler_flags(with_embedded_path)
+    env["prefix"] = "#{install_dir}/embedded/"
+    env["XCFLAGS"] = env["CFLAGS"]
 
     # https://www.linuxfromscratch.org/blfs/view/8.3/server/lmdb.html
     command "make -j #{workers}", :env => env
@@ -24,13 +23,6 @@ build do
     else
         command "sed -i 's| liblmdb.a||' Makefile", :env => env
     end
-
-    # We have to manually move the files into the correct directories because the Makefile for lmdb hardcodes the install directory to `/usr/local`, although we need this to be `#{install_dir}/embedded`
-    copy "liblmdb.so", "#{install_dir}/embedded/lib/liblmdb.so"
-    copy "lmdb.h", "#{install_dir}/embedded/include/lmdb.h"
-    copy "mdb_stat", "#{install_dir}/embedded/bin/mdb_stat"
-    copy "mdb_copy", "#{install_dir}/embedded/bin/mdb_copy"
-    copy "mdb_dump", "#{install_dir}/embedded/bin/mdb_dump"
-    copy "mdb_load", "#{install_dir}/embedded/bin/mdb_load"
+    command "make install", :env => env
 
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix and simplify the lmdb recipe

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We can now specify a different toolchain, use specific compiler flags, and don't have to copy each individual file we need to the install directory

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
