### PR TITLE
Add default location for chrony.conf on Ubuntu

### DIFF
--- a/pkg/collector/corechecks/net/ntp_local_defined_server_nowindows.go
+++ b/pkg/collector/corechecks/net/ntp_local_defined_server_nowindows.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getLocalDefinedNTPServers() ([]string, error) {
-	return getNTPServersFromFiles([]string{"/etc/ntp.conf", "/etc/xntp.conf", "/etc/chrony.conf", "/etc/ntpd.conf", "/etc/openntpd/ntpd.conf"})
+	return getNTPServersFromFiles([]string{"/etc/ntp.conf", "/etc/xntp.conf", "/etc/chrony.conf", "/etc/chrony/chrony.conf", "/etc/ntpd.conf", "/etc/openntpd/ntpd.conf"})
 }
 
 func getNTPServersFromFiles(files []string) ([]string, error) {

--- a/releasenotes/notes/add-ubuntu-chrony-default-location-4d50d846e8b1379e.yaml
+++ b/releasenotes/notes/add-ubuntu-chrony-default-location-4d50d846e8b1379e.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Updated the ntp check to support the default location of chrony.conf
+    on Ubuntu (/etc/chrony/chrony.conf).


### PR DESCRIPTION
### What does this PR do?
This PR adds the Ubuntu default location for chrony.conf to the list of locations returned by getLocalDefinedNTPServers

### Motivation
Without this change the agent will fail to find the ntp config when using chrony on Ubuntu

