### PR TITLE
[CWS] Fix ECS containerID parsing

### DIFF
--- a/pkg/security/common/containerutils/utils.go
+++ b/pkg/security/common/containerutils/utils.go
@@ -7,13 +7,14 @@
 package containerutils
 
 import (
-	"crypto/sha256"
-	"fmt"
 	"regexp"
 )
 
-// ContainerIDPatternStr is the pattern of a container ID
-var ContainerIDPatternStr = fmt.Sprintf(`([[:xdigit:]]{%v})`, sha256.Size*2)
+// ContainerIDPatternStr defines the regexp used to match container IDs
+// ([0-9a-fA-F]{64}) is standard container id used pretty much everywhere
+// ([0-9a-fA-F]{32}-[0-9]{10}) is container id used by AWS ECS
+// ([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4}) is container id used by Garden
+var ContainerIDPatternStr = "([0-9a-fA-F]{64})|([0-9a-fA-F]{32}-[0-9]{10})|([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4})"
 
 // containerIDPattern is the pattern of a container ID
 var containerIDPattern = regexp.MustCompile(ContainerIDPatternStr)

--- a/pkg/security/common/containerutils/utils_test.go
+++ b/pkg/security/common/containerutils/utils_test.go
@@ -11,7 +11,7 @@ package containerutils
 import (
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 type testCase struct {

--- a/pkg/security/common/containerutils/utils_test.go
+++ b/pkg/security/common/containerutils/utils_test.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package containerutils holds activitytree related files
+package containerutils
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func TestFindContainerID(t *testing.T) {
+	testCases := []testCase{
+		{ // classic decimal
+			input:  "0123456789012345678901234567890123456789012345678901234567890123",
+			output: "0123456789012345678901234567890123456789012345678901234567890123",
+		},
+		{ // classic hexa
+			input:  "aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
+			output: "aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
+		},
+		{ // classic hexa as present in proc
+			input:  "/docker/aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
+			output: "aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
+		},
+		{ // with prefix/suffix
+			input:  "prefixaAbBcCdDeEfF2345678901234567890123456789012345678901234567890123suffix",
+			output: "aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
+		},
+		{ // multiple
+			input:  "prefixaAbBcCdDeEfF2345678901234567890123456789012345678901234567890123-0123456789012345678901234567890123456789012345678901234567890123-9999999999999999999999999999999999999999999999999999999999999999suffix",
+			output: "aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
+		},
+		{ // GARDEN
+			input:  "01234567-0123-4567-890a-bcde",
+			output: "01234567-0123-4567-890a-bcde",
+		},
+		{ // GARDEN as present in proc
+			input:  "/docker/01234567-0123-4567-890a-bcde",
+			output: "01234567-0123-4567-890a-bcde",
+		},
+		{ // GARDEN with prefix / suffix
+			input:  "prefix01234567-0123-4567-890a-bcdesuffix",
+			output: "01234567-0123-4567-890a-bcde",
+		},
+		{ // ECS
+			input:  "0123456789aAbBcCdDeEfF0123456789-0123456789",
+			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
+		},
+		{ // ECS double with first having a bad format
+			input:  "0123456789aAbBcCdDeEfF0123456789-abcdef6789/0123456789aAbBcCdDeEfF0123456789-0123456789",
+			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
+		},
+		{ // ECS as present in proc
+			input:  "/proc/0123456789aAbBcCdDeEfF0123456789-0123456789",
+			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
+		},
+		{ // ECS with prefix / suffix
+			input:  "prefix0123456789aAbBcCdDeEfF0123456789-0123456789suffix",
+			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
+		},
+	}
+
+	for _, test := range testCases {
+		assert.Equal(t, test.output, FindContainerID(test.input))
+	}
+}


### PR DESCRIPTION
### What does this PR do?

It appears that AWS ECS container ID differs from the nominal format (64 hex chars) as follow:
`[32 hex car]-[10 decimal char]`

Garden have also its own container ID format

This PR handle both new formats, and make use of it in ptracer.

### Motivation

Having a good parsing of ECS/Fargate containerID in the ptracer

### Additional Notes


### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

It comes with unit tests, but should be validated too by hand:
launch a docker image, wrapped with cws-instrumentation, triggering a custom rule and look at the resulting event to see if the containerID is well populated.
You can do the same with ECS if you have the needed env

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
