### PR TITLE
Allow the install type to be unset for the trace agent

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -234,7 +234,7 @@ func (a *Agent) setRootSpanTags(root *pb.Span) {
 // setFirstTraceTags sets additional tags on the first trace ever processed by the agent,
 // so that we can see that the customer has successfully onboarded onto APM.
 func (a *Agent) setFirstTraceTags(root *pb.Span) {
-	if a.conf == nil || a.conf.InstallSignature.InstallType == "" || root == nil {
+	if a.conf == nil || a.conf.InstallSignature.InstallID == "" || root == nil {
 		return
 	}
 	a.firstSpanOnce.Do(func() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR is a follow-up on the end-to-end testing that we have been running for https://github.com/DataDog/datadog-agent/pull/20733 and related changes to the Helm chart and tracer libraries. Basically, at the time we set up the trace agent container on Kubernetes, we do not yet know if the customer is going to use a single-step APM instrumentation or a library injection without single step in their application. So we cannot set the `DD_INSTRUMENTATION_INSTALL_TYPE` environment variable to the correct value on the trace agent container.

Right now my code in the trace agent assumes that if DD_INSTRUMENTATION_INSTALL_TYPE is not set, then this is just an old version of the Helm chart, and does not propagate along DD_INSTRUMENTATION_INSTALL_ID or DD_INSTRUMENTATION_INSTALL_TIME either. After a discussion with @Kyle-Verhoog and @liliyadd , we think that in the short term, we will have the Helm chart set the install type environment variable to some "neutral" value like `Helm` or `Unspecified` (or `NoClue` etc.), but in the long run, we don't want to pollute the environment on the trace agent container with too many environment variables. So we want to instead allow the trace agent to apply INSTALL_ID and INSTALL_TIME to the first trace even if the INSTALL_TYPE is not specified, so that it eventually becomes compatible with Helm charts that do not set the install type.

In this PR I am updating the one line of code that checks for a non-null install type to check for a non-null install ID instead. The install ID is necessary to be able to tie a telemetry event to a specific install, so I don't think we will ever be in a scenario where a non-legacy Helm chart does not set it.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Jira: [https://datadoghq.atlassian.net/browse/AIT-9151](https://datadoghq.atlassian.net/browse/AIT-9151)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Build the trace agent with `go build ./cmd/trace-agent`, and then run it locally with `DD_INSTRUMENTATION_INSTALL_ID` and `DD_INSTRUMENTATION_INSTALL_TIME` set in your environment, but `DD_INSTRUMENTATION_INSTALL_TYPE` not set:

```
DD_INSTRUMENTATION_INSTALL_ID=cb6c021b-a595-447f-8263-7cdffe1354db DD_INSTRUMENTATION_INSTALL_TIME=1702588196 ./trace-agent -c /opt/datadog-agent/etc/datadog.yaml
```

Start an instrumented application on your laptop and send a trace through your local trace agent. With the old code, the first trace processed by the trace agent should not have any of the `_dd.install.id`, `_dd.install.type` or `_dd.install.time` tags set, [like so](https://dd.datad0g.com/api/ui/trace/5308170471304104118). With the new code, the tags should all be set, and the one for `_dd.install.type` should just be set to the empty string, [like so](https://dd.datad0g.com/api/ui/trace/2677334806082730023).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
