### PR TITLE
[ASCII-977] Go update auto-comment old versions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@
 /.github/workflows/windows-*.yml                    @DataDog/windows-agent
 /.github/workflows/cws-btfhub-sync.yml              @DataDog/agent-security
 /.github/workflows/gohai.yml                        @DataDog/agent-shared-components
+/.github/workflows/go-update-commenter.yml          @DataDog/agent-shared-components
 
 # Gitlab files
 # Files containing job contents are owned by teams in charge of the jobs + agent-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -505,6 +505,7 @@
 /tools/                                 @DataDog/agent-platform
 /tools/ebpf/                            @DataDog/ebpf-platform
 /tools/gdb/                             @DataDog/agent-shared-components
+/tools/go-update/                       @DataDog/agent-shared-components
 /tools/retry_file_dump/                 @DataDog/agent-metrics-logs
 /tools/windows/                         @DataDog/windows-agent
 /tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl @DataDog/windows-agent @DataDog/documentation

--- a/.github/workflows/go-update-commenter.yml
+++ b/.github/workflows/go-update-commenter.yml
@@ -2,13 +2,13 @@ name: "Go update commenter"
 
 on:
   pull_request:
+    # Only run on PR label events (in particular not on every commit)
     types: [ labeled ]
-  workflow_dispatch:
 
 jobs:
   old-versions-match:
-    # Only run if the PR is labeled with 'go-update' or if manually triggered
-    if: ${{ github.event.label.name == 'go-update' || github.event_name == 'workflow_dispatch' }}
+    # Only run if the PR is labeled with 'go-update'
+    if: ${{ github.event.label.name == 'go-update' }}
     runs-on: ubuntu-latest
     steps:
       # get the Go version of the target branch

--- a/.github/workflows/go-update-commenter.yml
+++ b/.github/workflows/go-update-commenter.yml
@@ -32,19 +32,28 @@ jobs:
         id: old_versions
         run: |
           set -euxo pipefail
+          # build the base of the Github URL to the current commit
           GITHUB_HEAD_URL='${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}'
           {
             echo "matches<<EOF"
             echo "Here are potential matches of the former version:"
             echo ""
+
+            # this step builds a Markdown list of potential matches
+            # the script `detect-old-version.sh` displays each matching line as "file:line_number:line_content"
+            # the sed command transforms this format into a markdown list with Github permalink URL for each file/line
+            # note that the sed command only works properly with GNU sed (MacOS sed doesn't seem to understand \S properly)
             bash -x ./tools/go-update/detect-old-version.sh "${{ steps.former_go_version.outputs.version }}" "${{ steps.new_go_version.outputs.version }}" | \
               sed -E 's|^([^:]+):([^:]+):\s*(\S.*)$|- [\1:\2]('"$GITHUB_HEAD_URL"'/\1#L\2): `\3`|'
+
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
       # and display it
       - uses: actions/github-script@v7
         env:
+          # We need to store the output in an environment variable and not use it directly in the createComment,
+          # as it will likely not be a valid JS string (eg. if it contains a quote character)
           CONTENT: ${{ steps.old_versions.outputs.matches }}
         with:
           script: |

--- a/.github/workflows/go-update-commenter.yml
+++ b/.github/workflows/go-update-commenter.yml
@@ -1,0 +1,56 @@
+name: "Go update commenter"
+
+on:
+  pull_request:
+    # Only run on PR label events (in particular not on every commit)
+    types: [ labeled ]
+
+jobs:
+  old-versions-match:
+    # Only run if the PR is labeled with 'go-update'
+    if: ${{ github.event.label.name == 'go-update' }}
+    runs-on: ubuntu-latest
+    steps:
+      # get the Go version of the target branch
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+      - name: Get former Go version
+        id: former_go_version
+        run: |
+          echo version="$(cat .go-version)" >> $GITHUB_OUTPUT
+
+      # get the Go version of the PR branch
+      - uses: actions/checkout@v3
+      - name: Get current Go version
+        id: new_go_version
+        run: |
+          echo version="$(cat .go-version)" >> $GITHUB_OUTPUT
+
+      # build the comment
+      - name: Build full comment
+        id: old_versions
+        run: |
+          set -euxo pipefail
+          GITHUB_HEAD_URL='${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}'
+          {
+            echo "matches<<EOF"
+            echo "Here are potential matches of the former version:"
+            echo ""
+            bash -x ./tools/go-update/detect-old-version.sh "${{ steps.former_go_version.outputs.version }}" "${{ steps.new_go_version.outputs.version }}" | \
+              sed -E 's|^([^:]+):([^:]+):\s*(\S.*)$|- [\1:\2]('"$GITHUB_HEAD_URL"'/\1#L\2): `\3`|'
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      # and display it
+      - uses: actions/github-script@v7
+        env:
+          CONTENT: ${{ steps.old_versions.outputs.matches }}
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: process.env.CONTENT
+            })

