### PR TITLE
telemetry: enable more go metrics

### DIFF
--- a/comp/core/telemetry/telemetry.go
+++ b/comp/core/telemetry/telemetry.go
@@ -39,7 +39,7 @@ type telemetryImpl struct {
 func newRegistry() *prometheus.Registry {
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	reg.MustRegister(collectors.NewGoCollector())
+	reg.MustRegister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsGC, collectors.MetricsMemory, collectors.MetricsScheduler)))
 	return reg
 }
 

--- a/comp/core/telemetry/telemetry_test.go
+++ b/comp/core/telemetry/telemetry_test.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestCounterInitializer(t *testing.T) {
@@ -161,4 +162,21 @@ func TestMeterProvider(t *testing.T) {
 	metric := metricFamily.GetMetric()[0]
 	assert.Equal(t, metric.GetCounter().GetValue(), 123.0)
 	assert.Equal(t, *metric.GetLabel()[0].Value, "foo")
+}
+
+func TestGoMetrics(t *testing.T) {
+	// Read the default global registry
+	metrics, err := registry.Gather()
+	assert.NoError(t, err)
+
+	metricNames := make(map[string]bool)
+	for _, m := range metrics {
+		metricNames[m.GetName()] = true
+	}
+	// Make sure we have one for each category at least.
+	assert.Contains(t, metricNames, "go_goroutines")
+	assert.Contains(t, metricNames, "go_memstats_alloc_bytes")
+	assert.Contains(t, metricNames, "go_sched_goroutines_goroutines")
+	assert.Contains(t, metricNames, "go_threads")
+	assert.Contains(t, metricNames, "go_gc_duration_seconds")
 }


### PR DESCRIPTION
### What does this PR do?

See https://pkg.go.dev/runtime/metrics

This will enable the collection of new runtime metrics, in particular `/sched/latencies:seconds` which is particularly useful to detect overloads

### Motivation

The goal is to observe scheduling latency and GC behavior under load to eventually build adaptive back-pressure

### Additional Notes

These telemetry metrics are not collected by default they require a custom check

### Possible Drawbacks / Trade-offs

This will add a few metrics per host, but this should be insignificant compared to the already handled metrics

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
