### PR TITLE
[CSPM] Detect K8s managed environment via node-labels

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -121,6 +121,8 @@ type Agent struct {
 
 	finish chan struct{}
 	cancel context.CancelFunc
+
+	k8sManaged *string
 }
 
 func xccdfEnabled() bool {
@@ -212,6 +214,11 @@ func (a *Agent) Start() error {
 			return a.getChecksStatus()
 		}),
 	)
+
+	_, k8sResourceData := k8sconfig.LoadConfiguration(ctx, a.opts.HostRoot)
+	if k8sResourceData != nil && k8sResourceData.ManagedEnvironment != nil {
+		a.k8sManaged = &k8sResourceData.ManagedEnvironment.Name
+	}
 
 	var wg sync.WaitGroup
 
@@ -536,6 +543,7 @@ func (a *Agent) reportCheckEvents(eventsTTL time.Duration, events ...*CheckEvent
 				event.Container.ImageTag = ctnr.Image.Tag
 			}
 		}
+		event.K8SManaged = a.k8sManaged
 		a.opts.Reporter.ReportEvent(event)
 	}
 }

--- a/pkg/compliance/data.go
+++ b/pkg/compliance/data.go
@@ -81,6 +81,7 @@ type CheckEvent struct {
 	ResourceType string                 `json:"resource_type,omitempty"`
 	ResourceID   string                 `json:"resource_id,omitempty"`
 	Container    *CheckContainerMeta    `json:"container,omitempty"`
+	K8SManaged   *string                `json:"k8s_managed,omitempty"`
 	Tags         []string               `json:"tags"`
 	Data         map[string]interface{} `json:"data"`
 

--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -28,7 +28,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const version = "202305"
+const version = "202312"
 
 const (
 	k8sManifestsDir   = "/etc/kubernetes/manifests"
@@ -78,13 +78,6 @@ func (l *loader) load(ctx context.Context, loadProcesses procsLoader) (string, *
 	node.Manifests.KubeScheduler = l.loadConfigFileMeta(filepath.Join(k8sManifestsDir, "kube-scheduler.yaml"))
 	node.Manifests.Etcd = l.loadConfigFileMeta(filepath.Join(k8sManifestsDir, "etcd.yaml"))
 
-	if eksMeta := l.loadConfigFileMeta("/etc/eks/release"); eksMeta != nil {
-		node.ManagedEnvironment = &K8sManagedEnvConfig{
-			Name:     "eks",
-			Metadata: eksMeta.Content,
-		}
-	}
-
 	for _, proc := range loadProcesses(ctx) {
 		switch proc.name {
 		case "etcd":
@@ -97,6 +90,7 @@ func (l *loader) load(ctx context.Context, loadProcesses procsLoader) (string, *
 			node.Components.KubeScheduler = l.newK8sKubeSchedulerConfig(proc.flags)
 		case "kubelet":
 			node.Components.Kubelet = l.newK8sKubeletConfig(proc.flags)
+			node.ManagedEnvironment = l.detectManagedEnvironment(proc.flags)
 		case "kube-proxy":
 			node.Components.KubeProxy = l.newK8sKubeProxyConfig(proc.flags)
 		}
@@ -107,11 +101,49 @@ func (l *loader) load(ctx context.Context, loadProcesses procsLoader) (string, *
 	}
 
 	resourceType := "kubernetes_worker_node"
-	if node.Components.KubeApiserver != nil {
+	if managedEnv := node.ManagedEnvironment; managedEnv != nil {
+		switch managedEnv.Name {
+		case "eks":
+			resourceType = "aws_eks_worker_node"
+		case "gke":
+			resourceType = "gcp_gke_worker_node"
+		case "aks":
+			resourceType = "azure_aks_worker_node"
+		}
+	} else if node.Components.KubeApiserver != nil ||
+		node.Components.Etcd != nil ||
+		node.Components.KubeControllerManager != nil ||
+		node.Components.KubeScheduler != nil {
 		resourceType = "kubernetes_master_node"
 	}
 
 	return resourceType, &node
+}
+
+func (l *loader) detectManagedEnvironment(flags map[string]string) *K8sManagedEnvConfig {
+	nodeLabels, ok := flags["--node-labels"]
+	if ok {
+		for _, label := range strings.Split(nodeLabels, ",") {
+			label = strings.TrimSpace(label)
+			switch {
+			case strings.HasPrefix(label, "cloud.google.com/gke"):
+				return &K8sManagedEnvConfig{
+					Name: "gke",
+				}
+			case strings.HasPrefix(label, "eks.amazonaws.com/"):
+				eksMeta := l.loadConfigFileMeta("/etc/eks/release")
+				return &K8sManagedEnvConfig{
+					Name:     "eks",
+					Metadata: eksMeta,
+				}
+			case strings.HasPrefix(label, "kubernetes.azure.com/"):
+				return &K8sManagedEnvConfig{
+					Name: "aks",
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (l *loader) loadMeta(name string, loadContent bool) (string, os.FileInfo, []byte, bool) {

--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -131,11 +131,14 @@ func (l *loader) detectManagedEnvironment(flags map[string]string) *K8sManagedEn
 					Name: "gke",
 				}
 			case strings.HasPrefix(label, "eks.amazonaws.com/"):
-				eksMeta := l.loadConfigFileMeta("/etc/eks/release")
-				return &K8sManagedEnvConfig{
-					Name:     "eks",
-					Metadata: eksMeta,
+				env := &K8sManagedEnvConfig{
+					Name: "eks",
 				}
+				eksMeta := l.loadConfigFileMeta("/etc/eks/release")
+				if eksMeta != nil {
+					env.Metadata = eksMeta.Content
+				}
+				return env
 			case strings.HasPrefix(label, "kubernetes.azure.com/"):
 				return &K8sManagedEnvConfig{
 					Name: "aks",


### PR DESCRIPTION
### What does this PR do?

Provides better detection of managed environment for K8s clusters and configuration relying on node-labels.

### Motivation

We were lacking detection for GKE and AKS and looking into the node-labels that are set, it looks like a good convention that we can rely on to safely detect whether a worker node is running on a specific managed environment.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
