### PR TITLE
[dogstatsd] Add inode origin detection

### DIFF
--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -54,6 +54,9 @@ type parser struct {
 
 	// readTimestamps is true if the parser has to read timestamps from messages.
 	readTimestamps bool
+
+	// Generic Metric Provider
+	provider provider.Provider
 }
 
 func newParser(cfg config.Reader, float64List *float64ListPool, workerNum int) *parser {
@@ -65,6 +68,7 @@ func newParser(cfg config.Reader, float64List *float64ListPool, workerNum int) *
 		readTimestamps:   readTimestamps,
 		float64List:      float64List,
 		dsdOriginEnabled: cfg.GetBool("dogstatsd_origin_detection_client"),
+		provider:         provider.GetProvider(),
 	}
 }
 
@@ -256,7 +260,7 @@ func (p *parser) extractContainerID(rawContainerIDField []byte) []byte {
 			return nil
 		}
 
-		containerID, err := provider.GetProvider().GetMetaCollector().GetContainerIDForInode(inodeField, cacheValidity)
+		containerID, err := p.provider.GetMetaCollector().GetContainerIDForInode(inodeField, cacheValidity)
 		if err != nil {
 			log.Debugf("Failed to get container ID, got %v", err)
 			return nil

--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -23,10 +23,7 @@ const (
 	metricSampleType messageType = iota
 	serviceCheckType
 	eventType
-	// readerCacheExpiration determines the duration for which the cgroups data is cached in the cgroups reader.
-	// This value needs to be large enough to reduce latency and I/O load.
-	// It also needs to be small enough to catch the first metrics of new containers.
-	readerCacheExpiration = 2 * time.Second
+	cacheValidity = 2 * time.Second
 )
 
 var (
@@ -259,7 +256,7 @@ func (p *parser) extractContainerID(rawContainerIDField []byte) []byte {
 			return nil
 		}
 
-		containerID, err := provider.GetProvider().GetMetaCollector().GetContainerIDForInode(inodeField, readerCacheExpiration)
+		containerID, err := provider.GetProvider().GetMetaCollector().GetContainerIDForInode(inodeField, cacheValidity)
 		if err != nil {
 			log.Debugf("Failed to get container ID, got %v", err)
 			return nil

--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -13,6 +13,8 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type messageType int
@@ -21,6 +23,10 @@ const (
 	metricSampleType messageType = iota
 	serviceCheckType
 	eventType
+	// readerCacheExpiration determines the duration for which the cgroups data is cached in the cgroups reader.
+	// This value needs to be large enough to reduce latency and I/O load.
+	// It also needs to be small enough to catch the first metrics of new containers.
+	readerCacheExpiration = 2 * time.Second
 )
 
 var (
@@ -33,6 +39,9 @@ var (
 
 	// containerIDFieldPrefix is the prefix for a common field holding the sender's container ID
 	containerIDFieldPrefix = []byte("c:")
+
+	// containerInodeFieldPrefix is the prefix for a notation holding the sender's container Inode in the containerIDField
+	containerIDFieldInodePrefix = []byte("in-")
 )
 
 // parser parses dogstatsd messages
@@ -238,8 +247,27 @@ func (p *parser) parseFloat64List(rawFloats []byte) ([]float64, error) {
 }
 
 // extractContainerID parses the value of the container ID field.
+// If the field is prefixed by `in-`, it corresponds to the cgroup controller's inode of the source
+// and is used for ContainerID resolution.
 func (p *parser) extractContainerID(rawContainerIDField []byte) []byte {
-	return rawContainerIDField[len(containerIDFieldPrefix):]
+	containerIDField := rawContainerIDField[len(containerIDFieldPrefix):]
+
+	if bytes.HasPrefix(containerIDField[:len(containerIDFieldInodePrefix)], containerIDFieldInodePrefix) {
+		inodeField, err := strconv.ParseUint(string(containerIDField[len(containerIDFieldPrefix)+1:]), 10, 64)
+		if err != nil {
+			log.Debugf("Failed to parse inode from %s, got %v", containerIDField, err)
+			return nil
+		}
+
+		containerID, err := provider.GetProvider().GetMetaCollector().GetContainerIDForInode(inodeField, readerCacheExpiration)
+		if err != nil {
+			log.Debugf("Failed to get container ID, got %v", err)
+			return nil
+		}
+		return []byte(containerID)
+	}
+
+	return containerIDField
 }
 
 // the std API does not have methods to do []byte => float parsing

--- a/comp/dogstatsd/server/parse_metrics_test.go
+++ b/comp/dogstatsd/server/parse_metrics_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,8 +22,14 @@ func parseMetricSample(t *testing.T, overrides map[string]any, rawSample []byte)
 		config.MockModule(),
 		fx.Replace(config.MockParams{Overrides: overrides}),
 	))
-	parser := newParser(cfg, newFloat64ListPool(), 1)
-	return parser.parseMetricSample(rawSample)
+
+	p := newParser(cfg, newFloat64ListPool(), 1)
+	_, found := overrides["parser"]
+	if found {
+		p = overrides["parser"].(*parser)
+	}
+
+	return p.parseMetricSample(rawSample)
 }
 
 const epsilon = 0.00001
@@ -560,4 +567,29 @@ func TestParseManyPipes(t *testing.T) {
 		assert.Equal(t, "environment:dev", sample.tags[0])
 		assert.InEpsilon(t, 1.0, sample.sampleRate, epsilon)
 	})
+}
+
+func TestParseContainerID(t *testing.T) {
+	cfg := map[string]any{}
+	cfg["dogstatsd_origin_detection_client"] = true
+
+	// Testing with a container ID
+	sample, err := parseMetricSample(t, cfg, []byte("metric:1234|g|c:1234567890abcdef"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("1234567890abcdef"), sample.containerID)
+
+	// Testing with an Inode
+	p := newParser(fxutil.Test[config.Component](t, config.MockModule(), fx.Replace(config.MockParams{Overrides: cfg})), newFloat64ListPool(), 1)
+	mockProvider := mock.NewMetricsProvider()
+	mockProvider.RegisterMetaCollector(&mock.MetaCollector{
+		CIDFromInode: map[uint64]string{
+			1234567890: "1234567890abcdef",
+		},
+	})
+	p.provider = mockProvider
+	cfg["parser"] = p
+
+	sample, err = parseMetricSample(t, cfg, []byte("metric:1234|g|c:in-1234567890"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("1234567890abcdef"), sample.containerID)
 }

--- a/comp/dogstatsd/server/parse_test.go
+++ b/comp/dogstatsd/server/parse_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -107,4 +108,22 @@ func TestUnsafeParseInt(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, integer, unsafeInteger)
+}
+
+func TestExtractContainerID(t *testing.T) {
+	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	p := newParser(cfg, newFloat64ListPool(), 1)
+	// Testing with a container ID
+	containerID := p.extractContainerID([]byte("c:1234567890abcdef"))
+	assert.Equal(t, []byte("1234567890abcdef"), containerID)
+	// Testing with an Inode
+	mockProvider := mock.NewMetricsProvider()
+	mockProvider.RegisterMetaCollector(&mock.MetaCollector{
+		CIDFromInode: map[uint64]string{
+			1234567890: "1234567890abcdef",
+		},
+	})
+	p.provider = mockProvider
+	containerIDFromInode := p.extractContainerID([]byte("c:in-1234567890"))
+	assert.Equal(t, []byte("1234567890abcdef"), containerIDFromInode)
 }

--- a/pkg/util/containers/metrics/mock/mock.go
+++ b/pkg/util/containers/metrics/mock/mock.go
@@ -21,6 +21,34 @@ type MetricsProvider struct {
 	metaCollector provider.MetaCollector
 }
 
+// MetaCollector is a mocked provider.MetaCollector
+type MetaCollector struct {
+	ContainerID  string
+	CIDFromPID   map[int]string
+	CIDFromInode map[uint64]string
+}
+
+// GetSelfContainerID returns the container ID for current container.
+func (mc *MetaCollector) GetSelfContainerID() (string, error) {
+	return mc.ContainerID, nil
+}
+
+// GetContainerIDForPID returns a container ID for given PID.
+func (mc *MetaCollector) GetContainerIDForPID(pid int, _ time.Duration) (string, error) {
+	if val, found := mc.CIDFromPID[pid]; found {
+		return val, nil
+	}
+	return "", nil
+}
+
+// GetContainerIDForInode returns a container ID for given inode.
+func (mc *MetaCollector) GetContainerIDForInode(inode uint64, _ time.Duration) (string, error) {
+	if val, found := mc.CIDFromInode[inode]; found {
+		return val, nil
+	}
+	return "", nil
+}
+
 // NewMetricsProvider creates a mock provider
 func NewMetricsProvider() *MetricsProvider {
 	return &MetricsProvider{

--- a/pkg/util/containers/metrics/provider/collector.go
+++ b/pkg/util/containers/metrics/provider/collector.go
@@ -49,8 +49,9 @@ type Collectors struct {
 	PIDs           CollectorRef[ContainerPIDsGetter]
 
 	// These collectors are used in the meta collector
-	ContainerIDForPID CollectorRef[ContainerIDForPIDRetriever]
-	SelfContainerID   CollectorRef[SelfContainerIDRetriever]
+	ContainerIDForPID   CollectorRef[ContainerIDForPIDRetriever]
+	ContainerIDForInode CollectorRef[ContainerIDForInodeRetriever]
+	SelfContainerID     CollectorRef[SelfContainerIDRetriever]
 }
 
 func (c *Collectors) merge(runtime Runtime, otherID string, oth *Collectors) {
@@ -59,6 +60,7 @@ func (c *Collectors) merge(runtime Runtime, otherID string, oth *Collectors) {
 	c.OpenFilesCount = c.OpenFilesCount.bestCollector(runtime, otherID, oth.OpenFilesCount)
 	c.PIDs = c.PIDs.bestCollector(runtime, otherID, oth.PIDs)
 	c.ContainerIDForPID = c.ContainerIDForPID.bestCollector(runtime, otherID, oth.ContainerIDForPID)
+	c.ContainerIDForInode = c.ContainerIDForInode.bestCollector(runtime, otherID, oth.ContainerIDForInode)
 	c.SelfContainerID = c.SelfContainerID.bestCollector(runtime, otherID, oth.SelfContainerID)
 }
 

--- a/pkg/util/containers/metrics/provider/collector_cache.go
+++ b/pkg/util/containers/metrics/provider/collector_cache.go
@@ -11,11 +11,12 @@ import (
 )
 
 const (
-	contCoreStatsCachePrefix = "cs-"
-	contOpenFilesCachePrefix = "of-"
-	contNetStatsCachePrefix  = "cns-"
-	contPidToCidCachePrefix  = "pid-"
-	contPidsCachePrefix      = "pids-"
+	contCoreStatsCachePrefix  = "cs-"
+	contOpenFilesCachePrefix  = "of-"
+	contNetStatsCachePrefix   = "cns-"
+	contPidToCidCachePrefix   = "pid-"
+	contInodeToCidCachePrefix = "in-"
+	contPidsCachePrefix       = "pids-"
 )
 
 // collectorCache is a wrapper handling cache for collectors.
@@ -47,12 +48,13 @@ func MakeCached(providerID string, cache *Cache, collectors *Collectors) *Collec
 	}
 
 	return &Collectors{
-		Stats:             makeCached(collectors.Stats, ContainerStatsGetter(collectorCache)),
-		Network:           makeCached(collectors.Network, ContainerNetworkStatsGetter(collectorCache)),
-		OpenFilesCount:    makeCached(collectors.OpenFilesCount, ContainerOpenFilesCountGetter(collectorCache)),
-		PIDs:              makeCached(collectors.PIDs, ContainerPIDsGetter(collectorCache)),
-		ContainerIDForPID: makeCached(collectors.ContainerIDForPID, ContainerIDForPIDRetriever(collectorCache)),
-		SelfContainerID:   makeCached(collectors.SelfContainerID, SelfContainerIDRetriever(collectorCache)),
+		Stats:               makeCached(collectors.Stats, ContainerStatsGetter(collectorCache)),
+		Network:             makeCached(collectors.Network, ContainerNetworkStatsGetter(collectorCache)),
+		OpenFilesCount:      makeCached(collectors.OpenFilesCount, ContainerOpenFilesCountGetter(collectorCache)),
+		PIDs:                makeCached(collectors.PIDs, ContainerPIDsGetter(collectorCache)),
+		ContainerIDForPID:   makeCached(collectors.ContainerIDForPID, ContainerIDForPIDRetriever(collectorCache)),
+		ContainerIDForInode: makeCached(collectors.ContainerIDForInode, ContainerIDForInodeRetriever(collectorCache)),
+		SelfContainerID:     makeCached(collectors.SelfContainerID, SelfContainerIDRetriever(collectorCache)),
 	}
 }
 
@@ -103,6 +105,16 @@ func (cc *collectorCache) GetContainerIDForPID(pid int, cacheValidity time.Durat
 
 	return getOrFallback(cc.cache, cacheKey, cacheValidity, func() (string, error) {
 		return cc.collectors.ContainerIDForPID.Collector.GetContainerIDForPID(pid, cacheValidity)
+	})
+}
+
+// GetContainerIDForInode returns the container ID for given Inode
+// errors are cached as well to avoid hammering underlying collector
+func (cc *collectorCache) GetContainerIDForInode(inode uint64, cacheValidity time.Duration) (string, error) {
+	cacheKey := cc.providerID + "-" + contInodeToCidCachePrefix + strconv.FormatUint(inode, 10)
+
+	return getOrFallback(cc.cache, cacheKey, cacheValidity, func() (string, error) {
+		return cc.collectors.ContainerIDForInode.Collector.GetContainerIDForInode(inode, cacheValidity)
 	})
 }
 

--- a/pkg/util/containers/metrics/provider/collector_types.go
+++ b/pkg/util/containers/metrics/provider/collector_types.go
@@ -38,6 +38,13 @@ type ContainerIDForPIDRetriever interface {
 	GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error)
 }
 
+// ContainerIDForInodeRetriever interface
+type ContainerIDForInodeRetriever interface {
+	// GetContainerIDForInode ContainerIDForInode returns a container ID for given Inode.
+	// ("", nil) will be returned if no error but the containerd ID was not found.
+	GetContainerIDForInode(inode uint64, cacheValidity time.Duration) (string, error)
+}
+
 // SelfContainerIDRetriever interface
 type SelfContainerIDRetriever interface {
 	// GetSelfContainerID returns the container ID for current container.
@@ -56,5 +63,6 @@ type Collector interface {
 // MetaCollector is a special collector that uses all available collectors, by priority order.
 type MetaCollector interface {
 	ContainerIDForPIDRetriever
+	ContainerIDForInodeRetriever
 	SelfContainerIDRetriever
 }

--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -120,7 +120,6 @@ func newSystemCollector(cache *provider.Cache) (provider.CollectorMetadata, erro
 			collectors.OpenFilesCount = provider.MakeRef[provider.ContainerOpenFilesCountGetter](systemCollector, collectorLowPriority)
 			collectors.PIDs = provider.MakeRef[provider.ContainerPIDsGetter](systemCollector, collectorLowPriority)
 			collectors.ContainerIDForPID = provider.MakeRef[provider.ContainerIDForPIDRetriever](systemCollector, collectorLowPriority)
-			collectors.ContainerIDForInode = provider.MakeRef[provider.ContainerIDForInodeRetriever](systemCollector, collectorLowPriority)
 		}
 
 		// We can retrieve self PID with cgroupv1 or cgroupv2 with host ns

--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -110,6 +110,7 @@ func newSystemCollector(cache *provider.Cache) (provider.CollectorMetadata, erro
 			collectors.OpenFilesCount = provider.MakeRef[provider.ContainerOpenFilesCountGetter](systemCollector, collectorHighPriority)
 			collectors.PIDs = provider.MakeRef[provider.ContainerPIDsGetter](systemCollector, collectorHighPriority)
 			collectors.ContainerIDForPID = provider.MakeRef[provider.ContainerIDForPIDRetriever](systemCollector, collectorHighPriority)
+			collectors.ContainerIDForInode = provider.MakeRef[provider.ContainerIDForInodeRetriever](systemCollector, collectorHighPriority)
 		} else if isAgentSidecar {
 			// When side car with sharedPIDNamespace, we can get the same data.
 			// As we don't know if we are sharedPIDNamespace, adding as low priority.
@@ -119,6 +120,7 @@ func newSystemCollector(cache *provider.Cache) (provider.CollectorMetadata, erro
 			collectors.OpenFilesCount = provider.MakeRef[provider.ContainerOpenFilesCountGetter](systemCollector, collectorLowPriority)
 			collectors.PIDs = provider.MakeRef[provider.ContainerPIDsGetter](systemCollector, collectorLowPriority)
 			collectors.ContainerIDForPID = provider.MakeRef[provider.ContainerIDForPIDRetriever](systemCollector, collectorLowPriority)
+			collectors.ContainerIDForInode = provider.MakeRef[provider.ContainerIDForInodeRetriever](systemCollector, collectorLowPriority)
 		}
 
 		// We can retrieve self PID with cgroupv1 or cgroupv2 with host ns
@@ -131,12 +133,13 @@ func newSystemCollector(cache *provider.Cache) (provider.CollectorMetadata, erro
 	} else {
 		// When not running in a container, we can use everything
 		collectors = &provider.Collectors{
-			Stats:             provider.MakeRef[provider.ContainerStatsGetter](systemCollector, collectorHighPriority),
-			Network:           provider.MakeRef[provider.ContainerNetworkStatsGetter](systemCollector, collectorHighPriority),
-			OpenFilesCount:    provider.MakeRef[provider.ContainerOpenFilesCountGetter](systemCollector, collectorHighPriority),
-			PIDs:              provider.MakeRef[provider.ContainerPIDsGetter](systemCollector, collectorHighPriority),
-			ContainerIDForPID: provider.MakeRef[provider.ContainerIDForPIDRetriever](systemCollector, collectorHighPriority),
-			SelfContainerID:   provider.MakeRef[provider.SelfContainerIDRetriever](systemCollector, collectorHighPriority),
+			Stats:               provider.MakeRef[provider.ContainerStatsGetter](systemCollector, collectorHighPriority),
+			Network:             provider.MakeRef[provider.ContainerNetworkStatsGetter](systemCollector, collectorHighPriority),
+			OpenFilesCount:      provider.MakeRef[provider.ContainerOpenFilesCountGetter](systemCollector, collectorHighPriority),
+			PIDs:                provider.MakeRef[provider.ContainerPIDsGetter](systemCollector, collectorHighPriority),
+			ContainerIDForPID:   provider.MakeRef[provider.ContainerIDForPIDRetriever](systemCollector, collectorHighPriority),
+			ContainerIDForInode: provider.MakeRef[provider.ContainerIDForInodeRetriever](systemCollector, collectorHighPriority),
+			SelfContainerID:     provider.MakeRef[provider.SelfContainerIDRetriever](systemCollector, collectorHighPriority),
 		}
 	}
 	log.Debugf("Chosen system collectors: %+v", collectors)
@@ -200,6 +203,23 @@ func (c *systemCollector) GetPIDs(_, containerID string, cacheValidity time.Dura
 func (c *systemCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) {
 	containerID, err := cgroups.IdentiferFromCgroupReferences(c.procPath, strconv.Itoa(pid), c.baseController, cgroups.ContainerFilter)
 	return containerID, err
+}
+
+func (c *systemCollector) GetContainerIDForInode(inode uint64, cacheValidity time.Duration) (string, error) {
+	cg := c.reader.GetCgroupByInode(inode)
+	if cg == nil {
+		err := c.reader.RefreshCgroups(cacheValidity)
+		if err != nil {
+			return "", fmt.Errorf("containerID not found from inode %d and unable to refresh cgroups, err: %w", inode, err)
+		}
+
+		cg = c.reader.GetCgroupByInode(inode)
+		if cg == nil {
+			return "", fmt.Errorf("containerID not found from inode %d, err: %w", inode, err)
+		}
+	}
+
+	return cg.Identifier(), nil
 }
 
 func (c *systemCollector) GetSelfContainerID() (string, error) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Adds Origin Detection support with inode for DogStatsD.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This is needed to support Origin Detection after the changes induced by Cgroupv2 and Pod Security Standards.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
To test this PR, you can use the following image in a Minikube cluster.
* Create a Minikube cluster
* Deploy the Agent with the following chart:
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  override:
    nodeAgent:
      containers:
        agent:
          env:
          - name: "DD_DOGSTATSD_TAG_CARDINALITY"
            value: "high"
          - name: "DD_DOGSTATSD_ORIGIN_DETECTION_CLIENT"
            value: "true"
          - name: "DD_AGENT_HOST"
            valueFrom:
              fieldRef:
                fieldPath: status.hostIP
[...]
  features:
    dogstatsd:
      originDetectionEnabled: true
      hostPortConfig:
        enabled: true
```
* Deploy the [dummy-dsd-app](https://hub.docker.com/r/alidatadog/dummy-dsd-app) with the following chart:
```
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: dummy-go-app
  spec:
    replicas: 1
    selector:
      matchLabels:
        app: dummy-go-app
    template:
      metadata:
        labels:
          app: dummy-go-app
          admission.datadoghq.com/enabled: "false"
      spec:
        containers:
        - name: dummy-go-app
          image: docker.io/alidatadog/dummy-dsd-app:0.2.0
          imagePullPolicy: Always
          env:
          - name: DD_AGENT_HOST
            valueFrom:
              fieldRef:
                fieldPath: status.hostIP
```
* Make sure that you can see the containerID on the `page.views` metric, with a valid container ID.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
