### PR TITLE
[APL-2624] run package build on file changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1010,3 +1010,7 @@ workflow:
 
 .if_run_e2e_tests:
   - <<: *if_run_e2e
+
+.on_omnibus_change:
+  - changes:
+      - omnibus/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1022,9 +1022,3 @@ workflow:
       paths:
         - .go-version
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
-
-.on_kitchen_test_change:
-  - changes:
-      paths:
-        - test/kitchen/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1013,4 +1013,18 @@ workflow:
 
 .on_omnibus_change:
   - changes:
-      - omnibus/**/*
+      paths:
+        - omnibus/**/*
+      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+
+.on_go-version_change:
+  - changes:
+      paths:
+        - .go-version
+      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+
+.on_kitchen_test_change:
+  - changes:
+      paths:
+        - test/kitchen/**/*
+      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -114,7 +114,6 @@ agent_deb-arm64-a6:
     - !reference [.on_all_builds_a6]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -204,7 +203,6 @@ iot_agent_deb-arm64:
     - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -219,7 +217,6 @@ iot_agent_deb-armhf:
     - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   # Run with platform:arm64 since no platform:armhf exists and arm64 should be backwards compatible
@@ -262,7 +259,6 @@ dogstatsd_deb-arm64:
     - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -41,9 +41,6 @@
 agent_deb-x64-a6:
   extends: .agent_build_common_deb
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -67,9 +64,6 @@ agent_deb-x64-a6:
 agent_deb-x64-a7:
   extends: .agent_build_common_deb
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -93,9 +87,6 @@ agent_deb-x64-a7:
 agent_deb-x64-a7-auto:
   extends: .agent_build_common_deb
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -120,10 +111,10 @@ agent_deb-x64-a7-auto:
 agent_deb-arm64-a6:
   extends: .agent_build_common_deb
   rules:
+    - !reference [.on_all_builds_a6]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
     - !reference [.on_kitchen_test_change]
-    - !reference [.on_all_builds_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -146,9 +137,6 @@ agent_deb-arm64-a6:
 agent_deb-arm64-a7:
   extends: .agent_build_common_deb
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
@@ -201,9 +189,6 @@ agent_deb-arm64-a7:
 iot_agent_deb-x64:
   extends: .iot_agent_build_common_deb
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -216,10 +201,10 @@ iot_agent_deb-x64:
 iot_agent_deb-arm64:
   extends: .iot_agent_build_common_deb
   rules:
+    - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
     - !reference [.on_kitchen_test_change]
-    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -231,10 +216,10 @@ iot_agent_deb-arm64:
 iot_agent_deb-armhf:
   extends: .iot_agent_build_common_deb
   rules:
+    - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
     - !reference [.on_kitchen_test_change]
-    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   # Run with platform:arm64 since no platform:armhf exists and arm64 should be backwards compatible
@@ -246,9 +231,6 @@ iot_agent_deb-armhf:
 
 dogstatsd_deb-x64:
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -277,10 +259,10 @@ dogstatsd_deb-x64:
 
 dogstatsd_deb-arm64:
   rules:
+    - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
     - !reference [.on_kitchen_test_change]
-    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -40,87 +40,112 @@
 
 agent_deb-x64-a6:
   extends: .agent_build_common_deb
-  rules:
-    !reference [.on_a6]
+  rules: !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-x64",
+      "go_deps",
+      "generate_minimized_btfs_x64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: '2,3'
+    PYTHON_RUNTIMES: "2,3"
     PACKAGE_ARCH: amd64
-    DESTINATION_DEB: 'datadog-agent_6_amd64.deb'
-    DESTINATION_DBG_DEB: 'datadog-agent-dbg_6_amd64.deb'
+    DESTINATION_DEB: "datadog-agent_6_amd64.deb"
+    DESTINATION_DBG_DEB: "datadog-agent-dbg_6_amd64.deb"
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_6
 
 agent_deb-x64-a7:
   extends: .agent_build_common_deb
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-x64",
+      "go_deps",
+      "generate_minimized_btfs_x64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: '3'
+    PYTHON_RUNTIMES: "3"
     PACKAGE_ARCH: amd64
-    DESTINATION_DEB: 'datadog-agent_7_amd64.deb'
-    DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_amd64.deb'
+    DESTINATION_DEB: "datadog-agent_7_amd64.deb"
+    DESTINATION_DBG_DEB: "datadog-agent-dbg_7_amd64.deb"
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
 agent_deb-x64-a7-auto:
   extends: .agent_build_common_deb
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-x64",
+      "go_deps",
+      "generate_minimized_btfs_x64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: '3'
+    PYTHON_RUNTIMES: "3"
     PACKAGE_ARCH: amd64
-    DESTINATION_DEB: 'datadog-agent_7_auto_amd64.deb'
-    DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_auto_amd64.deb'
+    DESTINATION_DEB: "datadog-agent_7_auto_amd64.deb"
+    DESTINATION_DBG_DEB: "datadog-agent-dbg_7_auto_amd64.deb"
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
     - export INSTALL_DIR=/opt/datadog/agents/$RELEASE_VERSION_7
 
 agent_deb-arm64-a6:
   extends: .agent_build_common_deb
-  rules:
-    !reference [.on_all_builds_a6]
+  rules: !reference [.on_all_builds_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-arm64",
+      "go_deps",
+      "generate_minimized_btfs_arm64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: '2,3'
+    PYTHON_RUNTIMES: "2,3"
     PACKAGE_ARCH: arm64
-    DESTINATION_DEB: 'datadog-agent_6_arm64.deb'
-    DESTINATION_DBG_DEB: 'datadog-agent-dbg_6_arm64.deb'
+    DESTINATION_DEB: "datadog-agent_6_arm64.deb"
+    DESTINATION_DBG_DEB: "datadog-agent-dbg_6_arm64.deb"
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_6
 
 agent_deb-arm64-a7:
   extends: .agent_build_common_deb
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-arm64",
+      "go_deps",
+      "generate_minimized_btfs_arm64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: '3'
+    PYTHON_RUNTIMES: "3"
     PACKAGE_ARCH: arm64
-    DESTINATION_DEB: 'datadog-agent_7_arm64.deb'
-    DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_arm64.deb'
+    DESTINATION_DEB: "datadog-agent_7_arm64.deb"
+    DESTINATION_DBG_DEB: "datadog-agent-dbg_7_arm64.deb"
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
@@ -155,32 +180,29 @@ agent_deb-arm64-a7:
 
 iot_agent_deb-x64:
   extends: .iot_agent_build_common_deb
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_mod_tidy_check", "go_deps"]
   variables:
     PACKAGE_ARCH: amd64
-    DESTINATION_DEB: 'datadog-iot-agent_7_amd64.deb'
+    DESTINATION_DEB: "datadog-iot-agent_7_amd64.deb"
 
 iot_agent_deb-arm64:
   extends: .iot_agent_build_common_deb
-  rules:
-    !reference [.on_all_builds_a7]
+  rules: !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
   needs: ["go_mod_tidy_check", "go_deps"]
   variables:
     PACKAGE_ARCH: arm64
-    DESTINATION_DEB: 'datadog-iot-agent_7_arm64.deb'
+    DESTINATION_DEB: "datadog-iot-agent_7_arm64.deb"
 
 iot_agent_deb-armhf:
   extends: .iot_agent_build_common_deb
-  rules:
-    !reference [.on_all_builds_a7]
+  rules: !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   # Run with platform:arm64 since no platform:armhf exists and arm64 should be backwards compatible
@@ -188,11 +210,10 @@ iot_agent_deb-armhf:
   needs: ["go_mod_tidy_check", "go_deps"]
   variables:
     PACKAGE_ARCH: armhf
-    DESTINATION_DEB: 'datadog-iot-agent_7_armhf.deb'
+    DESTINATION_DEB: "datadog-iot-agent_7_armhf.deb"
 
 dogstatsd_deb-x64:
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -219,8 +240,7 @@ dogstatsd_deb-x64:
       - $OMNIBUS_PACKAGE_DIR
 
 dogstatsd_deb-arm64:
-  rules:
-    !reference [.on_all_builds_a7]
+  rules: !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -248,13 +268,13 @@ dogstatsd_deb-arm64:
 agent_heroku_deb-x64-a6:
   extends: agent_deb-x64-a6
   variables:
-    DESTINATION_DEB: 'datadog-heroku-agent_6_amd64.deb'
-    DESTINATION_DBG_DEB: 'datadog-heroku-agent-dbg_6_amd64.deb'
+    DESTINATION_DEB: "datadog-heroku-agent_6_amd64.deb"
+    DESTINATION_DBG_DEB: "datadog-heroku-agent-dbg_6_amd64.deb"
     FLAVOR: heroku
 
 agent_heroku_deb-x64-a7:
   extends: agent_deb-x64-a7
   variables:
-    DESTINATION_DEB: 'datadog-heroku-agent_7_amd64.deb'
-    DESTINATION_DBG_DEB: 'datadog-heroku-agent-dbg_7_amd64.deb'
+    DESTINATION_DEB: "datadog-heroku-agent_7_amd64.deb"
+    DESTINATION_DBG_DEB: "datadog-heroku-agent-dbg_7_amd64.deb"
     FLAVOR: heroku

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -42,6 +42,8 @@ agent_deb-x64-a6:
   extends: .agent_build_common_deb
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -66,6 +68,8 @@ agent_deb-x64-a7:
   extends: .agent_build_common_deb
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -90,6 +94,8 @@ agent_deb-x64-a7-auto:
   extends: .agent_build_common_deb
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -115,6 +121,8 @@ agent_deb-arm64-a6:
   extends: .agent_build_common_deb
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_all_builds_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
@@ -139,6 +147,8 @@ agent_deb-arm64-a7:
   extends: .agent_build_common_deb
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
@@ -192,6 +202,8 @@ iot_agent_deb-x64:
   extends: .iot_agent_build_common_deb
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -205,6 +217,8 @@ iot_agent_deb-arm64:
   extends: .iot_agent_build_common_deb
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
@@ -218,6 +232,8 @@ iot_agent_deb-armhf:
   extends: .iot_agent_build_common_deb
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
@@ -231,6 +247,8 @@ iot_agent_deb-armhf:
 dogstatsd_deb-x64:
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -260,6 +278,8 @@ dogstatsd_deb-x64:
 dogstatsd_deb-arm64:
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -40,7 +40,9 @@
 
 agent_deb-x64-a6:
   extends: .agent_build_common_deb
-  rules: !reference [.on_a6]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -62,7 +64,9 @@ agent_deb-x64-a6:
 
 agent_deb-x64-a7:
   extends: .agent_build_common_deb
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -84,7 +88,9 @@ agent_deb-x64-a7:
 
 agent_deb-x64-a7-auto:
   extends: .agent_build_common_deb
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -107,7 +113,9 @@ agent_deb-x64-a7-auto:
 
 agent_deb-arm64-a6:
   extends: .agent_build_common_deb
-  rules: !reference [.on_all_builds_a6]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_all_builds_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -129,7 +137,9 @@ agent_deb-arm64-a6:
 
 agent_deb-arm64-a7:
   extends: .agent_build_common_deb
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -180,7 +190,9 @@ agent_deb-arm64-a7:
 
 iot_agent_deb-x64:
   extends: .iot_agent_build_common_deb
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -191,7 +203,9 @@ iot_agent_deb-x64:
 
 iot_agent_deb-arm64:
   extends: .iot_agent_build_common_deb
-  rules: !reference [.on_all_builds_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -202,7 +216,9 @@ iot_agent_deb-arm64:
 
 iot_agent_deb-armhf:
   extends: .iot_agent_build_common_deb
-  rules: !reference [.on_all_builds_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   # Run with platform:arm64 since no platform:armhf exists and arm64 should be backwards compatible
@@ -213,7 +229,9 @@ iot_agent_deb-armhf:
     DESTINATION_DEB: "datadog-iot-agent_7_armhf.deb"
 
 dogstatsd_deb-x64:
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -240,7 +258,9 @@ dogstatsd_deb-x64:
       - $OMNIBUS_PACKAGE_DIR
 
 dogstatsd_deb-arm64:
-  rules: !reference [.on_all_builds_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -22,7 +22,9 @@
 
 agent_dmg-x64-a7:
   extends: .agent_build_common_dmg
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -14,7 +14,7 @@
     - python3 -m pip install -r tasks/libs/requirements-github.txt
     - inv -e github.trigger-macos-build --datadog-agent-ref "$CI_COMMIT_SHA" --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --destination "$OMNIBUS_PACKAGE_DIR" --version-cache "$VERSION_CACHE_CONTENT"
     - !reference [.upload_sbom_artifacts]
-  timeout: 3h  # MacOS builds can take 1h~2h, increase the timeout to avoid timeout flakes
+  timeout: 3h # MacOS builds can take 1h~2h, increase the timeout to avoid timeout flakes
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -22,15 +22,14 @@
 
 agent_dmg-x64-a7:
   extends: .agent_build_common_dmg
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_mod_tidy_check"]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: '3'
+    PYTHON_RUNTIMES: "3"
   before_script:
     - source /root/.bashrc
     - export RELEASE_VERSION=$RELEASE_VERSION_7

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -24,6 +24,8 @@ agent_dmg-x64-a7:
   extends: .agent_build_common_dmg
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -23,9 +23,6 @@
 agent_dmg-x64-a7:
   extends: .agent_build_common_dmg
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -35,7 +35,9 @@
 # build Agent package for rpm-x64
 agent_rpm-x64-a6:
   extends: .agent_build_common_rpm
-  rules: !reference [.on_a6]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -57,7 +59,9 @@ agent_rpm-x64-a6:
 # build Agent package for rpm-x64
 agent_rpm-x64-a7:
   extends: .agent_build_common_rpm
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -79,7 +83,9 @@ agent_rpm-x64-a7:
 # build Agent package for rpm-arm64
 agent_rpm-arm64-a6:
   extends: .agent_build_common_rpm
-  rules: !reference [.on_all_builds_a6]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_all_builds_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -101,7 +107,9 @@ agent_rpm-arm64-a6:
 # build Agent package for rpm-arm64
 agent_rpm-arm64-a7:
   extends: .agent_build_common_rpm
-  rules: !reference [.on_all_builds_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -154,7 +162,9 @@ agent_rpm-arm64-a7:
 
 iot_agent_rpm-x64:
   extends: .iot_agent_build_common_rpm
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -162,7 +172,9 @@ iot_agent_rpm-x64:
 
 iot_agent_rpm-arm64:
   extends: .iot_agent_build_common_rpm
-  rules: !reference [.on_all_builds_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -170,7 +182,9 @@ iot_agent_rpm-arm64:
 
 iot_agent_rpm-armhf:
   extends: .iot_agent_build_common_rpm
-  rules: !reference [.on_all_builds_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   # Run with platform:arm64 since no platform:armhf exists and arm64 should be backwards compatible
@@ -181,7 +195,9 @@ iot_agent_rpm-armhf:
     - export LD_PRELOAD="/usr/local/lib/libfakearmv7l.so"
 
 dogstatsd_rpm-x64:
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -36,9 +36,6 @@
 agent_rpm-x64-a6:
   extends: .agent_build_common_rpm
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -62,9 +59,6 @@ agent_rpm-x64-a6:
 agent_rpm-x64-a7:
   extends: .agent_build_common_rpm
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -88,10 +82,10 @@ agent_rpm-x64-a7:
 agent_rpm-arm64-a6:
   extends: .agent_build_common_rpm
   rules:
+    - !reference [.on_all_builds_a6]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
     - !reference [.on_kitchen_test_change]
-    - !reference [.on_all_builds_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -114,10 +108,10 @@ agent_rpm-arm64-a6:
 agent_rpm-arm64-a7:
   extends: .agent_build_common_rpm
   rules:
+    - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
     - !reference [.on_kitchen_test_change]
-    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -171,9 +165,6 @@ agent_rpm-arm64-a7:
 iot_agent_rpm-x64:
   extends: .iot_agent_build_common_rpm
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -183,10 +174,10 @@ iot_agent_rpm-x64:
 iot_agent_rpm-arm64:
   extends: .iot_agent_build_common_rpm
   rules:
+    - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
     - !reference [.on_kitchen_test_change]
-    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -195,10 +186,10 @@ iot_agent_rpm-arm64:
 iot_agent_rpm-armhf:
   extends: .iot_agent_build_common_rpm
   rules:
+    - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
     - !reference [.on_kitchen_test_change]
-    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   # Run with platform:arm64 since no platform:armhf exists and arm64 should be backwards compatible
@@ -210,9 +201,6 @@ iot_agent_rpm-armhf:
 
 dogstatsd_rpm-x64:
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -85,7 +85,6 @@ agent_rpm-arm64-a6:
     - !reference [.on_all_builds_a6]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -111,7 +110,6 @@ agent_rpm-arm64-a7:
     - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -177,7 +175,6 @@ iot_agent_rpm-arm64:
     - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -189,7 +186,6 @@ iot_agent_rpm-armhf:
     - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   # Run with platform:arm64 since no platform:armhf exists and arm64 should be backwards compatible

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -37,6 +37,8 @@ agent_rpm-x64-a6:
   extends: .agent_build_common_rpm
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -61,6 +63,8 @@ agent_rpm-x64-a7:
   extends: .agent_build_common_rpm
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -85,6 +89,8 @@ agent_rpm-arm64-a6:
   extends: .agent_build_common_rpm
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_all_builds_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
@@ -109,6 +115,8 @@ agent_rpm-arm64-a7:
   extends: .agent_build_common_rpm
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
@@ -164,6 +172,8 @@ iot_agent_rpm-x64:
   extends: .iot_agent_build_common_rpm
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -174,6 +184,8 @@ iot_agent_rpm-arm64:
   extends: .iot_agent_build_common_rpm
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
@@ -184,6 +196,8 @@ iot_agent_rpm-armhf:
   extends: .iot_agent_build_common_rpm
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
@@ -197,6 +211,8 @@ iot_agent_rpm-armhf:
 dogstatsd_rpm-x64:
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -35,15 +35,20 @@
 # build Agent package for rpm-x64
 agent_rpm-x64-a6:
   extends: .agent_build_common_rpm
-  rules:
-    !reference [.on_a6]
+  rules: !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-x64",
+      "go_deps",
+      "generate_minimized_btfs_x64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: '2,3'
+    PYTHON_RUNTIMES: "2,3"
     PACKAGE_ARCH: amd64
   before_script:
     - source /root/.bashrc
@@ -52,15 +57,20 @@ agent_rpm-x64-a6:
 # build Agent package for rpm-x64
 agent_rpm-x64-a7:
   extends: .agent_build_common_rpm
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-x64",
+      "go_deps",
+      "generate_minimized_btfs_x64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: '3'
+    PYTHON_RUNTIMES: "3"
     PACKAGE_ARCH: amd64
   before_script:
     - source /root/.bashrc
@@ -69,15 +79,20 @@ agent_rpm-x64-a7:
 # build Agent package for rpm-arm64
 agent_rpm-arm64-a6:
   extends: .agent_build_common_rpm
-  rules:
-    !reference [.on_all_builds_a6]
+  rules: !reference [.on_all_builds_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-arm64",
+      "go_deps",
+      "generate_minimized_btfs_arm64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: '2,3'
+    PYTHON_RUNTIMES: "2,3"
     PACKAGE_ARCH: arm64
   before_script:
     - source /root/.bashrc
@@ -86,15 +101,20 @@ agent_rpm-arm64-a6:
 # build Agent package for rpm-arm64
 agent_rpm-arm64-a7:
   extends: .agent_build_common_rpm
-  rules:
-    !reference [.on_all_builds_a7]
+  rules: !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-arm64",
+      "go_deps",
+      "generate_minimized_btfs_arm64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: '3'
+    PYTHON_RUNTIMES: "3"
     PACKAGE_ARCH: arm64
   before_script:
     - source /root/.bashrc
@@ -134,8 +154,7 @@ agent_rpm-arm64-a7:
 
 iot_agent_rpm-x64:
   extends: .iot_agent_build_common_rpm
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -143,8 +162,7 @@ iot_agent_rpm-x64:
 
 iot_agent_rpm-arm64:
   extends: .iot_agent_build_common_rpm
-  rules:
-    !reference [.on_all_builds_a7]
+  rules: !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -152,8 +170,7 @@ iot_agent_rpm-arm64:
 
 iot_agent_rpm-armhf:
   extends: .iot_agent_build_common_rpm
-  rules:
-    !reference [.on_all_builds_a7]
+  rules: !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   # Run with platform:arm64 since no platform:armhf exists and arm64 should be backwards compatible
@@ -164,8 +181,7 @@ iot_agent_rpm-armhf:
     - export LD_PRELOAD="/usr/local/lib/libfakearmv7l.so"
 
 dogstatsd_rpm-x64:
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -89,7 +89,6 @@ agent_suse-arm64-a7:
     - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -40,6 +40,8 @@ agent_suse-x64-a6:
   extends: .agent_build_common_suse_rpm
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -64,6 +66,8 @@ agent_suse-x64-a7:
   extends: .agent_build_common_suse_rpm
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -89,6 +93,8 @@ agent_suse-arm64-a7:
   extends: .agent_build_common_suse_rpm
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
@@ -112,6 +118,8 @@ agent_suse-arm64-a7:
 iot_agent_suse-x64:
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -150,6 +158,8 @@ iot_agent_suse-x64:
 dogstatsd_suse-x64:
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -39,9 +39,6 @@
 agent_suse-x64-a6:
   extends: .agent_build_common_suse_rpm
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -65,9 +62,6 @@ agent_suse-x64-a6:
 agent_suse-x64-a7:
   extends: .agent_build_common_suse_rpm
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -92,10 +86,10 @@ agent_suse-x64-a7:
 agent_suse-arm64-a7:
   extends: .agent_build_common_suse_rpm
   rules:
+    - !reference [.on_all_builds_a7]
     - !reference [.on_omnibus_change]
     - !reference [.on_go-version_change]
     - !reference [.on_kitchen_test_change]
-    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -117,9 +111,6 @@ agent_suse-arm64-a7:
 
 iot_agent_suse-x64:
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -157,9 +148,6 @@ iot_agent_suse-x64:
 
 dogstatsd_suse-x64:
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -38,7 +38,9 @@
 # build Agent package for suse-x64
 agent_suse-x64-a6:
   extends: .agent_build_common_suse_rpm
-  rules: !reference [.on_a6]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -60,7 +62,9 @@ agent_suse-x64-a6:
 # build Agent package for suse-x64
 agent_suse-x64-a7:
   extends: .agent_build_common_suse_rpm
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -83,7 +87,9 @@ agent_suse-x64-a7:
 # This is a bit hackish and mostly mimics the CentOS7/arm64 build
 agent_suse-arm64-a7:
   extends: .agent_build_common_suse_rpm
-  rules: !reference [.on_all_builds_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -104,7 +110,9 @@ agent_suse-arm64-a7:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
 iot_agent_suse-x64:
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -140,7 +148,9 @@ iot_agent_suse-x64:
       - $OMNIBUS_PACKAGE_DIR_SUSE
 
 dogstatsd_suse-x64:
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -38,15 +38,20 @@
 # build Agent package for suse-x64
 agent_suse-x64-a6:
   extends: .agent_build_common_suse_rpm
-  rules:
-    !reference [.on_a6]
+  rules: !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-x64",
+      "go_deps",
+      "generate_minimized_btfs_x64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: '2,3'
+    PYTHON_RUNTIMES: "2,3"
     PACKAGE_ARCH: amd64
   before_script:
     - source /root/.bashrc
@@ -55,15 +60,20 @@ agent_suse-x64-a6:
 # build Agent package for suse-x64
 agent_suse-x64-a7:
   extends: .agent_build_common_suse_rpm
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-x64",
+      "go_deps",
+      "generate_minimized_btfs_x64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: '3'
+    PYTHON_RUNTIMES: "3"
     PACKAGE_ARCH: amd64
   before_script:
     - source /root/.bashrc
@@ -73,24 +83,28 @@ agent_suse-x64-a7:
 # This is a bit hackish and mostly mimics the CentOS7/arm64 build
 agent_suse-arm64-a7:
   extends: .agent_build_common_suse_rpm
-  rules:
-    !reference [.on_all_builds_a7]
+  rules: !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
+  needs:
+    [
+      "go_mod_tidy_check",
+      "build_system-probe-arm64",
+      "go_deps",
+      "generate_minimized_btfs_arm64",
+    ]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: '3'
+    PYTHON_RUNTIMES: "3"
     PACKAGE_ARCH: arm64
-    OMNIBUS_TASK_EXTRA_PARAMS: '--host-distribution=suse'
+    OMNIBUS_TASK_EXTRA_PARAMS: "--host-distribution=suse"
   before_script:
     - source /root/.bashrc
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
 iot_agent_suse-x64:
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -126,8 +140,7 @@ iot_agent_suse-x64:
       - $OMNIBUS_PACKAGE_DIR_SUSE
 
 dogstatsd_suse-x64:
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -55,7 +55,9 @@
 
 windows_msi_and_bosh_zip_x64-a7:
   extends: .windows_main_agent_base
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   variables:
     ARCH: "x64"
     AGENT_MAJOR_VERSION: 7
@@ -65,7 +67,9 @@ windows_msi_and_bosh_zip_x64-a7:
 
 windows_msi_x64-a6:
   extends: .windows_main_agent_base
-  rules: !reference [.on_a6]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a6]
   variables:
     ARCH: "x64"
     AGENT_MAJOR_VERSION: 6
@@ -76,7 +80,9 @@ windows_msi_x64-a6:
 
 # cloudfoundry IoT build for Windows
 windows_zip_agent_binaries_x64-a7:
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.on_omnibus_change]
+    - !reference [.on_a7]
   stage: package_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["go_mod_tidy_check", "go_deps"]

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -55,31 +55,28 @@
 
 windows_msi_and_bosh_zip_x64-a7:
   extends: .windows_main_agent_base
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   variables:
     ARCH: "x64"
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: '3'
+    PYTHON_RUNTIMES: "3"
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_7
 
 windows_msi_x64-a6:
   extends: .windows_main_agent_base
-  rules:
-    !reference [.on_a6]
+  rules: !reference [.on_a6]
   variables:
     ARCH: "x64"
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: '2,3'
+    PYTHON_RUNTIMES: "2,3"
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_6
   timeout: 3h
 
 # cloudfoundry IoT build for Windows
 windows_zip_agent_binaries_x64-a7:
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["go_mod_tidy_check", "go_deps"]

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -56,9 +56,6 @@
 windows_msi_and_bosh_zip_x64-a7:
   extends: .windows_main_agent_base
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   variables:
     ARCH: "x64"
@@ -70,9 +67,6 @@ windows_msi_and_bosh_zip_x64-a7:
 windows_msi_x64-a6:
   extends: .windows_main_agent_base
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a6]
   variables:
     ARCH: "x64"
@@ -85,9 +79,6 @@ windows_msi_x64-a6:
 # cloudfoundry IoT build for Windows
 windows_zip_agent_binaries_x64-a7:
   rules:
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
-    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   tags: ["runner:windows-docker", "windowsversion:1809"]

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -57,6 +57,8 @@ windows_msi_and_bosh_zip_x64-a7:
   extends: .windows_main_agent_base
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   variables:
     ARCH: "x64"
@@ -69,6 +71,8 @@ windows_msi_x64-a6:
   extends: .windows_main_agent_base
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a6]
   variables:
     ARCH: "x64"
@@ -82,6 +86,8 @@ windows_msi_x64-a6:
 windows_zip_agent_binaries_x64-a7:
   rules:
     - !reference [.on_omnibus_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_kitchen_test_change]
     - !reference [.on_a7]
   stage: package_build
   tags: ["runner:windows-docker", "windowsversion:1809"]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

[[APL-2624](https://datadoghq.atlassian.net/browse/APL-2624)] Add `changes` rules for `.go-version`, `omnibus/`, and `test/kitchen/` files to trigger package builds.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

To provide better CI coverage after a change in `omnibus/` broke package builds on on a specific platform/version which were not tested on branches.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[APL-2624]: https://datadoghq.atlassian.net/browse/APL-2624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