--- a/.github/workflows/go-update-commenter.yml
+++ b/.github/workflows/go-update-commenter.yml
@@ -2,13 +2,13 @@ name: "Go update commenter"
 
 on:
   pull_request:
-    # Only run on PR label events (in particular not on every commit)
     types: [ labeled ]
+  workflow_dispatch:
 
 jobs:
   old-versions-match:
-    # Only run if the PR is labeled with 'go-update'
-    if: ${{ github.event.label.name == 'go-update' }}
+    # Only run if the PR is labeled with 'go-update' or if manually triggered
+    if: ${{ github.event.label.name == 'go-update' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       # get the Go version of the target branch

--- a/tools/go-update/detect-old-version.sh
+++ b/tools/go-update/detect-old-version.sh
@@ -86,4 +86,6 @@ safegrep -r -I -i -n -E "$PATTERN" . \
     --exclude-dir omnibus --exclude-dir snmp --exclude-dir testdata \
     --exclude '*.rst' --exclude '*.sum' --exclude '*generated*.go' --exclude '*.svg' | \
 # exclude matches in go.mod files that are dependency versions (note the 'v' before the version)
-safegrep -v -E "go\.mod:.*v${PATTERN_GO_VERSION_ESCAPED}"
+safegrep -v -E "go\.mod:.*v${PATTERN_GO_VERSION_ESCAPED}" | \
+# grep outputs paths starting with ./, so we remove that
+sed -e 's|^./||'

--- a/tools/go-update/detect-old-version.sh
+++ b/tools/go-update/detect-old-version.sh
@@ -85,6 +85,7 @@ safegrep -r -I -i -n -E "$PATTERN" . \
     --exclude-dir fixtures --exclude-dir .git --exclude-dir releasenotes \
     --exclude-dir omnibus --exclude-dir snmp --exclude-dir testdata \
     --exclude '*.rst' --exclude '*.sum' --exclude '*generated*.go' --exclude '*.svg' | \
+# -v: invert match
 # exclude matches in go.mod files that are dependency versions (note the 'v' before the version)
 safegrep -v -E "go\.mod:.*v${PATTERN_GO_VERSION_ESCAPED}" | \
 # grep outputs paths starting with ./, so we remove that

--- a/tools/go-update/detect-old-version.sh
+++ b/tools/go-update/detect-old-version.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# This script is used to display files which might contain a reference to an old Go version.
+#
+# It can be explicitely given a Go version as argument to look for.
+# Otherwise, it assumes that the current branch is the one which contains the new Go version,
+# and compares it to $GITHUB_BASE_REF if it is defined, or "main" otherwise
+
+if [ $# -gt 2 ]; then
+    echo "This script takes at most two arguments, the old Go version we want to look for and the new one" 1>&2
+    echo "If no argument is given, they are fetched from the '.go-version' file, respectively of the branch from GITHUB_BASE_REF, or main if it is not defined." 1>&2
+    echo "" 1>&2
+    echo "If only one version is given, it is looked for without any particular checking." 1>&2
+    echo "If zero or two versions are given, the script checks whether the minor changed or only the bugfix, and uses either accordingly." 1>&2
+    exit 1
+fi
+
+if [ $# -eq 1 ]; then
+    # use the version given as argument
+    PATTERN_GO_VERSION="$1"
+else
+    if [ $# -eq 0 ]; then
+        # use the version from the .go-version file, and compare it to the one from GITHUB_BASE_REF, or main
+        GO_VERSION_PREV_BUGFIX=$(git show "${GITHUB_BASE_REF:-main}":.go-version)
+        GO_VERSION_NEW_BUGFIX=$(cat .go-version)
+    else
+        GO_VERSION_PREV_BUGFIX="$1"
+        GO_VERSION_NEW_BUGFIX="$2"
+    fi
+
+    GO_VERSION_PREV_MINOR="${GO_VERSION_PREV_BUGFIX%.*}"
+    echo "Former bugfix version: $GO_VERSION_PREV_BUGFIX" 1>&2
+    echo "Former minor version: $GO_VERSION_PREV_MINOR" 1>&2
+
+    GO_VERSION_NEW_MINOR="${GO_VERSION_NEW_BUGFIX%.*}"
+    echo "New bugfix version: $GO_VERSION_NEW_BUGFIX" 1>&2
+    echo "New minor version: $GO_VERSION_NEW_MINOR" 1>&2
+
+    # if the old bugfix is the same as the new one, return
+    if [ "$GO_VERSION_PREV_BUGFIX" == "$GO_VERSION_NEW_BUGFIX" ]; then
+        echo "This branch doesn't change the Go version" 1>&2
+        exit 1
+    fi
+
+    if [ "$GO_VERSION_PREV_MINOR" != "$GO_VERSION_NEW_MINOR" ]; then
+        # minor update
+        PATTERN_GO_VERSION="$GO_VERSION_PREV_MINOR"
+    else
+        # bugfix update
+        PATTERN_GO_VERSION="$GO_VERSION_PREV_BUGFIX"
+    fi
+fi
+
+echo "Looking for Go version: $PATTERN_GO_VERSION" 1>&2
+
+# Go versions can be preceded by a 'g' (golang), 'o' (go), 'v', or a non-alphanumerical character
+# Prevent matching when preceded by a dot, as it is likely not a Go version in that case
+PATTERN_PREFIX='(^|[^.a-fh-np-uw-z0-9])'
+# Go versions in go.dev/dl URLs are followed by a dot, so we need to allow it in the regex
+PATTERN_SUFFIX='($|[^a-z0-9])'
+
+# Go versions contain dots, which are special characters in regexes, so we need to escape them
+# Safely assume that the version only contains numbers and dots
+PATTERN_GO_VERSION_ESCAPED="$(echo "$PATTERN_GO_VERSION" | sed 's/\./\\./g')"
+# The regex is not perfect, but it should be good enough
+PATTERN="${PATTERN_PREFIX}${PATTERN_GO_VERSION_ESCAPED}${PATTERN_SUFFIX}"
+echo "Using pattern: $PATTERN" 1>&2
+
+# grep returns 1 when no match is found, which would cause the script to fail, wrap it to return 0 in that case.
+# It returns a non-zero value if grep returned >1.
+function safegrep() {
+    grep "$@" || [ $? -eq 1 ]
+}
+
+# -r: recursive
+# -I: ignore binary files
+# -i: ignore case
+# -n: print line number
+# -E: extended regexp pattern to match
+# --exclude-dir: exclude directories
+# --exclude: exclude file name patterns
+safegrep -r -I -i -n -E "$PATTERN" . \
+    --exclude-dir fixtures --exclude-dir .git --exclude-dir releasenotes \
+    --exclude-dir omnibus --exclude-dir snmp --exclude-dir testdata \
+    --exclude '*.rst' --exclude '*.sum' --exclude '*generated*.go' --exclude '*.svg' | \
+# exclude matches in go.mod files that are dependency versions (note the 'v' before the version)
+safegrep -v -E "go\.mod:.*v${PATTERN_GO_VERSION_ESCAPED}"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add a github workflow to comment on go-update PRs with the list of matches of the previous Go version.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Finding all references to the previous Go version can be hard due to the number of false positives.
Adding a script with complex rules will help, and having it print the result directly on the PR prevents forgetting it.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The workflow runs only when the `go-update` label is added to a PR, which prevents it from running on non-go-update PRs, and also prevents it from printing several times the results for the same PR (unless removing and adding back the label).

I tested the workflow directly in this PR, sorry for the mess.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
The script can run locally.
The workflow's result can be seen in the last [comment](https://github.com/DataDog/datadog-agent/pull/21476#issuecomment-1852308653) from `github-actions`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
