### PR TITLE
Backport Explicit ddagentuser service permissions (#21640)

### DIFF
--- a/releasenotes/notes/windows-agent-service-permissions-c2128fa1be37ce57.yaml
+++ b/releasenotes/notes/windows-agent-service-permissions-c2128fa1be37ce57.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix issue introduced in 7.47 that allowed all users to start/stop the
+    Windows Datadog Agent services. The Windows installer now, as in versions
+    before 7.47, grants this permission explicitly to ddagentuser.

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -41,7 +41,7 @@ namespace Datadog.CustomActions
             _fileSystemServices = fileSystemServices;
             _serviceController = serviceController;
 
-            _rollbackDataStore = new RollbackDataStore(_session, rollbackDataName, _fileSystemServices);
+            _rollbackDataStore = new RollbackDataStore(_session, rollbackDataName, _fileSystemServices, _serviceController);
         }
 
         public ConfigureUserCustomActions(ISession session, string rollbackDataName)
@@ -173,46 +173,6 @@ namespace Datadog.CustomActions
                 PropagationFlags.None,
                 AccessControlType.Allow));
             UpdateAndLogAccessControl(_session.Property("APPLICATIONDATADIRECTORY"), fileSystemSecurity);
-        }
-
-        private SecurityIdentifier GetPreviousAgentUser()
-        {
-            try
-            {
-                using var subkey =
-                    _registryServices.OpenRegistryKey(Registries.LocalMachine, Constants.DatadogAgentRegistryKey);
-                if (subkey == null)
-                {
-                    throw new Exception("Datadog registry key does not exist");
-                }
-                var domain = subkey.GetValue("installedDomain")?.ToString();
-                var user = subkey.GetValue("installedUser")?.ToString();
-                if (string.IsNullOrEmpty(domain) || string.IsNullOrEmpty(user))
-                {
-                    throw new Exception("Agent user information is not in registry");
-                }
-
-                var name = $"{domain}\\{user}";
-                _session.Log($"Found agent user information in registry {name}");
-                var userFound = _nativeMethods.LookupAccountName(name,
-                    out _,
-                    out _,
-                    out var securityIdentifier,
-                    out _);
-                if (!userFound || securityIdentifier == null)
-                {
-                    throw new Exception($"Could not find account for user {name}.");
-                }
-
-                _session.Log($"Found previous agent user {name} ({securityIdentifier})");
-                return securityIdentifier;
-            }
-            catch (Exception e)
-            {
-                _session.Log($"Could not find previous agent user: {e}");
-            }
-
-            return null;
         }
 
         /// <summary>
@@ -532,7 +492,7 @@ namespace Datadog.CustomActions
                     throw new Exception($"Could not find user {ddAgentUserName}.");
                 }
 
-                _previousDdAgentUserSID = GetPreviousAgentUser();
+                _previousDdAgentUserSID = InstallStateCustomActions.GetPreviousAgentUser(_session, _registryServices, _nativeMethods);
 
                 var resetPassword = _session.Property("DDAGENTUSER_RESET_PASSWORD");
                 var ddagentuserPassword = _session.Property("DDAGENTUSER_PROCESSED_PASSWORD");

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CustomActions.csproj
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CustomActions.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Native\ServiceController.cs" />
     <Compile Include="Native\ServiceControllerExtensions.cs" />
     <Compile Include="Native\WindowsService.cs" />
