### PR TITLE
[oracle] Adding the prefix `data_guard.` to Data Guard metrics (DBMON-3280)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -108,6 +108,10 @@ type resourceManagerConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
 
+type locksConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
 // InstanceConfig is used to deserialize integration instance config.
 type InstanceConfig struct {
 	Server                             string                 `yaml:"server"`
@@ -140,6 +144,7 @@ type InstanceConfig struct {
 	DatabaseInstanceCollectionInterval uint64                 `yaml:"database_instance_collection_interval"`
 	Asm                                asmConfig              `yaml:"asm"`
 	ResourceManager                    resourceManagerConfig  `yaml:"resource_manager"`
+	Locks                              locksConfig            `yaml:"locks"`
 }
 
 // CheckConfig holds the config needed for an integration instance to run.
@@ -199,6 +204,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.InactiveSessions.Enabled = true
 	instance.Asm.Enabled = true
 	instance.ResourceManager.Enabled = true
+	instance.Locks.Enabled = true
 
 	instance.UseGlobalCustomQueries = "true"
 

--- a/pkg/collector/corechecks/oracle-dbm/data_guard.go
+++ b/pkg/collector/corechecks/oracle-dbm/data_guard.go
@@ -59,7 +59,7 @@ func (c *Check) dataGuard() error {
 		} else {
 			v = invalidLagValue
 		}
-		sender.Gauge(fmt.Sprintf("%s.%s", common.IntegrationName, strings.ReplaceAll(string(s.Name), " ", "_")), v, "", c.tags)
+		sender.Gauge(fmt.Sprintf("%s.data_guard.%s", common.IntegrationName, strings.ReplaceAll(string(s.Name), " ", "_")), v, "", c.tags)
 	}
 	sender.Commit()
 	return nil

--- a/pkg/collector/corechecks/oracle-dbm/locks.go
+++ b/pkg/collector/corechecks/oracle-dbm/locks.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
+)
+
+const locksQuery12 = `SELECT 
+  MAX((SYSDATE - start_date)*24*3600) as seconds, 
+	s.sid,s.serial#, s.username, s.osuser, s.machine, s.program,
+  s.status, 
+	LISTAGG(d.owner || '.' || d.object_name, ',') WITHIN GROUP (ORDER BY d.owner, d.object_name) object, 
+	c.name as pdb_name
+    FROM v$transaction t, v$session s, v$locked_object v, dba_objects d, v$containers c
+    WHERE s.saddr = t.ses_addr 
+      AND v.object_id = d.object_id AND v.session_id = s.sid AND v.con_id(+) = c.con_id AND temporary = 'N'
+		GROUP BY s.sid,s.serial#, s.username, s.osuser, s.machine, s.program,
+			s.status, c.name`
+
+const locksQuery11 = `SELECT 
+  MAX((SYSDATE - start_date)*24*3600) as seconds, s.sid,s.serial#, s.username, s.osuser, s.machine, s.program,
+  s.status, 
+	LISTAGG(d.owner || '.' || d.object_name, ',') WITHIN GROUP (ORDER BY d.owner, d.object_name) object
+  FROM v$transaction t, v$session s, v$locked_object v, dba_objects d
+  WHERE s.saddr = t.ses_addr 
+    AND v.object_id = d.object_id AND v.session_id = s.sid AND temporary = 'N'
+	GROUP BY s.sid,s.serial#, s.username, s.osuser, s.machine, s.program,
+		s.status`
+
+type locksRowDB struct {
+	Seconds  sql.NullFloat64 `db:"SECONDS"`
+	Sid      sql.NullInt64   `db:"SID"`
+	Serial   sql.NullInt64   `db:"SERIAL#"`
+	Username sql.NullString  `db:"USERNAME"`
+	Program  sql.NullString  `db:"PROGRAM"`
+	Machine  sql.NullString  `db:"MACHINE"`
+	OsUser   sql.NullString  `db:"OSUSER"`
+	Status   sql.NullString  `db:"STATUS"`
+	Object   sql.NullString  `db:"OBJECT"`
+	PdbName  sql.NullString  `db:"PDB_NAME"`
+}
+
+func (c *Check) locks() error {
+	rows := []locksRowDB{}
+
+	var query string
+	if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
+		query = locksQuery12
+	} else {
+		query = locksQuery11
+	}
+	err := selectWrapper(c, &rows, query)
+	if err != nil {
+		return fmt.Errorf("failed to collect locks info: %w", err)
+	}
+	sender, err := c.GetSender()
+	if err != nil {
+		return fmt.Errorf("failed to initialize sender: %w", err)
+	}
+	for _, r := range rows {
+		if !r.Seconds.Valid {
+			continue
+		}
+		tags := appendPDBTag(c.tags, r.PdbName)
+		if r.Sid.Valid {
+			tags = append(tags, "sid:"+strconv.FormatInt(r.Sid.Int64, 10))
+		}
+		if r.Serial.Valid {
+			tags = append(tags, "serial:"+strconv.FormatInt(r.Serial.Int64, 10))
+		}
+		if r.Username.Valid {
+			tags = append(tags, "username:"+r.Username.String)
+		}
+		if r.Program.Valid {
+			tags = append(tags, "program:"+r.Program.String)
+		}
+		if r.Machine.Valid {
+			tags = append(tags, "machine:"+r.Machine.String)
+		}
+		if r.OsUser.Valid {
+			tags = append(tags, "osuser:"+r.OsUser.String)
+		}
+		if r.Status.Valid {
+			tags = append(tags, "status:"+r.Status.String)
+		}
+		if r.Object.Valid {
+			tags = append(tags, "objects:"+r.Object.String)
+		}
+
+		sender.Gauge(fmt.Sprintf("%s.seconds_in_transaction", common.IntegrationName), r.Seconds.Float64, "", tags)
+	}
+	sender.Commit()
+	return nil
+}

--- a/pkg/collector/corechecks/oracle-dbm/locks.go
+++ b/pkg/collector/corechecks/oracle-dbm/locks.go
@@ -9,96 +9,183 @@ package oracle
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
-	"strconv"
+	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const locksQuery12 = `SELECT 
-  MAX((SYSDATE - start_date)*24*3600) as seconds, 
-	s.sid,s.serial#, s.username, s.osuser, s.machine, s.program,
-  s.status, 
-	LISTAGG(d.owner || '.' || d.object_name, ',') WITHIN GROUP (ORDER BY d.owner, d.object_name) object, 
+const (
+	locksQuery12 = `SELECT
+  (SYSDATE - start_date)*24*3600 as seconds,
+	s.sid,s.serial#, s.username, s.osuser, s.machine, s.program, 
+	s.client_info, s.module, s.action, s.client_identifier,
+  s.status,
+	d.owner,
+	d.object_name,
+	v.locked_mode,
 	c.name as pdb_name
-    FROM v$transaction t, v$session s, v$locked_object v, dba_objects d, v$containers c
-    WHERE s.saddr = t.ses_addr 
-      AND v.object_id = d.object_id AND v.session_id = s.sid AND v.con_id(+) = c.con_id AND temporary = 'N'
-		GROUP BY s.sid,s.serial#, s.username, s.osuser, s.machine, s.program,
-			s.status, c.name`
+  FROM v$transaction t, v$session s, v$locked_object v, dba_objects d, v$containers c
+  WHERE s.saddr = t.ses_addr
+    AND v.object_id = d.object_id AND v.session_id = s.sid AND v.con_id(+) = c.con_id AND temporary = 'N'`
 
-const locksQuery11 = `SELECT 
-  MAX((SYSDATE - start_date)*24*3600) as seconds, s.sid,s.serial#, s.username, s.osuser, s.machine, s.program,
-  s.status, 
-	LISTAGG(d.owner || '.' || d.object_name, ',') WITHIN GROUP (ORDER BY d.owner, d.object_name) object
+	locksQuery11 = `SELECT
+  (SYSDATE - start_date)*24*3600 as seconds, 
+	s.sid,s.serial#, s.username, s.osuser, s.machine, s.program,
+  s.status,
+	d.owner,
+	d.object_name,
+	v.locked_mode
   FROM v$transaction t, v$session s, v$locked_object v, dba_objects d
-  WHERE s.saddr = t.ses_addr 
+  WHERE s.saddr = t.ses_addr
     AND v.object_id = d.object_id AND v.session_id = s.sid AND temporary = 'N'
 	GROUP BY s.sid,s.serial#, s.username, s.osuser, s.machine, s.program,
 		s.status`
+)
 
-type locksRowDB struct {
-	Seconds  sql.NullFloat64 `db:"SECONDS"`
-	Sid      sql.NullInt64   `db:"SID"`
-	Serial   sql.NullInt64   `db:"SERIAL#"`
-	Username sql.NullString  `db:"USERNAME"`
-	Program  sql.NullString  `db:"PROGRAM"`
-	Machine  sql.NullString  `db:"MACHINE"`
-	OsUser   sql.NullString  `db:"OSUSER"`
-	Status   sql.NullString  `db:"STATUS"`
-	Object   sql.NullString  `db:"OBJECT"`
-	PdbName  sql.NullString  `db:"PDB_NAME"`
+type lockRowDB struct {
+	Seconds          sql.NullFloat64 `db:"SECONDS"`
+	Sid              sql.NullInt64   `db:"SID"`
+	Serial           sql.NullInt64   `db:"SERIAL#"`
+	Username         sql.NullString  `db:"USERNAME"`
+	Program          sql.NullString  `db:"PROGRAM"`
+	Machine          sql.NullString  `db:"MACHINE"`
+	OsUser           sql.NullString  `db:"OSUSER"`
+	Module           sql.NullString  `db:"MODULE"`
+	Action           sql.NullString  `db:"ACTION"`
+	ClientInfo       sql.NullString  `db:"CLIENT_INFO"`
+	ClientIdentifier sql.NullString  `db:"CLIENT_IDENTIFIER"`
+	Status           sql.NullString  `db:"STATUS"`
+	Owner            sql.NullString  `db:"OWNER"`
+	ObjectName       sql.NullString  `db:"OBJECT_NAME"`
+	LockedMode       sql.NullString  `db:"LOCKED_MODE"`
+	PdbName          sql.NullString  `db:"PDB_NAME"`
+}
+
+type lockRowPayload struct {
+	Seconds          float64 `json:"seconds,omitempty"`
+	Sid              int64   `json:"sid,omitempty"`
+	Serial           int64   `json:"serial,omitempty"`
+	Username         string  `json:"username,omitempty"`
+	Program          string  `json:"program,omitempty"`
+	Machine          string  `json:"machine,omitempty"`
+	OsUser           string  `json:"os_user,omitempty"`
+	Module           string  `json:"module,omitempty"`
+	Action           string  `json:"action,omitempty"`
+	ClientInfo       string  `json:"client_info,omitempty"`
+	ClientIdentifier string  `json:"client_identifier,omitempty"`
+	Status           string  `json:"status,omitempty"`
+	Owner            string  `json:"owner,omitempty"`
+	ObjectName       string  `json:"object_name,omitempty"`
+	LockedMode       string  `json:"locked_mode,omitempty"`
+	PdbName          string  `json:"pdb_name,omitempty"`
+}
+
+type locksPayload struct {
+	Metadata
+	// Tags should be part of the common Metadata struct but because Activity payloads use a string array
+	// and samples use a comma-delimited list of tags in a single string, both flavors have to be handled differently
+	Tags               []string         `json:"ddtags,omitempty"`
+	CollectionInterval float64          `json:"collection_interval,omitempty"`
+	LockActivityRows   []lockRowPayload `json:"locks,omitempty"`
 }
 
 func (c *Check) locks() error {
-	rows := []locksRowDB{}
-
 	var query string
 	if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
 		query = locksQuery12
 	} else {
 		query = locksQuery11
 	}
-	err := selectWrapper(c, &rows, query)
+	var rowsDB []lockRowDB
+	err := selectWrapper(c, &rowsDB, query)
 	if err != nil {
 		return fmt.Errorf("failed to collect locks info: %w", err)
 	}
+	var locksRowsPayload []lockRowPayload
+	for _, rowDB := range rowsDB {
+		var rowPayload lockRowPayload
+		if rowDB.Seconds.Valid {
+			rowPayload.Seconds = rowDB.Seconds.Float64
+		}
+		if rowDB.Sid.Valid {
+			rowPayload.Sid = rowDB.Sid.Int64
+		}
+		if rowDB.Serial.Valid {
+			rowPayload.Serial = rowDB.Serial.Int64
+		}
+		if rowDB.Username.Valid {
+			rowPayload.Username = rowDB.Username.String
+		}
+		if rowDB.Program.Valid {
+			rowPayload.Program = rowDB.Program.String
+		}
+		if rowDB.Machine.Valid {
+			rowPayload.Machine = rowDB.Machine.String
+		}
+		if rowDB.OsUser.Valid {
+			rowPayload.OsUser = rowDB.OsUser.String
+		}
+		if rowDB.Module.Valid {
+			rowPayload.Module = rowDB.Module.String
+		}
+		if rowDB.Action.Valid {
+			rowPayload.Action = rowDB.Action.String
+		}
+		if rowDB.ClientInfo.Valid {
+			rowPayload.ClientInfo = rowDB.ClientInfo.String
+		}
+		if rowDB.ClientIdentifier.Valid {
+			rowPayload.ClientIdentifier = rowDB.ClientIdentifier.String
+		}
+		if rowDB.Status.Valid {
+			rowPayload.Status = rowDB.Status.String
+		}
+		if rowDB.Owner.Valid {
+			rowPayload.Owner = rowDB.Owner.String
+		}
+		if rowDB.ObjectName.Valid {
+			rowPayload.ObjectName = rowDB.ObjectName.String
+		}
+		if rowDB.LockedMode.Valid {
+			rowPayload.LockedMode = rowDB.LockedMode.String
+		}
+		if rowDB.PdbName.Valid {
+			rowPayload.PdbName = rowDB.PdbName.String
+		}
+		locksRowsPayload = append(locksRowsPayload, rowPayload)
+	}
+	payload := locksPayload{
+		Metadata: Metadata{
+			Timestamp:      float64(time.Now().UnixMilli()),
+			Host:           c.dbHostname,
+			Source:         common.IntegrationName,
+			DBMType:        "locks",
+			DDAgentVersion: c.agentVersion,
+		},
+		CollectionInterval: c.checkInterval,
+		Tags:               c.tags,
+		LockActivityRows:   locksRowsPayload,
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		log.Errorf("%s Error marshalling locks payload: %s", c.logPrompt, err)
+		return err
+	}
+
+	log.Debugf("%s Locks payload %s", c.logPrompt, strings.ReplaceAll(string(payloadBytes), "@", "XX"))
+
 	sender, err := c.GetSender()
 	if err != nil {
-		return fmt.Errorf("failed to initialize sender: %w", err)
+		log.Errorf("%s GetSender SampleSession %s", c.logPrompt, string(payloadBytes))
+		return err
 	}
-	for _, r := range rows {
-		if !r.Seconds.Valid {
-			continue
-		}
-		tags := appendPDBTag(c.tags, r.PdbName)
-		if r.Sid.Valid {
-			tags = append(tags, "sid:"+strconv.FormatInt(r.Sid.Int64, 10))
-		}
-		if r.Serial.Valid {
-			tags = append(tags, "serial:"+strconv.FormatInt(r.Serial.Int64, 10))
-		}
-		if r.Username.Valid {
-			tags = append(tags, "username:"+r.Username.String)
-		}
-		if r.Program.Valid {
-			tags = append(tags, "program:"+r.Program.String)
-		}
-		if r.Machine.Valid {
-			tags = append(tags, "machine:"+r.Machine.String)
-		}
-		if r.OsUser.Valid {
-			tags = append(tags, "osuser:"+r.OsUser.String)
-		}
-		if r.Status.Valid {
-			tags = append(tags, "status:"+r.Status.String)
-		}
-		if r.Object.Valid {
-			tags = append(tags, "objects:"+r.Object.String)
-		}
+	sender.EventPlatformEvent(payloadBytes, "dbm-locks")
 
-		sender.Gauge(fmt.Sprintf("%s.seconds_in_transaction", common.IntegrationName), r.Seconds.Float64, "", tags)
-	}
 	sender.Commit()
 	return nil
 }

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
+
 	//nolint:revive // TODO(DBM) Fix revive linter
 	_ "github.com/godror/godror"
 	go_version "github.com/hashicorp/go-version"
@@ -176,7 +177,6 @@ func (c *Check) Run() error {
 	}
 
 	metricIntervalExpired := checkIntervalExpired(&c.metricLastRun, c.config.MetricCollectionInterval)
-
 	if metricIntervalExpired {
 		if c.dbmEnabled {
 			err := c.dataGuard()
@@ -263,6 +263,12 @@ func (c *Check) Run() error {
 		if metricIntervalExpired {
 			if c.config.ResourceManager.Enabled {
 				err := c.resourceManager()
+				if err != nil {
+					return fmt.Errorf("%s %w", c.logPrompt, err)
+				}
+			}
+			if c.config.Locks.Enabled {
+				err := c.locks()
 				if err != nil {
 					return fmt.Errorf("%s %w", c.logPrompt, err)
 				}

--- a/releasenotes/notes/oracle-dataguard-metrics-ee7753302b2efb7e.yaml
+++ b/releasenotes/notes/oracle-dataguard-metrics-ee7753302b2efb7e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Renaming Data Guard metrics `oracle.apply_lag` and `oracle.transport_lag` to `oracle.data_guard.apply_lag` and `oracle.data_guard.transport_lag`.

--- a/releasenotes/notes/oracle-dataguard-metrics-ee7753302b2efb7e.yaml
+++ b/releasenotes/notes/oracle-dataguard-metrics-ee7753302b2efb7e.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Renaming Data Guard metrics `oracle.apply_lag` and `oracle.transport_lag` to `oracle.data_guard.apply_lag` and `oracle.data_guard.transport_lag`.
+    Breaking change for Data Guard Monitoring: Renaming Data Guard metrics `oracle.apply_lag` and `oracle.transport_lag` to `oracle.data_guard.apply_lag` and `oracle.data_guard.transport_lag`.


### PR DESCRIPTION
### What does this PR do?

Adding the prefix `data_guard.` to the Data Guard metrics.

### Motivation

Grouping the metrics belonging to Data Guard together.

### Possible Drawbacks / Trade-offs

It's a breaking change. Since Data Guard monitoring will be release in the agent version `7.51.0`, only the custom builds are impacted by this change. It's unlikely that many customers are using Data Guard monitoring because we support only active Data Guard, which is only a subset of Data Guard deployments.

### Describe how to test/QA your changes

Check the metrics `oracle.data_guard.apply_lag` and `oracle.data_guard.transport_lag`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
