### PR TITLE
[7.50] Backport check cancel timeout (#21543) and excluding checks from advanced dispatching (#21552) 

### DIFF
--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -71,7 +71,7 @@ func LoadComponents(ctx context.Context, senderManager sender.SenderManager, con
 
 	// create the Collector instance and start all the components
 	// NOTICE: this will also setup the Python environment, if available
-	Coll = collector.NewCollector(senderManager, GetPythonPaths()...)
+	Coll = collector.NewCollector(senderManager, config.Datadog.GetDuration("check_cancel_timeout"), GetPythonPaths()...)
 
 	// setup autodiscovery
 	confSearchPaths := []string{

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -30,12 +30,13 @@ const (
 
 // dispatcher holds the management logic for cluster-checks
 type dispatcher struct {
-	store                 *clusterStore
-	nodeExpirationSeconds int64
-	extraTags             []string
-	clcRunnersClient      clusteragent.CLCRunnerClientInterface
-	advancedDispatching   bool
-	excludedChecks        map[string]struct{}
+	store                         *clusterStore
+	nodeExpirationSeconds         int64
+	extraTags                     []string
+	clcRunnersClient              clusteragent.CLCRunnerClientInterface
+	advancedDispatching           bool
+	excludedChecks                map[string]struct{}
+	excludedChecksFromDispatching map[string]struct{}
 }
 
 func newDispatcher() *dispatcher {
@@ -51,6 +52,15 @@ func newDispatcher() *dispatcher {
 		d.excludedChecks = make(map[string]struct{}, len(excludedChecks))
 		for _, checkName := range excludedChecks {
 			d.excludedChecks[checkName] = struct{}{}
+		}
+	}
+
+	excludedChecksFromDispatching := config.Datadog.GetStringSlice("cluster_checks.exclude_checks_from_dispatching")
+	// This option will almost always be empty
+	if len(excludedChecksFromDispatching) > 0 {
+		d.excludedChecksFromDispatching = make(map[string]struct{}, len(excludedChecksFromDispatching))
+		for _, checkName := range excludedChecksFromDispatching {
+			d.excludedChecksFromDispatching[checkName] = struct{}{}
 		}
 	}
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -363,15 +363,12 @@ func (d *dispatcher) currentDistribution() checksDistribution {
 
 	for nodeName, nodeStoreInfo := range d.store.nodes {
 		for checkID, stats := range nodeStoreInfo.clcRunnerStats {
-			digest, found := d.store.idToDigest[checkid.ID(checkID)]
-			if !found { // Not a cluster check
+			if !stats.IsClusterCheck {
 				continue
 			}
 
 			minCollectionInterval := defaults.DefaultCheckInterval
-
-			conf := d.store.digestToConfig[digest]
-
+			conf := d.store.digestToConfig[d.store.idToDigest[checkid.ID(checkID)]]
 			if len(conf.Instances) > 0 {
 				commonOptions := integration.CommonInstanceConfig{}
 				err := yaml.Unmarshal(conf.Instances[0], &commonOptions)

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -42,16 +42,19 @@ type Collector struct {
 	runner    *runner.Runner
 	checks    map[checkid.ID]*middleware.CheckWrapper
 
+	cancelCheckTimeout time.Duration
+
 	m sync.RWMutex
 }
 
 // NewCollector create a Collector instance and sets up the Python Environment
-func NewCollector(senderManager sender.SenderManager, paths ...string) *Collector {
+func NewCollector(senderManager sender.SenderManager, cancelCheckTimeout time.Duration, paths ...string) *Collector {
 	c := &Collector{
-		senderManager:  senderManager,
-		checks:         make(map[checkid.ID]*middleware.CheckWrapper),
-		state:          atomic.NewUint32(stopped),
-		checkInstances: int64(0),
+		senderManager:      senderManager,
+		checks:             make(map[checkid.ID]*middleware.CheckWrapper),
+		state:              atomic.NewUint32(stopped),
+		checkInstances:     int64(0),
+		cancelCheckTimeout: cancelCheckTimeout,
 	}
 	pyVer, pyHome, pyPath := pySetup(paths...)
 
@@ -172,11 +175,11 @@ func (c *Collector) StopCheck(id checkid.ID) error {
 	err = c.runner.StopCheck(id)
 	if err != nil {
 		// still attempt to cancel the check before returning the error
-		_ = c.cancelCheck(ch, cancelCheckTimeout)
+		_ = c.cancelCheck(ch, c.cancelCheckTimeout)
 		return fmt.Errorf("an error occurred while stopping the check: %s", err)
 	}
 
-	err = c.cancelCheck(ch, cancelCheckTimeout)
+	err = c.cancelCheck(ch, c.cancelCheckTimeout)
 	if err != nil {
 		return fmt.Errorf("an error occurred while calling check.Cancel(): %s", err)
 	}
@@ -204,7 +207,7 @@ func (c *Collector) cancelCheck(ch check.Check, timeout time.Duration) error {
 	case <-done:
 		return nil
 	case <-time.After(timeout):
-		return fmt.Errorf("timeout while calling check.Cancel() on check ID %s", ch.ID())
+		return fmt.Errorf("timeout while calling check.Cancel() on check ID %s, timeout: %s", ch.ID(), timeout)
 	}
 }
 

--- a/pkg/collector/collector_demux_test.go
+++ b/pkg/collector/collector_demux_test.go
@@ -32,7 +32,7 @@ type CollectorDemuxTestSuite struct {
 func (suite *CollectorDemuxTestSuite) SetupTest() {
 	log := fxutil.Test[log.Component](suite.T(), log.MockModule)
 	suite.demux = aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 100*time.Hour)
-	suite.c = NewCollector(suite.demux)
+	suite.c = NewCollector(suite.demux, 500*time.Millisecond)
 
 	suite.c.Start()
 }

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -41,6 +41,7 @@ func (c *TestCheck) ID() checkid.ID {
 	}
 	return checkid.ID(c.String())
 }
+
 func (c *TestCheck) String() string {
 	if c.name != "" {
 		return c.name
@@ -84,7 +85,7 @@ type CollectorTestSuite struct {
 }
 
 func (suite *CollectorTestSuite) SetupTest() {
-	suite.c = NewCollector(aggregator.NewNoOpSenderManager())
+	suite.c = NewCollector(aggregator.NewNoOpSenderManager(), 500*time.Millisecond)
 	suite.c.Start()
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -263,6 +263,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("enable_metadata_collection", true)
 	config.BindEnvAndSetDefault("enable_gohai", true)
 	config.BindEnvAndSetDefault("check_runners", int64(4))
+	config.BindEnvAndSetDefault("check_cancel_timeout", 500*time.Millisecond)
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
 	config.BindEnv("bind_host")
 	config.BindEnvAndSetDefault("ipc_address", "localhost")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1025,6 +1025,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_percentage_improvement", 10) // Experimental. Subject to change. Rebalance only if the distribution found improves the current one by this.
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})
+	config.BindEnvAndSetDefault("cluster_checks.exclude_checks_from_dispatching", []string{})
 
 	// Cluster check runner
 	config.BindEnvAndSetDefault("clc_runner_enabled", false)


### PR DESCRIPTION
### What does this PR do?

Backport #21543 and #21552 to `7.50.x`

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

See each PR for QA. Testing was already done internally with custom image.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
