### PR TITLE
[oracle] Smaller adjustments on test cases (DBMON-3286)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -146,10 +146,14 @@ func TestChkRun(t *testing.T) {
 
 		tempLobsBefore, _ := getTemporaryLobs(chk.db)
 
+		/* Requires:
+		 * create table sys.t(n number);
+		 * grant insert on sys.t to c##datadog
+		 */
 		_, err = chk.db.Exec(`begin
 				for i in 1..1000
 				loop
-					execute immediate 'insert into t values (' || i || ')';
+					execute immediate 'insert into sys.t values (' || i || ')';
 				end loop;
 				end ;`)
 		assert.NoError(t, err, "error generating statements with %s driver", driver)
@@ -301,9 +305,9 @@ func TestObfuscator(t *testing.T) {
 	_, err := o.ObfuscateSQLString(`SELECT TRUNC(SYSDATE@!) from dual`)
 	assert.NoError(t, err, "can't obfuscate @!")
 
-	sql := "begin null ; end"
+	sql := "begin null ; end;"
 	obfuscatedStatement, err := o.ObfuscateSQLString(sql)
-	assert.Equal(t, sql, obfuscatedStatement.Query)
+	assert.Equal(t, obfuscatedStatement.Query, "begin null; end;")
 
 	sql = "select count (*) from dual"
 	obfuscatedStatement, err = o.ObfuscateSQLString(sql)


### PR DESCRIPTION
### What does this PR do?

- Removing a test table from C##DATADOG schema.
- Adjustment to changed obfuscator behaviour - no spaces in front of semi-columns anymore.

### Describe how to test/QA your changes

Run the tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
