### PR TITLE
usm: http2: rename structs

### DIFF
--- a/pkg/network/ebpf/c/protocols/grpc/helpers.h
+++ b/pkg/network/ebpf/c/protocols/grpc/helpers.h
@@ -145,7 +145,7 @@ static __always_inline grpc_status_t scan_headers(const struct __sk_buff *skb, s
 static __always_inline grpc_status_t is_grpc(const struct __sk_buff *skb, const skb_info_t *skb_info) {
     grpc_status_t status = PAYLOAD_UNDETERMINED;
     char frame_buf[HTTP2_FRAME_HEADER_SIZE];
-    struct http2_frame current_frame;
+    http2_frame_t current_frame;
 
     frame_info_t frames[GRPC_MAX_FRAMES_TO_PROCESS];
     u32 frames_count = 0;

--- a/pkg/network/ebpf/c/protocols/grpc/helpers.h
+++ b/pkg/network/ebpf/c/protocols/grpc/helpers.h
@@ -43,7 +43,7 @@ static __always_inline grpc_status_t is_content_type_grpc(const struct __sk_buff
         return PAYLOAD_UNDETERMINED;
     }
 
-    string_literal_header len;
+    string_literal_header_t len;
     if (skb_info->data_off + sizeof(len) > frame_end) {
         return PAYLOAD_NOT_GRPC;
     }
@@ -68,7 +68,7 @@ static __always_inline grpc_status_t is_content_type_grpc(const struct __sk_buff
 // skip_header increments skb_info->data_off so that it skips the remainder of
 // the current header (of which we already parsed the index value).
 static __always_inline void skip_literal_header(const struct __sk_buff *skb, skb_info_t *skb_info, __u32 frame_end, __u8 idx) {
-    string_literal_header len;
+    string_literal_header_t len;
     if (skb_info->data_off + sizeof(len) > frame_end) {
         return;
     }

--- a/pkg/network/ebpf/c/protocols/grpc/helpers.h
+++ b/pkg/network/ebpf/c/protocols/grpc/helpers.h
@@ -89,7 +89,7 @@ static __always_inline void skip_literal_header(const struct __sk_buff *skb, skb
 // Scan headers goes through the headers in a frame, and tries to find a
 // content-type header or a method header.
 static __always_inline grpc_status_t scan_headers(const struct __sk_buff *skb, skb_info_t *skb_info, __u32 frame_length) {
-    field_index idx;
+    field_index_t idx;
     grpc_status_t status = PAYLOAD_UNDETERMINED;
 
     __u32 frame_end = skb_info->data_off + frame_length;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -143,7 +143,7 @@ typedef struct {
 } http2_header_t;
 
 typedef struct {
-    struct http2_frame frame;
+    http2_frame_t frame;
     __u32 offset;
 } http2_frame_with_offset;
 

--- a/pkg/network/ebpf/c/protocols/http2/defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/defs.h
@@ -59,7 +59,7 @@ typedef union {
         __u8 reserved : 2;
     } __attribute__((packed)) literal;
     __u8 raw;
-} __attribute__((packed)) field_index;
+} __attribute__((packed)) field_index_t;
 
 // string_literal_header represents the length of a string as represented in HPACK
 // (see RFC 7541: 5.2 String Literal Representation).

--- a/pkg/network/ebpf/c/protocols/http2/defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/defs.h
@@ -31,13 +31,13 @@ typedef enum {
 
 // Struct which represent the http2 frame by its fields.
 // Checkout https://datatracker.ietf.org/doc/html/rfc7540#section-4.1 for frame format.
-struct http2_frame {
+typedef struct {
     __u32 length : 24;
     frame_type_t type;
     __u8 flags;
     __u8 reserved : 1;
     __u32 stream_id : 31;
-} __attribute__ ((packed));
+} __attribute__ ((packed)) http2_frame_t;
 
 
 /* Header parsing helper macros */

--- a/pkg/network/ebpf/c/protocols/http2/defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/defs.h
@@ -66,6 +66,6 @@ typedef union {
 typedef struct {
     __u8 length : 7;
     __u8 is_huffman : 1;
-} __attribute__((packed)) string_literal_header;
+} __attribute__((packed)) string_literal_header_t;
 
 #endif

--- a/pkg/network/ebpf/c/protocols/http2/helpers.h
+++ b/pkg/network/ebpf/c/protocols/http2/helpers.h
@@ -13,7 +13,7 @@ static __always_inline bool is_empty_frame_header(const char *frame) {
 }
 
 // This function reads the http2 frame header and validate the frame.
-static __always_inline bool read_http2_frame_header(const char *buf, size_t buf_size, struct http2_frame *out) {
+static __always_inline bool read_http2_frame_header(const char *buf, size_t buf_size, http2_frame_t *out) {
     if (buf == NULL) {
         return false;
     }
@@ -28,7 +28,7 @@ static __always_inline bool read_http2_frame_header(const char *buf, size_t buf_
 
     // We extract the frame by its shape to fields.
     // See: https://datatracker.ietf.org/doc/html/rfc7540#section-4.1
-    *out = *((struct http2_frame*)buf);
+    *out = *((http2_frame_t*)buf);
     out->length = bpf_ntohl(out->length << 8);
     out->stream_id = bpf_ntohl(out->stream_id << 1);
 
@@ -54,7 +54,7 @@ static __always_inline bool is_http2_preface(const char* buf, __u32 buf_size) {
 static __always_inline bool is_http2_server_settings(const char* buf, __u32 buf_size) {
     CHECK_PRELIMINARY_BUFFER_CONDITIONS(buf, buf_size, HTTP2_FRAME_HEADER_SIZE);
 
-    struct http2_frame frame_header;
+    http2_frame_t frame_header;
     if (!read_http2_frame_header(buf, buf_size, &frame_header)) {
         return false;
     }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Renames:
- http2_frame to http2_frame_t
- string_literal_header to string_literal_header_t
- struct http2_frame to http2_frame_t
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
not mixing type names and variable names.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
