### PR TITLE
[usm] Remove redundant metric

### DIFF
--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -37,7 +37,6 @@ type Telemetry struct {
 
 	hits1XX, hits2XX, hits3XX, hits4XX, hits5XX *TLSCounter
 
-	totalHits                                                        *TLSCounter
 	dropped                                                          *libtelemetry.Counter // this happens when statKeeper reaches capacity
 	rejected                                                         *libtelemetry.Counter // this happens when an user-defined reject-filter matches a request
 	emptyPath, unknownMethod, invalidLatency, nonPrintableCharacters *libtelemetry.Counter // this happens when the request doesn't have the expected format
@@ -52,18 +51,16 @@ func NewTelemetry(protocol string) *Telemetry {
 	metricGroupJoiner := libtelemetry.NewMetricGroup(fmt.Sprintf("usm.%s.joiner", protocol))
 
 	return &Telemetry{
-		protocol:    protocol,
-		metricGroup: metricGroup,
-
-		hits1XX:      NewTLSCounter(metricGroup, "hits", "status:1xx", libtelemetry.OptPrometheus),
-		hits2XX:      NewTLSCounter(metricGroup, "hits", "status:2xx", libtelemetry.OptPrometheus),
-		hits3XX:      NewTLSCounter(metricGroup, "hits", "status:3xx", libtelemetry.OptPrometheus),
-		hits4XX:      NewTLSCounter(metricGroup, "hits", "status:4xx", libtelemetry.OptPrometheus),
-		hits5XX:      NewTLSCounter(metricGroup, "hits", "status:5xx", libtelemetry.OptPrometheus),
+		protocol:     protocol,
+		metricGroup:  metricGroup,
 		aggregations: metricGroup.NewCounter("aggregations", libtelemetry.OptPrometheus),
 
 		// these metrics are also exported as statsd metrics
-		totalHits:              NewTLSCounter(metricGroup, "total_hits", libtelemetry.OptStatsd),
+		hits1XX:                NewTLSCounter(metricGroup, "total_hits", "status:1xx", libtelemetry.OptStatsd),
+		hits2XX:                NewTLSCounter(metricGroup, "total_hits", "status:2xx", libtelemetry.OptStatsd),
+		hits3XX:                NewTLSCounter(metricGroup, "total_hits", "status:3xx", libtelemetry.OptStatsd),
+		hits4XX:                NewTLSCounter(metricGroup, "total_hits", "status:4xx", libtelemetry.OptStatsd),
+		hits5XX:                NewTLSCounter(metricGroup, "total_hits", "status:5xx", libtelemetry.OptStatsd),
 		dropped:                metricGroup.NewCounter("dropped", libtelemetry.OptStatsd),
 		rejected:               metricGroup.NewCounter("rejected", libtelemetry.OptStatsd),
 		emptyPath:              metricGroup.NewCounter("malformed", "type:empty-path", libtelemetry.OptStatsd),
@@ -96,8 +93,6 @@ func (t *Telemetry) Count(tx Transaction) {
 	case 500:
 		t.hits5XX.Add(tx)
 	}
-
-	t.totalHits.Add(tx)
 }
 
 // Log logs the telemetry.

--- a/pkg/network/protocols/telemetry/reporters.go
+++ b/pkg/network/protocols/telemetry/reporters.go
@@ -35,6 +35,11 @@ func ReportStatsd() {
 			continue
 		}
 
+		// Don't emit counter metrics with zero values
+		if v == 0 {
+			continue
+		}
+
 		client.Count(statsdPrefix+base.name, v, tags, 1.0) //nolint:errcheck
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Remove redundant metric tracking HTTP requests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

We're dropping the Prometheus metric in favor of the existing Statsd one. As a consequence we do expect a slight increase in the cardinality of these metrics because we will be adding a new tag (`status:1xx`, `status:2xx`, `status:3xx`, `status:4xx` and `status:5xx`)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
