### PR TITLE
[USM] Support path that are not Huffman encoded 

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -68,13 +68,12 @@
 
 #define MAX_FRAME_SIZE 16384
 
-// Huffman-encoded strings for paths "/" and "/index.html". Needed for HTTP2
-// decoding, as these two paths are in the static table, we need to add the
-// plain string ourselves instead of reading them from the Header.
-#define HTTP_ROOT_PATH      "\x2f"
-#define HTTP_ROOT_PATH_LEN  (sizeof(HTTP_ROOT_PATH) - 1)
-#define HTTP_INDEX_PATH     "\x2f\x69\x6e\x64\x65\x78\x2e\x68\x74\x6d\x6c"
-#define HTTP_INDEX_PATH_LEN (sizeof(HTTP_INDEX_PATH) - 1)
+// Definitions representing empty and /index.html paths. These types are sent using the static table.
+// We include these to eliminate the necessity of copying the specified encoded path to the buffer.
+#define HTTP2_ROOT_PATH      "/"
+#define HTTP2_ROOT_PATH_LEN  (sizeof(HTTP_ROOT_PATH) - 1)
+#define HTTP2_INDEX_PATH     "/index.html"
+#define HTTP2_INDEX_PATH_LEN (sizeof(HTTP_INDEX_PATH) - 1)
 
 typedef enum {
     kGET = 2,

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -71,9 +71,9 @@
 // Definitions representing empty and /index.html paths. These types are sent using the static table.
 // We include these to eliminate the necessity of copying the specified encoded path to the buffer.
 #define HTTP2_ROOT_PATH      "/"
-#define HTTP2_ROOT_PATH_LEN  (sizeof(HTTP_ROOT_PATH) - 1)
+#define HTTP2_ROOT_PATH_LEN  (sizeof(HTTP2_ROOT_PATH) - 1)
 #define HTTP2_INDEX_PATH     "/index.html"
-#define HTTP2_INDEX_PATH_LEN (sizeof(HTTP_INDEX_PATH) - 1)
+#define HTTP2_INDEX_PATH_LEN (sizeof(HTTP2_INDEX_PATH) - 1)
 
 typedef enum {
     kGET = 2,

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -70,10 +70,10 @@
 
 // Huffman-encoded strings for paths "/" and "/index.html". Needed for HTTP2
 // decoding, as these two paths are in the static table, we need to add the
-// encoded string ourselves instead of reading them from the Header.
-#define HTTP_ROOT_PATH      "\x63"
+// plain string ourselves instead of reading them from the Header.
+#define HTTP_ROOT_PATH      "\x2f"
 #define HTTP_ROOT_PATH_LEN  (sizeof(HTTP_ROOT_PATH) - 1)
-#define HTTP_INDEX_PATH     "\x60\xd5\x48\x5f\x2b\xce\x9a\x68"
+#define HTTP_INDEX_PATH     "\x2f\x69\x6e\x64\x65\x78\x2e\x68\x74\x6d\x6c"
 #define HTTP_INDEX_PATH_LEN (sizeof(HTTP_INDEX_PATH) - 1)
 
 typedef enum {

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -95,6 +95,7 @@ typedef enum {
 typedef struct {
     char buffer[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
     __u8 string_len;
+    bool is_huffman_encoded;
 } dynamic_table_entry_t;
 
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -115,6 +115,7 @@ typedef struct {
     __u8 request_method;
     __u8 path_size;
     bool request_end_of_stream;
+    bool is_huffman_encoded;
 
     __u8 request_path[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
 } http2_stream_t;
@@ -140,6 +141,7 @@ typedef struct {
     __u32 new_dynamic_value_offset;
     __u32 new_dynamic_value_size;
     http2_header_type_t type;
+    bool is_huffman_encoded;
 } http2_header_t;
 
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -325,9 +325,11 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 break;
             }
             current_stream->path_size = dynamic_value->string_len;
+            current_stream->is_huffman_encoded = dynamic_value->is_huffman_encoded;
             bpf_memcpy(current_stream->request_path, dynamic_value->buffer, HTTP2_MAX_PATH_LEN);
         } else {
             dynamic_value.string_len = current_header->new_dynamic_value_size;
+            dynamic_value.is_huffman_encoded = current_header->is_huffman_encoded;
 
             // create the new dynamic value which will be added to the internal table.
             read_into_buffer_path(dynamic_value.buffer, skb, current_header->new_dynamic_value_offset);

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -309,11 +309,11 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 current_stream->response_status_code = *static_value;
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
             } else if (current_header->index == kEmptyPath) {
-                current_stream->path_size = HTTP_ROOT_PATH_LEN;
-                bpf_memcpy(current_stream->request_path, HTTP_ROOT_PATH, HTTP_ROOT_PATH_LEN);
+                current_stream->path_size = HTTP2_ROOT_PATH_LEN;
+                bpf_memcpy(current_stream->request_path, HTTP2_ROOT_PATH, HTTP2_ROOT_PATH_LEN);
             } else if (current_header->index == kIndexPath) {
-                current_stream->path_size = HTTP_INDEX_PATH_LEN;
-                bpf_memcpy(current_stream->request_path, HTTP_INDEX_PATH, HTTP_INDEX_PATH_LEN);
+                current_stream->path_size = HTTP2_INDEX_PATH_LEN;
+                bpf_memcpy(current_stream->request_path, HTTP2_INDEX_PATH, HTTP2_INDEX_PATH_LEN);
             }
             continue;
         }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -83,12 +83,14 @@ static __always_inline bool read_hpack_int_with_given_current_char(struct __sk_b
 //
 // read_hpack_int returns true if the integer was successfully parsed, and false
 // otherwise.
-static __always_inline bool read_hpack_int(struct __sk_buff *skb, skb_info_t *skb_info, __u64 max_number_for_bits, __u64 *out) {
+static __always_inline bool read_hpack_int(struct __sk_buff *skb, skb_info_t *skb_info, __u64 max_number_for_bits, __u64 *out, bool *is_huffman_encoded) {
     __u64 current_char_as_number = 0;
     if (bpf_skb_load_bytes(skb, skb_info->data_off, &current_char_as_number, 1) < 0) {
         return false;
     }
     skb_info->data_off++;
+    // We are only interested in the first bit of the first byte, which indicates if it is huffman encoded or not.
+    *is_huffman_encoded = (current_char_as_number & 128) > 0;
 
     return read_hpack_int_with_given_current_char(skb, skb_info, current_char_as_number, max_number_for_bits, out);
 }
@@ -157,8 +159,9 @@ static __always_inline void update_path_size_telemetry(http2_telemetry_t *http2_
 // dynamic table, and will skip headers that are not path headers.
 static __always_inline bool parse_field_literal(struct __sk_buff *skb, skb_info_t *skb_info, http2_header_t *headers_to_process, __u64 index, __u64 global_dynamic_counter, __u8 *interesting_headers_counter, http2_telemetry_t *http2_tel) {
     __u64 str_len = 0;
+    bool is_huffman_encoded = true;
     // String length supposed to be represented with at least 7 bits representation -https://datatracker.ietf.org/doc/html/rfc7541#section-5.2
-    if (!read_hpack_int(skb, skb_info, MAX_7_BITS, &str_len)) {
+    if (!read_hpack_int(skb, skb_info, MAX_7_BITS, &str_len, &is_huffman_encoded)) {
         return false;
     }
 
@@ -167,7 +170,7 @@ static __always_inline bool parse_field_literal(struct __sk_buff *skb, skb_info_
         skb_info->data_off += str_len;
         str_len = 0;
         // String length supposed to be represented with at least 7 bits representation -https://datatracker.ietf.org/doc/html/rfc7541#section-5.2
-        if (!read_hpack_int(skb, skb_info, MAX_7_BITS, &str_len)) {
+        if (!read_hpack_int(skb, skb_info, MAX_7_BITS, &str_len, &is_huffman_encoded)) {
             return false;
         }
         goto end;
@@ -196,6 +199,7 @@ static __always_inline bool parse_field_literal(struct __sk_buff *skb, skb_info_
     headers_to_process->type = kNewDynamicHeader;
     headers_to_process->new_dynamic_value_offset = skb_info->data_off;
     headers_to_process->new_dynamic_value_size = str_len;
+    headers_to_process->is_huffman_encoded = is_huffman_encoded;
     // If the string len (`str_len`) is in the range of [0, HTTP2_MAX_PATH_LEN], and we don't exceed packet boundaries
     // (skb_info->data_off + str_len <= skb_info->data_end) and the index is kIndexPath, then we have a path header,
     // and we're increasing the counter. In any other case, we're not increasing the counter.
@@ -303,9 +307,11 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
             } else if (current_header->index == kEmptyPath) {
                 current_stream->path_size = HTTP_ROOT_PATH_LEN;
+                current_stream->is_huffman_encoded = true;
                 bpf_memcpy(current_stream->request_path, HTTP_ROOT_PATH, HTTP_ROOT_PATH_LEN);
             } else if (current_header->index == kIndexPath) {
                 current_stream->path_size = HTTP_INDEX_PATH_LEN;
+                current_stream->is_huffman_encoded = true;
                 bpf_memcpy(current_stream->request_path, HTTP_INDEX_PATH, HTTP_INDEX_PATH_LEN);
             }
             continue;
@@ -326,6 +332,9 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
             read_into_buffer_path(dynamic_value.buffer, skb, current_header->new_dynamic_value_offset);
             bpf_map_update_elem(&http2_dynamic_table, dynamic_index, &dynamic_value, BPF_ANY);
             current_stream->path_size = current_header->new_dynamic_value_size;
+            // As long as we are not using the dynamic table, we can assume that the string is huffman encoded.
+            // if the string is indexed it would still be huffman encoded.
+            current_stream->is_huffman_encoded = current_header->is_huffman_encoded;
             bpf_memcpy(current_stream->request_path, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
         }
     }

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -65,11 +65,11 @@ func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
 		}
 	} else {
 		if tx.Stream.Path_size <= 0 {
-			log.Warn("path size is negative or zero")
+			log.Warnf("path size:%d is negative or zero", tx.Stream.Path_size)
 			return nil, false
 		}
 		if tx.Stream.Path_size > maxHTTP2Path {
-			log.Warn("invalid path size")
+			log.Warn("invalid path size: %d", tx.Stream.Path_size)
 			return nil, false
 		}
 		res = tx.Stream.Request_path[:tx.Stream.Path_size]

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -276,12 +276,12 @@ func (t http2StreamKey) String() string {
 
 // String returns a string representation of the http2 dynamic table.
 func (t http2DynamicTableEntry) String() string {
-	if t.Len == 0 {
+	if t.String_len == 0 {
 		return ""
 	}
 
-	b := make([]byte, t.Len)
-	for i := uint8(0); i < t.Len; i++ {
+	b := make([]byte, t.String_len)
+	for i := uint8(0); i < t.String_len; i++ {
 		b[i] = byte(t.Buffer[i])
 	}
 	// trim null byte + after

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // decodeHTTP2Path tries to decode (Huffman) the path from the given buffer.
@@ -63,6 +64,14 @@ func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
 			return nil, false
 		}
 	} else {
+		if tx.Stream.Path_size <= 0 {
+			log.Warn("path size is negative or zero")
+			return nil, false
+		}
+		if tx.Stream.Path_size > maxHTTP2Path {
+			log.Warn("invalid path size")
+			return nil, false
+		}
 		res = tx.Stream.Request_path[:tx.Stream.Path_size]
 	}
 

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -86,7 +86,8 @@ func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
 			return nil, false
 		}
 
-		if err = validatePath(string(tx.Stream.Request_path[:tx.Stream.Path_size])); err != nil {
+		res = tx.Stream.Request_path[:tx.Stream.Path_size]
+		if err = validatePath(string(res)); err != nil {
 			log.Errorf("path is invalid due to: %s", err)
 			return nil, false
 		}

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -69,7 +69,7 @@ func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
 			return nil, false
 		}
 		if tx.Stream.Path_size > maxHTTP2Path {
-			log.Warn("invalid path size: %d", tx.Stream.Path_size)
+			log.Warnf("invalid path size: %d", tx.Stream.Path_size)
 			return nil, false
 		}
 		res = tx.Stream.Request_path[:tx.Stream.Path_size]

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -55,10 +55,17 @@ func decodeHTTP2Path(buf [maxHTTP2Path]byte, pathSize uint8) ([]byte, error) {
 
 // Path returns the URL from the request fragment captured in eBPF.
 func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
-	res, err := decodeHTTP2Path(tx.Stream.Request_path, tx.Stream.Path_size)
-	if err != nil {
-		return nil, false
+	var res []byte
+	var err error
+	if tx.Stream.Is_huffman_encoded {
+		res, err = decodeHTTP2Path(tx.Stream.Request_path, tx.Stream.Path_size)
+		if err != nil {
+			return nil, false
+		}
+	} else {
+		res = tx.Stream.Request_path[:tx.Stream.Path_size]
 	}
+
 	n := copy(buffer, res)
 	return buffer[:n], true
 }

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -26,9 +26,10 @@ type http2DynamicTableIndex struct {
 	Tup   connTuple
 }
 type http2DynamicTableEntry struct {
-	Buffer    [160]int8
-	Len       uint8
-	Pad_cgo_0 [7]byte
+	Buffer             [160]int8
+	String_len         uint8
+	Is_huffman_encoded bool
+	Pad_cgo_0          [6]byte
 }
 type http2StreamKey struct {
 	Tup       connTuple

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -42,7 +42,8 @@ type http2Stream struct {
 	Request_method        uint8
 	Path_size             uint8
 	Request_end_of_stream bool
-	Pad_cgo_0             [3]byte
+	Is_huffman_encoded    bool
+	Pad_cgo_0             [2]byte
 	Request_path          [160]uint8
 }
 type EbpfTx struct {

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -666,8 +666,6 @@ func (s *USMHTTP2Suite) TestHTTP2ManyDifferentPaths() {
 
 func getExpectedOutcomeForPathWithRepeatedChars() map[http.Key]captureRange {
 	expected := make(map[http.Key]captureRange)
-	// The path `/a` and `/aa` are not being encoded with Huffman, and that's an edge case for our http2 monitoring for the moment,
-	// thus we're starting with `/aaa` and above.
 	for i := 1; i < 100; i++ {
 		expected[http.Key{
 			Path: http.Path{
@@ -743,7 +741,6 @@ func (s *USMHTTP2Suite) TestSimpleHTTP2() {
 			runClients: func(t *testing.T, clientsCount int) {
 				clients := getClientsArray(t, clientsCount)
 
-				// currently we have a bug with paths which are not Huffman encoded, therefor I am skipping them by string length 3.
 				for i := 1; i < 100; i++ {
 					path := strings.Repeat("a", i)
 					client := clients[getClientsIndex(i, clientsCount)]

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -668,7 +668,7 @@ func getExpectedOutcomeForPathWithRepeatedChars() map[http.Key]captureRange {
 	expected := make(map[http.Key]captureRange)
 	// The path `/a` and `/aa` are not being encoded with Huffman, and that's an edge case for our http2 monitoring for the moment,
 	// thus we're starting with `/aaa` and above.
-	for i := 3; i < 100; i++ {
+	for i := 1; i < 100; i++ {
 		expected[http.Key{
 			Path: http.Path{
 				Content: http.Interner.GetString(fmt.Sprintf("/%s", strings.Repeat("a", i))),
@@ -744,7 +744,7 @@ func (s *USMHTTP2Suite) TestSimpleHTTP2() {
 				clients := getClientsArray(t, clientsCount)
 
 				// currently we have a bug with paths which are not Huffman encoded, therefor I am skipping them by string length 3.
-				for i := 3; i < 100; i++ {
+				for i := 1; i < 100; i++ {
 					path := strings.Repeat("a", i)
 					client := clients[getClientsIndex(i, clientsCount)]
 					req, err := client.Post(http2SrvAddr+"/"+path, "application/json", bytes.NewReader([]byte("test")))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Support paths which are not Huffman encoded.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

In HTTP/2 decoding, as part of the HPACK algorithm, most of the paths are Huffman encoded, but there are cases that are not. This PR supports the paths that are not encoded, which will improve our accuracy in HTTP/2 or gRPC decoding.

The Huffman code for the symbol represented as a base-2 integer, aligned on the most significant bit (MSB).
For more context you can see the following: https://datatracker.ietf.org/doc/html/rfc7541#appendix-B

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
