### PR TITLE
[CWS] add filter to actions

### DIFF
--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -137,6 +137,11 @@ func (ce *CustomEvent) GetType() string {
 	return ce.eventType.String()
 }
 
+// GetActions returns the triggred actions
+func (ce *CustomEvent) GetActions() []*model.ActionTriggered {
+	return nil
+}
+
 // GetWorkloadID returns the workload id
 func (ce *CustomEvent) GetWorkloadID() string {
 	return ""

--- a/pkg/security/events/event.go
+++ b/pkg/security/events/event.go
@@ -8,7 +8,10 @@
 // Package events holds events related files
 package events
 
-import "github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
 
 // AgentContext serializes the agent context to JSON
 // easyjson:json
@@ -42,6 +45,7 @@ type Event interface {
 	GetWorkloadID() string
 	GetTags() []string
 	GetType() string
+	GetActions() []*model.ActionTriggered
 }
 
 // EventSender defines an event sender

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -264,9 +264,11 @@ func (a *APIServer) GetConfig(_ context.Context, _ *api.GetConfigParams) (*api.S
 // SendEvent forwards events sent by the runtime security module to Datadog
 func (a *APIServer) SendEvent(rule *rules.Rule, e events.Event, extTagsCb func() []string, service string) {
 	var ruleActions []events.RuleActionContext
-	for _, action := range rule.Definition.Actions {
-		if action.Kill != nil {
-			ruleActions = append(ruleActions, events.RuleActionContext{Name: "kill", Signal: action.Kill.Signal})
+
+	// report only kill action for now
+	for _, action := range e.GetActions() {
+		if action.Name == rules.KillAction {
+			ruleActions = append(ruleActions, events.RuleActionContext{Name: action.Name, Signal: action.Value})
 		}
 	}
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -39,7 +39,7 @@ type PlatformProbe interface {
 	FlushDiscarders() error
 	ApplyRuleSet(_ *rules.RuleSet) (*kfilters.ApplyRuleSetReport, error)
 	OnNewDiscarder(_ *rules.RuleSet, _ *model.Event, _ eval.Field, _ eval.EventType)
-	HandleActions(_ *rules.Rule, _ eval.Event)
+	HandleActions(_ *eval.Context, _ *rules.Rule)
 	NewEvent() *model.Event
 	GetFieldHandlers() model.FieldHandlers
 	DumpProcessCache(_ bool) (string, error)
@@ -161,7 +161,11 @@ func (p *Probe) GetDebugStats() map[string]interface{} {
 
 // HandleActions executes the actions of a triggered rule
 func (p *Probe) HandleActions(rule *rules.Rule, event eval.Event) {
-	p.PlatformProbe.HandleActions(rule, event)
+	ctx := &eval.Context{
+		Event: event.(*model.Event),
+	}
+
+	p.PlatformProbe.HandleActions(ctx, rule)
 }
 
 // AddEventHandler sets a probe event handler

--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -316,7 +316,7 @@ func (p *EBPFLessProbe) ApplyRuleSet(_ *rules.RuleSet) (*kfilters.ApplyRuleSetRe
 }
 
 // HandleActions handles the rule actions
-func (p *EBPFLessProbe) HandleActions(_ *rules.Rule, _ eval.Event) {}
+func (p *EBPFLessProbe) HandleActions(_ *eval.Context, _ *rules.Rule) {}
 
 // NewEvent returns a new event
 func (p *EBPFLessProbe) NewEvent() *model.Event {

--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -97,5 +97,4 @@ func (p *Probe) RefreshUserCache(_ string) error {
 }
 
 // HandleActions executes the actions of a triggered rule
-func (p *Probe) HandleActions(_ *rules.Rule, _ eval.Event) {
-}
+func (p *Probe) HandleActions(_ *rules.Rule, _ eval.Event) {}

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -249,7 +249,7 @@ func (p *WindowsProbe) NewEvent() *model.Event {
 }
 
 // HandleActions executes the actions of a triggered rule
-func (p *WindowsProbe) HandleActions(_ *rules.Rule, _ eval.Event) {}
+func (p *WindowsProbe) HandleActions(_ *eval.Context, _ *rules.Rule) {}
 
 // AddDiscarderPushedCallback add a callback to the list of func that have to be called when a discarder is pushed to kernel
 func (p *WindowsProbe) AddDiscarderPushedCallback(_ DiscarderPushedCallback) {}

--- a/pkg/security/rules/bundled_policy_provider_linux.go
+++ b/pkg/security/rules/bundled_policy_provider_linux.go
@@ -19,8 +19,8 @@ func newBundledPolicyRules(cfg *config.RuntimeSecurityConfig) []*rules.RuleDefin
 	return []*rules.RuleDefinition{{
 		ID:         events.RefreshUserCacheRuleID,
 		Expression: `rename.file.destination.path in [ "/etc/passwd", "/etc/group" ]`,
-		Actions: []rules.ActionDefinition{{
-			InternalCallbackDefinition: &rules.InternalCallbackDefinition{},
+		Actions: []*rules.ActionDefinition{{
+			InternalCallback: &rules.InternalCallbackDefinition{},
 		}},
 		Silent: true,
 	}}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -163,13 +163,14 @@ type SpanContext struct {
 
 // BaseEvent represents an event sent from the kernel
 type BaseEvent struct {
-	ID           string         `field:"-" event:"*"`
-	Type         uint32         `field:"-"`
-	Flags        uint32         `field:"-"`
-	TimestampRaw uint64         `field:"event.timestamp,handler:ResolveEventTimestamp" event:"*"` // SECLDoc[event.timestamp] Definition:`Timestamp of the event`
-	Timestamp    time.Time      `field:"timestamp,opts:getters_only,handler:ResolveEventTime"`
-	Rules        []*MatchedRule `field:"-"`
-	Origin       string         `field:"-"`
+	ID           string             `field:"-" event:"*"`
+	Type         uint32             `field:"-"`
+	Flags        uint32             `field:"-"`
+	TimestampRaw uint64             `field:"event.timestamp,handler:ResolveEventTimestamp" event:"*"` // SECLDoc[event.timestamp] Definition:`Timestamp of the event`
+	Timestamp    time.Time          `field:"timestamp,opts:getters_only,handler:ResolveEventTime"`
+	Rules        []*MatchedRule     `field:"-"`
+	Actions      []*ActionTriggered `field:"-"`
+	Origin       string             `field:"-"`
 
 	// context shared with all events
 	ProcessContext         *ProcessContext        `field:"process" event:"*"`
@@ -307,6 +308,11 @@ func (e *Event) GetTags() []string {
 	return tags
 }
 
+// GetActions returns the triggred actions
+func (e *Event) GetActions() []*ActionTriggered {
+	return e.Actions
+}
+
 // GetWorkloadID returns an ID that represents the workload
 func (e *Event) GetWorkloadID() string {
 	return e.SecurityProfileContext.Name
@@ -362,6 +368,12 @@ type MatchedRule struct {
 	RuleTags      map[string]string
 	PolicyName    string
 	PolicyVersion string
+}
+
+// ActionTriggered defines a triggered action
+type ActionTriggered struct {
+	Name  string
+	Value string
 }
 
 // NewMatchedRule return a new MatchedRule instance

--- a/pkg/security/secl/rules/actions.go
+++ b/pkg/security/secl/rules/actions.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package rules holds rules related files
+package rules
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// ActionName defines an action name
+type ActionName = string
+
+const (
+	// KillAction name a the kill action
+	KillAction ActionName = "kill"
+)
+
+// ActionDefinition describes a rule action section
+type ActionDefinition struct {
+	Filter *string         `yaml:"filter"`
+	Set    *SetDefinition  `yaml:"set"`
+	Kill   *KillDefinition `yaml:"kill"`
+
+	// internal
+	InternalCallback *InternalCallbackDefinition
+	FilterEvaluator  *eval.RuleEvaluator
+}
+
+// Check returns an error if the action in invalid
+func (a *ActionDefinition) Check() error {
+	if a.Set == nil && a.InternalCallback == nil && a.Kill == nil {
+		return errors.New("either 'set' or 'kill' section of an action must be specified")
+	}
+
+	if a.Set != nil {
+		if a.Kill != nil {
+			return errors.New("only of 'set' or 'kill' section of an action can be specified")
+		}
+
+		if a.Set.Name == "" {
+			return errors.New("action name is empty")
+		}
+
+		if (a.Set.Value == nil && a.Set.Field == "") || (a.Set.Value != nil && a.Set.Field != "") {
+			return errors.New("either 'value' or 'field' must be specified")
+		}
+	} else if a.Kill != nil {
+		if a.Kill.Signal == "" {
+			a.Kill.Signal = "SIGTERM"
+		}
+
+		if _, found := model.SignalConstants[a.Kill.Signal]; !found {
+			return fmt.Errorf("unsupported signal '%s'", a.Kill.Signal)
+		}
+	}
+
+	return nil
+}
+
+// CompileFilter compiles the filter expression
+func (a *ActionDefinition) CompileFilter(parsingContext *ast.ParsingContext, model eval.Model, evalOpts *eval.Opts) error {
+	if a.Filter == nil {
+		return nil
+	}
+
+	expression := *a.Filter
+
+	rule := &Rule{
+		Rule: eval.NewRule("action_rule", expression, evalOpts),
+	}
+
+	if err := rule.Parse(parsingContext); err != nil {
+		return &ErrActionFilter{Expression: expression, Err: err}
+	}
+
+	if err := rule.GenEvaluator(model, parsingContext); err != nil {
+		return &ErrActionFilter{Expression: expression, Err: err}
+	}
+
+	a.FilterEvaluator = rule.GetEvaluator()
+
+	return nil
+}
+
+// IsAccepted returns whether a filter is accepted and has to be executed
+func (a *ActionDefinition) IsAccepted(ctx *eval.Context) bool {
+	return a.FilterEvaluator == nil || a.FilterEvaluator.Eval(ctx)
+}
+
+// Scope describes the scope variables
+type Scope string
+
+// SetDefinition describes the 'set' section of a rule action
+type SetDefinition struct {
+	Name   string      `yaml:"name"`
+	Value  interface{} `yaml:"value"`
+	Field  string      `yaml:"field"`
+	Append bool        `yaml:"append"`
+	Scope  Scope       `yaml:"scope"`
+}
+
+// InternalCallbackDefinition describes an internal rule action
+type InternalCallbackDefinition struct{}
+
+// KillDefinition describes the 'kill' section of a rule action
+type KillDefinition struct {
+	Signal string `yaml:"signal"`
+	Scope  string `yaml:"scope"`
+}

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -172,3 +172,13 @@ type ErrRuleSyntax struct {
 func (e *ErrRuleSyntax) Error() string {
 	return fmt.Sprintf("syntax error `%v`", e.Err)
 }
+
+// ErrActionFilter is on filter definition error
+type ErrActionFilter struct {
+	Expression string
+	Err        error
+}
+
+func (e ErrActionFilter) Error() string {
+	return fmt.Sprintf("filter `%s` error: %s", e.Expression, e.Err)
+}

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -156,7 +156,7 @@ func TestActionSetVariable(t *testing.T) {
 		Rules: []*RuleDefinition{{
 			ID:         "test_rule",
 			Expression: `open.file.path == "/tmp/test"`,
-			Actions: []ActionDefinition{{
+			Actions: []*ActionDefinition{{
 				Set: &SetDefinition{
 					Name:  "var1",
 					Value: true,
@@ -293,7 +293,7 @@ func TestActionSetVariableConflict(t *testing.T) {
 		Rules: []*RuleDefinition{{
 			ID:         "test_rule",
 			Expression: `open.file.path == "/tmp/test"`,
-			Actions: []ActionDefinition{{
+			Actions: []*ActionDefinition{{
 				Set: &SetDefinition{
 					Name:  "var1",
 					Value: true,
@@ -514,7 +514,7 @@ func TestActionSetVariableInvalid(t *testing.T) {
 			Rules: []*RuleDefinition{{
 				ID:         "test_rule",
 				Expression: `open.file.path == "/tmp/test"`,
-				Actions: []ActionDefinition{{
+				Actions: []*ActionDefinition{{
 					Set: &SetDefinition{
 						Name:  "var1",
 						Value: []string{"abc"},
@@ -536,7 +536,7 @@ func TestActionSetVariableInvalid(t *testing.T) {
 			Rules: []*RuleDefinition{{
 				ID:         "test_rule",
 				Expression: `open.file.path == "/tmp/test"`,
-				Actions: []ActionDefinition{{
+				Actions: []*ActionDefinition{{
 					Set: &SetDefinition{
 						Name:  "var1",
 						Value: []bool{true},
@@ -561,7 +561,7 @@ func TestActionSetVariableInvalid(t *testing.T) {
 			Rules: []*RuleDefinition{{
 				ID:         "test_rule",
 				Expression: `open.file.path == "/tmp/test"`,
-				Actions: []ActionDefinition{{
+				Actions: []*ActionDefinition{{
 					Set: &SetDefinition{
 						Name:  "var1",
 						Value: []interface{}{"string", true},
@@ -586,7 +586,7 @@ func TestActionSetVariableInvalid(t *testing.T) {
 			Rules: []*RuleDefinition{{
 				ID:         "test_rule",
 				Expression: `open.file.path == "/tmp/test"`,
-				Actions: []ActionDefinition{{
+				Actions: []*ActionDefinition{{
 					Set: &SetDefinition{
 						Name:  "var1",
 						Value: nil,
@@ -607,7 +607,7 @@ func TestActionSetVariableInvalid(t *testing.T) {
 			Rules: []*RuleDefinition{{
 				ID:         "test_rule",
 				Expression: `open.file.path == "/tmp/test"`,
-				Actions: []ActionDefinition{{
+				Actions: []*ActionDefinition{{
 					Set: &SetDefinition{
 						Name:   "var1",
 						Value:  []string{"abc"},
@@ -639,7 +639,7 @@ func TestActionSetVariableInvalid(t *testing.T) {
 			Rules: []*RuleDefinition{{
 				ID:         "test_rule",
 				Expression: `open.file.path == "/tmp/test"`,
-				Actions: []ActionDefinition{{
+				Actions: []*ActionDefinition{{
 					Set: &SetDefinition{
 						Name:  "var1",
 						Field: "open.file.path",
@@ -670,7 +670,7 @@ func TestActionSetVariableInvalid(t *testing.T) {
 			Rules: []*RuleDefinition{{
 				ID:         "test_rule",
 				Expression: `open.file.path == "/tmp/test"`,
-				Actions: []ActionDefinition{{
+				Actions: []*ActionDefinition{{
 					Set: &SetDefinition{
 						Name:   "var1",
 						Field:  "open.file.path",

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -79,18 +79,18 @@ type RuleID = string
 
 // RuleDefinition holds the definition of a rule
 type RuleDefinition struct {
-	ID                     RuleID             `yaml:"id"`
-	Version                string             `yaml:"version"`
-	Expression             string             `yaml:"expression"`
-	Description            string             `yaml:"description"`
-	Tags                   map[string]string  `yaml:"tags"`
-	AgentVersionConstraint string             `yaml:"agent_version"`
-	Filters                []string           `yaml:"filters"`
-	Disabled               bool               `yaml:"disabled"`
-	Combine                CombinePolicy      `yaml:"combine"`
-	Actions                []ActionDefinition `yaml:"actions"`
-	Every                  time.Duration      `yaml:"every"`
-	Silent                 bool               `yaml:"silent"`
+	ID                     RuleID              `yaml:"id"`
+	Version                string              `yaml:"version"`
+	Expression             string              `yaml:"expression"`
+	Description            string              `yaml:"description"`
+	Tags                   map[string]string   `yaml:"tags"`
+	AgentVersionConstraint string              `yaml:"agent_version"`
+	Filters                []string            `yaml:"filters"`
+	Disabled               bool                `yaml:"disabled"`
+	Combine                CombinePolicy       `yaml:"combine"`
+	Actions                []*ActionDefinition `yaml:"actions"`
+	Every                  time.Duration       `yaml:"every"`
+	Silent                 bool                `yaml:"silent"`
 	Policy                 *Policy
 }
 
@@ -115,65 +115,6 @@ func (rd *RuleDefinition) MergeWith(rd2 *RuleDefinition) error {
 	}
 	rd.Disabled = rd2.Disabled
 	return nil
-}
-
-// ActionDefinition describes a rule action section
-type ActionDefinition struct {
-	Set                        *SetDefinition `yaml:"set"`
-	InternalCallbackDefinition *InternalCallbackDefinition
-	Kill                       *KillDefinition `yaml:"kill"`
-}
-
-// Check returns an error if the action in invalid
-func (a *ActionDefinition) Check() error {
-	if a.Set == nil && a.InternalCallbackDefinition == nil && a.Kill == nil {
-		return errors.New("either 'set' or 'kill' section of an action must be specified")
-	}
-
-	if a.Set != nil {
-		if a.Kill != nil {
-			return errors.New("only of 'set' or 'kill' section of an action can be specified")
-		}
-
-		if a.Set.Name == "" {
-			return errors.New("action name is empty")
-		}
-
-		if (a.Set.Value == nil && a.Set.Field == "") || (a.Set.Value != nil && a.Set.Field != "") {
-			return errors.New("either 'value' or 'field' must be specified")
-		}
-	} else if a.Kill != nil {
-		if a.Kill.Signal == "" {
-			a.Kill.Signal = "SIGTERM"
-		}
-
-		if _, found := model.SignalConstants[a.Kill.Signal]; !found {
-			return fmt.Errorf("unsupported signal '%s'", a.Kill.Signal)
-		}
-	}
-
-	return nil
-}
-
-// Scope describes the scope variables
-type Scope string
-
-// SetDefinition describes the 'set' section of a rule action
-type SetDefinition struct {
-	Name   string      `yaml:"name"`
-	Value  interface{} `yaml:"value"`
-	Field  string      `yaml:"field"`
-	Append bool        `yaml:"append"`
-	Scope  Scope       `yaml:"scope"`
-}
-
-// InternalCallbackDefinition describes an internal rule action
-type InternalCallbackDefinition struct{}
-
-// KillDefinition describes the 'kill' section of a rule action
-type KillDefinition struct {
-	Signal string `yaml:"signal"`
-	Scope  string `yaml:"scope"`
 }
 
 // Rule describes a rule of a ruleset
@@ -493,7 +434,6 @@ func (rs *RuleSet) AddRule(parsingContext *ast.ParsingContext, ruleDef *RuleDefi
 
 	rs.rules[ruleDef.ID] = rule
 
-	// Generate evaluator for fields that are used in variables
 	for _, action := range rule.Definition.Actions {
 		if action.Set != nil && action.Set.Field != "" {
 			if _, found := rs.fieldEvaluators[action.Set.Field]; !found {
@@ -502,6 +442,13 @@ func (rs *RuleSet) AddRule(parsingContext *ast.ParsingContext, ruleDef *RuleDefi
 					return nil, err
 				}
 				rs.fieldEvaluators[action.Set.Field] = evaluator
+			}
+		}
+
+		// compile action filter
+		if action.Filter != nil {
+			if err := action.CompileFilter(parsingContext, rs.model, rs.evalOpts); err != nil {
+				return nil, err
 			}
 		}
 	}

--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -93,7 +93,7 @@ func TestContainerScopedVariable(t *testing.T) {
 		{
 			ID:         "test_container_set_scoped_variable",
 			Expression: `open.file.path == "/tmp/test-open"`,
-			Actions: []rules.ActionDefinition{{
+			Actions: []*rules.ActionDefinition{{
 				Set: &rules.SetDefinition{
 					Name:  "var1",
 					Value: true,

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1045,7 +1045,7 @@ func TestProcessScopedVariable(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{{
 		ID:         "test_rule_set_mutable_vars",
 		Expression: `open.file.path == "{{.Root}}/test-open"`,
-		Actions: []rules.ActionDefinition{{
+		Actions: []*rules.ActionDefinition{{
 			Set: &rules.SetDefinition{
 				Name:  "var1",
 				Value: true,
@@ -1083,7 +1083,7 @@ func TestProcessScopedVariable(t *testing.T) {
 	}, {
 		ID:         "test_rule_modify_mutable_vars",
 		Expression: `open.file.path == "{{.Root}}/test-open-2"`,
-		Actions: []rules.ActionDefinition{{
+		Actions: []*rules.ActionDefinition{{
 			Set: &rules.SetDefinition{
 				Name:  "var2",
 				Value: "enabled",
@@ -1154,7 +1154,7 @@ func TestTimestampVariable(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{{
 		ID:         "test_rule_set_timestamp_var",
 		Expression: `open.file.path == "{{.Root}}/test-open"`,
-		Actions: []rules.ActionDefinition{{
+		Actions: []*rules.ActionDefinition{{
 			Set: &rules.SetDefinition{
 				Name:  "timestamp1",
 				Field: "event.timestamp",
@@ -2262,7 +2262,7 @@ func TestKillAction(t *testing.T) {
 		ID: "kill_action",
 		// using a wilcard to avoid approvers on basename. events will not match thus will be noisy
 		Expression: `process.file.name == "syscall_tester" && mkdir.file.path == "{{.Root}}/test-kill-action"`,
-		Actions: []rules.ActionDefinition{
+		Actions: []*rules.ActionDefinition{
 			{
 				Kill: &rules.KillDefinition{
 					Signal: "SIGUSR2",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The idea is to add a condition to trigger an action. If the action `filter` doesn't match the action won't be triggered and the event will be sent without the `rule_actions` section. The filter uses a regular SECL expression applied on the currently evaluated event.

```
  - id: test
    expression: exec.file.name == "test123"
    actions:
    - kill:
        signal: SIGKILL
      filter: process.envp in ["KILLME=true"]
```

or 

```
  - id: test
    expression: exec.file.name == "test123"
    actions:
    - kill:
        signal: SIGKILL
      filter: container.tags in ["image_name:testtest"]
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
