### PR TITLE
Fix parsing of /proc/mountinfo to retrieve self cgroup ID + fix HostCPUCount value in unit tests

### DIFF
--- a/pkg/util/containers/metrics/system/containerid_linux.go
+++ b/pkg/util/containers/metrics/system/containerid_linux.go
@@ -17,7 +17,7 @@ import (
 const (
 	selfMountInfoPath       = "/proc/self/mountinfo"
 	containerdSandboxPrefix = "sandboxes"
-	cIDRegexp               = `([^\s/]+)/(` + cgroups.ContainerRegexpStr + `)/[\S]*hostname`
+	cIDRegexp               = `.*/([^\s/]+)/(` + cgroups.ContainerRegexpStr + `)/[\S]*hostname`
 )
 
 var cIDMountInfoRegexp = regexp.MustCompile(cIDRegexp)

--- a/pkg/util/containers/metrics/system/containerid_linux_test.go
+++ b/pkg/util/containers/metrics/system/containerid_linux_test.go
@@ -32,6 +32,11 @@ func TestParseMountinfo(t *testing.T) {
 			filePath:        "./testdata/mountinfo_k8s_agent",
 			wantContainerID: "fc7038bc73a8d3850c66ddbfb0b2901afa378bfcbb942cc384b051767e4ac6b0",
 		},
+		{
+			name:            "Kind (containerd in docker)",
+			filePath:        "./testdata/mountinfo_kind",
+			wantContainerID: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/containers/metrics/system/testdata/mountinfo_kind
+++ b/pkg/util/containers/metrics/system/testdata/mountinfo_kind
@@ -1,0 +1,1 @@
+1258 1249 254:1 /docker/volumes/0919c2d87ec8ba99f3c85fdada5fe26eca73b2fce73a5974d6030f30bf91cbaf/_data/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/ca30bb64884083e29b1dc08a1081dd2df123f13f045dadb64dc346e56c0b6871/hostname /etc/hostname rw,relatime - ext4 /dev/vda1 rw,discard

--- a/pkg/util/system/cpu_mock.go
+++ b/pkg/util/system/cpu_mock.go
@@ -8,21 +8,10 @@
 package system
 
 const (
+	// Arbitrary CPU count used for unit tests
 	defaultCPUCountUnitTest = 3
 )
 
 func init() {
 	hostCPUCount.Store(defaultCPUCountUnitTest)
-}
-
-// SetHostCPUCount sets the host CPU count to the given value.
-// (Unit tests only)
-func SetHostCPUCount(count int) {
-	hostCPUCount.Store(int64(count))
-}
-
-// ResetHostCPUCount resets the host CPU count to the default value.
-// (Unit tests only)
-func ResetHostCPUCount() {
-	SetHostCPUCount(defaultCPUCountUnitTest)
 }

--- a/pkg/util/system/cpu_mock.go
+++ b/pkg/util/system/cpu_mock.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package system
+
+const (
+	defaultCPUCountUnitTest = 3
+)
+
+func init() {
+	hostCPUCount.Store(defaultCPUCountUnitTest)
+}
+
+// SetHostCPUCount sets the host CPU count to the given value.
+// (Unit tests only)
+func SetHostCPUCount(count int) {
+	hostCPUCount.Store(int64(count))
+}
+
+// ResetHostCPUCount resets the host CPU count to the default value.
+// (Unit tests only)
+func ResetHostCPUCount() {
+	SetHostCPUCount(defaultCPUCountUnitTest)
+}

--- a/pkg/util/system/cpu_test.go
+++ b/pkg/util/system/cpu_test.go
@@ -34,7 +34,7 @@ func (f *fakeCPUCount) info(context.Context, bool) (int, error) {
 }
 
 func TestHostCPUCount(t *testing.T) {
-	defer ResetHostCPUCount()
+	defer hostCPUCount.Store(defaultCPUCountUnitTest)
 
 	f := newFakeCPUCount(10000, nil)
 	assert.Equal(t, f.count, HostCPUCount())

--- a/pkg/util/system/cpu_test.go
+++ b/pkg/util/system/cpu_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package system
 
 import (
@@ -32,6 +34,8 @@ func (f *fakeCPUCount) info(context.Context, bool) (int, error) {
 }
 
 func TestHostCPUCount(t *testing.T) {
+	defer ResetHostCPUCount()
+
 	f := newFakeCPUCount(10000, nil)
 	assert.Equal(t, f.count, HostCPUCount())
 


### PR DESCRIPTION
### What does this PR do?

Fix regexp parsing `/proc/mountinfo` in case of multiple ids in mount line (kind, dind).
Fix `HostCPUCount` to have fixed value in tests (independent from actual runner).

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

There's nothing to QA as `/proc/mountinfo` code mostly serves as reference implementation (and for Agent to get its own CID).

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
