### PR TITLE
re-introduce ebpf feature tests

### DIFF
--- a/pkg/ebpf/feature_test.go
+++ b/pkg/ebpf/feature_test.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package ebpf
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/features"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKprobeHelperProbe(t *testing.T) {
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
+
+	var requiredFuncs = []asm.BuiltinFunc{
+		asm.FnMapLookupElem,
+		asm.FnMapUpdateElem,
+		asm.FnMapDeleteElem,
+		asm.FnPerfEventOutput,
+		asm.FnPerfEventRead,
+	}
+	for _, rf := range requiredFuncs {
+		if err := features.HaveProgramHelper(ebpf.Kprobe, rf); err != nil {
+			if errors.Is(err, ebpf.ErrNotSupported) {
+				t.Errorf("%s unsupported", rf.String())
+			} else {
+				t.Errorf("error checking for ebpf helper %s support: %s", rf.String(), err)
+			}
+		}
+	}
+}

--- a/pkg/network/tracer/utils_linux.go
+++ b/pkg/network/tracer/utils_linux.go
@@ -8,7 +8,13 @@
 package tracer
 
 import (
+	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/features"
 
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -52,5 +58,28 @@ func verifyOSVersion(kernelCode kernel.Version, platform string, exclusionList [
 	if platform == "ubuntu" && kernelCode >= kernel.VersionCode(4, 4, 114) && kernelCode <= kernel.VersionCode(4, 4, 127) {
 		return false, fmt.Errorf("Known bug for kernel %s on platform %s, see: \n- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCode, platform)
 	}
-	return true, nil
+
+	var requiredFuncs = []asm.BuiltinFunc{
+		asm.FnMapLookupElem,
+		asm.FnMapUpdateElem,
+		asm.FnMapDeleteElem,
+		asm.FnPerfEventOutput,
+		asm.FnPerfEventRead,
+	}
+	var missingFuncs []string
+	for _, rf := range requiredFuncs {
+		if err := features.HaveProgramHelper(ebpf.Kprobe, rf); err != nil {
+			if errors.Is(err, ebpf.ErrNotSupported) {
+				missingFuncs = append(missingFuncs, rf.String())
+			} else {
+				return false, fmt.Errorf("error checking for ebpf helper %s support: %w", rf.String(), err)
+			}
+		}
+	}
+	if len(missingFuncs) == 0 {
+		return true, nil
+	}
+	errMsg := fmt.Sprintf("Kernel unsupported (%s) - ", kernelCode)
+	errMsg += fmt.Sprintf("required functions missing: %s", strings.Join(missingFuncs, ", "))
+	return false, fmt.Errorf(errMsg)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add feature tests for minimal set of ebpf helpers in kprobe programs

### Motivation

Originally removed in #17691 after some customer support issues, an investigation revealed it was caused by not calling `rlimit.RemoveMemlock()` before the feature tests. This now happens before any modules which require eBPF are initialized.

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-361

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
