### PR TITLE
Allow excluding checks from advanced dispatching

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -30,12 +30,13 @@ const (
 
 // dispatcher holds the management logic for cluster-checks
 type dispatcher struct {
-	store                 *clusterStore
-	nodeExpirationSeconds int64
-	extraTags             []string
-	clcRunnersClient      clusteragent.CLCRunnerClientInterface
-	advancedDispatching   bool
-	excludedChecks        map[string]struct{}
+	store                         *clusterStore
+	nodeExpirationSeconds         int64
+	extraTags                     []string
+	clcRunnersClient              clusteragent.CLCRunnerClientInterface
+	advancedDispatching           bool
+	excludedChecks                map[string]struct{}
+	excludedChecksFromDispatching map[string]struct{}
 }
 
 func newDispatcher() *dispatcher {
@@ -51,6 +52,15 @@ func newDispatcher() *dispatcher {
 		d.excludedChecks = make(map[string]struct{}, len(excludedChecks))
 		for _, checkName := range excludedChecks {
 			d.excludedChecks[checkName] = struct{}{}
+		}
+	}
+
+	excludedChecksFromDispatching := config.Datadog.GetStringSlice("cluster_checks.exclude_checks_from_dispatching")
+	// This option will almost always be empty
+	if len(excludedChecksFromDispatching) > 0 {
+		d.excludedChecksFromDispatching = make(map[string]struct{}, len(excludedChecksFromDispatching))
+		for _, checkName := range excludedChecksFromDispatching {
+			d.excludedChecksFromDispatching[checkName] = struct{}{}
 		}
 	}
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -216,15 +216,24 @@ func (d *dispatcher) updateRunnersStats() {
 			continue
 		}
 		node.Lock()
-		for id, checkStats := range stats {
+		for idStr, checkStats := range stats {
+			id := checkid.ID(idStr)
+
 			// Stats contain info about all the running checks on a node
 			// Node checks must be filtered from Cluster Checks
 			// so they can be included in calculating node Agent busyness and excluded from rebalancing decisions.
-			if _, found := d.store.idToDigest[checkid.ID(id)]; found {
+			if _, found := d.store.idToDigest[id]; found {
 				// Cluster check detected (exists in the Cluster Agent checks store)
 				log.Tracef("Check %s running on node %s is a cluster check", id, node.name)
 				checkStats.IsClusterCheck = true
-				stats[id] = checkStats
+				stats[idStr] = checkStats
+			}
+
+			checkName := checkid.IDToCheckName(id)
+			if _, found := d.excludedChecksFromDispatching[checkName]; found {
+				// TODO: We are abusing the IsClusterCheck field to mark checks that should be excluded from rebalancing decisions.
+				// It behaves the same way as we want to count them in rebalance decisions but we don't want to move them.
+				checkStats.IsClusterCheck = false
 			}
 		}
 		node.clcRunnerStats = stats

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -234,6 +234,7 @@ func (d *dispatcher) updateRunnersStats() {
 				// TODO: We are abusing the IsClusterCheck field to mark checks that should be excluded from rebalancing decisions.
 				// It behaves the same way as we want to count them in rebalance decisions but we don't want to move them.
 				checkStats.IsClusterCheck = false
+				stats[idStr] = checkStats
 			}
 		}
 		node.clcRunnerStats = stats

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -364,15 +364,12 @@ func (d *dispatcher) currentDistribution() checksDistribution {
 
 	for nodeName, nodeStoreInfo := range d.store.nodes {
 		for checkID, stats := range nodeStoreInfo.clcRunnerStats {
-			digest, found := d.store.idToDigest[checkid.ID(checkID)]
-			if !found { // Not a cluster check
+			if !stats.IsClusterCheck {
 				continue
 			}
 
 			minCollectionInterval := defaults.DefaultCheckInterval
-
-			conf := d.store.digestToConfig[digest]
-
+			conf := d.store.digestToConfig[d.store.idToDigest[checkid.ID(checkID)]]
 			if len(conf.Instances) > 0 {
 				commonOptions := integration.CommonInstanceConfig{}
 				err := yaml.Unmarshal(conf.Instances[0], &commonOptions)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1009,6 +1009,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_percentage_improvement", 10) // Experimental. Subject to change. Rebalance only if the distribution found improves the current one by this.
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})
+	config.BindEnvAndSetDefault("cluster_checks.exclude_checks_from_dispatching", []string{})
 
 	// Cluster check runner
 	config.BindEnvAndSetDefault("clc_runner_enabled", false)


### PR DESCRIPTION
### What does this PR do?

Allow to set `cluster_checks.exclude_checks_from_dispatching`, enabling to remove some checks from advanced dispatching.
Checks will be assigned to a random CLC and stay there until it dies.

It's normally accounted for in the stats for advanced dispatching, but not when using it with the new utilization rebalancing.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Set `cluster_checks.exclude_checks_from_dispatching` to some Cluster Check name.
You can run `agent clusterchecks rebalance --force` to try to force a move, although it's more likely to work if you use `utilization` rebalancing (`cluster_checks.rebalance_with_utilization`).
You can also scale-up the number of CLC.

In any case the excluded check should not move.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
