### PR TITLE
Trigger child pipeline invoke task buffer flush to track progress

### DIFF
--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -158,14 +158,16 @@ def wait_for_pipeline(gitlab, pipeline_id, pipeline_finish_timeout_sec=PIPELINE_
             + " by "
             + color_message(commit_author, "bold"),
             "blue",
-            ), flush=True
+        ),
+        flush=True,
     )
     print(
         color_message(
             "Pipeline Link: "
             + color_message(f"https://gitlab.ddbuild.io/{gitlab.project_name}/pipelines/{pipeline_id}", "green"),
             "blue",
-        ), flush=True
+        ),
+        flush=True,
     )
 
     print(color_message("Waiting for pipeline to finish. Exiting won't cancel it.", "blue"), flush=True)
@@ -217,7 +219,8 @@ def pipeline_status(gitlab, pipeline_id, job_status):
             color_message(
                 f"Pipeline https://gitlab.ddbuild.io/{gitlab.project_name}/pipelines/{pipeline_id} for {ref} succeeded",
                 "green",
-                ), flush=True
+            ),
+            flush=True,
         )
         notify("Pipeline success", f"Pipeline {pipeline_id} for {ref} succeeded.")
         return True, job_status
@@ -227,7 +230,8 @@ def pipeline_status(gitlab, pipeline_id, job_status):
             color_message(
                 f"Pipeline https://gitlab.ddbuild.io/{gitlab.project_name}/pipelines/{pipeline_id} for {ref} failed",
                 "red",
-            ), flush=True
+            ),
+            flush=True,
         )
         notify("Pipeline failure", f"Pipeline {pipeline_id} for {ref} failed.")
         return True, job_status
@@ -237,7 +241,8 @@ def pipeline_status(gitlab, pipeline_id, job_status):
             color_message(
                 f"Pipeline https://gitlab.ddbuild.io/{gitlab.project_name}/pipelines/{pipeline_id} for {ref} was canceled",
                 "grey",
-            ), flush=True
+            ),
+            flush=True,
         )
         notify("Pipeline canceled", f"Pipeline {pipeline_id} for {ref} was canceled.")
         return True, job_status
@@ -295,7 +300,8 @@ def print_job_status(job):
             color_message(
                 f"[{date}] Job {name} (stage: {stage}) {status} [job duration: {duration // 60:.0f}m{duration % 60:2.0f}s]\n{link}".strip(),
                 color,
-            ), flush=True
+            ),
+            flush=True,
         )
 
     def print_retry(name, date):

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -158,17 +158,17 @@ def wait_for_pipeline(gitlab, pipeline_id, pipeline_finish_timeout_sec=PIPELINE_
             + " by "
             + color_message(commit_author, "bold"),
             "blue",
-        )
+            ), flush=True
     )
     print(
         color_message(
             "Pipeline Link: "
             + color_message(f"https://gitlab.ddbuild.io/{gitlab.project_name}/pipelines/{pipeline_id}", "green"),
             "blue",
-        )
+        ), flush=True
     )
 
-    print(color_message("Waiting for pipeline to finish. Exiting won't cancel it.", "blue"))
+    print(color_message("Waiting for pipeline to finish. Exiting won't cancel it.", "blue"), flush=True)
 
     f = functools.partial(pipeline_status, gitlab, pipeline_id)
 
@@ -217,7 +217,7 @@ def pipeline_status(gitlab, pipeline_id, job_status):
             color_message(
                 f"Pipeline https://gitlab.ddbuild.io/{gitlab.project_name}/pipelines/{pipeline_id} for {ref} succeeded",
                 "green",
-            )
+                ), flush=True
         )
         notify("Pipeline success", f"Pipeline {pipeline_id} for {ref} succeeded.")
         return True, job_status
@@ -227,7 +227,7 @@ def pipeline_status(gitlab, pipeline_id, job_status):
             color_message(
                 f"Pipeline https://gitlab.ddbuild.io/{gitlab.project_name}/pipelines/{pipeline_id} for {ref} failed",
                 "red",
-            )
+            ), flush=True
         )
         notify("Pipeline failure", f"Pipeline {pipeline_id} for {ref} failed.")
         return True, job_status
@@ -237,7 +237,7 @@ def pipeline_status(gitlab, pipeline_id, job_status):
             color_message(
                 f"Pipeline https://gitlab.ddbuild.io/{gitlab.project_name}/pipelines/{pipeline_id} for {ref} was canceled",
                 "grey",
-            )
+            ), flush=True
         )
         notify("Pipeline canceled", f"Pipeline {pipeline_id} for {ref} was canceled.")
         return True, job_status
@@ -295,7 +295,7 @@ def print_job_status(job):
             color_message(
                 f"[{date}] Job {name} (stage: {stage}) {status} [job duration: {duration // 60:.0f}m{duration % 60:2.0f}s]\n{link}".strip(),
                 color,
-            )
+            ), flush=True
         )
 
     def print_retry(name, date):

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -440,7 +440,10 @@ def trigger_child_pipeline(_, git_ref, project_name, variables="", follow=True):
     for v in variables.split(','):
         data['variables'][v] = os.environ[v]
 
-    print(f"Creating child pipeline in repo {project_name}, on git ref {git_ref} with params: {data['variables']}", flush=True)
+    print(
+        f"Creating child pipeline in repo {project_name}, on git ref {git_ref} with params: {data['variables']}",
+        flush=True,
+    )
 
     res = gitlab.trigger_pipeline(data)
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -440,7 +440,7 @@ def trigger_child_pipeline(_, git_ref, project_name, variables="", follow=True):
     for v in variables.split(','):
         data['variables'][v] = os.environ[v]
 
-    print(f"Creating child pipeline in repo {project_name}, on git ref {git_ref} with params: {data['variables']}")
+    print(f"Creating child pipeline in repo {project_name}, on git ref {git_ref} with params: {data['variables']}", flush=True)
 
     res = gitlab.trigger_pipeline(data)
 
@@ -449,10 +449,10 @@ def trigger_child_pipeline(_, git_ref, project_name, variables="", follow=True):
 
     pipeline_id = res['id']
     pipeline_url = res['web_url']
-    print(f"Created a child pipeline with id={pipeline_id}, url={pipeline_url}")
+    print(f"Created a child pipeline with id={pipeline_id}, url={pipeline_url}", flush=True)
 
     if follow:
-        print("Waiting for child pipeline to finish...")
+        print("Waiting for child pipeline to finish...", flush=True)
 
         wait_for_pipeline(gitlab, pipeline_id)
 
@@ -463,7 +463,7 @@ def trigger_child_pipeline(_, git_ref, project_name, variables="", follow=True):
         if pipestatus != "success":
             raise Exit(f"Error: child pipeline status {pipestatus.title()}", code=1)
 
-        print("Child pipeline finished successfully")
+        print("Child pipeline finished successfully", flush=True)
 
 
 def parse(commit_str):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds `flush=True` to some print function related to the `trigger-child-pipeline` invoke task to ensure the task progress is printed even if the gitlab job timeout.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

It happened in some scenario that the `inv trigger-child-pipeline` task wasn't printing it's output until the end of execution preventing to understand the issue on job's timeout.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
