### PR TITLE
Introduce memory goal process-agent experiments

### DIFF
--- a/test/regression/cases/process_agent_real_time_mode/datadog-agent/datadog.yaml
+++ b/test/regression/cases/process_agent_real_time_mode/datadog-agent/datadog.yaml
@@ -1,0 +1,13 @@
+auth_token_file_path: /tmp/agent-auth-token
+hostname: smp-regression
+
+dd_url: http://127.0.0.1:9092
+
+confd_path: /etc/datadog-agent/conf.d
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dogstatsd_socket: '/tmp/dsd.socket'

--- a/test/regression/cases/process_agent_real_time_mode/experiment.yaml
+++ b/test/regression/cases/process_agent_real_time_mode/experiment.yaml
@@ -1,0 +1,16 @@
+optimization_goal: memory
+erratic: false
+
+environment:
+  DD_TELEMETRY_ENABLED: true
+  DD_PROCESS_CONFIG_PROCESS_DD_URL: http://127.0.0.1:9092
+  # For regression detection we only care about the processes generated inside the container
+  # so this disables checking of the processes of the host the container is running on
+  HOST_PROC: /tmp/procfs
+
+profiling_environment:
+  DD_INTERNAL_PROFILING_ENABLED: true
+  DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+  DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+  DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+  HOST_PROC: /tmp/procfs

--- a/test/regression/cases/process_agent_real_time_mode/experiment.yaml
+++ b/test/regression/cases/process_agent_real_time_mode/experiment.yaml
@@ -7,6 +7,7 @@ environment:
   # For regression detection we only care about the processes generated inside the container
   # so this disables checking of the processes of the host the container is running on
   HOST_PROC: /tmp/procfs
+  DD_API_KEY: 00000001
 
 profiling_environment:
   DD_INTERNAL_PROFILING_ENABLED: true

--- a/test/regression/cases/process_agent_real_time_mode/lading/lading.yaml
+++ b/test/regression/cases/process_agent_real_time_mode/lading/lading.yaml
@@ -1,0 +1,21 @@
+generator:
+  - proc_fs:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      root: /tmp/procfs
+      copy_from_host:
+        - /proc/uptime
+        - /proc/stat
+        - /proc/cpuinfo
+      total_processes: 128
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      body_variant: "raw_bytes"
+      # process agent RT mode enabled response
+      raw_bytes: [0x1, 0x0, 0x17, 0x0, 0xa, 0x2, 0x20, 0x17, 0x1a, 0x4, 0x8, 0x2, 0x10, 0x2]
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"

--- a/test/regression/cases/process_agent_standard_check/datadog-agent/datadog.yaml
+++ b/test/regression/cases/process_agent_standard_check/datadog-agent/datadog.yaml
@@ -1,0 +1,16 @@
+api_key: 00000000000000000000000000000000
+auth_token_file_path: /tmp/agent-auth-token
+hostname: smp-regression
+
+dd_url: http://127.0.0.1:9092
+
+confd_path: /etc/datadog-agent/conf.d
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+process_config:
+  process_collection:
+    enabled: true

--- a/test/regression/cases/process_agent_standard_check/experiment.yaml
+++ b/test/regression/cases/process_agent_standard_check/experiment.yaml
@@ -1,0 +1,16 @@
+optimization_goal: memory
+erratic: false
+
+environment:
+  DD_TELEMETRY_ENABLED: true
+  DD_PROCESS_CONFIG_PROCESS_DD_URL: http://127.0.0.1:9092
+  # For regression detection we only care about the processes generated inside the container
+  # so this disables checking of the processes of the host the container is running on
+  HOST_PROC: /tmp/procfs
+
+profiling_environment:
+  DD_INTERNAL_PROFILING_ENABLED: true
+  DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+  DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+  DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+  HOST_PROC: /tmp/procfs

--- a/test/regression/cases/process_agent_standard_check/experiment.yaml
+++ b/test/regression/cases/process_agent_standard_check/experiment.yaml
@@ -7,6 +7,7 @@ environment:
   # For regression detection we only care about the processes generated inside the container
   # so this disables checking of the processes of the host the container is running on
   HOST_PROC: /tmp/procfs
+  DD_API_KEY: 00000001
 
 profiling_environment:
   DD_INTERNAL_PROFILING_ENABLED: true

--- a/test/regression/cases/process_agent_standard_check/lading/lading.yaml
+++ b/test/regression/cases/process_agent_standard_check/lading/lading.yaml
@@ -1,0 +1,21 @@
+generator:
+  - proc_fs:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      root: /tmp/procfs
+      copy_from_host:
+        - /proc/uptime
+        - /proc/stat
+        - /proc/cpuinfo
+      total_processes: 128
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      body_variant: "raw_bytes"
+      # process agent RT mode disabled response
+      raw_bytes: [0x1, 0x0, 0x17, 0x0, 0xa, 0x2, 0x20, 0x17, 0x1a, 0x2, 0x10, 0xa]
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"

--- a/test/regression/cases/process_agent_standard_check_with_stats/datadog-agent/datadog.yaml
+++ b/test/regression/cases/process_agent_standard_check_with_stats/datadog-agent/datadog.yaml
@@ -1,0 +1,16 @@
+api_key: 00000000000000000000000000000000
+auth_token_file_path: /tmp/agent-auth-token
+hostname: smp-regression
+
+dd_url: http://127.0.0.1:9092
+
+confd_path: /etc/datadog-agent/conf.d
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+process_config:
+  process_collection:
+    enabled: true

--- a/test/regression/cases/process_agent_standard_check_with_stats/experiment.yaml
+++ b/test/regression/cases/process_agent_standard_check_with_stats/experiment.yaml
@@ -1,0 +1,17 @@
+optimization_goal: memory
+erratic: false
+
+environment:
+  DD_TELEMETRY_ENABLED: true
+  DD_PROCESS_CONFIG_PROCESS_DD_URL: http://127.0.0.1:9092
+  # For regression detection we only care about the processes generated inside the container
+  # so this disables checking of the processes of the host the container is running on
+  HOST_PROC: /tmp/procfs
+  DD_SYSTEM_PROBE_PROCESS_ENABLED: true
+
+profiling_environment:
+  DD_INTERNAL_PROFILING_ENABLED: true
+  DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+  DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+  DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+  HOST_PROC: /tmp/procfs

--- a/test/regression/cases/process_agent_standard_check_with_stats/experiment.yaml
+++ b/test/regression/cases/process_agent_standard_check_with_stats/experiment.yaml
@@ -8,6 +8,7 @@ environment:
   # so this disables checking of the processes of the host the container is running on
   HOST_PROC: /tmp/procfs
   DD_SYSTEM_PROBE_PROCESS_ENABLED: true
+  DD_API_KEY: 00000001
 
 profiling_environment:
   DD_INTERNAL_PROFILING_ENABLED: true

--- a/test/regression/cases/process_agent_standard_check_with_stats/lading/lading.yaml
+++ b/test/regression/cases/process_agent_standard_check_with_stats/lading/lading.yaml
@@ -1,0 +1,21 @@
+generator:
+  - proc_fs:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      root: /tmp/procfs
+      copy_from_host:
+        - /proc/uptime
+        - /proc/stat
+        - /proc/cpuinfo
+      total_processes: 128
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      body_variant: "raw_bytes"
+      # process agent RT mode disabled response
+      raw_bytes: [0x1, 0x0, 0x17, 0x0, 0xa, 0x2, 0x20, 0x17, 0x1a, 0x2, 0x10, 0xa]
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"


### PR DESCRIPTION
This commit re-introduces the process-agent experiments cut in #21017. We modify the optimization goal to be memory focused.
