### PR TITLE
statsd: add CreateForAddrStrict to prioritize provided addr

### DIFF
--- a/comp/dogstatsd/statsd/component.go
+++ b/comp/dogstatsd/statsd/component.go
@@ -24,6 +24,9 @@ type Component interface {
 	// CreateForAddr returns a pre-configured statsd client that defaults to `addr` if no env var is set
 	CreateForAddr(addr string, options ...ddgostatsd.Option) (ddgostatsd.ClientInterface, error)
 
+	// CreateForAddrStrict returns a pre-configured statsd client that prioritizes `addr` over the env var
+	CreateForAddrStrict(addr string, options ...ddgostatsd.Option) (ddgostatsd.ClientInterface, error)
+
 	// CreateForHostPort returns a pre-configured statsd client that defaults to `host:port` if no env var is set
 	CreateForHostPort(host string, port int, options ...ddgostatsd.Option) (ddgostatsd.ClientInterface, error)
 }

--- a/comp/dogstatsd/statsd/statsd_mock.go
+++ b/comp/dogstatsd/statsd/statsd_mock.go
@@ -40,12 +40,17 @@ func (m *mockService) Create(_ ...ddgostatsd.Option) (ddgostatsd.ClientInterface
 	return m.client, nil
 }
 
-// GetForAddr returns a pre-configured statsd -client that defaults to `addr` if no env var is set
+// CreateForAddr returns a pre-configured statsd -client that defaults to `addr` if no env var is set
 func (m *mockService) CreateForAddr(_ string, _ ...ddgostatsd.Option) (ddgostatsd.ClientInterface, error) {
 	return m.client, nil
 }
 
-// GetForHostPort returns a pre-configured statsd client that defaults to `host:port` if no env var is set
+// CreateForAddrStrict returns a pre-configured statsd -client that defaults to `addr` if no env var is set
+func (m *mockService) CreateForAddrStrict(_ string, _ ...ddgostatsd.Option) (ddgostatsd.ClientInterface, error) {
+	return m.client, nil
+}
+
+// CreateForHostPort returns a pre-configured statsd client that defaults to `host:port` if no env var is set
 func (m *mockService) CreateForHostPort(_ string, _ int, _ ...ddgostatsd.Option) (ddgostatsd.ClientInterface, error) {
 	return m.client, nil
 }

--- a/comp/trace/agent/agent.go
+++ b/comp/trace/agent/agent.go
@@ -143,7 +143,7 @@ func setupMetrics(statsd statsd.Component, cfg config.Component, telemetryCollec
 	tracecfg := cfg.Object()
 
 	// TODO: Try to use statsd.Get() everywhere instead in the long run.
-	err := metrics.Configure(tracecfg, []string{"version:" + version.AgentVersion}, statsd.CreateForAddr)
+	err := metrics.Configure(tracecfg, []string{"version:" + version.AgentVersion}, statsd.CreateForAddrStrict)
 	if err != nil {
 		telemetryCollector.SendStartupError(telemetry.CantConfigureDogstatsd, err)
 		return fmt.Errorf("cannot configure dogstatsd: %v", err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

https://github.com/DataDog/datadog-agent/commit/3636e1ae04a094b05eb7ebcb9705c2e4e828ff06 broke compatibility in the trace-agent bc `CreateForAddr` prioritizes `STATSD_URL`. This PR fixes it.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The benchmarking platform reported this bug, it was triggered in their systems bc they run separate agents in CI for testing and have `STATSD_URL` automatically set by infra.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Trace agent metrics [appeared again on the benchmark dashboard](https://ddstaging.datadoghq.com/dashboard/vu2-f8r-kts?refresh_mode=paused&tpl_var_bp_branch%5B0%5D=ahmed%2Fdsd&tpl_var_bp_commit_sha%5B0%5D=74e771b0&tpl_var_ci_pipeline_id%5B0%5D=24875483&from_ts=1702365971683&to_ts=1702366871683&live=false&tile_focus=1874091771144013).

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
