### PR TITLE
Add used_by_otel field in modules.py and update update-go invoke task

### DIFF
--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -27,6 +27,7 @@ class GoModule:
         importable=True,
         independent=False,
         lint_targets=None,
+        used_by_otel=False,
     ):
         self.path = path
         self.targets = targets if targets else ["."]
@@ -39,6 +40,7 @@ class GoModule:
         # at the cost of spending some time parsing the module.
         self.importable = importable
         self.independent = independent
+        self.used_by_otel = used_by_otel
 
         self._dependencies = None
 
@@ -154,10 +156,10 @@ DEFAULT_MODULES = {
     "test/fakeintake": GoModule("test/fakeintake", independent=True),
     "pkg/aggregator/ckey": GoModule("pkg/aggregator/ckey", independent=True),
     "pkg/errors": GoModule("pkg/errors", independent=True),
-    "pkg/obfuscate": GoModule("pkg/obfuscate", independent=True),
+    "pkg/obfuscate": GoModule("pkg/obfuscate", independent=True, used_by_otel=True),
     "pkg/gohai": GoModule("pkg/gohai", independent=True, importable=False),
-    "pkg/proto": GoModule("pkg/proto", independent=True),
-    "pkg/trace": GoModule("pkg/trace", independent=True),
+    "pkg/proto": GoModule("pkg/proto", independent=True, used_by_otel=True),
+    "pkg/trace": GoModule("pkg/trace", independent=True, used_by_otel=True),
     "pkg/tagset": GoModule("pkg/tagset", independent=True),
     "pkg/metrics": GoModule("pkg/metrics", independent=True),
     "pkg/telemetry": GoModule("pkg/telemetry", independent=True),
@@ -170,12 +172,14 @@ DEFAULT_MODULES = {
     "pkg/config/remote": GoModule("pkg/config/remote", independent=True),
     "pkg/security/secl": GoModule("pkg/security/secl", independent=True),
     "pkg/status/health": GoModule("pkg/status/health", independent=True),
-    "pkg/remoteconfig/state": GoModule("pkg/remoteconfig/state", independent=True),
-    "pkg/util/cgroups": GoModule("pkg/util/cgroups", independent=True, condition=lambda: sys.platform == "linux"),
+    "pkg/remoteconfig/state": GoModule("pkg/remoteconfig/state", independent=True, used_by_otel=True),
+    "pkg/util/cgroups": GoModule(
+        "pkg/util/cgroups", independent=True, condition=lambda: sys.platform == "linux", used_by_otel=True
+    ),
     "pkg/util/http": GoModule("pkg/util/http", independent=True),
-    "pkg/util/log": GoModule("pkg/util/log", independent=True),
-    "pkg/util/pointer": GoModule("pkg/util/pointer", independent=True),
-    "pkg/util/scrubber": GoModule("pkg/util/scrubber", independent=True),
+    "pkg/util/log": GoModule("pkg/util/log", independent=True, used_by_otel=True),
+    "pkg/util/pointer": GoModule("pkg/util/pointer", independent=True, used_by_otel=True),
+    "pkg/util/scrubber": GoModule("pkg/util/scrubber", independent=True, used_by_otel=True),
     "pkg/util/backoff": GoModule("pkg/util/backoff", independent=True),
     "pkg/util/cache": GoModule("pkg/util/cache", independent=True),
     "pkg/util/common": GoModule("pkg/util/common", independent=True),

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -24,7 +24,7 @@ def go_version(_):
         "test_version": "Whether the image is a test image or not",
         "warn": "Don't exit in case of matching error, just warn.",
         "release_note": "Whether to create a release note or not. The default behaviour is to create a release note",
-        "all_modules": "Whether to update the version in go.mod files used by otel.",
+        "include_otel_modules": "Whether to update the version in go.mod files used by otel.",
     }
 )
 def update_go(
@@ -34,7 +34,7 @@ def update_go(
     test_version: Optional[bool] = False,
     warn: Optional[bool] = False,
     release_note: Optional[bool] = True,
-    all_modules: Optional[bool] = False,
+    include_otel_modules: Optional[bool] = False,
 ):
     """
     Updates the version of Go and build images.
@@ -70,7 +70,7 @@ def update_go(
 
     _update_root_readme(warn, new_major)
     _update_fakeintake_readme(warn, new_major)
-    _update_go_mods(warn, new_major, all_modules)
+    _update_go_mods(warn, new_major, include_otel_modules)
     _update_process_agent_readme(warn, new_major)
     _update_windowsevent_readme(warn, new_major)
     _update_go_version_file(warn, version)
@@ -219,9 +219,9 @@ def _update_windowsevent_readme(warn: bool, major: str):
     _update_file(warn, path, pattern, replace)
 
 
-def _update_go_mods(warn: bool, major: str, all_modules: bool):
+def _update_go_mods(warn: bool, major: str, include_otel_modules: bool):
     for path, module in DEFAULT_MODULES.items():
-        if not all_modules and module.used_by_otel:
+        if not include_otel_modules and module.used_by_otel:
             # only update the go directives in go.mod files not used by otel
             # to allow them to keep using the modules
             continue


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add a new `used_by_otel` field in the modules defined in `tasks/modules.py`, and use that field to determine whether to update the version of Go in `go.mod` files.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Modules used by OTel need to stay compatible with the previous minor version of Go.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The list of modules used in the OTel exporter can be found in their `go.mod` file https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/go.mod.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
