### PR TITLE
Fix inconsistent indentation on oracle-dbm yaml template

### DIFF
--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -90,28 +90,28 @@ instances:
   #
   # sysmetrics:
 
-      ## @param enabled - boolean - optional - default: true
-      ## Enable collection of database sysmetrics
-      #
-      # enabled: true
+    ## @param enabled - boolean - optional - default: true
+    ## Enable collection of database sysmetrics
+    #
+    # enabled: true
 
   ## Configure collection of tablespace usage
   #
   # tablespaces:
 
-      ## @param enabled - boolean - optional - default: true
-      ## Enable collection of tablespace usage
-      #
-      # enabled: true
+    ## @param enabled - boolean - optional - default: true
+    ## Enable collection of tablespace usage
+    #
+    # enabled: true
 
   ## Configure collection of process memory usage
   #
   # processes:
 
-      ## @param enabled - boolean - optional - default: true
-      ## Enable collection of process memory usage
-      #
-      # enabled: true
+    ## @param enabled - boolean - optional - default: true
+    ## Enable collection of process memory usage
+    #
+    # enabled: true
 
   ## @param dbm - boolean - optional - default: false
   ## Set to `true` to enable Database Monitoring.
@@ -122,165 +122,165 @@ instances:
   #
   # query_samples:
 
-      ## @param enabled - boolean - optional - default: true
-      ## Enable collection of query samples. Requires `dbm: true`.
-      #
-      # enabled: true
+    ## @param enabled - boolean - optional - default: true
+    ## Enable collection of query samples. Requires `dbm: true`.
+    #
+    # enabled: true
 
   ## Configure collection of query metrics
   #
   # query_metrics:
 
-      ## @param enabled - boolean - optional - default: true
-      ## Enable collection of query metrics. Requires enabled query samples.
-      #
-      # enabled: true
+    ## @param enabled - boolean - optional - default: true
+    ## Enable collection of query metrics. Requires enabled query samples.
+    #
+    # enabled: true
 
-      ## Configure query metrics collection for Datadog agent statements
-      #
-      # include_datadog_queries: false
-  
+    ## Configure query metrics collection for Datadog agent statements
+    #
+    # include_datadog_queries: false
+
   ## Configure collection of execution plans
   #
   # execution_plans:
 
-      ## @param enabled - boolean - optional - default: true
-      ## Enable collection of execution plans. Requires query metrics.
-      #
-      # enabled: true
+    ## @param enabled - boolean - optional - default: true
+    ## Enable collection of execution plans. Requires query metrics.
+    #
+    # enabled: true
 
   ## Configure how the SQL obfuscator behaves.
   ## Note: This option only applies when `dbm` is enabled.
   #
   # obfuscator_options:
 
-      ## @param replace_digits - boolean - optional - default: false
-      ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
-      ## Note: This option also applies to extracted tables using `collect_tables`.
-      #
-      # replace_digits: false
-
-      ## @param collect_metadata - boolean - optional - default: true
-      ## Set to `false` to disable the collection of metadata in your SQL statements.
-      ## Metadata includes things such as tables, commands, and comments.
-      #
-      # collect_metadata: true
-
-      ## @param collect_tables - boolean - optional - default: true
-      ## Set to `false` to disable the collection of tables in your SQL statements.
-      ## Requires `collect_metadata: true`.
-      #
-      # collect_tables: true
-
-      ## @param collect_commands - boolean - optional - default: true
-      ## Set to `false` to disable the collection of commands in your SQL statements.
-      ## Requires `collect_metadata: true`.
-      ##
-      ## Examples: SELECT, UPDATE, DELETE, etc.
-      #
-      # collect_commands: true
-
-      ## @param collect_comments - boolean - optional - default: true
-      ## Set to `false` to disable the collection of comments in your SQL statements.
-      ## Requires `collect_metadata: true`.
-      #
-      # collect_comments: true
-
-    ## Configure collection of shared memory usage
+    ## @param replace_digits - boolean - optional - default: false
+    ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
+    ## Note: This option also applies to extracted tables using `collect_tables`.
     #
-    # shared_memory:
+    # replace_digits: false
 
