### PR TITLE
[usm] Handle invalid perf events

### DIFF
--- a/pkg/network/protocols/events/consumer.go
+++ b/pkg/network/protocols/events/consumer.go
@@ -8,6 +8,7 @@
 package events
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"unsafe"
@@ -23,7 +24,10 @@ import (
 const (
 	batchMapSuffix  = "_batches"
 	eventsMapSuffix = "_batch_events"
+	sizeOfBatch     = int(unsafe.Sizeof(batch{}))
 )
+
+var errInvalidPerfEvent = errors.New("invalid perf event")
 
 // Consumer provides a standardized abstraction for consuming (batched) events from eBPF
 type Consumer[V any] struct {
@@ -40,11 +44,12 @@ type Consumer[V any] struct {
 	stopped     bool
 
 	// telemetry
-	metricGroup      *telemetry.MetricGroup
-	eventsCount      *telemetry.Counter
-	missesCount      *telemetry.Counter
-	kernelDropsCount *telemetry.Counter
-	batchSize        *atomic.Int64
+	metricGroup        *telemetry.MetricGroup
+	eventsCount        *telemetry.Counter
+	missesCount        *telemetry.Counter
+	kernelDropsCount   *telemetry.Counter
+	invalidEventsCount *telemetry.Counter
+	batchSize          *atomic.Int64
 }
 
 // NewConsumer instantiates a new event Consumer
@@ -85,6 +90,7 @@ func NewConsumer[V any](proto string, ebpf *manager.Manager, callback func([]V))
 	eventsCount := metricGroup.NewCounter("events_captured")
 	missesCount := metricGroup.NewCounter("events_missed")
 	kernelDropsCount := metricGroup.NewCounter("kernel_dropped_events")
+	invalidEventsCount := metricGroup.NewCounter("invalid_events")
 
 	return &Consumer[V]{
 		proto:       proto,
@@ -95,11 +101,12 @@ func NewConsumer[V any](proto string, ebpf *manager.Manager, callback func([]V))
 		batchReader: batchReader,
 
 		// telemetry
-		metricGroup:      metricGroup,
-		eventsCount:      eventsCount,
-		missesCount:      missesCount,
-		kernelDropsCount: kernelDropsCount,
-		batchSize:        atomic.NewInt64(0),
+		metricGroup:        metricGroup,
+		eventsCount:        eventsCount,
+		missesCount:        missesCount,
+		kernelDropsCount:   kernelDropsCount,
+		invalidEventsCount: invalidEventsCount,
+		batchSize:          atomic.NewInt64(0),
 	}, nil
 }
 
@@ -115,8 +122,12 @@ func (c *Consumer[V]) Start() {
 					return
 				}
 
-				b := batchFromEventData(dataEvent.Data)
-				c.process(dataEvent.CPU, b, false)
+				b, err := batchFromEventData(dataEvent.Data)
+				if err == nil {
+					c.process(dataEvent.CPU, b, false)
+				} else {
+					c.invalidEventsCount.Add(1)
+				}
 				dataEvent.Done()
 			case _, ok := <-c.handler.LostChannel:
 				if !ok {
@@ -174,7 +185,26 @@ func (c *Consumer[V]) Stop() {
 }
 
 func (c *Consumer[V]) process(cpu int, b *batch, syncing bool) {
+	// Determine the subset of data we're interested in as we might have read
+	// part of this batch before during a Sync() call
 	begin, end := c.offsets.Get(cpu, b, syncing)
+	length := end - begin
+
+	// This can happen in the context of a low-traffic host
+	// (that is, when no events are enqueued in a batch between two consecutive
+	// calls to `Sync()`)
+	if length == 0 {
+		return
+	}
+
+	// Sanity check. Ideally none of these conditions should evaluate to
+	// true. In case they do we bail out and increment the counter tracking
+	// invalid events
+	// TODO: investigate why we're sometimes getting invalid offsets
+	if length < 0 || length > int(b.Cap) {
+		c.invalidEventsCount.Add(1)
+		return
+	}
 
 	// telemetry stuff
 	c.batchSize.Store(int64(b.Cap))
@@ -182,15 +212,27 @@ func (c *Consumer[V]) process(cpu int, b *batch, syncing bool) {
 	c.kernelDropsCount.Add(int64(b.Dropped_events))
 
 	// generate a slice of type []V from the batch
-	length := end - begin
 	ptr := pointerToElement[V](b, begin)
 	events := unsafe.Slice(ptr, length)
 
 	c.callback(events)
 }
 
-func batchFromEventData(data []byte) *batch {
-	return (*batch)(unsafe.Pointer(&data[0]))
+func batchFromEventData(data []byte) (*batch, error) {
+	if len(data) < sizeOfBatch {
+		// For some reason the eBPF program sent us a perf event with a size
+		// different from what we're expecting.
+		//
+		// TODO: we're not ensuring that len(data) == sizeOfBatch, because we're
+		// consistently getting events that have a few bytes more than
+		// `sizeof(batch_event_t)`. I haven't determined yet where these extra
+		// bytes are coming from, but I already validated that is not padding
+		// coming from the clang/LLVM toolchain for alignment purposes, so it's
+		// something happening *after* the call to bpf_perf_event_output.
+		return nil, errInvalidPerfEvent
+	}
+
+	return (*batch)(unsafe.Pointer(&data[0])), nil
 }
 
 func pointerToElement[V any](b *batch, elementIdx int) *V {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Improve validation of USM perf events.

### Motivation

A recent PR (https://github.com/DataDog/datadog-agent/pull/21332) changed the way we "cast" a raw byte slice representing a perf event into a slice of USM events (`[]T` for an `event.Consumer[T]`), which may cause Go to panic if the perf event being sent from the kernel is invalid.

In this PR we add extra safe guards to ensure that we skip such events, but we still have to determine what is causing them in the first place. Having said that, these invalid events have been happening for a long time and therefore they're not related to a regression in our eBPF code, it just happens that they're now causing a panic since the aforementioned PR was merged.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
