### PR TITLE
[CWS] revert mount cleanup

### DIFF
--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -69,6 +69,7 @@ type Resolver struct {
 	statsdClient    statsd.ClientInterface
 	lock            sync.RWMutex
 	mounts          map[uint32]*model.Mount
+	pidToMounts     map[uint32]map[uint32]*model.Mount
 	minMountID      uint32 // used to find the first userspace visible mount ID
 	redemption      *simplelru.LRU[uint32, *redemptionEntry]
 	fallbackLimiter *utils.Limiter[uint64]
@@ -119,12 +120,13 @@ func (mr *Resolver) syncPid(pid uint32) error {
 	}
 
 	for _, mnt := range mnts {
-		if _, exists := mr.mounts[uint32(mnt.ID)]; exists {
+		if m, exists := mr.mounts[uint32(mnt.ID)]; exists {
+			mr.updatePidMapping(m, pid)
 			continue
 		}
 
 		m := newMountFromMountInfo(mnt)
-		mr.insert(m)
+		mr.insert(m, pid)
 	}
 
 	return nil
@@ -158,7 +160,7 @@ func (mr *Resolver) delete(mount *model.Mount) {
 		curr, rest := openQueue[len(openQueue)-1], openQueue[:len(openQueue)-1]
 		openQueue = rest
 
-		mr.finalize(curr)
+		delete(mr.mounts, curr.MountID)
 
 		entry := redemptionEntry{
 			mount:      curr,
@@ -170,6 +172,10 @@ func (mr *Resolver) delete(mount *model.Mount) {
 			if child.ParentPathKey.MountID == curr.MountID {
 				openQueue = append(openQueue, child)
 			}
+		}
+
+		for _, mounts := range mr.pidToMounts {
+			delete(mounts, mount.MountID)
 		}
 	}
 }
@@ -206,7 +212,7 @@ func (mr *Resolver) ResolveFilesystem(mountID uint32, device uint32, pid uint32,
 }
 
 // Insert a new mount point in the cache
-func (mr *Resolver) Insert(m model.Mount) error {
+func (mr *Resolver) Insert(m model.Mount, pid uint32) error {
 	if m.MountID == 0 {
 		return ErrMountUndefined
 	}
@@ -214,12 +220,37 @@ func (mr *Resolver) Insert(m model.Mount) error {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	mr.insert(&m)
+	mr.insert(&m, pid)
 
 	return nil
 }
 
-func (mr *Resolver) insert(m *model.Mount) {
+func (mr *Resolver) updatePidMapping(m *model.Mount, pid uint32) {
+	if pid == 0 {
+		return
+	}
+
+	mounts := mr.pidToMounts[pid]
+	if mounts == nil {
+		mounts = make(map[uint32]*model.Mount)
+		mr.pidToMounts[pid] = mounts
+	}
+	mounts[m.MountID] = m
+}
+
+// DelPid removes the pid form the pid mapping
+func (mr *Resolver) DelPid(pid uint32) {
+	if pid == 0 {
+		return
+	}
+
+	mr.lock.Lock()
+	defer mr.lock.Unlock()
+
+	delete(mr.pidToMounts, pid)
+}
+
+func (mr *Resolver) insert(m *model.Mount, pid uint32) {
 	// umount the previous one if exists
 	if prev, ok := mr.mounts[m.MountID]; ok {
 		// put the prev entry and the all the children in the redemption list
@@ -242,6 +273,8 @@ func (mr *Resolver) insert(m *model.Mount) {
 	}
 
 	mr.mounts[m.MountID] = m
+
+	mr.updatePidMapping(m, pid)
 }
 
 func (mr *Resolver) getFromRedemption(mountID uint32) *model.Mount {
@@ -253,13 +286,20 @@ func (mr *Resolver) getFromRedemption(mountID uint32) *model.Mount {
 }
 
 func (mr *Resolver) lookupByMountID(mountID uint32) *model.Mount {
-	return mr.mounts[mountID]
+	mount := mr.mounts[mountID]
+	if mount != nil {
+		return mount
+	}
+
+	return mr.getFromRedemption(mountID)
 }
 
-func (mr *Resolver) lookupByDevice(device uint32) *model.Mount {
+func (mr *Resolver) lookupByDevice(device uint32, pid uint32) *model.Mount {
 	var result *model.Mount
 
-	for _, mount := range mr.mounts {
+	mounts := mr.pidToMounts[pid]
+
+	for _, mount := range mounts {
 		if mount.Device == device {
 			// should be consistent across all the mounts
 			if result != nil && result.MountPointStr != mount.MountPointStr {
@@ -272,30 +312,21 @@ func (mr *Resolver) lookupByDevice(device uint32) *model.Mount {
 	return result
 }
 
-func (mr *Resolver) lookupMount(mountID uint32, device uint32, allowFallbacks bool) *model.Mount {
-	if m := mr.lookupByMountID(mountID); m != nil {
-		return m
+func (mr *Resolver) lookupMount(mountID uint32, device uint32, pid uint32) *model.Mount {
+	mount := mr.lookupByMountID(mountID)
+	if mount != nil {
+		return mount
 	}
 
-	if allowFallbacks {
-		if m := mr.lookupByDevice(device); m != nil {
-			return m
-		}
-
-		if m := mr.getFromRedemption(mountID); m != nil {
-			return m
-		}
-	}
-
-	return nil
+	return mr.lookupByDevice(device, pid)
 }
 
-func (mr *Resolver) _getMountPath(mountID uint32, device uint32, cache map[uint32]bool, allowFallbacks bool) (string, error) {
+func (mr *Resolver) _getMountPath(mountID uint32, device uint32, pid uint32, cache map[uint32]bool) (string, error) {
 	if _, err := mr.IsMountIDValid(mountID); err != nil {
 		return "", err
 	}
 
-	mount := mr.lookupMount(mountID, device, allowFallbacks)
+	mount := mr.lookupMount(mountID, device, pid)
 	if mount == nil {
 		return "", &ErrMountNotFound{MountID: mountID}
 	}
@@ -319,7 +350,7 @@ func (mr *Resolver) _getMountPath(mountID uint32, device uint32, cache map[uint3
 		return "", ErrMountUndefined
 	}
 
-	parentMountPath, err := mr._getMountPath(mount.ParentPathKey.MountID, mount.Device, cache, allowFallbacks)
+	parentMountPath, err := mr._getMountPath(mount.ParentPathKey.MountID, mount.Device, pid, cache)
 	if err != nil {
 		return "", err
 	}
@@ -334,8 +365,8 @@ func (mr *Resolver) _getMountPath(mountID uint32, device uint32, cache map[uint3
 	return mountPointStr, nil
 }
 
-func (mr *Resolver) getMountPath(mountID uint32, device uint32, allowDeviceFallback bool) (string, error) {
-	return mr._getMountPath(mountID, device, map[uint32]bool{}, allowDeviceFallback)
+func (mr *Resolver) getMountPath(mountID uint32, device uint32, pid uint32) (string, error) {
+	return mr._getMountPath(mountID, device, pid, map[uint32]bool{})
 }
 
 // ResolveMountRoot returns the root of a mount identified by its mount ID.
@@ -389,11 +420,7 @@ func (mr *Resolver) resolveMountPath(mountID uint32, device uint32, pid uint32, 
 	// force a resolution here to make sure the LRU keeps doing its job and doesn't evict important entries
 	workload, _ := mr.cgroupsResolver.GetWorkload(containerID)
 
-	// if UseProcFS is disabled, we can directly allow the device fallback and redemption since getMountPath will be called
-	// only once
-	allowFallbacks := !mr.opts.UseProcFS
-
-	path, err := mr.getMountPath(mountID, device, allowFallbacks)
+	path, err := mr.getMountPath(mountID, device, pid)
 	if err == nil {
 		mr.cacheHitsStats.Inc()
 		return path, nil
@@ -408,7 +435,7 @@ func (mr *Resolver) resolveMountPath(mountID uint32, device uint32, pid uint32, 
 		return "", err
 	}
 
-	path, err = mr.getMountPath(mountID, device, true)
+	path, err = mr.getMountPath(mountID, device, pid)
 	if err == nil {
 		mr.procHitsStats.Inc()
 		return path, nil
@@ -434,11 +461,7 @@ func (mr *Resolver) resolveMount(mountID uint32, device uint32, pid uint32, cont
 	// force a resolution here to make sure the LRU keeps doing its job and doesn't evict important entries
 	workload, _ := mr.cgroupsResolver.GetWorkload(containerID)
 
-	// if UseProcFS is disabled, we can directly allow the device fallback and redemption since getMountPath will be called
-	// only once
-	allowFallbacks := !mr.opts.UseProcFS
-
-	mount := mr.lookupMount(mountID, device, allowFallbacks)
+	mount := mr.lookupMount(mountID, device, pid)
 	if mount != nil {
 		mr.cacheHitsStats.Inc()
 		return mount, nil
@@ -453,7 +476,7 @@ func (mr *Resolver) resolveMount(mountID uint32, device uint32, pid uint32, cont
 		return nil, err
 	}
 
-	mount = mr.lookupMount(mountID, device, true)
+	mount = mr.mounts[mountID]
 	if mount != nil {
 		mr.procHitsStats.Inc()
 		return mount, nil
@@ -575,6 +598,7 @@ func NewResolver(statsdClient statsd.ClientInterface, cgroupsResolver *cgroup.Re
 		cgroupsResolver: cgroupsResolver,
 		lock:            sync.RWMutex{},
 		mounts:          make(map[uint32]*model.Mount),
+		pidToMounts:     make(map[uint32]map[uint32]*model.Mount),
 		cacheHitsStats:  atomic.NewInt64(0),
 		procHitsStats:   atomic.NewInt64(0),
 		cacheMissStats:  atomic.NewInt64(0),

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -256,7 +256,6 @@ func (mr *Resolver) lookupByMountID(mountID uint32) *model.Mount {
 	return mr.mounts[mountID]
 }
 
-/*
 func (mr *Resolver) lookupByDevice(device uint32) *model.Mount {
 	var result *model.Mount
 
@@ -272,18 +271,16 @@ func (mr *Resolver) lookupByDevice(device uint32) *model.Mount {
 
 	return result
 }
-*/
 
-func (mr *Resolver) lookupMount(mountID uint32, _ uint32, allowFallbacks bool) *model.Mount {
+func (mr *Resolver) lookupMount(mountID uint32, device uint32, allowFallbacks bool) *model.Mount {
 	if m := mr.lookupByMountID(mountID); m != nil {
 		return m
 	}
 
 	if allowFallbacks {
-		// TODO(safchain) reintroduce using a namespace aware approach
-		/*if m := mr.lookupByDevice(device); m != nil {
+		if m := mr.lookupByDevice(device); m != nil {
 			return m
-		}*/
+		}
 
 		if m := mr.getFromRedemption(mountID); m != nil {
 			return m

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -444,7 +444,7 @@ func TestMountResolver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, evt := range tt.args.events {
 				if evt.mount != nil {
-					mr.insert(&evt.mount.Mount)
+					mr.insert(&evt.mount.Mount, pid)
 				}
 				if evt.umount != nil {
 					mount, err := mr.ResolveMount(evt.umount.MountID, 0, pid, "")
@@ -505,7 +505,7 @@ func TestMountGetParentPath(t *testing.T) {
 		},
 	}
 
-	parentPath, err := mr.getMountPath(4, 44, false)
+	parentPath, err := mr.getMountPath(4, 44, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, "/a/b/c", parentPath)
 }
@@ -541,7 +541,7 @@ func TestMountLoop(t *testing.T) {
 		},
 	}
 
-	parentPath, err := mr.getMountPath(3, 44, false)
+	parentPath, err := mr.getMountPath(3, 44, 1)
 	assert.Equal(t, ErrMountLoop, err)
 	assert.Equal(t, "", parentPath)
 }
@@ -568,6 +568,6 @@ func BenchmarkGetParentPath(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = mr.getMountPath(100, 44, false)
+		_, _ = mr.getMountPath(100, 44, 1)
 	}
 }

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -110,7 +110,7 @@ func TestMountResolver(t *testing.T) {
 				},
 			},
 		},
-		/*{
+		{
 			"insert_device",
 			args{
 				[]event{
@@ -137,7 +137,7 @@ func TestMountResolver(t *testing.T) {
 					},
 				},
 			},
-		},*/
+		},
 		{
 			"remove_overlay",
 			args{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Reverts https://github.com/DataDog/datadog-agent/pull/21153 and https://github.com/DataDog/datadog-agent/pull/21030
The goal of those PRs was to clean up and improve the mount resolver, but it created other issues and showed that the current model has a lot of flaws. This reverts them for now.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
