### PR TITLE
Add logging in testDNSStats

### DIFF
--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1391,6 +1391,8 @@ func (s *TracerSuite) TestDNSStatsWithNAT() {
 	cfg.CollectDNSStats = true
 	cfg.DNSTimeout = 1 * time.Second
 	tr := setupTracer(t, cfg)
+
+	t.Logf("requesting golang.com@2.2.2.2 with conntrack type: %T", tr.conntracker)
 	testDNSStats(t, tr, "golang.org", 1, 0, 0, "2.2.2.2")
 }
 

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1007,9 +1007,6 @@ func testDNSStats(t *testing.T, tr *Tracer, domain string, success, failure, tim
 	tr.removeClient(clientID)
 	initTracerState(t, tr)
 
-	t.Logf("test: %s@%s running query on %s and expecting success=%d, failure=%d, timeout=%d with conntracker: %T",
-		t.Name(), domain, serverIP, success, failure, timeout, tr.conntracker)
-
 	dnsServerAddr := &net.UDPAddr{IP: net.ParseIP(serverIP), Port: 53}
 
 	queryMsg := new(dns.Msg)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1007,6 +1007,9 @@ func testDNSStats(t *testing.T, tr *Tracer, domain string, success, failure, tim
 	tr.removeClient(clientID)
 	initTracerState(t, tr)
 
+	t.Logf("test: %s@%s running query on %s and expecting success=%d, failure=%d, timeout=%d with conntracker: %T",
+		t.Name(), domain, serverIP, success, failure, timeout, tr.conntracker)
+
 	dnsServerAddr := &net.UDPAddr{IP: net.ParseIP(serverIP), Port: 53}
 
 	queryMsg := new(dns.Msg)


### PR DESCRIPTION
### What does this PR do?

TestDNSStatsWithNAT is still flaky, I'm noticing that many of the failures are on prebuilt, and the CO-RE failures have the suspicious 'clang timed out error'. I'm wondering if this is an issue of the netlink conntracker being behind the real tracer. These logs will help verify. If all the failures we see are on prebuilt, we can either skip this test with netlink conntrack,  or add some synchronization


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
