### PR TITLE
[e2e] lazy environment as an option

### DIFF
--- a/test/new-e2e/pkg/utils/e2e/params/params.go
+++ b/test/new-e2e/pkg/utils/e2e/params/params.go
@@ -15,6 +15,10 @@ type Params struct {
 	DevMode bool
 
 	SkipDeleteOnFailure bool
+
+	// Setting LazyEnvironment allows to skip environment creation
+	// until the first explicit call to suite.Env()
+	LazyEnvironment bool
 }
 
 // Option is an optional function parameter type for e2e options
@@ -41,5 +45,12 @@ func WithDevMode() func(*Params) {
 func WithSkipDeleteOnFailure() func(*Params) {
 	return func(options *Params) {
 		options.SkipDeleteOnFailure = true
+	}
+}
+
+// WithLazyEnvironment skips environment creation until the first explicit call to suite.Env()
+func WithLazyEnvironment() func(*Params) {
+	return func(options *Params) {
+		options.LazyEnvironment = true
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add an option to lazily setup an e2e environment on TestSuite, changing default behaviour to setup the environment at initialisation. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We recently spotted an unexpected amount of resources in agent-qa AWS account, created by tests executions on the CI, expected to be cleaned up at test end. 

By investigating it, we found out that we were often calling `suite.Env()` for the first time from a `testify.Eventually`. `testify.Eventually` runs the retried function from a go routine. The first thread calling `suite.Env()` started the creation of the remote environment as by default it was lazily created. Since it took longer than the total `Eventually` timeout, the assertion never succeeded, failing, but keeping those go routine running wild and free. After the assertion failures come the end of the test scenario, which asks pulumi to tear down the environment. This fails as the setup process is still running, protected by the stack lock file. Result: environment is leaked.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
