### PR TITLE
Fix KSM Tags sender initialization

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/customresources"
 	"github.com/DataDog/datadog-agent/pkg/config"
+
 	//nolint:revive // TODO(CINT) Fix revive linter
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
@@ -204,12 +205,6 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 	k.BuildID(integrationConfigDigest, config, initConfig)
 	k.agentConfig = ddconfig.Datadog
 
-	// Retrieve cluster name
-	k.getClusterName()
-
-	// Initialize global tags and check tags
-	k.initTags()
-
 	err := k.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
@@ -219,6 +214,12 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 	if err != nil {
 		return err
 	}
+
+	// Retrieve cluster name
+	k.getClusterName()
+
+	// Initialize global tags and check tags
+	k.initTags()
 
 	// Prepare label joins
 	for _, joinConf := range k.instance.LabelJoins {
@@ -472,6 +473,15 @@ func (k *KSMCheck) Run() error {
 		return err
 	}
 
+	// Normally the sender is kept for the lifetime of the check.
+	// But as `SetCheckCustomTags` is cheap and `k.instance.Tags` is immutable
+	// It's fast and safe to set it after we get the sender.
+	sender.SetCheckCustomTags(k.instance.Tags)
+
+	// Do not fallback to the Agent hostname if the hostname corresponding to the KSM metric is unknown
+	// Note that by design, some metrics cannot have hostnames (e.g kubernetes_state.pod.unschedulable)
+	sender.DisableDefaultHostname(true)
+
 	// If the check is configured as a cluster check, the cluster check worker needs to skip the leader election section.
 	// we also do a safety check for dedicated runners to avoid trying the leader election
 	if !k.isCLCRunner || !k.instance.LeaderSkip {
@@ -495,10 +505,6 @@ func (k *KSMCheck) Run() error {
 	}
 
 	defer sender.Commit()
-
-	// Do not fallback to the Agent hostname if the hostname corresponding to the KSM metric is unknown
-	// Note that by design, some metrics cannot have hostnames (e.g kubernetes_state.pod.unschedulable)
-	sender.DisableDefaultHostname(true)
 
 	labelJoiner := newLabelJoiner(k.instance.labelJoins)
 	for _, stores := range k.allStores {
@@ -778,10 +784,6 @@ func (k *KSMCheck) getClusterName() {
 // Sets the kube_cluster_name tag for all metrics.
 // Adds the global user-defined tags from the Agent config.
 func (k *KSMCheck) initTags() {
-	if k.instance.Tags == nil {
-		k.instance.Tags = []string{}
-	}
-
 	if k.clusterNameTagValue != "" {
 		k.instance.Tags = append(k.instance.Tags, "kube_cluster_name:"+k.clusterNameTagValue)
 	}


### PR DESCRIPTION
### What does this PR do?

Fix Tags value in `sender` as we're currently updating a field that is never read by `CommonConfig`.
There was an error in the sequence `parse` must be called first to get the value from YAML, then we can add custom tags in `initTags()`

### Motivation

Fixing missing `DD_TAGS` or `kube_cluster_name` tag in KSM checks.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Cluster Agent with `DD_TAGS` set with some values. Also set the `tags:` field in KSM Core configuration.
You should get both tags in `kubernetes_state.*` metrics.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
