### PR TITLE
[Serverless] Use custom aws event types to speed up json unmarshalling.

### DIFF
--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -79,7 +79,7 @@ func (lp *LifecycleProcessor) initFromALBEvent(event ddevents.ALBTargetGroupRequ
 	lp.addTags(trigger.GetTagsFromALBTargetGroupRequest(event))
 }
 
-func (lp *LifecycleProcessor) initFromCloudWatchEvent(event events.CloudWatchEvent) {
+func (lp *LifecycleProcessor) initFromCloudWatchEvent(event ddevents.CloudWatchEvent) {
 	lp.requestHandler.event = event
 	lp.addTag(tagFunctionTriggerEventSource, cloudwatchEvents)
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractCloudwatchEventARN(event))

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -13,9 +13,8 @@ import (
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
-	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
-
 	"github.com/DataDog/datadog-agent/pkg/serverless/trigger"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -37,7 +37,7 @@ func (lp *LifecycleProcessor) initFromAPIGatewayEvent(event ddevents.APIGatewayP
 	lp.addTags(trigger.GetTagsFromAPIGatewayEvent(event))
 }
 
-func (lp *LifecycleProcessor) initFromAPIGatewayV2Event(event events.APIGatewayV2HTTPRequest, region string) {
+func (lp *LifecycleProcessor) initFromAPIGatewayV2Event(event ddevents.APIGatewayV2HTTPRequest, region string) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithAPIGatewayHTTPEvent(event)
 	}

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -85,7 +85,7 @@ func (lp *LifecycleProcessor) initFromCloudWatchEvent(event ddevents.CloudWatchE
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractCloudwatchEventARN(event))
 }
 
-func (lp *LifecycleProcessor) initFromCloudWatchLogsEvent(event events.CloudwatchLogsEvent, region string, accountID string) {
+func (lp *LifecycleProcessor) initFromCloudWatchLogsEvent(event ddevents.CloudwatchLogsEvent, region string, accountID string) {
 	arn, err := trigger.ExtractCloudwatchLogsEventARN(event, region, accountID)
 	if err != nil {
 		log.Debugf("Error parsing event ARN from cloudwatch logs event: %v", err)

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -133,7 +133,7 @@ func (lp *LifecycleProcessor) initFromS3Event(event ddevents.S3Event) {
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractS3EventArn(event))
 }
 
-func (lp *LifecycleProcessor) initFromSNSEvent(event events.SNSEvent) {
+func (lp *LifecycleProcessor) initFromSNSEvent(event ddevents.SNSEvent) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithSNSEvent(event)
 	}
@@ -153,7 +153,7 @@ func (lp *LifecycleProcessor) initFromSQSEvent(event events.SQSEvent) {
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractSQSEventARN(event))
 
 	// test for SNS
-	var snsEntity events.SNSEntity
+	var snsEntity ddevents.SNSEntity
 	if err := json.Unmarshal([]byte(event.Records[0].Body), &snsEntity); err != nil {
 		return
 	}
@@ -172,8 +172,8 @@ func (lp *LifecycleProcessor) initFromSQSEvent(event events.SQSEvent) {
 		},
 	}
 
-	var snsEvent events.SNSEvent
-	snsEvent.Records = make([]events.SNSEventRecord, 1)
+	var snsEvent ddevents.SNSEvent
+	snsEvent.Records = make([]ddevents.SNSEventRecord, 1)
 	snsEvent.Records[0].SNS = snsEntity
 
 	lp.requestHandler.inferredSpans[1].EnrichInferredSpanWithSNSEvent(snsEvent)

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -143,7 +143,7 @@ func (lp *LifecycleProcessor) initFromSNSEvent(event ddevents.SNSEvent) {
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractSNSEventArn(event))
 }
 
-func (lp *LifecycleProcessor) initFromSQSEvent(event events.SQSEvent) {
+func (lp *LifecycleProcessor) initFromSQSEvent(event ddevents.SQSEvent) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithSQSEvent(event)
 	}

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -97,7 +97,7 @@ func (lp *LifecycleProcessor) initFromCloudWatchLogsEvent(event ddevents.Cloudwa
 	lp.addTag(tagFunctionTriggerEventSourceArn, arn)
 }
 
-func (lp *LifecycleProcessor) initFromDynamoDBStreamEvent(event events.DynamoDBEvent) {
+func (lp *LifecycleProcessor) initFromDynamoDBStreamEvent(event ddevents.DynamoDBEvent) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithDynamoDBEvent(event)
 	}

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -48,7 +48,7 @@ func (lp *LifecycleProcessor) initFromAPIGatewayV2Event(event ddevents.APIGatewa
 	lp.addTags(trigger.GetTagsFromAPIGatewayV2HTTPRequest(event))
 }
 
-func (lp *LifecycleProcessor) initFromAPIGatewayWebsocketEvent(event events.APIGatewayWebsocketProxyRequest, region string) {
+func (lp *LifecycleProcessor) initFromAPIGatewayWebsocketEvent(event ddevents.APIGatewayWebsocketProxyRequest, region string) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithAPIGatewayWebsocketEvent(event)
 	}

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -65,7 +65,7 @@ func (lp *LifecycleProcessor) initFromAPIGatewayLambdaAuthorizerTokenEvent(event
 	lp.addTags(trigger.GetTagsFromAPIGatewayCustomAuthorizerEvent(event))
 }
 
-func (lp *LifecycleProcessor) initFromAPIGatewayLambdaAuthorizerRequestParametersEvent(event events.APIGatewayCustomAuthorizerRequestTypeRequest) {
+func (lp *LifecycleProcessor) initFromAPIGatewayLambdaAuthorizerRequestParametersEvent(event ddevents.APIGatewayCustomAuthorizerRequestTypeRequest) {
 	lp.requestHandler.event = event
 	lp.addTag(tagFunctionTriggerEventSource, apiGateway)
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(event))

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -58,7 +58,7 @@ func (lp *LifecycleProcessor) initFromAPIGatewayWebsocketEvent(event ddevents.AP
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractAPIGatewayWebSocketEventARN(event, region))
 }
 
-func (lp *LifecycleProcessor) initFromAPIGatewayLambdaAuthorizerTokenEvent(event events.APIGatewayCustomAuthorizerRequest) {
+func (lp *LifecycleProcessor) initFromAPIGatewayLambdaAuthorizerTokenEvent(event ddevents.APIGatewayCustomAuthorizerRequest) {
 	lp.requestHandler.event = event
 	lp.addTag(tagFunctionTriggerEventSource, apiGateway)
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractAPIGatewayCustomAuthorizerEventARN(event))

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -72,7 +72,7 @@ func (lp *LifecycleProcessor) initFromAPIGatewayLambdaAuthorizerRequestParameter
 	lp.addTags(trigger.GetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(event))
 }
 
-func (lp *LifecycleProcessor) initFromALBEvent(event events.ALBTargetGroupRequest) {
+func (lp *LifecycleProcessor) initFromALBEvent(event ddevents.ALBTargetGroupRequest) {
 	lp.requestHandler.event = event
 	lp.addTag(tagFunctionTriggerEventSource, applicationLoadBalancer)
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractAlbEventARN(event))

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -13,6 +13,7 @@ import (
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
+	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 
 	"github.com/aws/aws-lambda-go/events"
 
@@ -25,7 +26,7 @@ const (
 	tagFunctionTriggerEventSourceArn = "function_trigger.event_source_arn"
 )
 
-func (lp *LifecycleProcessor) initFromAPIGatewayEvent(event events.APIGatewayProxyRequest, region string) {
+func (lp *LifecycleProcessor) initFromAPIGatewayEvent(event ddevents.APIGatewayProxyRequest, region string) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithAPIGatewayRESTEvent(event)
 	}

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -107,7 +107,7 @@ func (lp *LifecycleProcessor) initFromDynamoDBStreamEvent(event ddevents.DynamoD
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractDynamoDBStreamEventARN(event))
 }
 
-func (lp *LifecycleProcessor) initFromEventBridgeEvent(event inferredspan.EventBridgeEvent) {
+func (lp *LifecycleProcessor) initFromEventBridgeEvent(event ddevents.EventBridgeEvent) {
 	lp.requestHandler.event = event
 	lp.addTag(tagFunctionTriggerEventSource, eventBridge)
 	lp.addTag(tagFunctionTriggerEventSourceArn, event.Source)

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -13,7 +13,7 @@ import (
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
-	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/trigger"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -24,7 +24,7 @@ const (
 	tagFunctionTriggerEventSourceArn = "function_trigger.event_source_arn"
 )
 
-func (lp *LifecycleProcessor) initFromAPIGatewayEvent(event ddevents.APIGatewayProxyRequest, region string) {
+func (lp *LifecycleProcessor) initFromAPIGatewayEvent(event events.APIGatewayProxyRequest, region string) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithAPIGatewayRESTEvent(event)
 	}
@@ -35,7 +35,7 @@ func (lp *LifecycleProcessor) initFromAPIGatewayEvent(event ddevents.APIGatewayP
 	lp.addTags(trigger.GetTagsFromAPIGatewayEvent(event))
 }
 
-func (lp *LifecycleProcessor) initFromAPIGatewayV2Event(event ddevents.APIGatewayV2HTTPRequest, region string) {
+func (lp *LifecycleProcessor) initFromAPIGatewayV2Event(event events.APIGatewayV2HTTPRequest, region string) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithAPIGatewayHTTPEvent(event)
 	}
@@ -46,7 +46,7 @@ func (lp *LifecycleProcessor) initFromAPIGatewayV2Event(event ddevents.APIGatewa
 	lp.addTags(trigger.GetTagsFromAPIGatewayV2HTTPRequest(event))
 }
 
-func (lp *LifecycleProcessor) initFromAPIGatewayWebsocketEvent(event ddevents.APIGatewayWebsocketProxyRequest, region string) {
+func (lp *LifecycleProcessor) initFromAPIGatewayWebsocketEvent(event events.APIGatewayWebsocketProxyRequest, region string) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithAPIGatewayWebsocketEvent(event)
 	}
@@ -56,34 +56,34 @@ func (lp *LifecycleProcessor) initFromAPIGatewayWebsocketEvent(event ddevents.AP
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractAPIGatewayWebSocketEventARN(event, region))
 }
 
-func (lp *LifecycleProcessor) initFromAPIGatewayLambdaAuthorizerTokenEvent(event ddevents.APIGatewayCustomAuthorizerRequest) {
+func (lp *LifecycleProcessor) initFromAPIGatewayLambdaAuthorizerTokenEvent(event events.APIGatewayCustomAuthorizerRequest) {
 	lp.requestHandler.event = event
 	lp.addTag(tagFunctionTriggerEventSource, apiGateway)
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractAPIGatewayCustomAuthorizerEventARN(event))
 	lp.addTags(trigger.GetTagsFromAPIGatewayCustomAuthorizerEvent(event))
 }
 
-func (lp *LifecycleProcessor) initFromAPIGatewayLambdaAuthorizerRequestParametersEvent(event ddevents.APIGatewayCustomAuthorizerRequestTypeRequest) {
+func (lp *LifecycleProcessor) initFromAPIGatewayLambdaAuthorizerRequestParametersEvent(event events.APIGatewayCustomAuthorizerRequestTypeRequest) {
 	lp.requestHandler.event = event
 	lp.addTag(tagFunctionTriggerEventSource, apiGateway)
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(event))
 	lp.addTags(trigger.GetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(event))
 }
 
-func (lp *LifecycleProcessor) initFromALBEvent(event ddevents.ALBTargetGroupRequest) {
+func (lp *LifecycleProcessor) initFromALBEvent(event events.ALBTargetGroupRequest) {
 	lp.requestHandler.event = event
 	lp.addTag(tagFunctionTriggerEventSource, applicationLoadBalancer)
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractAlbEventARN(event))
 	lp.addTags(trigger.GetTagsFromALBTargetGroupRequest(event))
 }
 
-func (lp *LifecycleProcessor) initFromCloudWatchEvent(event ddevents.CloudWatchEvent) {
+func (lp *LifecycleProcessor) initFromCloudWatchEvent(event events.CloudWatchEvent) {
 	lp.requestHandler.event = event
 	lp.addTag(tagFunctionTriggerEventSource, cloudwatchEvents)
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractCloudwatchEventARN(event))
 }
 
-func (lp *LifecycleProcessor) initFromCloudWatchLogsEvent(event ddevents.CloudwatchLogsEvent, region string, accountID string) {
+func (lp *LifecycleProcessor) initFromCloudWatchLogsEvent(event events.CloudwatchLogsEvent, region string, accountID string) {
 	arn, err := trigger.ExtractCloudwatchLogsEventARN(event, region, accountID)
 	if err != nil {
 		log.Debugf("Error parsing event ARN from cloudwatch logs event: %v", err)
@@ -95,7 +95,7 @@ func (lp *LifecycleProcessor) initFromCloudWatchLogsEvent(event ddevents.Cloudwa
 	lp.addTag(tagFunctionTriggerEventSourceArn, arn)
 }
 
-func (lp *LifecycleProcessor) initFromDynamoDBStreamEvent(event ddevents.DynamoDBEvent) {
+func (lp *LifecycleProcessor) initFromDynamoDBStreamEvent(event events.DynamoDBEvent) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithDynamoDBEvent(event)
 	}
@@ -105,13 +105,13 @@ func (lp *LifecycleProcessor) initFromDynamoDBStreamEvent(event ddevents.DynamoD
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractDynamoDBStreamEventARN(event))
 }
 
-func (lp *LifecycleProcessor) initFromEventBridgeEvent(event ddevents.EventBridgeEvent) {
+func (lp *LifecycleProcessor) initFromEventBridgeEvent(event events.EventBridgeEvent) {
 	lp.requestHandler.event = event
 	lp.addTag(tagFunctionTriggerEventSource, eventBridge)
 	lp.addTag(tagFunctionTriggerEventSourceArn, event.Source)
 }
 
-func (lp *LifecycleProcessor) initFromKinesisStreamEvent(event ddevents.KinesisEvent) {
+func (lp *LifecycleProcessor) initFromKinesisStreamEvent(event events.KinesisEvent) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithKinesisEvent(event)
 	}
@@ -121,7 +121,7 @@ func (lp *LifecycleProcessor) initFromKinesisStreamEvent(event ddevents.KinesisE
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractKinesisStreamEventARN(event))
 }
 
-func (lp *LifecycleProcessor) initFromS3Event(event ddevents.S3Event) {
+func (lp *LifecycleProcessor) initFromS3Event(event events.S3Event) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithS3Event(event)
 	}
@@ -131,7 +131,7 @@ func (lp *LifecycleProcessor) initFromS3Event(event ddevents.S3Event) {
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractS3EventArn(event))
 }
 
-func (lp *LifecycleProcessor) initFromSNSEvent(event ddevents.SNSEvent) {
+func (lp *LifecycleProcessor) initFromSNSEvent(event events.SNSEvent) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithSNSEvent(event)
 	}
@@ -141,7 +141,7 @@ func (lp *LifecycleProcessor) initFromSNSEvent(event ddevents.SNSEvent) {
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractSNSEventArn(event))
 }
 
-func (lp *LifecycleProcessor) initFromSQSEvent(event ddevents.SQSEvent) {
+func (lp *LifecycleProcessor) initFromSQSEvent(event events.SQSEvent) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithSQSEvent(event)
 	}
@@ -151,7 +151,7 @@ func (lp *LifecycleProcessor) initFromSQSEvent(event ddevents.SQSEvent) {
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractSQSEventARN(event))
 
 	// test for SNS
-	var snsEntity ddevents.SNSEntity
+	var snsEntity events.SNSEntity
 	if err := json.Unmarshal([]byte(event.Records[0].Body), &snsEntity); err != nil {
 		return
 	}
@@ -170,8 +170,8 @@ func (lp *LifecycleProcessor) initFromSQSEvent(event ddevents.SQSEvent) {
 		},
 	}
 
-	var snsEvent ddevents.SNSEvent
-	snsEvent.Records = make([]ddevents.SNSEventRecord, 1)
+	var snsEvent events.SNSEvent
+	snsEvent.Records = make([]events.SNSEventRecord, 1)
 	snsEvent.Records[0].SNS = snsEntity
 
 	lp.requestHandler.inferredSpans[1].EnrichInferredSpanWithSNSEvent(snsEvent)
@@ -180,7 +180,7 @@ func (lp *LifecycleProcessor) initFromSQSEvent(event ddevents.SQSEvent) {
 
 }
 
-func (lp *LifecycleProcessor) initFromLambdaFunctionURLEvent(event ddevents.LambdaFunctionURLRequest, region string, accountID string, functionName string) {
+func (lp *LifecycleProcessor) initFromLambdaFunctionURLEvent(event events.LambdaFunctionURLRequest, region string, accountID string, functionName string) {
 	lp.requestHandler.event = event
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithLambdaFunctionURLEvent(event)

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -15,8 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
 	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 
-	"github.com/aws/aws-lambda-go/events"
-
 	"github.com/DataDog/datadog-agent/pkg/serverless/trigger"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -182,7 +180,7 @@ func (lp *LifecycleProcessor) initFromSQSEvent(event ddevents.SQSEvent) {
 
 }
 
-func (lp *LifecycleProcessor) initFromLambdaFunctionURLEvent(event events.LambdaFunctionURLRequest, region string, accountID string, functionName string) {
+func (lp *LifecycleProcessor) initFromLambdaFunctionURLEvent(event ddevents.LambdaFunctionURLRequest, region string, accountID string, functionName string) {
 	lp.requestHandler.event = event
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithLambdaFunctionURLEvent(event)

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -123,7 +123,7 @@ func (lp *LifecycleProcessor) initFromKinesisStreamEvent(event ddevents.KinesisE
 	lp.addTag(tagFunctionTriggerEventSourceArn, trigger.ExtractKinesisStreamEventARN(event))
 }
 
-func (lp *LifecycleProcessor) initFromS3Event(event events.S3Event) {
+func (lp *LifecycleProcessor) initFromS3Event(event ddevents.S3Event) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithS3Event(event)
 	}

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -113,7 +113,7 @@ func (lp *LifecycleProcessor) initFromEventBridgeEvent(event inferredspan.EventB
 	lp.addTag(tagFunctionTriggerEventSourceArn, event.Source)
 }
 
-func (lp *LifecycleProcessor) initFromKinesisStreamEvent(event events.KinesisEvent) {
+func (lp *LifecycleProcessor) initFromKinesisStreamEvent(event ddevents.KinesisEvent) {
 	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
 		lp.GetInferredSpan().EnrichInferredSpanWithKinesisEvent(event)
 	}

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -184,7 +184,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromDynamoDBStreamEvent(event)
 	case trigger.KinesisStreamEvent:
-		var event events.KinesisEvent
+		var event ddevents.KinesisEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", kinesis, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -176,7 +176,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromCloudWatchLogsEvent(event, region, account)
 	case trigger.DynamoDBStreamEvent:
-		var event events.DynamoDBEvent
+		var event ddevents.DynamoDBEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", dynamoDB, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -168,7 +168,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromCloudWatchEvent(event)
 	case trigger.CloudWatchLogsEvent:
-		var event events.CloudwatchLogsEvent
+		var event ddevents.CloudwatchLogsEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil && arnParseErr != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", cloudwatchLogs, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -160,7 +160,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromALBEvent(event)
 	case trigger.CloudWatchEvent:
-		var event events.CloudWatchEvent
+		var event ddevents.CloudWatchEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", cloudwatchEvents, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/propagation"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trigger"
-	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -110,7 +110,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 	var ev interface{}
 	switch eventType {
 	case trigger.APIGatewayEvent:
-		var event ddevents.APIGatewayProxyRequest
+		var event events.APIGatewayProxyRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break
@@ -118,7 +118,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromAPIGatewayEvent(event, region)
 	case trigger.APIGatewayV2Event:
-		var event ddevents.APIGatewayV2HTTPRequest
+		var event events.APIGatewayV2HTTPRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break
@@ -126,7 +126,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromAPIGatewayV2Event(event, region)
 	case trigger.APIGatewayWebsocketEvent:
-		var event ddevents.APIGatewayWebsocketProxyRequest
+		var event events.APIGatewayWebsocketProxyRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break
@@ -134,7 +134,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromAPIGatewayWebsocketEvent(event, region)
 	case trigger.APIGatewayLambdaAuthorizerTokenEvent:
-		var event ddevents.APIGatewayCustomAuthorizerRequest
+		var event events.APIGatewayCustomAuthorizerRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break
@@ -142,7 +142,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromAPIGatewayLambdaAuthorizerTokenEvent(event)
 	case trigger.APIGatewayLambdaAuthorizerRequestParametersEvent:
-		var event ddevents.APIGatewayCustomAuthorizerRequestTypeRequest
+		var event events.APIGatewayCustomAuthorizerRequestTypeRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break
@@ -150,7 +150,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromAPIGatewayLambdaAuthorizerRequestParametersEvent(event)
 	case trigger.ALBEvent:
-		var event ddevents.ALBTargetGroupRequest
+		var event events.ALBTargetGroupRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", applicationLoadBalancer, err)
 			break
@@ -158,7 +158,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromALBEvent(event)
 	case trigger.CloudWatchEvent:
-		var event ddevents.CloudWatchEvent
+		var event events.CloudWatchEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", cloudwatchEvents, err)
 			break
@@ -166,7 +166,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromCloudWatchEvent(event)
 	case trigger.CloudWatchLogsEvent:
-		var event ddevents.CloudwatchLogsEvent
+		var event events.CloudwatchLogsEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil && arnParseErr != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", cloudwatchLogs, err)
 			break
@@ -174,7 +174,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromCloudWatchLogsEvent(event, region, account)
 	case trigger.DynamoDBStreamEvent:
-		var event ddevents.DynamoDBEvent
+		var event events.DynamoDBEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", dynamoDB, err)
 			break
@@ -182,7 +182,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromDynamoDBStreamEvent(event)
 	case trigger.KinesisStreamEvent:
-		var event ddevents.KinesisEvent
+		var event events.KinesisEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", kinesis, err)
 			break
@@ -190,7 +190,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromKinesisStreamEvent(event)
 	case trigger.EventBridgeEvent:
-		var event ddevents.EventBridgeEvent
+		var event events.EventBridgeEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", eventBridge, err)
 			break
@@ -198,7 +198,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromEventBridgeEvent(event)
 	case trigger.S3Event:
-		var event ddevents.S3Event
+		var event events.S3Event
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", s3, err)
 			break
@@ -206,7 +206,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromS3Event(event)
 	case trigger.SNSEvent:
-		var event ddevents.SNSEvent
+		var event events.SNSEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", sns, err)
 			break
@@ -214,7 +214,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromSNSEvent(event)
 	case trigger.SQSEvent:
-		var event ddevents.SQSEvent
+		var event events.SQSEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", sqs, err)
 			break
@@ -222,7 +222,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromSQSEvent(event)
 	case trigger.LambdaFunctionURLEvent:
-		var event ddevents.LambdaFunctionURLRequest
+		var event events.LambdaFunctionURLRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil && arnParseErr != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", functionURL, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -216,7 +216,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromSNSEvent(event)
 	case trigger.SQSEvent:
-		var event events.SQSEvent
+		var event ddevents.SQSEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", sqs, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -144,7 +144,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromAPIGatewayLambdaAuthorizerTokenEvent(event)
 	case trigger.APIGatewayLambdaAuthorizerRequestParametersEvent:
-		var event events.APIGatewayCustomAuthorizerRequestTypeRequest
+		var event ddevents.APIGatewayCustomAuthorizerRequestTypeRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -192,7 +192,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromKinesisStreamEvent(event)
 	case trigger.EventBridgeEvent:
-		var event inferredspan.EventBridgeEvent
+		var event ddevents.EventBridgeEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", eventBridge, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -208,7 +208,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromS3Event(event)
 	case trigger.SNSEvent:
-		var event events.SNSEvent
+		var event ddevents.SNSEvent
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", sns, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -200,7 +200,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromEventBridgeEvent(event)
 	case trigger.S3Event:
-		var event events.S3Event
+		var event ddevents.S3Event
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", s3, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/propagation"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trigger"
+	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -111,7 +112,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 	var ev interface{}
 	switch eventType {
 	case trigger.APIGatewayEvent:
-		var event events.APIGatewayProxyRequest
+		var event ddevents.APIGatewayProxyRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -152,7 +152,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromAPIGatewayLambdaAuthorizerRequestParametersEvent(event)
 	case trigger.ALBEvent:
-		var event events.ALBTargetGroupRequest
+		var event ddevents.ALBTargetGroupRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", applicationLoadBalancer, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -136,7 +136,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromAPIGatewayWebsocketEvent(event, region)
 	case trigger.APIGatewayLambdaAuthorizerTokenEvent:
-		var event events.APIGatewayCustomAuthorizerRequest
+		var event ddevents.APIGatewayCustomAuthorizerRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -120,7 +120,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromAPIGatewayEvent(event, region)
 	case trigger.APIGatewayV2Event:
-		var event events.APIGatewayV2HTTPRequest
+		var event ddevents.APIGatewayV2HTTPRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-lambda-go/events"
-
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	serverlessLog "github.com/DataDog/datadog-agent/pkg/serverless/logs"
@@ -224,7 +222,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromSQSEvent(event)
 	case trigger.LambdaFunctionURLEvent:
-		var event events.LambdaFunctionURLRequest
+		var event ddevents.LambdaFunctionURLRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil && arnParseErr != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", functionURL, err)
 			break

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -128,7 +128,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		ev = event
 		lp.initFromAPIGatewayV2Event(event, region)
 	case trigger.APIGatewayWebsocketEvent:
-		var event events.APIGatewayWebsocketProxyRequest
+		var event ddevents.APIGatewayWebsocketProxyRequest
 		if err := json.Unmarshal(payloadBytes, &event); err != nil {
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break

--- a/pkg/serverless/invocationlifecycle/trace_test.go
+++ b/pkg/serverless/invocationlifecycle/trace_test.go
@@ -14,7 +14,7 @@ import (
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
-	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 )
 
@@ -75,8 +75,8 @@ func TestInjectSpanIDWithContext(t *testing.T) {
 }
 
 func TestStartExecutionSpan(t *testing.T) {
-	eventWithoutCtx := ddevents.APIGatewayV2HTTPRequest{}
-	eventWithCtx := ddevents.APIGatewayV2HTTPRequest{
+	eventWithoutCtx := events.APIGatewayV2HTTPRequest{}
+	eventWithCtx := events.APIGatewayV2HTTPRequest{
 		Headers: map[string]string{
 			"x-datadog-trace-id":          "1",
 			"x-datadog-parent-id":         "1",

--- a/pkg/serverless/invocationlifecycle/trace_test.go
+++ b/pkg/serverless/invocationlifecycle/trace_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/assert"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
+	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 )
 
@@ -75,8 +75,8 @@ func TestInjectSpanIDWithContext(t *testing.T) {
 }
 
 func TestStartExecutionSpan(t *testing.T) {
-	eventWithoutCtx := events.APIGatewayV2HTTPRequest{}
-	eventWithCtx := events.APIGatewayV2HTTPRequest{
+	eventWithoutCtx := ddevents.APIGatewayV2HTTPRequest{}
+	eventWithCtx := ddevents.APIGatewayV2HTTPRequest{
 		Headers: map[string]string{
 			"x-datadog-trace-id":          "1",
 			"x-datadog-parent-id":         "1",

--- a/pkg/serverless/trace/inferredspan/constants.go
+++ b/pkg/serverless/trace/inferredspan/constants.go
@@ -55,11 +55,3 @@ const (
 	// in the payload headers
 	invocationType = "X-Amz-Invocation-Type"
 )
-
-// EventBridgeEvent is used for unmarshalling a EventBridge event.
-// AWS Go libraries do not provide this type of event for deserialization.
-type EventBridgeEvent struct {
-	DetailType string `json:"detail-type"`
-	Source     string `json:"source"`
-	StartTime  string `json:"time"`
-}

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -307,7 +307,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithEventBridgeEvent(eventPa
 // EnrichInferredSpanWithKinesisEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a Kinesis event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithKinesisEvent(eventPayload events.KinesisEvent) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithKinesisEvent(eventPayload ddevents.KinesisEvent) {
 	eventRecord := eventPayload.Records[0]
 	eventSourceARN := eventRecord.EventSourceArn
 	parts := strings.Split(eventSourceARN, "/")

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -237,7 +237,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithSNSEvent(eventPayload ev
 // EnrichInferredSpanWithS3Event uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from an S3 event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithS3Event(eventPayload events.S3Event) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithS3Event(eventPayload ddevents.S3Event) {
 	eventRecord := eventPayload.Records[0]
 	bucketNameVar := eventRecord.S3.Bucket.Name
 	serviceName := DetermineServiceName(serviceMapping, bucketNameVar, "lambda_s3", "s3")

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -171,7 +171,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithLambdaFunctionURLEvent(e
 // EnrichInferredSpanWithAPIGatewayWebsocketEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a Websocket event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayWebsocketEvent(eventPayload events.APIGatewayWebsocketProxyRequest) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayWebsocketEvent(eventPayload ddevents.APIGatewayWebsocketProxyRequest) {
 	log.Debug("Enriching an inferred span for a Websocket API Gateway")
 	requestContext := eventPayload.RequestContext
 	routeKey := requestContext.RouteKey

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -69,7 +69,7 @@ func DetermineServiceName(serviceMapping map[string]string, specificKey string, 
 // EnrichInferredSpanWithAPIGatewayRESTEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a REST event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayRESTEvent(eventPayload ddevents.APIGatewayProxyRequest) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayRESTEvent(eventPayload events.APIGatewayProxyRequest) {
 	log.Debug("Enriching an inferred span for a REST API Gateway")
 	requestContext := eventPayload.RequestContext
 	resource := fmt.Sprintf("%s %s", eventPayload.HTTPMethod, eventPayload.Path)
@@ -101,7 +101,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayRESTEvent(even
 // EnrichInferredSpanWithAPIGatewayHTTPEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a HTTP event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayHTTPEvent(eventPayload ddevents.APIGatewayV2HTTPRequest) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayHTTPEvent(eventPayload events.APIGatewayV2HTTPRequest) {
 	log.Debug("Enriching an inferred span for a HTTP API Gateway")
 	requestContext := eventPayload.RequestContext
 	http := requestContext.HTTP
@@ -136,7 +136,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayHTTPEvent(even
 // EnrichInferredSpanWithLambdaFunctionURLEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a Lambda Function URL event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithLambdaFunctionURLEvent(eventPayload ddevents.LambdaFunctionURLRequest) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithLambdaFunctionURLEvent(eventPayload events.LambdaFunctionURLRequest) {
 	log.Debug("Enriching an inferred span for a Lambda Function URL")
 	requestContext := eventPayload.RequestContext
 	http := requestContext.HTTP
@@ -170,7 +170,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithLambdaFunctionURLEvent(e
 // EnrichInferredSpanWithAPIGatewayWebsocketEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a Websocket event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayWebsocketEvent(eventPayload ddevents.APIGatewayWebsocketProxyRequest) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayWebsocketEvent(eventPayload events.APIGatewayWebsocketProxyRequest) {
 	log.Debug("Enriching an inferred span for a Websocket API Gateway")
 	requestContext := eventPayload.RequestContext
 	routeKey := requestContext.RouteKey
@@ -204,7 +204,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayWebsocketEvent
 // EnrichInferredSpanWithSNSEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from an SNS event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithSNSEvent(eventPayload ddevents.SNSEvent) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithSNSEvent(eventPayload events.SNSEvent) {
 	eventRecord := eventPayload.Records[0]
 	snsMessage := eventRecord.SNS
 	splitArn := strings.Split(snsMessage.TopicArn, ":")
@@ -236,7 +236,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithSNSEvent(eventPayload dd
 // EnrichInferredSpanWithS3Event uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from an S3 event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithS3Event(eventPayload ddevents.S3Event) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithS3Event(eventPayload events.S3Event) {
 	eventRecord := eventPayload.Records[0]
 	bucketNameVar := eventRecord.S3.Bucket.Name
 	serviceName := DetermineServiceName(serviceMapping, bucketNameVar, "lambda_s3", "s3")
@@ -261,7 +261,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithS3Event(eventPayload dde
 // EnrichInferredSpanWithSQSEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from an SQS event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithSQSEvent(eventPayload ddevents.SQSEvent) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithSQSEvent(eventPayload events.SQSEvent) {
 	eventRecord := eventPayload.Records[0]
 	splitArn := strings.Split(eventRecord.EventSourceARN, ":")
 	parsedQueueName := splitArn[len(splitArn)-1]
@@ -287,7 +287,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithSQSEvent(eventPayload dd
 // EnrichInferredSpanWithEventBridgeEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from an EventBridge event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithEventBridgeEvent(eventPayload ddevents.EventBridgeEvent) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithEventBridgeEvent(eventPayload events.EventBridgeEvent) {
 	source := eventPayload.Source
 	serviceName := DetermineServiceName(serviceMapping, source, "lambda_eventbridge", "eventbridge")
 	inferredSpan.IsAsync = true
@@ -306,7 +306,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithEventBridgeEvent(eventPa
 // EnrichInferredSpanWithKinesisEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a Kinesis event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithKinesisEvent(eventPayload ddevents.KinesisEvent) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithKinesisEvent(eventPayload events.KinesisEvent) {
 	eventRecord := eventPayload.Records[0]
 	eventSourceARN := eventRecord.EventSourceArn
 	parts := strings.Split(eventSourceARN, "/")
@@ -335,7 +335,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithKinesisEvent(eventPayloa
 // EnrichInferredSpanWithDynamoDBEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a DynamoDB event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithDynamoDBEvent(eventPayload ddevents.DynamoDBEvent) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithDynamoDBEvent(eventPayload events.DynamoDBEvent) {
 	eventRecord := eventPayload.Records[0]
 	parsedTableName := strings.Split(eventRecord.EventSourceArn, "/")[1]
 	eventMessage := eventRecord.Change

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/aws/aws-lambda-go/events"
 )
 
 // Define and initialize serviceMapping as a global variable.
@@ -137,7 +136,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayHTTPEvent(even
 // EnrichInferredSpanWithLambdaFunctionURLEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a Lambda Function URL event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithLambdaFunctionURLEvent(eventPayload events.LambdaFunctionURLRequest) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithLambdaFunctionURLEvent(eventPayload ddevents.LambdaFunctionURLRequest) {
 	log.Debug("Enriching an inferred span for a Lambda Function URL")
 	requestContext := eventPayload.RequestContext
 	http := requestContext.HTTP

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -288,7 +288,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithSQSEvent(eventPayload ev
 // EnrichInferredSpanWithEventBridgeEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from an EventBridge event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithEventBridgeEvent(eventPayload EventBridgeEvent) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithEventBridgeEvent(eventPayload ddevents.EventBridgeEvent) {
 	source := eventPayload.Source
 	serviceName := DetermineServiceName(serviceMapping, source, "lambda_eventbridge", "eventbridge")
 	inferredSpan.IsAsync = true

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -336,7 +336,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithKinesisEvent(eventPayloa
 // EnrichInferredSpanWithDynamoDBEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a DynamoDB event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithDynamoDBEvent(eventPayload events.DynamoDBEvent) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithDynamoDBEvent(eventPayload ddevents.DynamoDBEvent) {
 	eventRecord := eventPayload.Records[0]
 	parsedTableName := strings.Split(eventRecord.EventSourceArn, "/")[1]
 	eventMessage := eventRecord.Change

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -262,7 +262,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithS3Event(eventPayload dde
 // EnrichInferredSpanWithSQSEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from an SQS event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithSQSEvent(eventPayload events.SQSEvent) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithSQSEvent(eventPayload ddevents.SQSEvent) {
 	eventRecord := eventPayload.Records[0]
 	splitArn := strings.Split(eventRecord.EventSourceARN, ":")
 	parsedQueueName := splitArn[len(splitArn)-1]

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -102,7 +102,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayRESTEvent(even
 // EnrichInferredSpanWithAPIGatewayHTTPEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a HTTP event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayHTTPEvent(eventPayload events.APIGatewayV2HTTPRequest) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayHTTPEvent(eventPayload ddevents.APIGatewayV2HTTPRequest) {
 	log.Debug("Enriching an inferred span for a HTTP API Gateway")
 	requestContext := eventPayload.RequestContext
 	http := requestContext.HTTP

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -205,7 +205,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayWebsocketEvent
 // EnrichInferredSpanWithSNSEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from an SNS event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithSNSEvent(eventPayload events.SNSEvent) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithSNSEvent(eventPayload ddevents.SNSEvent) {
 	eventRecord := eventPayload.Records[0]
 	snsMessage := eventRecord.SNS
 	splitArn := strings.Split(snsMessage.TopicArn, ":")

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/aws/aws-lambda-go/events"
 )
@@ -69,7 +70,7 @@ func DetermineServiceName(serviceMapping map[string]string, specificKey string, 
 // EnrichInferredSpanWithAPIGatewayRESTEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a REST event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayRESTEvent(eventPayload events.APIGatewayProxyRequest) {
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayRESTEvent(eventPayload ddevents.APIGatewayProxyRequest) {
 	log.Debug("Enriching an inferred span for a REST API Gateway")
 	requestContext := eventPayload.RequestContext
 	resource := fmt.Sprintf("%s %s", eventPayload.HTTPMethod, eventPayload.Path)

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -319,7 +319,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayHTTPAPIEvent(t *tes
 }
 
 func TestEnrichInferredSpanWithAPIGatewayWebsocketDefaultEvent(t *testing.T) {
-	var apiGatewayWebsocketEvent events.APIGatewayWebsocketProxyRequest
+	var apiGatewayWebsocketEvent ddevents.APIGatewayWebsocketProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway-websocket-default.json"), &apiGatewayWebsocketEvent)
 	inferredSpan := mockInferredSpan()
 	span := inferredSpan.Span
@@ -347,7 +347,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketDefaultEvent(t *testing.T) {
 
 func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayWebsocketDefaultEvent(t *testing.T) {
 	// Load the original event
-	var apiGatewayWebsocketEvent events.APIGatewayWebsocketProxyRequest
+	var apiGatewayWebsocketEvent ddevents.APIGatewayWebsocketProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway-websocket-default.json"), &apiGatewayWebsocketEvent)
 	// Store the original service mapping
 	origServiceMapping := GetServiceMapping()
@@ -382,7 +382,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayWebsocketDefaultEve
 }
 
 func TestEnrichInferredSpanWithAPIGatewayWebsocketConnectEvent(t *testing.T) {
-	var apiGatewayWebsocketEvent events.APIGatewayWebsocketProxyRequest
+	var apiGatewayWebsocketEvent ddevents.APIGatewayWebsocketProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway-websocket-connect.json"), &apiGatewayWebsocketEvent)
 	inferredSpan := mockInferredSpan()
 	span := inferredSpan.Span
@@ -409,7 +409,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketConnectEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithAPIGatewayWebsocketDisconnectEvent(t *testing.T) {
-	var apiGatewayWebsocketEvent events.APIGatewayWebsocketProxyRequest
+	var apiGatewayWebsocketEvent ddevents.APIGatewayWebsocketProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway-websocket-disconnect.json"), &apiGatewayWebsocketEvent)
 	inferredSpan := mockInferredSpan()
 	span := inferredSpan.Span

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -235,7 +235,7 @@ func TestEnrichInferredSpanWithAPIGatewayNonProxyAsyncRESTEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithAPIGatewayHTTPEvent(t *testing.T) {
-	var apiGatewayHTTPEvent events.APIGatewayV2HTTPRequest
+	var apiGatewayHTTPEvent ddevents.APIGatewayV2HTTPRequest
 	_ = json.Unmarshal(getEventFromFile("http-api.json"), &apiGatewayHTTPEvent)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithAPIGatewayHTTPEvent(apiGatewayHTTPEvent)
@@ -284,7 +284,7 @@ func TestEnrichInferredSpanWithLambdaFunctionURLEventt(t *testing.T) {
 
 func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayHTTPAPIEvent(t *testing.T) {
 	// Load the original event
-	var apiGatewayHTTPAPIEvent events.APIGatewayV2HTTPRequest
+	var apiGatewayHTTPAPIEvent ddevents.APIGatewayV2HTTPRequest
 	_ = json.Unmarshal(getEventFromFile("http-api.json"), &apiGatewayHTTPAPIEvent)
 	// Store the original service mapping
 	origServiceMapping := GetServiceMapping()

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -724,7 +724,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromEventBridgeEvent(t *testing.T
 }
 
 func TestEnrichInferredSpanWithSQSEvent(t *testing.T) {
-	var sqsRequest events.SQSEvent
+	var sqsRequest ddevents.SQSEvent
 	_ = json.Unmarshal(getEventFromFile("sqs.json"), &sqsRequest)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithSQSEvent(sqsRequest)
@@ -760,7 +760,7 @@ func TestRemapsAllInferredSpanServiceNamesFromSQSEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var sqsRequest events.SQSEvent
+	var sqsRequest ddevents.SQSEvent
 	_ = json.Unmarshal(getEventFromFile("sqs.json"), &sqsRequest)
 
 	inferredSpan := mockInferredSpan()
@@ -796,7 +796,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromSQSEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var sqsRequest events.SQSEvent
+	var sqsRequest ddevents.SQSEvent
 	_ = json.Unmarshal(getEventFromFile("sqs.json"), &sqsRequest)
 
 	inferredSpan := mockInferredSpan()

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -818,7 +818,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromSQSEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithKinesisEvent(t *testing.T) {
-	var kinesisRequest events.KinesisEvent
+	var kinesisRequest ddevents.KinesisEvent
 	_ = json.Unmarshal(getEventFromFile("kinesis.json"), &kinesisRequest)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithKinesisEvent(kinesisRequest)
@@ -856,7 +856,7 @@ func TestRemapsAllInferredSpanServiceNamesFromKinesisEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var kinesisRequest events.KinesisEvent
+	var kinesisRequest ddevents.KinesisEvent
 	_ = json.Unmarshal(getEventFromFile("kinesis.json"), &kinesisRequest)
 
 	inferredSpan := mockInferredSpan()
@@ -892,7 +892,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromKinesisEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var kinesisRequest events.KinesisEvent
+	var kinesisRequest ddevents.KinesisEvent
 	_ = json.Unmarshal(getEventFromFile("kinesis.json"), &kinesisRequest)
 
 	inferredSpan := mockInferredSpan()

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -633,7 +633,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromS3Event(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithEventBridgeEvent(t *testing.T) {
-	var eventBridgeEvent EventBridgeEvent
+	var eventBridgeEvent ddevents.EventBridgeEvent
 	_ = json.Unmarshal(getEventFromFile("eventbridge-custom.json"), &eventBridgeEvent)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithEventBridgeEvent(eventBridgeEvent)
@@ -647,6 +647,7 @@ func TestEnrichInferredSpanWithEventBridgeEvent(t *testing.T) {
 	assert.Equal(t, "web", span.Type)
 	assert.Equal(t, "aws.eventbridge", span.Meta[operationName])
 	assert.Equal(t, "eventbridge.custom.event.sender", span.Meta[resourceNames])
+	assert.Equal(t, "testdetail", span.Meta[detailType])
 	assert.True(t, inferredSpan.IsAsync)
 }
 
@@ -664,7 +665,7 @@ func TestRemapsAllInferredSpanServiceNamesFromEventBridgeEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var eventBridgeEvent EventBridgeEvent
+	var eventBridgeEvent ddevents.EventBridgeEvent
 	_ = json.Unmarshal(getEventFromFile("eventbridge-custom.json"), &eventBridgeEvent)
 
 	inferredSpan := mockInferredSpan()
@@ -700,7 +701,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromEventBridgeEvent(t *testing.T
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var eventBridgeEvent EventBridgeEvent
+	var eventBridgeEvent ddevents.EventBridgeEvent
 	_ = json.Unmarshal(getEventFromFile("eventbridge-custom.json"), &eventBridgeEvent)
 
 	inferredSpan := mockInferredSpan()

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 )
 
 const (
@@ -110,7 +111,7 @@ func TestDetermineServiceName(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithAPIGatewayRESTEvent(t *testing.T) {
-	var apiGatewayRestEvent events.APIGatewayProxyRequest
+	var apiGatewayRestEvent ddevents.APIGatewayProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway.json"), &apiGatewayRestEvent)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithAPIGatewayRESTEvent(apiGatewayRestEvent)
@@ -137,7 +138,7 @@ func TestEnrichInferredSpanWithAPIGatewayRESTEvent(t *testing.T) {
 
 func TestRemapsAllInferredSpanServiceNamesFromAPIGatewayEvent(t *testing.T) {
 	// Load the original event
-	var apiGatewayRestEvent events.APIGatewayProxyRequest
+	var apiGatewayRestEvent ddevents.APIGatewayProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway.json"), &apiGatewayRestEvent)
 
 	inferredSpan := mockInferredSpan()
@@ -174,7 +175,7 @@ func TestRemapsAllInferredSpanServiceNamesFromAPIGatewayEvent(t *testing.T) {
 
 func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayEvent(t *testing.T) {
 	// Load the original event
-	var apiGatewayRestEvent events.APIGatewayProxyRequest
+	var apiGatewayRestEvent ddevents.APIGatewayProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway.json"), &apiGatewayRestEvent)
 	// Store the original service mapping
 	origServiceMapping := GetServiceMapping()
@@ -209,7 +210,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayEvent(t *testing.T)
 }
 
 func TestEnrichInferredSpanWithAPIGatewayNonProxyAsyncRESTEvent(t *testing.T) {
-	var apiGatewayRestEvent events.APIGatewayProxyRequest
+	var apiGatewayRestEvent ddevents.APIGatewayProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway-non-proxy-async.json"), &apiGatewayRestEvent)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithAPIGatewayRESTEvent(apiGatewayRestEvent)

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -534,7 +534,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromSNSEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanForS3Event(t *testing.T) {
-	var s3Request events.S3Event
+	var s3Request ddevents.S3Event
 	_ = json.Unmarshal(getEventFromFile("s3.json"), &s3Request)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithS3Event(s3Request)
@@ -573,7 +573,7 @@ func TestRemapsAllInferredSpanServiceNamesFromS3Event(t *testing.T) {
 	SetServiceMapping(newServiceMapping)
 
 	// Load the original event
-	var s3Event events.S3Event
+	var s3Event ddevents.S3Event
 	_ = json.Unmarshal(getEventFromFile("s3.json"), &s3Event)
 
 	inferredSpan := mockInferredSpan()
@@ -610,7 +610,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromS3Event(t *testing.T) {
 	SetServiceMapping(newServiceMapping)
 
 	// Load the original event
-	var s3Event events.S3Event
+	var s3Event ddevents.S3Event
 	_ = json.Unmarshal(getEventFromFile("s3.json"), &s3Event)
 
 	inferredSpan := mockInferredSpan()

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -436,7 +436,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketDisconnectEvent(t *testing.T) 
 }
 
 func TestEnrichInferredSpanWithSNSEvent(t *testing.T) {
-	var snsRequest events.SNSEvent
+	var snsRequest ddevents.SNSEvent
 	_ = json.Unmarshal(getEventFromFile("sns.json"), &snsRequest)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithSNSEvent(snsRequest)
@@ -475,7 +475,7 @@ func TestRemapsAllInferredSpanServiceNamesFromSNSEvent(t *testing.T) {
 	SetServiceMapping(newServiceMapping)
 
 	// Load the original event
-	var snsEvent events.SNSEvent
+	var snsEvent ddevents.SNSEvent
 	_ = json.Unmarshal(getEventFromFile("sns.json"), &snsEvent)
 
 	inferredSpan := mockInferredSpan()
@@ -511,7 +511,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromSNSEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var snsEvent events.SNSEvent
+	var snsEvent ddevents.SNSEvent
 	_ = json.Unmarshal(getEventFromFile("sns.json"), &snsEvent)
 
 	inferredSpan := mockInferredSpan()

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -915,7 +915,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromKinesisEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithDynamoDBEvent(t *testing.T) {
-	var dynamoRequest events.DynamoDBEvent
+	var dynamoRequest ddevents.DynamoDBEvent
 	_ = json.Unmarshal(getEventFromFile("dynamodb.json"), &dynamoRequest)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithDynamoDBEvent(dynamoRequest)
@@ -953,7 +953,7 @@ func TestRemapsAllInferredSpanServiceNamesFromDynamoDBEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var dynamoRequest events.DynamoDBEvent
+	var dynamoRequest ddevents.DynamoDBEvent
 	_ = json.Unmarshal(getEventFromFile("dynamodb.json"), &dynamoRequest)
 
 	inferredSpan := mockInferredSpan()
@@ -989,7 +989,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromDynamoDBEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var dynamoRequest events.DynamoDBEvent
+	var dynamoRequest ddevents.DynamoDBEvent
 	_ = json.Unmarshal(getEventFromFile("dynamodb.json"), &dynamoRequest)
 
 	inferredSpan := mockInferredSpan()

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/assert"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
@@ -259,7 +258,7 @@ func TestEnrichInferredSpanWithAPIGatewayHTTPEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithLambdaFunctionURLEventt(t *testing.T) {
-	var apiGatewayHTTPEvent events.LambdaFunctionURLRequest
+	var apiGatewayHTTPEvent ddevents.LambdaFunctionURLRequest
 	_ = json.Unmarshal(getEventFromFile("http-api.json"), &apiGatewayHTTPEvent)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithLambdaFunctionURLEvent(apiGatewayHTTPEvent)

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 )
 
 const (
@@ -110,7 +110,7 @@ func TestDetermineServiceName(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithAPIGatewayRESTEvent(t *testing.T) {
-	var apiGatewayRestEvent ddevents.APIGatewayProxyRequest
+	var apiGatewayRestEvent events.APIGatewayProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway.json"), &apiGatewayRestEvent)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithAPIGatewayRESTEvent(apiGatewayRestEvent)
@@ -137,7 +137,7 @@ func TestEnrichInferredSpanWithAPIGatewayRESTEvent(t *testing.T) {
 
 func TestRemapsAllInferredSpanServiceNamesFromAPIGatewayEvent(t *testing.T) {
 	// Load the original event
-	var apiGatewayRestEvent ddevents.APIGatewayProxyRequest
+	var apiGatewayRestEvent events.APIGatewayProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway.json"), &apiGatewayRestEvent)
 
 	inferredSpan := mockInferredSpan()
@@ -174,7 +174,7 @@ func TestRemapsAllInferredSpanServiceNamesFromAPIGatewayEvent(t *testing.T) {
 
 func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayEvent(t *testing.T) {
 	// Load the original event
-	var apiGatewayRestEvent ddevents.APIGatewayProxyRequest
+	var apiGatewayRestEvent events.APIGatewayProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway.json"), &apiGatewayRestEvent)
 	// Store the original service mapping
 	origServiceMapping := GetServiceMapping()
@@ -209,7 +209,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayEvent(t *testing.T)
 }
 
 func TestEnrichInferredSpanWithAPIGatewayNonProxyAsyncRESTEvent(t *testing.T) {
-	var apiGatewayRestEvent ddevents.APIGatewayProxyRequest
+	var apiGatewayRestEvent events.APIGatewayProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway-non-proxy-async.json"), &apiGatewayRestEvent)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithAPIGatewayRESTEvent(apiGatewayRestEvent)
@@ -234,7 +234,7 @@ func TestEnrichInferredSpanWithAPIGatewayNonProxyAsyncRESTEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithAPIGatewayHTTPEvent(t *testing.T) {
-	var apiGatewayHTTPEvent ddevents.APIGatewayV2HTTPRequest
+	var apiGatewayHTTPEvent events.APIGatewayV2HTTPRequest
 	_ = json.Unmarshal(getEventFromFile("http-api.json"), &apiGatewayHTTPEvent)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithAPIGatewayHTTPEvent(apiGatewayHTTPEvent)
@@ -258,7 +258,7 @@ func TestEnrichInferredSpanWithAPIGatewayHTTPEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithLambdaFunctionURLEventt(t *testing.T) {
-	var apiGatewayHTTPEvent ddevents.LambdaFunctionURLRequest
+	var apiGatewayHTTPEvent events.LambdaFunctionURLRequest
 	_ = json.Unmarshal(getEventFromFile("http-api.json"), &apiGatewayHTTPEvent)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithLambdaFunctionURLEvent(apiGatewayHTTPEvent)
@@ -283,7 +283,7 @@ func TestEnrichInferredSpanWithLambdaFunctionURLEventt(t *testing.T) {
 
 func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayHTTPAPIEvent(t *testing.T) {
 	// Load the original event
-	var apiGatewayHTTPAPIEvent ddevents.APIGatewayV2HTTPRequest
+	var apiGatewayHTTPAPIEvent events.APIGatewayV2HTTPRequest
 	_ = json.Unmarshal(getEventFromFile("http-api.json"), &apiGatewayHTTPAPIEvent)
 	// Store the original service mapping
 	origServiceMapping := GetServiceMapping()
@@ -318,7 +318,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayHTTPAPIEvent(t *tes
 }
 
 func TestEnrichInferredSpanWithAPIGatewayWebsocketDefaultEvent(t *testing.T) {
-	var apiGatewayWebsocketEvent ddevents.APIGatewayWebsocketProxyRequest
+	var apiGatewayWebsocketEvent events.APIGatewayWebsocketProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway-websocket-default.json"), &apiGatewayWebsocketEvent)
 	inferredSpan := mockInferredSpan()
 	span := inferredSpan.Span
@@ -346,7 +346,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketDefaultEvent(t *testing.T) {
 
 func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayWebsocketDefaultEvent(t *testing.T) {
 	// Load the original event
-	var apiGatewayWebsocketEvent ddevents.APIGatewayWebsocketProxyRequest
+	var apiGatewayWebsocketEvent events.APIGatewayWebsocketProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway-websocket-default.json"), &apiGatewayWebsocketEvent)
 	// Store the original service mapping
 	origServiceMapping := GetServiceMapping()
@@ -381,7 +381,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayWebsocketDefaultEve
 }
 
 func TestEnrichInferredSpanWithAPIGatewayWebsocketConnectEvent(t *testing.T) {
-	var apiGatewayWebsocketEvent ddevents.APIGatewayWebsocketProxyRequest
+	var apiGatewayWebsocketEvent events.APIGatewayWebsocketProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway-websocket-connect.json"), &apiGatewayWebsocketEvent)
 	inferredSpan := mockInferredSpan()
 	span := inferredSpan.Span
@@ -408,7 +408,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketConnectEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithAPIGatewayWebsocketDisconnectEvent(t *testing.T) {
-	var apiGatewayWebsocketEvent ddevents.APIGatewayWebsocketProxyRequest
+	var apiGatewayWebsocketEvent events.APIGatewayWebsocketProxyRequest
 	_ = json.Unmarshal(getEventFromFile("api-gateway-websocket-disconnect.json"), &apiGatewayWebsocketEvent)
 	inferredSpan := mockInferredSpan()
 	span := inferredSpan.Span
@@ -435,7 +435,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketDisconnectEvent(t *testing.T) 
 }
 
 func TestEnrichInferredSpanWithSNSEvent(t *testing.T) {
-	var snsRequest ddevents.SNSEvent
+	var snsRequest events.SNSEvent
 	_ = json.Unmarshal(getEventFromFile("sns.json"), &snsRequest)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithSNSEvent(snsRequest)
@@ -474,7 +474,7 @@ func TestRemapsAllInferredSpanServiceNamesFromSNSEvent(t *testing.T) {
 	SetServiceMapping(newServiceMapping)
 
 	// Load the original event
-	var snsEvent ddevents.SNSEvent
+	var snsEvent events.SNSEvent
 	_ = json.Unmarshal(getEventFromFile("sns.json"), &snsEvent)
 
 	inferredSpan := mockInferredSpan()
@@ -510,7 +510,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromSNSEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var snsEvent ddevents.SNSEvent
+	var snsEvent events.SNSEvent
 	_ = json.Unmarshal(getEventFromFile("sns.json"), &snsEvent)
 
 	inferredSpan := mockInferredSpan()
@@ -533,7 +533,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromSNSEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanForS3Event(t *testing.T) {
-	var s3Request ddevents.S3Event
+	var s3Request events.S3Event
 	_ = json.Unmarshal(getEventFromFile("s3.json"), &s3Request)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithS3Event(s3Request)
@@ -572,7 +572,7 @@ func TestRemapsAllInferredSpanServiceNamesFromS3Event(t *testing.T) {
 	SetServiceMapping(newServiceMapping)
 
 	// Load the original event
-	var s3Event ddevents.S3Event
+	var s3Event events.S3Event
 	_ = json.Unmarshal(getEventFromFile("s3.json"), &s3Event)
 
 	inferredSpan := mockInferredSpan()
@@ -609,7 +609,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromS3Event(t *testing.T) {
 	SetServiceMapping(newServiceMapping)
 
 	// Load the original event
-	var s3Event ddevents.S3Event
+	var s3Event events.S3Event
 	_ = json.Unmarshal(getEventFromFile("s3.json"), &s3Event)
 
 	inferredSpan := mockInferredSpan()
@@ -632,7 +632,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromS3Event(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithEventBridgeEvent(t *testing.T) {
-	var eventBridgeEvent ddevents.EventBridgeEvent
+	var eventBridgeEvent events.EventBridgeEvent
 	_ = json.Unmarshal(getEventFromFile("eventbridge-custom.json"), &eventBridgeEvent)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithEventBridgeEvent(eventBridgeEvent)
@@ -664,7 +664,7 @@ func TestRemapsAllInferredSpanServiceNamesFromEventBridgeEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var eventBridgeEvent ddevents.EventBridgeEvent
+	var eventBridgeEvent events.EventBridgeEvent
 	_ = json.Unmarshal(getEventFromFile("eventbridge-custom.json"), &eventBridgeEvent)
 
 	inferredSpan := mockInferredSpan()
@@ -700,7 +700,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromEventBridgeEvent(t *testing.T
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var eventBridgeEvent ddevents.EventBridgeEvent
+	var eventBridgeEvent events.EventBridgeEvent
 	_ = json.Unmarshal(getEventFromFile("eventbridge-custom.json"), &eventBridgeEvent)
 
 	inferredSpan := mockInferredSpan()
@@ -723,7 +723,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromEventBridgeEvent(t *testing.T
 }
 
 func TestEnrichInferredSpanWithSQSEvent(t *testing.T) {
-	var sqsRequest ddevents.SQSEvent
+	var sqsRequest events.SQSEvent
 	_ = json.Unmarshal(getEventFromFile("sqs.json"), &sqsRequest)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithSQSEvent(sqsRequest)
@@ -759,7 +759,7 @@ func TestRemapsAllInferredSpanServiceNamesFromSQSEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var sqsRequest ddevents.SQSEvent
+	var sqsRequest events.SQSEvent
 	_ = json.Unmarshal(getEventFromFile("sqs.json"), &sqsRequest)
 
 	inferredSpan := mockInferredSpan()
@@ -795,7 +795,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromSQSEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var sqsRequest ddevents.SQSEvent
+	var sqsRequest events.SQSEvent
 	_ = json.Unmarshal(getEventFromFile("sqs.json"), &sqsRequest)
 
 	inferredSpan := mockInferredSpan()
@@ -818,7 +818,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromSQSEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithKinesisEvent(t *testing.T) {
-	var kinesisRequest ddevents.KinesisEvent
+	var kinesisRequest events.KinesisEvent
 	_ = json.Unmarshal(getEventFromFile("kinesis.json"), &kinesisRequest)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithKinesisEvent(kinesisRequest)
@@ -856,7 +856,7 @@ func TestRemapsAllInferredSpanServiceNamesFromKinesisEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var kinesisRequest ddevents.KinesisEvent
+	var kinesisRequest events.KinesisEvent
 	_ = json.Unmarshal(getEventFromFile("kinesis.json"), &kinesisRequest)
 
 	inferredSpan := mockInferredSpan()
@@ -892,7 +892,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromKinesisEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var kinesisRequest ddevents.KinesisEvent
+	var kinesisRequest events.KinesisEvent
 	_ = json.Unmarshal(getEventFromFile("kinesis.json"), &kinesisRequest)
 
 	inferredSpan := mockInferredSpan()
@@ -915,7 +915,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromKinesisEvent(t *testing.T) {
 }
 
 func TestEnrichInferredSpanWithDynamoDBEvent(t *testing.T) {
-	var dynamoRequest ddevents.DynamoDBEvent
+	var dynamoRequest events.DynamoDBEvent
 	_ = json.Unmarshal(getEventFromFile("dynamodb.json"), &dynamoRequest)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithDynamoDBEvent(dynamoRequest)
@@ -953,7 +953,7 @@ func TestRemapsAllInferredSpanServiceNamesFromDynamoDBEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var dynamoRequest ddevents.DynamoDBEvent
+	var dynamoRequest events.DynamoDBEvent
 	_ = json.Unmarshal(getEventFromFile("dynamodb.json"), &dynamoRequest)
 
 	inferredSpan := mockInferredSpan()
@@ -989,7 +989,7 @@ func TestRemapsSpecificInferredSpanServiceNamesFromDynamoDBEvent(t *testing.T) {
 	}
 	SetServiceMapping(newServiceMapping)
 	// Load the original event
-	var dynamoRequest ddevents.DynamoDBEvent
+	var dynamoRequest events.DynamoDBEvent
 	_ = json.Unmarshal(getEventFromFile("dynamodb.json"), &dynamoRequest)
 
 	inferredSpan := mockInferredSpan()

--- a/pkg/serverless/trace/propagation/carriers.go
+++ b/pkg/serverless/trace/propagation/carriers.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"strings"
 
-	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -93,7 +93,7 @@ func extractTraceContextfromAWSTraceHeader(value string) (*TraceContext, error) 
 
 // sqsMessageCarrier returns the tracer.TextMapReader used to extract trace
 // context from the events.SQSMessage type.
-func sqsMessageCarrier(event ddevents.SQSMessage) (tracer.TextMapReader, error) {
+func sqsMessageCarrier(event events.SQSMessage) (tracer.TextMapReader, error) {
 	if attr, ok := event.MessageAttributes[datadogSQSHeader]; ok {
 		return sqsMessageAttrCarrier(attr)
 	}
@@ -103,7 +103,7 @@ func sqsMessageCarrier(event ddevents.SQSMessage) (tracer.TextMapReader, error) 
 // sqsMessageAttrCarrier returns the tracer.TextMapReader used to extract trace
 // context from the events.SQSMessageAttribute field on an events.SQSMessage
 // type.
-func sqsMessageAttrCarrier(attr ddevents.SQSMessageAttribute) (tracer.TextMapReader, error) {
+func sqsMessageAttrCarrier(attr events.SQSMessageAttribute) (tracer.TextMapReader, error) {
 	var bytes []byte
 	switch attr.DataType {
 	case "String":
@@ -128,7 +128,7 @@ func sqsMessageAttrCarrier(attr ddevents.SQSMessageAttribute) (tracer.TextMapRea
 
 // snsSqsMessageCarrier returns the tracer.TextMapReader used to extract trace
 // context from the body of an events.SQSMessage type.
-func snsSqsMessageCarrier(event ddevents.SQSMessage) (tracer.TextMapReader, error) {
+func snsSqsMessageCarrier(event events.SQSMessage) (tracer.TextMapReader, error) {
 	var body struct {
 		MessageAttributes map[string]struct {
 			Type  string

--- a/pkg/serverless/trace/propagation/carriers.go
+++ b/pkg/serverless/trace/propagation/carriers.go
@@ -15,8 +15,8 @@ import (
 	"strconv"
 	"strings"
 
+	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/aws/aws-lambda-go/events"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
@@ -93,7 +93,7 @@ func extractTraceContextfromAWSTraceHeader(value string) (*TraceContext, error) 
 
 // sqsMessageCarrier returns the tracer.TextMapReader used to extract trace
 // context from the events.SQSMessage type.
-func sqsMessageCarrier(event events.SQSMessage) (tracer.TextMapReader, error) {
+func sqsMessageCarrier(event ddevents.SQSMessage) (tracer.TextMapReader, error) {
 	if attr, ok := event.MessageAttributes[datadogSQSHeader]; ok {
 		return sqsMessageAttrCarrier(attr)
 	}
@@ -103,7 +103,7 @@ func sqsMessageCarrier(event events.SQSMessage) (tracer.TextMapReader, error) {
 // sqsMessageAttrCarrier returns the tracer.TextMapReader used to extract trace
 // context from the events.SQSMessageAttribute field on an events.SQSMessage
 // type.
-func sqsMessageAttrCarrier(attr events.SQSMessageAttribute) (tracer.TextMapReader, error) {
+func sqsMessageAttrCarrier(attr ddevents.SQSMessageAttribute) (tracer.TextMapReader, error) {
 	var bytes []byte
 	switch attr.DataType {
 	case "String":
@@ -128,7 +128,7 @@ func sqsMessageAttrCarrier(attr events.SQSMessageAttribute) (tracer.TextMapReade
 
 // snsSqsMessageCarrier returns the tracer.TextMapReader used to extract trace
 // context from the body of an events.SQSMessage type.
-func snsSqsMessageCarrier(event events.SQSMessage) (tracer.TextMapReader, error) {
+func snsSqsMessageCarrier(event ddevents.SQSMessage) (tracer.TextMapReader, error) {
 	var body struct {
 		MessageAttributes map[string]struct {
 			Type  string

--- a/pkg/serverless/trace/propagation/carriers_test.go
+++ b/pkg/serverless/trace/propagation/carriers_test.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"testing"
 
-	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
@@ -32,13 +32,13 @@ func getMapFromCarrier(tm tracer.TextMapReader) map[string]string {
 func TestSQSMessageAttrCarrier(t *testing.T) {
 	testcases := []struct {
 		name     string
-		attr     ddevents.SQSMessageAttribute
+		attr     events.SQSMessageAttribute
 		expMap   map[string]string
 		expNoErr bool
 	}{
 		{
 			name: "string-datadog-map",
-			attr: ddevents.SQSMessageAttribute{
+			attr: events.SQSMessageAttribute{
 				DataType:    "String",
 				StringValue: aws.String(headersAll),
 			},
@@ -47,7 +47,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "string-empty-map",
-			attr: ddevents.SQSMessageAttribute{
+			attr: events.SQSMessageAttribute{
 				DataType:    "String",
 				StringValue: aws.String("{}"),
 			},
@@ -56,7 +56,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "string-empty-string",
-			attr: ddevents.SQSMessageAttribute{
+			attr: events.SQSMessageAttribute{
 				DataType:    "String",
 				StringValue: aws.String(""),
 			},
@@ -65,7 +65,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "string-nil-string",
-			attr: ddevents.SQSMessageAttribute{
+			attr: events.SQSMessageAttribute{
 				DataType:    "String",
 				StringValue: nil,
 			},
@@ -74,7 +74,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "binary-datadog-map",
-			attr: ddevents.SQSMessageAttribute{
+			attr: events.SQSMessageAttribute{
 				DataType:    "Binary",
 				BinaryValue: []byte(headersAll),
 			},
@@ -83,7 +83,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "binary-empty-map",
-			attr: ddevents.SQSMessageAttribute{
+			attr: events.SQSMessageAttribute{
 				DataType:    "Binary",
 				BinaryValue: []byte("{}"),
 			},
@@ -92,7 +92,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "binary-empty-string",
-			attr: ddevents.SQSMessageAttribute{
+			attr: events.SQSMessageAttribute{
 				DataType:    "Binary",
 				BinaryValue: []byte(""),
 			},
@@ -101,7 +101,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "binary-nil-string",
-			attr: ddevents.SQSMessageAttribute{
+			attr: events.SQSMessageAttribute{
 				DataType:    "Binary",
 				BinaryValue: nil,
 			},
@@ -110,7 +110,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "wrong-data-type",
-			attr: ddevents.SQSMessageAttribute{
+			attr: events.SQSMessageAttribute{
 				DataType: "Purple",
 			},
 			expMap:   nil,
@@ -131,13 +131,13 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 func TestSnsSqsMessageCarrier(t *testing.T) {
 	testcases := []struct {
 		name   string
-		event  ddevents.SQSMessage
+		event  events.SQSMessage
 		expMap map[string]string
 		expErr error
 	}{
 		{
 			name: "empty-string-body",
-			event: ddevents.SQSMessage{
+			event: events.SQSMessage{
 				Body: "",
 			},
 			expMap: nil,
@@ -145,7 +145,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "empty-map-body",
-			event: ddevents.SQSMessage{
+			event: events.SQSMessage{
 				Body: "{}",
 			},
 			expMap: nil,
@@ -153,7 +153,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "no-msg-attrs",
-			event: ddevents.SQSMessage{
+			event: events.SQSMessage{
 				Body: `{
 					"MessageAttributes": {}
 				}`,
@@ -163,7 +163,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "wrong-type-msg-attrs",
-			event: ddevents.SQSMessage{
+			event: events.SQSMessage{
 				Body: `{
 					"MessageAttributes": "attrs"
 				}`,
@@ -173,7 +173,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "non-binary-type",
-			event: ddevents.SQSMessage{
+			event: events.SQSMessage{
 				Body: `{
 					"MessageAttributes": {
 						"_datadog": {
@@ -188,7 +188,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "cannot-decode",
-			event: ddevents.SQSMessage{
+			event: events.SQSMessage{
 				Body: `{
 					"MessageAttributes": {
 						"_datadog": {
@@ -203,7 +203,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "empty-string-encoded",
-			event: ddevents.SQSMessage{
+			event: events.SQSMessage{
 				Body: `{
 					"MessageAttributes": {
 						"_datadog": {
@@ -460,7 +460,7 @@ func TestExtractTraceContextfromAWSTraceHeader(t *testing.T) {
 func TestSqsMessageCarrier(t *testing.T) {
 	testcases := []struct {
 		name   string
-		event  ddevents.SQSMessage
+		event  events.SQSMessage
 		expMap map[string]string
 		expErr error
 	}{

--- a/pkg/serverless/trace/propagation/carriers_test.go
+++ b/pkg/serverless/trace/propagation/carriers_test.go
@@ -10,8 +10,8 @@ import (
 	"errors"
 	"testing"
 
+	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -32,13 +32,13 @@ func getMapFromCarrier(tm tracer.TextMapReader) map[string]string {
 func TestSQSMessageAttrCarrier(t *testing.T) {
 	testcases := []struct {
 		name     string
-		attr     events.SQSMessageAttribute
+		attr     ddevents.SQSMessageAttribute
 		expMap   map[string]string
 		expNoErr bool
 	}{
 		{
 			name: "string-datadog-map",
-			attr: events.SQSMessageAttribute{
+			attr: ddevents.SQSMessageAttribute{
 				DataType:    "String",
 				StringValue: aws.String(headersAll),
 			},
@@ -47,7 +47,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "string-empty-map",
-			attr: events.SQSMessageAttribute{
+			attr: ddevents.SQSMessageAttribute{
 				DataType:    "String",
 				StringValue: aws.String("{}"),
 			},
@@ -56,7 +56,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "string-empty-string",
-			attr: events.SQSMessageAttribute{
+			attr: ddevents.SQSMessageAttribute{
 				DataType:    "String",
 				StringValue: aws.String(""),
 			},
@@ -65,7 +65,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "string-nil-string",
-			attr: events.SQSMessageAttribute{
+			attr: ddevents.SQSMessageAttribute{
 				DataType:    "String",
 				StringValue: nil,
 			},
@@ -74,7 +74,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "binary-datadog-map",
-			attr: events.SQSMessageAttribute{
+			attr: ddevents.SQSMessageAttribute{
 				DataType:    "Binary",
 				BinaryValue: []byte(headersAll),
 			},
@@ -83,7 +83,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "binary-empty-map",
-			attr: events.SQSMessageAttribute{
+			attr: ddevents.SQSMessageAttribute{
 				DataType:    "Binary",
 				BinaryValue: []byte("{}"),
 			},
@@ -92,7 +92,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "binary-empty-string",
-			attr: events.SQSMessageAttribute{
+			attr: ddevents.SQSMessageAttribute{
 				DataType:    "Binary",
 				BinaryValue: []byte(""),
 			},
@@ -101,7 +101,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "binary-nil-string",
-			attr: events.SQSMessageAttribute{
+			attr: ddevents.SQSMessageAttribute{
 				DataType:    "Binary",
 				BinaryValue: nil,
 			},
@@ -110,7 +110,7 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 		},
 		{
 			name: "wrong-data-type",
-			attr: events.SQSMessageAttribute{
+			attr: ddevents.SQSMessageAttribute{
 				DataType: "Purple",
 			},
 			expMap:   nil,
@@ -131,13 +131,13 @@ func TestSQSMessageAttrCarrier(t *testing.T) {
 func TestSnsSqsMessageCarrier(t *testing.T) {
 	testcases := []struct {
 		name   string
-		event  events.SQSMessage
+		event  ddevents.SQSMessage
 		expMap map[string]string
 		expErr error
 	}{
 		{
 			name: "empty-string-body",
-			event: events.SQSMessage{
+			event: ddevents.SQSMessage{
 				Body: "",
 			},
 			expMap: nil,
@@ -145,7 +145,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "empty-map-body",
-			event: events.SQSMessage{
+			event: ddevents.SQSMessage{
 				Body: "{}",
 			},
 			expMap: nil,
@@ -153,7 +153,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "no-msg-attrs",
-			event: events.SQSMessage{
+			event: ddevents.SQSMessage{
 				Body: `{
 					"MessageAttributes": {}
 				}`,
@@ -163,7 +163,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "wrong-type-msg-attrs",
-			event: events.SQSMessage{
+			event: ddevents.SQSMessage{
 				Body: `{
 					"MessageAttributes": "attrs"
 				}`,
@@ -173,7 +173,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "non-binary-type",
-			event: events.SQSMessage{
+			event: ddevents.SQSMessage{
 				Body: `{
 					"MessageAttributes": {
 						"_datadog": {
@@ -188,7 +188,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "cannot-decode",
-			event: events.SQSMessage{
+			event: ddevents.SQSMessage{
 				Body: `{
 					"MessageAttributes": {
 						"_datadog": {
@@ -203,7 +203,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		},
 		{
 			name: "empty-string-encoded",
-			event: events.SQSMessage{
+			event: ddevents.SQSMessage{
 				Body: `{
 					"MessageAttributes": {
 						"_datadog": {
@@ -460,7 +460,7 @@ func TestExtractTraceContextfromAWSTraceHeader(t *testing.T) {
 func TestSqsMessageCarrier(t *testing.T) {
 	testcases := []struct {
 		name   string
-		event  events.SQSMessage
+		event  ddevents.SQSMessage
 		expMap map[string]string
 		expErr error
 	}{

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -94,7 +94,7 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 		carrier, err = sqsMessageCarrier(ev)
 	case ddevents.APIGatewayProxyRequest:
 		carrier, err = headersCarrier(ev.Headers)
-	case events.APIGatewayV2HTTPRequest:
+	case ddevents.APIGatewayV2HTTPRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	case events.APIGatewayWebsocketProxyRequest:
 		carrier, err = headersCarrier(ev.Headers)

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -98,7 +98,7 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 		carrier, err = headersCarrier(ev.Headers)
 	case ddevents.APIGatewayWebsocketProxyRequest:
 		carrier, err = headersCarrier(ev.Headers)
-	case events.APIGatewayCustomAuthorizerRequestTypeRequest:
+	case ddevents.APIGatewayCustomAuthorizerRequestTypeRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	case events.ALBTargetGroupRequest:
 		carrier, err = headersCarrier(ev.Headers)

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strconv"
 
+	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/aws/aws-lambda-go/events"
@@ -91,7 +92,7 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 			}
 		}
 		carrier, err = sqsMessageCarrier(ev)
-	case events.APIGatewayProxyRequest:
+	case ddevents.APIGatewayProxyRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	case events.APIGatewayV2HTTPRequest:
 		carrier, err = headersCarrier(ev.Headers)

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -78,13 +78,13 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 	switch ev := event.(type) {
 	case []byte:
 		carrier, err = rawPayloadCarrier(ev)
-	case events.SQSEvent:
+	case ddevents.SQSEvent:
 		// look for context in just the first message
 		if len(ev.Records) > 0 {
 			return e.extract(ev.Records[0])
 		}
 		return nil, errorNoSQSRecordFound
-	case events.SQSMessage:
+	case ddevents.SQSMessage:
 		if attr, ok := ev.Attributes[awsTraceHeader]; ok {
 			if tc, err := extractTraceContextfromAWSTraceHeader(attr); err == nil {
 				// Return early if AWSTraceHeader contains trace context

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -96,7 +96,7 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 		carrier, err = headersCarrier(ev.Headers)
 	case ddevents.APIGatewayV2HTTPRequest:
 		carrier, err = headersCarrier(ev.Headers)
-	case events.APIGatewayWebsocketProxyRequest:
+	case ddevents.APIGatewayWebsocketProxyRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	case events.APIGatewayCustomAuthorizerRequestTypeRequest:
 		carrier, err = headersCarrier(ev.Headers)

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strconv"
 
-	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -77,13 +77,13 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 	switch ev := event.(type) {
 	case []byte:
 		carrier, err = rawPayloadCarrier(ev)
-	case ddevents.SQSEvent:
+	case events.SQSEvent:
 		// look for context in just the first message
 		if len(ev.Records) > 0 {
 			return e.extract(ev.Records[0])
 		}
 		return nil, errorNoSQSRecordFound
-	case ddevents.SQSMessage:
+	case events.SQSMessage:
 		if attr, ok := ev.Attributes[awsTraceHeader]; ok {
 			if tc, err := extractTraceContextfromAWSTraceHeader(attr); err == nil {
 				// Return early if AWSTraceHeader contains trace context
@@ -91,17 +91,17 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 			}
 		}
 		carrier, err = sqsMessageCarrier(ev)
-	case ddevents.APIGatewayProxyRequest:
+	case events.APIGatewayProxyRequest:
 		carrier, err = headersCarrier(ev.Headers)
-	case ddevents.APIGatewayV2HTTPRequest:
+	case events.APIGatewayV2HTTPRequest:
 		carrier, err = headersCarrier(ev.Headers)
-	case ddevents.APIGatewayWebsocketProxyRequest:
+	case events.APIGatewayWebsocketProxyRequest:
 		carrier, err = headersCarrier(ev.Headers)
-	case ddevents.APIGatewayCustomAuthorizerRequestTypeRequest:
+	case events.APIGatewayCustomAuthorizerRequestTypeRequest:
 		carrier, err = headersCarrier(ev.Headers)
-	case ddevents.ALBTargetGroupRequest:
+	case events.ALBTargetGroupRequest:
 		carrier, err = headersCarrier(ev.Headers)
-	case ddevents.LambdaFunctionURLRequest:
+	case events.LambdaFunctionURLRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	default:
 		err = errorUnsupportedExtractionType

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -100,7 +100,7 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 		carrier, err = headersCarrier(ev.Headers)
 	case ddevents.APIGatewayCustomAuthorizerRequestTypeRequest:
 		carrier, err = headersCarrier(ev.Headers)
-	case events.ALBTargetGroupRequest:
+	case ddevents.ALBTargetGroupRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	case events.LambdaFunctionURLRequest:
 		carrier, err = headersCarrier(ev.Headers)

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -14,7 +14,6 @@ import (
 	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/aws/aws-lambda-go/events"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -102,7 +101,7 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 		carrier, err = headersCarrier(ev.Headers)
 	case ddevents.ALBTargetGroupRequest:
 		carrier, err = headersCarrier(ev.Headers)
-	case events.LambdaFunctionURLRequest:
+	case ddevents.LambdaFunctionURLRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	default:
 		err = errorUnsupportedExtractionType

--- a/pkg/serverless/trace/propagation/extractor_test.go
+++ b/pkg/serverless/trace/propagation/extractor_test.go
@@ -317,7 +317,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "APIGatewayWebsocketProxyRequest",
 			events: []interface{}{
-				events.APIGatewayWebsocketProxyRequest{
+				ddevents.APIGatewayWebsocketProxyRequest{
 					Headers: headersMapAll,
 				},
 			},

--- a/pkg/serverless/trace/propagation/extractor_test.go
+++ b/pkg/serverless/trace/propagation/extractor_test.go
@@ -341,7 +341,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "ALBTargetGroupRequest",
 			events: []interface{}{
-				events.ALBTargetGroupRequest{
+				ddevents.ALBTargetGroupRequest{
 					Headers: headersMapAll,
 				},
 			},

--- a/pkg/serverless/trace/propagation/extractor_test.go
+++ b/pkg/serverless/trace/propagation/extractor_test.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"testing"
 
-	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
@@ -123,10 +123,10 @@ var (
 	headersDdXray = "Root=1-00000000-00000000" + ddx.trace.asStr + ";Parent=" + ddx.span.asStr
 	headersXray   = "Root=1-12345678-12345678" + x.trace.asStr + ";Parent=" + x.span.asStr
 
-	eventSqsMessage = func(sqsHdrs, snsHdrs, awsHdr string) ddevents.SQSMessage {
-		e := ddevents.SQSMessage{}
+	eventSqsMessage = func(sqsHdrs, snsHdrs, awsHdr string) events.SQSMessage {
+		e := events.SQSMessage{}
 		if sqsHdrs != "" {
-			e.MessageAttributes = map[string]ddevents.SQSMessageAttribute{
+			e.MessageAttributes = map[string]events.SQSMessageAttribute{
 				"_datadog": {
 					DataType:    "String",
 					StringValue: aws.String(sqsHdrs),
@@ -196,8 +196,8 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "sqs-event-uses-first-record",
 			events: []interface{}{
-				ddevents.SQSEvent{
-					Records: []ddevents.SQSMessage{
+				events.SQSEvent{
+					Records: []events.SQSMessage{
 						// Uses the first message only
 						eventSqsMessage(headersDD, headersNone, headersNone),
 						eventSqsMessage(headersW3C, headersNone, headersNone),
@@ -210,8 +210,8 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "sqs-event-uses-first-record-empty",
 			events: []interface{}{
-				ddevents.SQSEvent{
-					Records: []ddevents.SQSMessage{
+				events.SQSEvent{
+					Records: []events.SQSMessage{
 						// Uses the first message only
 						eventSqsMessage(headersNone, headersNone, headersNone),
 						eventSqsMessage(headersW3C, headersNone, headersNone),
@@ -226,7 +226,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "unable-to-get-carrier",
 			events: []interface{}{
-				ddevents.SQSMessage{Body: ""},
+				events.SQSMessage{Body: ""},
 			},
 			expCtx:   nil,
 			expNoErr: false,
@@ -292,7 +292,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "APIGatewayProxyRequest",
 			events: []interface{}{
-				ddevents.APIGatewayProxyRequest{
+				events.APIGatewayProxyRequest{
 					Headers: headersMapAll,
 				},
 			},
@@ -304,7 +304,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "APIGatewayV2HTTPRequest",
 			events: []interface{}{
-				ddevents.APIGatewayV2HTTPRequest{
+				events.APIGatewayV2HTTPRequest{
 					Headers: headersMapAll,
 				},
 			},
@@ -316,7 +316,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "APIGatewayWebsocketProxyRequest",
 			events: []interface{}{
-				ddevents.APIGatewayWebsocketProxyRequest{
+				events.APIGatewayWebsocketProxyRequest{
 					Headers: headersMapAll,
 				},
 			},
@@ -328,7 +328,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "APIGatewayCustomAuthorizerRequestTypeRequest",
 			events: []interface{}{
-				ddevents.APIGatewayCustomAuthorizerRequestTypeRequest{
+				events.APIGatewayCustomAuthorizerRequestTypeRequest{
 					Headers: headersMapAll,
 				},
 			},
@@ -340,7 +340,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "ALBTargetGroupRequest",
 			events: []interface{}{
-				ddevents.ALBTargetGroupRequest{
+				events.ALBTargetGroupRequest{
 					Headers: headersMapAll,
 				},
 			},
@@ -352,7 +352,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "LambdaFunctionURLRequest",
 			events: []interface{}{
-				ddevents.LambdaFunctionURLRequest{
+				events.LambdaFunctionURLRequest{
 					Headers: headersMapAll,
 				},
 			},

--- a/pkg/serverless/trace/propagation/extractor_test.go
+++ b/pkg/serverless/trace/propagation/extractor_test.go
@@ -329,7 +329,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "APIGatewayCustomAuthorizerRequestTypeRequest",
 			events: []interface{}{
-				events.APIGatewayCustomAuthorizerRequestTypeRequest{
+				ddevents.APIGatewayCustomAuthorizerRequestTypeRequest{
 					Headers: headersMapAll,
 				},
 			},

--- a/pkg/serverless/trace/propagation/extractor_test.go
+++ b/pkg/serverless/trace/propagation/extractor_test.go
@@ -14,7 +14,6 @@ import (
 
 	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -353,7 +352,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "LambdaFunctionURLRequest",
 			events: []interface{}{
-				events.LambdaFunctionURLRequest{
+				ddevents.LambdaFunctionURLRequest{
 					Headers: headersMapAll,
 				},
 			},

--- a/pkg/serverless/trace/propagation/extractor_test.go
+++ b/pkg/serverless/trace/propagation/extractor_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"testing"
 
+	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -292,7 +293,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "APIGatewayProxyRequest",
 			events: []interface{}{
-				events.APIGatewayProxyRequest{
+				ddevents.APIGatewayProxyRequest{
 					Headers: headersMapAll,
 				},
 			},

--- a/pkg/serverless/trace/propagation/extractor_test.go
+++ b/pkg/serverless/trace/propagation/extractor_test.go
@@ -305,7 +305,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "APIGatewayV2HTTPRequest",
 			events: []interface{}{
-				events.APIGatewayV2HTTPRequest{
+				ddevents.APIGatewayV2HTTPRequest{
 					Headers: headersMapAll,
 				},
 			},

--- a/pkg/serverless/trace/propagation/extractor_test.go
+++ b/pkg/serverless/trace/propagation/extractor_test.go
@@ -124,10 +124,10 @@ var (
 	headersDdXray = "Root=1-00000000-00000000" + ddx.trace.asStr + ";Parent=" + ddx.span.asStr
 	headersXray   = "Root=1-12345678-12345678" + x.trace.asStr + ";Parent=" + x.span.asStr
 
-	eventSqsMessage = func(sqsHdrs, snsHdrs, awsHdr string) events.SQSMessage {
-		e := events.SQSMessage{}
+	eventSqsMessage = func(sqsHdrs, snsHdrs, awsHdr string) ddevents.SQSMessage {
+		e := ddevents.SQSMessage{}
 		if sqsHdrs != "" {
-			e.MessageAttributes = map[string]events.SQSMessageAttribute{
+			e.MessageAttributes = map[string]ddevents.SQSMessageAttribute{
 				"_datadog": {
 					DataType:    "String",
 					StringValue: aws.String(sqsHdrs),
@@ -197,8 +197,8 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "sqs-event-uses-first-record",
 			events: []interface{}{
-				events.SQSEvent{
-					Records: []events.SQSMessage{
+				ddevents.SQSEvent{
+					Records: []ddevents.SQSMessage{
 						// Uses the first message only
 						eventSqsMessage(headersDD, headersNone, headersNone),
 						eventSqsMessage(headersW3C, headersNone, headersNone),
@@ -211,8 +211,8 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "sqs-event-uses-first-record-empty",
 			events: []interface{}{
-				events.SQSEvent{
-					Records: []events.SQSMessage{
+				ddevents.SQSEvent{
+					Records: []ddevents.SQSMessage{
 						// Uses the first message only
 						eventSqsMessage(headersNone, headersNone, headersNone),
 						eventSqsMessage(headersW3C, headersNone, headersNone),
@@ -227,7 +227,7 @@ func TestExtractorExtract(t *testing.T) {
 		{
 			name: "unable-to-get-carrier",
 			events: []interface{}{
-				events.SQSMessage{Body: ""},
+				ddevents.SQSMessage{Body: ""},
 			},
 			expCtx:   nil,
 			expNoErr: false,

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -90,3 +90,7 @@ type ALBTargetGroupRequestContext struct {
 type ELBContext struct {
 	TargetGroupArn string
 }
+
+type CloudWatchEvent struct {
+	Resources []string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -177,7 +177,7 @@ type EventBridgeEvent struct {
 }
 
 type S3Event struct {
-	Records []S3EventRecord `json:"Records"`
+	Records []S3EventRecord
 }
 
 type S3EventRecord struct {
@@ -204,7 +204,7 @@ type S3Object struct {
 }
 
 type SNSEvent struct {
-	Records []SNSEventRecord `json:"Records"`
+	Records []SNSEventRecord
 }
 
 type SNSEventRecord struct {

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -17,3 +17,26 @@ type APIGatewayProxyRequestContext struct {
 	RequestTimeEpoch int64
 	APIID            string
 }
+
+type APIGatewayV2HTTPRequest struct {
+	RouteKey       string
+	Headers        map[string]string
+	RequestContext APIGatewayV2HTTPRequestContext
+}
+
+type APIGatewayV2HTTPRequestContext struct {
+	Stage      string
+	RequestID  string
+	APIID      string
+	DomainName string
+	TimeEpoch  int64
+	HTTP       APIGatewayV2HTTPRequestContextHTTPDescription
+}
+
+type APIGatewayV2HTTPRequestContextHTTPDescription struct {
+	Method    string
+	Path      string
+	Protocol  string
+	SourceIP  string
+	UserAgent string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -1,5 +1,7 @@
 package events
 
+import "github.com/aws/aws-lambda-go/events"
+
 type APIGatewayProxyRequest struct {
 	Resource       string
 	Path           string
@@ -93,4 +95,8 @@ type ELBContext struct {
 
 type CloudWatchEvent struct {
 	Resources []string
+}
+
+type CloudwatchLogsEvent struct {
+	AWSLogs events.CloudwatchLogsRawData
 }

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -1,6 +1,8 @@
 package events
 
 import (
+	"time"
+
 	"github.com/aws/aws-lambda-go/events"
 )
 
@@ -142,4 +144,15 @@ type EventBridgeEvent struct {
 	DetailType string `json:"detail-type"`
 	Source     string
 	StartTime  string
+}
+
+type S3Event struct {
+	Records []S3EventRecord `json:"Records"`
+}
+
+type S3EventRecord struct {
+	EventSource string
+	EventTime   time.Time
+	EventName   string
+	S3          events.S3Entity
 }

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -190,3 +190,24 @@ type SQSMessageAttribute struct {
 	BinaryValue []byte
 	DataType    string
 }
+
+type LambdaFunctionURLRequest struct {
+	Headers        map[string]string
+	RequestContext LambdaFunctionURLRequestContext
+}
+
+type LambdaFunctionURLRequestContext struct {
+	RequestID  string
+	APIID      string
+	DomainName string
+	TimeEpoch  int64
+	HTTP       LambdaFunctionURLRequestContextHTTPDescription
+}
+
+type LambdaFunctionURLRequestContextHTTPDescription struct {
+	Method    string
+	Path      string
+	Protocol  string
+	SourceIP  string
+	UserAgent string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -1,6 +1,8 @@
 package events
 
-import "github.com/aws/aws-lambda-go/events"
+import (
+	"github.com/aws/aws-lambda-go/events"
+)
 
 type APIGatewayProxyRequest struct {
 	Resource       string
@@ -99,4 +101,22 @@ type CloudWatchEvent struct {
 
 type CloudwatchLogsEvent struct {
 	AWSLogs events.CloudwatchLogsRawData
+}
+
+type DynamoDBEvent struct {
+	Records []DynamoDBEventRecord
+}
+
+type DynamoDBEventRecord struct {
+	Change         DynamoDBStreamRecord `json:"dynamodb"`
+	EventID        string
+	EventName      string
+	EventVersion   string
+	EventSourceArn string
+}
+
+type DynamoDBStreamRecord struct {
+	ApproximateCreationDateTime events.SecondsEpochTime
+	SizeBytes                   int64
+	StreamViewType              string
 }

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -1,0 +1,19 @@
+package events
+
+type APIGatewayProxyRequest struct {
+	Resource       string
+	Path           string
+	HTTPMethod     string
+	Headers        map[string]string
+	RequestContext APIGatewayProxyRequestContext
+}
+
+type APIGatewayProxyRequestContext struct {
+	Stage            string
+	DomainName       string
+	RequestID        string
+	Path             string
+	HTTPMethod       string
+	RequestTimeEpoch int64
+	APIID            string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -172,3 +172,21 @@ type SNSEntity struct {
 	Timestamp time.Time
 	Subject   string
 }
+
+type SQSEvent struct {
+	Records []SQSMessage
+}
+
+type SQSMessage struct {
+	ReceiptHandle     string
+	Body              string
+	Attributes        map[string]string
+	MessageAttributes map[string]SQSMessageAttribute
+	EventSourceARN    string
+}
+
+type SQSMessageAttribute struct {
+	StringValue *string
+	BinaryValue []byte
+	DataType    string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -40,3 +40,20 @@ type APIGatewayV2HTTPRequestContextHTTPDescription struct {
 	SourceIP  string
 	UserAgent string
 }
+
+type APIGatewayWebsocketProxyRequest struct {
+	Headers        map[string]string
+	RequestContext APIGatewayWebsocketProxyRequestContext
+}
+
+type APIGatewayWebsocketProxyRequestContext struct {
+	Stage            string
+	RequestID        string
+	APIID            string
+	ConnectionID     string
+	DomainName       string
+	EventType        string
+	MessageDirection string
+	RequestTimeEpoch int64
+	RouteKey         string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -154,7 +154,23 @@ type S3EventRecord struct {
 	EventSource string
 	EventTime   time.Time
 	EventName   string
-	S3          events.S3Entity
+	S3          S3Entity
+}
+
+type S3Entity struct {
+	Bucket S3Bucket
+	Object S3Object
+}
+
+type S3Bucket struct {
+	Name string
+	Arn  string
+}
+
+type S3Object struct {
+	Key  string
+	Size int64
+	ETag string
 }
 
 type SNSEvent struct {

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -120,3 +120,20 @@ type DynamoDBStreamRecord struct {
 	SizeBytes                   int64
 	StreamViewType              string
 }
+
+type KinesisEvent struct {
+	Records []KinesisEventRecord
+}
+
+type KinesisEventRecord struct {
+	EventID        string
+	EventName      string
+	EventSourceArn string
+	EventVersion   string
+	Kinesis        KinesisRecord
+}
+
+type KinesisRecord struct {
+	ApproximateArrivalTimestamp events.SecondsEpochTime
+	PartitionKey                string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -63,3 +63,15 @@ type APIGatewayCustomAuthorizerRequest struct {
 	AuthorizationToken string
 	MethodArn          string
 }
+
+type APIGatewayCustomAuthorizerRequestTypeRequest struct {
+	MethodArn      string
+	Resource       string
+	HTTPMethod     string
+	Headers        map[string]string
+	RequestContext APIGatewayCustomAuthorizerRequestTypeRequestContext
+}
+
+type APIGatewayCustomAuthorizerRequestTypeRequestContext struct {
+	Path string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -75,3 +75,18 @@ type APIGatewayCustomAuthorizerRequestTypeRequest struct {
 type APIGatewayCustomAuthorizerRequestTypeRequestContext struct {
 	Path string
 }
+
+type ALBTargetGroupRequest struct {
+	HTTPMethod     string
+	Path           string
+	Headers        map[string]string
+	RequestContext ALBTargetGroupRequestContext
+}
+
+type ALBTargetGroupRequestContext struct {
+	ELB ELBContext
+}
+
+type ELBContext struct {
+	TargetGroupArn string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -156,3 +156,19 @@ type S3EventRecord struct {
 	EventName   string
 	S3          events.S3Entity
 }
+
+type SNSEvent struct {
+	Records []SNSEventRecord `json:"Records"`
+}
+
+type SNSEventRecord struct {
+	SNS SNSEntity
+}
+
+type SNSEntity struct {
+	MessageID string
+	Type      string
+	TopicArn  string
+	Timestamp time.Time
+	Subject   string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -57,3 +57,9 @@ type APIGatewayWebsocketProxyRequestContext struct {
 	RequestTimeEpoch int64
 	RouteKey         string
 }
+
+type APIGatewayCustomAuthorizerRequest struct {
+	Type               string
+	AuthorizationToken string
+	MethodArn          string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -137,3 +137,9 @@ type KinesisRecord struct {
 	ApproximateArrivalTimestamp events.SecondsEpochTime
 	PartitionKey                string
 }
+
+type EventBridgeEvent struct {
+	DetailType string `json:"detail-type"`
+	Source     string
+	StartTime  string
+}

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -1,3 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+// Package events provides a series of drop in replacements for
+// "github.com/aws/aws-lambda-go/events".  Using these types for json
+// unmarshalling event payloads provides huge reduction in processing time.
+// This means fewer map/slice allocations since only the fields which we will
+// use will be unmarshalled.
 package events
 
 import (
@@ -10,6 +20,8 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
+// APIGatewayProxyRequest mirrors events.APIGatewayProxyRequest type, removing
+// unused fields.
 type APIGatewayProxyRequest struct {
 	Resource       string
 	Path           string
@@ -18,6 +30,8 @@ type APIGatewayProxyRequest struct {
 	RequestContext APIGatewayProxyRequestContext
 }
 
+// APIGatewayProxyRequestContext mirrors events.APIGatewayProxyRequestContext
+// type, removing unused fields.
 type APIGatewayProxyRequestContext struct {
 	Stage            string
 	DomainName       string
@@ -28,12 +42,16 @@ type APIGatewayProxyRequestContext struct {
 	APIID            string
 }
 
+// APIGatewayV2HTTPRequest mirrors events.APIGatewayV2HTTPRequest type,
+// removing unused fields.
 type APIGatewayV2HTTPRequest struct {
 	RouteKey       string
 	Headers        map[string]string
 	RequestContext APIGatewayV2HTTPRequestContext
 }
 
+// APIGatewayV2HTTPRequestContext mirrors events.APIGatewayV2HTTPRequestContext
+// type, removing unused fields.
 type APIGatewayV2HTTPRequestContext struct {
 	Stage      string
 	RequestID  string
@@ -43,6 +61,9 @@ type APIGatewayV2HTTPRequestContext struct {
 	HTTP       APIGatewayV2HTTPRequestContextHTTPDescription
 }
 
+// APIGatewayV2HTTPRequestContextHTTPDescription mirrors
+// events.APIGatewayV2HTTPRequestContextHTTPDescription type, removing unused
+// fields.
 type APIGatewayV2HTTPRequestContextHTTPDescription struct {
 	Method    string
 	Path      string
@@ -51,11 +72,15 @@ type APIGatewayV2HTTPRequestContextHTTPDescription struct {
 	UserAgent string
 }
 
+// APIGatewayWebsocketProxyRequest mirrors
+// events.APIGatewayWebsocketProxyRequest type, removing unused fields.
 type APIGatewayWebsocketProxyRequest struct {
 	Headers        map[string]string
 	RequestContext APIGatewayWebsocketProxyRequestContext
 }
 
+// APIGatewayWebsocketProxyRequestContext mirrors
+// events.APIGatewayWebsocketProxyRequestContext type, removing unused fields.
 type APIGatewayWebsocketProxyRequestContext struct {
 	Stage            string
 	RequestID        string
@@ -68,12 +93,17 @@ type APIGatewayWebsocketProxyRequestContext struct {
 	RouteKey         string
 }
 
+// APIGatewayCustomAuthorizerRequest mirrors
+// events.APIGatewayCustomAuthorizerRequest type, removing unused fields.
 type APIGatewayCustomAuthorizerRequest struct {
 	Type               string
 	AuthorizationToken string
 	MethodArn          string
 }
 
+// APIGatewayCustomAuthorizerRequestTypeRequest mirrors
+// events.APIGatewayCustomAuthorizerRequestTypeRequest type, removing unused
+// fields.
 type APIGatewayCustomAuthorizerRequestTypeRequest struct {
 	MethodArn      string
 	Resource       string
@@ -82,10 +112,15 @@ type APIGatewayCustomAuthorizerRequestTypeRequest struct {
 	RequestContext APIGatewayCustomAuthorizerRequestTypeRequestContext
 }
 
+// APIGatewayCustomAuthorizerRequestTypeRequestContext mirrors
+// events.APIGatewayCustomAuthorizerRequestTypeRequestContext type, removing
+// unused fields.
 type APIGatewayCustomAuthorizerRequestTypeRequestContext struct {
 	Path string
 }
 
+// ALBTargetGroupRequest mirrors events.ALBTargetGroupRequest type, removing
+// unused fields.
 type ALBTargetGroupRequest struct {
 	HTTPMethod     string
 	Path           string
@@ -93,26 +128,35 @@ type ALBTargetGroupRequest struct {
 	RequestContext ALBTargetGroupRequestContext
 }
 
+// ALBTargetGroupRequestContext mirrors events.ALBTargetGroupRequestContext
+// type, removing unused fields.
 type ALBTargetGroupRequestContext struct {
 	ELB ELBContext
 }
 
+// ELBContext mirrors events.ELBContext type, removing unused fields.
 type ELBContext struct {
 	TargetGroupArn string
 }
 
+// CloudWatchEvent mirrors events.CloudWatchEvent type, removing unused fields.
 type CloudWatchEvent struct {
 	Resources []string
 }
 
+// CloudwatchLogsEvent mirrors events.CloudwatchLogsEvent type, removing unused
+// fields.
 type CloudwatchLogsEvent struct {
 	AWSLogs CloudwatchLogsRawData
 }
 
+// CloudwatchLogsRawData mirrors events.CloudwatchLogsRawData type, removing
+// unused fields.
 type CloudwatchLogsRawData struct {
 	Data string
 }
 
+// Parse returns a struct representing a usable CloudwatchLogs event
 func (c CloudwatchLogsRawData) Parse() (d CloudwatchLogsData, err error) {
 	data, err := base64.StdEncoding.DecodeString(c.Data)
 	if err != nil {
@@ -131,14 +175,19 @@ func (c CloudwatchLogsRawData) Parse() (d CloudwatchLogsData, err error) {
 	return
 }
 
+// CloudwatchLogsData mirrors events.CloudwatchLogsData type, removing unused
+// fields.
 type CloudwatchLogsData struct {
 	LogGroup string
 }
 
+// DynamoDBEvent mirrors events.DynamoDBEvent type, removing unused fields.
 type DynamoDBEvent struct {
 	Records []DynamoDBEventRecord
 }
 
+// DynamoDBEventRecord mirrors events.DynamoDBEventRecord type, removing unused
+// fields.
 type DynamoDBEventRecord struct {
 	Change         DynamoDBStreamRecord `json:"dynamodb"`
 	EventID        string
@@ -147,16 +196,21 @@ type DynamoDBEventRecord struct {
 	EventSourceArn string
 }
 
+// DynamoDBStreamRecord mirrors events.DynamoDBStreamRecord type, removing
+// unused fields.
 type DynamoDBStreamRecord struct {
 	ApproximateCreationDateTime events.SecondsEpochTime
 	SizeBytes                   int64
 	StreamViewType              string
 }
 
+// KinesisEvent mirrors events.KinesisEvent type, removing unused fields.
 type KinesisEvent struct {
 	Records []KinesisEventRecord
 }
 
+// KinesisEventRecord mirrors events.KinesisEventRecord type, removing unused
+// fields.
 type KinesisEventRecord struct {
 	EventID        string
 	EventName      string
@@ -165,21 +219,26 @@ type KinesisEventRecord struct {
 	Kinesis        KinesisRecord
 }
 
+// KinesisRecord mirrors events.KinesisRecord type, removing unused fields.
 type KinesisRecord struct {
 	ApproximateArrivalTimestamp events.SecondsEpochTime
 	PartitionKey                string
 }
 
+// EventBridgeEvent is used for unmarshalling a EventBridge event.  AWS Go
+// libraries do not provide this type of event for deserialization.
 type EventBridgeEvent struct {
 	DetailType string `json:"detail-type"`
 	Source     string
 	StartTime  string
 }
 
+// S3Event mirrors events.S3Event type, removing unused fields.
 type S3Event struct {
 	Records []S3EventRecord
 }
 
+// S3EventRecord mirrors events.S3EventRecord type, removing unused fields.
 type S3EventRecord struct {
 	EventSource string
 	EventTime   time.Time
@@ -187,30 +246,36 @@ type S3EventRecord struct {
 	S3          S3Entity
 }
 
+// S3Entity mirrors events.S3Entity type, removing unused fields.
 type S3Entity struct {
 	Bucket S3Bucket
 	Object S3Object
 }
 
+// S3Bucket mirrors events.S3Bucket type, removing unused fields.
 type S3Bucket struct {
 	Name string
 	Arn  string
 }
 
+// S3Object mirrors events.S3Object type, removing unused fields.
 type S3Object struct {
 	Key  string
 	Size int64
 	ETag string
 }
 
+// SNSEvent mirrors events.SNSEvent type, removing unused fields.
 type SNSEvent struct {
 	Records []SNSEventRecord
 }
 
+// SNSEventRecord mirrors events.SNSEventRecord type, removing unused fields.
 type SNSEventRecord struct {
 	SNS SNSEntity
 }
 
+// SNSEntity mirrors events.SNSEntity type, removing unused fields.
 type SNSEntity struct {
 	MessageID string
 	Type      string
@@ -219,10 +284,12 @@ type SNSEntity struct {
 	Subject   string
 }
 
+// SQSEvent mirrors events.SQSEvent type, removing unused fields.
 type SQSEvent struct {
 	Records []SQSMessage
 }
 
+// SQSMessage mirrors events.SQSMessage type, removing unused fields.
 type SQSMessage struct {
 	ReceiptHandle     string
 	Body              string
@@ -231,17 +298,23 @@ type SQSMessage struct {
 	EventSourceARN    string
 }
 
+// SQSMessageAttribute mirrors events.SQSMessageAttribute type, removing unused
+// fields.
 type SQSMessageAttribute struct {
 	StringValue *string
 	BinaryValue []byte
 	DataType    string
 }
 
+// LambdaFunctionURLRequest mirrors events.LambdaFunctionURLRequest type,
+// removing unused fields.
 type LambdaFunctionURLRequest struct {
 	Headers        map[string]string
 	RequestContext LambdaFunctionURLRequestContext
 }
 
+// LambdaFunctionURLRequestContext mirrors
+// events.LambdaFunctionURLRequestContext type, removing unused fields.
 type LambdaFunctionURLRequestContext struct {
 	RequestID  string
 	APIID      string
@@ -250,6 +323,9 @@ type LambdaFunctionURLRequestContext struct {
 	HTTP       LambdaFunctionURLRequestContextHTTPDescription
 }
 
+// LambdaFunctionURLRequestContextHTTPDescription mirrors
+// events.LambdaFunctionURLRequestContextHTTPDescription type, removing unused
+// fields.
 type LambdaFunctionURLRequestContextHTTPDescription struct {
 	Method    string
 	Path      string

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -83,7 +83,7 @@ func ExtractDynamoDBStreamEventARN(event ddevents.DynamoDBEvent) string {
 }
 
 // ExtractKinesisStreamEventARN returns an ARN from a KinesisEvent
-func ExtractKinesisStreamEventARN(event events.KinesisEvent) string {
+func ExtractKinesisStreamEventARN(event ddevents.KinesisEvent) string {
 	return event.Records[0].EventSourceArn
 }
 

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -34,7 +34,7 @@ func ExtractAPIGatewayEventARN(event ddevents.APIGatewayProxyRequest, region str
 }
 
 // ExtractAPIGatewayV2EventARN returns an ARN from an APIGatewayV2HTTPRequest
-func ExtractAPIGatewayV2EventARN(event events.APIGatewayV2HTTPRequest, region string) string {
+func ExtractAPIGatewayV2EventARN(event ddevents.APIGatewayV2HTTPRequest, region string) string {
 	requestContext := event.RequestContext
 	return fmt.Sprintf("arn:%v:apigateway:%v::/restapis/%v/stages/%v", GetAWSPartitionByRegion(region), region, requestContext.APIID, requestContext.Stage)
 }
@@ -127,7 +127,7 @@ func GetTagsFromAPIGatewayEvent(event ddevents.APIGatewayProxyRequest) map[strin
 
 // GetTagsFromAPIGatewayV2HTTPRequest returns a tagset containing http tags from an
 // APIGatewayProxyRequest
-func GetTagsFromAPIGatewayV2HTTPRequest(event events.APIGatewayV2HTTPRequest) map[string]string {
+func GetTagsFromAPIGatewayV2HTTPRequest(event ddevents.APIGatewayV2HTTPRequest) map[string]string {
 	httpTags := make(map[string]string)
 	httpTags["http.url"] = event.RequestContext.DomainName
 	httpTags["http.url_details.path"] = event.RequestContext.HTTP.Path

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -78,7 +78,7 @@ func ExtractCloudwatchLogsEventARN(event ddevents.CloudwatchLogsEvent, region st
 }
 
 // ExtractDynamoDBStreamEventARN returns an ARN from a DynamoDBEvent
-func ExtractDynamoDBStreamEventARN(event events.DynamoDBEvent) string {
+func ExtractDynamoDBStreamEventARN(event ddevents.DynamoDBEvent) string {
 	return event.Records[0].EventSourceArn
 }
 

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -40,7 +40,7 @@ func ExtractAPIGatewayV2EventARN(event ddevents.APIGatewayV2HTTPRequest, region 
 }
 
 // ExtractAPIGatewayWebSocketEventARN returns an ARN from an APIGatewayWebsocketProxyRequest
-func ExtractAPIGatewayWebSocketEventARN(event events.APIGatewayWebsocketProxyRequest, region string) string {
+func ExtractAPIGatewayWebSocketEventARN(event ddevents.APIGatewayWebsocketProxyRequest, region string) string {
 	requestContext := event.RequestContext
 	return fmt.Sprintf("arn:%v:apigateway:%v::/restapis/%v/stages/%v", GetAWSPartitionByRegion(region), region, requestContext.APIID, requestContext.Stage)
 }

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 )
 
@@ -202,7 +201,7 @@ func GetTagsFromALBTargetGroupRequest(event ddevents.ALBTargetGroupRequest) map[
 
 // GetTagsFromLambdaFunctionURLRequest returns a tagset containing http tags from a
 // LambdaFunctionURLRequest
-func GetTagsFromLambdaFunctionURLRequest(event events.LambdaFunctionURLRequest) map[string]string {
+func GetTagsFromLambdaFunctionURLRequest(event ddevents.LambdaFunctionURLRequest) map[string]string {
 	httpTags := make(map[string]string)
 	if event.RequestContext.DomainName != "" {
 		httpTags["http.url"] = event.RequestContext.DomainName

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -46,7 +46,7 @@ func ExtractAPIGatewayWebSocketEventARN(event ddevents.APIGatewayWebsocketProxyR
 }
 
 // ExtractAPIGatewayCustomAuthorizerEventARN returns an ARN from an APIGatewayCustomAuthorizerRequest
-func ExtractAPIGatewayCustomAuthorizerEventARN(event events.APIGatewayCustomAuthorizerRequest) string {
+func ExtractAPIGatewayCustomAuthorizerEventARN(event ddevents.APIGatewayCustomAuthorizerRequest) string {
 	return event.MethodArn
 }
 
@@ -148,7 +148,7 @@ func GetTagsFromAPIGatewayV2HTTPRequest(event ddevents.APIGatewayV2HTTPRequest) 
 
 // GetTagsFromAPIGatewayCustomAuthorizerEvent returns a tagset containing http tags from an
 // APIGatewayCustomAuthorizerRequest
-func GetTagsFromAPIGatewayCustomAuthorizerEvent(event events.APIGatewayCustomAuthorizerRequest) map[string]string {
+func GetTagsFromAPIGatewayCustomAuthorizerEvent(event ddevents.APIGatewayCustomAuthorizerRequest) map[string]string {
 	httpTags := make(map[string]string, 2)
 
 	if methodArn, err := arn.Parse(event.MethodArn); err == nil {

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -88,7 +88,7 @@ func ExtractKinesisStreamEventARN(event ddevents.KinesisEvent) string {
 }
 
 // ExtractS3EventArn returns an ARN from a S3Event
-func ExtractS3EventArn(event events.S3Event) string {
+func ExtractS3EventArn(event ddevents.S3Event) string {
 	return event.Records[0].EventSource
 }
 

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -69,7 +69,7 @@ func ExtractCloudwatchEventARN(event ddevents.CloudWatchEvent) string {
 }
 
 // ExtractCloudwatchLogsEventARN returns an ARN from a CloudwatchLogsEvent
-func ExtractCloudwatchLogsEventARN(event events.CloudwatchLogsEvent, region string, accountID string) (string, error) {
+func ExtractCloudwatchLogsEventARN(event ddevents.CloudwatchLogsEvent, region string, accountID string) (string, error) {
 	decodedLog, err := event.AWSLogs.Parse()
 	if err != nil {
 		return "", fmt.Errorf("Couldn't decode Cloudwatch Logs event: %v", err)

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -56,7 +56,7 @@ func ExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(event ddevents.APIGate
 }
 
 // ExtractAlbEventARN returns an ARN from an ALBTargetGroupRequest
-func ExtractAlbEventARN(event events.ALBTargetGroupRequest) string {
+func ExtractAlbEventARN(event ddevents.ALBTargetGroupRequest) string {
 	return event.RequestContext.ELB.TargetGroupArn
 }
 
@@ -185,7 +185,7 @@ func GetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(event ddevents.APIGat
 
 // GetTagsFromALBTargetGroupRequest returns a tagset containing http tags from an
 // ALBTargetGroupRequest
-func GetTagsFromALBTargetGroupRequest(event events.ALBTargetGroupRequest) map[string]string {
+func GetTagsFromALBTargetGroupRequest(event ddevents.ALBTargetGroupRequest) map[string]string {
 	httpTags := make(map[string]string)
 	httpTags["http.url_details.path"] = event.Path
 	httpTags["http.method"] = event.HTTPMethod

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -98,7 +98,7 @@ func ExtractSNSEventArn(event ddevents.SNSEvent) string {
 }
 
 // ExtractSQSEventARN returns an ARN from a SQSEvent
-func ExtractSQSEventARN(event events.SQSEvent) string {
+func ExtractSQSEventARN(event ddevents.SQSEvent) string {
 	return event.Records[0].EventSourceARN
 }
 

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -11,8 +11,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 )
 
 // GetAWSPartitionByRegion parses an AWS region and returns an AWS partition

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -51,7 +51,7 @@ func ExtractAPIGatewayCustomAuthorizerEventARN(event ddevents.APIGatewayCustomAu
 }
 
 // ExtractAPIGatewayCustomAuthorizerRequestTypeEventARN returns an ARN from an APIGatewayCustomAuthorizerRequestTypeRequest
-func ExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(event events.APIGatewayCustomAuthorizerRequestTypeRequest) string {
+func ExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(event ddevents.APIGatewayCustomAuthorizerRequestTypeRequest) string {
 	return event.MethodArn
 }
 
@@ -167,7 +167,7 @@ func GetTagsFromAPIGatewayCustomAuthorizerEvent(event ddevents.APIGatewayCustomA
 
 // GetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent returns a tagset containing http tags from an
 // APIGatewayCustomAuthorizerRequestTypeRequest
-func GetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(event events.APIGatewayCustomAuthorizerRequestTypeRequest) map[string]string {
+func GetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(event ddevents.APIGatewayCustomAuthorizerRequestTypeRequest) map[string]string {
 	httpTags := make(map[string]string)
 	httpTags["http.url_details.path"] = event.RequestContext.Path
 	httpTags["http.method"] = event.HTTPMethod

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -61,7 +61,7 @@ func ExtractAlbEventARN(event ddevents.ALBTargetGroupRequest) string {
 }
 
 // ExtractCloudwatchEventARN returns an ARN from a CloudWatchEvent
-func ExtractCloudwatchEventARN(event events.CloudWatchEvent) string {
+func ExtractCloudwatchEventARN(event ddevents.CloudWatchEvent) string {
 	if len(event.Resources) == 0 {
 		return ""
 	}

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 )
 
@@ -27,40 +27,40 @@ func GetAWSPartitionByRegion(region string) string {
 }
 
 // ExtractAPIGatewayEventARN returns an ARN from an APIGatewayProxyRequest
-func ExtractAPIGatewayEventARN(event ddevents.APIGatewayProxyRequest, region string) string {
+func ExtractAPIGatewayEventARN(event events.APIGatewayProxyRequest, region string) string {
 	requestContext := event.RequestContext
 	return fmt.Sprintf("arn:%v:apigateway:%v::/restapis/%v/stages/%v", GetAWSPartitionByRegion(region), region, requestContext.APIID, requestContext.Stage)
 }
 
 // ExtractAPIGatewayV2EventARN returns an ARN from an APIGatewayV2HTTPRequest
-func ExtractAPIGatewayV2EventARN(event ddevents.APIGatewayV2HTTPRequest, region string) string {
+func ExtractAPIGatewayV2EventARN(event events.APIGatewayV2HTTPRequest, region string) string {
 	requestContext := event.RequestContext
 	return fmt.Sprintf("arn:%v:apigateway:%v::/restapis/%v/stages/%v", GetAWSPartitionByRegion(region), region, requestContext.APIID, requestContext.Stage)
 }
 
 // ExtractAPIGatewayWebSocketEventARN returns an ARN from an APIGatewayWebsocketProxyRequest
-func ExtractAPIGatewayWebSocketEventARN(event ddevents.APIGatewayWebsocketProxyRequest, region string) string {
+func ExtractAPIGatewayWebSocketEventARN(event events.APIGatewayWebsocketProxyRequest, region string) string {
 	requestContext := event.RequestContext
 	return fmt.Sprintf("arn:%v:apigateway:%v::/restapis/%v/stages/%v", GetAWSPartitionByRegion(region), region, requestContext.APIID, requestContext.Stage)
 }
 
 // ExtractAPIGatewayCustomAuthorizerEventARN returns an ARN from an APIGatewayCustomAuthorizerRequest
-func ExtractAPIGatewayCustomAuthorizerEventARN(event ddevents.APIGatewayCustomAuthorizerRequest) string {
+func ExtractAPIGatewayCustomAuthorizerEventARN(event events.APIGatewayCustomAuthorizerRequest) string {
 	return event.MethodArn
 }
 
 // ExtractAPIGatewayCustomAuthorizerRequestTypeEventARN returns an ARN from an APIGatewayCustomAuthorizerRequestTypeRequest
-func ExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(event ddevents.APIGatewayCustomAuthorizerRequestTypeRequest) string {
+func ExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(event events.APIGatewayCustomAuthorizerRequestTypeRequest) string {
 	return event.MethodArn
 }
 
 // ExtractAlbEventARN returns an ARN from an ALBTargetGroupRequest
-func ExtractAlbEventARN(event ddevents.ALBTargetGroupRequest) string {
+func ExtractAlbEventARN(event events.ALBTargetGroupRequest) string {
 	return event.RequestContext.ELB.TargetGroupArn
 }
 
 // ExtractCloudwatchEventARN returns an ARN from a CloudWatchEvent
-func ExtractCloudwatchEventARN(event ddevents.CloudWatchEvent) string {
+func ExtractCloudwatchEventARN(event events.CloudWatchEvent) string {
 	if len(event.Resources) == 0 {
 		return ""
 	}
@@ -68,7 +68,7 @@ func ExtractCloudwatchEventARN(event ddevents.CloudWatchEvent) string {
 }
 
 // ExtractCloudwatchLogsEventARN returns an ARN from a CloudwatchLogsEvent
-func ExtractCloudwatchLogsEventARN(event ddevents.CloudwatchLogsEvent, region string, accountID string) (string, error) {
+func ExtractCloudwatchLogsEventARN(event events.CloudwatchLogsEvent, region string, accountID string) (string, error) {
 	decodedLog, err := event.AWSLogs.Parse()
 	if err != nil {
 		return "", fmt.Errorf("Couldn't decode Cloudwatch Logs event: %v", err)
@@ -77,33 +77,33 @@ func ExtractCloudwatchLogsEventARN(event ddevents.CloudwatchLogsEvent, region st
 }
 
 // ExtractDynamoDBStreamEventARN returns an ARN from a DynamoDBEvent
-func ExtractDynamoDBStreamEventARN(event ddevents.DynamoDBEvent) string {
+func ExtractDynamoDBStreamEventARN(event events.DynamoDBEvent) string {
 	return event.Records[0].EventSourceArn
 }
 
 // ExtractKinesisStreamEventARN returns an ARN from a KinesisEvent
-func ExtractKinesisStreamEventARN(event ddevents.KinesisEvent) string {
+func ExtractKinesisStreamEventARN(event events.KinesisEvent) string {
 	return event.Records[0].EventSourceArn
 }
 
 // ExtractS3EventArn returns an ARN from a S3Event
-func ExtractS3EventArn(event ddevents.S3Event) string {
+func ExtractS3EventArn(event events.S3Event) string {
 	return event.Records[0].EventSource
 }
 
 // ExtractSNSEventArn returns an ARN from a SNSEvent
-func ExtractSNSEventArn(event ddevents.SNSEvent) string {
+func ExtractSNSEventArn(event events.SNSEvent) string {
 	return event.Records[0].SNS.TopicArn
 }
 
 // ExtractSQSEventARN returns an ARN from a SQSEvent
-func ExtractSQSEventARN(event ddevents.SQSEvent) string {
+func ExtractSQSEventARN(event events.SQSEvent) string {
 	return event.Records[0].EventSourceARN
 }
 
 // GetTagsFromAPIGatewayEvent returns a tagset containing http tags from an
 // APIGatewayProxyRequest
-func GetTagsFromAPIGatewayEvent(event ddevents.APIGatewayProxyRequest) map[string]string {
+func GetTagsFromAPIGatewayEvent(event events.APIGatewayProxyRequest) map[string]string {
 	httpTags := make(map[string]string)
 	if event.RequestContext.DomainName != "" {
 		httpTags["http.url"] = event.RequestContext.DomainName
@@ -126,7 +126,7 @@ func GetTagsFromAPIGatewayEvent(event ddevents.APIGatewayProxyRequest) map[strin
 
 // GetTagsFromAPIGatewayV2HTTPRequest returns a tagset containing http tags from an
 // APIGatewayProxyRequest
-func GetTagsFromAPIGatewayV2HTTPRequest(event ddevents.APIGatewayV2HTTPRequest) map[string]string {
+func GetTagsFromAPIGatewayV2HTTPRequest(event events.APIGatewayV2HTTPRequest) map[string]string {
 	httpTags := make(map[string]string)
 	httpTags["http.url"] = event.RequestContext.DomainName
 	httpTags["http.url_details.path"] = event.RequestContext.HTTP.Path
@@ -147,7 +147,7 @@ func GetTagsFromAPIGatewayV2HTTPRequest(event ddevents.APIGatewayV2HTTPRequest) 
 
 // GetTagsFromAPIGatewayCustomAuthorizerEvent returns a tagset containing http tags from an
 // APIGatewayCustomAuthorizerRequest
-func GetTagsFromAPIGatewayCustomAuthorizerEvent(event ddevents.APIGatewayCustomAuthorizerRequest) map[string]string {
+func GetTagsFromAPIGatewayCustomAuthorizerEvent(event events.APIGatewayCustomAuthorizerRequest) map[string]string {
 	httpTags := make(map[string]string, 2)
 
 	if methodArn, err := arn.Parse(event.MethodArn); err == nil {
@@ -166,7 +166,7 @@ func GetTagsFromAPIGatewayCustomAuthorizerEvent(event ddevents.APIGatewayCustomA
 
 // GetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent returns a tagset containing http tags from an
 // APIGatewayCustomAuthorizerRequestTypeRequest
-func GetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(event ddevents.APIGatewayCustomAuthorizerRequestTypeRequest) map[string]string {
+func GetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(event events.APIGatewayCustomAuthorizerRequestTypeRequest) map[string]string {
 	httpTags := make(map[string]string)
 	httpTags["http.url_details.path"] = event.RequestContext.Path
 	httpTags["http.method"] = event.HTTPMethod
@@ -184,7 +184,7 @@ func GetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(event ddevents.APIGat
 
 // GetTagsFromALBTargetGroupRequest returns a tagset containing http tags from an
 // ALBTargetGroupRequest
-func GetTagsFromALBTargetGroupRequest(event ddevents.ALBTargetGroupRequest) map[string]string {
+func GetTagsFromALBTargetGroupRequest(event events.ALBTargetGroupRequest) map[string]string {
 	httpTags := make(map[string]string)
 	httpTags["http.url_details.path"] = event.Path
 	httpTags["http.method"] = event.HTTPMethod
@@ -201,7 +201,7 @@ func GetTagsFromALBTargetGroupRequest(event ddevents.ALBTargetGroupRequest) map[
 
 // GetTagsFromLambdaFunctionURLRequest returns a tagset containing http tags from a
 // LambdaFunctionURLRequest
-func GetTagsFromLambdaFunctionURLRequest(event ddevents.LambdaFunctionURLRequest) map[string]string {
+func GetTagsFromLambdaFunctionURLRequest(event events.LambdaFunctionURLRequest) map[string]string {
 	httpTags := make(map[string]string)
 	if event.RequestContext.DomainName != "" {
 		httpTags["http.url"] = event.RequestContext.DomainName

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -93,7 +93,7 @@ func ExtractS3EventArn(event ddevents.S3Event) string {
 }
 
 // ExtractSNSEventArn returns an ARN from a SNSEvent
-func ExtractSNSEventArn(event events.SNSEvent) string {
+func ExtractSNSEventArn(event ddevents.SNSEvent) string {
 	return event.Records[0].SNS.TopicArn
 }
 

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 )
@@ -27,7 +28,7 @@ func GetAWSPartitionByRegion(region string) string {
 }
 
 // ExtractAPIGatewayEventARN returns an ARN from an APIGatewayProxyRequest
-func ExtractAPIGatewayEventARN(event events.APIGatewayProxyRequest, region string) string {
+func ExtractAPIGatewayEventARN(event ddevents.APIGatewayProxyRequest, region string) string {
 	requestContext := event.RequestContext
 	return fmt.Sprintf("arn:%v:apigateway:%v::/restapis/%v/stages/%v", GetAWSPartitionByRegion(region), region, requestContext.APIID, requestContext.Stage)
 }
@@ -103,7 +104,7 @@ func ExtractSQSEventARN(event events.SQSEvent) string {
 
 // GetTagsFromAPIGatewayEvent returns a tagset containing http tags from an
 // APIGatewayProxyRequest
-func GetTagsFromAPIGatewayEvent(event events.APIGatewayProxyRequest) map[string]string {
+func GetTagsFromAPIGatewayEvent(event ddevents.APIGatewayProxyRequest) map[string]string {
 	httpTags := make(map[string]string)
 	if event.RequestContext.DomainName != "" {
 		httpTags["http.url"] = event.RequestContext.DomainName

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -354,14 +354,14 @@ func TestGetTagsFromALBTargetGroupRequest(t *testing.T) {
 }
 
 func TestGetTagsFromFunctionURLRequest(t *testing.T) {
-	event := events.LambdaFunctionURLRequest{
+	event := ddevents.LambdaFunctionURLRequest{
 		Headers: map[string]string{
 			"key":     "val",
 			"Referer": "referer",
 		},
-		RequestContext: events.LambdaFunctionURLRequestContext{
+		RequestContext: ddevents.LambdaFunctionURLRequestContext{
 			DomainName: "test-domain",
-			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
+			HTTP: ddevents.LambdaFunctionURLRequestContextHTTPDescription{
 				Path:   "asd",
 				Method: "GET",
 			},

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -50,8 +50,8 @@ func TestExtractAPIGatewayV2EventARN(t *testing.T) {
 
 func TestExtractAPIGatewayWebSocketEventARN(t *testing.T) {
 	region := "us-east-1"
-	event := events.APIGatewayWebsocketProxyRequest{
-		RequestContext: events.APIGatewayWebsocketProxyRequestContext{
+	event := ddevents.APIGatewayWebsocketProxyRequest{
+		RequestContext: ddevents.APIGatewayWebsocketProxyRequestContext{
 			APIID: "test-id",
 			Stage: "test-stage",
 		},

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -80,9 +80,9 @@ func TestExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(t *testing.T) {
 }
 
 func TestExtractAlbEventARN(t *testing.T) {
-	event := events.ALBTargetGroupRequest{
-		RequestContext: events.ALBTargetGroupRequestContext{
-			ELB: events.ELBContext{
+	event := ddevents.ALBTargetGroupRequest{
+		RequestContext: ddevents.ALBTargetGroupRequestContext{
+			ELB: ddevents.ELBContext{
 				TargetGroupArn: "test-arn",
 			},
 		},
@@ -335,7 +335,7 @@ func TestGetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(t *testing.T) {
 }
 
 func TestGetTagsFromALBTargetGroupRequest(t *testing.T) {
-	event := events.ALBTargetGroupRequest{
+	event := ddevents.ALBTargetGroupRequest{
 		Headers: map[string]string{
 			"key":     "val",
 			"Referer": "referer",

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"testing"
 
+	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +24,8 @@ func TestGetAWSPartitionByRegion(t *testing.T) {
 
 func TestExtractAPIGatewayEventARN(t *testing.T) {
 	region := "us-east-1"
-	event := events.APIGatewayProxyRequest{
-		RequestContext: events.APIGatewayProxyRequestContext{
+	event := ddevents.APIGatewayProxyRequest{
+		RequestContext: ddevents.APIGatewayProxyRequestContext{
 			APIID: "test-id",
 			Stage: "test-stage",
 		},
@@ -228,12 +229,12 @@ func TestExtractSQSEventARN(t *testing.T) {
 }
 
 func TestExtractFunctionURLEventARN(t *testing.T) {
-	event := events.APIGatewayProxyRequest{
+	event := ddevents.APIGatewayProxyRequest{
 		Headers: map[string]string{
 			"key":     "val",
 			"Referer": "referer",
 		},
-		RequestContext: events.APIGatewayProxyRequestContext{
+		RequestContext: ddevents.APIGatewayProxyRequestContext{
 			DomainName: "domain-name",
 			Path:       "path",
 			HTTPMethod: "http-method",
@@ -253,12 +254,12 @@ func TestExtractFunctionURLEventARN(t *testing.T) {
 }
 
 func TestGetTagsFromAPIGatewayEvent(t *testing.T) {
-	event := events.APIGatewayProxyRequest{
+	event := ddevents.APIGatewayProxyRequest{
 		Headers: map[string]string{
 			"key":     "val",
 			"Referer": "referer",
 		},
-		RequestContext: events.APIGatewayProxyRequestContext{
+		RequestContext: ddevents.APIGatewayProxyRequestContext{
 			DomainName: "domain-name",
 			Path:       "path",
 			HTTPMethod: "http-method",

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -72,7 +72,7 @@ func TestExtractAPIGatewayCustomAuthorizerEventARN(t *testing.T) {
 
 func TestExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(t *testing.T) {
 	methodArn := "arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/some/resource/path"
-	event := events.APIGatewayCustomAuthorizerRequestTypeRequest{
+	event := ddevents.APIGatewayCustomAuthorizerRequestTypeRequest{
 		MethodArn: methodArn,
 	}
 	arn := ExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(event)
@@ -317,9 +317,9 @@ func TestGetTagsFromAPIGatewayCustomAuthorizerEvent(t *testing.T) {
 }
 
 func TestGetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(t *testing.T) {
-	event := events.APIGatewayCustomAuthorizerRequestTypeRequest{
+	event := ddevents.APIGatewayCustomAuthorizerRequestTypeRequest{
 		HTTPMethod: "GET",
-		RequestContext: events.APIGatewayCustomAuthorizerRequestTypeRequestContext{
+		RequestContext: ddevents.APIGatewayCustomAuthorizerRequestTypeRequestContext{
 			Path: "/path/to/resource",
 		},
 		Resource: "/{route}",

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -63,7 +63,7 @@ func TestExtractAPIGatewayWebSocketEventARN(t *testing.T) {
 
 func TestExtractAPIGatewayCustomAuthorizerEventARN(t *testing.T) {
 	methodArn := "arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/some/resource/path"
-	event := events.APIGatewayCustomAuthorizerRequest{
+	event := ddevents.APIGatewayCustomAuthorizerRequest{
 		MethodArn: methodArn,
 	}
 	arn := ExtractAPIGatewayCustomAuthorizerEventARN(event)
@@ -304,7 +304,7 @@ func TestGetTagsFromAPIGatewayV2HTTPRequestNoReferer(t *testing.T) {
 }
 
 func TestGetTagsFromAPIGatewayCustomAuthorizerEvent(t *testing.T) {
-	event := events.APIGatewayCustomAuthorizerRequest{
+	event := ddevents.APIGatewayCustomAuthorizerRequest{
 		MethodArn: "arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/path/to/resource",
 	}
 

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -213,8 +213,8 @@ func TestExtractSNSEventArn(t *testing.T) {
 }
 
 func TestExtractSQSEventARN(t *testing.T) {
-	event := events.SQSEvent{
-		Records: []events.SQSMessage{
+	event := ddevents.SQSEvent{
+		Records: []ddevents.SQSMessage{
 			{
 				EventSourceARN: "test-arn",
 			},

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -11,8 +11,9 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 )
 
 func TestGetAWSPartitionByRegion(t *testing.T) {

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -145,8 +145,8 @@ func TestExtractCloudwatchLogsEventARN(t *testing.T) {
 }
 
 func TestExtractDynamoDBStreamEventARN(t *testing.T) {
-	event := events.DynamoDBEvent{
-		Records: []events.DynamoDBEventRecord{
+	event := ddevents.DynamoDBEvent{
+		Records: []ddevents.DynamoDBEventRecord{
 			{
 				EventSourceArn: "test-arn",
 			},

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -114,7 +114,7 @@ func TestExtractCloudwatchEventARN(t *testing.T) {
 func TestExtractCloudwatchLogsEventARN(t *testing.T) {
 	region := "us-east-1"
 	accountID := "account-id"
-	event := events.CloudwatchLogsEvent{
+	event := ddevents.CloudwatchLogsEvent{
 		AWSLogs: events.CloudwatchLogsRawData{
 			Data: "invalid",
 		},
@@ -133,7 +133,7 @@ func TestExtractCloudwatchLogsEventARN(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, gz.Close())
 
-	event = events.CloudwatchLogsEvent{
+	event = ddevents.CloudwatchLogsEvent{
 		AWSLogs: events.CloudwatchLogsRawData{
 			Data: base64.StdEncoding.EncodeToString(b.Bytes()),
 		},

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -37,8 +37,8 @@ func TestExtractAPIGatewayEventARN(t *testing.T) {
 
 func TestExtractAPIGatewayV2EventARN(t *testing.T) {
 	region := "us-east-1"
-	event := events.APIGatewayV2HTTPRequest{
-		RequestContext: events.APIGatewayV2HTTPRequestContext{
+	event := ddevents.APIGatewayV2HTTPRequest{
+		RequestContext: ddevents.APIGatewayV2HTTPRequestContext{
 			APIID: "test-id",
 			Stage: "test-stage",
 		},
@@ -279,13 +279,13 @@ func TestGetTagsFromAPIGatewayEvent(t *testing.T) {
 }
 
 func TestGetTagsFromAPIGatewayV2HTTPRequestNoReferer(t *testing.T) {
-	event := events.APIGatewayV2HTTPRequest{
+	event := ddevents.APIGatewayV2HTTPRequest{
 		Headers: map[string]string{
 			"key": "val",
 		},
-		RequestContext: events.APIGatewayV2HTTPRequestContext{
+		RequestContext: ddevents.APIGatewayV2HTTPRequestContext{
 			DomainName: "domain-name",
-			HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+			HTTP: ddevents.APIGatewayV2HTTPRequestContextHTTPDescription{
 				Path:   "path",
 				Method: "http-method",
 			},

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -161,8 +161,8 @@ func TestExtractDynamoDBStreamEventARN(t *testing.T) {
 }
 
 func TestExtractKinesisStreamEventARN(t *testing.T) {
-	event := events.KinesisEvent{
-		Records: []events.KinesisEventRecord{
+	event := ddevents.KinesisEvent{
+		Records: []ddevents.KinesisEventRecord{
 			{
 				EventSourceArn: "test-arn",
 			},

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -193,15 +193,15 @@ func TestExtractS3EventArn(t *testing.T) {
 }
 
 func TestExtractSNSEventArn(t *testing.T) {
-	event := events.SNSEvent{
-		Records: []events.SNSEventRecord{
+	event := ddevents.SNSEvent{
+		Records: []ddevents.SNSEventRecord{
 			{
-				SNS: events.SNSEntity{
+				SNS: ddevents.SNSEntity{
 					TopicArn: "test-arn",
 				},
 			},
 			{
-				SNS: events.SNSEntity{
+				SNS: ddevents.SNSEntity{
 					TopicArn: "test-arn2",
 				},
 			},

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -11,8 +11,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	ddevents "github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
-	"github.com/aws/aws-lambda-go/events"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,8 +23,8 @@ func TestGetAWSPartitionByRegion(t *testing.T) {
 
 func TestExtractAPIGatewayEventARN(t *testing.T) {
 	region := "us-east-1"
-	event := ddevents.APIGatewayProxyRequest{
-		RequestContext: ddevents.APIGatewayProxyRequestContext{
+	event := events.APIGatewayProxyRequest{
+		RequestContext: events.APIGatewayProxyRequestContext{
 			APIID: "test-id",
 			Stage: "test-stage",
 		},
@@ -37,8 +36,8 @@ func TestExtractAPIGatewayEventARN(t *testing.T) {
 
 func TestExtractAPIGatewayV2EventARN(t *testing.T) {
 	region := "us-east-1"
-	event := ddevents.APIGatewayV2HTTPRequest{
-		RequestContext: ddevents.APIGatewayV2HTTPRequestContext{
+	event := events.APIGatewayV2HTTPRequest{
+		RequestContext: events.APIGatewayV2HTTPRequestContext{
 			APIID: "test-id",
 			Stage: "test-stage",
 		},
@@ -50,8 +49,8 @@ func TestExtractAPIGatewayV2EventARN(t *testing.T) {
 
 func TestExtractAPIGatewayWebSocketEventARN(t *testing.T) {
 	region := "us-east-1"
-	event := ddevents.APIGatewayWebsocketProxyRequest{
-		RequestContext: ddevents.APIGatewayWebsocketProxyRequestContext{
+	event := events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{
 			APIID: "test-id",
 			Stage: "test-stage",
 		},
@@ -63,7 +62,7 @@ func TestExtractAPIGatewayWebSocketEventARN(t *testing.T) {
 
 func TestExtractAPIGatewayCustomAuthorizerEventARN(t *testing.T) {
 	methodArn := "arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/some/resource/path"
-	event := ddevents.APIGatewayCustomAuthorizerRequest{
+	event := events.APIGatewayCustomAuthorizerRequest{
 		MethodArn: methodArn,
 	}
 	arn := ExtractAPIGatewayCustomAuthorizerEventARN(event)
@@ -72,7 +71,7 @@ func TestExtractAPIGatewayCustomAuthorizerEventARN(t *testing.T) {
 
 func TestExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(t *testing.T) {
 	methodArn := "arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/some/resource/path"
-	event := ddevents.APIGatewayCustomAuthorizerRequestTypeRequest{
+	event := events.APIGatewayCustomAuthorizerRequestTypeRequest{
 		MethodArn: methodArn,
 	}
 	arn := ExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(event)
@@ -80,9 +79,9 @@ func TestExtractAPIGatewayCustomAuthorizerRequestTypeEventARN(t *testing.T) {
 }
 
 func TestExtractAlbEventARN(t *testing.T) {
-	event := ddevents.ALBTargetGroupRequest{
-		RequestContext: ddevents.ALBTargetGroupRequestContext{
-			ELB: ddevents.ELBContext{
+	event := events.ALBTargetGroupRequest{
+		RequestContext: events.ALBTargetGroupRequestContext{
+			ELB: events.ELBContext{
 				TargetGroupArn: "test-arn",
 			},
 		},
@@ -93,7 +92,7 @@ func TestExtractAlbEventARN(t *testing.T) {
 }
 
 func TestExtractCloudwatchEventARN(t *testing.T) {
-	event := ddevents.CloudWatchEvent{
+	event := events.CloudWatchEvent{
 		Resources: []string{
 			"test-arn",
 			"test-arn-2",
@@ -103,7 +102,7 @@ func TestExtractCloudwatchEventARN(t *testing.T) {
 	arn := ExtractCloudwatchEventARN(event)
 	assert.Equal(t, "test-arn", arn)
 
-	eventEmptyResources := ddevents.CloudWatchEvent{
+	eventEmptyResources := events.CloudWatchEvent{
 		Resources: []string{},
 	}
 
@@ -114,7 +113,7 @@ func TestExtractCloudwatchEventARN(t *testing.T) {
 func TestExtractCloudwatchLogsEventARN(t *testing.T) {
 	region := "us-east-1"
 	accountID := "account-id"
-	event := ddevents.CloudwatchLogsEvent{
+	event := events.CloudwatchLogsEvent{
 		AWSLogs: events.CloudwatchLogsRawData{
 			Data: "invalid",
 		},
@@ -133,7 +132,7 @@ func TestExtractCloudwatchLogsEventARN(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, gz.Close())
 
-	event = ddevents.CloudwatchLogsEvent{
+	event = events.CloudwatchLogsEvent{
 		AWSLogs: events.CloudwatchLogsRawData{
 			Data: base64.StdEncoding.EncodeToString(b.Bytes()),
 		},
@@ -145,8 +144,8 @@ func TestExtractCloudwatchLogsEventARN(t *testing.T) {
 }
 
 func TestExtractDynamoDBStreamEventARN(t *testing.T) {
-	event := ddevents.DynamoDBEvent{
-		Records: []ddevents.DynamoDBEventRecord{
+	event := events.DynamoDBEvent{
+		Records: []events.DynamoDBEventRecord{
 			{
 				EventSourceArn: "test-arn",
 			},
@@ -161,8 +160,8 @@ func TestExtractDynamoDBStreamEventARN(t *testing.T) {
 }
 
 func TestExtractKinesisStreamEventARN(t *testing.T) {
-	event := ddevents.KinesisEvent{
-		Records: []ddevents.KinesisEventRecord{
+	event := events.KinesisEvent{
+		Records: []events.KinesisEventRecord{
 			{
 				EventSourceArn: "test-arn",
 			},
@@ -177,8 +176,8 @@ func TestExtractKinesisStreamEventARN(t *testing.T) {
 }
 
 func TestExtractS3EventArn(t *testing.T) {
-	event := ddevents.S3Event{
-		Records: []ddevents.S3EventRecord{
+	event := events.S3Event{
+		Records: []events.S3EventRecord{
 			{
 				EventSource: "test-arn",
 			},
@@ -193,15 +192,15 @@ func TestExtractS3EventArn(t *testing.T) {
 }
 
 func TestExtractSNSEventArn(t *testing.T) {
-	event := ddevents.SNSEvent{
-		Records: []ddevents.SNSEventRecord{
+	event := events.SNSEvent{
+		Records: []events.SNSEventRecord{
 			{
-				SNS: ddevents.SNSEntity{
+				SNS: events.SNSEntity{
 					TopicArn: "test-arn",
 				},
 			},
 			{
-				SNS: ddevents.SNSEntity{
+				SNS: events.SNSEntity{
 					TopicArn: "test-arn2",
 				},
 			},
@@ -213,8 +212,8 @@ func TestExtractSNSEventArn(t *testing.T) {
 }
 
 func TestExtractSQSEventARN(t *testing.T) {
-	event := ddevents.SQSEvent{
-		Records: []ddevents.SQSMessage{
+	event := events.SQSEvent{
+		Records: []events.SQSMessage{
 			{
 				EventSourceARN: "test-arn",
 			},
@@ -229,12 +228,12 @@ func TestExtractSQSEventARN(t *testing.T) {
 }
 
 func TestExtractFunctionURLEventARN(t *testing.T) {
-	event := ddevents.APIGatewayProxyRequest{
+	event := events.APIGatewayProxyRequest{
 		Headers: map[string]string{
 			"key":     "val",
 			"Referer": "referer",
 		},
-		RequestContext: ddevents.APIGatewayProxyRequestContext{
+		RequestContext: events.APIGatewayProxyRequestContext{
 			DomainName: "domain-name",
 			Path:       "path",
 			HTTPMethod: "http-method",
@@ -254,12 +253,12 @@ func TestExtractFunctionURLEventARN(t *testing.T) {
 }
 
 func TestGetTagsFromAPIGatewayEvent(t *testing.T) {
-	event := ddevents.APIGatewayProxyRequest{
+	event := events.APIGatewayProxyRequest{
 		Headers: map[string]string{
 			"key":     "val",
 			"Referer": "referer",
 		},
-		RequestContext: ddevents.APIGatewayProxyRequestContext{
+		RequestContext: events.APIGatewayProxyRequestContext{
 			DomainName: "domain-name",
 			Path:       "path",
 			HTTPMethod: "http-method",
@@ -279,13 +278,13 @@ func TestGetTagsFromAPIGatewayEvent(t *testing.T) {
 }
 
 func TestGetTagsFromAPIGatewayV2HTTPRequestNoReferer(t *testing.T) {
-	event := ddevents.APIGatewayV2HTTPRequest{
+	event := events.APIGatewayV2HTTPRequest{
 		Headers: map[string]string{
 			"key": "val",
 		},
-		RequestContext: ddevents.APIGatewayV2HTTPRequestContext{
+		RequestContext: events.APIGatewayV2HTTPRequestContext{
 			DomainName: "domain-name",
-			HTTP: ddevents.APIGatewayV2HTTPRequestContextHTTPDescription{
+			HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
 				Path:   "path",
 				Method: "http-method",
 			},
@@ -304,7 +303,7 @@ func TestGetTagsFromAPIGatewayV2HTTPRequestNoReferer(t *testing.T) {
 }
 
 func TestGetTagsFromAPIGatewayCustomAuthorizerEvent(t *testing.T) {
-	event := ddevents.APIGatewayCustomAuthorizerRequest{
+	event := events.APIGatewayCustomAuthorizerRequest{
 		MethodArn: "arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/path/to/resource",
 	}
 
@@ -317,9 +316,9 @@ func TestGetTagsFromAPIGatewayCustomAuthorizerEvent(t *testing.T) {
 }
 
 func TestGetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(t *testing.T) {
-	event := ddevents.APIGatewayCustomAuthorizerRequestTypeRequest{
+	event := events.APIGatewayCustomAuthorizerRequestTypeRequest{
 		HTTPMethod: "GET",
-		RequestContext: ddevents.APIGatewayCustomAuthorizerRequestTypeRequestContext{
+		RequestContext: events.APIGatewayCustomAuthorizerRequestTypeRequestContext{
 			Path: "/path/to/resource",
 		},
 		Resource: "/{route}",
@@ -335,7 +334,7 @@ func TestGetTagsFromAPIGatewayCustomAuthorizerRequestTypeEvent(t *testing.T) {
 }
 
 func TestGetTagsFromALBTargetGroupRequest(t *testing.T) {
-	event := ddevents.ALBTargetGroupRequest{
+	event := events.ALBTargetGroupRequest{
 		Headers: map[string]string{
 			"key":     "val",
 			"Referer": "referer",
@@ -354,14 +353,14 @@ func TestGetTagsFromALBTargetGroupRequest(t *testing.T) {
 }
 
 func TestGetTagsFromFunctionURLRequest(t *testing.T) {
-	event := ddevents.LambdaFunctionURLRequest{
+	event := events.LambdaFunctionURLRequest{
 		Headers: map[string]string{
 			"key":     "val",
 			"Referer": "referer",
 		},
-		RequestContext: ddevents.LambdaFunctionURLRequestContext{
+		RequestContext: events.LambdaFunctionURLRequestContext{
 			DomainName: "test-domain",
-			HTTP: ddevents.LambdaFunctionURLRequestContextHTTPDescription{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
 				Path:   "asd",
 				Method: "GET",
 			},

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -93,7 +93,7 @@ func TestExtractAlbEventARN(t *testing.T) {
 }
 
 func TestExtractCloudwatchEventARN(t *testing.T) {
-	event := events.CloudWatchEvent{
+	event := ddevents.CloudWatchEvent{
 		Resources: []string{
 			"test-arn",
 			"test-arn-2",
@@ -103,7 +103,7 @@ func TestExtractCloudwatchEventARN(t *testing.T) {
 	arn := ExtractCloudwatchEventARN(event)
 	assert.Equal(t, "test-arn", arn)
 
-	eventEmptyResources := events.CloudWatchEvent{
+	eventEmptyResources := ddevents.CloudWatchEvent{
 		Resources: []string{},
 	}
 

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -177,8 +177,8 @@ func TestExtractKinesisStreamEventARN(t *testing.T) {
 }
 
 func TestExtractS3EventArn(t *testing.T) {
-	event := events.S3Event{
-		Records: []events.S3EventRecord{
+	event := ddevents.S3Event{
+		Records: []ddevents.S3EventRecord{
 			{
 				EventSource: "test-arn",
 			},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Creates drop in replacement types for all aws event types used by the serverless extension. This means that when an event is unmarshalled, we will only be unmarshalling the fields that we need. This avoids many allocations and speeds up processing time significantly.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The need for speed.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
