### PR TITLE
[HA] add support for HA configuration in subsection and expose via API

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -232,6 +232,7 @@ func run(log log.Component,
 	}()
 
 	if err := startAgent(cliParams,
+		config,
 		log,
 		flare,
 		telemetry,
@@ -335,6 +336,7 @@ func getSharedFxOption() fx.Option {
 // startAgent Initializes the agent process
 func startAgent(
 	cliParams *cliParams,
+	cfg config.Component,
 	log log.Component,
 	flare flare.Component,
 	telemetry telemetry.Component,

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -232,7 +232,6 @@ func run(log log.Component,
 	}()
 
 	if err := startAgent(cliParams,
-		config,
 		log,
 		flare,
 		telemetry,
@@ -336,7 +335,6 @@ func getSharedFxOption() fx.Option {
 // startAgent Initializes the agent process
 func startAgent(
 	cliParams *cliParams,
-	cfg config.Component,
 	log log.Component,
 	flare flare.Component,
 	telemetry telemetry.Component,

--- a/cmd/agent/subcommands/run/internal/settings/runtime_setting_hamr.go
+++ b/cmd/agent/subcommands/run/internal/settings/runtime_setting_hamr.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package settings
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/config/settings"
+)
+
+// HAMRRuntimeSetting wraps operations to change the HAMR settings at runtime.
+type HAMRRuntimeSetting struct {
+	value string
+	desc  string
+}
+
+// NewHAMRRuntimeSetting creates a new instance of HAMRRuntimeSetting
+func NewHAMRRuntimeSetting(name, desc string) *HAMRRuntimeSetting {
+	return &HAMRRuntimeSetting{
+		value: name,
+		desc:  desc,
+	}
+}
+
+// Description returns the runtime setting's description
+func (h *HAMRRuntimeSetting) Description() string {
+	return h.desc
+}
+
+// Hidden returns whether or not this setting is hidden from the list of runtime settings
+func (h *HAMRRuntimeSetting) Hidden() bool {
+	return false
+}
+
+// Name returns the name of the runtime setting
+func (h *HAMRRuntimeSetting) Name() string {
+	return h.value
+}
+
+// Get returns the current value of the runtime setting
+func (h *HAMRRuntimeSetting) Get() (interface{}, error) {
+	return config.Datadog.GetBool(h.value), nil
+}
+
+// Set changes the value of the runtime setting; expected to be boolean
+func (h *HAMRRuntimeSetting) Set(v interface{}, source model.Source) error {
+	var newValue bool
+	var err error
+
+	if newValue, err = settings.GetBool(v); err != nil {
+		return fmt.Errorf("%v: %v", h.value, err)
+	}
+
+	config.Datadog.Set(h.value, newValue, source)
+	return nil
+}

--- a/cmd/agent/subcommands/run/settings.go
+++ b/cmd/agent/subcommands/run/settings.go
@@ -29,6 +29,16 @@ func initRuntimeSettings(serverDebug dogstatsddebug.Component) error {
 	if err := commonsettings.RegisterRuntimeSetting(settings.NewDsdCaptureDurationRuntimeSetting("dogstatsd_capture_duration")); err != nil {
 		return err
 	}
+	if err := commonsettings.RegisterRuntimeSetting(
+		settings.NewHAMRRuntimeSetting("ha.enabled", "Enable/disable the HA region subsystem."),
+	); err != nil {
+		return err
+	}
+	if err := commonsettings.RegisterRuntimeSetting(
+		settings.NewHAMRRuntimeSetting("ha.failover", "Enable/disable the HA region failover; enabled submits to the secondary site."),
+	); err != nil {
+		return err
+	}
 	if err := commonsettings.RegisterRuntimeSetting(commonsettings.NewLogPayloadsRuntimeSetting()); err != nil {
 		return err
 	}

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/api/api"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
@@ -39,6 +40,7 @@ func Module() fxutil.Module {
 }
 
 type apiServer struct {
+	config          config.Component
 	flare           flare.Component
 	dogstatsdServer dogstatsdServer.Component
 	capture         replay.Component
@@ -55,6 +57,7 @@ type apiServer struct {
 type dependencies struct {
 	fx.In
 
+	Config          config.Component
 	Flare           flare.Component
 	DogstatsdServer dogstatsdServer.Component
 	Capture         replay.Component
@@ -72,6 +75,7 @@ var _ api.Component = (*apiServer)(nil)
 
 func newAPIServer(deps dependencies) api.Component {
 	return &apiServer{
+		config:          deps.Config,
 		flare:           deps.Flare,
 		dogstatsdServer: deps.DogstatsdServer,
 		capture:         deps.Capture,
@@ -95,6 +99,7 @@ func (server *apiServer) StartServer(
 	senderManager sender.DiagnoseSenderManager,
 ) error {
 	return StartServers(configService,
+		server.config,
 		server.flare,
 		server.dogstatsdServer,
 		server.capture,

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -158,12 +158,12 @@ func configRequestHandler(w http.ResponseWriter, r *http.Request, cfg cfgcomp.Co
 	switch subsection {
 	case "ha":
 		settings := make(map[string]interface{})
-		settings["ha"] = cfg.Object().GetStringMap(subsection)
+		settings["ha"] = cfg.GetStringMap(subsection)
 		settings["site"] = cfg.GetString("site")
 		settings["api_key"] = cfg.GetString("api_key")
 		body, err = json.Marshal(settings)
 	default:
-		settings := cfg.Object().GetStringMap(subsection)
+		settings := cfg.GetStringMap(subsection)
 		body, err = json.Marshal(settings)
 	}
 

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/response"
+	cfgcomp "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
@@ -63,6 +64,7 @@ import (
 // SetupHandlers adds the specific handlers for /agent endpoints
 func SetupHandlers(
 	r *mux.Router,
+	confComp cfgcomp.Component,
 	flareComp flare.Component,
 	server dogstatsdServer.Component,
 	serverDebug dogstatsddebug.Component,
@@ -92,6 +94,7 @@ func SetupHandlers(
 	r.HandleFunc("/gui/csrf-token", getCSRFToken).Methods("GET")
 	r.HandleFunc("/config-check", getConfigCheck).Methods("GET")
 	r.HandleFunc("/config", settingshttp.Server.GetFullDatadogConfig("")).Methods("GET")
+	r.HandleFunc("/config/section/{subsection}", func(w http.ResponseWriter, r *http.Request) { configRequestHandler(w, r, confComp) }).Methods("GET")
 	r.HandleFunc("/config/list-runtime", settingshttp.Server.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")
@@ -143,6 +146,38 @@ func getHostname(w http.ResponseWriter, r *http.Request) {
 	}
 	j, _ := json.Marshal(hname)
 	w.Write(j)
+}
+
+func configRequestHandler(w http.ResponseWriter, r *http.Request, cfg cfgcomp.Component) {
+	vars := mux.Vars(r)
+	subsection := vars["subsection"]
+
+	var body []byte
+	var err error
+
+	switch subsection {
+	case "ha":
+		settings := make(map[string]interface{})
+		settings["ha"] = cfg.Object().GetStringMap(subsection)
+		settings["site"] = cfg.GetString("site")
+		settings["api_key"] = cfg.GetString("api_key")
+		body, err = json.Marshal(settings)
+	default:
+		settings := cfg.Object().GetStringMap(subsection)
+		body, err = json.Marshal(settings)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		w.WriteHeader(400)
+		body, _ = json.Marshal(map[string]string{
+			"error":      err.Error(),
+			"error_type": "Bad section specified",
+		})
+	}
+
+	log.Infof("Requested config: %v\n", string(body[:]))
+	w.Write(body)
 }
 
 func makeFlare(w http.ResponseWriter, r *http.Request, flareComp flare.Component) {

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -158,7 +158,7 @@ func configRequestHandler(w http.ResponseWriter, r *http.Request, cfg cfgcomp.Co
 	switch subsection {
 	case "ha":
 		settings := make(map[string]interface{})
-		settings["ha"] = cfg.GetStringMap(subsection)
+		settings["ha"] = cfg.AllSettings().GetStringMap(subsection)
 		settings["site"] = cfg.GetString("site")
 		settings["api_key"] = cfg.GetString("api_key")
 		body, err = json.Marshal(settings)

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -161,13 +161,13 @@ func configRequestHandler(w http.ResponseWriter, r *http.Request, cfg cfgcomp.Co
 		settings["site"] = cfg.GetString("site")
 		settings["dd_url"] = cfg.GetString("dd_url")
 		settings["api_key"] = cfg.GetString("api_key")
-		ha_settings := make(map[string]interface{})
-		ha_settings["api_key"] = cfg.GetString("ha.api_key")
-		ha_settings["site"] = cfg.GetString("ha.site")
-		ha_settings["dd_url"] = cfg.GetString("ha.dd_url")
-		ha_settings["enabled"] = cfg.GetString("ha.enabled")
-		ha_settings["failover"] = cfg.GetString("ha.failover")
-		settings["ha"] = ha_settings
+		haSettings := make(map[string]interface{})
+		haSettings["api_key"] = cfg.GetString("ha.api_key")
+		haSettings["site"] = cfg.GetString("ha.site")
+		haSettings["dd_url"] = cfg.GetString("ha.dd_url")
+		haSettings["enabled"] = cfg.GetString("ha.enabled")
+		haSettings["failover"] = cfg.GetString("ha.failover")
+		settings["ha"] = haSettings
 		body, err = json.Marshal(settings)
 	default:
 		settings := cfg.GetStringMap(subsection)

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -158,9 +158,14 @@ func configRequestHandler(w http.ResponseWriter, r *http.Request, cfg cfgcomp.Co
 	switch subsection {
 	case "ha":
 		settings := make(map[string]interface{})
-		settings["ha"] = cfg.AllSettings().GetStringMap(subsection)
 		settings["site"] = cfg.GetString("site")
 		settings["api_key"] = cfg.GetString("api_key")
+		ha_settings := make(map[string]interface{})
+		ha_settings["api_key"] = cfg.GetString("ha.api_key")
+		ha_settings["site"] = cfg.GetString("ha.site")
+		ha_settings["enabled"] = cfg.GetString("ha.enabled")
+		ha_settings["failover"] = cfg.GetString("ha.failover")
+		settings["ha"] = ha_settings
 		body, err = json.Marshal(settings)
 	default:
 		settings := cfg.GetStringMap(subsection)

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -159,10 +159,12 @@ func configRequestHandler(w http.ResponseWriter, r *http.Request, cfg cfgcomp.Co
 	case "ha":
 		settings := make(map[string]interface{})
 		settings["site"] = cfg.GetString("site")
+		settings["dd_url"] = cfg.GetString("dd_url")
 		settings["api_key"] = cfg.GetString("api_key")
 		ha_settings := make(map[string]interface{})
 		ha_settings["api_key"] = cfg.GetString("ha.api_key")
 		ha_settings["site"] = cfg.GetString("ha.site")
+		ha_settings["dd_url"] = cfg.GetString("ha.dd_url")
 		ha_settings["enabled"] = cfg.GetString("ha.enabled")
 		ha_settings["failover"] = cfg.GetString("ha.failover")
 		settings["ha"] = ha_settings

--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
@@ -30,7 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -38,7 +39,7 @@ import (
 
 func startServer(listener net.Listener, srv *http.Server, name string) {
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
-	logWriter, _ := config.NewLogWriter(5, seelog.ErrorLvl)
+	logWriter, _ := pkgconfig.NewLogWriter(5, seelog.ErrorLvl)
 
 	srv.ErrorLog = stdLog.New(logWriter, fmt.Sprintf("Error from the Agent HTTP server '%s': ", name), 0) // log errors to seelog
 
@@ -62,6 +63,7 @@ func stopServer(listener net.Listener, name string) {
 // StartServers creates certificates and starts API servers
 func StartServers(
 	configService *remoteconfig.Service,
+	config config.Component,
 	flare flare.Component,
 	dogstatsdServer dogstatsdServer.Component,
 	capture replay.Component,
@@ -111,6 +113,7 @@ func StartServers(
 		tlsConfig,
 		tlsCertPool,
 		configService,
+		config,
 		flare,
 		dogstatsdServer,
 		capture,

--- a/comp/api/api/apiimpl/server_cmd.go
+++ b/comp/api/api/apiimpl/server_cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/internal/agent"
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/internal/check"
 	apiutils "github.com/DataDog/datadog-agent/comp/api/api/apiimpl/utils"
+	cfgcomp "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
@@ -56,6 +57,7 @@ func startCMDServer(
 	tlsConfig *tls.Config,
 	tlsCertPool *x509.CertPool,
 	configService *remoteconfig.Service,
+	cfg cfgcomp.Component,
 	flare flare.Component,
 	dogstatsdServer dogstatsdServer.Component,
 	capture replay.Component,
@@ -135,6 +137,7 @@ func startCMDServer(
 		http.StripPrefix("/agent",
 			agent.SetupHandlers(
 				agentMux,
+				cfg,
 				flare,
 				dogstatsdServer,
 				serverDebug,

--- a/pkg/cli/subcommands/config/command.go
+++ b/pkg/cli/subcommands/config/command.go
@@ -72,6 +72,14 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 		RunE:  oneShotRunE(showRuntimeConfiguration),
 	}
 
+	showSubsectionCmd := &cobra.Command{
+		Use:   "subsection [value]",
+		Short: "Get runtime configuration subsection",
+		Long:  ``,
+		RunE:  oneShotRunE(showSubsectionConfiguration),
+	}
+	cmd.AddCommand(showSubsectionCmd)
+
 	listRuntimeCmd := &cobra.Command{
 		Use:   "list-runtime",
 		Short: "List settings that can be changed at runtime",
@@ -98,6 +106,27 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 	getCmd.Flags().BoolVarP(&cliParams.source, "source", "s", false, "print every source and its value")
 
 	return cmd
+}
+
+func showSubsectionConfiguration(_ log.Component, _ config.Component, cliParams *cliParams) error {
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	c, err := cliParams.GlobalParams.SettingsClient()
+	if err != nil {
+		return err
+	}
+
+	runtimeConfig, err := c.SubsectionConfig(cliParams.args[0])
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(runtimeConfig)
+
+	return nil
 }
 
 func showRuntimeConfiguration(_ log.Component, _ config.Component, cliParams *cliParams) error {

--- a/pkg/cli/subcommands/config/command.go
+++ b/pkg/cli/subcommands/config/command.go
@@ -114,6 +114,10 @@ func showSubsectionConfiguration(_ log.Component, _ config.Component, cliParams 
 		return err
 	}
 
+	if len(cliParams.args) != 1 {
+		return fmt.Errorf("Empty or invalid subsection specified")
+	}
+
 	c, err := cliParams.GlobalParams.SettingsClient()
 	if err != nil {
 		return err

--- a/pkg/config/hamr.go
+++ b/pkg/config/hamr.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+func setupHAMR(config Config) {
+	config.BindEnv("ha.api_key", "DD_HA_API_KEY")
+	config.BindEnv("ha.site", "DD_HA_SITE")
+	config.BindEnvAndSetDefault("ha.enabled", false, "DD_HA_ENABLED")
+	config.BindEnvAndSetDefault("ha.failover", false, "DD_HA_FAILOVER")
+}

--- a/pkg/config/hamr.go
+++ b/pkg/config/hamr.go
@@ -6,8 +6,8 @@
 package config
 
 func setupHAMR(config Config) {
-	config.BindEnv("ha.api_key", "DD_HA_API_KEY")
-	config.BindEnv("ha.site", "DD_HA_SITE")
-	config.BindEnvAndSetDefault("ha.enabled", false, "DD_HA_ENABLED")
-	config.BindEnvAndSetDefault("ha.failover", false, "DD_HA_FAILOVER")
+	config.BindEnv("ha.api_key")
+	config.BindEnv("ha.site")
+	config.BindEnvAndSetDefault("ha.enabled", false)
+	config.BindEnvAndSetDefault("ha.failover", false)
 }

--- a/pkg/config/hamr.go
+++ b/pkg/config/hamr.go
@@ -8,6 +8,7 @@ package config
 func setupHAMR(config Config) {
 	config.BindEnv("ha.api_key")
 	config.BindEnv("ha.site")
+	config.BindEnv("ha.dd_url")
 	config.BindEnvAndSetDefault("ha.enabled", false)
 	config.BindEnvAndSetDefault("ha.failover", false)
 }

--- a/pkg/config/settings/api.go
+++ b/pkg/config/settings/api.go
@@ -14,6 +14,7 @@ type Client interface {
 	Set(key string, value string) (bool, error)
 	List() (map[string]RuntimeSettingResponse, error)
 	FullConfig() (string, error)
+	SubsectionConfig(key string) (string, error)
 }
 
 // ClientBuilder represents a function returning a runtime settings API client

--- a/pkg/config/settings/http/client.go
+++ b/pkg/config/settings/http/client.go
@@ -44,6 +44,21 @@ func (rc *runtimeSettingsHTTPClient) FullConfig() (string, error) {
 	return string(r), nil
 }
 
+func (rc *runtimeSettingsHTTPClient) SubsectionConfig(key string) (string, error) {
+	r, err := util.DoGet(rc.c, fmt.Sprintf("%s/%s/%s", rc.baseURL, "section", key), util.LeaveConnectionOpen)
+	if err != nil {
+		var errMap = make(map[string]string)
+		_ = json.Unmarshal(r, &errMap)
+		// If the error has been marshalled into a json object, check it and return it properly
+		if e, found := errMap["error"]; found {
+			return "", fmt.Errorf(e)
+		}
+		return "", err
+	}
+
+	return string(r), nil
+}
+
 func (rc *runtimeSettingsHTTPClient) List() (map[string]settings.RuntimeSettingResponse, error) {
 	r, err := util.DoGet(rc.c, fmt.Sprintf("%s/%s", rc.baseURL, "list-runtime"), util.LeaveConnectionOpen)
 	if err != nil {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1273,6 +1273,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("language_detection.enabled", false)
 	config.BindEnvAndSetDefault("language_detection.client_period", "10s")
 
+	setupHAMR(config)
 	setupAPM(config)
 	OTLP(config)
 	setupProcesses(config)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds an **experimental** HA config subsection and said configuration is exposed via an API endpoint for potential consumption by other processes.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Ease of use of configuration of alternative endpoints for HA support.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This is an initial and **experimental** approach to introduce HA support configuration semantics in the agent. Depending on future development decisions additional logic may be added to implement forwarding logic in the agent (or not).  

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The HA semantics are added in a new `ha` subsection to the configuration template. Please refer to the internal RFC available for a full description of the options available. Environment variables are indeed available to override configuration file definitions. To test the features we should test:
1. Config file definitions are correctly picked up.
2. Environment variable overrides (`DD_HA_*`) supersede config file definitions. 
3. CLI commands available allow toggling HA endpoints at runtime.
4. HA configuration is correctly exposed over the API.  

CLI changes can be triggered with the runtime config CLI facilities:
```
datadog-agent config set ha.failover true
datadog-agent config get ha.failover
```

API can be queried to collect the configuration (and may also be queried via the CLI as an API frontend):
```
datadog-agent config
datadog-agent config subsection ha
``` 


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
