### PR TITLE
Add tooling for opening PRs from other repos

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -917,6 +917,8 @@ def version(
     major_version='7',
     version_cached=False,
     pipeline_id=None,
+    include_git=True,
+    include_pre=True,
 ):
     """
     Get the agent version.
@@ -934,12 +936,13 @@ def version(
 
     version = get_version(
         ctx,
-        include_git=True,
+        include_git=include_git,
         url_safe=url_safe,
         git_sha_length=git_sha_length,
         major_version=major_version,
         include_pipeline_id=True,
         pipeline_id=pipeline_id,
+        include_pre=include_pre,
     )
     if omnibus_format:
         # See: https://github.com/DataDog/omnibus-ruby/blob/datadog-5.5.0/lib/omnibus/packagers/deb.rb#L599

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -152,3 +152,16 @@ def _get_code_owners(root_folder):
                 # example /tools/retry_file_dump ['@DataDog/agent-metrics-logs']
                 owners[path] = parts[1:]
     return owners
+
+
+@task
+def get_milestone_id(_, milestone):
+    # Local import as github isn't part of our default set of installed
+    # dependencies, and we don't to propagate it to files importing this one
+    from libs.common.github_api import GithubAPI
+
+    gh = GithubAPI('DataDog/datadog-agent')
+    m = gh.get_milestone_by_name(milestone)
+    if not m:
+        raise Exit(f'Milestone {milestone} wasn\'t found in the repo', code=1)
+    print(m.id)

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -157,7 +157,7 @@ def _get_code_owners(root_folder):
 @task
 def get_milestone_id(_, milestone):
     # Local import as github isn't part of our default set of installed
-    # dependencies, and we don't to propagate it to files importing this one
+    # dependencies, and we don't want to propagate it to files importing this one
     from libs.common.github_api import GithubAPI
 
     gh = GithubAPI('DataDog/datadog-agent')

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1234,6 +1234,23 @@ def build_rc(ctx, major_versions="6,7", patch_version=False, k8s_deployments=Fal
     )
 
 
+@task(help={'key': "Path to an existing release.json key, separated with double colons, eg. 'last_stable::6'"})
+def set_release_json(_, key, value):
+    release_json = _load_release_json()
+    path = key.split('::')
+    current_node = release_json
+    for key_idx in range(len(path)):
+        key = path[key_idx]
+        if key not in current_node:
+            raise Exit(code=1, message=f"Couldn't find '{key}' in release.json")
+        if key_idx == len(path) - 1:
+            current_node[key] = value
+            break
+        else:
+            current_node = current_node[key]
+    _save_release_json(release_json)
+
+
 @task(help={'key': "Path to the release.json key, separated with double colons, eg. 'last_stable::6'"})
 def get_release_json_value(_, key):
     release_json = _get_release_json_value(key)

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -374,13 +374,13 @@ def cache_version(ctx, git_sha_length=7, prefix=None):
 
 def get_version(
     ctx,
-    include_git=False,
     url_safe=False,
     git_sha_length=7,
     prefix=None,
     major_version='7',
     include_pipeline_id=False,
     pipeline_id=None,
+    include_git=False,
     include_pre=True,
 ):
     version = ""

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -381,6 +381,7 @@ def get_version(
     major_version='7',
     include_pipeline_id=False,
     pipeline_id=None,
+    include_pre=True,
 ):
     version = ""
     if pipeline_id is None:
@@ -405,7 +406,7 @@ def get_version(
             # Dev's versions behave the same as nightly
             is_nightly = cache_data["nightly"] or cache_data["dev"]
 
-            if pre:
+            if pre and include_pre:
                 version = f"{version}-{pre}"
     except (IOError, json.JSONDecodeError, IndexError) as e:
         # If a cache file is found but corrupted we ignore it.
@@ -423,7 +424,7 @@ def get_version(
         # Dev's versions behave the same as nightly
         bucket_branch = os.getenv("BUCKET_BRANCH")
         is_nightly = is_allowed_repo_nightly_branch(bucket_branch) or bucket_branch == "dev"
-        if pre:
+        if pre and include_pre:
             version = f"{version}-{pre}"
 
     if not commits_since_version and is_nightly and include_git:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds some tooling that allows an `omnibus-software` to bump some fields in our `release.json` and to open a PR on `datadog-agent`.
In order for the PR to have the correct milestone, another task has been added and `get_version` modified in order to get the next release version without any git/pre fields included.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Associated PR on omnibus-software: https://github.com/DataDog/omnibus-software/pull/498 (beware, this is still a WIP)

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
