### PR TITLE
[CWS] ebpfless: per client seqnums

### DIFF
--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -36,8 +36,14 @@ import (
 )
 
 type client struct {
-	conn  net.Conn
-	probe *EBPFLessProbe
+	conn   net.Conn
+	probe  *EBPFLessProbe
+	seqNum uint64
+}
+
+type clientMsg struct {
+	ebpfless.SyscallMsg
+	*client
 }
 
 // EBPFLessProbe defines an eBPF less probe
@@ -54,7 +60,6 @@ type EBPFLessProbe struct {
 	// internals
 	event         *model.Event
 	server        *grpc.Server
-	seqNum        uint64
 	probe         *Probe
 	ctx           context.Context
 	cancelFnc     context.CancelFunc
@@ -63,11 +68,12 @@ type EBPFLessProbe struct {
 	clients       map[net.Conn]*client
 }
 
-func (p *EBPFLessProbe) handleSyscallMsg(syscallMsg *ebpfless.SyscallMsg) {
-	if p.seqNum != syscallMsg.SeqNum {
-		seclog.Errorf("communication out of sync %d vs %d", p.seqNum, syscallMsg.SeqNum)
+func (p *EBPFLessProbe) handleClientMsg(msg *clientMsg) {
+	syscallMsg := &msg.SyscallMsg
+	if msg.client.seqNum != syscallMsg.SeqNum {
+		seclog.Errorf("communication out of sync %d vs %d", msg.client.seqNum, syscallMsg.SeqNum)
 	}
-	p.seqNum++
+	msg.client.seqNum++
 
 	event := p.zeroEvent()
 	event.NSID = syscallMsg.NSID
@@ -148,7 +154,7 @@ func (p *EBPFLessProbe) Close() error {
 	return nil
 }
 
-func (p *EBPFLessProbe) readMsg(conn net.Conn, msg *ebpfless.SyscallMsg) error {
+func (p *EBPFLessProbe) readSyscallMsg(conn net.Conn, msg *ebpfless.SyscallMsg) error {
 	sizeBuf := make([]byte, 4)
 
 	n, err := conn.Read(sizeBuf)
@@ -178,7 +184,7 @@ func (p *EBPFLessProbe) readMsg(conn net.Conn, msg *ebpfless.SyscallMsg) error {
 	return msgpack.Unmarshal(p.buf[0:n], msg)
 }
 
-func (p *EBPFLessProbe) handleNewClient(conn net.Conn, ch chan ebpfless.SyscallMsg) {
+func (p *EBPFLessProbe) handleNewClient(conn net.Conn, ch chan clientMsg) {
 	client := &client{
 		conn:  conn,
 		probe: p,
@@ -191,9 +197,11 @@ func (p *EBPFLessProbe) handleNewClient(conn net.Conn, ch chan ebpfless.SyscallM
 	seclog.Debugf("new connection from: %v", conn.RemoteAddr())
 
 	go func() {
-		var msg ebpfless.SyscallMsg
+		msg := clientMsg{
+			client: client,
+		}
 		for {
-			if err := p.readMsg(conn, &msg); err != nil {
+			if err := p.readSyscallMsg(conn, &msg.SyscallMsg); err != nil {
 				if errors.Is(err, io.EOF) {
 					seclog.Debugf("connection closed by client: %v", conn.RemoteAddr())
 				} else {
@@ -229,7 +237,7 @@ func (p *EBPFLessProbe) Start() error {
 		return err
 	}
 
-	ch := make(chan ebpfless.SyscallMsg, 100)
+	ch := make(chan clientMsg, 100)
 
 	go func() {
 		for {
@@ -245,7 +253,7 @@ func (p *EBPFLessProbe) Start() error {
 
 	go func() {
 		for msg := range ch {
-			p.handleSyscallMsg(&msg)
+			p.handleClientMsg(&msg)
 		}
 	}()
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Makes the sequence number part of the client structure rather than the probe to avoid incorrect out-of-sync errors when the probe handles multiple clients.  

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
