### PR TITLE
[CSPM] Adds some missing field in db_mongodb config struct

### DIFF
--- a/pkg/compliance/dbconfig/types.go
+++ b/pkg/compliance/dbconfig/types.go
@@ -209,4 +209,9 @@ type mongoDBConfig struct {
 		Engine                 *string  `yaml:"engine,omitempty" json:"engine,omitempty"`
 		OplogMinRetentionHours *float64 `yaml:"oplogMinRetentionHours,omitempty" json:"oplogMinRetentionHours,omitempty"`
 	} `yaml:"storage,omitempty" json:"storage,omitempty"`
+
+	SetParameter *struct {
+		EnableLocalhostAuthBypass *bool   `yaml:"enableLocalhostAuthBypass,omitempty" json:"enableLocalhostAuthBypass,omitempty"`
+		AuthenticationMechanisms  *string `yaml:"authenticationMechanisms,omitempty" json:"authenticationMechanisms,omitempty"`
+	} `yaml:"setParameter,omitempty" json:"setParameter,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?

Adds a missing field in the mongodb configuration payload for server parameters.

### Motivation

CIS checks require to have access to `enableLocalhostAuthBypass` and `authenticationMechanisms` parameters.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
