### PR TITLE
[oracle] Bug fix for obfuscation error false positive

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -337,12 +337,13 @@ func (c *Check) copyToPreviousMap(newMap map[StatementMetricsKeyDB]StatementMetr
 }
 
 func handlePredicate(predicateType string, dbValue sql.NullString, payloadValue *string, statement StatementMetricsDB, c *Check, o *obfuscate.Obfuscator) {
-	if dbValue.Valid {
+	if dbValue.Valid && dbValue.String != "" {
 		obfuscated, err := o.ObfuscateSQLString(dbValue.String)
 		if err == nil {
 			*payloadValue = obfuscated.Query
 		} else {
-			*payloadValue = fmt.Sprintf("%s obfuscation error", predicateType)
+			*payloadValue = fmt.Sprintf("%s obfuscation error %d", predicateType, len(dbValue.String))
+			//*payloadValue = dbValue.String
 			logEntry := fmt.Sprintf("%s %s for sql_id: %s, plan_hash_value: %d", c.logPrompt, *payloadValue, statement.SQLID, statement.PlanHashValue)
 			if c.config.ExecutionPlans.LogUnobfuscatedPlans {
 				logEntry = fmt.Sprintf("%s unobfuscated filter: %s", logEntry, dbValue.String)

--- a/releasenotes/notes/oracle-obuscation-error-false-207d782244887115.yaml
+++ b/releasenotes/notes/oracle-obuscation-error-false-207d782244887115.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed obfuscation error false positive when the access or filter predicates are empty.


### PR DESCRIPTION
### What does this PR do?

Fixes massive false positives obfuscation errors with `godror` driver.

### Motivation

We advised a Korean customer to switch to `godror` because `go-ora` driver has a bug with a Korean character set for Windows.  

https://datadoghq.atlassian.net/browse/SDBM-745

### Additional Notes

`godror` returns empty string for `null`.

### Describe how to test/QA your changes

Configure `godror` driver and check if there are obfuscation errors.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
