### PR TITLE
[USMON-668] Moves connection tuple normalization to https entrypoint rather than the TLS hooks

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
+++ b/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
@@ -60,19 +60,6 @@ static __always_inline conn_tuple_t* conn_tup_from_tls_conn(tls_offsets_data_t* 
         return NULL;
     }
 
-    // Set the `.netns` and `.pid` values to always be 0.
-    // They can't be sourced from inside `read_conn_tuple_skb`,
-    // which is used elsewhere to produce the same `conn_tuple_t` value from a `struct __sk_buff*` value,
-    // so we ensure it is always 0 here so that both paths produce the same `conn_tuple_t` value.
-    // `netns` is not used in the userspace program part that binds http information to `ConnectionStats`,
-    // so this is isn't a problem.
-    conn_tuple.netns = 0;
-    conn_tuple.pid = 0;
-
-    if (!is_ephemeral_port(conn_tuple.sport)) {
-        flip_tuple(&conn_tuple);
-    }
-
     bpf_map_update_elem(&conn_tup_by_go_tls_conn, &conn, &conn_tuple, BPF_ANY);
     return bpf_map_lookup_elem(&conn_tup_by_go_tls_conn, &conn);
 }

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -76,6 +76,7 @@ static __always_inline void tls_process(struct pt_regs *ctx, conn_tuple_t *t, vo
     switch (protocol) {
     case PROTOCOL_HTTP:
         prog = TLS_HTTP_PROCESS;
+        normalize_tuple(t);
         break;
     default:
         return;

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -76,11 +76,13 @@ static __always_inline void tls_process(struct pt_regs *ctx, conn_tuple_t *t, vo
     switch (protocol) {
     case PROTOCOL_HTTP:
         prog = TLS_HTTP_PROCESS;
-
-        // We flip the tuple in the GoTLS read uprobe so it matches the tuple
-        // from the write uprobe. However this breaks https monitoring, so we
-        // flip it back here.
+        // HTTP implementation relies on the assumption of having a normalized tuple (as we're sharing implementation
+        // with the socket_filter program).
         normalize_tuple(t);
+        // HTTP implementation relies on the assumption of not having pid and netns (as we're sharing implementation
+        // with the socket_filter program which does not have access to such fields).
+        t->pid = 0;
+        t->netns = 0;
         break;
     default:
         return;
@@ -109,6 +111,13 @@ static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t) {
     switch (protocol) {
     case PROTOCOL_HTTP:
         prog = TLS_HTTP_TERMINATION;
+        // HTTP implementation relies on the assumption of having a normalized tuple (as we're sharing implementation
+        // with the socket_filter program).
+        normalize_tuple(t);
+        // HTTP implementation relies on the assumption of not having pid and netns (as we're sharing implementation
+        // with the socket_filter program which does not have access to such fields).
+        t->pid = 0;
+        t->netns = 0;
         break;
     default:
         return;
@@ -163,21 +172,7 @@ static __always_inline conn_tuple_t* tup_from_ssl_ctx(void *ssl_ctx, u64 pid_tgi
         return NULL;
     }
 
-    // Set the `.netns` and `.pid` values to always be 0.
-    // They can't be sourced from inside `read_conn_tuple_skb`,
-    // which is used elsewhere to produce the same `conn_tuple_t` value from a `struct __sk_buff*` value,
-    // so we ensure it is always 0 here so that both paths produce the same `conn_tuple_t` value.
-    // `netns` is not used in the userspace program part that binds http information to `ConnectionStats`,
-    // so this is isn't a problem.
-    t.netns = 0;
-    t.pid = 0;
-
     bpf_memcpy(&ssl_sock->tup, &t, sizeof(conn_tuple_t));
-
-    if (!is_ephemeral_port(ssl_sock->tup.sport)) {
-        flip_tuple(&ssl_sock->tup);
-    }
-
     return &ssl_sock->tup;
 }
 
@@ -199,9 +194,6 @@ static __always_inline void map_ssl_ctx_to_sock(struct sock *skp) {
     if (!read_conn_tuple(&ssl_sock.tup, skp, pid_tgid, CONN_TYPE_TCP)) {
         return;
     }
-    ssl_sock.tup.netns = 0;
-    ssl_sock.tup.pid = 0;
-    normalize_tuple(&ssl_sock.tup);
 
     // copy map value to stack. required for older kernels
     void *ssl_ctx = *ssl_ctx_map_val;

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -76,6 +76,10 @@ static __always_inline void tls_process(struct pt_regs *ctx, conn_tuple_t *t, vo
     switch (protocol) {
     case PROTOCOL_HTTP:
         prog = TLS_HTTP_PROCESS;
+
+        // We flip the tuple in the GoTLS read uprobe so it matches the tuple
+        // from the write uprobe. However this breaks https monitoring, so we
+        // flip it back here.
         normalize_tuple(t);
         break;
     default:

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -262,10 +262,13 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
         return 0;
     }
 
-    char *buffer_ptr = (char*)call_data_ptr->b_data;
-    bpf_map_delete_elem(&go_tls_read_args, (go_tls_function_args_key_t*)&call_key);
+    conn_tuple_t copy = *t;
+    flip_tuple(&copy);
 
-    tls_process(ctx, t, buffer_ptr, bytes_read, GO);
+    char *buffer_ptr = (char *)call_data_ptr->b_data;
+    bpf_map_delete_elem(&go_tls_read_args, (go_tls_function_args_key_t *)&call_key);
+
+    tls_process(ctx, &copy, buffer_ptr, bytes_read, GO);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -262,11 +262,10 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
         return 0;
     }
 
-    char *buffer_ptr = (char *)call_data_ptr->b_data;
-    bpf_map_delete_elem(&go_tls_read_args, (go_tls_function_args_key_t *)&call_key);
+    char *buffer_ptr = (char*)call_data_ptr->b_data;
+    bpf_map_delete_elem(&go_tls_read_args, (go_tls_function_args_key_t*)&call_key);
 
     tls_process(ctx, t, buffer_ptr, bytes_read, GO);
-
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -265,13 +265,7 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
     char *buffer_ptr = (char *)call_data_ptr->b_data;
     bpf_map_delete_elem(&go_tls_read_args, (go_tls_function_args_key_t *)&call_key);
 
-    // We need to flip the tuple to match the tuple from the write uprobe. This
-    // is needed for HTTP2 decoding to work properly, as without that tuple flip,
-    // we would use different dynamic tables for decoding the buffers from the read
-    // & write uprobes.
-    conn_tuple_t copy = *t;
-    flip_tuple(&copy);
-    tls_process(ctx, &copy, buffer_ptr, bytes_read, GO);
+    tls_process(ctx, t, buffer_ptr, bytes_read, GO);
 
     return 0;
 }

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -262,13 +262,17 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
         return 0;
     }
 
-    conn_tuple_t copy = *t;
-    flip_tuple(&copy);
-
     char *buffer_ptr = (char *)call_data_ptr->b_data;
     bpf_map_delete_elem(&go_tls_read_args, (go_tls_function_args_key_t *)&call_key);
 
+    // We need to flip the tuple to match the tuple from the write uprobe. This
+    // is needed for HTTP2 decoding to work properly, as without that tuple flip,
+    // we would use different dynamic tables for decoding the buffers from the read
+    // & write uprobes.
+    conn_tuple_t copy = *t;
+    flip_tuple(&copy);
     tls_process(ctx, &copy, buffer_ptr, bytes_read, GO);
+
     return 0;
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

The PR moves the connection tuple normalization out of the TLS hooks and moves it to the HTTPs entrypoint.

### Motivation

Preliminary change required for HTTP2-TLS support, as we need to have unnormalized connection, while HTTPs does require normalization

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
