### PR TITLE
simplify docker-compose network

### DIFF
--- a/pkg/network/protocols/amqp/testdata/docker-compose.yml
+++ b/pkg/network/protocols/amqp/testdata/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3'
+name: amqp
 services:
   rabbitmq:
     image: rabbitmq:3-management-alpine
@@ -8,9 +9,3 @@ services:
     environment:
       - "RABBITMQ_DEFAULT_PASS=${PASS:-guest}"
       - "RABBITMQ_DEFAULT_USER=${USER:-guest}"
-    networks:
-      - amqp
-
-networks:
-  amqp:
-    driver: bridge

--- a/pkg/network/protocols/kafka/testdata/docker-compose.yml
+++ b/pkg/network/protocols/kafka/testdata/docker-compose.yml
@@ -1,5 +1,5 @@
-version: "2"
-
+version: '3'
+name: kafka
 services:
   zookeeper:
     image: bitnami/zookeeper:3.8
@@ -7,8 +7,6 @@ services:
       - "2181:2181"
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
-    networks:
-      - kafka
     tmpfs:
       - /bitnami/zookeeper/data
   kafka:
@@ -27,11 +25,5 @@ services:
       - KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS=30000
     depends_on:
       - zookeeper
-    networks:
-      - kafka
     tmpfs:
       - /bitnami/kafka/data
-
-networks:
-  kafka:
-    driver: bridge

--- a/pkg/network/protocols/mongo/testdata/docker-compose.yml
+++ b/pkg/network/protocols/mongo/testdata/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3'
+name: mongo
 services:
   mongodb-primary:
     image: 'mongo:5.0.14'
@@ -7,11 +8,5 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USER:-root}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
-    networks:
-      - mongo
     tmpfs:
       - /data/db
-
-networks:
-  mongo:
-    driver: bridge

--- a/pkg/network/protocols/mysql/testdata/docker-compose.yml
+++ b/pkg/network/protocols/mysql/testdata/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3'
+name: mysql
 services:
   mysql:
     image: mysql:8.0.32
@@ -10,9 +11,3 @@ services:
       - ${MYSQL_ADDR:-127.0.0.1}:${MYSQL_PORT:-3306}:3306
     tmpfs:
       - /var/lib/mysql
-    networks:
-      - mysql
-
-networks:
-  mysql:
-    driver: bridge

--- a/pkg/network/protocols/postgres/testdata/docker-compose.yml
+++ b/pkg/network/protocols/postgres/testdata/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '3.1'
-
+name: postgres
 services:
   postgres:
    image: postgres:15-alpine
@@ -10,9 +10,3 @@ services:
      POSTGRES_USER: admin
      POSTGRES_PASSWORD: password
      POSTGRES_DB: testdb
-   networks:
-     - postgres
-
-networks:
-  postgres:
-    driver: bridge

--- a/pkg/network/protocols/redis/testdata/docker-compose.yml
+++ b/pkg/network/protocols/redis/testdata/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3'
+name: redis
 services:
   redis:
     image: redis:7-alpine
@@ -7,9 +8,3 @@ services:
       - ${REDIS_ADDR:-127.0.0.1}:${REDIS_PORT:-6379}:6379
     environment:
       - "ALLOW_EMPTY_PASSWORD=yes"
-    networks:
-      - redis
-
-networks:
-  redis:
-    driver: bridge

--- a/pkg/network/protocols/testutil/serverutils.go
+++ b/pkg/network/protocols/testutil/serverutils.go
@@ -42,7 +42,7 @@ func RunDockerServer(t testing.TB, serverName, dockerPath string, env []string, 
 func runDockerServer(t testing.TB, serverName, dockerPath string, env []string, serverStartRegex *regexp.Regexp, timeout time.Duration) error {
 	t.Helper()
 	// Ensuring no previous instances exists.
-	c := exec.Command("docker-compose", "-f", dockerPath, "down", "--remove-orphans")
+	c := exec.Command("docker-compose", "-f", dockerPath, "down", "--remove-orphans", "--volumes")
 	c.Env = append(c.Env, env...)
 	_ = c.Run()
 
@@ -62,7 +62,7 @@ func runDockerServer(t testing.TB, serverName, dockerPath string, env []string, 
 		cancel()
 		_ = cmd.Wait()
 
-		c := exec.Command("docker-compose", "-f", dockerPath, "down", "--remove-orphans")
+		c := exec.Command("docker-compose", "-f", dockerPath, "down", "--remove-orphans", "--volumes")
 		c.Env = append(c.Env, env...)
 		// Not waiting for its finish.
 		_ = c.Start()

--- a/pkg/network/protocols/tls/gotls/testdata/docker-compose.yml
+++ b/pkg/network/protocols/tls/gotls/testdata/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3'
+name: gotls
 services:
   gohttpbin:
     image: public.ecr.aws/b1o7r7e0/usm-team/go-httpbin:https

--- a/pkg/network/protocols/tls/java/testdata/docker-compose.yml
+++ b/pkg/network/protocols/tls/java/testdata/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3'
+name: java
 services:
   java:
     image: ${IMAGE_VERSION}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

- Specifies a name for each `docker-compose.yml` file to influence the default network name.
- Fixes the `kafka` file to specify `version: 3`
- Removes anonymous volumes on `docker-compose down`

### Motivation

Simpler files with the need to explicitly include a network.

### Additional Notes



### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
