### PR TITLE
Fix deb artifact path causing docker build to become flaky

### DIFF
--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -84,8 +84,8 @@ agent_deb-x64-a7-auto:
     AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: amd64
-    DESTINATION_DEB: 'datadog-agent_7_amd64.deb'
-    DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_amd64.deb'
+    DESTINATION_DEB: 'datadog-agent_7_auto_amd64.deb'
+    DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_auto_amd64.deb'
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
     - export INSTALL_DIR=/opt/datadog/agents/$RELEASE_VERSION_7


### PR DESCRIPTION
### What does this PR do?

Changes the `DESTINATION_DEB*` variable of the `agent_deb-x64-a7-auto` gitlab job to something unique to this job

### Motivation

In a previous PR, a new job was introduced which uploaded an artifact named `datadog-agent_7_amd64.deb`. However, this name is already being used by the [`agent_deb-x64-a7` job](https://github.com/DataDog/datadog-agent/blob/main/.gitlab/package_build/deb.yml#L70-L71). This is resulting in a race condition when the `docker_build_agent7` job kicks off, if the `agent_deb-x64-a7-auto` finished after the `agent_deb-x64-a7` job

This is causing the `docker_build_agent7` job to become flaky, failing periodically on [this line](https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/Dockerfile#L93) because it cannot find the opt/datadog-agent/ folder, which looks like it is because [the new job is setting the INSTALL_DIR](https://github.com/DataDog/datadog-agent/pull/21436/files#diff-95f1f60442aaa91710c54da8467376d477f3f2f4b26729601f44b70cbda82bbaR91) to a different directory by default

### Additional Notes

Follow-up to [this PR](https://github.com/DataDog/datadog-agent/pull/21436)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
