### PR TITLE
Disable trigger_auto_staging_release when conductor is running

### DIFF
--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -30,7 +30,9 @@ trigger_auto_staging_release:
     AUTO_RELEASE: "true"
     TARGET_REPO: staging
   rules:
-    !reference [.on_deploy]
+    - if: $DDR == "true"
+      when: never
+    - !reference [.on_deploy]
 
 trigger_manual_prod_release:
   extends: .agent_release_management_trigger


### PR DESCRIPTION
### What does this PR do?

Disables the trigger_auto_staging_release gitlab job when the pipeline was triggered via conductor

### Motivation

Conductor was recently enabled for this repo, and the pipeline that was generated by it scheduled [this job](https://gitlab.ddbuild.io/DataDog/agent-release-management/-/pipelines/24747568) to run with a malformed config. The cause of the malformed config has not yet been confirmed, but in conversation it was determined that we do not want conductor triggering this job at all.

### Additional Notes

All conductor pipelines are kicked off with the variable `DDR=true`

### Possible Drawbacks / Trade-offs

Short term, this is hacky, but in a longer term we want to evaluate all of the jobs that are being kicked off as part of the pipeline and trim down what we do not need.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
