### PR TITLE
Allow configuring check cancel timeout

### DIFF
--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -65,9 +65,7 @@ func GetWorkloadmetaInit() workloadmeta.InitHelper {
 	})
 }
 
-var (
-	collectorOnce sync.Once
-)
+var collectorOnce sync.Once
 
 // LoadCollector instantiate the collector and init the global state 'Coll'.
 //
@@ -77,7 +75,7 @@ func LoadCollector(senderManager sender.SenderManager) collector.Collector {
 	collectorOnce.Do(func() {
 		// create the Collector instance and start all the components
 		// NOTICE: this will also setup the Python environment, if available
-		Coll = collector.NewCollector(senderManager, GetPythonPaths()...)
+		Coll = collector.NewCollector(senderManager, config.Datadog.GetDuration("check_cancel_timeout"), GetPythonPaths()...)
 	})
 	return Coll
 }
@@ -85,7 +83,6 @@ func LoadCollector(senderManager sender.SenderManager) collector.Collector {
 // LoadComponents configures several common Agent components:
 // tagger, collector, scheduler and autodiscovery
 func LoadComponents(senderManager sender.SenderManager, secretResolver secrets.Component, confdPath string) {
-
 	confSearchPaths := []string{
 		confdPath,
 		filepath.Join(path.GetDistPath(), "conf.d"),

--- a/pkg/collector/collector_demux_test.go
+++ b/pkg/collector/collector_demux_test.go
@@ -33,7 +33,7 @@ type CollectorDemuxTestSuite struct {
 func (suite *CollectorDemuxTestSuite) SetupTest() {
 	log := fxutil.Test[log.Component](suite.T(), logimpl.MockModule())
 	suite.demux = aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 100*time.Hour)
-	suite.c = NewCollector(suite.demux).(*collector)
+	suite.c = NewCollector(suite.demux, 500*time.Millisecond).(*collector)
 
 	suite.c.Start()
 }

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -41,6 +41,7 @@ func (c *TestCheck) ID() checkid.ID {
 	}
 	return checkid.ID(c.String())
 }
+
 func (c *TestCheck) String() string {
 	if c.name != "" {
 		return c.name
@@ -84,7 +85,7 @@ type CollectorTestSuite struct {
 }
 
 func (suite *CollectorTestSuite) SetupTest() {
-	suite.c = NewCollector(aggregator.NewNoOpSenderManager()).(*collector)
+	suite.c = NewCollector(aggregator.NewNoOpSenderManager(), 500*time.Millisecond).(*collector)
 	suite.c.Start()
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -257,6 +257,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("enable_metadata_collection", true)
 	config.BindEnvAndSetDefault("enable_gohai", true)
 	config.BindEnvAndSetDefault("check_runners", int64(4))
+	config.BindEnvAndSetDefault("check_cancel_timeout", 500*time.Millisecond)
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
 	config.BindEnv("bind_host")
 	config.BindEnvAndSetDefault("health_port", int64(0))


### PR DESCRIPTION
### What does this PR do?

This PR allows to configure cancel timeout. Stil default to previous value of `500ms`.
It may be required to increase the timeout in certain situation (mostly Python check that are not getting back the GIL or doing long operations).

It's a temporary solution as, ideally, it should be per-check (like `Interval`), and should not block Scheduling/Unscheduling operation if not necessary (e.g. not the same check).

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

An internal grep on `timeout while calling check.Cancel() on check ID` will show if TO has been take into consideration.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
