### PR TITLE
[CSPM] Remove last remaining linter TODOs

### DIFF
--- a/pkg/compliance/data.go
+++ b/pkg/compliance/data.go
@@ -159,8 +159,6 @@ func NewCheckEvent(
 }
 
 // NewCheckSkipped returns a CheckEvent with skipped status.
-//
-//nolint:revive // TODO(CSPM) Fix revive linter
 func NewCheckSkipped(
 	evaluator Evaluator,
 	skipReason error,
@@ -173,6 +171,8 @@ func NewCheckSkipped(
 		AgentVersion: version.AgentVersion,
 		RuleID:       rule.ID,
 		FrameworkID:  benchmark.FrameworkID,
+		ResourceID:   resourceID,
+		ResourceType: resourceType,
 		Evaluator:    evaluator,
 		Result:       CheckSkipped,
 		Data:         map[string]interface{}{"error": skipReason.Error()},

--- a/pkg/compliance/inputs_docker_nodocker.go
+++ b/pkg/compliance/inputs_docker_nodocker.go
@@ -13,7 +13,6 @@ import (
 	docker "github.com/docker/docker/client"
 )
 
-//nolint:revive // TODO(CSPM) Fix revive linter
-func newDockerClient(ctx context.Context) (docker.CommonAPIClient, error) {
+func newDockerClient(_ context.Context) (docker.CommonAPIClient, error) {
 	return nil, ErrIncompatibleEnvironment
 }

--- a/pkg/compliance/resolver.go
+++ b/pkg/compliance/resolver.go
@@ -69,7 +69,7 @@ func DefaultDockerProvider(ctx context.Context) (docker.CommonAPIClient, error) 
 }
 
 // DefaultLinuxAuditProvider returns the default Linux Audit client.
-func DefaultLinuxAuditProvider(ctx context.Context) (LinuxAuditClient, error) { //nolint:revive // TODO fix revive unused-parameter
+func DefaultLinuxAuditProvider(_ context.Context) (LinuxAuditClient, error) {
 	return newLinuxAuditClient()
 }
 
@@ -498,8 +498,7 @@ func (r *defaultResolver) getProcs(ctx context.Context) ([]*process.Process, err
 	return r.procsCache, nil
 }
 
-//nolint:revive // TODO(CSPM) Fix revive linter
-func (r *defaultResolver) resolveGroup(ctx context.Context, spec InputSpecGroup) (interface{}, error) {
+func (r *defaultResolver) resolveGroup(_ context.Context, spec InputSpecGroup) (interface{}, error) {
 	f, err := os.Open(r.pathNormalizeToHostRoot("/etc/group"))
 	if err != nil {
 		return nil, err
@@ -533,8 +532,7 @@ func (r *defaultResolver) resolveGroup(ctx context.Context, spec InputSpecGroup)
 	return nil, nil
 }
 
-//nolint:revive // TODO(CSPM) Fix revive linter
-func (r *defaultResolver) resolveAudit(ctx context.Context, spec InputSpecAudit) (interface{}, error) {
+func (r *defaultResolver) resolveAudit(_ context.Context, spec InputSpecAudit) (interface{}, error) {
 	cl := r.linuxAuditCl
 	if cl == nil {
 		return nil, ErrIncompatibleEnvironment

--- a/pkg/compliance/tests/base_test.go
+++ b/pkg/compliance/tests/base_test.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package tests implements the unit tests for pkg/compliance.
 package tests
 
 import (

--- a/pkg/compliance/tests/base_test.go
+++ b/pkg/compliance/tests/base_test.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(CSPM) Fix revive linter
 package tests
 
 import (

--- a/pkg/compliance/tests/kubernetes_test.go
+++ b/pkg/compliance/tests/kubernetes_test.go
@@ -20,8 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-//nolint:revive // TODO(CSPM) Fix revive linter
-func getMockedKubeClient(t *testing.T, objects ...runtime.Object) dynamic.Interface {
+func getMockedKubeClient(objects ...runtime.Object) dynamic.Interface {
 	addKnownTypes := func(scheme *runtime.Scheme) error {
 		scheme.AddKnownTypes(schema.GroupVersion{Group: "mygroup.com", Version: "v1"},
 			&MyObj{},
@@ -35,7 +34,7 @@ func getMockedKubeClient(t *testing.T, objects ...runtime.Object) dynamic.Interf
 }
 
 func TestKubernetesCluster(t *testing.T) {
-	kubeClient := getMockedKubeClient(t,
+	kubeClient := getMockedKubeClient(
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				UID:  "my-cluster",


### PR DESCRIPTION
### What does this PR do?

Review and fix the last remaining TODOs from revive linters.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
