### PR TITLE
[Tooling] Add `flake8`, `black`, `isort` & `vulture` to the requirements

### DIFF
--- a/tasks/requirements_all_tasks.txt
+++ b/tasks/requirements_all_tasks.txt
@@ -1,5 +1,15 @@
--r kernel_matrix_testing/requirements.txt
 -r libs/requirements-github.txt
 -r libs/requirements-notifications.txt
 -r show_linters_issues/requirements.txt
--r requirements_release_tasks.txt
+
+# From release.py (needed to run inv update-build-links)
+atlassian-python-api==3.41.3
+
+# From test.py (needed to run inv lint-python)
+flake8-bugbear==21.11.28
+flake8-comprehensions==3.7.0
+flake8-unused-arguments==0.0.6
+flake8-use-fstring==1.3.0
+black==22.3.0
+isort==5.12.0
+vulture==2.3

--- a/tasks/requirements_release_tasks.txt
+++ b/tasks/requirements_release_tasks.txt
@@ -1,1 +1,0 @@
-atlassian-python-api==3.41.3


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?


This PR adds `flake8`, `black`, `isort` & `vulture` to the requirements.

This PR also incorporate the `atlassian-python-api` dependency into the `tasks/requirements_all_tasks.txt` file, to avoid having multiple req files at the root of the `/tasks` folder.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

As of today if you run `inv lint-python` you get a dependency error.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