+    <Compile Include="Rollback\ServicePermissionRollbackData.cs" />
     <Compile Include="Rollback\RestoreDaclRollbackCustomAction.cs" />
     <Compile Include="Rollback\FilePermissionRollbackData.cs" />
     <Compile Include="Rollback\RollbackDataStore.cs" />

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRollbackAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRollbackAction.cs
@@ -2,6 +2,6 @@ namespace Datadog.CustomActions.Interfaces
 {
     interface IRollbackAction
     {
-        public void Restore(ISession session, IFileSystemServices fileSystemServices);
+        public void Restore(ISession session, IFileSystemServices fileSystemServices, IServiceController serviceController);
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IServiceController.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IServiceController.cs
@@ -1,6 +1,7 @@
 using Datadog.CustomActions.Native;
 using System;
 using System.Collections.Generic;
+using System.Security.AccessControl;
 
 namespace Datadog.CustomActions.Interfaces
 {
@@ -10,5 +11,7 @@ namespace Datadog.CustomActions.Interfaces
         void SetCredentials(string serviceName, string username, string password);
         void StopService(string serviceName, TimeSpan timeout);
         void StartService(string serviceName, TimeSpan timeout);
+        public CommonSecurityDescriptor GetAccessSecurity(string serviceName);
+        public void SetAccessSecurity(string serviceName, CommonSecurityDescriptor sd);
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -1,12 +1,13 @@
 using System;
 using System.ComponentModel;
-using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.DirectoryServices.ActiveDirectory;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text;
 using Datadog.CustomActions.Interfaces;
+
 // ReSharper disable InconsistentNaming
 
 namespace Datadog.CustomActions.Native
@@ -45,6 +46,27 @@ namespace Datadog.CustomActions.Native
         SidTypeInvalid,
         SidTypeUnknown,
         SidTypeComputer
+    }
+
+    // https://learn.microsoft.com/en-us/windows/win32/services/service-security-and-access-rights
+    [Flags]
+    public enum ServiceAccess
+    {
+        // specific access rights
+        SERVICE_QUERY_CONFIG = 0x0001,
+        SERVICE_QUERY_STATUS = 0x0004,
+        SERVICE_ENUMERATE_DEPENDENTS = 0x0008,
+        SERVICE_START = 0x0010,
+        SERVICE_STOP = 0x0020,
+        SERVICE_INTERROGATE = 0x0080,
+
+        // standard access rights
+        READ_CONTROL = 0x20000,
+
+        STANDARD_RIGHTS_READ = READ_CONTROL,
+        GENERIC_READ = STANDARD_RIGHTS_READ | SERVICE_QUERY_CONFIG | SERVICE_QUERY_STATUS | SERVICE_INTERROGATE | SERVICE_ENUMERATE_DEPENDENTS,
+
+        SERVICE_ALL_ACCESS = 0xF01FF
     }
 
     public class Win32NativeMethods : INativeMethods
@@ -396,6 +418,15 @@ namespace Datadog.CustomActions.Native
         int dwStartType, int dwErrorControl, string lpBinaryPathName, string lpLoadOrderGroup,
         string lpdwTagId, string lpDependencies, string lpServiceStartName, string lpPassword,
         string lpDisplayName);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        private static extern bool QueryServiceObjectSecurity(SafeHandle serviceHandle,
+            SecurityInfos secInfo,
+            byte[] lpSecDescBuf, uint bufSize, out uint bufSizeNeeded);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        static extern bool SetServiceObjectSecurity(SafeHandle serviceHandle,
+            SecurityInfos secInfos, byte[] lpSecDescBuf);
 
         [StructLayout(LayoutKind.Sequential)]
         public class GuidClass
@@ -756,6 +787,8 @@ namespace Datadog.CustomActions.Native
             return result;
         }
 
+
+
         /// <summary>
         /// Enable privilege on current token
         /// https://learn.microsoft.com/en-us/windows/win32/secauthz/enabling-and-disabling-privileges-in-c--
@@ -816,6 +849,52 @@ namespace Datadog.CustomActions.Native
                 {
                     CloseHandle(token);
                 }
