### PR TITLE
usm: http2: Handle the scenario of dynamic table size update during HEADERS frame

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -215,8 +215,8 @@ static __always_inline __u8 filter_relevant_headers(struct __sk_buff *skb, skb_i
     http2_header_t *current_header;
     const __u32 frame_end = skb_info->data_off + frame_length;
     const __u32 end = frame_end < skb_info->data_end + 1 ? frame_end : skb_info->data_end + 1;
-    bool is_literal = false;
     bool is_indexed = false;
+    bool is_dynamic_table_update = false;
     __u64 max_bits = 0;
     __u64 index = 0;
 
@@ -233,16 +233,34 @@ static __always_inline __u8 filter_relevant_headers(struct __sk_buff *skb, skb_i
         bpf_skb_load_bytes(skb, skb_info->data_off, &current_ch, sizeof(current_ch));
         skb_info->data_off++;
 
-        is_indexed = (current_ch & 128) != 0;
-        is_literal = (current_ch & 192) == 64;
-
-        if (is_indexed) {
-            max_bits = MAX_7_BITS;
-        } else if (is_literal) {
-            max_bits = MAX_6_BITS;
-        } else {
+        // We need to read the size of the dynamic table update, which is represented by an integer representation,
+        // we need to read byte by byte until we get a byte without the MSB set, only then we know we consumed the
+        // entire integer. So if we're in the context if dynamic table update, we modify the state to be true
+        // if the MSB is set, and false otherwise, and continue to the next byte.
+        // More on the feature - https://httpwg.org/specs/rfc7541.html#rfc.section.6.3.
+        if (is_dynamic_table_update) {
+            is_dynamic_table_update = (current_ch & 128) != 0;
             continue;
         }
+        // 224 is represented as 0b11100000, which is the OR operation for
+        // - indexed representation     (0b10000000)
+        // - literal representation     (0b01000000)
+        // - dynamic table size update  (0b00100000)
+        // Thus current_ch & 224 will be 0 only if the top 3 bits are 0, which means that the current byte is not
+        // representing any of the above.
+        if ((current_ch & 224) == 0) {
+            continue;
+        }
+        // 32 is represented as 0b00100000, which is the scenario of dynamic table size update.
+        // From the previous condition we know that the top 3 bits are not 0, so if the top 3 bits are 001, then
+        // we have a dynamic table size update.
+        is_dynamic_table_update = (current_ch & 224) == 32;
+        if (is_dynamic_table_update) {
+            continue;
+        }
+
+        is_indexed = (current_ch & 128) != 0;
+        max_bits = is_indexed ? MAX_7_BITS : MAX_6_BITS;
 
         index = 0;
         if (!read_hpack_int_with_given_current_char(skb, skb_info, current_ch, max_bits, &index)) {

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -233,10 +233,10 @@ static __always_inline __u8 filter_relevant_headers(struct __sk_buff *skb, skb_i
         bpf_skb_load_bytes(skb, skb_info->data_off, &current_ch, sizeof(current_ch));
         skb_info->data_off++;
 
-        // We need to read the size of the dynamic table update, which is represented by an integer representation,
-        // we need to read byte by byte until we get a byte without the MSB set, only then we know we consumed the
-        // entire integer. So if we're in the context if dynamic table update, we modify the state to be true
-        // if the MSB is set, and false otherwise, and continue to the next byte.
+        // To determine the size of the dynamic table update, we read an integer representation byte by byte. 
+        // We continue reading bytes until we encounter a byte without the Most Significant Bit (MSB) set, 
+        // indicating that we've consumed the complete integer. While in the context of the dynamic table 
+        // update, we set the state as true if the MSB is set, and false otherwise. Then, we proceed to the next byte.
         // More on the feature - https://httpwg.org/specs/rfc7541.html#rfc.section.6.3.
         if (is_dynamic_table_update) {
             is_dynamic_table_update = (current_ch & 128) != 0;


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
In the HEADERS frame we can get the scenario of dynamic table size update (https://httpwg.org/specs/rfc7541.html#rfc.section.6.3) which messes with our parsing. I added logic to ignore the case and continue with parsing as expected
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Edge case found in tests
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Covered by TestHTTP2ManyDifferentPaths
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
