### PR TITLE
Add e2e config/env debugging helper

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -323,6 +323,11 @@ KeyFingerprint = NamedTuple('KeyFingerprint', [('md5', str), ('sha1', str), ('sh
 KeyInfo = NamedTuple('KeyFingerprint', [('path', str), ('fingerprint', KeyFingerprint)])
 
 def get_key_info(ctx, path):
+    # Make sure the key is ascii
+    with open(path, 'rb') as f:
+        if '\0' in f.read():
+            raise ValueError(f"Key file {path} is not ascii, it may be in utf-16, please convert it to ascii")
+    # aws returns fingerprints in different formats so get a couple
     fingerprints = dict()
     for fmt in KeyFingerprint._fields:
         out = ctx.run(f"ssh-keygen -l -E {fmt} -f \"{path}\"", hide=True)

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -412,12 +412,6 @@ def get_ssh_keys():
     return list(map(root.joinpath, os.listdir(root)))
 
 
-def load_test_infra_config():
-    with open(Path.home().joinpath(".test_infra_config.yaml")) as f:
-        config = yaml.safe_load(f)
-    return config
-
-
 @task
 def debug_keys(ctx):
     """
@@ -437,7 +431,7 @@ def debug_keys(ctx):
     print("Checking for valid SSH key configuration")
 
     # Get keypair name
-    config = load_test_infra_config()
+    config = _load_test_infra_config()
     awsConf = config["configParams"]["aws"]
     keypair_name = awsConf["keyPairName"]
 

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -325,7 +325,7 @@ KeyInfo = NamedTuple('KeyFingerprint', [('path', str), ('fingerprint', KeyFinger
 def get_key_info(ctx, path):
     fingerprints = dict()
     for fmt in KeyFingerprint._fields:
-        out = ctx.run(f"ssh-keygen -l -E {fmt} -f '{path}'", hide=True)
+        out = ctx.run(f"ssh-keygen -l -E {fmt} -f \"{path}\"", hide=True)
         if out.exited != 0:
             print("No AWS keypair found, please create one")
             return

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -325,7 +325,7 @@ KeyInfo = NamedTuple('KeyFingerprint', [('path', str), ('fingerprint', KeyFinger
 def get_key_info(ctx, path):
     fingerprints = dict()
     for fmt in KeyFingerprint._fields:
-        out = ctx.run(f"ssh-keygen -l -E {fmt} -f {path}", hide=True)
+        out = ctx.run(f"ssh-keygen -l -E {fmt} -f '{path}'", hide=True)
         if out.exited != 0:
             print("No AWS keypair found, please create one")
             return
@@ -395,8 +395,8 @@ def debug_keys(ctx):
 
     # lookup configured keypair
     print(f"Checking configured keypair:")
-    print(f"\tname: {keypair_name}")
-    print(f"\tpath: {keypair_path}")
+    print(f"\taws.keyPairName: {keypair_name}")
+    print(f"\taws.publicKeyPath: {keypair_path}")
     keyinfo, keypair = find_matching_ec2_keypair(ctx, keypairs, keypair_path)
     if keypair is not None:
         print("Configured publicKeyPath found in aws!")

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -325,7 +325,7 @@ KeyInfo = NamedTuple('KeyFingerprint', [('path', str), ('fingerprint', KeyFinger
 def get_key_info(ctx, path):
     # Make sure the key is ascii
     with open(path, 'rb') as f:
-        if '\0' in f.read():
+        if b'\0' in f.read():
             raise ValueError(f"Key file {path} is not ascii, it may be in utf-16, please convert it to ascii")
     # aws returns fingerprints in different formats so get a couple
     fingerprints = dict()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds new invoke task that will check your tools and configuration and try to let you know if anything is wrong

```
aws-vault exec sso-agent-sandbox-account-admin -- inv new-e2e-tests.debug
```

Current checks
* pulumi installed
* aws cli installed with right version
* aws-vault installed
* aws creds available+valid
* correct aws sso profile name
* ssh-agent is running
* key pair name and path are configured
* configured keys loaded into ssh-agent
* configured keys match keys in EC2
* finds keys in `~/.ssh` that match keys in EC2
* ssh key is in ascii

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Other common issues that I'm not sure how to validate are
* appgate running/connected
* pulumi plugins updated/synced
* user/team does not have access to AWS

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
currently shells out to `openssl` and `ssh-keygen` to get key fingerprints. Tested on debian and Windows (`openssl` coming from git-for-windows), but it could be made more platform agnostic by using a python crypto package.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