+            }
+        }
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-queryserviceobjectsecurity
+        public static CommonSecurityDescriptor QueryServiceObjectSecurity(SafeHandle serviceHandle,
+            System.Security.AccessControl.SecurityInfos secInfo)
+        {
+            byte[] secDescBuf = null;
+            if (!QueryServiceObjectSecurity(serviceHandle, secInfo, null, 0, out var bytesNeeded))
+            {
+                var result = (ReturnCodes)Marshal.GetLastWin32Error();
+                if (result != ReturnCodes.ERROR_INSUFFICIENT_BUFFER)
+                {
+                    throw new Exception("Failed to get size for service security descriptor",
+                        new Win32Exception((int)result));
+                }
+            }
+            else
+            {
+                throw new Exception("Failed to get size for service security descriptor");
+            }
+
+            // alloc space
+            secDescBuf = new byte[bytesNeeded];
+
+            if (!QueryServiceObjectSecurity(serviceHandle, secInfo, secDescBuf, bytesNeeded, out _))
+            {
+                throw new Exception("Failed to get service security descriptor",
+                    new Win32Exception(Marshal.GetLastWin32Error()));
+            }
+
+            // isContainer/isDS are N/A to service ACL
+            return new CommonSecurityDescriptor(false, false, new RawSecurityDescriptor(secDescBuf, 0));
+        }
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-setserviceobjectsecurity
+        public static void SetServiceObjectSecurity(SafeHandle serviceHandle,
+            System.Security.AccessControl.SecurityInfos secInfo,
+            CommonSecurityDescriptor securityDescriptor)
+        {
+            var secDescBuf = new byte[securityDescriptor.BinaryLength];
+            securityDescriptor.GetBinaryForm(secDescBuf, 0);
+            if (!SetServiceObjectSecurity(serviceHandle, secInfo, secDescBuf))
+            {
+                throw new Exception("Failed to set service security descriptor",
+                    new Win32Exception(Marshal.GetLastWin32Error()));
             }
         }
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/ServiceController.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/ServiceController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Security.AccessControl;
 using System.ServiceProcess;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,6 +66,18 @@ namespace Datadog.CustomActions.Native
             {
                 throw new Win32Exception($"ChangeServiceConfig({serviceName}) failed");
             }
+        }
+
+        public CommonSecurityDescriptor GetAccessSecurity(string serviceName)
+        {
+            var svc = new System.ServiceProcess.ServiceController(serviceName);
+            return Win32NativeMethods.QueryServiceObjectSecurity(svc.ServiceHandle, SecurityInfos.DiscretionaryAcl);
+        }
+
+        public void SetAccessSecurity(string serviceName, CommonSecurityDescriptor securityDescriptor)
+        {
+            var svc = new System.ServiceProcess.ServiceController(serviceName);
+            Win32NativeMethods.SetServiceObjectSecurity(svc.ServiceHandle, SecurityInfos.DiscretionaryAcl, securityDescriptor);
         }
 
         private async Task<ServiceControllerStatus> WaitForStatusChange(System.ServiceProcess.ServiceController svc, ServiceControllerStatus state, TimeSpan timeout)

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/FilePermissionRollbackData.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/FilePermissionRollbackData.cs
@@ -34,7 +34,7 @@ namespace Datadog.CustomActions.RollbackData
         /// is called with SeRestorePrivilege enabled. The error is NOT returned by the .NET API, so there's no way to tell that this occurred
         /// until looking at the DACL of the child.
         /// </remarks>