-        ## @param enabled - boolean - optional - default: true. Requires `dbm: true`.
-        ## Enable collection of database shared memory usages
-        #
-        # enabled: true
+    ## @param collect_metadata - boolean - optional - default: true
+    ## Set to `false` to disable the collection of metadata in your SQL statements.
+    ## Metadata includes things such as tables, commands, and comments.
+    #
+    # collect_metadata: true
 
-    ## @param use_global_custom_queries - string - optional - default: 'true'
-    ## How `global_custom_queries` should be used for this instance. There are 3 options:
+    ## @param collect_tables - boolean - optional - default: true
+    ## Set to `false` to disable the collection of tables in your SQL statements.
+    ## Requires `collect_metadata: true`.
+    #
+    # collect_tables: true
+
+    ## @param collect_commands - boolean - optional - default: true
+    ## Set to `false` to disable the collection of commands in your SQL statements.
+    ## Requires `collect_metadata: true`.
     ##
-    ## 1. true - `global_custom_queries` override `custom_queries`.
-    ## 2. false - `custom_queries` override `global_custom_queries`.
-    ## 3. extend - `global_custom_queries` are used in addition to any `custom_queries`.
+    ## Examples: SELECT, UPDATE, DELETE, etc.
     #
-    # use_global_custom_queries: 'true'
+    # collect_commands: true
 
-    ## @param tags - list of strings - optional
-    ## A list of tags to attach to every metric and service check emitted by this instance.
-    ##
-    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    ## @param collect_comments - boolean - optional - default: true
+    ## Set to `false` to disable the collection of comments in your SQL statements.
+    ## Requires `collect_metadata: true`.
     #
-    # tags:
-    #   - <KEY_1>:<VALUE_1>
-    #   - <KEY_2>:<VALUE_2>
+    # collect_comments: true
 
-    ## @param custom_queries - list of mappings - optional
-    ## Each query must have 2 fields, and can have a third optional field:
-    ##
-    ## 1. metric_prefix - Each metric starts with the chosen prefix.
-    ## 2. query - The SQL to execute. It can be a simple statement or a multi-line script.
-    ##            Use the pipe `|` if you require a multi-line script.
-    ## 3. columns - The list representing each column, ordered sequentially from left to right.
-    ##              The number of columns must equal the number of columns returned in the query.
-    ##              There are 2 required pieces of data:
-    ##                a. name - The suffix to append to `metric_prefix` to form
-    ##                          the full metric name. If `type` is `tag`, this column is
-    ##                          considered a tag and applied to every
-    ##                          metric collected by this particular query.
-    ##                b. type - The submission method (gauge, monotonic_count, etc.).
-    ##                          This can also be set to `tag` to tag each metric in the row
-    ##                          with the name and value of the item in this column. You can
-    ##                          use the `count` type to perform aggregation for queries that
-    ##                          return multiple rows with the same or no tags.
-    ##              Columns without a name are ignored. To skip a column, enter:
-    ##                - {}
-    ## 4. tags (optional) - A list of tags to apply to each metric.
+  ## Configure collection of shared memory usage
+  #
+  # shared_memory:
+
+    ## @param enabled - boolean - optional - default: true. Requires `dbm: true`.
+    ## Enable collection of database shared memory usages
     #
-    custom_queries:
-      - metric_prefix: oracle.custom_query.table_events
-        query: SELECT program, COUNT(*) FROM table_events GROUP BY program
-        columns:
-        - name: foo
-          type: tag
-        - name: total
-          type: gauge
-        tags:
-        - tag1:value1
+    # enabled: true
 
-    ## WARNING: Running custom queries may result in additional costs or fees assessed by Oracle.
-    
-    # custom_queries:
-    #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
-    #     columns:
-    #     - name: foo
-    #       type: tag
-    #     - name: event.total
-    #       type: gauge
-    #     tags:
-    #     - test:tag_value_1
-    #     pdb: <MYPDB>
+  ## @param use_global_custom_queries - string - optional - default: 'true'
+  ## How `global_custom_queries` should be used for this instance. There are 3 options:
+  ##
+  ## 1. true - `global_custom_queries` override `custom_queries`.
+  ## 2. false - `custom_queries` override `global_custom_queries`.
+  ## 3. extend - `global_custom_queries` are used in addition to any `custom_queries`.
+  #
+  # use_global_custom_queries: 'true'
 
