### PR TITLE
[CONTINT-3589] Do not close sbom channel on shutdown

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -10,9 +10,7 @@ package containerd
 import (
 	"context"
 	"fmt"
-
 	"github.com/CycloneDX/cyclonedx-go"
-
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
@@ -50,9 +48,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 	go func() {
 		for {
 			select {
-			// We don't want to keep scanning if image channel is not empty but context is expired
 			case <-ctx.Done():
-				close(resultChan)
 				return
 
 			case eventBundle, ok := <-imgEventsCh:
@@ -80,46 +76,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 		}
 	}()
 
-	go func() {
-		for result := range resultChan {
-			if result.ImgMeta == nil {
-				log.Errorf("Scan result does not hold the image identifier. Error: %s", result.Error)
-				continue
-			}
-
-			status := workloadmeta.Success
-			reportedError := ""
-			var report *cyclonedx.BOM
-			if result.Error != nil {
-				// TODO: add a retry mechanism for retryable errors
-				log.Errorf("Failed to generate SBOM for containerd image: %s", result.Error)
-				status = workloadmeta.Failed
-				reportedError = result.Error.Error()
-			} else {
-				bom, err := result.Report.ToCycloneDX()
-				if err != nil {
-					log.Errorf("Failed to extract SBOM from report")
-					status = workloadmeta.Failed
-					reportedError = err.Error()
-				}
-				report = bom
-			}
-
-			sbom := &workloadmeta.SBOM{
-				CycloneDXBOM:       report,
-				GenerationTime:     result.CreatedAt,
-				GenerationDuration: result.Duration,
-				Status:             status,
-				Error:              reportedError,
-			}
-
-			// Updating workloadmeta entities directly is not thread-safe, that's why we
-			// generate an update event here instead.
-			if err := c.handleImageCreateOrUpdate(ctx, result.ImgMeta.Namespace, result.ImgMeta.Name, sbom); err != nil {
-				log.Warnf("Error extracting SBOM for image: namespace=%s name=%s, err: %s", result.ImgMeta.Namespace, result.ImgMeta.Name, err)
-			}
-		}
-	}()
+	go c.startScanResultHandler(ctx, resultChan)
 
 	return nil
 }
@@ -142,4 +99,54 @@ func (c *collector) extractSBOMWithTrivy(_ context.Context, storedImage *workloa
 	}
 
 	return nil
+}
+
+func (c *collector) startScanResultHandler(ctx context.Context, resultChan <-chan sbom.ScanResult) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case result := <-resultChan:
+			c.processScanResult(ctx, result)
+		}
+	}
+}
+
+func (c *collector) processScanResult(ctx context.Context, result sbom.ScanResult) {
+	if result.ImgMeta == nil {
+		log.Errorf("Scan result does not hold the image identifier. Error: %s", result.Error)
+		return
+	}
+
+	// Updating workloadmeta entities directly is not thread-safe, that's why we
+	// generate an update event here instead.
+	if err := c.handleImageCreateOrUpdate(ctx, result.ImgMeta.Namespace, result.ImgMeta.Name, convertScanResultToSBOM(result)); err != nil {
+		log.Warnf("Error extracting SBOM for image: namespace=%s name=%s, err: %s", result.ImgMeta.Namespace, result.ImgMeta.Name, err)
+	}
+}
+
+func convertScanResultToSBOM(result sbom.ScanResult) *workloadmeta.SBOM {
+	status := workloadmeta.Success
+	reportedError := ""
+	var report *cyclonedx.BOM
+
+	if result.Error != nil {
+		log.Errorf("Failed to generate SBOM for containerd image: %s", result.Error)
+		status = workloadmeta.Failed
+		reportedError = result.Error.Error()
+	} else if bom, err := result.Report.ToCycloneDX(); err != nil {
+		log.Errorf("Failed to extract SBOM from report")
+		status = workloadmeta.Failed
+		reportedError = err.Error()
+	} else {
+		report = bom
+	}
+
+	return &workloadmeta.SBOM{
+		CycloneDXBOM:       report,
+		GenerationTime:     result.CreatedAt,
+		GenerationDuration: result.Duration,
+		Status:             status,
+		Error:              reportedError,
+	}
 }

--- a/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -106,7 +106,8 @@ func (c *collector) startScanResultHandler(ctx context.Context, resultChan <-cha
 		select {
 		case <-ctx.Done():
 			return
-		case result := <-resultChan:
+		case result, ok := <-resultChan:
+		  if !ok { return }
 			c.processScanResult(ctx, result)
 		}
 	}

--- a/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -10,6 +10,7 @@ package containerd
 import (
 	"context"
 	"fmt"
+
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -107,9 +108,9 @@ func (c *collector) startScanResultHandler(ctx context.Context, resultChan <-cha
 		case <-ctx.Done():
 			return
 		case result, ok := <-resultChan:
-		  if !ok { 
-		    return 
-		  }
+			if !ok {
+				return
+			}
 			c.processScanResult(ctx, result)
 		}
 	}

--- a/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -107,7 +107,9 @@ func (c *collector) startScanResultHandler(ctx context.Context, resultChan <-cha
 		case <-ctx.Done():
 			return
 		case result, ok := <-resultChan:
-		  if !ok { return }
+		  if !ok { 
+		    return 
+		  }
 			c.processScanResult(ctx, result)
 		}
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR removes the logic that closes the channel on shut down and splits the code into functions for readability.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Only writers are supposed to close channels because writing to a closed channel can trigger a panic.
Since wlm is running in an fx component, it results in a recoverable panic on shutdown.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
It's difficult to reproduce because it depends on a timing issue. We can check that sbom collection of container images still works and that we don't see a panic log on shutdown internally.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
