### PR TITLE
[CWS] add origin as rule filter

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -144,7 +144,7 @@ func DefaultRuleFilter(r *Rule) bool {
 		return false
 	}
 	if len(r.Filters) > 0 {
-		ruleFilterModel, err := rules.NewRuleFilterModel()
+		ruleFilterModel, err := rules.NewRuleFilterModel("")
 		if err != nil {
 			log.Errorf("failed to apply rule filters: %v", err)
 			return false
@@ -397,7 +397,7 @@ func (a *Agent) runKubernetesConfigurationsExport(ctx context.Context) {
 }
 
 func (a *Agent) runAptConfigurationExport(ctx context.Context) {
-	ruleFilterModel, err := rules.NewRuleFilterModel()
+	ruleFilterModel, err := rules.NewRuleFilterModel("")
 	if err != nil {
 		log.Errorf("failed to run apt configuration export: %v", err)
 		return

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -11,6 +11,7 @@ import (
 	json "encoding/json"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 
@@ -94,6 +95,16 @@ func NewRuleEngine(evm *eventmonitor.EventMonitor, config *config.RuntimeSecurit
 	return engine, nil
 }
 
+func getOrigin(cfg *config.RuntimeSecurityConfig) string {
+	if runtime.GOOS == "linux" {
+		if cfg.EBPFLessEnabled {
+			return "ebpfless"
+		}
+		return "ebpf"
+	}
+	return ""
+}
+
 // Start the rule engine
 func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}, wg *sync.WaitGroup) error {
 	// monitor policies
@@ -118,7 +129,7 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}, wg *
 		ruleFilters = append(ruleFilters, agentVersionFilter)
 	}
 
-	ruleFilterModel, err := NewRuleFilterModel()
+	ruleFilterModel, err := NewRuleFilterModel(getOrigin(e.config))
 	if err != nil {
 		return fmt.Errorf("failed to create rule filter: %w", err)
 	}

--- a/pkg/security/rules/rule_filters_model_linux.go
+++ b/pkg/security/rules/rule_filters_model_linux.go
@@ -19,21 +19,24 @@ import (
 // RuleFilterEvent defines a rule filter event
 type RuleFilterEvent struct {
 	*kernel.Version
+	origin string
 }
 
 // RuleFilterModel defines a filter model
 type RuleFilterModel struct {
 	*kernel.Version
+	origin string
 }
 
 // NewRuleFilterModel returns a new rule filter model
-func NewRuleFilterModel() (*RuleFilterModel, error) {
+func NewRuleFilterModel(origin string) (*RuleFilterModel, error) {
 	kv, err := kernel.NewKernelVersion()
 	if err != nil {
 		return nil, err
 	}
 	return &RuleFilterModel{
 		Version: kv,
+		origin:  origin,
 	}, nil
 }
 
@@ -41,6 +44,7 @@ func NewRuleFilterModel() (*RuleFilterModel, error) {
 func (m *RuleFilterModel) NewEvent() eval.Event {
 	return &RuleFilterEvent{
 		Version: m.Version,
+		origin:  m.origin,
 	}
 }
 
@@ -180,6 +184,11 @@ func (m *RuleFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID) (eva
 			Values: os.Environ(),
 			Field:  field,
 		}, nil
+	case "origin":
+		return &eval.StringEvaluator{
+			Value: m.origin,
+			Field: field,
+		}, nil
 	}
 
 	return nil, &eval.ErrFieldNotFound{Field: field}
@@ -245,6 +254,8 @@ func (e *RuleFilterEvent) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.IsSuse15Kernel(), nil
 	case "envs":
 		return os.Environ(), nil
+	case "origin":
+		return e.origin, nil
 	}
 
 	return nil, &eval.ErrFieldNotFound{Field: field}

--- a/pkg/security/rules/rule_filters_model_other.go
+++ b/pkg/security/rules/rule_filters_model_other.go
@@ -17,20 +17,26 @@ import (
 
 // RuleFilterEvent represents a rule filtering event
 type RuleFilterEvent struct {
+	origin string
 }
 
 // RuleFilterModel represents a rule fitlering model
 type RuleFilterModel struct {
+	origin string
 }
 
 // NewRuleFilterModel returns a new rule filtering model
-func NewRuleFilterModel() (*RuleFilterModel, error) {
-	return &RuleFilterModel{}, nil
+func NewRuleFilterModel(origin string) (*RuleFilterModel, error) {
+	return &RuleFilterModel{
+		origin: origin,
+	}, nil
 }
 
 // NewEvent returns a new rule filtering event
 func (m *RuleFilterModel) NewEvent() eval.Event {
-	return &RuleFilterEvent{}
+	return &RuleFilterEvent{
+		origin: m.origin,
+	}
 }
 
 // GetEvaluator returns a new evaluator for a rule filtering field
@@ -64,7 +70,11 @@ func (m *RuleFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID) (eva
 	case "envs":
 		return &eval.StringArrayEvaluator{
 			Values: os.Environ(),
-			Field:  field,
+		}, nil
+	case "origin":
+		return &eval.StringEvaluator{
+			Value: m.origin,
+			Field: field,
 		}, nil
 	}
 
@@ -89,6 +99,8 @@ func (e *RuleFilterEvent) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "envs":
 		return os.Environ(), nil
+	case "origin":
+		return e.origin, nil
 	}
 
 	return nil, &eval.ErrFieldNotFound{Field: field}

--- a/pkg/security/tests/rule_filters_test.go
+++ b/pkg/security/tests/rule_filters_test.go
@@ -27,7 +27,7 @@ func TestSECLRuleFilter(t *testing.T) {
 		Code:         kernel.Kernel5_9,
 	}
 
-	m, err := rulesmodule.NewRuleFilterModel()
+	m, err := rulesmodule.NewRuleFilterModel("")
 	assert.NoError(t, err)
 	m.Version = kv
 	seclRuleFilter := rules.NewSECLRuleFilter(m)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This allows to write filter : 

```
  - id: TEST
    expression: open.file.path == "/tmp/abc"
    filters:
      - origin != "ebpfless"
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
