### PR TITLE
Fix PID size for the ETW component

### DIFF
--- a/comp/apm/etwtracer/impl/apmetwtracerimpl.go
+++ b/comp/apm/etwtracer/impl/apmetwtracerimpl.go
@@ -112,8 +112,8 @@ const (
 	// ERROR_NO_DATA The pipe is being closed.
 	ERROR_NO_DATA = 232
 
-	// MAX_EVENT_FILTER_PID_COUNT
-	// https://github.com/tpn/winsdk-10/blob/master/Include/10.0.16299.0/shared/evntprov.h#L96
+	// MAX_EVENT_FILTER_PID_COUNT The maximum number of PIDs that can be used for filtering
+	// see https://github.com/tpn/winsdk-10/blob/master/Include/10.0.16299.0/shared/evntprov.h#L96
 	MAX_EVENT_FILTER_PID_COUNT = 8
 	//revive:enable:var-naming
 )

--- a/comp/apm/etwtracer/impl/apmetwtracerimpl.go
+++ b/comp/apm/etwtracer/impl/apmetwtracerimpl.go
@@ -50,7 +50,7 @@ type pidContext struct {
 	conn net.Conn
 }
 
-type pidMap = map[uint64]pidContext
+type pidMap = map[uint32]pidContext
 
 func newApmEtwTracerImpl(deps dependencies) (apmetwtracer.Component, error) {
 	// Microsoft-Windows-DotNETRuntime
@@ -111,6 +111,10 @@ const (
 
 	// ERROR_NO_DATA The pipe is being closed.
 	ERROR_NO_DATA = 232
+
+	// MAX_EVENT_FILTER_PID_COUNT
+	// https://github.com/tpn/winsdk-10/blob/master/Include/10.0.16299.0/shared/evntprov.h#L96
+	MAX_EVENT_FILTER_PID_COUNT = 8
 	//revive:enable:var-naming
 )
 
@@ -224,7 +228,7 @@ func (a *apmetwtracerimpl) handleConnection(c net.Conn) {
 		case registerCommand:
 			a.log.Infof("Registering process with ID %d", pid)
 			a.pidMutex.Lock()
-			err = a.addPID(pid)
+			err = a.addPID(uint32(pid))
 			a.pidMutex.Unlock()
 			if err != nil {
 				a.log.Errorf("Failed to reconfigure the ETW provider for PID %d: %v", pid, err)
@@ -235,7 +239,7 @@ func (a *apmetwtracerimpl) handleConnection(c net.Conn) {
 		case unregisterCommand:
 			a.log.Infof("Unregistering process with ID %d", pid)
 			a.pidMutex.Lock()
-			err = a.removePID(pid)
+			err = a.removePID(uint32(pid))
 			a.pidMutex.Unlock()
 			if err != nil {
 				a.log.Errorf("Failed to reconfigure the ETW provider for PID %d: %v", pid, err)
@@ -327,7 +331,6 @@ func (a *apmetwtracerimpl) doTrace() {
 	// StartTracing blocks the caller
 	_ = a.session.StartTracing(func(e *etw.DDEventRecord) {
 		a.log.Debugf("Received event %d for PID %d", e.EventHeader.EventDescriptor.ID, e.EventHeader.ProcessID)
-		pid := uint64(e.EventHeader.ProcessID)
 
 		a.pidMutex.Lock()
 		var err error
@@ -336,12 +339,12 @@ func (a *apmetwtracerimpl) doTrace() {
 				if err == syscall.Errno(ERROR_BROKEN_PIPE) ||
 					err == syscall.Errno(ERROR_NO_DATA) {
 					// Don't log error for normal pipe termination
-					a.log.Trace("Listener for process %d disconnected", pid)
+					a.log.Trace("Listener for process %d disconnected", e.EventHeader.ProcessID)
 				} else {
-					a.log.Errorf("Could not write ETW event for PID %d, %v", pid, err)
-					err = a.removePID(pid)
+					a.log.Errorf("Could not write ETW event for PID %d, %v", e.EventHeader.ProcessID, err)
+					err = a.removePID(e.EventHeader.ProcessID)
 					if err != nil {
-						a.log.Errorf("Could not remove PID %d, %v", pid, err)
+						a.log.Errorf("Could not remove PID %d, %v", e.EventHeader.ProcessID, err)
 					}
 				}
 			}
@@ -350,7 +353,7 @@ func (a *apmetwtracerimpl) doTrace() {
 
 		var pidCtx pidContext
 		var ok bool
-		if pidCtx, ok = a.pids[pid]; !ok {
+		if pidCtx, ok = a.pids[e.EventHeader.ProcessID]; !ok {
 			// We may still be receiving events a few moments
 			// after a process un-registers itself, no need to log anything here.
 			return
@@ -430,13 +433,13 @@ func (a *apmetwtracerimpl) stop(_ context.Context) error {
 	return err
 }
 
-func (a *apmetwtracerimpl) addPID(pid uint64) error {
+func (a *apmetwtracerimpl) addPID(pid uint32) error {
 	c, err := winio.DialPipe(fmt.Sprintf(clientNamedPipePath, pid), nil)
 	if err != nil {
 		return err
 	}
-	// Only allow 15 PIDs to be registered
-	if len(a.pids) > 15 {
+
+	if len(a.pids) > MAX_EVENT_FILTER_PID_COUNT {
 		return fmt.Errorf("too many processes registered")
 	}
 	a.pids[pid] = pidContext{
@@ -445,7 +448,7 @@ func (a *apmetwtracerimpl) addPID(pid uint64) error {
 	return a.reconfigureProvider()
 }
 
-func (a *apmetwtracerimpl) removePID(pid uint64) error {
+func (a *apmetwtracerimpl) removePID(pid uint32) error {
 	var pidCtx pidContext
 	var ok bool
 	if pidCtx, ok = a.pids[pid]; !ok {
@@ -458,7 +461,7 @@ func (a *apmetwtracerimpl) removePID(pid uint64) error {
 }
 
 func (a *apmetwtracerimpl) reconfigureProvider() error {
-	pidsList := make([]uint64, 0, len(a.pids))
+	pidsList := make([]uint32, 0, len(a.pids))
 	for p := range a.pids {
 		pidsList = append(pidsList, p)
 	}

--- a/comp/etw/component.go
+++ b/comp/etw/component.go
@@ -103,7 +103,7 @@ type ProviderConfiguration struct {
 	MatchAllKeyword uint64
 
 	// PIDs allow filtering by PIDs if non-empty
-	PIDs []uint64
+	PIDs []uint32
 }
 
 // ProviderConfigurationFunc is a function used to configure a provider

--- a/comp/etw/impl/etwSession.go
+++ b/comp/etw/impl/etwSession.go
@@ -44,10 +44,10 @@ func (e *etwSession) EnableProvider(providerGUID windows.GUID) error {
 	}
 
 	cfg := e.providers[providerGUID]
-	var pids *C.ULONGLONG
+	var pids *C.ULONG
 	var pidCount C.ULONG
 	if len(cfg.PIDs) > 0 {
-		pids = (*C.ULONGLONG)(unsafe.Pointer(&cfg.PIDs[0]))
+		pids = (*C.ULONG)(unsafe.SliceData(cfg.PIDs))
 		pidCount = C.ULONG(len(cfg.PIDs))
 	}
 

--- a/comp/etw/impl/etwSession.go
+++ b/comp/etw/impl/etwSession.go
@@ -91,8 +91,8 @@ func (e *etwSession) DisableProvider(providerGUID windows.GUID) error {
 	return ret
 }
 
-//export etwCallbackC
-func etwCallbackC(eventRecord C.PEVENT_RECORD) {
+//export ddEtwCallbackC
+func ddEtwCallbackC(eventRecord C.PEVENT_RECORD) {
 	handle := cgo.Handle(eventRecord.UserContext)
 	eventInfo := (*etw.DDEventRecord)(unsafe.Pointer(eventRecord))
 	handle.Value().(etw.EventCallback)(eventInfo)

--- a/comp/etw/impl/session.c
+++ b/comp/etw/impl/session.c
@@ -3,11 +3,11 @@
 // This constant defines the maximum number of filter types supported.
 #define MAX_FILTER_SUPPORTED                2
 
-extern void etwCallbackC(PEVENT_RECORD);
+extern void ddEtwCallbackC(PEVENT_RECORD);
 
 static void WINAPI RecordEventCallback(PEVENT_RECORD event)
 {
-    etwCallbackC(event);
+    ddEtwCallbackC(event);
 }
 
 TRACEHANDLE DDStartTracing(LPWSTR name, uintptr_t context)

--- a/comp/etw/impl/session.c
+++ b/comp/etw/impl/session.c
@@ -29,7 +29,7 @@ ULONG DDEnableTrace(
     ULONGLONG   MatchAnyKeyword,
     ULONGLONG   MatchAllKeyword,
     ULONG       Timeout,
-    ULONGLONG*  PIDs,
+    ULONG*      PIDs,
     ULONG       PIDCount
 )
 {

--- a/comp/etw/impl/session.h
+++ b/comp/etw/impl/session.h
@@ -20,7 +20,7 @@ ULONG DDEnableTrace(
     ULONGLONG   MatchAnyKeyword,
     ULONGLONG   MatchAllKeyword,
     ULONG       Timeout,
-    ULONGLONG*  PIDs,
+    ULONG*      PIDs,
     ULONG       PIDCount
 );
 TRACEHANDLE DDStartTracing(LPWSTR name, uintptr_t context);


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR changes the size of the PIDs from 64 bit to 32 bit, since that's what the underlying API expects.

Additionally, this PR changes the name of the C function callback to be different from the current ETW implementation that lives in System-Probe to prevent conflicts.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Working PID filtering.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
- Run 9 instances of a .Net program and note their PIDs.
- Use https://github.com/DataDog/dd-trace-dotnet/tree/master/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-client to subscribe for GC contention notifications for each of the PIDs above.
- Ensure that the *last* PID subscription fails.
- Ensure that the GC contention info received are limited to the PIDs where the subscription succeeded.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
