### PR TITLE
Add wrappers around PingTCP and PingUDP to ensure non-nil return

### DIFF
--- a/pkg/network/netlink/conntrack_integration_test.go
+++ b/pkg/network/netlink/conntrack_integration_test.go
@@ -44,10 +44,10 @@ func TestConntrackExists(t *testing.T) {
 	udpCloser := nettestutil.StartServerUDPNs(t, net.ParseIP("2.2.2.4"), 8080, ns)
 	defer udpCloser.Close()
 
-	tcpConn := nettestutil.PingTCP(t, net.ParseIP("2.2.2.4"), 80)
+	tcpConn := nettestutil.MustPingTCP(t, net.ParseIP("2.2.2.4"), 80)
 	defer tcpConn.Close()
 
-	udpConn := nettestutil.PingUDP(t, net.ParseIP("2.2.2.4"), 80)
+	udpConn := nettestutil.MustPingUDP(t, net.ParseIP("2.2.2.4"), 80)
 	defer udpConn.Close()
 
 	testNs, err := netns.GetFromName(ns)
@@ -74,7 +74,7 @@ func BenchmarkConntrackExists(b *testing.B) {
 	tcpCloser := nettestutil.StartServerTCPNs(b, net.ParseIP("2.2.2.4"), 8080, ns)
 	defer tcpCloser.Close()
 
-	tcpConn := nettestutil.PingTCP(b, net.ParseIP("2.2.2.4"), 80)
+	tcpConn := nettestutil.MustPingTCP(b, net.ParseIP("2.2.2.4"), 80)
 	defer tcpConn.Close()
 
 	testNs, err := netns.GetFromName(ns)
@@ -169,10 +169,10 @@ func TestConntrackExists6(t *testing.T) {
 	udpCloser := nettestutil.StartServerUDPNs(t, net.ParseIP("fd00::2"), 8080, ns)
 	defer udpCloser.Close()
 
-	tcpConn := nettestutil.PingTCP(t, net.ParseIP("fd00::2"), 80)
+	tcpConn := nettestutil.MustPingTCP(t, net.ParseIP("fd00::2"), 80)
 	defer tcpConn.Close()
 
-	udpConn := nettestutil.PingUDP(t, net.ParseIP("fd00::2"), 80)
+	udpConn := nettestutil.MustPingUDP(t, net.ParseIP("fd00::2"), 80)
 	defer udpConn.Close()
 
 	testNs, err := netns.GetFromName(ns)
@@ -220,7 +220,7 @@ func TestConntrackExistsRootDNAT(t *testing.T) {
 	tcpCloser := nettestutil.StartServerTCPNs(t, net.ParseIP(listenIP), listenPort, ns)
 	defer tcpCloser.Close()
 
-	tcpConn := nettestutil.PingTCP(t, net.ParseIP(destIP), destPort)
+	tcpConn := nettestutil.MustPingTCP(t, net.ParseIP(destIP), destPort)
 	defer tcpConn.Close()
 
 	rootck, err := NewConntrack(rootNs)

--- a/pkg/network/netlink/conntracker_integration_test.go
+++ b/pkg/network/netlink/conntracker_integration_test.go
@@ -47,7 +47,7 @@ func TestConnTrackerCrossNamespaceAllNsDisabled(t *testing.T) {
 	time.Sleep(time.Second)
 
 	closer := nettestutil.StartServerTCPNs(t, net.ParseIP("2.2.2.4"), 8080, ns)
-	laddr := nettestutil.PingTCP(t, net.ParseIP("2.2.2.4"), 80).LocalAddr().(*net.TCPAddr)
+	laddr := nettestutil.MustPingTCP(t, net.ParseIP("2.2.2.4"), 80).LocalAddr().(*net.TCPAddr)
 	defer closer.Close()
 
 	testNs, err := netns.GetFromName(ns)
@@ -133,9 +133,9 @@ func testMessageDump(t *testing.T, f *os.File, serverIP, clientIP net.IP) {
 	defer udpServer.Close()
 
 	for i := 0; i < 100; i++ {
-		tc := nettestutil.PingTCP(t, clientIP, natPort)
+		tc := nettestutil.MustPingTCP(t, clientIP, natPort)
 		tc.Close()
-		uc := nettestutil.PingUDP(t, clientIP, nonNatPort)
+		uc := nettestutil.MustPingUDP(t, clientIP, nonNatPort)
 		uc.Close()
 	}
 

--- a/pkg/network/testutil/ping.go
+++ b/pkg/network/testutil/ping.go
@@ -14,6 +14,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// MustPingTCP is a wrapper around PingTCP that guarantees a non-nil
+// connection is returned
+func MustPingTCP(tb require.TestingT, ip net.IP, port int) net.Conn {
+	c := PingTCP(tb, ip, port)
+	require.NotNil(tb, c, "pinged tcp connection must not be nil")
+	return c
+}
+
+// MustPingUDP is a wrapper around PingUDP that guarantees a non-nil
+// connection is returned
+func MustPingUDP(tb require.TestingT, ip net.IP, port int) net.Conn {
+	c := PingUDP(tb, ip, port)
+	require.NotNil(tb, c, "pinged udp connection must not be nil")
+	return c
+}
+
 // PingTCP connects to the provided IP address over TCP/TCPv6, sends the string "ping",
 // reads from the connection, and returns the open connection for further use/inspection.
 func PingTCP(tb require.TestingT, ip net.IP, port int) net.Conn {

--- a/pkg/network/tracer/conntracker_test.go
+++ b/pkg/network/tracer/conntracker_test.go
@@ -127,7 +127,7 @@ func testConntracker(t *testing.T, serverIP, clientIP net.IP, ct netlink.Conntra
 		srv2 := nettestutil.StartServerTCP(t, serverIP, nonNatPort)
 		defer srv2.Close()
 
-		localAddr := nettestutil.PingTCP(t, clientIP, natPort).LocalAddr().(*net.TCPAddr)
+		localAddr := nettestutil.MustPingTCP(t, clientIP, natPort).LocalAddr().(*net.TCPAddr)
 		var trans *network.IPTranslation
 		cs := network.ConnectionStats{
 			Source: util.AddressFromNetIP(localAddr.IP),
@@ -145,7 +145,7 @@ func testConntracker(t *testing.T, serverIP, clientIP net.IP, ct netlink.Conntra
 		assert.Equal(t, util.AddressFromNetIP(serverIP), trans.ReplSrcIP)
 
 		// now dial TCP directly
-		localAddr = nettestutil.PingTCP(t, serverIP, nonNatPort).LocalAddr().(*net.TCPAddr)
+		localAddr = nettestutil.MustPingTCP(t, serverIP, nonNatPort).LocalAddr().(*net.TCPAddr)
 
 		cs = network.ConnectionStats{
 			Source: util.AddressFromNetIP(localAddr.IP),
@@ -166,7 +166,7 @@ func testConntracker(t *testing.T, serverIP, clientIP net.IP, ct netlink.Conntra
 		srv3 := nettestutil.StartServerUDP(t, serverIP, natPort)
 		defer srv3.Close()
 
-		localAddrUDP := nettestutil.PingUDP(t, clientIP, natPort).LocalAddr().(*net.UDPAddr)
+		localAddrUDP := nettestutil.MustPingUDP(t, clientIP, natPort).LocalAddr().(*net.UDPAddr)
 		var trans *network.IPTranslation
 		cs := network.ConnectionStats{
 			Source: util.AddressFromNetIP(localAddrUDP.IP),
@@ -189,7 +189,7 @@ func testConntrackerCrossNamespace(t *testing.T, ct netlink.Conntracker) {
 	ns := netlinktestutil.SetupCrossNsDNAT(t)
 
 	closer := nettestutil.StartServerTCPNs(t, net.ParseIP("2.2.2.4"), 8080, ns)
-	laddr := nettestutil.PingTCP(t, net.ParseIP("2.2.2.4"), 80).LocalAddr().(*net.TCPAddr)
+	laddr := nettestutil.MustPingTCP(t, net.ParseIP("2.2.2.4"), 80).LocalAddr().(*net.TCPAddr)
 	defer closer.Close()
 
 	testNs, err := netns.GetFromName(ns)
@@ -247,7 +247,7 @@ func testConntrackerCrossNamespaceNATonRoot(t *testing.T, ct netlink.Conntracker
 		defer netns.Set(originalNS)
 		defer close(done)
 		netns.Set(testNS)
-		laddr = nettestutil.PingTCP(t, net.ParseIP("3.3.3.3"), 80).LocalAddr().(*net.TCPAddr)
+		laddr = nettestutil.MustPingTCP(t, net.ParseIP("3.3.3.3"), 80).LocalAddr().(*net.TCPAddr)
 	}()
 	<-done
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix failures like: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/388240894

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
