### PR TITLE
Remove call to metrics.WithResourceAttributesAsTags()

### DIFF
--- a/comp/otelcol/otlp/internal/serializerexporter/exporter.go
+++ b/comp/otelcol/otlp/internal/serializerexporter/exporter.go
@@ -105,10 +105,6 @@ func translatorFromConfig(logger *zap.Logger, cfg *exporterConfig) (*metrics.Tra
 		options = append(options, metrics.WithQuantiles())
 	}
 
-	if cfg.Metrics.ExporterConfig.ResourceAttributesAsTags {
-		options = append(options, metrics.WithResourceAttributesAsTags())
-	}
-
 	if cfg.Metrics.ExporterConfig.InstrumentationLibraryMetadataAsTags && cfg.Metrics.ExporterConfig.InstrumentationScopeMetadataAsTags {
 		return nil, fmt.Errorf("cannot use both instrumentation_library_metadata_as_tags(deprecated) and instrumentation_scope_metadata_as_tags")
 	}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3891,7 +3891,7 @@ api_key:
     ## @env DD_OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS - boolean - optional - default: false
     ## Set to true to add resource attributes of a metric to its metric tags. Please note that any of 
     ## the subset of resource attributes in this list https://docs.datadoghq.com/opentelemetry/guide/semantic_mapping/ 
-    ## are converted to datadog conventions and set to to metric tags whether this option is enabled or not.
+    ## are converted to Datadog conventions and set to to metric tags whether this option is enabled or not.
     #
     # resource_attributes_as_tags: false
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3889,9 +3889,9 @@ api_key:
 
     ## @param resource_attributes_as_tags - boolean - optional - default: false
     ## @env DD_OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS - boolean - optional - default: false
-    ## Set to true to add all resource attributes of a metric to its metric tags.
-    ## When set to false, only a small predefined subset of resource attributes is converted
-    ## to metric tags.
+    ## Set to true to add resource attributes of a metric to its metric tags. Please note that any of 
+    ## the subset of resource attributes in this list https://docs.datadoghq.com/opentelemetry/guide/semantic_mapping/ 
+    ## are converted to datadog conventions and set to to metric tags whether this option is enabled or not.
     #
     # resource_attributes_as_tags: false
 


### PR DESCRIPTION
### What does this PR do?

Removes call to `metrics.WithResourceAttributesAsTags()` which is a no-op. This option is picked up here: https://github.com/DataDog/datadog-agent/blob/main/comp/otelcol/otlp/internal/serializerexporter/factory.go#L60.

This option will been removed from `pkg/otlp/metrics` in this PR: https://github.com/DataDog/opentelemetry-mapping-go/pull/219

### Motivation

This was flagged here: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29702

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
