### PR TITLE
[clusterchecks/handler_test] Fix flaky TestHandlerRun

### DIFF
--- a/pkg/clusteragent/clusterchecks/handler_test.go
+++ b/pkg/clusteragent/clusterchecks/handler_test.go
@@ -158,7 +158,6 @@ func TestHandlerRun(t *testing.T) {
 	//
 	// Initialisation and unknown state
 	//
-	recorder := httptest.NewRecorder()
 	ctx, cancelRun := context.WithCancel(context.Background())
 	runReturned := make(chan struct{}, 1)
 	go func() {
@@ -173,18 +172,23 @@ func TestHandlerRun(t *testing.T) {
 	})
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 1*time.Second, func() bool {
 		// API replys not ready, does not forward
-		return h.RejectOrForwardLeaderQuery(recorder, httptest.NewRequest("GET", "https://dd-cluster-agent-service:5005/test", nil))
+		recorder := httptest.NewRecorder()
+		res := h.RejectOrForwardLeaderQuery(recorder, httptest.NewRequest("GET", "https://dd-cluster-agent-service:5005/test", nil))
+		if !res {
+			return false
+		}
+
+		resp := recorder.Result()
+		assert.NotNil(t, resp)
+		assert.Equal(t, "503 Service Unavailable", resp.Status)
+		assert.Equal(t, 503, resp.StatusCode)
+		resp.Body.Close()
+		return true
 	})
-	resp := recorder.Result()
-	assert.NotNil(t, resp)
-	assert.Equal(t, "503 Service Unavailable", resp.Status)
-	assert.Equal(t, 503, resp.StatusCode)
-	resp.Body.Close()
 
 	//
 	// Unknown -> follower
 	//
-	recorder = httptest.NewRecorder()
 	le.set("127.0.0.1", nil)
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 1*time.Second, func() bool {
 		// Internal state change
@@ -194,13 +198,19 @@ func TestHandlerRun(t *testing.T) {
 	})
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 1*time.Second, func() bool {
 		// API redirects to leader
-		return h.RejectOrForwardLeaderQuery(recorder, httptest.NewRequest("GET", "https://dd-cluster-agent-service:5005/test", nil))
+		recorder := httptest.NewRecorder()
+		res := h.RejectOrForwardLeaderQuery(recorder, httptest.NewRequest("GET", "https://dd-cluster-agent-service:5005/test", nil))
+		if !res {
+			return false
+		}
+
+		resp := recorder.Result()
+		assert.NotNil(t, resp)
+		assert.Equal(t, "418 I'm a teapot", resp.Status)
+		assert.Equal(t, 418, resp.StatusCode)
+		resp.Body.Close()
+		return true
 	})
-	resp = recorder.Result()
-	assert.NotNil(t, resp)
-	assert.Equal(t, "418 I'm a teapot", resp.Status)
-	assert.Equal(t, 418, resp.StatusCode)
-	resp.Body.Close()
 
 	//
 	// Follower -> leader
@@ -213,7 +223,7 @@ func TestHandlerRun(t *testing.T) {
 		return h.state == leader && h.leaderIP == ""
 	})
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 1*time.Second, func() bool {
-		return !h.RejectOrForwardLeaderQuery(recorder, httptest.NewRequest("GET", "https://dd-cluster-agent-service:5005/test", nil))
+		return !h.RejectOrForwardLeaderQuery(httptest.NewRecorder(), httptest.NewRequest("GET", "https://dd-cluster-agent-service:5005/test", nil))
 	})
 	ac.On("AddScheduler", schedulerName, mock.AnythingOfType("*clusterchecks.dispatcher"), true).Return()
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 1*time.Second, func() bool {
@@ -246,7 +256,6 @@ func TestHandlerRun(t *testing.T) {
 	//
 	// Leader -> follower
 	//
-	recorder = httptest.NewRecorder()
 	ac.On("RemoveScheduler", schedulerName).Return()
 	le.set("127.0.0.1", nil)
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 1*time.Second, func() bool {
@@ -257,13 +266,19 @@ func TestHandlerRun(t *testing.T) {
 	})
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 1*time.Second, func() bool {
 		// API redirects to leader
-		return h.RejectOrForwardLeaderQuery(recorder, httptest.NewRequest("GET", "https://dd-cluster-agent-service:5005/test", nil))
+		recorder := httptest.NewRecorder()
+		res := h.RejectOrForwardLeaderQuery(recorder, httptest.NewRequest("GET", "https://dd-cluster-agent-service:5005/test", nil))
+		if !res {
+			return false
+		}
+
+		resp := recorder.Result()
+		assert.NotNil(t, resp)
+		assert.Equal(t, "418 I'm a teapot", resp.Status)
+		assert.Equal(t, 418, resp.StatusCode)
+		resp.Body.Close()
+		return true
 	})
-	resp = recorder.Result()
-	assert.NotNil(t, resp)
-	assert.Equal(t, "418 I'm a teapot", resp.Status)
-	assert.Equal(t, 418, resp.StatusCode)
-	resp.Body.Close()
 
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 2*time.Second, func() bool {
 		// RemoveScheduler is called
@@ -276,7 +291,7 @@ func TestHandlerRun(t *testing.T) {
 	le.set("", nil)
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 1*time.Second, func() bool {
 		// API redirects to leader
-		return !h.RejectOrForwardLeaderQuery(recorder, httptest.NewRequest("GET", "https://dd-cluster-agent-service:5005/test", nil))
+		return !h.RejectOrForwardLeaderQuery(httptest.NewRecorder(), httptest.NewRequest("GET", "https://dd-cluster-agent-service:5005/test", nil))
 	})
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 1*time.Second, func() bool {
 		// Dispatcher has been flushed, no config remain


### PR DESCRIPTION
### What does this PR do?

Fixes a flaky test in `pkg/clusteragent/clusterchecks/handler_test.go`.

The test was reading and writing ResponseRecorder instances from different goroutines:

```
=== RUN   TestHandlerRun
==================
Read at 0x00c000014550 by goroutine 156:
  github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks.TestHandlerRun.func4()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/handler_test.go:176 +0x64
  github.com/DataDog/datadog-agent/pkg/util/testutil.assertTrueBeforeTimeout.func1()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/util/testutil/timeout.go:49 +0x1b6

Previous write at 0x00c000014550 by goroutine 152:
  github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks.TestHandlerRun()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/handler_test.go:187 +0xcb2
  testing.tRunner()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/testing/testing.go:1629 +0x47

Goroutine 156 (running) created at:
  github.com/DataDog/datadog-agent/pkg/util/testutil.assertTrueBeforeTimeout()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/util/testutil/timeout.go:39 +0x1fa
  github.com/DataDog/datadog-agent/pkg/util/testutil.AssertTrueBeforeTimeout()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/util/testutil/timeout.go:22 +0x56
  github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks.TestHandlerRun()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/handler_test.go:174 +0xa4d
  testing.tRunner()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/testing/testing.go:1629 +0x47

Goroutine 152 (running) created at:
  testing.(*T).Run()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/testing/testing.go:1629 +0x805
  testing.runTests.func1()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/testing/testing.go:2036 +0x8d
  testing.tRunner()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/testing/testing.go:1576 +0x216
  testing.runTests()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/testing/testing.go:2034 +0x87c
  testing.(*M).Run()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/testing/testing.go:1906 +0xb44
  main.main()
      _testmain.go:123 +0x2e9
==================
==================
Read at 0x00c000a3e008 by goroutine 156:
  net/http/httptest.(*ResponseRecorder).Header()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/net/http/httptest/recorder.go:68 +0x3e
  net/http.Error()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/net/http/server.go:2132 +0x6d
  github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks.(*Handler).RejectOrForwardLeaderQuery()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/handler_api.go:41 +0x138
  github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks.TestHandlerRun.func4()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/handler_test.go:176 +0x84
  github.com/DataDog/datadog-agent/pkg/util/testutil.assertTrueBeforeTimeout.func1()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/util/testutil/timeout.go:49 +0x1b6

Previous write at 0x00c000a3e008 by goroutine 152:
  net/http/httptest.NewRecorder()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/net/http/httptest/recorder.go:52 +0xbaf
  github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks.TestHandlerRun()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/handler_test.go:187 +0xca6
  testing.tRunner()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /Users/runner/.gimme/versions/go1.20.11.darwin.amd64/src/testing/testing.go:1629 +0x47
      
      ........
```

### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
