### PR TITLE
usm: http2: Move dynamic table management to a new struct

### DIFF
--- a/pkg/network/protocols/http2/dynamic_table.go
+++ b/pkg/network/protocols/http2/dynamic_table.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package http2
+
+import (
+	"fmt"
+	"sync"
+
+	manager "github.com/DataDog/ebpf-manager"
+
+	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
+)
+
+const (
+	terminatedConnectionsEventStream = "terminated_http2"
+
+	defaultMapCleanerBatchSize = 1024
+)
+
+// DynamicTable encapsulates the management of the dynamic table in the user mode.
+type DynamicTable struct {
+	// terminatedConnectionsEventsConsumer is the consumer used to receive terminated connections events from the kernel.
+	terminatedConnectionsEventsConsumer *events.Consumer[netebpf.ConnTuple]
+	// terminatedConnections is the list of terminated connections received from the kernel.
+	terminatedConnections []netebpf.ConnTuple
+	// terminatedConnectionMux is used to protect the terminated connections list from concurrent access.
+	terminatedConnectionMux sync.Mutex
+	// mapCleaner is the map cleaner used to clear entries of terminated connections from the kernel map.
+	mapCleaner *ddebpf.MapCleaner[http2DynamicTableIndex, http2DynamicTableEntry]
+}
+
+// NewDynamicTable creates a new dynamic table.
+func NewDynamicTable() *DynamicTable {
+	return &DynamicTable{}
+}
+
+// configureOptions configures the perf handler options for the map cleaner.
+func (dt *DynamicTable) configureOptions(mgr *manager.Manager, opts *manager.Options) {
+	events.Configure(terminatedConnectionsEventStream, mgr, opts)
+}
+
+// preStart sets up the terminated connections events consumer.
+func (dt *DynamicTable) preStart(mgr *manager.Manager) (err error) {
+	dt.terminatedConnectionsEventsConsumer, err = events.NewConsumer(
+		terminatedConnectionsEventStream,
+		mgr,
+		dt.processTerminatedConnections,
+	)
+	if err != nil {
+		return
+	}
+
+	dt.terminatedConnectionsEventsConsumer.Start()
+
+	return nil
+}
+
+// postStart sets up the dynamic table map cleaner.
+func (dt *DynamicTable) postStart(mgr *manager.Manager, cfg *config.Config) error {
+	return dt.setupDynamicTableMapCleaner(mgr, cfg)
+}
+
+// processTerminatedConnections processes the terminated connections received from the kernel.
+func (dt *DynamicTable) processTerminatedConnections(events []netebpf.ConnTuple) {
+	dt.terminatedConnectionMux.Lock()
+	defer dt.terminatedConnectionMux.Unlock()
+	dt.terminatedConnections = append(dt.terminatedConnections, events...)
+}
+
+// setupDynamicTableMapCleaner sets up the map cleaner used to clear entries of terminated connections from the kernel map.
+func (dt *DynamicTable) setupDynamicTableMapCleaner(mgr *manager.Manager, cfg *config.Config) error {
+	dynamicTableMap, _, err := mgr.GetMap(dynamicTable)
+	if err != nil {
+		return fmt.Errorf("error getting http2 dynamic table map: %w", err)
+	}
+
+	mapCleaner, err := ddebpf.NewMapCleaner[http2DynamicTableIndex, http2DynamicTableEntry](dynamicTableMap, defaultMapCleanerBatchSize)
+	if err != nil {
+		return fmt.Errorf("error creating a map cleaner for http2 dynamic table: %w", err)
+	}
+
+	terminatedConnectionsMap := make(map[netebpf.ConnTuple]struct{})
+	mapCleaner.Clean(cfg.HTTP2DynamicTableMapCleanerInterval,
+		func() bool {
+			dt.terminatedConnectionsEventsConsumer.Sync()
+			dt.terminatedConnectionMux.Lock()
+			for _, conn := range dt.terminatedConnections {
+				terminatedConnectionsMap[conn] = struct{}{}
+			}
+			dt.terminatedConnections = dt.terminatedConnections[:0]
+			dt.terminatedConnectionMux.Unlock()
+
+			return len(terminatedConnectionsMap) > 0
+		},
+		func() {
+			terminatedConnectionsMap = make(map[netebpf.ConnTuple]struct{})
+		},
+		func(_ int64, key http2DynamicTableIndex, _ http2DynamicTableEntry) bool {
+			_, ok := terminatedConnectionsMap[key.Tup]
+			return ok
+		})
+	dt.mapCleaner = mapCleaner
+	return nil
+}
+
+// stop stops all the goroutines used by the dynamic table.
+func (dt *DynamicTable) stop() {
+	dt.mapCleaner.Stop()
+
+	if dt.terminatedConnectionsEventsConsumer != nil {
+		dt.terminatedConnectionsEventsConsumer.Stop()
+	}
+}

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 	"unsafe"
 
@@ -22,7 +21,6 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
@@ -41,30 +39,26 @@ type Protocol struct {
 	// TODO: Do we need to duplicate?
 	statkeeper              *http.StatKeeper
 	http2InFlightMapCleaner *ddebpf.MapCleaner[http2StreamKey, EbpfTx]
-	dynamicTableMapCleaner  *ddebpf.MapCleaner[http2DynamicTableIndex, http2DynamicTableEntry]
 	eventsConsumer          *events.Consumer[EbpfTx]
-
-	terminatedConnectionsEventsConsumer *events.Consumer[netebpf.ConnTuple]
-	terminatedConnections               []netebpf.ConnTuple
-	terminatedConnectionMux             sync.Mutex
 
 	// http2Telemetry is used to retrieve metrics from the kernel
 	http2Telemetry             *kernelTelemetry
 	kernelTelemetryStopChannel chan struct{}
+
+	dynamicTable *DynamicTable
 }
 
 const (
-	inFlightMap                      = "http2_in_flight"
-	dynamicTable                     = "http2_dynamic_table"
-	dynamicTableCounter              = "http2_dynamic_counter_table"
-	http2IterationsTable             = "http2_iterations"
-	staticTable                      = "http2_static_table"
-	firstFrameHandlerTailCall        = "socket__http2_handle_first_frame"
-	filterTailCall                   = "socket__http2_filter"
-	parserTailCall                   = "socket__http2_frames_parser"
-	eventStream                      = "http2"
-	terminatedConnectionsEventStream = "terminated_http2"
-	telemetryMap                     = "http2_telemetry"
+	inFlightMap               = "http2_in_flight"
+	dynamicTable              = "http2_dynamic_table"
+	dynamicTableCounter       = "http2_dynamic_counter_table"
+	http2IterationsTable      = "http2_iterations"
+	staticTable               = "http2_static_table"
+	firstFrameHandlerTailCall = "socket__http2_handle_first_frame"
+	filterTailCall            = "socket__http2_filter"
+	parserTailCall            = "socket__http2_frames_parser"
+	eventStream               = "http2"
+	telemetryMap              = "http2_telemetry"
 )
 
 // Spec is the protocol spec for HTTP/2.
@@ -141,6 +135,7 @@ func newHTTP2Protocol(cfg *config.Config) (protocols.Protocol, error) {
 		telemetry:                  telemetry,
 		http2Telemetry:             http2KernelTelemetry,
 		kernelTelemetryStopChannel: make(chan struct{}),
+		dynamicTable:               NewDynamicTable(),
 	}, nil
 }
 
@@ -181,7 +176,7 @@ func (p *Protocol) ConfigureOptions(mgr *manager.Manager, opts *manager.Options)
 	utils.EnableOption(opts, "http2_monitoring_enabled")
 	// Configure event stream
 	events.Configure(eventStream, mgr, opts)
-	events.Configure(terminatedConnectionsEventStream, mgr, opts)
+	p.dynamicTable.configureOptions(mgr, opts)
 }
 
 // PreStart is called before the start of the provided eBPF manager.
@@ -198,18 +193,11 @@ func (p *Protocol) PreStart(mgr *manager.Manager) (err error) {
 		return
 	}
 
-	p.terminatedConnectionsEventsConsumer, err = events.NewConsumer(
-		terminatedConnectionsEventStream,
-		mgr,
-		p.processTerminatedConnections,
-	)
-	if err != nil {
+	if err = p.dynamicTable.preStart(mgr); err != nil {
 		return
 	}
-
 	p.statkeeper = http.NewStatkeeper(p.cfg, p.telemetry)
 	p.eventsConsumer.Start()
-	p.terminatedConnectionsEventsConsumer.Start()
 
 	if err = p.createStaticTable(mgr); err != nil {
 		return fmt.Errorf("error creating a static table for http2 monitoring: %w", err)
@@ -223,11 +211,10 @@ func (p *Protocol) PreStart(mgr *manager.Manager) (err error) {
 // performed here.
 func (p *Protocol) PostStart(mgr *manager.Manager) error {
 	// Setup map cleaner after manager start.
-
 	p.setupHTTP2InFlightMapCleaner(mgr)
-	p.setupDynamicTableMapCleaner(mgr)
 	p.updateKernelTelemetry(mgr)
-	return nil
+
+	return p.dynamicTable.postStart(mgr, p.cfg)
 }
 
 func (p *Protocol) updateKernelTelemetry(mgr *manager.Manager) {
@@ -270,17 +257,12 @@ func (p *Protocol) updateKernelTelemetry(mgr *manager.Manager) {
 // Note that since this method is a cleanup method, it *should not* fail and
 // tries to cleanup resources as best as it can.
 func (p *Protocol) Stop(_ *manager.Manager) {
+	p.dynamicTable.stop()
 	// http2InFlightMapCleaner handles nil pointer receivers
 	p.http2InFlightMapCleaner.Stop()
-	// dynamicTableMapCleaner handles nil pointer receivers
-	p.dynamicTableMapCleaner.Stop()
 
 	if p.eventsConsumer != nil {
 		p.eventsConsumer.Stop()
-	}
-
-	if p.terminatedConnectionsEventsConsumer != nil {
-		p.terminatedConnectionsEventsConsumer.Stop()
 	}
 
 	if p.statkeeper != nil {
@@ -320,12 +302,6 @@ func (p *Protocol) processHTTP2(events []EbpfTx) {
 	}
 }
 
-func (p *Protocol) processTerminatedConnections(events []netebpf.ConnTuple) {
-	p.terminatedConnectionMux.Lock()
-	defer p.terminatedConnectionMux.Unlock()
-	p.terminatedConnections = append(p.terminatedConnections, events...)
-}
-
 func (p *Protocol) setupHTTP2InFlightMapCleaner(mgr *manager.Manager) {
 	http2Map, _, err := mgr.GetMap(inFlightMap)
 	if err != nil {
@@ -349,42 +325,6 @@ func (p *Protocol) setupHTTP2InFlightMapCleaner(mgr *manager.Manager) {
 	})
 
 	p.http2InFlightMapCleaner = mapCleaner
-}
-
-func (p *Protocol) setupDynamicTableMapCleaner(mgr *manager.Manager) {
-	dynamicTableMap, _, err := mgr.GetMap(dynamicTable)
-	if err != nil {
-		log.Errorf("error getting %q map: %s", dynamicTable, err)
-		return
-	}
-
-	mapCleaner, err := ddebpf.NewMapCleaner[http2DynamicTableIndex, http2DynamicTableEntry](dynamicTableMap, 1024)
-	if err != nil {
-		log.Errorf("error creating map cleaner: %s", err)
-		return
-	}
-
-	terminatedConnectionsMap := make(map[netebpf.ConnTuple]struct{})
-	mapCleaner.Clean(p.cfg.HTTP2DynamicTableMapCleanerInterval,
-		func() bool {
-			p.terminatedConnectionsEventsConsumer.Sync()
-			p.terminatedConnectionMux.Lock()
-			for _, conn := range p.terminatedConnections {
-				terminatedConnectionsMap[conn] = struct{}{}
-			}
-			p.terminatedConnections = p.terminatedConnections[:0]
-			p.terminatedConnectionMux.Unlock()
-
-			return len(terminatedConnectionsMap) > 0
-		},
-		func() {
-			terminatedConnectionsMap = make(map[netebpf.ConnTuple]struct{})
-		},
-		func(_ int64, key http2DynamicTableIndex, _ http2DynamicTableEntry) bool {
-			_, ok := terminatedConnectionsMap[key.Tup]
-			return ok
-		})
-	p.dynamicTableMapCleaner = mapCleaner
 }
 
 // GetStats returns a map of HTTP2 stats stored in the following format:


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

We're adding more logic to the dynamic table management in the user mode, thus, we're encapsulating all management in a single struct. Currently just moving (without changing) the terminated connections cleanup


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Splitting a large PR to reduce complexity 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
