### PR TITLE
[Orchestrator] Cutover pod check by default to core agent

### DIFF
--- a/pkg/collector/corechecks/orchestrator/pod/pod_test.go
+++ b/pkg/collector/corechecks/orchestrator/pod/pod_test.go
@@ -121,7 +121,7 @@ func (suite *PodTestSuite) SetupTest() {
 	mockConfig.SetWithoutSource("kubernetes_https_kubelet_port", kubeletPort)
 	mockConfig.SetWithoutSource("kubelet_tls_verify", false)
 	mockConfig.SetWithoutSource("orchestrator_explorer.enabled", true)
-	mockConfig.SetWithoutSource("orchestrator_explorer.run_on_node_agent", false)
+	mockConfig.SetWithoutSource("orchestrator_explorer.run_on_node_agent", true)
 	mockConfig.SetWithoutSource("orchestrator_explorer.manifest_collection.enabled", true)
 
 	kubeutil, _ := kubelet.GetKubeUtilWithRetrier()

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1104,7 +1104,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.buffer_manifest", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.buffer_flush_interval", 20*time.Second)
-	config.BindEnvAndSetDefault("orchestrator_explorer.run_on_node_agent", false)
+	config.BindEnvAndSetDefault("orchestrator_explorer.run_on_node_agent", true)
 
 	// Container lifecycle configuration
 	config.BindEnvAndSetDefault("container_lifecycle.enabled", true)

--- a/pkg/process/checks/enabled_checks_pod_test.go
+++ b/pkg/process/checks/enabled_checks_pod_test.go
@@ -24,7 +24,7 @@ func TestPodCheck(t *testing.T) {
 
 		cfg := config.Mock(t)
 		cfg.SetWithoutSource("orchestrator_explorer.enabled", true)
-		cfg.SetWithoutSource("orchestrator_explorer.run_on_node_agent", true)
+		cfg.SetWithoutSource("orchestrator_explorer.run_on_node_agent", false)
 		cfg.SetWithoutSource("cluster_name", "test")
 
 		enabledChecks := getEnabledChecks(t, cfg, config.MockSystemProbe(t))

--- a/pkg/process/checks/enabled_checks_pod_test.go
+++ b/pkg/process/checks/enabled_checks_pod_test.go
@@ -24,6 +24,7 @@ func TestPodCheck(t *testing.T) {
 
 		cfg := config.Mock(t)
 		cfg.SetWithoutSource("orchestrator_explorer.enabled", true)
+		cfg.SetWithoutSource("orchestrator_explorer.run_on_node_agent", true)
 		cfg.SetWithoutSource("cluster_name", "test")
 
 		enabledChecks := getEnabledChecks(t, cfg, config.MockSystemProbe(t))

--- a/pkg/process/checks/pod.go
+++ b/pkg/process/checks/pod.go
@@ -48,24 +48,13 @@ func (c *PodCheck) Init(_ *SysProbeConfig, hostInfo *HostInfo, _ bool) error {
 // IsEnabled returns true if the check is enabled by configuration
 func (c *PodCheck) IsEnabled() bool {
 	// activate the pod collection if enabled and we have the cluster name set
-	orchestratorEnabled, coreCheck, kubeClusterName := oconfig.IsOrchestratorEnabled()
-	if !orchestratorEnabled {
-		return false
-	}
+	_, coreCheck, _ := oconfig.IsOrchestratorEnabled()
 
 	// Do not run this check if we enabled the corecheck for pods
-	if coreCheck {
-		log.Info("Skipping pod check on process agent")
-		return false
+	if !coreCheck {
+		log.Error("This Process Agent is deprecated as of 7.51.0 and moved to the Node Agent")
 	}
-
-	log.Warn("This Process Agent check will be deprecated in 7.51.0 and moved to the Node Agent")
-
-	if kubeClusterName == "" {
-		_ = log.Warnf("Failed to auto-detect a Kubernetes cluster name. Pod collection will not start. To fix this, set it manually via the cluster_name config option")
-		return false
-	}
-	return true
+	return false
 }
 
 // SupportsRunOptions returns true if the check supports RunOptions

--- a/releasenotes/notes/PodCheckCutover-b858c2f7b2b4fdc7.yaml
+++ b/releasenotes/notes/PodCheckCutover-b858c2f7b2b4fdc7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    The orchestrator check is moving from the Process Agent to the Node Agent. Any orchestrator configuration set on the Process Agent will need to be moved to the Node Agent.  No other changes are required. If you need to go back to the old check you can temporarily by manually setting the environment variable ``DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT`` to ``false``. The Process Agent pod check will be deprecated in the following release.

--- a/releasenotes/notes/PodCheckCutover-b858c2f7b2b4fdc7.yaml
+++ b/releasenotes/notes/PodCheckCutover-b858c2f7b2b4fdc7.yaml
@@ -8,4 +8,4 @@
 ---
 upgrade:
   - |
-    The orchestrator check is moving from the Process Agent to the Node Agent. Any orchestrator configuration set on the Process Agent will need to be moved to the Node Agent.  No other changes are required. If you need to go back to the old check you can temporarily by manually setting the environment variable ``DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT`` to ``false``. The Process Agent pod check will be deprecated in the following release.
+    The orchestrator check is moving from the Process Agent to the Core Agent. Any orchestrator configuration set on the Process Agent will need to be moved to the Core Agent.  No other changes are required. If you need to go back to the old check you can temporarily by manually setting the environment variable ``DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT`` to ``false``. The Process Agent pod check will be deprecated in the following release.

--- a/releasenotes/notes/PodCheckCutover-b858c2f7b2b4fdc7.yaml
+++ b/releasenotes/notes/PodCheckCutover-b858c2f7b2b4fdc7.yaml
@@ -8,4 +8,4 @@
 ---
 upgrade:
   - |
-    The orchestrator check is moving from the Process Agent to the Core Agent. Any orchestrator configuration set on the Process Agent will need to be moved to the Core Agent.  No other changes are required. If you need to go back to the old check you can temporarily by manually setting the environment variable ``DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT`` to ``false``. The Process Agent pod check will be deprecated in the following release.
+    The orchestrator check is moving from the Process Agent to the Core Agent. Any orchestrator configuration set on the Process Agent will need to be moved to the Core Agent.  No other changes are required. If you need to go back to the old check, you can do so temporarily by manually setting the environment variable ``DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT`` to ``false``. The Process Agent pod check will be deprecated in the following release.


### PR DESCRIPTION
### What does this PR do?

The pod check has moved from the process agent to the core agent. We want to fully deprecate the process pod check. For now we will change the default check, but leave the old check in case someone needs to still use it.

### Motivation

We want to remove things from the process agent that do not need to be there. This will improve the overall quality of the agents.

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
