### PR TITLE
Expose pulumi log level via runner parameters

### DIFF
--- a/test/new-e2e/pkg/runner/parameters/const.go
+++ b/test/new-e2e/pkg/runner/parameters/const.go
@@ -39,4 +39,8 @@ const (
 	VerifyCodeSignature StoreKey = "verify_code_signature"
 	// OutputDir config file parameter name
 	OutputDir StoreKey = "output_dir"
+	// PulumiLogLevel config file parameter name
+	PulumiLogLevel StoreKey = "pulumi_log_level"
+	// PulumiLogToStdErr config file parameter name
+	PulumiLogToStdErr StoreKey = "pulumi_log_to_stderr"
 )

--- a/test/new-e2e/pkg/runner/parameters/store.go
+++ b/test/new-e2e/pkg/runner/parameters/store.go
@@ -45,6 +45,16 @@ func (s Store) GetBoolWithDefault(key StoreKey, def bool) (bool, error) {
 	return getWithDefault(key, s.GetBool, def)
 }
 
+// GetInt returns an integer value from the store
+func (s Store) GetInt(key StoreKey) (int, error) {
+	return getAndConvert(s.vs, key, strconv.Atoi)
+}
+
+// GetIntWithDefault returns an integer value from the store with default on missing key
+func (s Store) GetIntWithDefault(key StoreKey, def int) (int, error) {
+	return getWithDefault(key, s.GetInt, def)
+}
+
 func getWithDefault[T any](key StoreKey, getFunc func(StoreKey) (T, error), defaultValue T) (T, error) {
 	val, err := getFunc(key)
 	if err != nil {

--- a/test/new-e2e/pkg/runner/parameters/store_config_file.go
+++ b/test/new-e2e/pkg/runner/parameters/store_config_file.go
@@ -37,6 +37,7 @@ type ConfigParams struct {
 	AWS       AWS    `yaml:"aws"`
 	Agent     Agent  `yaml:"agent"`
 	OutputDir string `yaml:"outputDir"`
+	Pulumi    Pulumi `yaml:"pulumi"`
 }
 
 // AWS instance contains AWS related parameters
@@ -54,6 +55,18 @@ type Agent struct {
 	APIKey              string `yaml:"apiKey"`
 	APPKey              string `yaml:"appKey"`
 	VerifyCodeSignature string `yaml:"verifyCodeSignature"`
+}
+
+// Pulumi instance contains pulumi related parameters
+type Pulumi struct {
+	// Sets the log level for Pulumi operations
+	// Be careful setting this value, as it can expose sensitive information in the logs.
+	// https://www.pulumi.com/docs/support/troubleshooting/#verbose-logging
+	LogLevel string `yaml:"logLevel"`
+	// By default pulumi logs to /tmp, and creates symlinks to the most recent log, e.g. /tmp/pulumi.INFO
+	// Set this option to true to log to stderr instead.
+	// https://www.pulumi.com/docs/support/troubleshooting/#verbose-logging
+	LogToStdErr string `yaml:"logToStdErr"`
 }
 
 var _ valueStore = &configFileValueStore{}
@@ -127,6 +140,10 @@ func (s configFileValueStore) get(key StoreKey) (string, error) {
 		value = s.config.ConfigParams.Agent.VerifyCodeSignature
 	case OutputDir:
 		value = s.config.ConfigParams.OutputDir
+	case PulumiLogLevel:
+		value = s.config.ConfigParams.Pulumi.LogLevel
+	case PulumiLogToStdErr:
+		value = s.config.ConfigParams.Pulumi.LogToStdErr
 	}
 
 	if value == "" {

--- a/test/new-e2e/pkg/utils/infra/stack_manager.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager.go
@@ -48,6 +48,11 @@ var (
 
 	stackManager     *StackManager
 	initStackManager sync.Once
+
+	// Sets the log level for Pulumi operations
+	// Be careful setting this value, as it can expose sensitive information in the logs.
+	// https://www.pulumi.com/docs/support/troubleshooting/#verbose-logging
+	pulumiLogLevel = flag.Int("pulumi-log-level", 1, "Pulumi log level")
 )
 
 // StackManager handles
@@ -241,7 +246,7 @@ func (sm *StackManager) getStack(ctx context.Context, name string, config runner
 		return nil, auto.UpResult{}, err
 	}
 
-	var loglevel uint = 1
+	var loglevel uint = uint(*pulumiLogLevel)
 	var logger io.Writer
 
 	if logWriter == nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds runner parameters to control [pulumi logging](https://www.pulumi.com/docs/support/troubleshooting/#verbose-logging) to make debugging pulumi issues easier.

example `.test_infra_config.yaml` options
```yaml
configParams:
  pulumi:
    logLevel: 9
    logToStdErr: true
```

Like other options, can be set via env vars
- `E2E_PULUMI_LOG_LEVEL=9`
- `E2E_PULUMI_LOG_TO_STDERR=true`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
pulumi's default log output doesn't contain enough information to debug issues

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

test-infra config model PR: https://github.com/DataDog/test-infra-definitions/pull/561

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
