### PR TITLE
[RC-1441] Support integration log configuration

### DIFF
--- a/pkg/autodiscovery/providers/remote_config.go
+++ b/pkg/autodiscovery/providers/remote_config.go
@@ -119,7 +119,7 @@ func (rc *RemoteConfigProvider) IntegrationScheduleCallback(updates map[string]s
 				State: state.ApplyStateError,
 				Error: fmt.Sprintf("Integration %s is not allowed to be scheduled in this agent", d.Name),
 			})
-			break
+			continue
 		}
 
 		applyStateCallback(cfgPath, state.ApplyStatus{State: state.ApplyStateUnacknowledged})

--- a/pkg/autodiscovery/providers/remote_config.go
+++ b/pkg/autodiscovery/providers/remote_config.go
@@ -32,6 +32,7 @@ type rcAgentIntegration struct {
 	Name       string            `json:"name"`
 	Instances  []json.RawMessage `json:"instances"`
 	InitConfig json.RawMessage   `json:"init_config"`
+	LogsConfig json.RawMessage   `json:"logs"`
 }
 
 var datadogConfigIDRegexp = regexp.MustCompile(`^datadog/\d+/AGENT_INTEGRATIONS/([^/]+)/([^/]+)$`)
@@ -135,6 +136,7 @@ func (rc *RemoteConfigProvider) IntegrationScheduleCallback(updates map[string]s
 			Name:       d.Name,
 			Instances:  []integration.Data{},
 			InitConfig: integration.Data(d.InitConfig),
+			LogsConfig: integration.Data(d.LogsConfig),
 			Source:     source,
 		}
 		for _, inst := range d.Instances {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Make sure we parse the log configuration from the integration configuration file sent by remote-config, so we can schedule a log config 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Support integration logs through remote-config

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

* Start an agent with the following configuration to enable agent integration
```
remote_configuration:
  agent_integrations:
    allow_list: ["redisdb"]
    enabled: true
```
* Create a configuration in the backend with this kind of content
```
{
  "name": "redisdb",
  "init_config": {},
  "instances": [
    {
      "host": "localhost",
      "port": 6378
    }
  ],
  "logs": [
    {
      "type": "file",
      "path": "/var/log/redis_6379",
      "source": "redis",
      "service": "paulredis"
    }
  ]
}
```
* Run `agent configcheck` and verify the integration is scheduled with a log section

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