-  ## Start an SQL trace for Agent queries. This feature is only meant for Agent troubleshooting, and 
+  ## @param tags - list of strings - optional
+  ## A list of tags to attach to every metric and service check emitted by this instance.
+  ##
+  ## Learn more about tagging at https://docs.datadoghq.com/tagging
+  #
+  # tags:
+  #   - <KEY_1>:<VALUE_1>
+  #   - <KEY_2>:<VALUE_2>
+
+  ## @param custom_queries - list of mappings - optional
+  ## Each query must have 2 fields, and can have a third optional field:
+  ##
+  ## 1. metric_prefix - Each metric starts with the chosen prefix.
+  ## 2. query - The SQL to execute. It can be a simple statement or a multi-line script.
+  ##            Use the pipe `|` if you require a multi-line script.
+  ## 3. columns - The list representing each column, ordered sequentially from left to right.
+  ##              The number of columns must equal the number of columns returned in the query.
+  ##              There are 2 required pieces of data:
+  ##                a. name - The suffix to append to `metric_prefix` to form
+  ##                          the full metric name. If `type` is `tag`, this column is
+  ##                          considered a tag and applied to every
+  ##                          metric collected by this particular query.
+  ##                b. type - The submission method (gauge, monotonic_count, etc.).
+  ##                          This can also be set to `tag` to tag each metric in the row
+  ##                          with the name and value of the item in this column. You can
+  ##                          use the `count` type to perform aggregation for queries that
+  ##                          return multiple rows with the same or no tags.
+  ##              Columns without a name are ignored. To skip a column, enter:
+  ##                - {}
+  ## 4. tags (optional) - A list of tags to apply to each metric.
+  #
+  custom_queries:
+    - metric_prefix: oracle.custom_query.table_events
+      query: SELECT program, COUNT(*) FROM table_events GROUP BY program
+      columns:
+      - name: foo
+        type: tag
+      - name: total
+        type: gauge
+      tags:
+      - tag1:value1
+
+  ## WARNING: Running custom queries may result in additional costs or fees assessed by Oracle.
+
+  # custom_queries:
+  #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
+  #     columns:
+  #     - name: foo
+  #       type: tag
+  #     - name: event.total
+  #       type: gauge
+  #     tags:
+  #     - test:tag_value_1
+  #     pdb: <MYPDB>
+
+  ## Start an SQL trace for Agent queries. This feature is only meant for Agent troubleshooting, and
   ## should normally be switched off.
   ## Requires execute the execute privilege on `dbms_monitor` to datadog user
   #
   # agent_sql_trace:
 
-      ## @param enabled - boolean - optional - default: false
-      ## Enable SQL trace
-      #
-      # enabled: false
+    ## @param enabled - boolean - optional - default: false
+    ## Enable SQL trace
+    #
+    # enabled: false
 
-      ## @param enabled - boolean - optional - default: false
-      ## include bind variables in trace
-      #
-      # binds: false
+    ## @param enabled - boolean - optional - default: false
+    ## include bind variables in trace
+    #
+    # binds: false
 
-      ## @param enabled - boolean - optional - default: false
-      ## include wait events in trace
-      #
-      # waits: false
+    ## @param enabled - boolean - optional - default: false
+    ## include wait events in trace
+    #
+    # waits: false
 
-      ## @param enabled - int - optional - default: 10
-      ## Limit the number of traced check executions to avoid filling the file system.
-      #
-      # traced_runs: 10
+    ## @param enabled - int - optional - default: 10
+    ## Limit the number of traced check executions to avoid filling the file system.
+    #
+    # traced_runs: 10


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix inconsistent indentation so that it's easier to apply the oracle-dbm configuration without mistakes.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

When adding tags, I've noticed that it required one indentation less. Seeing the rest of the
file, I've noticed more inconsistencies. This aims to keep every indentation with 2 spaces.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

As it's only a change in a template, I had added the option to skip the CI. But had to turn it back because it got stuck.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