-        public void Restore(ISession session, IFileSystemServices fileSystemServices)
+        public void Restore(ISession session, IFileSystemServices fileSystemServices, IServiceController _)
         {
             var fileSystemSecurity = fileSystemServices.GetAccessControl(_filePath);
             session.Log(

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/RollbackDataStore.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/RollbackDataStore.cs
@@ -15,6 +15,7 @@ namespace Datadog.CustomActions.RollbackData
     {
         private readonly ISession _session;
         private readonly IFileSystemServices _fileSystemServices;
+        private readonly IServiceController _serviceController;
         private readonly string _storageName;
         private readonly string _dataPath;
 
@@ -41,10 +42,11 @@ namespace Datadog.CustomActions.RollbackData
             }
         }
 
-        public RollbackDataStore(ISession session, string name, IFileSystemServices fileSystemServices)
+        public RollbackDataStore(ISession session, string name, IFileSystemServices fileSystemServices, IServiceController serviceController)
         {
             _session = session;
             _fileSystemServices = fileSystemServices;
+            _serviceController = serviceController;
             _storageName = name;
             _dataPath = CreateStoragePath();
 
@@ -55,7 +57,8 @@ namespace Datadog.CustomActions.RollbackData
             : this(
                 session,
                 name,
-                new FileSystemServices()
+                new FileSystemServices(),
+                new ServiceController()
             )
         {
         }
@@ -134,7 +137,7 @@ namespace Datadog.CustomActions.RollbackData
             Load();
             for (var i = RollbackActions.Count - 1; i >= 0; i--)
             {
-                RollbackActions[i].Restore(_session, _fileSystemServices);
+                RollbackActions[i].Restore(_session, _fileSystemServices, _serviceController);
             }
         }
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/ServicePermissionRollbackData.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/ServicePermissionRollbackData.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Security.AccessControl;
+using Newtonsoft.Json;
+using Datadog.CustomActions.Interfaces;
+using System.ServiceProcess;
+
+namespace Datadog.CustomActions.RollbackData
+{
+    class ServicePermissionRollbackData : IRollbackAction
+    {
+        [JsonProperty("ServiceName")] private string _serviceName;
+        [JsonProperty("SDDL")] private string _sddl;
+
+        [JsonConstructor]
+        public ServicePermissionRollbackData()
+        {
+        }
+
+        public ServicePermissionRollbackData(string serviceName, IServiceController serviceController)
+        {
+            var securityDescriptor = serviceController.GetAccessSecurity(serviceName);
+            _sddl = securityDescriptor.GetSddlForm(AccessControlSections.All);
+            _serviceName = serviceName;
+        }
+
+        /// <summary>
+        /// Set service access/object security
+        /// https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-setserviceobjectsecurity
+        /// </summary>
+        public void Restore(ISession session, IFileSystemServices _, IServiceController serviceController)
+        {
+            var securityDescriptor = serviceController.GetAccessSecurity(_serviceName);
+            session.Log(
+                $"{_serviceName} current ACLs: {securityDescriptor.GetSddlForm(AccessControlSections.All)}");
+            securityDescriptor = new CommonSecurityDescriptor(false, false, _sddl);
+            session.Log($"{_serviceName} rollback SDDL {_sddl}");
+            try
+            {
+                serviceController.SetAccessSecurity(_serviceName, securityDescriptor);
+            }
+            catch (Exception e)
+            {
+                session.Log($"Error writing ACL: {e}");
+            }
+
+            securityDescriptor = serviceController.GetAccessSecurity(_serviceName);
+            session.Log(
+                $"{_serviceName} new ACLs: {securityDescriptor.GetSddlForm(AccessControlSections.All)}");
+        }
+    }
+}

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Security.AccessControl;
+using System.Security.Authentication.ExtendedProtection;
 using System.Security.Principal;
 using System.ServiceProcess;
 using Datadog.CustomActions.Extensions;
 using Datadog.CustomActions.Interfaces;
 using Datadog.CustomActions.Native;
+using Datadog.CustomActions.RollbackData;
 using Microsoft.Deployment.WindowsInstaller;
 using Microsoft.Win32;
 using ServiceController = Datadog.CustomActions.Native.ServiceController;
@@ -19,14 +23,19 @@ namespace Datadog.CustomActions
         private readonly IDirectoryServices _directoryServices;
         private readonly IFileServices _fileServices;
         private readonly IServiceController _serviceController;
+        private readonly IFileSystemServices _fileSystemServices;
+
+        private readonly RollbackDataStore _rollbackDataStore;
 
         public ServiceCustomAction(
             ISession session,
+            string rollbackDataName,
             INativeMethods nativeMethods,
             IRegistryServices registryServices,
             IDirectoryServices directoryServices,
             IFileServices fileServices,
-            IServiceController serviceController)
+            IServiceController serviceController,
+            IFileSystemServices fileSystemServices)
         {
             _session = session;
             _nativeMethods = nativeMethods;
@@ -34,16 +43,38 @@ namespace Datadog.CustomActions
             _directoryServices = directoryServices;
             _fileServices = fileServices;
             _serviceController = serviceController;
+            _fileSystemServices = fileSystemServices;
+
+            if (!string.IsNullOrEmpty(rollbackDataName))
+            {
+                _rollbackDataStore = new RollbackDataStore(_session, rollbackDataName, _fileSystemServices, _serviceController);
+            }
         }
 
         public ServiceCustomAction(ISession session)
+            : this(
+                session,
+                null,
+                new Win32NativeMethods(),
+                new RegistryServices(),
+                new DirectoryServices(),
+                new FileServices(),
+                new ServiceController(),
+                new FileSystemServices()
+            )
+        {
+        }
+
+        public ServiceCustomAction(ISession session, string rollbackDataName)
         : this(
             session,
+            rollbackDataName,
             new Win32NativeMethods(),
             new RegistryServices(),
             new DirectoryServices(),
             new FileServices(),
-            new ServiceController()
+            new ServiceController(),
+            new FileSystemServices()
         )
         {
         }
@@ -79,8 +110,7 @@ namespace Datadog.CustomActions
         {
             return EnsureNpmServiceDependendency(new SessionWrapper(session));
         }
-
-        private ActionResult ConfigureServiceUsers()
+        private ActionResult ConfigureServices()
         {
             try
             {
@@ -97,73 +127,171 @@ namespace Datadog.CustomActions
                     throw new Exception($"Could not find user {ddAgentUserName}.");
                 }
 
-                var ddAgentUserPassword = _session.Property("DDAGENTUSER_PROCESSED_PASSWORD");
-                var isServiceAccount = _nativeMethods.IsServiceAccount(securityIdentifier);
-                if (!isServiceAccount && string.IsNullOrEmpty(ddAgentUserPassword))
-                {
-                    _session.Log("Password not provided, will not change service user password");
-                    // set to null so we don't modify the service config
-                    ddAgentUserPassword = null;
-                }
-                else if (isServiceAccount)
-                {
-                    _session.Log("Ignoring provided password because account is a service account");
-                    // Follow rules for ChangeServiceConfig
-                    if (securityIdentifier.IsWellKnown(WellKnownSidType.LocalSystemSid) ||
-                        securityIdentifier.IsWellKnown(WellKnownSidType.LocalServiceSid) ||
-                        securityIdentifier.IsWellKnown(WellKnownSidType.NetworkServiceSid))
-                    {
-                        // Specify an empty string if the account has no password or if the service runs in the LocalService, NetworkService, or LocalSystem account.
-                        ddAgentUserPassword = "";
-                    }
-                    else
-                    {
-                        // If the account name specified by the lpServiceStartName parameter is the name of a managed service account or virtual account name, the lpPassword parameter must be NULL.
-                        ddAgentUserPassword = null;
-                    }
-                }
-
-                _session.Log($"Configuring services with account {ddAgentUserName}");
-
-                // ddagentuser
-                if (securityIdentifier.IsWellKnown(WellKnownSidType.LocalSystemSid))
-                {
-                    ddAgentUserName = "LocalSystem";
-                }
-                else if (securityIdentifier.IsWellKnown(WellKnownSidType.LocalServiceSid))
-                {
-                    ddAgentUserName = "LocalService";
-                }
-                else if (securityIdentifier.IsWellKnown(WellKnownSidType.NetworkServiceSid))
-                {
-                    ddAgentUserName = "NetworkService";
-                }
-                _serviceController.SetCredentials(Constants.AgentServiceName, ddAgentUserName, ddAgentUserPassword);
-                _serviceController.SetCredentials(Constants.TraceAgentServiceName, ddAgentUserName, ddAgentUserPassword);
-
-                // SYSTEM
-                // LocalSystem is a SCM specific shorthand that doesn't need to be localized
-                _serviceController.SetCredentials(Constants.SystemProbeServiceName, "LocalSystem", "");
-                _serviceController.SetCredentials(Constants.ProcessAgentServiceName, "LocalSystem", "");
-
-                var installCWS = _session.Property("INSTALL_CWS");
-                if (!string.IsNullOrEmpty(installCWS))
-                {
-                    _serviceController.SetCredentials(Constants.SecurityAgentServiceName, ddAgentUserName, ddAgentUserPassword);
-                }
+                ConfigureServiceUsers(ddAgentUserName, securityIdentifier);
+                ConfigureServicePermissions(securityIdentifier);
             }
             catch (Exception e)
             {
-                _session.Log($"Failed to configure service logon users: {e}");
+                _session.Log($"Failed to configure services: {e}");
                 return ActionResult.Failure;
+            }
+            finally
+            {
+                _rollbackDataStore.Store();
             }
             return ActionResult.Success;
         }
 
-        [CustomAction]
-        public static ActionResult ConfigureServiceUsers(Session session)
+        private void ConfigureServiceUsers(string ddAgentUserName, SecurityIdentifier ddAgentUserSID)
         {
-            return new ServiceCustomAction(new SessionWrapper(session)).ConfigureServiceUsers();
+            var ddAgentUserPassword = _session.Property("DDAGENTUSER_PROCESSED_PASSWORD");
+            var isServiceAccount = _nativeMethods.IsServiceAccount(ddAgentUserSID);
+            if (!isServiceAccount && string.IsNullOrEmpty(ddAgentUserPassword))
+            {
+                _session.Log("Password not provided, will not change service user password");
+                // set to null so we don't modify the service config
+                ddAgentUserPassword = null;
+            }
+            else if (isServiceAccount)
+            {
+                _session.Log("Ignoring provided password because account is a service account");
+                // Follow rules for ChangeServiceConfig
+                if (ddAgentUserSID.IsWellKnown(WellKnownSidType.LocalSystemSid) ||
+                    ddAgentUserSID.IsWellKnown(WellKnownSidType.LocalServiceSid) ||
+                    ddAgentUserSID.IsWellKnown(WellKnownSidType.NetworkServiceSid))
+                {
+                    // Specify an empty string if the account has no password or if the service runs in the LocalService, NetworkService, or LocalSystem account.
+                    ddAgentUserPassword = "";
+                }
+                else
+                {
+                    // If the account name specified by the lpServiceStartName parameter is the name of a managed service account or virtual account name, the lpPassword parameter must be NULL.
+                    ddAgentUserPassword = null;
+                }
+            }
+
+            _session.Log($"Configuring services with account {ddAgentUserName}");
+
+            // ddagentuser
+            if (ddAgentUserSID.IsWellKnown(WellKnownSidType.LocalSystemSid))
+            {
+                ddAgentUserName = "LocalSystem";
+            }
+            else if (ddAgentUserSID.IsWellKnown(WellKnownSidType.LocalServiceSid))
+            {
+                ddAgentUserName = "LocalService";
+            }
+            else if (ddAgentUserSID.IsWellKnown(WellKnownSidType.NetworkServiceSid))
+            {
+                ddAgentUserName = "NetworkService";
+            }
+            _serviceController.SetCredentials(Constants.AgentServiceName, ddAgentUserName, ddAgentUserPassword);
+            _serviceController.SetCredentials(Constants.TraceAgentServiceName, ddAgentUserName, ddAgentUserPassword);
+
+            // SYSTEM
+            // LocalSystem is a SCM specific shorthand that doesn't need to be localized
+            _serviceController.SetCredentials(Constants.SystemProbeServiceName, "LocalSystem", "");
+            _serviceController.SetCredentials(Constants.ProcessAgentServiceName, "LocalSystem", "");
+
+            var installCWS = _session.Property("INSTALL_CWS");
+            if (!string.IsNullOrEmpty(installCWS))
+            {
+                _serviceController.SetCredentials(Constants.SecurityAgentServiceName, ddAgentUserName, ddAgentUserPassword);
+            }
+        }
+
+        private void UpdateAndLogAccessControl(string serviceName, CommonSecurityDescriptor securityDescriptor)
+        {
+            var oldSD = _serviceController.GetAccessSecurity(serviceName);
+            _session.Log(
+                $"{serviceName} current ACLs: {oldSD.GetSddlForm(AccessControlSections.All)}");
+
+            _rollbackDataStore.Add(new ServicePermissionRollbackData(serviceName, _serviceController));
+            _serviceController.SetAccessSecurity(serviceName, securityDescriptor);
+
+            var newSD = _serviceController.GetAccessSecurity(serviceName);
+            _session.Log(
+                $"{serviceName} new ACLs: {newSD.GetSddlForm(AccessControlSections.All)}");
+        }
+
+        /// <summary>
+        /// Grant ddagentuser start/stop service privileges for the agent services
+        /// </summary>
+        private void ConfigureServicePermissions(SecurityIdentifier ddAgentUserSID)
+        {
+            var previousDdAgentUserSid = InstallStateCustomActions.GetPreviousAgentUser(_session, _registryServices, _nativeMethods);
+
+            var services = new List<string>
+            {
+                Constants.ProcessAgentServiceName,
+                Constants.SystemProbeServiceName,
+                Constants.TraceAgentServiceName,
+                Constants.AgentServiceName,
+            };
+
+            if (!string.IsNullOrEmpty(_session.Property("INSTALL_CWS")))
+            {
+                services.Add(Constants.SecurityAgentServiceName);
+            }
+
+            foreach (var serviceName in services)
+            {
+                var securityDescriptor = _serviceController.GetAccessSecurity(serviceName);
+
+                // remove previous user
+                if (previousDdAgentUserSid != null && previousDdAgentUserSid != ddAgentUserSID)
+                {
+                    // unless that user is LocalSystem
+                    if (!previousDdAgentUserSid.IsWellKnown(WellKnownSidType.LocalSystemSid))
+                    {
+                        securityDescriptor.DiscretionaryAcl.RemoveAccess(AccessControlType.Allow,
+                            previousDdAgentUserSid,
+                            (int)(ServiceAccess.SERVICE_ALL_ACCESS), InheritanceFlags.None, PropagationFlags.None);
+                    }
+                }
+
+                // Remove Everyone
+                // [7.47 - 7.50) added an ACE for Everyone, so make sure to remove it
+                securityDescriptor.DiscretionaryAcl.RemoveAccess(AccessControlType.Allow, new SecurityIdentifier("WD"),
+                    (int)(ServiceAccess.SERVICE_ALL_ACCESS), InheritanceFlags.None, PropagationFlags.None);
+
+                // add current user
+                // Unless the user is LocalSystem since it already has access
+                if (!ddAgentUserSID.IsWellKnown(WellKnownSidType.LocalSystemSid))
+                {
+                    securityDescriptor.DiscretionaryAcl.AddAccess(AccessControlType.Allow, ddAgentUserSID,
+                        (int)(ServiceAccess.SERVICE_START | ServiceAccess.SERVICE_STOP | ServiceAccess.GENERIC_READ),
+                        InheritanceFlags.None, PropagationFlags.None);
+                }
+
+                UpdateAndLogAccessControl(serviceName, securityDescriptor);
+            }
+        }
+
+        [CustomAction]
+        public static ActionResult ConfigureServices(Session session)
+        {
+            return new ServiceCustomAction(new SessionWrapper(session), "ConfigureServices").ConfigureServices();
+        }
+
+        private ActionResult ConfigureServicesRollback()
+        {
+            try
+            {
+                _rollbackDataStore.Restore();
+            }
+            catch (Exception e)
+            {
+                _session.Log($"Failed to rollback service configuration: {e}");
+            }
+
+            return ActionResult.Success;
+        }
+
+        [CustomAction]
+        public static ActionResult ConfigureServicesRollback(Session session)
+        {
+            return new ServiceCustomAction(new SessionWrapper(session), "ConfigureServices").ConfigureServicesRollback();
         }
 
         /// <summary>

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -375,19 +375,6 @@ namespace WixSetup.Datadog
             return new Dir(new Id("DatadogAppRoot"), "%ProgramFiles%\\Datadog", datadogAgentFolder);
         }
 
