### PR TITLE
Remove load balancer from process agent e2e test on Linux VM

### DIFF
--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/fakeintake/fakeintakeparams"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
@@ -23,7 +24,9 @@ type linuxTestSuite struct {
 func TestLinuxTestSuite(t *testing.T) {
 	e2e.Run(t, &linuxTestSuite{},
 		e2e.FakeIntakeStackDef(
-			e2e.WithAgentParams(agentparams.WithAgentConfig(processCheckConfigStr))))
+			e2e.WithFakeIntakeParams(fakeintakeparams.WithoutLoadBalancer()),
+			e2e.WithAgentParams(agentparams.WithAgentConfig(processCheckConfigStr)),
+		))
 }
 
 func (s *linuxTestSuite) SetupSuite() {


### PR DESCRIPTION
### What does this PR do?

Add fakeintake parameter to remove the load balancer from the process agent's linux VM e2e test.

### Motivation

https://datadoghq.atlassian.net/browse/PROCS-3556

We saw a test job failed because the AWS account had reached the max number of LBs. @pducolin mentioned that tests on VM don't need the load balancer and we can remove it.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run e2e test on CI.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
