### PR TITLE
[Serverless] Support trace context extraction from SNS events.

### DIFF
--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -241,13 +241,12 @@ func TestStartEndInvocationSpanParenting(t *testing.T) {
 			expPriority: 1,
 		},
 		{
-			// NOTE: sns trace extraction not yet implemented
 			name:        "sns",
 			payload:     getEventFromFile("sns.json"),
 			expInfSpans: 1,
-			expTraceID:  0,
-			expParentID: 0,
-			expPriority: -128,
+			expTraceID:  4948377316357291421,
+			expParentID: 6746998015037429512,
+			expPriority: 1,
 		},
 		{
 			name:        "sns-sqs",

--- a/pkg/serverless/trace/propagation/carriers_test.go
+++ b/pkg/serverless/trace/propagation/carriers_test.go
@@ -169,7 +169,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 				}`,
 			},
 			expMap: nil,
-			expErr: errors.New("Error unmarshaling message body: json: cannot unmarshal string into Go struct field .MessageAttributes of type map[string]struct { Type string; Value string }"),
+			expErr: errors.New("Error unmarshaling message body: json: cannot unmarshal string into Go struct field SNSEntity.MessageAttributes of type map[string]interface {}"),
 		},
 		{
 			name: "non-binary-type",
@@ -177,14 +177,14 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 				Body: `{
 					"MessageAttributes": {
 						"_datadog": {
-							"Type": "String",
+							"Type": "Purple",
 							"Value": "Value"
 						}
 					}
 				}`,
 			},
 			expMap: nil,
-			expErr: errors.New("Unsupported DataType in _datadog payload"),
+			expErr: errors.New("Unsupported Type in _datadog payload"),
 		},
 		{
 			name: "cannot-decode",
@@ -234,6 +234,135 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tm, err := snsSqsMessageCarrier(tc.event)
 			t.Logf("snsSqsMessageCarrier returned TextMapReader=%#v error=%#v", tm, err)
+			assert.Equal(t, tc.expErr != nil, err != nil)
+			if tc.expErr != nil && err != nil {
+				assert.Equal(t, tc.expErr.Error(), err.Error())
+			}
+			assert.Equal(t, tc.expMap, getMapFromCarrier(tm))
+		})
+	}
+}
+
+func TestSnsEntityCarrier(t *testing.T) {
+	testcases := []struct {
+		name   string
+		event  events.SNSEntity
+		expMap map[string]string
+		expErr error
+	}{
+		{
+			name:   "no-msg-attrs",
+			event:  events.SNSEntity{},
+			expMap: nil,
+			expErr: errors.New("No Datadog trace context found"),
+		},
+		{
+			name: "wrong-type-msg-attrs",
+			event: events.SNSEntity{
+				MessageAttributes: map[string]interface{}{
+					"_datadog": 12345,
+				},
+			},
+			expMap: nil,
+			expErr: errors.New("Unsupported type for _datadog payload"),
+		},
+		{
+			name: "wrong-type-type",
+			event: events.SNSEntity{
+				MessageAttributes: map[string]interface{}{
+					"_datadog": map[string]interface{}{
+						"Type":  12345,
+						"Value": "Value",
+					},
+				},
+			},
+			expMap: nil,
+			expErr: errors.New("Unsupported type in _datadog payload"),
+		},
+		{
+			name: "wrong-value-type",
+			event: events.SNSEntity{
+				MessageAttributes: map[string]interface{}{
+					"_datadog": map[string]interface{}{
+						"Type":  "Binary",
+						"Value": 12345,
+					},
+				},
+			},
+			expMap: nil,
+			expErr: errors.New("Unsupported value type in _datadog payload"),
+		},
+		{
+			name: "cannot-decode",
+			event: events.SNSEntity{
+				MessageAttributes: map[string]interface{}{
+					"_datadog": map[string]interface{}{
+						"Type":  "Binary",
+						"Value": "Value",
+					},
+				},
+			},
+			expMap: nil,
+			expErr: errors.New("Error decoding binary: illegal base64 data at input byte 4"),
+		},
+		{
+			name: "unknown-type",
+			event: events.SNSEntity{
+				MessageAttributes: map[string]interface{}{
+					"_datadog": map[string]interface{}{
+						"Type":  "Purple",
+						"Value": "Value",
+					},
+				},
+			},
+			expMap: nil,
+			expErr: errors.New("Unsupported Type in _datadog payload"),
+		},
+		{
+			name: "empty-string-encoded",
+			event: events.SNSEntity{
+				MessageAttributes: map[string]interface{}{
+					"_datadog": map[string]interface{}{
+						"Type":  "Binary",
+						"Value": base64.StdEncoding.EncodeToString([]byte(``)),
+					},
+				},
+			},
+			expMap: nil,
+			expErr: errors.New("Error unmarshaling the decoded binary: unexpected end of JSON input"),
+		},
+		{
+			name: "binary-type",
+			event: events.SNSEntity{
+				MessageAttributes: map[string]interface{}{
+					"_datadog": map[string]interface{}{
+						"Type":  "Binary",
+						"Value": base64.StdEncoding.EncodeToString([]byte(headersAll)),
+					},
+				},
+			},
+			expMap: headersMapAll,
+			expErr: nil,
+		},
+		{
+			name: "string-type",
+			event: events.SNSEntity{
+				MessageAttributes: map[string]interface{}{
+					"_datadog": map[string]interface{}{
+						"Type":  "String",
+						"Value": headersAll,
+					},
+				},
+			},
+			expMap: headersMapAll,
+			expErr: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tm, err := snsEntityCarrier(tc.event)
+			t.Logf("snsEntityCarrier returned TextMapReader=%#v error=%#v", tm, err)
 			assert.Equal(t, tc.expErr != nil, err != nil)
 			if tc.expErr != nil && err != nil {
 				assert.Equal(t, tc.expErr.Error(), err.Error())
@@ -441,6 +570,24 @@ func TestExtractTraceContextfromAWSTraceHeader(t *testing.T) {
 		{
 			name:     "parent key no parent value",
 			value:    "Root=1-00000000-000000000000000000000001;Parent=",
+			expTc:    nil,
+			expNoErr: false,
+		},
+		{
+			name:     "bad trace id",
+			value:    "Root=1-00000000-000000000000000000000001purple;Parent=0000000000000002;Sampled=1",
+			expTc:    nil,
+			expNoErr: false,
+		},
+		{
+			name:     "bad parent id",
+			value:    "Root=1-00000000-000000000000000000000001;Parent=0000000000000002purple;Sampled=1",
+			expTc:    nil,
+			expNoErr: false,
+		},
+		{
+			name:     "zero value trace and parent id",
+			value:    "Root=1-00000000-000000000000000000000000;Parent=0000000000000000;Sampled=1",
 			expTc:    nil,
 			expNoErr: false,
 		},

--- a/pkg/serverless/trace/propagation/carriers_test.go
+++ b/pkg/serverless/trace/propagation/carriers_test.go
@@ -169,7 +169,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 				}`,
 			},
 			expMap: nil,
-			expErr: errors.New("Error unmarshaling message body: json: cannot unmarshal string into Go struct field SNSEntity.MessageAttributes of type map[string]interface {}"),
+			expErr: errors.New("Error unmarshaling message body: json: cannot unmarshal string into Go struct field snsBody.MessageAttributes of type map[string]interface {}"),
 		},
 		{
 			name: "non-binary-type",

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -32,6 +32,7 @@ var (
 	errorUnsupportedExtractionType = errors.New("Unsupported event type for trace context extraction")
 	errorNoContextFound            = errors.New("No trace context found")
 	errorNoSQSRecordFound          = errors.New("No sqs message records found for trace context extraction")
+	errorNoSNSRecordFound          = errors.New("No sns message records found for trace context extraction")
 	errorNoTraceIDFound            = errors.New("No trace ID found")
 	errorNoParentIDFound           = errors.New("No parent ID found")
 )
@@ -91,6 +92,14 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 			}
 		}
 		carrier, err = sqsMessageCarrier(ev)
+	case events.SNSEvent:
+		// look for context in just the first message
+		if len(ev.Records) > 0 {
+			return e.extract(ev.Records[0].SNS)
+		}
+		return nil, errorNoSNSRecordFound
+	case events.SNSEntity:
+		carrier, err = snsEntityCarrier(ev)
 	case events.APIGatewayProxyRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	case events.APIGatewayV2HTTPRequest:

--- a/pkg/serverless/trace/propagation/extractor_test.go
+++ b/pkg/serverless/trace/propagation/extractor_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
@@ -150,6 +151,28 @@ var (
 		}
 		return e
 	}
+
+	eventSnsEntity = func(binHdrs, strHdrs string) events.SNSEntity {
+		e := events.SNSEntity{}
+		if len(binHdrs) > 0 && len(strHdrs) == 0 {
+			e.MessageAttributes = map[string]interface{}{
+				"_datadog": map[string]interface{}{
+					"Type":  "Binary",
+					"Value": base64.StdEncoding.EncodeToString([]byte(binHdrs)),
+				},
+			}
+		} else if len(binHdrs) == 0 && len(strHdrs) > 0 {
+			e.MessageAttributes = map[string]interface{}{
+				"_datadog": map[string]interface{}{
+					"Type":  "String",
+					"Value": strHdrs,
+				},
+			}
+		} else if len(binHdrs) > 0 && len(strHdrs) > 0 {
+			panic("expecting one of binHdrs or strHdrs, not both")
+		}
+		return e
+	}
 )
 
 func TestNilPropagator(t *testing.T) {
@@ -193,6 +216,16 @@ func TestExtractorExtract(t *testing.T) {
 		},
 
 		// events.SQSEvent
+		{
+			name: "sqs-event-no-records",
+			events: []interface{}{
+				events.SQSEvent{
+					Records: []events.SQSMessage{},
+				},
+			},
+			expCtx:   nil,
+			expNoErr: false,
+		},
 		{
 			name: "sqs-event-uses-first-record",
 			events: []interface{}{
@@ -285,6 +318,92 @@ func TestExtractorExtract(t *testing.T) {
 				eventSqsMessage(headersNone, headersDD, headersXray),
 			},
 			expCtx:   ddTraceContext,
+			expNoErr: true,
+		},
+
+		// events.SNSEvent
+		{
+			name: "sns-event-no-records",
+			events: []interface{}{
+				events.SNSEvent{
+					Records: []events.SNSEventRecord{},
+				},
+			},
+			expCtx:   nil,
+			expNoErr: false,
+		},
+		{
+			name: "sns-event-uses-first-record",
+			events: []interface{}{
+				events.SNSEvent{
+					Records: []events.SNSEventRecord{
+						// Uses the first message only
+						{SNS: eventSnsEntity(headersDD, headersNone)},
+						{SNS: eventSnsEntity(headersW3C, headersNone)},
+					},
+				},
+			},
+			expCtx:   ddTraceContext,
+			expNoErr: true,
+		},
+		{
+			name: "sqs-event-uses-first-record-empty",
+			events: []interface{}{
+				events.SNSEvent{
+					Records: []events.SNSEventRecord{
+						// Uses the first message only
+						{SNS: eventSnsEntity(headersNone, headersNone)},
+						{SNS: eventSnsEntity(headersW3C, headersNone)},
+					},
+				},
+			},
+			expCtx:   nil,
+			expNoErr: false,
+		},
+
+		// events.SNSEntity
+		{
+			name: "unable-to-get-carrier",
+			events: []interface{}{
+				events.SNSEntity{},
+			},
+			expCtx:   nil,
+			expNoErr: false,
+		},
+		{
+			name: "extraction-error",
+			events: []interface{}{
+				events.SNSEvent{
+					Records: []events.SNSEventRecord{
+						{SNS: eventSnsEntity(headersNone, headersNone)},
+					},
+				},
+			},
+			expCtx:   nil,
+			expNoErr: false,
+		},
+		{
+			name: "extract-binary",
+			events: []interface{}{
+				events.SNSEvent{
+					Records: []events.SNSEventRecord{
+						{SNS: eventSnsEntity(headersAll, headersNone)},
+					},
+				},
+			},
+			expCtx:   w3cTraceContext,
+			expNoErr: true,
+		},
+		{
+			name: "extract-string",
+			events: []interface{}{
+				events.SNSEvent{
+					Records: []events.SNSEventRecord{
+						{SNS: eventSnsEntity(headersNone, headersAll)},
+					},
+				},
+			},
+			expCtx:   w3cTraceContext,
 			expNoErr: true,
 		},
 
@@ -404,6 +523,112 @@ func TestExtractorExtract(t *testing.T) {
 	}
 }
 
+func TestExtractorExtractPayloadJson(t *testing.T) {
+	testcases := []struct {
+		filename string
+		eventTyp string
+		expCtx   *TraceContext
+	}{
+		{
+			filename: "api-gateway.json",
+			eventTyp: "APIGatewayProxyRequest",
+			expCtx: &TraceContext{
+				TraceID:          12345,
+				ParentID:         67890,
+				SamplingPriority: 2,
+			},
+		},
+		{
+			filename: "sns-batch.json",
+			eventTyp: "SNSEvent",
+			expCtx: &TraceContext{
+				TraceID:          4948377316357291421,
+				ParentID:         6746998015037429512,
+				SamplingPriority: 1,
+			},
+		},
+		{
+			filename: "sns.json",
+			eventTyp: "SNSEvent",
+			expCtx: &TraceContext{
+				TraceID:          4948377316357291421,
+				ParentID:         6746998015037429512,
+				SamplingPriority: 1,
+			},
+		},
+		{
+			filename: "snssqs.json",
+			eventTyp: "SQSEvent",
+			expCtx: &TraceContext{
+				TraceID:          1728904347387697031,
+				ParentID:         353722510835624345,
+				SamplingPriority: 1,
+			},
+		},
+		{
+			filename: "sqs-aws-header.json",
+			eventTyp: "SQSEvent",
+			expCtx: &TraceContext{
+				TraceID:          12297829382473034410,
+				ParentID:         13527612320720337851,
+				SamplingPriority: 1,
+			},
+		},
+		{
+			filename: "sqs-batch.json",
+			eventTyp: "SQSEvent",
+			expCtx: &TraceContext{
+				TraceID:          2684756524522091840,
+				ParentID:         7431398482019833808,
+				SamplingPriority: 1,
+			},
+		},
+		{
+			filename: "sqs.json",
+			eventTyp: "SQSEvent",
+			expCtx: &TraceContext{
+				TraceID:          2684756524522091840,
+				ParentID:         7431398482019833808,
+				SamplingPriority: 1,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.filename, func(t *testing.T) {
+			body, err := os.ReadFile("../testdata/event_samples/" + tc.filename)
+			assert.NoError(t, err)
+
+			var ev interface{}
+			switch tc.eventTyp {
+			case "APIGatewayProxyRequest":
+				var event events.APIGatewayProxyRequest
+				err = json.Unmarshal(body, &event)
+				assert.NoError(t, err)
+				ev = event
+			case "SNSEvent":
+				var event events.SNSEvent
+				err = json.Unmarshal(body, &event)
+				assert.NoError(t, err)
+				ev = event
+			case "SQSEvent":
+				var event events.SQSEvent
+				err = json.Unmarshal(body, &event)
+				assert.NoError(t, err)
+				ev = event
+			default:
+				t.Fatalf("bad type: %s", tc.eventTyp)
+			}
+
+			extractor := Extractor{}
+			ctx, err := extractor.Extract(ev)
+			t.Logf("Extract returned TraceContext=%#v error=%#v", ctx, err)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expCtx, ctx)
+		})
+	}
+}
+
 func TestPropagationStyle(t *testing.T) {
 	testcases := []struct {
 		name       string
@@ -430,9 +655,6 @@ func TestPropagationStyle(t *testing.T) {
 			expTraceID: w3c.trace.asUint,
 		},
 		{
-			// XXX: This is surprising
-			// The go tracer is designed to always place the tracecontext propagator first
-			// see https://github.com/DataDog/dd-trace-go/blob/6a938b3b4054ce036cc60147ab42a86f743fcdd5/ddtrace/tracer/textmap.go#L231
 			name:       "datadog,tracecontext-type-headers-all",
 			propType:   "datadog,tracecontext",
 			hdrs:       headersAll,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Support for extracting trace context from SNS event objects.

Most of the code for this was already present, particularly extracting from SNS->SQS messages.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Users like seeing connected traces.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.

[SVLS-4115](https://datadoghq.atlassian.net/browse/SVLS-4115)

[SVLS-4115]: https://datadoghq.atlassian.net/browse/SVLS-4115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