-        private static PermissionEx DefaultPermissions()
-        {
-            return new PermissionEx
-            {
-                User = "Everyone",
-                ServicePauseContinue = true,
-                ServiceQueryStatus = true,
-                ServiceStart = true,
-                ServiceStop = true,
-                ServiceUserDefinedControl = true
-            };
-        }
-
         private static ServiceInstaller GenerateServiceInstaller(string name, string displayName, string description)
         {
             return new ServiceInstaller
@@ -410,7 +397,6 @@ namespace WixSetup.Datadog
                 RestartServiceDelayInSeconds = 60,
                 ResetPeriodInDays = 0,
                 PreShutdownDelay = 1000 * 60 * 3,
-                PermissionEx = DefaultPermissions(),
                 // Account must be a fully qualified name.
                 Account = "[DDAGENTUSER_PROCESSED_FQ_NAME]",
                 Password = "[DDAGENTUSER_PROCESSED_PASSWORD]"
@@ -445,7 +431,6 @@ namespace WixSetup.Datadog
                 RestartServiceDelayInSeconds = 60,
                 ResetPeriodInDays = 0,
                 PreShutdownDelay = 1000 * 60 * 3,
-                PermissionEx = DefaultPermissions(),
                 Interactive = false,
                 Type = SvcType.ownProcess,
                 // Account must be a fully qualified name.


### PR DESCRIPTION
Explicit ddagentuser service permissions

(cherry picked from commit ae1798c72a0ac609a3a6c6428af5392892534344)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR back ports https://github.com/DataDog/datadog-agent/pull/21640 to 7.50.2

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
