### PR TITLE
Fix e2e tests report publication

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -211,7 +211,6 @@ new-e2e-agent-shared-components-main:
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestSubcommandSuite
-      - EXTRA_PARAMS: --run TestAgentSecretSuite
       - EXTRA_PARAMS: --run TestAgentConfigSuite
       - EXTRA_PARAMS: --run TestAgentHostnameEC2Suite
       - EXTRA_PARAMS: --run TestAgentDiagnoseEC2Suite

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -65,4 +65,5 @@ e2e_test_junit_upload:
     - set +x
     - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
     - set -x
+    - set +e
     - for f in junit-new-e2e-*.tgz; do inv -e junit-upload --tgz-path "$f"; done


### PR DESCRIPTION
### What does this PR do?

Fix e2e tests report publication in the [Datadog CI app](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22&citest_explorer_sort=time%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%2C%40duration%2C%40test.service%2C%40git.branch&index=citest&mode=sliding&saved-view-id=2236559&start=1702550267530&end=1703155067530&paused=false).

### Motivation

There is no `containers` e2e test result in the [Datadog CI app](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22&citest_explorer_sort=time%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%2C%40duration%2C%40test.service%2C%40git.branch&index=citest&mode=sliding&saved-view-id=2236559&start=1702550316614&end=1703155116614&paused=false) since 2 days.

### Additional Notes

This has been broken by #21582 because it introduced a job `new-e2e-agent-subcommands-main: [--run TestAgentSecretSuite]` that has no test.

Such jobs ([here is an example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/394714028)) are logging:
```
DONE 0 tests in 130.770s
No tests were run, skipping coverage report
```

The issue is that it generates an empty Junit report.
It generates a [tarball which has no XML file in it](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/394714028/artifacts/file/junit-new-e2e-agent-subcommands-main:%20%5B--run%20TestAgentSecretSuite%5D.tgz).

This tarball with no XML file makes `inv junit-upload` fail with:
```
No JUnit XML files for upload found in: junit-new-e2e-agent-subcommands-main: [--run TestAgentSecretSuite].tgz
```

And because GitLab runs scripts with `set -e`, the whole `e2e_test_junit_upload` job prematurely exits and doesn’t process other Junit report coming from other jobs.
[Here is an example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/394714042).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
