### PR TITLE
Windows E2E installer utils

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -499,11 +499,13 @@
 /test/new-e2e/tests/cws                       @DataDog/agent-security
 /test/new-e2e/tests/agent-platform            @DataDog/agent-platform
 /test/new-e2e/tests/agent-metric-logs   @DataDog/agent-metrics-logs
+/test/new-e2e/tests/windows                   @DataDog/windows-agent @DataDog/windows-kernel-integrations
 /test/system/                                 @DataDog/agent-shared-components
 /test/system/dogstatsd/                       @DataDog/agent-metrics-logs
 /test/benchmarks/apm_scripts/                 @DataDog/agent-apm
 /test/regression/                             @DataDog/single-machine-performance
 /test/workload-checks/                        @DataDog/single-machine-performance
+
 /tools/                                 @DataDog/agent-platform
 /tools/ebpf/                            @DataDog/ebpf-platform
 /tools/gdb/                             @DataDog/agent-shared-components

--- a/test/new-e2e/pkg/utils/clients/ssh.go
+++ b/test/new-e2e/pkg/utils/clients/ssh.go
@@ -117,6 +117,33 @@ func CopyFolder(client *ssh.Client, srcFolder string, dstFolder string) error {
 	return copyFolder(sftpClient, srcFolder, dstFolder)
 }
 
+// GetFile create a sftp session and copy a single file from the remote host through SSH
+func GetFile(client *ssh.Client, src string, dst string) error {
+
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return err
+	}
+	defer sftpClient.Close()
+
+	// remote
+	fsrc, err := sftpClient.Open(src)
+	if err != nil {
+		return err
+	}
+	defer fsrc.Close()
+
+	// local
+	fdst, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE, 0640)
+	if err != nil {
+		return err
+	}
+	defer fdst.Close()
+
+	_, err = fsrc.WriteTo(fdst)
+	return err
+}
+
 func copyFolder(sftpClient *sftp.Client, srcFolder string, dstFolder string) error {
 
 	folderContent, err := os.ReadDir(srcFolder)

--- a/test/new-e2e/pkg/utils/e2e/client/vm.go
+++ b/test/new-e2e/pkg/utils/e2e/client/vm.go
@@ -29,6 +29,9 @@ type VM interface {
 	// GetOSType returns the OS type of the VM.
 	GetOSType() componentos.Type
 
+	// GetFile copy file from the remote host
+	GetFile(src string, dst string) error
+
 	// FileExists returns true if the file exists and is a regular file and returns an error if any
 	FileExists(path string) (bool, error)
 

--- a/test/new-e2e/pkg/utils/e2e/client/vm_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/vm_client.go
@@ -104,6 +104,11 @@ func (vmClient *VMClient) CopyFolder(srcFolder string, dstFolder string) {
 	require.NoError(vmClient.t, err)
 }
 
+// GetFile copy file from the remote host
+func (vmClient *VMClient) GetFile(src string, dst string) error {
+	return clients.GetFile(vmClient.client, src, dst)
+}
+
 // FileExists returns true if the file exists and is a regular file and returns an error if any
 func (vmClient *VMClient) FileExists(path string) (bool, error) {
 	return clients.FileExists(vmClient.client, path)

--- a/test/new-e2e/tests/windows/agent/agent.go
+++ b/test/new-e2e/tests/windows/agent/agent.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package agent
+
+import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
+)
+
+// GetDatadogAgentProductCode returns the product code GUID for the Datadog Agent
+func GetDatadogAgentProductCode(client client.VM) (string, error) {
+	return windows.GetProductCodeByName(client, "Datadog Agent")
+}
+
+// UninstallAgent uninstalls the Datadog Agent
+func UninstallAgent(client client.VM, logPath string) error {
+	product, err := GetDatadogAgentProductCode(client)
+	if err != nil {
+		return err
+	}
+	return windows.UninstallMSI(client, product, logPath)
+}

--- a/test/new-e2e/tests/windows/agent/agent.go
+++ b/test/new-e2e/tests/windows/agent/agent.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
+// Package agent includes helpers related to the Datadog Agent on Windows
 package agent
 
 import (

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package installscript
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
+	windows "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
+	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/agent"
+
+	"testing"
+)
+
+type agentMSISuite struct {
+	e2e.Suite[e2e.VMEnv]
+}
+
+func TestMSI(t *testing.T) {
+	e2e.Run(t,
+		&agentMSISuite{},
+		e2e.EC2VMStackDef(ec2params.WithOS(ec2os.WindowsOS)),
+		params.WithStackName(fmt.Sprintf("msi-test-%v", os.Getenv("CI_PIPELINE_ID"))),
+		params.WithDevMode())
+}
+
+func (is *agentMSISuite) TestInstallAgent() {
+	vm := is.Env().VM.(*client.PulumiStackVM)
+
+	msi := `https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi`
+	is.Run("install the agent", func() {
+		err := windows.InstallMSI(vm, msi, "", "install.log")
+		is.Require().NoError(err, "should install the agent")
+	})
+	is.Run("uninstall the agent", func() {
+		err := windowsAgent.UninstallAgent(vm, "uninstall.log")
+		is.Require().NoError(err, "should uninstall the agent")
+	})
+}

--- a/test/new-e2e/tests/windows/msi.go
+++ b/test/new-e2e/tests/windows/msi.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
+// Package windows contains helpers for Windows E2E tests
 package windows
 
 import (
@@ -13,36 +14,42 @@ import (
 
 // InstallMSI installs an MSI on the VM with the provided args and collects the install log
 func InstallMSI(client client.VM, msiPath string, args string, logPath string) error {
-	remoteLogPath := `C:\Windows\Temp\install.log`
+	remoteLogPath, err := GetTemporaryFile(client)
+	if err != nil {
+		return err
+	}
 	cmd := fmt.Sprintf(`Start-Process -Wait msiexec -PassThru -ArgumentList '/qn /l %s /i %s %s'`,
 		remoteLogPath, msiPath, args)
 
 	output, installErr := client.ExecuteWithError(cmd)
 	// Collect the install log
-	err := client.GetFile(remoteLogPath, logPath)
+	err = client.GetFile(remoteLogPath, logPath)
 	if err != nil {
 		fmt.Printf("failed to collect install log: %s\n", err)
 	}
 	if installErr != nil {
-		return fmt.Errorf("failed to install MSI: %w\n%s\n", installErr, output)
+		return fmt.Errorf("failed to install MSI: %w\n%s", installErr, output)
 	}
 	return nil
 }
 
 // UninstallMSI uninstalls an MSI on the VM and collects the uninstall log
 func UninstallMSI(client client.VM, msiPath string, logPath string) error {
-	remoteLogPath := `C:\Windows\Temp\uninstall.log`
+	remoteLogPath, err := GetTemporaryFile(client)
+	if err != nil {
+		return err
+	}
 	cmd := fmt.Sprintf("Exit (start-process -passthru -wait msiexec.exe -argumentList /x,'%s',/qn,/l,%s).ExitCode", msiPath, remoteLogPath)
 
 	output, uninstallerr := client.ExecuteWithError(cmd)
 	// Collect the install log
-	err := client.GetFile(remoteLogPath, logPath)
+	err = client.GetFile(remoteLogPath, logPath)
 	if err != nil {
 		fmt.Printf("failed to collect uninstall log: %s\n", err)
 	}
 
 	if uninstallerr != nil {
-		return fmt.Errorf("failed to uninstall MSI: %w\n%s\n", uninstallerr, output)
+		return fmt.Errorf("failed to uninstall MSI: %w\n%s", uninstallerr, output)
 	}
 	return nil
 }

--- a/test/new-e2e/tests/windows/msi.go
+++ b/test/new-e2e/tests/windows/msi.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package windows
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+)
+
+// InstallMSI installs an MSI on the VM with the provided args and collects the install log
+func InstallMSI(client client.VM, msiPath string, args string, logPath string) error {
+	remoteLogPath := `C:\Windows\Temp\install.log`
+	cmd := fmt.Sprintf(`Start-Process -Wait msiexec -PassThru -ArgumentList '/qn /l %s /i %s %s'`,
+		remoteLogPath, msiPath, args)
+
+	output, installErr := client.ExecuteWithError(cmd)
+	// Collect the install log
+	err := client.GetFile(remoteLogPath, logPath)
+	if err != nil {
+		fmt.Printf("failed to collect install log: %s\n", err)
+	}
+	if installErr != nil {
+		return fmt.Errorf("failed to install MSI: %w\n%s\n", installErr, output)
+	}
+	return nil
+}
+
+// UninstallMSI uninstalls an MSI on the VM and collects the uninstall log
+func UninstallMSI(client client.VM, msiPath string, logPath string) error {
+	remoteLogPath := `C:\Windows\Temp\uninstall.log`
+	cmd := fmt.Sprintf("Exit (start-process -passthru -wait msiexec.exe -argumentList /x,'%s',/qn,/l,%s).ExitCode", msiPath, remoteLogPath)
+
+	output, uninstallerr := client.ExecuteWithError(cmd)
+	// Collect the install log
+	err := client.GetFile(remoteLogPath, logPath)
+	if err != nil {
+		fmt.Printf("failed to collect uninstall log: %s\n", err)
+	}
+
+	if uninstallerr != nil {
+		return fmt.Errorf("failed to uninstall MSI: %w\n%s\n", uninstallerr, output)
+	}
+	return nil
+}

--- a/test/new-e2e/tests/windows/product.go
+++ b/test/new-e2e/tests/windows/product.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package windows
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+)
+
+// GetProductCodeByName returns the product code GUID for the given product name
+func GetProductCodeByName(client client.VM, name string) (string, error) {
+	// TODO: Don't use Win32_Product
+	cmd := fmt.Sprintf("(Get-WmiObject Win32_Product | Where-Object -Property Name -Value '%s' -match).IdentifyingNumber", name)
+	val, err := client.ExecuteWithError(cmd)
+	if err != nil {
+		fmt.Println(val)
+		return "", err
+	}
+	return strings.TrimSpace(val), nil
+}

--- a/test/new-e2e/tests/windows/product.go
+++ b/test/new-e2e/tests/windows/product.go
@@ -14,8 +14,9 @@ import (
 
 // GetProductCodeByName returns the product code GUID for the given product name
 func GetProductCodeByName(client client.VM, name string) (string, error) {
-	// TODO: Don't use Win32_Product
-	cmd := fmt.Sprintf("(Get-WmiObject Win32_Product | Where-Object -Property Name -Value '%s' -match).IdentifyingNumber", name)
+	// Read from registry instead of using Win32_Product, which has negative side effects
+	// https://gregramsey.net/2012/02/20/win32_product-is-evil/
+	cmd := fmt.Sprintf(`(@(Get-ChildItem -Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" -Recurse ; Get-ChildItem -Path "HKLM:SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall" -Recurse ) | Where {$_.GetValue("DisplayName") -like "%s" }).PSChildName`, name)
 	val, err := client.ExecuteWithError(cmd)
 	if err != nil {
 		fmt.Println(val)

--- a/test/new-e2e/tests/windows/temp.go
+++ b/test/new-e2e/tests/windows/temp.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package windows
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+)
+
+// GetTemporaryFile returns a new temporary file path
+// https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/new-temporaryfile?view=powershell-7.4
+func GetTemporaryFile(vm client.VM) (string, error) {
+	cmd := "(New-TemporaryFile).FullName"
+	out, err := vm.ExecuteWithError(cmd)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Begins the Windows test helpers with some MSI/installer related helpers, and adds a basic first test.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-571

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
