### PR TITLE
APL-2621 Change Pulumi logger to write to t.Log

### DIFF
--- a/test/new-e2e/pkg/utils/e2e/e2e.go
+++ b/test/new-e2e/pkg/utils/e2e/e2e.go
@@ -519,7 +519,7 @@ func (suite *Suite[Env]) TearDownSuite() {
 	// TODO: Implement retry on delete
 	ctx, cancel := context.WithTimeout(context.Background(), deleteTimeout)
 	defer cancel()
-	err := infra.GetStackManager().DeleteStack(ctx, suite.params.StackName)
+	err := infra.GetStackManager().DeleteStack(ctx, suite.params.StackName, testWriter{t: suite.T()})
 	if err != nil {
 		suite.T().Errorf("unable to delete stack: %s, err :%v", suite.params.StackName, err)
 		suite.T().Fail()
@@ -530,7 +530,7 @@ func createEnv[Env any](suite *Suite[Env], stackDef *StackDefinition[Env]) (*Env
 	var env *Env
 	ctx := context.Background()
 	suite.T().Logf("Creating stack %v", suite.params.StackName)
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailureWithLogger(
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(
 		ctx,
 		suite.params.StackName,
 		stackDef.configMap,

--- a/test/new-e2e/pkg/utils/e2e/e2e.go
+++ b/test/new-e2e/pkg/utils/e2e/e2e.go
@@ -529,7 +529,6 @@ func (suite *Suite[Env]) TearDownSuite() {
 func createEnv[Env any](suite *Suite[Env], stackDef *StackDefinition[Env]) (*Env, auto.UpResult, error) {
 	var env *Env
 	ctx := context.Background()
-	suite.T().Logf("Creating stack %v", suite.params.StackName)
 	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(
 		ctx,
 		suite.params.StackName,

--- a/test/new-e2e/pkg/utils/infra/stack_manager.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager.go
@@ -72,7 +72,7 @@ func (s *safeStackMap) Set(key string, value *auto.Stack) {
 }
 
 func (s *safeStackMap) Range(f func(string, *auto.Stack)) {
-	s.lock.Lock()
+	s.lock.RLock()
 	defer s.lock.RUnlock()
 
 	for key, value := range s.stacks {

--- a/test/new-e2e/pkg/utils/infra/stack_manager.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager.go
@@ -76,7 +76,6 @@ func (s *safeStackMap) Set(key string, value *auto.Stack) {
 func (s *safeStackMap) SetLogger(key string, value io.Writer) {
 	s.lockLogger.Lock()
 	defer s.lockLogger.Unlock()
-	value.Write([]byte(fmt.Sprintf("UPDATING LOGGER FOR Stack: %s with logger %v\n", key, value)))
 	s.loggers[key] = value
 }
 
@@ -85,7 +84,6 @@ func (s *safeStackMap) GetLogger(key string) (io.Writer, bool) {
 	defer s.lockLogger.RUnlock()
 
 	logger, ok := s.loggers[key]
-	logger.Write([]byte(fmt.Sprintf("%v GETTING LOGGER FOR Stack: %s with logger %v\n", ok, key, &logger)))
 	return logger, ok
 }
 func (s *safeStackMap) Range(f func(string, *auto.Stack)) {

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -242,7 +242,7 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 				return fmt.Errorf("setup micro-vms in remote instance: %w", err)
 			}
 			return nil
-		}, opts.FailOnMissing)
+		}, opts.FailOnMissing, nil)
 		if err != nil {
 			return handleScenarioFailure(err, func(possibleError handledError) {
 				// handle the following errors by trying in a different availability zone
@@ -270,7 +270,7 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 
 //nolint:revive // TODO(EBPF) Fix revive linter
 func Destroy(name string) error {
-	return infra.GetStackManager().DeleteStack(context.Background(), name)
+	return infra.GetStackManager().DeleteStack(context.Background(), name, nil)
 }
 
 //nolint:revive // TODO(EBPF) Fix revive linter

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -202,7 +202,7 @@ func CheckAgentPython(t *testing.T, client *TestClient, version string) {
 		require.NoError(tt, err, "failed to set python version: ", err)
 
 		_, err = client.SvcManager.Restart("datadog-agent")
-		require.NoError(tt, err, "agent should be able to restart after editing python version")
+		require.Error(tt, err, "agent should be able to restart after editing python version")
 	})
 
 	t.Run(fmt.Sprintf("check python %s is used", version), func(tt *testing.T) {

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -202,7 +202,7 @@ func CheckAgentPython(t *testing.T, client *TestClient, version string) {
 		require.NoError(tt, err, "failed to set python version: ", err)
 
 		_, err = client.SvcManager.Restart("datadog-agent")
-		require.Error(tt, err, "agent should be able to restart after editing python version")
+		require.NoError(tt, err, "agent should be able to restart after editing python version")
 	})
 
 	t.Run(fmt.Sprintf("check python %s is used", version), func(tt *testing.T) {

--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -69,7 +69,7 @@ func TestInstallScript(t *testing.T) {
 	osVersions := strings.Split(*osVersion, ",")
 	cwsSupportedOsVersionList := strings.Split(*cwsSupportedOsVersion, ",")
 
-	fmt.Println("Parsed platform json file: ", platformJSON)
+	t.Log("Parsed platform json file: ", platformJSON)
 
 	for _, osVers := range osVersions {
 		vmOpts := []ec2params.Option{}
@@ -99,7 +99,7 @@ func TestInstallScript(t *testing.T) {
 		}
 		t.Run(fmt.Sprintf("test install script on %s %s %s agent %s", osVers, *architecture, *flavor, *majorVersion), func(tt *testing.T) {
 			tt.Parallel()
-			fmt.Printf("Testing %s", osVers)
+			tt.Logf("Testing %s", osVers)
 			e2e.Run(tt, &installScriptSuite{cwsSupported: cwsSupported}, e2e.EC2VMStackDef(vmOpts...), params.WithStackName(fmt.Sprintf("install-script-test-%v-%v-%s-%s-%v", os.Getenv("CI_PIPELINE_ID"), osVers, *architecture, *flavor, *majorVersion)))
 		})
 	}

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -42,13 +42,13 @@ func (suite *eksSuite) SetupSuite() {
 		"dddogstatsd:deploy":    auto.ConfigValue{Value: "true"},
 	}
 
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(ctx, "eks-cluster", stackConfig, eks.Run, false)
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(ctx, "eks-cluster", stackConfig, eks.Run, false, nil)
 	if !suite.Assert().NoError(err) {
 		stackName, err := infra.GetStackManager().GetPulumiStackName("eks-cluster")
 		suite.Require().NoError(err)
 		suite.T().Log(dumpEKSClusterState(ctx, stackName))
 		if !runner.GetProfile().AllowDevMode() || !*keepStacks {
-			infra.GetStackManager().DeleteStack(ctx, "eks-cluster")
+			infra.GetStackManager().DeleteStack(ctx, "eks-cluster", nil)
 		}
 		suite.T().FailNow()
 	}

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -41,13 +41,13 @@ func (suite *kindSuite) SetupSuite() {
 		"dddogstatsd:deploy":    auto.ConfigValue{Value: "true"},
 	}
 
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(ctx, "kind-cluster", stackConfig, kindvm.Run, false)
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(ctx, "kind-cluster", stackConfig, kindvm.Run, false, nil)
 	if !suite.Assert().NoError(err) {
 		stackName, err := infra.GetStackManager().GetPulumiStackName("kind-cluster")
 		suite.Require().NoError(err)
 		suite.T().Log(dumpKindClusterState(ctx, stackName))
 		if !runner.GetProfile().AllowDevMode() || !*keepStacks {
-			infra.GetStackManager().DeleteStack(ctx, "kind-cluster")
+			infra.GetStackManager().DeleteStack(ctx, "kind-cluster", nil)
 		}
 		suite.T().FailNow()
 	}

--- a/test/new-e2e/tests/ndm/snmp/snmpTestEnv.go
+++ b/test/new-e2e/tests/ndm/snmp/snmpTestEnv.go
@@ -131,7 +131,7 @@ func NewTestEnv() (*TestEnv, error) {
 
 // Destroy delete the NDM stack. Deprecated, should port to NDM
 func (testEnv *TestEnv) Destroy() error {
-	return infra.GetStackManager().DeleteStack(testEnv.context, testEnv.name)
+	return infra.GetStackManager().DeleteStack(testEnv.context, testEnv.name, nil)
 }
 
 //go:embed compose/data


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Currently, Pulumi write all its logs to Stderr or Stdout, which makes it hard to know what Pulumi execution correspond to what test. With this little change the Pulumi logs will be written under the corresponding test log

The default test suite provided by the e2e automatically uses the test logger, once this PR is merged. For the other tests the logger is set to `nil` and will result in no changes in the behavior
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
