### PR TITLE
(fleet) scaffolding of apt updater packaging

### DIFF
--- a/omnibus/config/projects/updater.rb
+++ b/omnibus/config/projects/updater.rb
@@ -121,7 +121,7 @@ end
 exclude '\.git*'
 exclude 'bundler\/git'
 
-if linux_target? or windows_target?
+if linux_target?
   # the stripper will drop the symbols in a `.debug` folder in the installdir
   # we want to make sure that directory is not in the main build, while present
   # in the debug package.

--- a/omnibus/config/projects/updater.rb
+++ b/omnibus/config/projects/updater.rb
@@ -1,0 +1,130 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https:#www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+require "./lib/ostools.rb"
+
+name 'updater'
+package_name 'datadog-updater'
+license "Apache-2.0"
+license_file "../LICENSE"
+
+third_party_licenses "../LICENSE-3rdparty.csv"
+
+homepage 'http://www.datadoghq.com'
+
+INSTALL_DIR = '/opt/datadog/updater'
+
+install_dir INSTALL_DIR
+
+if redhat_target? || suse_target?
+  maintainer 'Datadog, Inc <package@datadoghq.com>'
+
+  # NOTE: with script dependencies, we only care about preinst/postinst/posttrans,
+  # because these would be used in a kickstart during package installation phase.
+  # All of the packages that we depend on in prerm/postrm scripts always have to be
+  # installed on all distros that we support, so we don't have to depend on them
+  # explicitly.
+
+  # postinst and posttrans scripts use a subset of preinst script deps, so we don't
+  # have to list them, because they'll already be there because of preinst
+  runtime_script_dependency :pre, "coreutils"
+  runtime_script_dependency :pre, "findutils"
+  runtime_script_dependency :pre, "grep"
+  if redhat_target?
+    runtime_script_dependency :pre, "glibc-common"
+    runtime_script_dependency :pre, "shadow-utils"
+  else
+    runtime_script_dependency :pre, "glibc"
+    runtime_script_dependency :pre, "shadow"
+  end
+else
+  maintainer 'Datadog Packages <package@datadoghq.com>'
+end
+
+if debian_target?
+  runtime_recommended_dependency 'datadog-signing-keys (>= 1:1.3.1)'
+end
+
+# build_version is computed by an invoke command/function.
+# We can't call it directly from there, we pass it through the environment instead.
+build_version ENV['PACKAGE_VERSION']
+
+build_iteration 1
+
+description 'Datadog Updater
+ The Datadog Updater is a lightweight process that updates the Datadog Agent
+ and Tracers.
+ 
+ See http://www.datadoghq.com/ for more information
+'
+
+# ------------------------------------
+# Generic package information
+# ------------------------------------
+
+# .deb specific flags
+package :deb do
+  vendor 'Datadog <package@datadoghq.com>'
+  epoch 1
+  license 'Apache License Version 2.0'
+  section 'utils'
+  priority 'extra'
+  if ENV.has_key?('DEB_SIGNING_PASSPHRASE') and not ENV['DEB_SIGNING_PASSPHRASE'].empty?
+    signing_passphrase "#{ENV['DEB_SIGNING_PASSPHRASE']}"
+    if ENV.has_key?('DEB_GPG_KEY_NAME') and not ENV['DEB_GPG_KEY_NAME'].empty?
+      gpg_key_name "#{ENV['DEB_GPG_KEY_NAME']}"
+    end
+  end
+end
+
+# ------------------------------------
+# Dependencies
+# ------------------------------------
+
+# creates required build directories
+dependency 'preparation'
+
+dependency 'updater'
+
+# version manifest file
+dependency 'version-manifest'
+
+if linux_target?
+  systemd_directory = "/usr/lib/systemd/system"
+  if debian_target?
+    systemd_directory = "/lib/systemd/system"
+  end
+  extra_package_file "#{systemd_directory}/datadog-updater.service"
+  extra_package_file "#{systemd_directory}/datadog-agent.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-exp.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-trace.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-trace-exp.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-process.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-process-exp.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-security.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-security-exp.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-sysprobe.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-sysprobe-exp.service"
+  extra_package_file "#{systemd_directory}/start-experiment.path"
+  extra_package_file "#{systemd_directory}/stop-experiment.path"
+  extra_package_file '/etc/datadog-agent/'
+  extra_package_file '/var/log/datadog/'
+end
+
+if linux_target?
+  if debian_target?
+    package_scripts_path "#{Omnibus::Config.project_root}/package-scripts/updater-deb"
+  end
+end
+
+exclude '\.git*'
+exclude 'bundler\/git'
+
+if linux_target? or windows_target?
+  # the stripper will drop the symbols in a `.debug` folder in the installdir
+  # we want to make sure that directory is not in the main build, while present
+  # in the debug package.
+  strip_build true
+  debug_path ".debug"  # the strip symbols will be in here
+end

--- a/omnibus/config/software/updater.rb
+++ b/omnibus/config/software/updater.rb
@@ -1,0 +1,88 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https:#www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+require './lib/ostools.rb'
+require 'pathname'
+
+name 'updater'
+
+source path: '..'
+relative_path 'src/github.com/DataDog/datadog-agent'
+
+build do
+  license :project_license
+
+  # set GOPATH on the omnibus source dir for this software
+  gopath = Pathname.new(project_dir) + '../../../..'
+  etc_dir = "/etc/datadog-agent"
+  gomodcache = Pathname.new("/modcache")
+  env = {
+    'GOPATH' => gopath.to_path,
+    'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
+  }
+
+  unless ENV["OMNIBUS_GOMODCACHE"].nil? || ENV["OMNIBUS_GOMODCACHE"].empty?
+    gomodcache = Pathname.new(ENV["OMNIBUS_GOMODCACHE"])
+    env["GOMODCACHE"] = gomodcache.to_path
+  end
+
+  # include embedded path (mostly for `pkg-config` binary)
+  env = with_embedded_path(env)
+
+  major_version_arg = "$MAJOR_VERSION"
+
+  if linux_target?
+    command "invoke updater.build --rebuild --major-version #{major_version_arg}", env: env
+    mkdir "#{install_dir}/bin"
+    mkdir "#{install_dir}/run/"
+
+
+    # Config
+    mkdir '/etc/datadog-agent'
+    mkdir "/etc/init"
+    mkdir "/var/log/datadog"
+
+    move 'bin/agent/dist/datadog.yaml', '/etc/datadog-agent/datadog.yaml.example'
+    move 'bin/agent/dist/conf.d', '/etc/datadog-agent/'
+    copy 'bin/updater', "#{install_dir}/bin/"
+
+    # Systemd
+    systemdPath = "/lib/systemd/system/"
+    if not debian_target?
+      mkdir "/usr/lib/systemd/system/"
+      systemdPath = "/usr/lib/systemd/system/"
+    end
+    templateToFile = {
+      "datadog-agent.service.erb" => "datadog-agent.service",
+      "datadog-agent-exp.service.erb" => "datadog-agent-exp.service",
+      "datadog-agent-trace.service.erb" => "datadog-agent-trace.service",
+      "datadog-agent-trace-exp.service.erb" => "datadog-agent-trace-exp.service",
+      "datadog-agent-process.service.erb" => "datadog-agent-process.service",
+      "datadog-agent-process-exp.service.erb" => "datadog-agent-process-exp.service",
+      "datadog-agent-security.service.erb" => "datadog-agent-security.service",
+      "datadog-agent-security-exp.service.erb" => "datadog-agent-security-exp.service",
+      "datadog-agent-sysprobe.service.erb" => "datadog-agent-sysprobe.service",
+      "datadog-agent-sysprobe-exp.service.erb" => "datadog-agent-sysprobe-exp.service",
+      "start-experiment.path.erb" => "start-experiment.path",
+      "stop-experiment.path.erb" => "stop-experiment.path",
+      "datadog-updater.service.erb" => "datadog-updater.service",
+    }
+    templateToFile.each do |template, file|
+      erb source: template,
+         dest: systemdPath + file,
+         mode: 0644,
+         vars: { install_dir: install_dir, etc_dir: etc_dir }
+  end
+
+  end
+  block do
+  end
+
+  # The file below is touched by software builds that don't put anything in the installation
+  # directory (libgcc right now) so that the git_cache gets updated let's remove it from the
+  # final package
+  delete "#{install_dir}/uselessfile"
+end
+

--- a/omnibus/config/software/updater.rb
+++ b/omnibus/config/software/updater.rb
@@ -31,10 +31,8 @@ build do
   # include embedded path (mostly for `pkg-config` binary)
   env = with_embedded_path(env)
 
-  major_version_arg = "$MAJOR_VERSION"
-
   if linux_target?
-    command "invoke updater.build --rebuild --major-version #{major_version_arg}", env: env
+    command "invoke updater.build --rebuild", env: env
     mkdir "#{install_dir}/bin"
     mkdir "#{install_dir}/run/"
 
@@ -74,10 +72,8 @@ build do
          dest: systemdPath + file,
          mode: 0644,
          vars: { install_dir: install_dir, etc_dir: etc_dir }
-  end
+    end
 
-  end
-  block do
   end
 
   # The file below is touched by software builds that don't put anything in the installation

--- a/omnibus/config/templates/updater/datadog-agent-exp.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-exp.service.erb
@@ -1,0 +1,22 @@
+[Unit]
+Description=Datadog Agent Experiment
+After=network.target
+OnFailure=datadog-agent.service 
+Conflicts=datadog-agent.service 
+Before=datadog-agent.service 
+JobTimeoutSec=3000
+Wants=datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service
+
+[Service]
+Type=oneshot
+PIDFile=<%= install_dir %>/run/agent.pid
+User=dd-agent
+EnvironmentFile=-<%= etc_dir %>/environment
+ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/agent run -p <%= install_dir %>/run/agent.pid
+ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/agent run -p <%= install_dir %>/run/agent.pid
+ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/agent run -p <%= install_dir %>/run/agent.pid
+ExecStart=/bin/false
+ExecStop=/bin/false
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-agent-process-exp.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-process-exp.service.erb
@@ -1,0 +1,19 @@
+[Unit]
+Description=Datadog Process Agent Experiment
+After=network.target
+BindsTo=datadog-agent-exp.service
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/process-agent.pid
+User=dd-agent
+Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
+ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/embedded/bin/process-agent --cfgpath=<%= etc_dir %>/datadog.yaml --sysprobe-config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/process-agent.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-agent-process.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-process.service.erb
@@ -1,0 +1,19 @@
+[Unit]
+Description=Datadog Process Agent
+After=network.target datadog-agent.service
+BindsTo=datadog-agent.service
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/process-agent.pid
+User=dd-agent
+Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
+ExecStart=<%= install_dir %>/agent_entrypoints/agent/embedded/bin/process-agent --cfgpath=<%= etc_dir %>/datadog.yaml --sysprobe-config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/process-agent.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-agent-security-exp.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-security-exp.service.erb
@@ -1,0 +1,19 @@
+[Unit]
+Description=Datadog Security Agent Experiment
+After=network.target
+BindsTo=datadog-agent-exp.service
+ConditionPathExists=<%= etc_dir %>/security-agent.yaml
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/security-agent.pid
+Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
+ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/embedded/bin/security-agent -c <%= etc_dir %>/datadog.yaml --pidfile <%= install_dir %>/run/security-agent.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-agent-security.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-security.service.erb
@@ -1,0 +1,19 @@
+[Unit]
+Description=Datadog Security Agent
+After=network.target datadog-agent.service
+BindsTo=datadog-agent.service
+ConditionPathExists=<%= etc_dir %>/security-agent.yaml
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/security-agent.pid
+Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
+ExecStart=<%= install_dir %>/agent_entrypoints/agent/embedded/bin/security-agent -c <%= etc_dir %>/datadog.yaml --pidfile <%= install_dir %>/run/security-agent.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-agent-sysprobe-exp.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-sysprobe-exp.service.erb
@@ -1,0 +1,20 @@
+[Unit]
+Description=Datadog System Probe Experiment
+Requires=sys-kernel-debug.mount
+Before=datadog-agent.service
+After=network.target sys-kernel-debug.mount
+BindsTo=datadog-agent-exp.service
+ConditionPathExists=<%= etc_dir %>/system-probe.yaml
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/system-probe.pid
+Restart=on-failure
+ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/embedded/bin/system-probe run --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-agent-sysprobe.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-sysprobe.service.erb
@@ -1,0 +1,20 @@
+[Unit]
+Description=Datadog System Probe
+Requires=sys-kernel-debug.mount
+Before=datadog-agent.service
+After=network.target sys-kernel-debug.mount
+BindsTo=datadog-agent.service
+ConditionPathExists=<%= etc_dir %>/system-probe.yaml
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/system-probe.pid
+Restart=on-failure
+ExecStart=<%= install_dir %>/agent_entrypoints/agent/embedded/bin/system-probe run --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-agent-trace-exp.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-trace-exp.service.erb
@@ -1,0 +1,18 @@
+[Unit]
+Description=Datadog Trace Agent Experiment
+BindsTo=datadog-agent-exp.service
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/trace-agent.pid
+User=dd-agent
+Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
+ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/embedded/bin/trace-agent --config <%= etc_dir %>/datadog.yaml --pidfile <%= install_dir %>/run/trace-agent.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-agent-trace.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-trace.service.erb
@@ -1,0 +1,19 @@
+[Unit]
+Description=Datadog Trace Agent (APM)
+After=datadog-agent.service
+BindsTo=datadog-agent.service
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/trace-agent.pid
+User=dd-agent
+Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
+ExecStart=<%= install_dir %>/agent_entrypoints/agent/embedded/bin/trace-agent --config <%= etc_dir %>/datadog.yaml --pidfile <%= install_dir %>/run/trace-agent.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-agent.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent.service.erb
@@ -1,0 +1,21 @@
+[Unit]
+Description=Datadog Agent
+After=network.target
+Wants=datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service
+Conflicts=datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service
+Before=datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/agent.pid
+User=dd-agent
+Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
+ExecStart=<%= install_dir %>/agent_entrypoints/agent/agent run -p <%= install_dir %>/run/agent.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-updater.service.erb
+++ b/omnibus/config/templates/updater/datadog-updater.service.erb
@@ -1,0 +1,18 @@
+[Unit]
+Description=Datadog Updater
+After=network.target
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/updater.pid
+User=dd-agent
+Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
+ExecStart=<%= install_dir %>/bin/updater/updater run -p <%= install_dir %>/run/updater.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/start-experiment.path.erb
+++ b/omnibus/config/templates/updater/start-experiment.path.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description="Monitor requests to start experiment"
+
+[PATH]
+PathModifed=<%= install_dir %>/systemd_commands/start_experiment
+Unit=datadog-agent-exp
+
+[Install]
+WantedBy=multi-user.target
+

--- a/omnibus/config/templates/updater/stop-experiment.path.erb
+++ b/omnibus/config/templates/updater/stop-experiment.path.erb
@@ -1,0 +1,9 @@
+[Unit]
+Description="Monitor requests to stop experiment
+
+[PATH]
+PathModifed=<%= install_dir %>/systemd_commands/stop_experiment
+Unit=datadog-agent
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -12,18 +12,18 @@ add_user_and_group() {
     # Only create group and/or user if they don't already exist
     NAME=$1
     HOME_DIR=$2
-    getent group $NAME >/dev/null || (echo "Creating $NAME group" && addgroup --system $NAME --quiet)
+    getent group "$NAME" >/dev/null || (echo "Creating $NAME group" && addgroup --system "$NAME" --quiet)
     set +e
-    id -u $NAME >/dev/null 2>&1
+    id -u "$NAME" >/dev/null 2>&1
     USER_EXISTS=$?
     set -e
     if [ ! $USER_EXISTS -eq 0 ]; then
         echo "Creating $NAME user"
-        adduser --system $NAME --disabled-login --shell /usr/sbin/nologin --home $HOME_DIR --no-create-home --group --quiet
-    elif id -nG $NAME | grep --invert-match --word-regexp --quiet '$NAME'; then
+        adduser --system "$NAME" --disabled-login --shell /usr/sbin/nologin --home "$HOME_DIR" --no-create-home --group --quiet
+    elif id -nG "$NAME" | grep --invert-match --word-regexp --quiet '$NAME'; then
         # User exists but is not part of the $NAME group
         echo "Adding $NAME user to $NAME group"
-        usermod -g $NAME $NAME
+        usermod -g "$NAME" "$NAME"
     fi
 }
 

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -1,0 +1,111 @@
+#!/bin/sh
+#
+# Perform necessary datadog-updater setup steps after package is installed.
+#
+# .deb: STEP 5 of 5
+
+INSTALL_DIR=/opt/datadog
+LOG_DIR=/var/log/datadog
+CONFIG_DIR=/etc/datadog-agent
+
+add_user_and_group() {
+    # Only create group and/or user if they don't already exist
+    NAME=$1
+    HOME_DIR=$2
+    getent group $NAME >/dev/null || (echo "Creating $NAME group" && addgroup --system $NAME --quiet)
+    set +e
+    id -u $NAME >/dev/null 2>&1
+    USER_EXISTS=$?
+    set -e
+    if [ ! $USER_EXISTS -eq 0 ]; then
+        echo "Creating $NAME user"
+        adduser --system $NAME --disabled-login --shell /usr/sbin/nologin --home $HOME_DIR --no-create-home --group --quiet
+    elif id -nG $NAME | grep --invert-match --word-regexp --quiet '$NAME'; then
+        # User exists but is not part of the $NAME group
+        echo "Adding $NAME user to $NAME group"
+        usermod -g $NAME $NAME
+    fi
+}
+
+enable_stable_agents() {
+    if command -v systemctl >/dev/null 2>&1; then
+        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
+        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-updater || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-process || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-sysprobe || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-trace || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-security || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent || true
+        # experiment agents are not enabled as we don't systemctl enable them
+    fi
+
+
+}
+
+set -e
+case "$1" in
+    configure)
+        add_user_and_group 'dd-agent' $INSTALL_DIR/agents
+        add_user_and_group 'dd-updater' $INSTALL_DIR
+        usermod -g dd-agent dd-updater
+    ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+    *)
+    ;;
+esac
+#DEBHELPER#
+
+# Set the installation information if not already present;
+# This is done in posttrans for .rpm packages
+if [ ! -f "$CONFIG_DIR/install_info" ]; then
+
+    if command -v dpkg >/dev/null 2>&1 && command -v dpkg-query >/dev/null 2>&1; then
+        tool=dpkg
+        tool_version=dpkg-$(dpkg-query --showformat='${Version}' --show dpkg  | cut -d "." -f 1-3 || echo "unknown")
+    else
+        tool=unknown
+        tool_version=unknown
+    fi
+
+    install_info_content="---
+install_method:
+  tool: $tool
+  tool_version: $tool_version
+  installer_version: deb_package
+"
+    echo "$install_info_content" > $CONFIG_DIR/install_info
+fi
+
+# Set proper rights to the dd-agent user
+chown -R dd-agent:dd-agent ${CONFIG_DIR}
+chown -R dd-agent:dd-agent ${LOG_DIR}
+chown -R dd-updater:dd-updater ${INSTALL_DIR}
+
+chmod -R 755 ${INSTALL_DIR}
+
+# Make system-probe configs read-only
+chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true
+if [ -f "$CONFIG_DIR/system-probe.yaml" ]; then
+    chmod 0440 ${CONFIG_DIR}/system-probe.yaml || true
+fi
+
+# Make security-agent config read-only
+chmod 0440 ${CONFIG_DIR}/security-agent.yaml.example || true
+if [ -f "$CONFIG_DIR/security-agent.yaml" ]; then
+    chmod 0440 ${CONFIG_DIR}/security-agent.yaml || true
+fi
+
+if [ -d "$CONFIG_DIR/compliance.d" ]; then
+    chown -R root:root ${CONFIG_DIR}/compliance.d || true
+fi
+
+if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
+    chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
+fi
+
+# start udpater
+SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process-exp || true
+enable_stable_agents
+
+exit 0

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -105,7 +105,7 @@ if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
 fi
 
 # start udpater
-SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process-exp || true
+SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-updater || true
 enable_stable_agents
 
 exit 0

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -73,6 +73,7 @@ install_method:
   tool: $tool
   tool_version: $tool_version
   installer_version: deb_package
+  installer: updater
 "
     echo "$install_info_content" > $CONFIG_DIR/install_info
 fi

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -20,7 +20,7 @@ add_user_and_group() {
     if [ ! $USER_EXISTS -eq 0 ]; then
         echo "Creating $NAME user"
         adduser --system "$NAME" --disabled-login --shell /usr/sbin/nologin --home "$HOME_DIR" --no-create-home --group --quiet
-    elif id -nG "$NAME" | grep --invert-match --word-regexp --quiet '$NAME'; then
+    elif id -nG "$NAME" | grep --invert-match --word-regexp --quiet "$NAME"; then
         # User exists but is not part of the $NAME group
         echo "Adding $NAME user to $NAME group"
         usermod -g "$NAME" "$NAME"

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -30,7 +30,6 @@ add_user_and_group() {
 enable_stable_agents() {
     if command -v systemctl >/dev/null 2>&1; then
         # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
-        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-updater || true
         SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-process || true
         SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-sysprobe || true
         SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-trace || true
@@ -106,6 +105,7 @@ if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
 fi
 
 # start udpater
+SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-updater || true
 SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-updater || true
 enable_stable_agents
 

--- a/omnibus/package-scripts/updater-deb/postinst-dbg
+++ b/omnibus/package-scripts/updater-deb/postinst-dbg
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Perform necessary datadog-updater setup steps after package is installed.
+#
+# .deb: STEP 2 of 5
+
+## NOTHING HERE
+
+exit 0

--- a/omnibus/package-scripts/updater-deb/postrm
+++ b/omnibus/package-scripts/updater-deb/postrm
@@ -15,7 +15,7 @@ case "$1" in
         echo "Deleting dd-agent user"
         deluser dd-agent --quiet
         echo "Deleting dd-updater user"
-	deluser dd-updater --quiet
+        deluser dd-updater --quiet
         echo "Deleting dd-agent group"
         (getent group dd-agent >/dev/null && delgroup dd-agent --quiet) || true
         echo "Deleting dd-updater group"

--- a/omnibus/package-scripts/updater-deb/postrm
+++ b/omnibus/package-scripts/updater-deb/postrm
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Perform necessary datadog-updater removal steps after package is uninstalled.
+#
+# .deb: STEP 3 of 5
+
+INSTALL_DIR=/opt/datadog
+LOG_DIR=/var/log/datadog
+CONFIG_DIR=/etc/datadog-agent
+
+set -e
+
+case "$1" in
+    purge)
+        echo "Deleting dd-agent user"
+        deluser dd-agent --quiet
+        echo "Deleting dd-updater user"
+	deluser dd-updater --quiet
+        echo "Deleting dd-agent group"
+        (getent group dd-agent >/dev/null && delgroup dd-agent --quiet) || true
+        echo "Deleting dd-updater group"
+        (getent group dd-updater >/dev/null && delgroup dd-updater --quiet) || true
+        echo "Force-deleting $INSTALL_DIR"
+        rm -rf $INSTALL_DIR
+        rm -rf $LOG_DIR
+        rm -rf $CONFIG_DIR
+    ;;
+    remove)
+        rm "$CONFIG_DIR/install_info" || true
+    ;;
+    *)
+    ;;
+esac
+
+exit 0

--- a/omnibus/package-scripts/updater-deb/postrm-dbg
+++ b/omnibus/package-scripts/updater-deb/postrm-dbg
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Perform necessary datadog-updater removal steps after package is uninstalled.
+#
+# .deb: STEP 3 of 5
+
+## NOTHING HERE
+
+exit 0

--- a/omnibus/package-scripts/updater-deb/preinst
+++ b/omnibus/package-scripts/updater-deb/preinst
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+#
+# .deb: STEP 2 of 5
+
+
+stop_agents()
+{
+    if command -v systemctl >/dev/null 2>&1; then
+        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
+        
+        # starting with experiment agents to avoid retriggering agent
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process-exp || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-sysprobe-exp || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-trace-exp || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-security-exp || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-exp || true
+
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-sysprobe || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-trace || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-security || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent || true
+        
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
+    fi
+}
+
+stop_agents
+exit 0

--- a/omnibus/package-scripts/updater-deb/preinst
+++ b/omnibus/package-scripts/updater-deb/preinst
@@ -4,27 +4,6 @@
 # .deb: STEP 2 of 5
 
 
-stop_agents()
-{
-    if command -v systemctl >/dev/null 2>&1; then
-        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
-        
-        # starting with experiment agents to avoid retriggering agent
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process-exp || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-sysprobe-exp || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-trace-exp || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-security-exp || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-exp || true
+SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
 
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-sysprobe || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-trace || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-security || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent || true
-        
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
-    fi
-}
-
-stop_agents
 exit 0

--- a/omnibus/package-scripts/updater-deb/preinst-dbg
+++ b/omnibus/package-scripts/updater-deb/preinst-dbg
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Perform necessary datadog-updater setup steps before package is installed.
+#
+# .deb: STEP 2 of 5
+
+## NOTHING HERE
+
+exit 0

--- a/omnibus/package-scripts/updater-deb/prerm
+++ b/omnibus/package-scripts/updater-deb/prerm
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+#
+# .deb: STEP 1 of 5
+
+
+stop_agents()
+{
+    if command -v systemctl >/dev/null 2>&1; then
+        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
+        
+        # starting with experiment agents to avoid retriggering agent
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process-exp || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-sysprobe-exp || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-trace-exp || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-security-exp || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-exp || true
+
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-sysprobe || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-trace || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-security || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent || true
+        
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
+    fi
+}
+
+deregister_agents()
+{
+    if command -v systemctl >/dev/null 2>&1; then
+        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-updater || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-process || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-sysprobe || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-trace || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-security || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent || true
+        
+        # experiment agents are not disabled as we don't systemctl enable them
+    fi
+}
+
+stop_agents
+deregister_agents
+
+exit 0

--- a/omnibus/package-scripts/updater-deb/prerm
+++ b/omnibus/package-scripts/updater-deb/prerm
@@ -21,8 +21,6 @@ stop_agents()
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-trace || true
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-security || true
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent || true
-        
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
     fi
 }
 
@@ -30,7 +28,6 @@ deregister_agents()
 {
     if command -v systemctl >/dev/null 2>&1; then
         # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-updater || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-process || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-sysprobe || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-trace || true
@@ -40,8 +37,17 @@ deregister_agents()
         # experiment agents are not disabled as we don't systemctl enable them
     fi
 }
-
-stop_agents
-deregister_agents
+case "$1" in
+    remove)
+        stop_agents
+        deregister_agents
+    ;;
+    upgrade)
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-updater || true
+    ;;
+    *)
+    ;;
+esac
 
 exit 0

--- a/omnibus/package-scripts/updater-deb/prerm-dbg
+++ b/omnibus/package-scripts/updater-deb/prerm-dbg
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Perform necessary datadog-updater setup steps prior to remove the old package.
+#
+# .deb: STEP 1 of 5
+
+## NOTHING HERE
+
+exit 0
+~

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -32,6 +32,7 @@ from . import (
     system_probe,
     systray,
     trace_agent,
+    updater,
     vscode,
 )
 from .build_tags import audit_tag_impact, print_default_build_tags
@@ -151,6 +152,7 @@ ns.add_collection(new_e2e_tests)
 ns.add_collection(fakeintake)
 ns.add_collection(kmt)
 ns.add_collection(diff)
+ns.add_collection(updater)
 ns.configure(
     {
         'run': {

--- a/tasks/updater.py
+++ b/tasks/updater.py
@@ -10,16 +10,10 @@ from invoke import task
 
 from .build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
 from .go import deps
-from .utils import (
-    REPO_PATH,
-    bin_name,
-    get_build_flags,
-    get_version,
-    load_release_versions,
-    timed,
-)
+from .utils import REPO_PATH, bin_name, get_build_flags, get_version, load_release_versions, timed
 
 BIN_PATH = os.path.join(".", "bin", "updater")
+
 
 @task
 def build(
@@ -57,6 +51,7 @@ def build(
     cmd += f"-o {updater_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/updater"
 
     ctx.run(cmd, env=env)
+
 
 def get_omnibus_env(
     ctx,

--- a/tasks/updater.py
+++ b/tasks/updater.py
@@ -13,6 +13,7 @@ from .go import deps
 from .utils import REPO_PATH, bin_name, get_build_flags, get_version, load_release_versions, timed
 
 BIN_PATH = os.path.join(".", "bin", "updater")
+MAJOR_VERSION = '7'
 
 
 @task
@@ -22,7 +23,6 @@ def build(
     race=False,
     build_include=None,
     build_exclude=None,
-    major_version='7',
     arch="x64",
     go_mod="mod",
 ):
@@ -30,7 +30,7 @@ def build(
     Build the updater.
     """
 
-    ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version)
+    ldflags, gcflags, env = get_build_flags(ctx, major_version=MAJOR_VERSION)
 
     build_include = (
         get_default_build_tags(
@@ -57,7 +57,6 @@ def get_omnibus_env(
     ctx,
     skip_sign=False,
     release_version="nightly",
-    major_version='7',
     hardened_runtime=False,
     go_mod_cache=None,
 ):
@@ -70,8 +69,7 @@ def get_omnibus_env(
     if go_mod_cache:
         env['OMNIBUS_GOMODCACHE'] = go_mod_cache
 
-    if int(major_version) > 6:
-        env['OMNIBUS_OPENSSL_SOFTWARE'] = 'openssl3'
+    env['OMNIBUS_OPENSSL_SOFTWARE'] = 'openssl3'
 
     env_override = ['INTEGRATIONS_CORE_VERSION', 'OMNIBUS_SOFTWARE_VERSION']
     for key in env_override:
@@ -90,9 +88,9 @@ def get_omnibus_env(
         env['HARDENED_RUNTIME_MAC'] = 'true'
 
     env['PACKAGE_VERSION'] = get_version(
-        ctx, include_git=True, url_safe=True, major_version=major_version, include_pipeline_id=True
+        ctx, include_git=True, url_safe=True, major_version=MAJOR_VERSION, include_pipeline_id=True
     )
-    env['MAJOR_VERSION'] = major_version
+    env['MAJOR_VERSION'] = MAJOR_VERSION
 
     return env
 
@@ -151,7 +149,6 @@ def omnibus_build(
     skip_deps=False,
     skip_sign=False,
     release_version="nightly",
-    major_version='7',
     omnibus_s3_cache=False,
     hardened_runtime=False,
     go_mod_cache=None,
@@ -170,7 +167,6 @@ def omnibus_build(
         ctx,
         skip_sign=skip_sign,
         release_version=release_version,
-        major_version=major_version,
         hardened_runtime=hardened_runtime,
         go_mod_cache=go_mod_cache,
     )

--- a/tasks/updater.py
+++ b/tasks/updater.py
@@ -54,7 +54,7 @@ def build(
     go_build_tags = " ".join(build_tags)
     updater_bin = os.path.join(BIN_PATH, bin_name("updater"))
     cmd = f"go build -mod={go_mod} {race_opt} {build_type} -tags \"{go_build_tags}\" "
-    cmd += f"-o {updater_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/rc-updater/main"
+    cmd += f"-o {updater_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/updater"
 
     ctx.run(cmd, env=env)
 

--- a/tasks/updater.py
+++ b/tasks/updater.py
@@ -150,7 +150,6 @@ def bundle_install_omnibus(ctx, gem_path=None, env=None):
 )
 def omnibus_build(
     ctx,
-    agent_binaries=False,
     log_level="info",
     base_dir=None,
     gem_path=None,

--- a/tasks/updater.py
+++ b/tasks/updater.py
@@ -1,0 +1,204 @@
+"""
+Updater namespaced tasks
+"""
+
+
+import os
+import sys
+
+from invoke import task
+
+from .build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
+from .go import deps
+from .utils import (
+    REPO_PATH,
+    bin_name,
+    get_build_flags,
+    get_version,
+    load_release_versions,
+    timed,
+)
+
+BIN_PATH = os.path.join(".", "bin", "updater")
+
+@task
+def build(
+    ctx,
+    rebuild=False,
+    race=False,
+    build_include=None,
+    build_exclude=None,
+    major_version='7',
+    arch="x64",
+    go_mod="mod",
+):
+    """
+    Build the updater.
+    """
+
+    ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version)
+
+    build_include = (
+        get_default_build_tags(
+            build="updater",
+        )  # TODO/FIXME: Arch not passed to preserve build tags. Should this be fixed?
+        if build_include is None
+        else filter_incompatible_tags(build_include.split(","), arch=arch)
+    )
+    build_exclude = [] if build_exclude is None else build_exclude.split(",")
+
+    build_tags = get_build_tags(build_include, build_exclude)
+
+    race_opt = "-race" if race else ""
+    build_type = "-a" if rebuild else ""
+    go_build_tags = " ".join(build_tags)
+    updater_bin = os.path.join(BIN_PATH, bin_name("updater"))
+    cmd = f"go build -mod={go_mod} {race_opt} {build_type} -tags \"{go_build_tags}\" "
+    cmd += f"-o {updater_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/rc-updater/main"
+
+    ctx.run(cmd, env=env)
+
+def get_omnibus_env(
+    ctx,
+    skip_sign=False,
+    release_version="nightly",
+    major_version='7',
+    hardened_runtime=False,
+    go_mod_cache=None,
+):
+    env = load_release_versions(ctx, release_version)
+
+    # If the host has a GOMODCACHE set, try to reuse it
+    if not go_mod_cache and os.environ.get('GOMODCACHE'):
+        go_mod_cache = os.environ.get('GOMODCACHE')
+
+    if go_mod_cache:
+        env['OMNIBUS_GOMODCACHE'] = go_mod_cache
+
+    if int(major_version) > 6:
+        env['OMNIBUS_OPENSSL_SOFTWARE'] = 'openssl3'
+
+    env_override = ['INTEGRATIONS_CORE_VERSION', 'OMNIBUS_SOFTWARE_VERSION']
+    for key in env_override:
+        value = os.environ.get(key)
+        # Only overrides the env var if the value is a non-empty string.
+        if value:
+            env[key] = value
+
+    if sys.platform == 'darwin':
+        # Target MacOS 10.12
+        env['MACOSX_DEPLOYMENT_TARGET'] = '10.12'
+
+    if skip_sign:
+        env['SKIP_SIGN_MAC'] = 'true'
+    if hardened_runtime:
+        env['HARDENED_RUNTIME_MAC'] = 'true'
+
+    env['PACKAGE_VERSION'] = get_version(
+        ctx, include_git=True, url_safe=True, major_version=major_version, include_pipeline_id=True
+    )
+    env['MAJOR_VERSION'] = major_version
+
+    return env
+
+
+def omnibus_run_task(ctx, task, target_project, base_dir, env, omnibus_s3_cache=False, log_level="info"):
+    with ctx.cd("omnibus"):
+        overrides_cmd = ""
+        if base_dir:
+            overrides_cmd = f"--override=base_dir:{base_dir}"
+
+        omnibus = "bundle exec omnibus"
+        if omnibus_s3_cache:
+            populate_s3_cache = "--populate-s3-cache"
+        else:
+            populate_s3_cache = ""
+
+        cmd = "{omnibus} {task} {project_name} --log-level={log_level} {populate_s3_cache} {overrides}"
+        args = {
+            "omnibus": omnibus,
+            "task": task,
+            "project_name": target_project,
+            "log_level": log_level,
+            "overrides": overrides_cmd,
+            "populate_s3_cache": populate_s3_cache,
+        }
+
+        ctx.run(cmd.format(**args), env=env)
+
+
+def bundle_install_omnibus(ctx, gem_path=None, env=None):
+    with ctx.cd("omnibus"):
+        # make sure bundle install starts from a clean state
+        try:
+            os.remove("Gemfile.lock")
+        except Exception:
+            pass
+
+        cmd = "bundle install"
+        if gem_path:
+            cmd += f" --path {gem_path}"
+        ctx.run(cmd, env=env)
+
+
+# hardened-runtime needs to be set to False to build on MacOS < 10.13.6, as the -o runtime option is not supported.
+@task(
+    help={
+        'skip-sign': "On macOS, use this option to build an unsigned package if you don't have Datadog's developer keys.",
+        'hardened-runtime': "On macOS, use this option to enforce the hardened runtime setting, adding '-o runtime' to all codesign commands",
+    }
+)
+def omnibus_build(
+    ctx,
+    agent_binaries=False,
+    log_level="info",
+    base_dir=None,
+    gem_path=None,
+    skip_deps=False,
+    skip_sign=False,
+    release_version="nightly",
+    major_version='7',
+    omnibus_s3_cache=False,
+    hardened_runtime=False,
+    go_mod_cache=None,
+):
+    """
+    Build the Agent packages with Omnibus Installer.
+    """
+    if not skip_deps:
+        with timed(quiet=True) as deps_elapsed:
+            deps(ctx)
+
+    # base dir (can be overridden through env vars, command line takes precedence)
+    base_dir = base_dir or os.environ.get("OMNIBUS_BASE_DIR")
+
+    env = get_omnibus_env(
+        ctx,
+        skip_sign=skip_sign,
+        release_version=release_version,
+        major_version=major_version,
+        hardened_runtime=hardened_runtime,
+        go_mod_cache=go_mod_cache,
+    )
+
+    target_project = "updater"
+
+    with timed(quiet=True) as bundle_elapsed:
+        bundle_install_omnibus(ctx, gem_path, env)
+
+    with timed(quiet=True) as omnibus_elapsed:
+        omnibus_run_task(
+            ctx=ctx,
+            task="build",
+            target_project=target_project,
+            base_dir=base_dir,
+            env=env,
+            omnibus_s3_cache=omnibus_s3_cache,
+            log_level=log_level,
+        )
+
+    print("Build component timing:")
+    if not skip_deps:
+        print(f"Deps:    {deps_elapsed.duration}")
+    print(f"Bundle:  {bundle_elapsed.duration}")
+    print(f"Omnibus: {omnibus_elapsed.duration}")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add a simple build for an apt updater package. This is based on existing agent package.
Init scripts and systemd files are added following spec

Follow-ups
- tests that verify and enforces systemd behaviours
- tests on init scripts
- support rpm

### Test packages content
```
$ dpkg -e omnibus/pkg/datadog-updater_7.49.0~devel.git.1795.56d3c90-1_arm64.deb unpack_meta
tree unpack_meta
unpack_meta
├── control
├── md5sums
├── postinst
├── postrm
├── preinst
└── prerm
```
```
$ dpkg -x omnibus/pkg/datadog-updater_7.49.0~devel.git.1792.4bdbb3b-1_arm64.deb unpack_debug
❯ tree -l unpack_debug
unpack_debug
├── etc
│   └── datadog-agent
│       ├── conf.d
│       │   ├── apm.yaml.default
│       │   ├── container.d
│       │   │   └── conf.yaml.default
│       │   ├...
│       │   └── winproc.d
│       │       └── conf.yaml.default
│       └── datadog.yaml.example
├── lib
│   └── systemd
│       └── system
│           ├── datadog-agent-exp.service
│           ├── datadog-agent-process-exp.service
│           ├── datadog-agent-process.service
│           ├── datadog-agent-security-exp.service
│           ├── datadog-agent-security.service
│           ├── datadog-agent-sysprobe-exp.service
│           ├── datadog-agent-sysprobe.service
│           ├── datadog-agent-trace-exp.service
│           ├── datadog-agent-trace.service
│           ├── datadog-agent.service
│           ├── datadog-updater.service
│           ├── start-experiment.path
│           └── stop-experiment.path
├── opt
│   └── datadog
│       └── updater
│           ├── LICENSE
│           ├── LICENSES
│           │   ├── THIRD-PARTY-0BSD
│           │   ├── THIRD-PARTY-Apache-2.0
│           │   ├── THIRD-PARTY-BSD-2-Clause
│           │   ├── THIRD-PARTY-BSD-3-Clause
│           │   ├── THIRD-PARTY-ISC
│           │   ├── THIRD-PARTY-MIT
│           │   └── THIRD-PARTY-MPL-2.0
│           ├── bin
│           │   └── updater
│           │       └── updater
│           ├── embedded
│           │   ├── bin
│           │   └── lib
│           ├── run
│           ├── sources
│           │   ├── attr
│           │   │   └── offer.txt
│           │   ├── elfutils
│           │   │   └── offer.txt
│           │   ├── freetds
│           │   │   └── offer.txt
│           │   ├── gmp
│           │   │   └── offer.txt
│           │   ├── gnutls
│           │   │   └── offer.txt
│           │   ├── libacl
│           │   │   └── offer.txt
│           │   ├── libdb
│           │   │   └── offer.txt
│           │   ├── libgcrypt
│           │   │   └── offer.txt
│           │   ├── libgpg-error
│           │   │   └── offer.txt
│           │   ├── libsepol
│           │   │   └── offer.txt
│           │   ├── libtasn1
│           │   │   └── offer.txt
│           │   ├── libxcrypt
│           │   │   └── offer.txt
│           │   ├── m4
│           │   │   └── offer.txt
│           │   ├── nettle
│           │   │   └── offer.txt
│           │   ├── openscap
│           │   │   └── offer.txt
│           │   ├── procps-ng
│           │   │   └── procps-ng-procps-v3.3.16.tar.gz
│           │   ├── rpm
│           │   │   └── offer.txt
│           │   └── util-linux
│           │       └── offer.txt
│           ├── version-manifest.json
│           └── version-manifest.txt
└── var
    └── log
        └── datadog
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
