### PR TITLE
Add definition of new labels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,15 @@ jobs:
           command: inv -e lint-teamassignment
           name: run PR check for team assignment labels
 
+  skip_qa:
+    <<: *job_template
+    steps:
+      - restore_cache: *restore_source
+      - restore_cache: *restore_deps
+      - run:
+          command: inv -e lint-skip-qa
+          name: run PR check for skip-qa labels
+
   milestone:
     <<: *job_template
     steps:
@@ -208,8 +217,8 @@ jobs:
       - run:
           name: setting env vars for click
           command: |
-              echo 'export LC_ALL="C.UTF-8"' >> $BASH_ENV
-              echo 'export LANG="C.UTF-8"' >> $BASH_ENV
+            echo 'export LC_ALL="C.UTF-8"' >> $BASH_ENV
+            echo 'export LANG="C.UTF-8"' >> $BASH_ENV
       - run:
           name: lint python files
           command: inv -e lint-python
@@ -301,6 +310,13 @@ workflows:
           requires:
             - dependencies
       - team_label:
+          filters:
+            branches:
+              ignore:
+                - main
+          requires:
+            - dependencies
+      - skip_qa:
           filters:
             branches:
               ignore:

--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -6,6 +6,8 @@ qa_statuses = [
 ]
 ignored_labels = [
   "qa/skip-qa",
+  "qa/done",
+  "qa/no-code-change",
 ]
 
 [teams."Agent Metrics Logs"]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -57,7 +57,7 @@ Note: Adding GitHub labels is only possible for contributors with write access.
 - [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
 - [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
 - [ ] Changed code has automated tests for its functionality.
-- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
+- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-chande` labels, are applied.
 - [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
 - [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
 - [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -57,7 +57,7 @@ Note: Adding GitHub labels is only possible for contributors with write access.
 - [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
 - [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
 - [ ] Changed code has automated tests for its functionality.
-- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-chande` labels, are applied.
+- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
 - [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
 - [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
 - [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -113,6 +113,7 @@ updates:
       - team/agent-platform
       - changelog/no-changelog
       - qa/skip-qa
+      - qa/no-code-change
     milestone: 22
     schedule:
       interval: monthly
@@ -139,6 +140,7 @@ updates:
       - team/agent-e2e-test
       - changelog/no-changelog
       - qa/skip-qa
+      - qa/no-code-change
       - dev/testing
     milestone: 22
     ignore:
@@ -157,6 +159,7 @@ updates:
       - team/agent-e2e-test
       - changelog/no-changelog
       - qa/skip-qa
+      - qa/no-code-change
       - dev/testing
     milestone: 22
     schedule:
@@ -170,6 +173,7 @@ updates:
       - team/agent-platform
       - changelog/no-changelog
       - qa/skip-qa
+      - qa/no-code-change
       - dev/tooling
     milestone: 22
     schedule:
@@ -183,6 +187,7 @@ updates:
       - team/agent-security
       - changelog/no-changelog
       - qa/skip-qa
+      - qa/no-code-change
       - dev/tooling
     milestone: 22
     schedule:
@@ -195,6 +200,7 @@ updates:
       - team/agent-e2e-test
       - changelog/no-changelog
       - qa/skip-qa
+      - qa/no-code-change
       - dev/testing
     milestone: 22
     schedule:
@@ -208,6 +214,7 @@ updates:
       - team/agent-platform
       - changelog/no-changelog
       - qa/skip-qa
+      - qa/no-code-change
       - dev/tooling
     milestone: 22
     schedule:

--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -85,5 +85,5 @@ jobs:
               owner,
               repo,
               issue_number: result.data.number,
-              labels: ['changelog/no-changelog', 'qa/skip-qa', 'team/agent-security']
+              labels: ['changelog/no-changelog', 'qa/skip-qa', 'qa/no-code-change', 'team/agent-security']
             });

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -258,8 +258,10 @@ labels that can be use:
 - `community`: for community PRs.
 - `changelog/no-changelog`: for PRs that don't require a reno releasenote
   (useful for PRs only changing documentation or tests).
-- `qa/skip-qa`: this will skip creating a QA card for the PR during the release
-  process (example: for a documentation only PRs).
+- `qa/skip-qa`, `qa/done`, `qa/no-code-change`: if the `qa/skip-qa` label is set with
+  an additional required `qa/done` or `qa/no-code-change`, it will skip the creation
+  of a QA card related to this PR during next release process (example: for a
+  documentation only PRs).
 - `major_change`: to flag the PR as a major change impacting many/all teams
   working on the agent and will require deeper QA (example: when we change the
   Python version shipped in the agent).

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -260,8 +260,8 @@ labels that can be use:
   (useful for PRs only changing documentation or tests).
 - `qa/skip-qa`, `qa/done`, `qa/no-code-change`: if the `qa/skip-qa` label is set with
   an additional required `qa/done` or `qa/no-code-change`, it will skip the creation
-  of a QA card related to this PR during next release process (example: for a
-  documentation only PRs).
+  of a QA card related to this PR during next release process (example:
+  documentation-only PRs).
 - `major_change`: to flag the PR as a major change impacting many/all teams
   working on the agent and will require deeper QA (example: when we change the
   Python version shipped in the agent).

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -50,8 +50,7 @@ from .go import (
     reset,
     tidy_all,
 )
-from .show_linters_issues import show_linters_issues
-from .test import (
+from .go_test import (
     codecov,
     download_tools,
     e2e_tests,
@@ -68,10 +67,12 @@ from .test import (
     lint_milestone,
     lint_python,
     lint_releasenote,
+    lint_skip_qa,
     lint_teamassignment,
     send_unit_tests_stats,
     test,
 )
+from .show_linters_issues import show_linters_issues
 from .update_go import go_version, update_go
 from .utils import generate_config
 from .windows_resources import build_messagetable
@@ -95,6 +96,7 @@ ns.add_task(reset)
 ns.add_task(lint_copyrights),
 ns.add_task(lint_teamassignment)
 ns.add_task(lint_releasenote)
+ns.add_task(lint_skip_qa)
 ns.add_task(lint_milestone)
 ns.add_task(lint_filenames)
 ns.add_task(lint_python)

--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -876,6 +876,39 @@ def lint_teamassignment(_):
 
 
 @task
+def lint_skip_qa(_):
+    """
+    Ensure that when qa/skip-qa is used, we have one of [qa/done , qa/no-code-change]. Error if not valid.
+    """
+    branch = os.environ.get("CIRCLE_BRANCH")
+    pr_url = os.environ.get("CIRCLE_PULL_REQUEST")
+
+    if branch == DEFAULT_BRANCH:
+        print(f"Running on {DEFAULT_BRANCH}, skipping check for skip-qa label.")
+    elif pr_url:
+        import requests
+
+        pr_id = pr_url.rsplit('/')[-1]
+
+        res = requests.get(f"https://api.github.com/repos/DataDog/datadog-agent/issues/{pr_id}")
+        issue = res.json()
+
+        labels = {l['name'] for l in issue.get('labels', [])}
+        skip_qa = "qa/skip-qa"
+        new_qa_labels = ["qa/done", "qa/no-code-change"]
+        if skip_qa in labels and not any(skip_label in labels for skip_label in new_qa_labels):
+            print(
+                f"PR {pr_url} request to skip QA without justification. Requires an additional `qa/done` or `qa/no-code-change`."
+            )
+            raise Exit(code=1)
+        return
+    # No PR is associated with this build: given that we have the "run only on PRs" setting activated,
+    # this can only happen when we're building on a tag. We don't need to check for skip-qa.
+    else:
+        print("PR not found, skipping check for skip-qa.")
+
+
+@task
 def lint_milestone(_):
     """
     Make sure PRs are assigned a milestone

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -15,9 +15,9 @@ from invoke.exceptions import Exit
 from invoke.tasks import task
 
 from .flavor import AgentFlavor
+from .go_test import test_flavor
 from .libs.junit_upload import produce_junit_tar
 from .modules import DEFAULT_MODULES
-from .test import test_flavor
 from .utils import REPO_PATH, get_git_commit
 
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1135,6 +1135,7 @@ Make sure that milestone is open before trying again.""",
         labels=[
             "changelog/no-changelog",
             "qa/skip-qa",
+            "qa/no-code-change",
             "team/agent-platform",
             "team/agent-release-management",
             "category/release_operations",

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -13,6 +13,7 @@ from invoke.exceptions import Exit
 
 from .build_tags import get_default_build_tags
 from .go import run_golangci_lint
+from .go_test import environ
 from .libs.ninja_syntax import NinjaWriter
 from .process_agent import TempDir
 from .system_probe import (
@@ -22,7 +23,6 @@ from .system_probe import (
     ninja_define_ebpf_compiler,
     ninja_define_exe_compiler,
 )
-from .test import environ
 from .utils import (
     REPO_PATH,
     bin_name,

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -17,9 +17,9 @@ from invoke import task
 from invoke.exceptions import Exit
 
 from .build_tags import UNIT_TEST_TAGS, get_default_build_tags
+from .go_test import environ
 from .libs.common.color import color_message
 from .libs.ninja_syntax import NinjaWriter
-from .test import environ
 from .utils import REPO_PATH, bin_name, get_build_flags, get_gobin, get_version_numeric_only
 from .windows_resources import MESSAGESTRINGS_MC_PATH, arch_to_windres_target
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -854,8 +854,9 @@ def lint_teamassignment(_):
         issue = res.json()
 
         labels = {l['name'] for l in issue.get('labels', [])}
-        if "qa/skip-qa" in labels:
-            print("qa/skip-qa label set -- no need for team assignment")
+        skip_qa_labels = ["qa/skip-qa", "qa/done", "qa/no-code-change"]
+        if any(skip_label in labels for skip_label in skip_qa_labels):
+            print("A label to skip QA is set -- no need for team assignment")
             return
 
         for label in labels:

--- a/tasks/unit-tests/linters_tests.py
+++ b/tasks/unit-tests/linters_tests.py
@@ -1,0 +1,97 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from invoke import MockContext
+from invoke.exceptions import Exit
+
+from .. import go_test
+
+
+class TestLintSkipQA(unittest.TestCase):
+    @patch('builtins.print')
+    def test_on_default(self, mock_print):
+        os.environ["CIRCLE_BRANCH"] = "main"
+        os.environ["CIRCLE_PULL_REQUEST"] = "42"
+        go_test.lint_skip_qa(MockContext())
+        mock_print.assert_called_with(f"Running on {go_test.DEFAULT_BRANCH}, skipping check for skip-qa label.")
+
+    @patch('builtins.print')
+    def test_no_pr(self, mock_print):
+        os.environ["CIRCLE_BRANCH"] = "pied"
+        go_test.lint_skip_qa(MockContext())
+        mock_print.assert_called_with("PR not found, skipping check for skip-qa.")
+
+    @patch('builtins.print')
+    @patch('requests.get')
+    def test_no_skip_qa(self, mock_requests_get, mock_print):
+        os.environ["CIRCLE_BRANCH"] = "oak"
+        os.environ["CIRCLE_PULL_REQUEST"] = "51"
+        issue = {'labels': [{'name': 'de_cadix_a_des_yeux_de_velours'}]}
+        mock_response = MagicMock()
+        mock_response.json.return_value = issue
+        mock_requests_get.return_value = mock_response
+        go_test.lint_skip_qa(MockContext())
+        mock_print.assert_not_called()
+
+    @patch('requests.get')
+    def test_skip_qa_alone(self, mock_requests_get):
+        os.environ["CIRCLE_BRANCH"] = "mapple"
+        os.environ["CIRCLE_PULL_REQUEST"] = "69"
+        issue = {'labels': [{'name': 'qa/skip-qa'}]}
+        mock_response = MagicMock()
+        mock_response.json.return_value = issue
+        mock_requests_get.return_value = mock_response
+        with self.assertRaises(Exit):
+            go_test.lint_skip_qa(MockContext())
+
+    @patch('requests.get')
+    def test_skip_qa_bad_label(self, mock_requests_get):
+        os.environ["CIRCLE_BRANCH"] = "ash"
+        os.environ["CIRCLE_PULL_REQUEST"] = "666"
+        issue = {'labels': [{'name': 'qa/skip-qa'}, {"name": "qa/lity-streets"}]}
+        mock_response = MagicMock()
+        mock_response.json.return_value = issue
+        mock_requests_get.return_value = mock_response
+        with self.assertRaises(Exit):
+            go_test.lint_skip_qa(MockContext())
+
+    @patch('builtins.print')
+    @patch('requests.get')
+    def test_skip_qa_done(self, mock_requests_get, mock_print):
+        os.environ["CIRCLE_BRANCH"] = "gingko"
+        os.environ["CIRCLE_PULL_REQUEST"] = "1337"
+        issue = {'labels': [{'name': 'qa/skip-qa'}, {'name': 'qa/done'}]}
+        mock_response = MagicMock()
+        mock_response.json.return_value = issue
+        mock_requests_get.return_value = mock_response
+        go_test.lint_skip_qa(MockContext())
+        mock_print.assert_not_called()
+
+    @patch('builtins.print')
+    @patch('requests.get')
+    def test_skip_qa_done_alone(self, mock_requests_get, mock_print):
+        os.environ["CIRCLE_BRANCH"] = "beech"
+        os.environ["CIRCLE_PULL_REQUEST"] = "1515"
+        issue = {'labels': [{'name': 'qa/done'}]}
+        mock_response = MagicMock()
+        mock_response.json.return_value = issue
+        mock_requests_get.return_value = mock_response
+        go_test.lint_skip_qa(MockContext())
+        mock_print.assert_not_called()
+
+    @patch('builtins.print')
+    @patch('requests.get')
+    def test_skip_qa_no_code(self, mock_requests_get, mock_print):
+        os.environ["CIRCLE_BRANCH"] = "sequoia"
+        os.environ["CIRCLE_PULL_REQUEST"] = "1664"
+        issue = {'labels': [{'name': 'qa/skip-qa'}, {'name': 'qa/no-code-change'}]}
+        mock_response = MagicMock()
+        mock_response.json.return_value = issue
+        mock_requests_get.return_value = mock_response
+        go_test.lint_skip_qa(MockContext())
+        mock_print.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
To improve our QA phase we want to enforce anticipated QA. As a consequence, we introduced new labels to identify PR delivery QA automation (`qa/done`) or the ones not impacting Agent functionalities (`qa/no-code-change`). Right now we want one of the latests to be added alongside `qa/skip-qa` when this one is used.
More details [here](https://datadoghq.atlassian.net/wiki/x/uYQtxw)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Improvements on QA phase for releasing (enforce shift left and delivery of QA automation)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Linked to failed [job](https://app.circleci.com/pipelines/github/DataDog/datadog-agent/109718/workflows/bdc01cd3-365e-4e13-bac4-57d9e25de38a/jobs/1313368) with only `qa/skip-qa` label
<img width="309" alt="image" src="https://github.com/DataDog/datadog-agent/assets/24426034/b1d3a2b5-4782-4c5b-9927-866cfb40f584">

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
