### PR TITLE
[fakeintake] make client thread safe

### DIFF
--- a/test/fakeintake/aggregator/common.go
+++ b/test/fakeintake/aggregator/common.go
@@ -80,9 +80,6 @@ func (agg *Aggregator[P]) ContainsPayloadName(name string) bool {
 // ContainsPayloadNameAndTags return true if the payload name exist and on of the payloads contains all the tags
 func (agg *Aggregator[P]) ContainsPayloadNameAndTags(name string, tags []string) bool {
 	payloads := agg.GetPayloadsByName(name)
-	if len(payloads) == 0 {
-		return false
-	}
 
 	for _, payloadItem := range payloads {
 		if AreTagsSubsetOfOtherTags(tags, payloadItem.GetTags()) {

--- a/test/fakeintake/aggregator/common.go
+++ b/test/fakeintake/aggregator/common.go
@@ -11,9 +11,11 @@ import (
 	"compress/zlib"
 	"io"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+	"golang.org/x/exp/maps"
 )
 
 //nolint:revive // TODO(APL) Fix revive linter
@@ -29,6 +31,8 @@ type parseFunc[P PayloadItem] func(payload api.Payload) (items []P, err error)
 type Aggregator[P PayloadItem] struct {
 	payloadsByName map[string][]P
 	parse          parseFunc[P]
+
+	mutex sync.RWMutex
 }
 
 const (
@@ -43,40 +47,41 @@ func newAggregator[P PayloadItem](parse parseFunc[P]) Aggregator[P] {
 	return Aggregator[P]{
 		payloadsByName: map[string][]P{},
 		parse:          parse,
+		mutex:          sync.RWMutex{},
 	}
 }
 
 // UnmarshallPayloads aggregate the payloads
 func (agg *Aggregator[P]) UnmarshallPayloads(payloads []api.Payload) error {
-	// reset map
-	agg.Reset()
-	// build map
+	// build new map
+	payloadsByName := map[string][]P{}
 	for _, p := range payloads {
 		payloads, err := agg.parse(p)
 		if err != nil {
 			return err
 		}
+
 		for _, item := range payloads {
-			if _, found := agg.payloadsByName[item.name()]; !found {
-				agg.payloadsByName[item.name()] = []P{}
+			if _, found := payloadsByName[item.name()]; !found {
+				payloadsByName[item.name()] = []P{}
 			}
-			agg.payloadsByName[item.name()] = append(agg.payloadsByName[item.name()], item)
+			payloadsByName[item.name()] = append(payloadsByName[item.name()], item)
 		}
 	}
+	agg.Replace(payloadsByName)
 
 	return nil
 }
 
 // ContainsPayloadName return true if name match one of the payloads
 func (agg *Aggregator[P]) ContainsPayloadName(name string) bool {
-	_, found := agg.payloadsByName[name]
-	return found
+	return len(agg.GetPayloadsByName(name)) != 0
 }
 
 // ContainsPayloadNameAndTags return true if the payload name exist and on of the payloads contains all the tags
 func (agg *Aggregator[P]) ContainsPayloadNameAndTags(name string, tags []string) bool {
-	payloads, found := agg.payloadsByName[name]
-	if !found {
+	payloads := agg.GetPayloadsByName(name)
+	if len(payloads) == 0 {
 		return false
 	}
 
@@ -92,8 +97,12 @@ func (agg *Aggregator[P]) ContainsPayloadNameAndTags(name string, tags []string)
 // GetNames return the names of the payloads
 func (agg *Aggregator[P]) GetNames() []string {
 	names := []string{}
-	for name := range agg.payloadsByName {
-		names = append(names, name)
+	{
+		agg.mutex.RLock()
+		defer agg.mutex.RUnlock()
+		for name := range agg.payloadsByName {
+			names = append(names, name)
+		}
 	}
 	sort.Strings(names)
 	return names
@@ -126,12 +135,25 @@ func getReadCloserForEncoding(payload []byte, encoding string) (rc io.ReadCloser
 
 // GetPayloadsByName return the payloads for the resource name
 func (agg *Aggregator[P]) GetPayloadsByName(name string) []P {
-	return agg.payloadsByName[name]
+	agg.mutex.RLock()
+	defer agg.mutex.RUnlock()
+	payloads := agg.payloadsByName[name]
+	return payloads
 }
 
 // Reset the aggregation
 func (agg *Aggregator[P]) Reset() {
+	agg.mutex.Lock()
+	defer agg.mutex.Unlock()
 	agg.payloadsByName = map[string][]P{}
+}
+
+// Replace payloads
+func (agg *Aggregator[P]) Replace(payloadsByName map[string][]P) {
+	agg.Reset()
+	agg.mutex.Lock()
+	defer agg.mutex.Unlock()
+	maps.Copy(agg.payloadsByName, payloadsByName)
 }
 
 // FilterByTags return the payloads that match all the tags

--- a/test/fakeintake/aggregator/common_test.go
+++ b/test/fakeintake/aggregator/common_test.go
@@ -66,7 +66,7 @@ func generateTestData() (data []api.Payload, err error) {
 	}, nil
 }
 
-func validateCollectionTime(t *testing.T, agg Aggregator[*mockPayloadItem]) {
+func validateCollectionTime(t *testing.T, agg *Aggregator[*mockPayloadItem]) {
 	if runtime.GOOS != "linux" {
 		t.Logf("validateCollectionTime test skip on %s", runtime.GOOS)
 		return
@@ -87,7 +87,7 @@ func TestCommonAggregator(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, agg.ContainsPayloadName("totoro"))
 		assert.False(t, agg.ContainsPayloadName("ponyo"))
-		validateCollectionTime(t, agg)
+		validateCollectionTime(t, &agg)
 	})
 
 	t.Run("ContainsPayloadNameAndTags", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestCommonAggregator(t *testing.T) {
 		assert.True(t, agg.ContainsPayloadNameAndTags("totoro", []string{"age:123"}))
 		assert.False(t, agg.ContainsPayloadNameAndTags("porco rosso", []string{"country:it", "role:king"}))
 		assert.True(t, agg.ContainsPayloadNameAndTags("porco rosso", []string{"country:it", "role:pilot"}))
-		validateCollectionTime(t, agg)
+		validateCollectionTime(t, &agg)
 	})
 
 	t.Run("AreTagsSubsetOfOtherTags", func(t *testing.T) {
@@ -132,6 +132,6 @@ func TestCommonAggregator(t *testing.T) {
 		agg := newAggregator(parseMockPayloadItem)
 		agg.Reset()
 		assert.Equal(t, 0, len(agg.payloadsByName))
-		validateCollectionTime(t, agg)
+		validateCollectionTime(t, &agg)
 	})
 }

--- a/test/fakeintake/aggregator/common_test.go
+++ b/test/fakeintake/aggregator/common_test.go
@@ -80,9 +80,10 @@ func validateCollectionTime(t *testing.T, agg *Aggregator[*mockPayloadItem]) {
 
 func TestCommonAggregator(t *testing.T) {
 	t.Run("ContainsPayloadName", func(t *testing.T) {
+		agg := newAggregator(parseMockPayloadItem)
+		assert.False(t, agg.ContainsPayloadName("totoro"))
 		data, err := generateTestData()
 		require.NoError(t, err)
-		agg := newAggregator(parseMockPayloadItem)
 		err = agg.UnmarshallPayloads(data)
 		assert.NoError(t, err)
 		assert.True(t, agg.ContainsPayloadName("totoro"))
@@ -91,9 +92,10 @@ func TestCommonAggregator(t *testing.T) {
 	})
 
 	t.Run("ContainsPayloadNameAndTags", func(t *testing.T) {
+		agg := newAggregator(parseMockPayloadItem)
+		assert.False(t, agg.ContainsPayloadNameAndTags("totoro", []string{"age:123"}))
 		data, err := generateTestData()
 		require.NoError(t, err)
-		agg := newAggregator(parseMockPayloadItem)
 		err = agg.UnmarshallPayloads(data)
 		assert.NoError(t, err)
 		assert.True(t, agg.ContainsPayloadNameAndTags("totoro", []string{"age:123"}))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add mutex to log aggregator's payloads, to have thread safe calls to the fakeintake client

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We often use it in EventuallyWithT calls, that run in a separate go routine. Even without parallelism, this leaves room for flakiness due to race condition at timeout. 

Found  and analysed by @L3n41c 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
