### PR TITLE
[CI] Add a comment on PRs modifying omnibus files

### DIFF
--- a/.github/workflows/risky-pr-commenter.yml
+++ b/.github/workflows/risky-pr-commenter.yml
@@ -1,0 +1,24 @@
+name: "Risky PR Commenter"
+
+on:
+  pull_request:
+    paths:
+      - 'omnibus/**'
+
+jobs:
+  check-for-risky-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            FULL_PIPELINE_MSG = `**Warning**: You just modified the \`/omnibus\` folder impacting a big part of the CI.
+            Only a fraction of the tests are run by default in the CI. **Please consider running a full pipeline:**
+            - To run a full pipeline on the current branch, use \`inv pipeline.run --here\` **(recommended)**.
+            - To run a full pipeline on an arbitrary \`git\` reference (branch or tag), use \`inv pipeline.run --git-ref <git ref>\`.`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: FULL_PIPELINE_MSG
+            });

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -5,6 +5,8 @@
 require "./lib/ostools.rb"
 flavor = ENV['AGENT_FLAVOR']
 
+# TEST TEST TEST TEST
+
 if flavor.nil? || flavor == 'base'
   name 'agent'
   package_name 'datadog-agent'

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -5,8 +5,6 @@
 require "./lib/ostools.rb"
 flavor = ENV['AGENT_FLAVOR']
 
-# TEST TEST TEST TEST
-
 if flavor.nil? || flavor == 'base'
   name 'agent'
   package_name 'datadog-agent'


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR creates a risky PRs commenter workflow, incentivising people to run a full pipeline on their PR modifying sensitive files. For now I only made it to be triggered when `omnibus/*` gets modified.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Incentivise people to run a full pipeline on their PR modifying sensitive files.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
