### PR TITLE
[CONTINT-1093] Run kind E2E for multiple k8s versions in parallel

### DIFF
--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -77,12 +77,12 @@ func (suite *kindSuite) SetupSuite() {
 
 	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(ctx, suite.stackName, stackConfig, kindvm.Run, false, nil)
 	if !suite.Assert().NoError(err) {
-		_, err := infra.GetStackManager().GetPulumiStackName(suite.stackName)
+		stackname, err := infra.GetStackManager().GetPulumiStackName(suite.stackName)
 		suite.Require().NoError(err)
-		suite.T().Log(dumpKindClusterState(ctx, suite.stackName))
+		suite.T().Log(dumpKindClusterState(ctx, stackname))
 		if !runner.GetProfile().AllowDevMode() || !*keepStacks {
 
-			infra.GetStackManager().DeleteStack(ctx, suite.stackName, nil)
+			infra.GetStackManager().DeleteStack(ctx, stackname, nil)
 		}
 		suite.T().FailNow()
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Allows running kind E2E tests for multiple kubernetes versions in parallel.

### Motivation
Speedup E2E testing for multiple versions of kubernetes. 

There are 3 ways to run the kindvm e2e tests:
- **Default behaviour:** 
   - if no kubernetes version is specified, the tests will be run in parallel for the following versions `"1.27", "1.23", "1.20", "1.19"`. 
   - Example: `inv new-e2e-tests.run --targets ./tests/containers/ --run TestKindSuite`
- **Matrix Version:** 
   - You can run the invoke command with `KUBERNETES_VERSIONS` env var set to a comma separated string of versions you wish to run the tests for in parallel.
   - Example: `KUBERNETES_VERSIONS=1.29,1.25 inv new-e2e-tests.run --targets ./tests/containers/ --run TestKindSuite`
- **Single Version:**
   - You can run the E2E tests for a single kubernetes version by setting the `-c ddinfra:kubernetesVersion` config param in the cli
   - Example: `inv new-e2e-tests.run --targets ./tests/containers/ --run TestKindSuite -c ddinfra:kubernetesVersion=1.29`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
- Using the current approach, the test logs emitted by pulumi will be a bit messy. However, at the end of the test, we will have a full report of all test results for each tested kubernetes version. For example, running the test for `1.27`, `1.26` and `1.25` produced the following report:
```
--- FAIL: TestKindSuite (0.00s)
    --- FAIL: TestKindSuite/TestKind_1.27 (967.22s)
        --- PASS: TestKindSuite/TestKind_1.27/Test00UpAndRunning (11.21s)
            --- PASS: TestKindSuite/TestKind_1.27/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting (11.21s)
        --- PASS: TestKindSuite/TestKind_1.27/TestCPU (48.93s)
            --- PASS: TestKindSuite/TestKind_1.27/TestCPU/metric___container.cpu.usage{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (12.94s)
            --- PASS: TestKindSuite/TestKind_1.27/TestCPU/metric___container.cpu.limit{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (11.92s)
            --- PASS: TestKindSuite/TestKind_1.27/TestCPU/metric___kubernetes.cpu.usage.total{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (11.45s)
            --- PASS: TestKindSuite/TestKind_1.27/TestCPU/metric___kubernetes.cpu.limits{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (12.61s)
        --- PASS: TestKindSuite/TestKind_1.27/TestDogstatsdInAgent (25.24s)
            --- PASS: TestKindSuite/TestKind_1.27/TestDogstatsdInAgent/metric___custom.metric{kube_deployment:dogstatsd-uds,kube_namespace:workload-dogstatsd} (13.27s)
            --- PASS: TestKindSuite/TestKind_1.27/TestDogstatsdInAgent/metric___custom.metric{kube_deployment:dogstatsd-udp,kube_namespace:workload-dogstatsd} (11.96s)
        --- PASS: TestKindSuite/TestKind_1.27/TestDogstatsdStandalone (25.66s)
            --- PASS: TestKindSuite/TestKind_1.27/TestDogstatsdStandalone/metric___custom.metric{kube_deployment:dogstatsd-uds,kube_namespace:workload-dogstatsd-standalone} (11.83s)
            --- PASS: TestKindSuite/TestKind_1.27/TestDogstatsdStandalone/metric___custom.metric{kube_deployment:dogstatsd-udp,kube_namespace:workload-dogstatsd-standalone} (13.83s)
        --- PASS: TestKindSuite/TestKind_1.27/TestNginx (369.78s)
            --- PASS: TestKindSuite/TestKind_1.27/TestNginx/metric___nginx.net.request_per_s{} (21.79s)
            --- PASS: TestKindSuite/TestKind_1.27/TestNginx/metric___network.http.response_time{} (18.19s)
            --- PASS: TestKindSuite/TestKind_1.27/TestNginx/metric___kubernetes_state.deployment.replicas_available{kube_deployment:nginx,kube_namespace:workload-nginx} (15.21s)
            --- PASS: TestKindSuite/TestKind_1.27/TestNginx/log___apps-nginx-server{} (10.91s)
            --- PASS: TestKindSuite/TestKind_1.27/TestNginx/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-nginx,kube_deployment:nginx} (303.67s)
        --- PASS: TestKindSuite/TestKind_1.27/TestPrometheus (22.21s)
            --- PASS: TestKindSuite/TestKind_1.27/TestPrometheus/metric___prom_gauge{kube_deployment:prometheus,kube_namespace:workload-prometheus} (22.21s)
        --- PASS: TestKindSuite/TestKind_1.27/TestRedis (78.33s)
            --- PASS: TestKindSuite/TestKind_1.27/TestRedis/metric___redis.net.instantaneous_ops_per_sec{} (19.93s)
            --- PASS: TestKindSuite/TestKind_1.27/TestRedis/metric___kubernetes_state.deployment.replicas_available{kube_deployment:redis,kube_namespace:workload-redis} (19.62s)
            --- PASS: TestKindSuite/TestKind_1.27/TestRedis/log___redis{} (11.93s)
            --- PASS: TestKindSuite/TestKind_1.27/TestRedis/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-redis,kube_deployment:redis} (26.85s)
        --- FAIL: TestKindSuite/TestKind_1.27/TestVersion (5.42s)
            --- FAIL: TestKindSuite/TestKind_1.27/TestVersion/Linux_agent_pods_are_running_the_good_version (2.99s)
            --- PASS: TestKindSuite/TestKind_1.27/TestVersion/Windows_agent_pods_are_running_the_good_version (0.13s)
            --- FAIL: TestKindSuite/TestKind_1.27/TestVersion/cluster_agent_pods_are_running_the_good_version (1.15s)
            --- FAIL: TestKindSuite/TestKind_1.27/TestVersion/cluster_checks_pods_are_running_the_good_version (1.15s)
        --- PASS: TestKindSuite/TestKind_1.27/TestZZUpAndRunning (12.72s)
            --- PASS: TestKindSuite/TestKind_1.27/TestZZUpAndRunning/agent_pods_are_ready_and_not_restarting (12.72s)
    --- FAIL: TestKindSuite/TestKind_1.25 (986.71s)
        --- PASS: TestKindSuite/TestKind_1.25/Test00UpAndRunning (11.17s)
            --- PASS: TestKindSuite/TestKind_1.25/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting (11.17s)
        --- PASS: TestKindSuite/TestKind_1.25/TestCPU (56.81s)
            --- PASS: TestKindSuite/TestKind_1.25/TestCPU/metric___container.cpu.usage{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (12.02s)
            --- PASS: TestKindSuite/TestKind_1.25/TestCPU/metric___container.cpu.limit{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (11.50s)
            --- PASS: TestKindSuite/TestKind_1.25/TestCPU/metric___kubernetes.cpu.usage.total{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (21.30s)
            --- PASS: TestKindSuite/TestKind_1.25/TestCPU/metric___kubernetes.cpu.limits{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (11.99s)
        --- PASS: TestKindSuite/TestKind_1.25/TestDogstatsdInAgent (25.49s)
            --- PASS: TestKindSuite/TestKind_1.25/TestDogstatsdInAgent/metric___custom.metric{kube_deployment:dogstatsd-uds,kube_namespace:workload-dogstatsd} (13.48s)
            --- PASS: TestKindSuite/TestKind_1.25/TestDogstatsdInAgent/metric___custom.metric{kube_deployment:dogstatsd-udp,kube_namespace:workload-dogstatsd} (12.00s)
        --- PASS: TestKindSuite/TestKind_1.25/TestDogstatsdStandalone (29.15s)
            --- PASS: TestKindSuite/TestKind_1.25/TestDogstatsdStandalone/metric___custom.metric{kube_deployment:dogstatsd-uds,kube_namespace:workload-dogstatsd-standalone} (14.07s)
            --- PASS: TestKindSuite/TestKind_1.25/TestDogstatsdStandalone/metric___custom.metric{kube_deployment:dogstatsd-udp,kube_namespace:workload-dogstatsd-standalone} (15.08s)
        --- PASS: TestKindSuite/TestKind_1.25/TestNginx (380.05s)
            --- PASS: TestKindSuite/TestKind_1.25/TestNginx/metric___nginx.net.request_per_s{} (17.56s)
            --- PASS: TestKindSuite/TestKind_1.25/TestNginx/metric___network.http.response_time{} (17.53s)
            --- PASS: TestKindSuite/TestKind_1.25/TestNginx/metric___kubernetes_state.deployment.replicas_available{kube_deployment:nginx,kube_namespace:workload-nginx} (15.68s)
            --- PASS: TestKindSuite/TestKind_1.25/TestNginx/log___apps-nginx-server{} (13.39s)
            --- PASS: TestKindSuite/TestKind_1.25/TestNginx/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-nginx,kube_deployment:nginx} (315.89s)
        --- PASS: TestKindSuite/TestKind_1.25/TestPrometheus (45.62s)
            --- PASS: TestKindSuite/TestKind_1.25/TestPrometheus/metric___prom_gauge{kube_deployment:prometheus,kube_namespace:workload-prometheus} (45.62s)
        --- PASS: TestKindSuite/TestKind_1.25/TestRedis (76.03s)
            --- PASS: TestKindSuite/TestKind_1.25/TestRedis/metric___redis.net.instantaneous_ops_per_sec{} (18.40s)
            --- PASS: TestKindSuite/TestKind_1.25/TestRedis/metric___kubernetes_state.deployment.replicas_available{kube_deployment:redis,kube_namespace:workload-redis} (27.54s)
            --- PASS: TestKindSuite/TestKind_1.25/TestRedis/log___redis{} (11.62s)
            --- PASS: TestKindSuite/TestKind_1.25/TestRedis/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-redis,kube_deployment:redis} (18.46s)
        --- FAIL: TestKindSuite/TestKind_1.25/TestVersion (4.37s)
            --- FAIL: TestKindSuite/TestKind_1.25/TestVersion/Linux_agent_pods_are_running_the_good_version (1.60s)
            --- PASS: TestKindSuite/TestKind_1.25/TestVersion/Windows_agent_pods_are_running_the_good_version (0.14s)
            --- FAIL: TestKindSuite/TestKind_1.25/TestVersion/cluster_agent_pods_are_running_the_good_version (1.25s)
            --- FAIL: TestKindSuite/TestKind_1.25/TestVersion/cluster_checks_pods_are_running_the_good_version (1.38s)
        --- PASS: TestKindSuite/TestKind_1.25/TestZZUpAndRunning (11.68s)
            --- PASS: TestKindSuite/TestKind_1.25/TestZZUpAndRunning/agent_pods_are_ready_and_not_restarting (11.68s)
    --- FAIL: TestKindSuite/TestKind_1.26 (1031.60s)
        --- PASS: TestKindSuite/TestKind_1.26/Test00UpAndRunning (12.30s)
            --- PASS: TestKindSuite/TestKind_1.26/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting (12.30s)
        --- PASS: TestKindSuite/TestKind_1.26/TestCPU (111.58s)
            --- PASS: TestKindSuite/TestKind_1.26/TestCPU/metric___container.cpu.usage{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (16.35s)
            --- PASS: TestKindSuite/TestKind_1.26/TestCPU/metric___container.cpu.limit{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (14.77s)
            --- PASS: TestKindSuite/TestKind_1.26/TestCPU/metric___kubernetes.cpu.usage.total{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (66.00s)
            --- PASS: TestKindSuite/TestKind_1.26/TestCPU/metric___kubernetes.cpu.limits{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (14.46s)
        --- PASS: TestKindSuite/TestKind_1.26/TestDogstatsdInAgent (27.30s)
            --- PASS: TestKindSuite/TestKind_1.26/TestDogstatsdInAgent/metric___custom.metric{kube_deployment:dogstatsd-uds,kube_namespace:workload-dogstatsd} (13.09s)
            --- PASS: TestKindSuite/TestKind_1.26/TestDogstatsdInAgent/metric___custom.metric{kube_deployment:dogstatsd-udp,kube_namespace:workload-dogstatsd} (14.21s)
        --- FAIL: TestKindSuite/TestKind_1.26/TestDogstatsdStandalone (240.97s)
            --- FAIL: TestKindSuite/TestKind_1.26/TestDogstatsdStandalone/metric___custom.metric{kube_deployment:dogstatsd-uds,kube_namespace:workload-dogstatsd-standalone} (120.46s)
            --- FAIL: TestKindSuite/TestKind_1.26/TestDogstatsdStandalone/metric___custom.metric{kube_deployment:dogstatsd-udp,kube_namespace:workload-dogstatsd-standalone} (120.51s)
        --- PASS: TestKindSuite/TestKind_1.26/TestNginx (106.29s)
            --- PASS: TestKindSuite/TestKind_1.26/TestNginx/metric___nginx.net.request_per_s{} (29.26s)
            --- PASS: TestKindSuite/TestKind_1.26/TestNginx/metric___network.http.response_time{} (24.50s)
            --- PASS: TestKindSuite/TestKind_1.26/TestNginx/metric___kubernetes_state.deployment.replicas_available{kube_deployment:nginx,kube_namespace:workload-nginx} (23.89s)
            --- PASS: TestKindSuite/TestKind_1.26/TestNginx/log___apps-nginx-server{} (11.60s)
            --- PASS: TestKindSuite/TestKind_1.26/TestNginx/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-nginx,kube_deployment:nginx} (17.05s)
        --- PASS: TestKindSuite/TestKind_1.26/TestPrometheus (24.88s)
            --- PASS: TestKindSuite/TestKind_1.26/TestPrometheus/metric___prom_gauge{kube_deployment:prometheus,kube_namespace:workload-prometheus} (24.88s)
        --- PASS: TestKindSuite/TestKind_1.26/TestRedis (68.42s)
            --- PASS: TestKindSuite/TestKind_1.26/TestRedis/metric___redis.net.instantaneous_ops_per_sec{} (18.43s)
            --- PASS: TestKindSuite/TestKind_1.26/TestRedis/metric___kubernetes_state.deployment.replicas_available{kube_deployment:redis,kube_namespace:workload-redis} (19.70s)
            --- PASS: TestKindSuite/TestKind_1.26/TestRedis/log___redis{} (11.60s)
            --- PASS: TestKindSuite/TestKind_1.26/TestRedis/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-redis,kube_deployment:redis} (18.69s)
        --- FAIL: TestKindSuite/TestKind_1.26/TestVersion (4.95s)
            --- FAIL: TestKindSuite/TestKind_1.26/TestVersion/Linux_agent_pods_are_running_the_good_version (2.22s)
            --- PASS: TestKindSuite/TestKind_1.26/TestVersion/Windows_agent_pods_are_running_the_good_version (0.13s)
            --- FAIL: TestKindSuite/TestKind_1.26/TestVersion/cluster_agent_pods_are_running_the_good_version (1.20s)
            --- FAIL: TestKindSuite/TestKind_1.26/TestVersion/cluster_checks_pods_are_running_the_good_version (1.40s)
        --- PASS: TestKindSuite/TestKind_1.26/TestZZUpAndRunning (11.07s)
            --- PASS: TestKindSuite/TestKind_1.26/TestZZUpAndRunning/agent_pods_are_ready_and_not_restarting (11.07s)
```
- Potential improvement: currently, we create 1 stack per kubernetes version. It would make sense, from resource optimisation standpoint, to have all resources created within one stack and run the tests for each version. However, this will require handling resources isolation based on kubernetes versions.
- Potential improvement: the tests for different kubernetes versions may be able to share the same fakeintake. However, currently it is not possible to distinguish sources via the fakeintake.


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
