### PR TITLE
[APL-2576] Add option to run new e2e tests with pipeline.run invoke task

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -287,6 +287,9 @@ variables:
 .if_not_e2e: &if_not_e2e
   if: $RUN_KITCHEN_TESTS == "false"
 
+.if_e2e: &if_e2e
+  if: $RUN_E2E_TESTS == "true"
+
 .if_deploy_on_beta_repo_branch: &if_deploy_on_beta_repo_branch
   if: $DEPLOY_AGENT == "true" && $BUCKET_BRANCH == "beta"
 
@@ -885,6 +888,7 @@ workflow:
     when: never
   - <<: *if_not_version_7
     when: never
+  - <<: *if_e2e
   - <<: *if_kitchen
   - <<: *if_default_kitchen
     variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -287,7 +287,7 @@ variables:
 .if_not_e2e: &if_not_e2e
   if: $RUN_KITCHEN_TESTS == "false"
 
-.if_e2e: &if_e2e
+.if_run_e2e: &if_run_e2e
   if: $RUN_E2E_TESTS == "true"
 
 .if_deploy_on_beta_repo_branch: &if_deploy_on_beta_repo_branch
@@ -888,7 +888,7 @@ workflow:
     when: never
   - <<: *if_not_version_7
     when: never
-  - <<: *if_e2e
+  - <<: *if_run_e2e
   - <<: *if_kitchen
   - <<: *if_default_kitchen
     variables:
@@ -1009,4 +1009,4 @@ workflow:
     when: never
 
 .if_run_e2e_tests:
-  if: $RUN_E2E_TESTS == "true"
+  - <<: *if_run_e2e

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1007,3 +1007,6 @@ workflow:
 .except_mergequeue:
   - <<: *if_mergequeue
     when: never
+
+.if_run_e2e_tests:
+  if: $RUN_E2E_TESTS == "true"

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -36,8 +36,7 @@
 # build agent6 py2 image
 docker_build_agent6:
   extends: .docker_build_job_definition_amd64
-  rules:
-    !reference [.on_a6]
+  rules: !reference [.on_a6]
   needs:
     - job: agent_deb-x64-a6
       artifacts: false
@@ -49,8 +48,7 @@ docker_build_agent6:
 
 docker_build_agent6_arm64:
   extends: .docker_build_job_definition_arm64
-  rules:
-    !reference [.on_all_builds_a6]
+  rules: !reference [.on_all_builds_a6]
   needs:
     - job: agent_deb-arm64-a6
       artifacts: false
@@ -63,8 +61,7 @@ docker_build_agent6_arm64:
 # build agent6 py2 jmx image
 docker_build_agent6_jmx:
   extends: .docker_build_job_definition_amd64
-  rules:
-    !reference [.on_a6]
+  rules: !reference [.on_a6]
   needs:
     - job: agent_deb-x64-a6
       artifacts: false
@@ -78,8 +75,7 @@ docker_build_agent6_jmx:
 # build agent6 py2 jmx image
 docker_build_agent6_jmx_arm64:
   extends: .docker_build_job_definition_arm64
-  rules:
-    !reference [.on_all_builds_a6]
+  rules: !reference [.on_all_builds_a6]
   needs:
     - job: agent_deb-arm64-a6
       artifacts: false
@@ -94,8 +90,7 @@ docker_build_agent6_jmx_arm64:
 # build agent6 jmx unified image (including python3)
 docker_build_agent6_py2py3_jmx:
   extends: .docker_build_job_definition_amd64
-  rules:
-    !reference [.on_a6]
+  rules: !reference [.on_a6]
   needs:
     - job: agent_deb-x64-a6
       artifacts: false
@@ -108,8 +103,7 @@ docker_build_agent6_py2py3_jmx:
 # build agent7 image
 docker_build_agent7:
   extends: .docker_build_job_definition_amd64
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   needs:
     - job: agent_deb-x64-a7
       artifacts: false
@@ -122,8 +116,7 @@ docker_build_agent7:
 single_machine_performance-amd64-a7:
   extends: .docker_publish_job_definition
   stage: container_build
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   needs:
     - docker_build_agent7
   variables:
@@ -133,8 +126,7 @@ single_machine_performance-amd64-a7:
 
 docker_build_agent7_arm64:
   extends: .docker_build_job_definition_arm64
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   needs:
     - job: agent_deb-arm64-a7
       artifacts: false
@@ -147,8 +139,7 @@ docker_build_agent7_arm64:
 # build agent7 jmx image
 docker_build_agent7_jmx:
   extends: .docker_build_job_definition_amd64
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   needs:
     - job: agent_deb-x64-a7
       artifacts: false
@@ -160,8 +151,7 @@ docker_build_agent7_jmx:
 
 docker_build_agent7_jmx_arm64:
   extends: .docker_build_job_definition_arm64
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   needs:
     - job: agent_deb-arm64-a7
       artifacts: false
@@ -174,8 +164,7 @@ docker_build_agent7_jmx_arm64:
 # build the cluster-agent image
 docker_build_cluster_agent_amd64:
   extends: .docker_build_job_definition_amd64
-  rules:
-    !reference [.on_tag_or_a7]
+  rules: !reference [.on_tag_or_a7]
   needs:
     - job: cluster_agent-build_amd64
       artifacts: false
@@ -187,8 +176,7 @@ docker_build_cluster_agent_amd64:
 
 docker_build_cluster_agent_arm64:
   extends: .docker_build_job_definition_arm64
-  rules:
-    !reference [.on_tag_or_a7]
+  rules: !reference [.on_tag_or_a7]
   needs:
     - job: cluster_agent-build_arm64
       artifacts: false
@@ -201,8 +189,7 @@ docker_build_cluster_agent_arm64:
 # build the cws-instrumentation image
 docker_build_cws_instrumentation_amd64:
   extends: .docker_build_job_definition_amd64
-  rules:
-    !reference [.on_tag_or_a7]
+  rules: !reference [.on_tag_or_a7]
   needs:
     - job: cws_instrumentation-build_amd64
       artifacts: false
@@ -212,8 +199,7 @@ docker_build_cws_instrumentation_amd64:
 
 docker_build_cws_instrumentation_arm64:
   extends: .docker_build_job_definition_arm64
-  rules:
-    !reference [.on_tag_or_a7]
+  rules: !reference [.on_tag_or_a7]
   needs:
     - job: cws_instrumentation-build_arm64
       artifacts: false
@@ -224,8 +210,7 @@ docker_build_cws_instrumentation_arm64:
 # build the dogstatsd image
 docker_build_dogstatsd_amd64:
   extends: .docker_build_job_definition_amd64
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   needs:
     - job: build_dogstatsd_static-binary_x64
       artifacts: false
@@ -236,8 +221,7 @@ docker_build_dogstatsd_amd64:
 # build the dogstatsd image
 docker_build_dogstatsd_arm64:
   extends: .docker_build_job_definition_arm64
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   needs:
     - job: build_dogstatsd_static-binary_arm64
       artifacts: false

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -5,8 +5,7 @@ include:
 dev_branch-a6:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_a6_manual]
+  rules: !reference [.on_a6_manual]
   needs:
     - docker_build_agent6
     - docker_build_agent6_jmx
@@ -25,8 +24,7 @@ dev_branch-a6:
 dev_branch-dogstatsd:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_a7_manual]
+  rules: !reference [.on_a7_manual]
   needs:
     - docker_build_dogstatsd_amd64
     - docker_build_dogstatsd_arm64
@@ -38,8 +36,7 @@ dev_branch-dogstatsd:
 dev_branch_multiarch-a6:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_all_builds_a6_manual]
+  rules: !reference [.on_all_builds_a6_manual]
   needs:
     - docker_build_agent6
     - docker_build_agent6_arm64
@@ -60,8 +57,7 @@ dev_branch_multiarch-a6:
 dev_branch_multiarch-a7:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_a7_manual]
+  rules: !reference [.on_a7_manual]
   needs:
     - docker_build_agent7
     - docker_build_agent7_arm64
@@ -79,8 +75,7 @@ dev_branch_multiarch-a7:
 dev_branch_multiarch-dogstatsd:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_a7_manual]
+  rules: !reference [.on_a7_manual]
   needs:
     - docker_build_dogstatsd_amd64
     - docker_build_dogstatsd_arm64
@@ -92,8 +87,7 @@ dev_branch_multiarch-dogstatsd:
 dev_master-a6:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_main_a6]
+  rules: !reference [.on_main_a6]
   needs:
     - docker_build_agent6
     - docker_build_agent6_arm64
@@ -112,8 +106,7 @@ dev_master-a6:
 dev_master-a7:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_main_a7]
+  rules: !reference [.on_main_a7]
   needs:
     - docker_build_agent7
     - docker_build_agent7_arm64
@@ -131,8 +124,7 @@ dev_master-a7:
 dev_master-dogstatsd:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_main_a7]
+  rules: !reference [.on_main_a7]
   needs:
     - docker_build_dogstatsd_amd64
     - docker_build_dogstatsd_arm64
@@ -144,8 +136,7 @@ dev_master-dogstatsd:
 dca_dev_branch:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_a7_manual]
+  rules: !reference [.on_a7_manual]
   needs:
     - docker_build_cluster_agent_amd64
   variables:
@@ -156,8 +147,7 @@ dca_dev_branch:
 dca_dev_branch_multiarch:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_all_builds_a7_manual]
+  rules: !reference [.on_all_builds_a7_manual]
   needs:
     - docker_build_cluster_agent_amd64
     - docker_build_cluster_agent_arm64
@@ -169,8 +159,7 @@ dca_dev_branch_multiarch:
 dca_dev_master:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_main_a7]
+  rules: !reference [.on_main_a7]
   needs:
     - docker_build_cluster_agent_amd64
   variables:
@@ -181,8 +170,7 @@ dca_dev_master:
 cws_instrumentation_dev_branch_multiarch:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_all_builds_a7_manual]
+  rules: !reference [.on_all_builds_a7_manual]
   needs:
     - docker_build_cws_instrumentation_amd64
     - docker_build_cws_instrumentation_arm64
@@ -195,8 +183,7 @@ cws_instrumentation_dev_branch_multiarch:
 dev_nightly_docker_hub-a6:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_deploy_nightly_repo_branch_a6]
+  rules: !reference [.on_deploy_nightly_repo_branch_a6]
   needs:
     - docker_build_agent6
     - docker_build_agent6_arm64
@@ -216,8 +203,7 @@ dev_nightly_docker_hub-a6:
 dev_nightly-a7:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_deploy_nightly_repo_branch_a7]
+  rules: !reference [.on_deploy_nightly_repo_branch_a7]
   needs:
     - docker_build_agent7
     - docker_build_agent7_arm64
@@ -236,8 +222,7 @@ dev_nightly-a7:
 single_machine_performance-nightly-amd64-a7:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_scheduled_main]
+  rules: !reference [.on_scheduled_main]
   needs:
     - docker_build_agent7
   variables:
@@ -249,8 +234,7 @@ single_machine_performance-nightly-amd64-a7:
 dev_nightly-dogstatsd:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    !reference [.on_deploy_nightly_repo_branch_a7]
+  rules: !reference [.on_deploy_nightly_repo_branch_a7]
   needs:
     - docker_build_dogstatsd_amd64
     - docker_build_dogstatsd_arm64
@@ -297,30 +281,30 @@ dev_nightly-dogstatsd:
 
 qa_main_agent:
   extends: .qa_agent
-  rules:
-    !reference [.on_main_and_no_skip_e2e]
+  rules: !reference [.on_main_and_no_skip_e2e]
 
 qa_branch_agent:
   extends: .qa_agent
   rules:
-    !reference [.on_dev_branch_manual]
+    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.on_dev_branch_manual]
 
 qa_main_dca:
   extends: .qa_dca
-  rules:
-    !reference [.on_main_and_no_skip_e2e]
+  rules: !reference [.on_main_and_no_skip_e2e]
 
 qa_branch_dca:
   extends: .qa_dca
   rules:
-    !reference [.on_dev_branch_manual]
+    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.on_dev_branch_manual]
 
 qa_main_dogstatsd:
   extends: .qa_dogstatsd
-  rules:
-    !reference [.on_main_and_no_skip_e2e]
+  rules: !reference [.on_main_and_no_skip_e2e]
 
 qa_branch_dogstatsd:
   extends: .qa_dogstatsd
   rules:
-    !reference [.on_dev_branch_manual]
+    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.on_dev_branch_manual]

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -286,7 +286,7 @@ qa_main_agent:
 qa_branch_agent:
   extends: .qa_agent
   rules:
-    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
 
 qa_main_dca:
@@ -296,7 +296,7 @@ qa_main_dca:
 qa_branch_dca:
   extends: .qa_dca
   rules:
-    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
 
 qa_main_dogstatsd:
@@ -306,5 +306,5 @@ qa_main_dogstatsd:
 qa_branch_dogstatsd:
   extends: .qa_dogstatsd
   rules:
-    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -1,6 +1,8 @@
 ---
 # e2e stage
 # Contains jobs which runs e2e tests on our Docker images.
+.if_e2e: &if_e2e
+  if: $RUN_E2E_TESTS == "true"
 
 .k8s_e2e_template:
   stage: e2e
@@ -159,7 +161,7 @@ new-e2e-containers-dev:
   # on_main_and_no_skip_e2e adding on_dev_branch_manual rules
   # and move rules to template
   rules:
-    - if: $RUN_E2E_TESTS == "true"
+    - <<: *if_e2e
     - !reference [.on_dev_branch_manual]
   needs:
     - qa_branch_agent
@@ -197,7 +199,7 @@ new-e2e-containers-main:
 new-e2e-agent-shared-components-dev:
   extends: .new_e2e_template
   rules:
-    - if: $RUN_E2E_TESTS == "true"
+    - <<: *if_e2e
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -231,7 +233,7 @@ new-e2e-agent-shared-components-main:
 new-e2e-agent-subcommands-dev:
   extends: .new_e2e_template
   rules:
-    - if: $RUN_E2E_TESTS == "true"
+    - <<: *if_e2e
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -250,13 +252,10 @@ new-e2e-agent-subcommands-main:
   allow_failure: true
   <<: *agent-subcommands-tests-matrix
 
-
-
-# e2e through invoke currently works up to this job
 new-e2e-language-detection-dev:
   extends: .new_e2e_template
   rules:
-    - if: $RUN_E2E_TESTS == "true"
+    - <<: *if_e2e
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -273,7 +272,7 @@ new-e2e-language-detection-main:
 new-e2e-npm-dev:
   extends: .new_e2e_template
   rules:
-    - if: $RUN_E2E_TESTS == "true"
+    - <<: *if_e2e
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -290,7 +289,7 @@ new-e2e-npm-main:
 new-e2e-aml-dev:
   extends: .new_e2e_template
   rules:
-    - if: $RUN_E2E_TESTS == "true"
+    - <<: *if_e2e
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -307,7 +306,7 @@ new-e2e-aml-main:
 new-e2e-cws-dev:
   extends: .new_e2e_template
   rules:
-    - if: $RUN_E2E_TESTS == "true"
+    - <<: *if_e2e
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -328,7 +327,7 @@ new-e2e-cws-main:
 new-e2e-process-dev:
   extends: .new_e2e_template
   rules:
-    - if: $RUN_E2E_TESTS == "true"
+    - <<: *if_e2e
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -1,8 +1,6 @@
 ---
 # e2e stage
 # Contains jobs which runs e2e tests on our Docker images.
-.if_e2e: &if_e2e
-  if: $RUN_E2E_TESTS == "true"
 
 .k8s_e2e_template:
   stage: e2e
@@ -161,7 +159,7 @@ new-e2e-containers-dev:
   # on_main_and_no_skip_e2e adding on_dev_branch_manual rules
   # and move rules to template
   rules:
-    - <<: *if_e2e
+    - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
   needs:
     - qa_branch_agent
@@ -199,7 +197,7 @@ new-e2e-containers-main:
 new-e2e-agent-shared-components-dev:
   extends: .new_e2e_template
   rules:
-    - <<: *if_e2e
+    - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -233,7 +231,7 @@ new-e2e-agent-shared-components-main:
 new-e2e-agent-subcommands-dev:
   extends: .new_e2e_template
   rules:
-    - <<: *if_e2e
+    - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -255,7 +253,7 @@ new-e2e-agent-subcommands-main:
 new-e2e-language-detection-dev:
   extends: .new_e2e_template
   rules:
-    - <<: *if_e2e
+    - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -272,7 +270,7 @@ new-e2e-language-detection-main:
 new-e2e-npm-dev:
   extends: .new_e2e_template
   rules:
-    - <<: *if_e2e
+    - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -289,7 +287,7 @@ new-e2e-npm-main:
 new-e2e-aml-dev:
   extends: .new_e2e_template
   rules:
-    - <<: *if_e2e
+    - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -306,7 +304,7 @@ new-e2e-aml-main:
 new-e2e-cws-dev:
   extends: .new_e2e_template
   rules:
-    - <<: *if_e2e
+    - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:
@@ -327,7 +325,7 @@ new-e2e-cws-main:
 new-e2e-process-dev:
   extends: .new_e2e_template
   rules:
-    - <<: *if_e2e
+    - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
   needs: ["deploy_deb_testing-a7_x64"]
   variables:

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -158,8 +158,13 @@ new-e2e-containers-dev:
   # TODO once images are deployed to ECR for dev branches, update
   # on_main_and_no_skip_e2e adding on_dev_branch_manual rules
   # and move rules to template
-  rules: !reference [.on_dev_branch_manual]
-  needs: []
+  rules:
+    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.on_dev_branch_manual]
+  needs:
+    - qa_branch_agent
+    - qa_branch_dca
+    - qa_branch_dogstatsd
   variables:
     TARGETS: ./tests/containers
     TEAM: container-integrations
@@ -191,8 +196,10 @@ new-e2e-containers-main:
 
 new-e2e-agent-shared-components-dev:
   extends: .new_e2e_template
-  rules: !reference [.on_dev_branch_manual]
-  needs: []
+  rules:
+    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.on_dev_branch_manual]
+  needs: ["deploy_deb_testing-a7_x64"]
   variables:
     TARGETS: ./tests/agent-shared-components
     TEAM: agent-shared-components
@@ -223,8 +230,10 @@ new-e2e-agent-shared-components-main:
 
 new-e2e-agent-subcommands-dev:
   extends: .new_e2e_template
-  rules: !reference [.on_dev_branch_manual]
-  needs: []
+  rules:
+    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.on_dev_branch_manual]
+  needs: ["deploy_deb_testing-a7_x64"]
   variables:
     TARGETS: ./tests/agent-subcommands
     TEAM: agent-shared-components
@@ -243,10 +252,12 @@ new-e2e-agent-subcommands-main:
 
 
 
+# e2e through invoke currently works up to this job
 new-e2e-language-detection-dev:
   extends: .new_e2e_template
-  rules: !reference [.on_dev_branch_manual]
-  needs: []
+  rules:
+    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.on_dev_branch_manual]
   variables:
     TARGETS: ./tests/language-detection
     TEAM: processes
@@ -260,8 +271,9 @@ new-e2e-language-detection-main:
 
 new-e2e-npm-dev:
   extends: .new_e2e_template
-  rules: !reference [.on_dev_branch_manual]
-  needs: []
+  rules:
+    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.on_dev_branch_manual]
   variables:
     TARGETS: ./tests/npm
 
@@ -275,7 +287,9 @@ new-e2e-npm-main:
 
 new-e2e-aml-dev:
   extends: .new_e2e_template
-  rules: !reference [.on_dev_branch_manual]
+  rules:
+    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.on_dev_branch_manual]
   variables:
     TARGETS: ./tests/agent-metric-logs
     TEAM: agent-metric-logs
@@ -289,8 +303,9 @@ new-e2e-aml-main:
 
 new-e2e-cws-dev:
   extends: .new_e2e_template
-  rules: !reference [.on_dev_branch_manual]
-  needs: []
+  rules:
+    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.on_dev_branch_manual]
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
@@ -308,8 +323,9 @@ new-e2e-cws-main:
 
 new-e2e-process-dev:
   extends: .new_e2e_template
-  rules: !reference [.on_dev_branch_manual]
-  needs: []
+  rules:
+    - if: $RUN_E2E_TESTS == "true"
+    - !reference [.on_dev_branch_manual]
   variables:
     TARGETS: ./tests/process
     TEAM: processes

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -258,6 +258,7 @@ new-e2e-language-detection-dev:
   rules:
     - if: $RUN_E2E_TESTS == "true"
     - !reference [.on_dev_branch_manual]
+  needs: ["deploy_deb_testing-a7_x64"]
   variables:
     TARGETS: ./tests/language-detection
     TEAM: processes
@@ -274,6 +275,7 @@ new-e2e-npm-dev:
   rules:
     - if: $RUN_E2E_TESTS == "true"
     - !reference [.on_dev_branch_manual]
+  needs: ["deploy_deb_testing-a7_x64"]
   variables:
     TARGETS: ./tests/npm
 
@@ -290,6 +292,7 @@ new-e2e-aml-dev:
   rules:
     - if: $RUN_E2E_TESTS == "true"
     - !reference [.on_dev_branch_manual]
+  needs: ["deploy_deb_testing-a7_x64"]
   variables:
     TARGETS: ./tests/agent-metric-logs
     TEAM: agent-metric-logs
@@ -306,6 +309,7 @@ new-e2e-cws-dev:
   rules:
     - if: $RUN_E2E_TESTS == "true"
     - !reference [.on_dev_branch_manual]
+  needs: ["deploy_deb_testing-a7_x64"]
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
@@ -326,6 +330,7 @@ new-e2e-process-dev:
   rules:
     - if: $RUN_E2E_TESTS == "true"
     - !reference [.on_dev_branch_manual]
+  needs: ["deploy_deb_testing-a7_x64"]
   variables:
     TARGETS: ./tests/process
     TEAM: processes

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -200,7 +200,7 @@ new-e2e-agent-shared-components-dev:
 new-e2e-agent-shared-components-main:
   extends: .new_e2e_template
   rules: !reference [.on_main_and_no_skip_e2e]
-  needs: ['deploy_deb_testing-a7_x64']
+  needs: ["deploy_deb_testing-a7_x64"]
   variables:
     TARGETS: ./tests/agent-shared-components
     TEAM: agent-shared-components
@@ -233,7 +233,7 @@ new-e2e-agent-subcommands-dev:
 new-e2e-agent-subcommands-main:
   extends: .new_e2e_template
   rules: !reference [.on_main_and_no_skip_e2e]
-  needs: ['deploy_deb_testing-a7_x64']
+  needs: ["deploy_deb_testing-a7_x64"]
   variables:
     TARGETS: ./tests/agent-subcommands
     TEAM: agent-shared-components
@@ -320,8 +320,6 @@ new-e2e-process-main:
   variables:
     TARGETS: ./tests/process
     TEAM: processes
-
-
 #   ^    If you create a new job here that extends `.new_e2e_template`,
 #  /!\   do not forget to add it in the `dependencies` statement of the
 # /___\  `e2e_test_junit_upload` job in the `.gitlab/e2e_test_junit_upload.yml` file

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -88,12 +88,14 @@ def trigger_agent_pipeline(
     deploy=False,
     all_builds=False,
     kitchen_tests=False,
+    e2e_tests=False,
     rc_k8s_deployments=False,
 ):
     """
     Trigger a pipeline on the datadog-agent repositories. Multiple options are available:
     - run a pipeline with all builds (by default, a pipeline only runs a subset of all available builds),
     - run a pipeline with all kitchen tests,
+    - run a pipeline with all end-to-end tests,
     - run a deploy pipeline (includes all builds & kitchen tests + uploads artifacts to staging repositories);
     """
     args = {}
@@ -114,6 +116,11 @@ def trigger_agent_pipeline(
         args["RUN_KITCHEN_TESTS"] = "true"
     else:
         args["RUN_KITCHEN_TESTS"] = "false"
+
+    # End to end tests can be selectively enabled, or disabled on pipelines where they're
+    # enabled by default (default branch and deploy pipelines).
+    if e2e_tests:
+        args["RUN_E2E_TESTS"] = "true"
 
     if release_version_6 is not None:
         args["RELEASE_VERSION_6"] = release_version_6

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -219,6 +219,7 @@ def run(
     deploy=False,
     all_builds=True,
     kitchen_tests=True,
+    e2e_tests=False,
     rc_k8s_deployments=False,
 ):
     """
@@ -227,6 +228,7 @@ def run(
     Use --deploy to make this pipeline a deploy pipeline, which will upload artifacts to the staging repositories.
     Use --no-all-builds to not run builds for all architectures (only a subset of jobs will run. No effect on pipelines on the default branch).
     Use --no-kitchen-tests to not run all kitchen tests on the pipeline.
+    Use --e2e-tests to run all e2e tests on the pipeline.
 
     By default, the nightly release.json entries (nightly and nightly-a7) are used.
     Use the --use-release-entries option to use the release-a6 and release-a7 release.json entries instead.
@@ -249,6 +251,9 @@ def run(
 
     Run a pipeline without kitchen tests on the current branch:
       inv pipeline.run --here --no-kitchen-tests
+
+    Run a pipeline with e2e tets on the current branch:
+      inv pipeline.run --here --e2e-tests
 
     Run a deploy pipeline on the 7.32.0 tag, uploading the artifacts to the stable branch of the staging repositories:
       inv pipeline.run --deploy --use-release-entries --major-versions "6,7" --git-ref "7.32.0" --repo-branch "stable"
@@ -320,6 +325,7 @@ def run(
             deploy=deploy,
             all_builds=all_builds,
             kitchen_tests=kitchen_tests,
+            e2e_tests=e2e_tests,
             rc_k8s_deployments=rc_k8s_deployments,
         )
     except FilteredOutException:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add a new `--e2e-tests` flag to the `pipeline.run` task which triggers the "-dev" variations of the new e2e tests.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Opt in to running e2e tests for dev branches for easier testing.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Job triggered with the task and the new flag: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/25338060

Two of the `-dev` jobs failed but are `allow_failure: true` for the `-main` jobs, I opted _not_ to include that option when adjusting the jobs but happy to add that back in.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
