### PR TITLE
[task] delete lock folders

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -179,18 +179,13 @@ def _clean_locks():
     lock_dir = os.path.join(Path.home(), ".pulumi", "locks")
 
     for entry in os.listdir(Path(lock_dir)):
-        subdir = os.path.join(lock_dir, entry)
-        if os.path.isdir(subdir):
-            for filename in os.listdir(Path(subdir)):
-                path = os.path.join(subdir, filename)
-                if os.path.isfile(path) and filename.endswith(".json"):
-                    os.remove(path)
-                    print(f"🗑️ Deleted lock: {path}")
-                elif os.path.isdir(path):
-                    shutil.rmtree(path)
-        elif os.path.isfile(subdir) and entry.endswith(".json"):
-            os.remove(subdir)
-            print(f"🗑️ Deleted lock: {subdir}")
+        path = os.path.join(lock_dir, entry)
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+            print(f"🗑️  Deleted lock: {path}")
+        elif os.path.isfile(path) and entry.endswith(".json"):
+            os.remove(path)
+            print(f"🗑️  Deleted lock: {path}")
 
 
 def _clean_stacks(ctx: Context):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Delete any folder under `$TEMP/.pulumi/locks` on invoke task `new-e2e.clean -l`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Current implementation is way too complex and was not deleting lock files. We can safely delete any entry under `locks`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
