### PR TITLE
Secret resolution callback only bubbles up until acknowledged

### DIFF
--- a/comp/core/secrets/secretsimpl/walker.go
+++ b/comp/core/secrets/secretsimpl/walker.go
@@ -31,10 +31,8 @@ type walker struct {
 // notification on the parent node in the yamlPath.
 func (w *walker) notify(yamlPath []string, value any) {
 	if w.notifier != nil {
-		if !w.notifier(yamlPath, value) {
-			// notification was refuse, will retry from the parent type.
-			w.notificationPending = true
-		}
+		// if notification is refused, retry from the parent type.
+		w.notificationPending = !w.notifier(yamlPath, value)
 	}
 }
 


### PR DESCRIPTION
Once a resolution callback gets acknowledged, disable the `notificationPending` flag so that the callback stops being repeatedly called.

### What does this PR do?

Fixes a bug with the secrets resolver callback, but other does not change any functionality.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

No need for QA

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
