### PR TITLE
Provide available CPUs for cpu pinning

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -304,7 +304,7 @@ upload_minimized_btfs_arm64:
   script:
     - echo "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE" > $STACK_DIR
     - pulumi login $(cat $STACK_DIR | tr -d '\n')
-    - inv -e kmt.gen-config --ci --arch=$ARCH --output-file=$VMCONFIG_FILE --sets=$TEST_SETS
+    - inv -e kmt.gen-config --ci --arch=$ARCH --output-file=$VMCONFIG_FILE --sets=$TEST_SETS --host-cpus=$AVAILABLE_CPUS
     - inv -e system-probe.start-microvms --provision --vmconfig=$VMCONFIG_FILE $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$ARCH-$CI_PIPELINE_ID --run-agent
     - cat $CI_PROJECT_DIR/stack.output
     - pulumi logout
@@ -332,6 +332,7 @@ kernel_matrix_testing_setup_env_arm64:
     ARCH: arm64
     AMI_ID_ARG: "--arm-ami-id=$KERNEL_MATRIX_TESTING_ARM_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-arm
+    AVAILABLE_CPUS: "64"
 
 kernel_matrix_testing_setup_env_x64:
   extends:
@@ -342,6 +343,7 @@ kernel_matrix_testing_setup_env_x64:
     ARCH: x86_64
     AMI_ID_ARG: "--x86-ami-id=$KERNEL_MATRIX_TESTING_X86_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-x86
+    AVAILABLE_CPUS: "96"
 
 .kernel_matrix_testing_run_tests:
   stage: kernel_matrix_testing

--- a/tasks/kernel_matrix_testing/vmconfig.py
+++ b/tasks/kernel_matrix_testing/vmconfig.py
@@ -581,6 +581,8 @@ def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, o
         set_ls = sets.split(",")
 
     if not ci:
+        if host_cpus is None:
+            host_cpus = multiprocessing.cpu_count()
         return gen_config_for_stack(
             ctx,
             stack,
@@ -591,7 +593,7 @@ def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, o
             ls_to_int(memory_ls),
             new,
             ci,
-            host_cpus,
+            int(host_cpus),
         )
 
     arch_ls = ["x86_64", "arm64"]
@@ -601,9 +603,9 @@ def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, o
     vms_to_generate = list_all_distro_normalized_vms(arch_ls)
 
     if host_cpus is None:
-        host_cpus = multiprocessing.cpu_count()
+        raise Exit("no value for available cpus provided")
     vm_config = generate_vmconfig(
-        {"vmsets": []}, vms_to_generate, ls_to_int(vcpu_ls), ls_to_int(memory_ls), set_ls, ci, host_cpus
+        {"vmsets": []}, vms_to_generate, ls_to_int(vcpu_ls), ls_to_int(memory_ls), set_ls, ci, int(host_cpus)
     )
 
     with open(output_file, "w") as f:

--- a/tasks/kernel_matrix_testing/vmconfig.py
+++ b/tasks/kernel_matrix_testing/vmconfig.py
@@ -2,6 +2,7 @@ import copy
 import itertools
 import json
 import math
+import multiprocessing
 import os
 import platform
 from urllib.parse import urlparse
@@ -360,6 +361,10 @@ def add_console(vmset):
     vmset["console_type"] = "file"
 
 
+def add_available_cpus(vmset, cpus):
+    vmset["host"] = {"available_cpus": cpus}
+
+
 def url_to_fspath(url):
     source = urlparse(url)
     if os.path.basename(source.path).endswith(".xz"):
@@ -429,7 +434,7 @@ def custom_version_prefix(version):
     return "lte_414" if lte_414(version) else "gt_414"
 
 
-def generate_vmconfig(vm_config, normalized_vm_defs, vcpu, memory, sets, ci):
+def generate_vmconfig(vm_config, normalized_vm_defs, vcpu, memory, sets, ci, host_cpus):
     with open(vmconfig_file) as f:
         vmconfig_template = json.load(f)
 
@@ -478,6 +483,8 @@ def generate_vmconfig(vm_config, normalized_vm_defs, vcpu, memory, sets, ci):
         if ci:
             add_console(vmset)
 
+        add_available_cpus(vmset, host_cpus)
+
     return vm_config
 
 
@@ -489,7 +496,7 @@ def ls_to_int(ls):
     return int_ls
 
 
-def gen_config_for_stack(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci):
+def gen_config_for_stack(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, host_cpus):
     stack = check_and_get_stack(stack)
     if not stack_exists(stack) and not init_stack:
         raise Exit(
@@ -520,7 +527,7 @@ def gen_config_for_stack(ctx, stack, vms, sets, init_stack, vcpu, memory, new, c
         orig_vm_config = f.read()
     vm_config = json.loads(orig_vm_config)
 
-    vm_config = generate_vmconfig(vm_config, normalized_vms, vcpu, memory, sets, ci)
+    vm_config = generate_vmconfig(vm_config, normalized_vms, vcpu, memory, sets, ci, host_cpus)
     vm_config_str = json.dumps(vm_config, indent=4)
 
     tmpfile = "/tmp/vm.json"
@@ -563,7 +570,7 @@ def list_all_distro_normalized_vms(archs):
     return vms
 
 
-def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file):
+def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file, host_cpus):
     vcpu_ls = vcpu.split(',')
     memory_ls = memory.split(',')
 
@@ -575,7 +582,16 @@ def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, o
 
     if not ci:
         return gen_config_for_stack(
-            ctx, stack, vms, set_ls, init_stack, ls_to_int(vcpu_ls), ls_to_int(memory_ls), new, ci
+            ctx,
+            stack,
+            vms,
+            set_ls,
+            init_stack,
+            ls_to_int(vcpu_ls),
+            ls_to_int(memory_ls),
+            new,
+            ci,
+            host_cpus,
         )
 
     arch_ls = ["x86_64", "arm64"]
@@ -584,7 +600,11 @@ def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, o
 
     vms_to_generate = list_all_distro_normalized_vms(arch_ls)
 
-    vm_config = generate_vmconfig({"vmsets": []}, vms_to_generate, ls_to_int(vcpu_ls), ls_to_int(memory_ls), set_ls, ci)
+    if host_cpus is None:
+        host_cpus = multiprocessing.cpu_count()
+    vm_config = generate_vmconfig(
+        {"vmsets": []}, vms_to_generate, ls_to_int(vcpu_ls), ls_to_int(memory_ls), set_ls, ci, host_cpus
+    )
 
     with open(output_file, "w") as f:
         f.write(json.dumps(vm_config, indent=4))

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -57,8 +57,9 @@ def gen_config(
     ci=False,
     arch="",
     output_file="vmconfig.json",
+    host_cpus=None,
 ):
-    vmconfig.gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file)
+    vmconfig.gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file, host_cpus)
 
 
 @task

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -22,7 +22,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20231213170602-24db45bffe8a
+	github.com/DataDog/test-infra-definitions v0.0.0-20231213180903-63ee1e4ca52f
 	github.com/aws/aws-sdk-go-v2 v1.24.0
 	github.com/aws/aws-sdk-go-v2/config v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -22,7 +22,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20231212184529-0b56d0bf4a3d
+	github.com/DataDog/test-infra-definitions v0.0.0-20231213170602-24db45bffe8a
 	github.com/aws/aws-sdk-go-v2 v1.24.0
 	github.com/aws/aws-sdk-go-v2/config v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -22,7 +22,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20231213180903-63ee1e4ca52f
+	github.com/DataDog/test-infra-definitions v0.0.0-20231213183458-3ac4bc000825
 	github.com/aws/aws-sdk-go-v2 v1.24.0
 	github.com/aws/aws-sdk-go-v2/config v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20231213180903-63ee1e4ca52f h1:INb7U4bPTGfr/EjTm0y3LrXefSI3ZXichOQZUPmnqb0=
-github.com/DataDog/test-infra-definitions v0.0.0-20231213180903-63ee1e4ca52f/go.mod h1:pS50ENq41vbF+59otYFA/k2xh4Xar4+ZQSiMgF1vMLQ=
+github.com/DataDog/test-infra-definitions v0.0.0-20231213183458-3ac4bc000825 h1:B8t1+D4G/zvFhMSHrE67KhkTqHpjif7+5Vl1YEwlwTo=
+github.com/DataDog/test-infra-definitions v0.0.0-20231213183458-3ac4bc000825/go.mod h1:pS50ENq41vbF+59otYFA/k2xh4Xar4+ZQSiMgF1vMLQ=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20231212184529-0b56d0bf4a3d h1:/ZCx9VdOSM6qV2PI4LtRL3Zrnk7F3WmU4OqTZ/sygM8=
-github.com/DataDog/test-infra-definitions v0.0.0-20231212184529-0b56d0bf4a3d/go.mod h1:pS50ENq41vbF+59otYFA/k2xh4Xar4+ZQSiMgF1vMLQ=
+github.com/DataDog/test-infra-definitions v0.0.0-20231213170602-24db45bffe8a h1:aPtTeU7nrevMFLEDlsKTl+Jv09arysUnihmhxcktJUM=
+github.com/DataDog/test-infra-definitions v0.0.0-20231213170602-24db45bffe8a/go.mod h1:pS50ENq41vbF+59otYFA/k2xh4Xar4+ZQSiMgF1vMLQ=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20231213170602-24db45bffe8a h1:aPtTeU7nrevMFLEDlsKTl+Jv09arysUnihmhxcktJUM=
-github.com/DataDog/test-infra-definitions v0.0.0-20231213170602-24db45bffe8a/go.mod h1:pS50ENq41vbF+59otYFA/k2xh4Xar4+ZQSiMgF1vMLQ=
+github.com/DataDog/test-infra-definitions v0.0.0-20231213180903-63ee1e4ca52f h1:INb7U4bPTGfr/EjTm0y3LrXefSI3ZXichOQZUPmnqb0=
+github.com/DataDog/test-infra-definitions v0.0.0-20231213180903-63ee1e4ca52f/go.mod h1:pS50ENq41vbF+59otYFA/k2xh4Xar4+ZQSiMgF1vMLQ=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR add the `available_cpus` field in the configuration file for KMT.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
