### PR TITLE
[ASCII-976 ] Status component minor improvements

### DIFF
--- a/comp/core/status/statusimpl/common_header_provider_test.go
+++ b/comp/core/status/statusimpl/common_header_provider_test.go
@@ -58,16 +58,6 @@ func TestCommonHeaderProviderJSON(t *testing.T) {
 	assert.NotEqual(t, "", stats["title"])
 }
 
-var expectedTextOutput = fmt.Sprintf(`  Status date: 2018-01-05 11:25:15 UTC (1515151515000)
-  Agent start: 2018-01-05 11:25:15 UTC (1515151515000)
-  Pid: %d
-  Go Version: %s
-  Python Version: n/a
-  Build arch: %s
-  Agent flavor: %s
-  Log Level: info
-`, pid, goVersion, arch, agentFlavor)
-
 func TestCommonHeaderProviderText(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
@@ -83,6 +73,16 @@ func TestCommonHeaderProviderText(t *testing.T) {
 
 	buffer := new(bytes.Buffer)
 	provider.Text(buffer)
+
+	expectedTextOutput := fmt.Sprintf(`  Status date: 2018-01-05 11:25:15 UTC (1515151515000)
+  Agent start: 2018-01-05 11:25:15 UTC (1515151515000)
+  Pid: %d
+  Go Version: %s
+  Python Version: n/a
+  Build arch: %s
+  Agent flavor: %s
+  Log Level: info
+`, pid, goVersion, arch, agentFlavor)
 
 	// We replace windows line break by linux so the tests pass on every OS
 	expectedResult := strings.Replace(expectedTextOutput, "\r\n", "\n", -1)

--- a/comp/core/status/statusimpl/status.go
+++ b/comp/core/status/statusimpl/status.go
@@ -150,7 +150,6 @@ func (s *statusImplementation) GetStatus(format string, _ bool) ([]byte, error) 
 		}
 
 		for _, section := range s.sortedSectionNames {
-
 			printHeader(b, section)
 			newLine(b)
 
@@ -231,8 +230,18 @@ func (s *statusImplementation) GetStatusBySection(section string, format string,
 
 				err := sc.Text(b)
 				if err != nil {
-					return b.Bytes(), err
+					errors = append(errors, err)
 				}
+			}
+
+			newLine(b)
+
+			if len(errors) > 0 {
+				if err := renderErrors(b, errors); err != nil {
+					return []byte{}, err
+				}
+
+				return b.Bytes(), nil
 			}
 
 			return b.Bytes(), nil

--- a/comp/core/status/statusimpl/status.go
+++ b/comp/core/status/statusimpl/status.go
@@ -62,13 +62,23 @@ func newStatus(deps dependencies) (status.Component, error) {
 	// The exception is the collector section. We want that to be the first section to be displayed
 	// We manually insert the collector section in the first place after sorting them alphabetically
 	sortedSectionNames := []string{}
+	collectorSectionPresent := false
+
 	for _, provider := range deps.Providers {
+		if provider.Section() == status.CollectorSection && !collectorSectionPresent {
+			collectorSectionPresent = true
+		}
+
 		if !present(provider.Section(), sortedSectionNames) && provider.Section() != status.CollectorSection {
 			sortedSectionNames = append(sortedSectionNames, provider.Section())
 		}
 	}
+
 	sort.Strings(sortedSectionNames)
-	sortedSectionNames = append([]string{status.CollectorSection}, sortedSectionNames...)
+
+	if collectorSectionPresent {
+		sortedSectionNames = append([]string{status.CollectorSection}, sortedSectionNames...)
+	}
 
 	// Providers of each section are sort alphabetically by name
 	sortedProvidersBySection := map[string][]status.Provider{}

--- a/comp/core/status/statusimpl/status_test.go
+++ b/comp/core/status/statusimpl/status_test.go
@@ -26,11 +26,12 @@ import (
 )
 
 type mockProvider struct {
-	data    map[string]interface{}
-	text    string
-	html    string
-	name    string
-	section string
+	data        map[string]interface{}
+	text        string
+	html        string
+	name        string
+	section     string
+	returnError bool
 }
 
 func (m mockProvider) Name() string {
@@ -42,6 +43,10 @@ func (m mockProvider) Section() string {
 }
 
 func (m mockProvider) JSON(stats map[string]interface{}) error {
+	if m.returnError {
+		return fmt.Errorf("JSON error")
+	}
+
 	for key, value := range m.data {
 		stats[key] = value
 	}
@@ -50,21 +55,30 @@ func (m mockProvider) JSON(stats map[string]interface{}) error {
 }
 
 func (m mockProvider) Text(buffer io.Writer) error {
+	if m.returnError {
+		return fmt.Errorf("Text error")
+	}
+
 	_, err := buffer.Write([]byte(m.text))
 	return err
 }
 
 func (m mockProvider) HTML(buffer io.Writer) error {
+	if m.returnError {
+		return fmt.Errorf("HTML error")
+	}
+
 	_, err := buffer.Write([]byte(m.html))
 	return err
 }
 
 type mockHeaderProvider struct {
-	data  map[string]interface{}
-	text  string
-	html  string
-	index int
-	name  string
+	data        map[string]interface{}
+	text        string
+	html        string
+	index       int
+	name        string
+	returnError bool
 }
 
 func (m mockHeaderProvider) Index() int {
@@ -76,6 +90,10 @@ func (m mockHeaderProvider) Name() string {
 }
 
 func (m mockHeaderProvider) JSON(stats map[string]interface{}) error {
+	if m.returnError {
+		return fmt.Errorf("JSON error")
+	}
+
 	for key, value := range m.data {
 		stats[key] = value
 	}
@@ -84,35 +102,21 @@ func (m mockHeaderProvider) JSON(stats map[string]interface{}) error {
 }
 
 func (m mockHeaderProvider) Text(buffer io.Writer) error {
+	if m.returnError {
+		return fmt.Errorf("Text error")
+	}
+
 	_, err := buffer.Write([]byte(m.text))
 	return err
 }
 
 func (m mockHeaderProvider) HTML(buffer io.Writer) error {
+	if m.returnError {
+		return fmt.Errorf("HTML error")
+	}
+
 	_, err := buffer.Write([]byte(m.html))
 	return err
-}
-
-type errorMockProvider struct{}
-
-func (m errorMockProvider) Name() string {
-	return "error mock"
-}
-
-func (m errorMockProvider) Section() string {
-	return "error section"
-}
-
-func (m errorMockProvider) JSON(map[string]interface{}) error {
-	return fmt.Errorf("testing JSON errors")
-}
-
-func (m errorMockProvider) Text(io.Writer) error {
-	return fmt.Errorf("testing Text errors")
-}
-
-func (m errorMockProvider) HTML(io.Writer) error {
-	return fmt.Errorf("testing HTML errors")
 }
 
 var (
@@ -421,7 +425,7 @@ Error Section
 ====================
 Status render errors
 ====================
-  - testing Text errors
+  - Text error
 
 `, testTextHeader, pid, goVersion, arch)
 
@@ -440,7 +444,11 @@ func TestGetStatusWithErrors(t *testing.T) {
 	deps := fxutil.Test[dependencies](t, fx.Options(
 		config.MockModule(),
 		fx.Supply(
-			status.NewInformationProvider(errorMockProvider{}),
+			status.NewInformationProvider(mockProvider{
+				section:     "error section",
+				name:        "a",
+				returnError: true,
+			}),
 			status.NewInformationProvider(mockProvider{
 				data: map[string]interface{}{
 					"foo2": "bar2",
@@ -470,7 +478,7 @@ func TestGetStatusWithErrors(t *testing.T) {
 
 				assert.NoError(t, err)
 
-				assert.Equal(t, "testing JSON errors", result["errors"].([]interface{})[0].(string))
+				assert.Equal(t, "JSON error", result["errors"].([]interface{})[0].(string))
 			},
 		},
 		{
@@ -657,7 +665,16 @@ func TestGetStatusBySectionsWithErrors(t *testing.T) {
 	deps := fxutil.Test[dependencies](t, fx.Options(
 		config.MockModule(),
 		fx.Supply(
-			status.NewInformationProvider(errorMockProvider{}),
+			status.NewInformationProvider(mockProvider{
+				returnError: true,
+				section:     "error section",
+				name:        "a",
+			}),
+			status.NewHeaderInformationProvider(mockHeaderProvider{
+				returnError: true,
+				name:        "a",
+				index:       3,
+			}),
 			status.NewInformationProvider(mockProvider{
 				data: map[string]interface{}{
 					"foo2": "bar2",
@@ -676,23 +693,26 @@ func TestGetStatusBySectionsWithErrors(t *testing.T) {
 	testCases := []struct {
 		name       string
 		format     string
+		section    string
 		assertFunc func(*testing.T, []byte)
 	}{
 		{
-			name:   "JSON",
-			format: "json",
+			name:    "JSON",
+			format:  "json",
+			section: "error section",
 			assertFunc: func(t *testing.T, bytes []byte) {
 				result := map[string]interface{}{}
 				err = json.Unmarshal(bytes, &result)
 
 				assert.NoError(t, err)
 
-				assert.Equal(t, "testing JSON errors", result["errors"].([]interface{})[0].(string))
+				assert.Equal(t, "JSON error", result["errors"].([]interface{})[0].(string))
 			},
 		},
 		{
-			name:   "Text",
-			format: "text",
+			name:    "Text",
+			format:  "text",
+			section: "error section",
 			assertFunc: func(t *testing.T, bytes []byte) {
 				expected := `=============
 Error Section
@@ -700,7 +720,7 @@ Error Section
 ====================
 Status render errors
 ====================
-  - testing Text errors
+  - Text error
 
 `
 
@@ -711,11 +731,54 @@ Status render errors
 				assert.Equal(t, expectedResult, output)
 			},
 		},
+		{
+			name:    "Header section JSON format",
+			format:  "json",
+			section: "header",
+			assertFunc: func(t *testing.T, bytes []byte) {
+				result := map[string]interface{}{}
+				err = json.Unmarshal(bytes, &result)
+
+				assert.NoError(t, err)
+
+				assert.Equal(t, "JSON error", result["errors"].([]interface{})[0].(string))
+			},
+		},
+		{
+			name:    "Header section text format",
+			format:  "text",
+			section: "header",
+			assertFunc: func(t *testing.T, bytes []byte) {
+
+				expectedStatusTextErrorOutput = fmt.Sprintf(`%s
+  Status date: 2018-01-05 11:25:15 UTC (1515151515000)
+  Agent start: 2018-01-05 11:25:15 UTC (1515151515000)
+  Pid: %d
+  Go Version: %s
+  Python Version: n/a
+  Build arch: %s
+  Agent flavor: agent
+  Log Level: info
+
+====================
+Status render errors
+====================
+  - Text error
+
+`, testTextHeader, pid, goVersion, arch)
+
+				// We replace windows line break by linux so the tests pass on every OS
+				expectedResult := strings.Replace(expectedStatusTextErrorOutput, "\r\n", "\n", -1)
+				output := strings.Replace(string(bytes), "\r\n", "\n", -1)
+
+				assert.Equal(t, expectedResult, output)
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			bytesResult, err := statusComponent.GetStatusBySection("error section", testCase.format, false)
+			bytesResult, err := statusComponent.GetStatusBySection(testCase.section, testCase.format, false)
 
 			assert.NoError(t, err)
 

--- a/comp/core/status/statusimpl/status_test.go
+++ b/comp/core/status/statusimpl/status_test.go
@@ -400,7 +400,11 @@ Section
 
 `, testTextHeader, pid, goVersion, arch, agentFlavor)
 
-	assert.Equal(t, expectedOutput, string(bytesResult))
+	// We replace windows line break by linux so the tests pass on every OS
+	expectedResult := strings.Replace(expectedOutput, "\r\n", "\n", -1)
+	output := strings.Replace(string(bytesResult), "\r\n", "\n", -1)
+
+	assert.Equal(t, expectedResult, output)
 }
 
 func TestGetStatusWithErrors(t *testing.T) {

--- a/comp/core/status/statusimpl/status_test.go
+++ b/comp/core/status/statusimpl/status_test.go
@@ -133,41 +133,6 @@ var testTextHeader = fmt.Sprintf(`%s
 %s
 %s`, status.PrintDashes(testTitle, "="), testTitle, status.PrintDashes(testTitle, "="))
 
-var expectedStatusTextOutput = fmt.Sprintf(`%s
-  Status date: 2018-01-05 11:25:15 UTC (1515151515000)
-  Agent start: 2018-01-05 11:25:15 UTC (1515151515000)
-  Pid: %d
-  Go Version: %s
-  Python Version: n/a
-  Build arch: %s
-  Agent flavor: %s
-  Log Level: info
-
-==========
-Header Foo
-==========
-  header foo: header bar
-  header foo2: header bar 2
-
-=========
-Collector
-=========
- text from a
- text from b
-
-=========
-A Section
-=========
- text from a
-
-=========
-X Section
-=========
- text from a
- text from x
-
-`, testTextHeader, pid, goVersion, arch, agentFlavor)
-
 func TestGetStatus(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
@@ -276,6 +241,41 @@ func TestGetStatus(t *testing.T) {
 			name:   "Text",
 			format: "text",
 			assertFunc: func(t *testing.T, bytes []byte) {
+				expectedStatusTextOutput := fmt.Sprintf(`%s
+  Status date: 2018-01-05 11:25:15 UTC (1515151515000)
+  Agent start: 2018-01-05 11:25:15 UTC (1515151515000)
+  Pid: %d
+  Go Version: %s
+  Python Version: n/a
+  Build arch: %s
+  Agent flavor: %s
+  Log Level: info
+
+==========
+Header Foo
+==========
+  header foo: header bar
+  header foo2: header bar 2
+
+=========
+Collector
+=========
+ text from a
+ text from b
+
+=========
+A Section
+=========
+ text from a
+
+=========
+X Section
+=========
+ text from a
+ text from x
+
+`, testTextHeader, pid, goVersion, arch, agentFlavor)
+
 				// We replace windows line break by linux so the tests pass on every OS
 				expectedResult := strings.Replace(expectedStatusTextOutput, "\r\n", "\n", -1)
 				output := strings.Replace(string(bytes), "\r\n", "\n", -1)
@@ -403,32 +403,6 @@ Section
 	assert.Equal(t, expectedOutput, string(bytesResult))
 }
 
-var expectedStatusTextErrorOutput = fmt.Sprintf(`%s
-  Status date: 2018-01-05 11:25:15 UTC (1515151515000)
-  Agent start: 2018-01-05 11:25:15 UTC (1515151515000)
-  Pid: %d
-  Go Version: %s
-  Python Version: n/a
-  Build arch: %s
-  Agent flavor: agent
-  Log Level: info
-
-=========
-Collector
-=========
- text from b
-
-=============
-Error Section
-=============
-
-====================
-Status render errors
-====================
-  - Text error
-
-`, testTextHeader, pid, goVersion, arch)
-
 func TestGetStatusWithErrors(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
@@ -485,6 +459,32 @@ func TestGetStatusWithErrors(t *testing.T) {
 			name:   "Text",
 			format: "text",
 			assertFunc: func(t *testing.T, bytes []byte) {
+				expectedStatusTextErrorOutput := fmt.Sprintf(`%s
+  Status date: 2018-01-05 11:25:15 UTC (1515151515000)
+  Agent start: 2018-01-05 11:25:15 UTC (1515151515000)
+  Pid: %d
+  Go Version: %s
+  Python Version: n/a
+  Build arch: %s
+  Agent flavor: agent
+  Log Level: info
+
+=========
+Collector
+=========
+ text from b
+
+=============
+Error Section
+=============
+
+====================
+Status render errors
+====================
+  - Text error
+
+`, testTextHeader, pid, goVersion, arch)
+
 				// We replace windows line break by linux so the tests pass on every OS
 				expectedResult := strings.Replace(expectedStatusTextErrorOutput, "\r\n", "\n", -1)
 				output := strings.Replace(string(bytes), "\r\n", "\n", -1)
@@ -750,7 +750,7 @@ Status render errors
 			section: "header",
 			assertFunc: func(t *testing.T, bytes []byte) {
 
-				expectedStatusTextErrorOutput = fmt.Sprintf(`%s
+				expectedStatusTextErrorOutput := fmt.Sprintf(`%s
   Status date: 2018-01-05 11:25:15 UTC (1515151515000)
   Agent start: 2018-01-05 11:25:15 UTC (1515151515000)
   Pid: %d


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

- Fix the edge case that we print the collector header when no provider populates the collector section
- Handle errors when getting the status for the header section and text format
- Move test variables from top-level var to local variables scoped to each tests for readability

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
