### PR TITLE
[POC] Status component render status output

### DIFF
--- a/cmd/agent/gui/gui.go
+++ b/cmd/agent/gui/gui.go
@@ -27,6 +27,7 @@ import (
 	"github.com/urfave/negroni"
 
 	"github.com/DataDog/datadog-agent/comp/core/flare"
+	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -61,7 +62,7 @@ func StopGUIServer() {
 }
 
 // StartGUIServer creates the router, starts the HTTP server & generates the authentication token for access
-func StartGUIServer(port string, flare flare.Component, invAgent inventoryagent.Component) error {
+func StartGUIServer(port string, flare flare.Component, invAgent inventoryagent.Component, statusComponent status.Component) error {
 	// Set start time...
 	startTimestamp = time.Now().Unix()
 
@@ -79,7 +80,7 @@ func StartGUIServer(port string, flare flare.Component, invAgent inventoryagent.
 
 	// Set up handlers for the API
 	agentRouter := mux.NewRouter().PathPrefix("/agent").Subrouter().StrictSlash(true)
-	agentHandler(agentRouter, flare, invAgent)
+	agentHandler(agentRouter, flare, invAgent, statusComponent)
 	checkRouter := mux.NewRouter().PathPrefix("/checks").Subrouter().StrictSlash(true)
 	checkHandler(checkRouter)
 

--- a/cmd/agent/gui/render.go
+++ b/cmd/agent/gui/render.go
@@ -11,7 +11,6 @@ import (
 	"expvar"
 	"html/template"
 	"io"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/collector"
@@ -20,13 +19,6 @@ import (
 )
 
 var fmap = render.Fmap()
-
-func init() {
-	fmap["lastErrorTraceback"] = lastErrorTraceback
-	fmap["lastErrorMessage"] = lastErrorMessage
-	fmap["pythonLoaderError"] = pythonLoaderError
-	fmap["status"] = displayStatus
-}
 
 // Data is a struct used for filling templates
 type Data struct {
@@ -109,51 +101,4 @@ func fillTemplate(w io.Writer, data Data, request string) error {
 	}
 	e = t.Execute(w, data)
 	return e
-}
-
-/****** Helper functions for the template formatting ******/
-
-func pythonLoaderError(value string) template.HTML {
-	value = template.HTMLEscapeString(value)
-
-	value = strings.Replace(value, "\n", "<br>", -1)
-	value = strings.Replace(value, "  ", "&nbsp;&nbsp;&nbsp;", -1)
-	return template.HTML(value)
-}
-
-func lastErrorTraceback(value string) template.HTML {
-	var lastErrorArray []map[string]string
-
-	err := json.Unmarshal([]byte(value), &lastErrorArray)
-	if err != nil || len(lastErrorArray) == 0 {
-		return template.HTML("No traceback")
-	}
-
-	traceback := template.HTMLEscapeString(lastErrorArray[0]["traceback"])
-
-	traceback = strings.Replace(traceback, "\n", "<br>", -1)
-	traceback = strings.Replace(traceback, "  ", "&nbsp;&nbsp;&nbsp;", -1)
-
-	return template.HTML(traceback)
-}
-
-func lastErrorMessage(value string) string {
-	var lastErrorArray []map[string]string
-	err := json.Unmarshal([]byte(value), &lastErrorArray)
-	if err == nil && len(lastErrorArray) > 0 {
-		if msg, ok := lastErrorArray[0]["message"]; ok {
-			return msg
-		}
-	}
-	return "UNKNOWN ERROR"
-}
-
-func displayStatus(check map[string]interface{}) template.HTML {
-	if check["LastError"].(string) != "" {
-		return template.HTML("[<span class=\"error\">ERROR</span>]")
-	}
-	if len(check["LastWarnings"].([]interface{})) != 0 {
-		return template.HTML("[<span class=\"warning\">WARNING</span>]")
-	}
-	return template.HTML("[<span class=\"ok\">OK</span>]")
 }

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -47,6 +47,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/comp/core/status/statusimpl"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
@@ -92,6 +94,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/snmp/traps"
+	collectorStatus "github.com/DataDog/datadog-agent/pkg/status/collector"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	otlpStatus "github.com/DataDog/datadog-agent/pkg/status/otlp"
 	pkgTelemetry "github.com/DataDog/datadog-agent/pkg/telemetry"
@@ -221,6 +224,7 @@ func run(log log.Component,
 	_ netflowServer.Component,
 	_ langDetectionCl.Component,
 	agentAPI internalAPI.Component,
+	statusComponent status.Component,
 ) error {
 	defer func() {
 		stopAgent(cliParams, server, demultiplexer, agentAPI)
@@ -325,6 +329,10 @@ func getSharedFxOption() fx.Option {
 			}
 		}),
 		workloadmeta.Module(),
+		fx.Supply(
+			status.NewInformationProvider(collectorStatus.StatusProvider()),
+		),
+		statusimpl.Module(),
 		apiimpl.Module(),
 
 		dogstatsd.Bundle(),

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -284,6 +284,7 @@ func run(log log.Component,
 		invAgent,
 		agentAPI,
 		invChecks,
+		statusComponent,
 	); err != nil {
 		return err
 	}
@@ -404,6 +405,7 @@ func startAgent(
 	invAgent inventoryagent.Component,
 	agentAPI internalAPI.Component,
 	invChecks inventorychecks.Component,
+	statusComponent status.Component,
 ) error {
 
 	var err error
@@ -571,7 +573,7 @@ func startAgent(
 	guiPort := pkgconfig.Datadog.GetString("GUI_port")
 	if guiPort == "-1" {
 		log.Infof("GUI server port -1 specified: not starting the GUI.")
-	} else if err = gui.StartGUIServer(guiPort, flare, invAgent); err != nil {
+	} else if err = gui.StartGUIServer(guiPort, flare, invAgent, statusComponent); err != nil {
 		log.Errorf("Error while starting GUI: %v", err)
 	}
 

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -25,7 +25,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/status/render"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 
@@ -151,6 +150,12 @@ func requestStatus(config config.Component, cliParams *cliParams) error {
 		v.Set("verbose", "true")
 	}
 
+	if cliParams.prettyPrintJSON || cliParams.jsonStatus {
+		v.Set("format", "json")
+	} else {
+		v.Set("format", "text")
+	}
+
 	url := url.URL{
 		Scheme:   "https",
 		Host:     fmt.Sprintf("%v:%v", ipcAddress, config.GetInt("cmd_port")),
@@ -171,11 +176,7 @@ func requestStatus(config config.Component, cliParams *cliParams) error {
 	} else if cliParams.jsonStatus {
 		s = string(r)
 	} else {
-		formattedStatus, err := render.FormatStatus(r)
-		if err != nil {
-			return err
-		}
-		s = scrubMessage(formattedStatus)
+		s = scrubMessage(string(r))
 	}
 
 	if cliParams.statusFilePath != "" {

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/api/api"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/replay"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
@@ -47,6 +48,7 @@ type apiServer struct {
 	invHost         inventoryhost.Component
 	secretResolver  secrets.Component
 	invChecks       inventorychecks.Component
+	statusComponent status.Component
 }
 
 type dependencies struct {
@@ -62,6 +64,7 @@ type dependencies struct {
 	InvHost         inventoryhost.Component
 	SecretResolver  secrets.Component
 	InvChecks       inventorychecks.Component
+	StatusComponent status.Component
 }
 
 var _ api.Component = (*apiServer)(nil)
@@ -78,6 +81,7 @@ func newAPIServer(deps dependencies) api.Component {
 		invHost:         deps.InvHost,
 		secretResolver:  deps.SecretResolver,
 		invChecks:       deps.InvChecks,
+		statusComponent: deps.StatusComponent,
 	}
 }
 
@@ -102,6 +106,7 @@ func (server *apiServer) StartServer(
 		server.invHost,
 		server.secretResolver,
 		server.invChecks,
+		server.statusComponent,
 	)
 }
 

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -31,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/response"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	dogstatsddebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
@@ -48,7 +49,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
 	"github.com/DataDog/datadog-agent/pkg/gohai"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
-	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
@@ -74,15 +74,16 @@ func SetupHandlers(
 	invHost inventoryhost.Component,
 	secretResolver secrets.Component,
 	invChecks inventorychecks.Component,
+	statusComponent status.Component,
 ) *mux.Router {
 
 	r.HandleFunc("/version", common.GetVersion).Methods("GET")
 	r.HandleFunc("/hostname", getHostname).Methods("GET")
 	r.HandleFunc("/flare", func(w http.ResponseWriter, r *http.Request) { makeFlare(w, r, flareComp) }).Methods("POST")
 	r.HandleFunc("/stop", stopAgent).Methods("POST")
-	r.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) { getStatus(w, r, invAgent) }).Methods("GET")
+	r.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) { getStatus(w, r, invAgent, statusComponent) }).Methods("GET")
 	r.HandleFunc("/stream-event-platform", streamEventPlatform()).Methods("POST")
-	r.HandleFunc("/status/formatted", func(w http.ResponseWriter, r *http.Request) { getFormattedStatus(w, r, invAgent) }).Methods("GET")
+	// r.HandleFunc("/status/formatted", func(w http.ResponseWriter, r *http.Request) { getFormattedStatus(w, r, invAgent) }).Methods("GET")
 	r.HandleFunc("/status/health", getHealth).Methods("GET")
 	r.HandleFunc("/{component}/status", componentStatusGetterHandler).Methods("GET")
 	r.HandleFunc("/{component}/status", componentStatusHandler).Methods("POST")
@@ -211,23 +212,19 @@ func componentStatusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getStatus(w http.ResponseWriter, r *http.Request, invAgent inventoryagent.Component) {
+func getStatus(w http.ResponseWriter, r *http.Request, invAgent inventoryagent.Component, statusComponent status.Component) {
 	log.Info("Got a request for the status. Making status.")
 	verbose := r.URL.Query().Get("verbose") == "true"
-	s, err := status.GetStatus(verbose, invAgent)
-	w.Header().Set("Content-Type", "application/json")
+	format := r.URL.Query().Get("format")
+
+	s, err := statusComponent.GetStatus(format, verbose)
+
 	if err != nil {
 		setJSONError(w, log.Errorf("Error getting status. Error: %v, Status: %v", err, s), 500)
 		return
 	}
 
-	jsonStats, err := json.Marshal(s)
-	if err != nil {
-		setJSONError(w, log.Errorf("Error marshalling status. Error: %v, Status: %v", err, s), 500)
-		return
-	}
-
-	w.Write(jsonStats)
+	w.Write(s)
 }
 
 func streamLogs(logsAgent logsAgent.Component) func(w http.ResponseWriter, r *http.Request) {
@@ -349,16 +346,16 @@ func getDogstatsdStats(w http.ResponseWriter, _ *http.Request, dogstatsdServer d
 	w.Write(jsonStats)
 }
 
-func getFormattedStatus(w http.ResponseWriter, _ *http.Request, invAgent inventoryagent.Component) {
-	log.Info("Got a request for the formatted status. Making formatted status.")
-	s, err := status.GetAndFormatStatus(invAgent)
-	if err != nil {
-		setJSONError(w, log.Errorf("Error getting status: %v %v", err, s), 500)
-		return
-	}
+// func getFormattedStatus(w http.ResponseWriter, _ *http.Request, invAgent inventoryagent.Component) {
+// 	log.Info("Got a request for the formatted status. Making formatted status.")
+// 	s, err := status.GetAndFormatStatus(invAgent)
+// 	if err != nil {
+// 		setJSONError(w, log.Errorf("Error getting status: %v %v", err, s), 500)
+// 		return
+// 	}
 
-	w.Write(s)
-}
+// 	w.Write(s)
+// }
 
 func getHealth(w http.ResponseWriter, _ *http.Request) {
 	h := health.GetReady()

--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/replay"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
@@ -73,6 +74,7 @@ func StartServers(
 	invHost inventoryhost.Component,
 	secretResolver secrets.Component,
 	invChecks inventorychecks.Component,
+	statusComponent status.Component,
 ) error {
 	apiAddr, err := getIPCAddressPort()
 	if err != nil {
@@ -120,6 +122,7 @@ func StartServers(
 		invHost,
 		secretResolver,
 		invChecks,
+		statusComponent,
 	); err != nil {
 		return fmt.Errorf("unable to start CMD API server: %v", err)
 	}

--- a/comp/api/api/apiimpl/server_cmd.go
+++ b/comp/api/api/apiimpl/server_cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/internal/check"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	workloadmetaServer "github.com/DataDog/datadog-agent/comp/core/workloadmeta/server"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/replay"
@@ -67,6 +68,7 @@ func startCMDServer(
 	invHost inventoryhost.Component,
 	secretResolver secrets.Component,
 	invChecks inventorychecks.Component,
+	statusComponent status.Component,
 ) (err error) {
 	// get the transport we're going to use under HTTP
 	cmdListener, err = getListener(cmdAddr)
@@ -142,6 +144,7 @@ func startCMDServer(
 				invHost,
 				secretResolver,
 				invChecks,
+				statusComponent,
 			)))
 	cmdMux.Handle("/check/", http.StripPrefix("/check", check.SetupHandlers(checkMux)))
 	cmdMux.Handle("/", gwmux)

--- a/comp/core/status/component.go
+++ b/comp/core/status/component.go
@@ -20,7 +20,7 @@ const CollectorSection string = "collector"
 // Component interface to access the agent status.
 type Component interface {
 	// Returns all the agent status information for the format type
-	GetStatus(format string, verbose bool) ([]byte, error)
+	GetStatus(format string, verbose bool, skipSections ...string) ([]byte, error)
 	// Returns only the agent status for the especify section and format type
 	GetStatusBySection(section string, format string, verbose bool) ([]byte, error)
 }

--- a/comp/core/status/component.go
+++ b/comp/core/status/component.go
@@ -23,6 +23,8 @@ type Component interface {
 	GetStatus(format string, verbose bool) ([]byte, error)
 	// Returns only the agent status for the especify section and format type
 	GetStatusBySection(section string, format string, verbose bool) ([]byte, error)
+	// Render
+	Render(section, format string, data any) ([]byte, error)
 }
 
 // Provider interface
@@ -34,7 +36,9 @@ type Provider interface {
 	Section() string
 	JSON(stats map[string]interface{}) error
 	Text(buffer io.Writer) error
+	TextWithData(buffer io.Writer, data any) error
 	HTML(buffer io.Writer) error
+	HTMLWithData(buffer io.Writer, data any) error
 }
 
 // HeaderProvider interface

--- a/comp/core/status/component.go
+++ b/comp/core/status/component.go
@@ -23,8 +23,6 @@ type Component interface {
 	GetStatus(format string, verbose bool) ([]byte, error)
 	// Returns only the agent status for the especify section and format type
 	GetStatusBySection(section string, format string, verbose bool) ([]byte, error)
-	// Render
-	Render(section, format string, data any) ([]byte, error)
 }
 
 // Provider interface
@@ -36,9 +34,7 @@ type Provider interface {
 	Section() string
 	JSON(stats map[string]interface{}) error
 	Text(buffer io.Writer) error
-	TextWithData(buffer io.Writer, data any) error
 	HTML(buffer io.Writer) error
-	HTMLWithData(buffer io.Writer, data any) error
 }
 
 // HeaderProvider interface

--- a/comp/core/status/statusimpl/status.go
+++ b/comp/core/status/statusimpl/status.go
@@ -318,49 +318,6 @@ func (s *statusImplementation) GetStatusBySection(section string, format string,
 	}
 }
 
-func (s *statusImplementation) Render(section, format string, data any) ([]byte, error) {
-	var errors []error
-
-	providers := s.sortedProvidersBySection[section]
-	switch format {
-	case "text":
-		var b = new(bytes.Buffer)
-
-		for i, sc := range providers {
-			if i == 0 {
-				printHeader(b, section)
-				newLine(b)
-			}
-
-			if err := sc.TextWithData(b, data); err != nil {
-				errors = append(errors, err)
-			}
-		}
-
-		if len(errors) > 0 {
-			if err := renderErrors(b, errors); err != nil {
-				return []byte{}, err
-			}
-
-			return b.Bytes(), nil
-		}
-
-		return b.Bytes(), nil
-	case "html":
-		var b = new(bytes.Buffer)
-
-		for _, sc := range providers {
-			err := sc.HTMLWithData(b, data)
-			if err != nil {
-				return b.Bytes(), err
-			}
-		}
-		return b.Bytes(), nil
-	default:
-		return []byte{}, nil
-	}
-}
-
 func present(value string, container []string) bool {
 	for _, v := range container {
 		if v == value {

--- a/comp/core/status/statusimpl/status.go
+++ b/comp/core/status/statusimpl/status.go
@@ -106,7 +106,7 @@ func newStatus(deps dependencies) (status.Component, error) {
 	}, nil
 }
 
-func (s *statusImplementation) GetStatus(format string, _ bool) ([]byte, error) {
+func (s *statusImplementation) GetStatus(format string, _ bool, skipSections ...string) ([]byte, error) {
 	var errors []error
 
 	switch format {
@@ -118,7 +118,11 @@ func (s *statusImplementation) GetStatus(format string, _ bool) ([]byte, error) 
 			}
 		}
 
-		for _, providers := range s.sortedProvidersBySection {
+		for section, providers := range s.sortedProvidersBySection {
+			if present(section, skipSections) {
+				continue
+			}
+
 			for _, provider := range providers {
 				if err := provider.JSON(stats); err != nil {
 					errors = append(errors, err)
@@ -150,6 +154,10 @@ func (s *statusImplementation) GetStatus(format string, _ bool) ([]byte, error) 
 		}
 
 		for _, section := range s.sortedSectionNames {
+			if present(section, skipSections) {
+				continue
+			}
+
 			printHeader(b, section)
 			newLine(b)
 
@@ -181,6 +189,10 @@ func (s *statusImplementation) GetStatus(format string, _ bool) ([]byte, error) 
 		}
 
 		for _, section := range s.sortedSectionNames {
+			if present(section, skipSections) {
+				continue
+			}
+
 			for _, provider := range s.sortedProvidersBySection[section] {
 				err := provider.HTML(b)
 				if err != nil {

--- a/comp/core/status/statusimpl/status.go
+++ b/comp/core/status/statusimpl/status.go
@@ -318,6 +318,49 @@ func (s *statusImplementation) GetStatusBySection(section string, format string,
 	}
 }
 
+func (s *statusImplementation) Render(section, format string, data any) ([]byte, error) {
+	var errors []error
+
+	providers := s.sortedProvidersBySection[section]
+	switch format {
+	case "text":
+		var b = new(bytes.Buffer)
+
+		for i, sc := range providers {
+			if i == 0 {
+				printHeader(b, section)
+				newLine(b)
+			}
+
+			if err := sc.TextWithData(b, data); err != nil {
+				errors = append(errors, err)
+			}
+		}
+
+		if len(errors) > 0 {
+			if err := renderErrors(b, errors); err != nil {
+				return []byte{}, err
+			}
+
+			return b.Bytes(), nil
+		}
+
+		return b.Bytes(), nil
+	case "html":
+		var b = new(bytes.Buffer)
+
+		for _, sc := range providers {
+			err := sc.HTMLWithData(b, data)
+			if err != nil {
+				return b.Bytes(), err
+			}
+		}
+		return b.Bytes(), nil
+	default:
+		return []byte{}, nil
+	}
+}
+
 func present(value string, container []string) bool {
 	for _, v := range container {
 		if v == value {

--- a/comp/forwarder/defaultforwarder/status.go
+++ b/comp/forwarder/defaultforwarder/status.go
@@ -1,0 +1,88 @@
+package defaultforwarder
+
+import (
+	"embed"
+	"encoding/json"
+	"expvar"
+	htmlTemplate "html/template"
+	"io"
+	"path"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/status"
+)
+
+//go:embed status_templates
+var templatesFS embed.FS
+
+type statusProvider struct {
+	config config.Component
+}
+
+func (s statusProvider) getStatusInfo() map[string]interface{} {
+	stats := make(map[string]interface{})
+
+	s.populateStatus(stats)
+
+	return stats
+}
+
+func (s statusProvider) populateStatus(stats map[string]interface{}) {
+	forwarderStatsJSON := []byte(expvar.Get("forwarder").String())
+	forwarderStats := make(map[string]interface{})
+	json.Unmarshal(forwarderStatsJSON, &forwarderStats) //nolint:errcheck
+	forwarderStorageMaxSizeInBytes := s.config.GetInt("forwarder_storage_max_size_in_bytes")
+	if forwarderStorageMaxSizeInBytes > 0 {
+		forwarderStats["forwarder_storage_max_size_in_bytes"] = strconv.Itoa(forwarderStorageMaxSizeInBytes)
+	}
+	stats["forwarderStats"] = forwarderStats
+}
+
+func (s statusProvider) Name() string {
+	return "Forwarder"
+}
+
+func (s statusProvider) Section() string {
+	return "forwarder"
+}
+
+func (s statusProvider) JSON(stats map[string]interface{}) error {
+	s.populateStatus(stats)
+
+	return nil
+}
+
+func (s statusProvider) Text(buffer io.Writer) error {
+	return renderText(buffer, s.getStatusInfo())
+}
+
+func (s statusProvider) HTML(buffer io.Writer) error {
+	return renderHTML(buffer, s.getStatusInfo())
+}
+
+func (statusProvider) TextWithData(buffer io.Writer, data any) error {
+	return renderText(buffer, data)
+}
+
+func (statusProvider) HTMLWithData(buffer io.Writer, data any) error {
+	return renderHTML(buffer, data)
+}
+
+func renderHTML(buffer io.Writer, data any) error {
+	tmpl, tmplErr := templatesFS.ReadFile(path.Join("status_templates", "forwarderHTML.tmpl"))
+	if tmplErr != nil {
+		return tmplErr
+	}
+	t := htmlTemplate.Must(htmlTemplate.New("forwarderHTML").Funcs(status.HTMLFmap()).Parse(string(tmpl)))
+	return t.Execute(buffer, data)
+}
+
+func renderText(buffer io.Writer, data any) error {
+	tmpl, tmplErr := templatesFS.ReadFile(path.Join("status_templates", "forwarder.tmpl"))
+	if tmplErr != nil {
+		return tmplErr
+	}
+	t := htmlTemplate.Must(htmlTemplate.New("forwarder").Funcs(status.HTMLFmap()).Parse(string(tmpl)))
+	return t.Execute(buffer, data)
+}

--- a/comp/forwarder/defaultforwarder/status.go
+++ b/comp/forwarder/defaultforwarder/status.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"path"
 	"strconv"
+	textTemplate "text/template"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/status"
@@ -61,14 +62,6 @@ func (s statusProvider) HTML(buffer io.Writer) error {
 	return renderHTML(buffer, s.getStatusInfo())
 }
 
-func (statusProvider) TextWithData(buffer io.Writer, data any) error {
-	return renderText(buffer, data)
-}
-
-func (statusProvider) HTMLWithData(buffer io.Writer, data any) error {
-	return renderHTML(buffer, data)
-}
-
 func renderHTML(buffer io.Writer, data any) error {
 	tmpl, tmplErr := templatesFS.ReadFile(path.Join("status_templates", "forwarderHTML.tmpl"))
 	if tmplErr != nil {
@@ -83,6 +76,6 @@ func renderText(buffer io.Writer, data any) error {
 	if tmplErr != nil {
 		return tmplErr
 	}
-	t := htmlTemplate.Must(htmlTemplate.New("forwarder").Funcs(status.HTMLFmap()).Parse(string(tmpl)))
+	t := textTemplate.Must(textTemplate.New("forwarder").Funcs(status.HTMLFmap()).Parse(string(tmpl)))
 	return t.Execute(buffer, data)
 }

--- a/comp/forwarder/defaultforwarder/status_templates/forwarder.tmpl
+++ b/comp/forwarder/defaultforwarder/status_templates/forwarder.tmpl
@@ -1,0 +1,87 @@
+{{with .forwarderStats -}}
+{{ if .Transactions }}
+  Transactions
+  ============
+  {{- range $key, $value := .Transactions }}
+    {{- if and (ne $key "InputBytesByEndpoint") (ne $key "InputCountByEndpoint") (ne $key "DroppedByEndpoint") (ne $key "RequeuedByEndpoint") (ne $key "RetriedByEndpoint") (ne $key "Success") (ne $key "SuccessByEndpoint") (ne $key "SuccessBytesByEndpoint") (ne $key "Errors") (ne $key "ErrorsByType") (ne $key "HTTPErrors") (ne $key "HTTPErrorsByCode") (ne $key "ConnectionEvents")}}
+    {{$key}}: {{humanize $value}}
+    {{- end}}
+  {{- end}}
+  {{- if .Transactions.DroppedOnInput }}
+
+    Warning: the forwarder dropped transactions, there is probably an issue with your network
+    More info at https://github.com/DataDog/datadog-agent/tree/main/docs/agent/status.md
+  {{- end}}
+  {{- if .Transactions.Success}}
+
+  Transaction Successes
+  =====================
+    Total number: {{.Transactions.Success}}
+    Successes By Endpoint:
+          {{- range $type, $count := .Transactions.SuccessByEndpoint }}
+            {{- if $count }}
+      {{$type}}: {{humanize $count}}
+            {{- end}}
+          {{- end}}
+  {{- end}}
+  {{- if .Transactions.Errors }}
+
+  Transaction Errors
+  ==================
+    Total number: {{.Transactions.Errors}}
+    Errors By Type:
+          {{- range $type, $count := .Transactions.ErrorsByType }}
+            {{- if $count }}
+      {{$type}}: {{humanize $count}}
+            {{- end}}
+          {{- end}}
+  {{- end}}
+  {{- if .Transactions.HTTPErrors }}
+
+  HTTP Errors
+  ==================
+    Total number: {{.Transactions.HTTPErrors}}
+    HTTP Errors By Code:
+      {{- range $code, $count := .Transactions.HTTPErrorsByCode }}
+        {{- if $count}}
+      {{$code}}: {{humanize $count}}
+        {{- end}}
+      {{- end}}
+  {{- end}}
+{{- end}}
+
+  On-disk storage
+  ===============
+  {{- if .forwarder_storage_max_size_in_bytes }}
+    {{- if .FileStorage.CurrentSizeInBytes }}
+    Disk usage in bytes: {{ .FileStorage.CurrentSizeInBytes }}
+    Current number of files: {{ .FileStorage.FilesCount }}
+    Number of files dropped: {{ .FileStorage.FilesRemovedCount }}
+    Deserialization errors count: {{ .FileStorage.DeserializeErrorsCount }}
+    Outdated files removed at startup: {{ .RemovalPolicy.OutdatedFilesCount }}
+    {{- else }}
+    Enabled, not in-use.
+    {{- end}}
+  {{- else }}
+    On-disk storage is disabled. Configure `forwarder_storage_max_size_in_bytes` to enable it.
+  {{- end}}
+
+{{- if .APIKeyStatus }}
+
+  API Keys status
+  ===============
+  {{- range $key, $value := .APIKeyStatus }}
+    {{$key}}: {{$value}}
+  {{- end }}
+{{- end}}
+
+{{- if .APIKeyFailure }}
+
+  API Keys errors
+  ===============
+  {{- range $key, $value := .APIKeyFailure }}
+    {{yellowText $key}}{{yellowText ":"}} {{yellowText $value}}
+  {{- end }}
+{{- end}}
+{{- end}}
+

--- a/comp/forwarder/defaultforwarder/status_templates/forwarderHTML.tmpl
+++ b/comp/forwarder/defaultforwarder/status_templates/forwarderHTML.tmpl
@@ -1,0 +1,91 @@
+<div class="stat">
+  <span class="stat_title">Forwarder</span>
+  <span class="stat_data">
+    {{- with .forwarderStats -}}
+      {{- range $key, $value := .Transactions }}
+          {{- if and (ne $key "InputBytesByEndpoint") (ne $key "InputCountByEndpoint") (ne $key "DroppedByEndpoint") (ne $key "RequeuedByEndpoint") (ne $key "RetriedByEndpoint") (ne $key "Success") (ne $key "SuccessByEndpoint") (ne $key "SuccessBytesByEndpoint") (ne $key "Errors") (ne $key "ErrorsByType") (ne $key "HTTPErrors") (ne $key "HTTPErrorsByCode") (ne $key "ConnectionEvents")}}
+        {{formatTitle $key}}: {{humanize $value}}<br>
+          {{- end}}
+      {{- end}}
+      {{- if .Transactions.Success }}
+        <span class="stat_subtitle">Transaction Successes</span>
+          <span class="stat_subdata">
+            Total number: {{.Transactions.Success}}<br>
+            Successes By Endpoint:<br>
+            <span class="stat_subdata">
+              {{- range $type, $count := .Transactions.SuccessByEndpoint }}
+                {{- if $count}}
+                  {{$type}}: {{humanize $count}}<br>
+                {{- end}}
+              {{- end}}
+            </span>
+          </span>
+        </span>
+      {{- end}}
+      {{- if .Transactions.Errors }}
+        <span class="stat_subtitle">Transaction Errors</span>
+          <span class="stat_subdata">
+            Total number: {{.Transactions.Errors}}<br>
+            Errors By Type:<br>
+            <span class="stat_subdata">
+              {{- range $type, $count := .Transactions.ErrorsByType }}
+                {{- if $count}}
+                  {{$type}}: {{humanize $count}}<br>
+                {{- end}}
+              {{- end}}
+            </span>
+          </span>
+        </span>
+      {{- end}}
+      {{- if .Transactions.HTTPErrors }}
+        <span class="stat_subtitle">HTTP Errors</span>
+          <span class="stat_subdata">
+            Total number: {{.Transactions.HTTPErrors}}<br>
+            HTTP Errors By Code:<br>
+            <span class="stat_subdata">
+              {{- range $code, $count := .Transactions.HTTPErrorsByCode }}
+                {{- if $count}}
+                  {{$code}}: {{humanize $count}}<br>
+                {{- end}}
+              {{- end}}
+            </span>
+          </span>
+        </span>
+      {{- end}}
+    {{- end -}}
+    {{- with .forwarderStats -}}
+      <span class="stat_subtitle">On-disk storage</span>
+      <span class="stat_subdata">
+      {{- if .forwarder_storage_max_size_in_bytes }}
+        {{- if .FileStorage.CurrentSizeInBytes }}
+        Disk usage in bytes: {{ .FileStorage.CurrentSizeInBytes }}<br>
+        Number of files: {{ .FileStorage.FilesCount }}<br>
+        Number of files dropped: {{ .FileStorage.FilesRemovedCount }}<br>
+        Deserialization errors count: {{ .FileStorage.DeserializeErrorsCount }}<br>
+        Outdated files removed at startup: {{ .RemovalPolicy.OutdatedFilesCount }}<br>
+        {{- else }}
+        Enabled, not in-use.<br>
+        {{- end}}
+      {{- else }}
+        On-disk storage is disabled. Configure `forwarder_storage_max_size_in_bytes` to enable it.<br>
+      {{- end}}
+      </span>
+      {{- if .APIKeyStatus}}
+        <span class="stat_subtitle">API Keys Status</span>
+        <span class="stat_subdata">
+          {{- range $key, $value := .APIKeyStatus}}
+            {{$key}}: {{$value}}<br>
+          {{- end -}}
+        </span>
+      {{- end}}
+      {{- if .APIKeyFailure}}
+        <span class="stat_subtitle">API Keys Errors</span>
+        <span class="stat_subdata">
+          {{ range $key, $value := .APIKeyFailure}}
+            <span class="warning"> {{$key}}: {{$value}} <span> <br>
+          {{- end -}}
+        </span>
+      {{- end}}
+    {{- end -}}
+  </span>
+</div>

--- a/comp/metadata/inventoryagent/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/metadata/internal/util"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -78,9 +79,10 @@ type dependencies struct {
 type provides struct {
 	fx.Out
 
-	Comp          Component
-	Provider      runnerimpl.Provider
-	FlareProvider flaretypes.Provider
+	Comp           Component
+	Provider       runnerimpl.Provider
+	FlareProvider  flaretypes.Provider
+	StatusProvider status.HeaderInformationProvider
 }
 
 func newInventoryAgentProvider(deps dependencies) provides {
@@ -100,9 +102,10 @@ func newInventoryAgentProvider(deps dependencies) provides {
 	}
 
 	return provides{
-		Comp:          ia,
-		Provider:      ia.MetadataProvider(),
-		FlareProvider: ia.FlareProvider(),
+		Comp:           ia,
+		Provider:       ia.MetadataProvider(),
+		FlareProvider:  ia.FlareProvider(),
+		StatusProvider: status.NewHeaderInformationProvider(newStatusProvider(ia)),
 	}
 }
 

--- a/comp/metadata/inventoryagent/status.go
+++ b/comp/metadata/inventoryagent/status.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package inventoryagent
+
+import (
+	"embed"
+	htmlTemplate "html/template"
+	"io"
+	"path"
+	textTemplate "text/template"
+
+	"github.com/DataDog/datadog-agent/comp/core/status"
+)
+
+type statusProvider struct {
+	ia *inventoryagent
+}
+
+func newStatusProvider(ia *inventoryagent) statusProvider {
+	return statusProvider{
+		ia: ia,
+	}
+}
+
+func (s statusProvider) Name() string {
+	return "metadata"
+}
+
+func (s statusProvider) Index() int {
+	return 1
+}
+
+func (s statusProvider) getStatusInfo() map[string]interface{} {
+	return s.ia.Get()
+}
+
+func (s statusProvider) JSON(stats map[string]interface{}) error {
+	for k, v := range s.getStatusInfo() {
+		stats[k] = v
+	}
+
+	return nil
+}
+
+func (s statusProvider) Text(buffer io.Writer) error {
+	return renderText(buffer, s.getStatusInfo())
+}
+
+func (s statusProvider) HTML(buffer io.Writer) error {
+	return renderHTML(buffer, s.getStatusInfo())
+}
+
+//go:embed status_templates
+var templatesFS embed.FS
+
+func renderHTML(buffer io.Writer, data any) error {
+	tmpl, tmplErr := templatesFS.ReadFile(path.Join("status_templates", "statusHTML.tmpl"))
+	if tmplErr != nil {
+		return tmplErr
+	}
+	t := htmlTemplate.Must(htmlTemplate.New("inventoryHTML").Funcs(status.HTMLFmap()).Parse(string(tmpl)))
+	return t.Execute(buffer, data)
+}
+
+func renderText(buffer io.Writer, data any) error {
+	tmpl, tmplErr := templatesFS.ReadFile(path.Join("status_templates", "status.tmpl"))
+	if tmplErr != nil {
+		return tmplErr
+	}
+	t := textTemplate.Must(textTemplate.New("inventory").Funcs(status.HTMLFmap()).Parse(string(tmpl)))
+	return t.Execute(buffer, data)
+}

--- a/comp/metadata/inventoryagent/status_templates/status.tmpl
+++ b/comp/metadata/inventoryagent/status_templates/status.tmpl
@@ -1,0 +1,3 @@
+{{- range $key, $value := . }}
+  {{ $key }}: {{ $value }}
+{{- end }}

--- a/comp/metadata/inventoryagent/status_templates/statusHTML.tmpl
+++ b/comp/metadata/inventoryagent/status_templates/statusHTML.tmpl
@@ -1,0 +1,8 @@
+<div class="stat">
+  <span class="stat_title">Metadata</span>
+  <span class="stat_data">
+  {{- range $key, $value := . }}
+    {{ $key }}: {{ $value }}<br>
+  {{- end }}
+  </span>
+</div>

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -447,8 +447,8 @@ func run(
 	for _, c := range cs {
 		s := runCheck(cliParams, c, printer)
 		var checkResult map[string]interface{}
-		bytes, _ := json.Marshal(s)
-		json.Unmarshal(bytes, &checkResult)
+		resultBytes, _ := json.Marshal(s)
+		json.Unmarshal(resultBytes, &checkResult)
 		checkMap := make(map[string]interface{})
 
 		checkMap[string(c.ID())] = checkResult
@@ -528,8 +528,16 @@ func run(
 				checkFileOutput.WriteString(data + "\n")
 			}
 
-			checkStatus, _ := statusComponent.Render(status.CollectorSection, "text", collectorData)
-			p(string(checkStatus))
+			// workaround to this one use case of the status component
+			// we want to render the collector text format with custom data
+			collectorProvider := statuscollector.StatusProvider()
+			buffer := new(bytes.Buffer)
+			err := collectorProvider.TextWithData(buffer, collectorData)
+			if err != nil {
+				return err
+			}
+
+			p(buffer.String())
 
 			p("  Metadata\n  ========")
 

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -35,6 +35,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/comp/core/status/statusimpl"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/replay"
@@ -55,13 +57,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/cli/standalone"
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/stats"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	statuscollector "github.com/DataDog/datadog-agent/pkg/status/collector"
-	"github.com/DataDog/datadog-agent/pkg/status/render"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
@@ -172,6 +172,11 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 					return demultiplexerimpl.Params{Options: opts}
 				}),
 
+				fx.Supply(
+					status.NewInformationProvider(statuscollector.StatusProvider()),
+				),
+				statusimpl.Module(),
+
 				// TODO(components): this is a temporary hack as the StartServer() method of the API package was previously called with nil arguments
 				// This highlights the fact that the API Server created by JMX (through ExecJmx... function) should be different from the ones created
 				// in others commands such as run.
@@ -230,6 +235,7 @@ func run(
 	secretResolver secrets.Component,
 	agentAPI internalAPI.Component,
 	invChecks inventorychecks.Component,
+	statusComponent status.Component,
 ) error {
 	previousIntegrationTracing := false
 	previousIntegrationTracingExhaustive := false
@@ -424,12 +430,28 @@ func run(
 	var checkFileOutput bytes.Buffer
 	var instancesData []interface{}
 	printer := aggregator.AgentDemultiplexerPrinter{DemultiplexerWithAggregator: demultiplexer}
-	collectorData := statuscollector.GetStatusInfo()
+	data, err := statusComponent.GetStatusBySection(status.CollectorSection, "json", false)
+
+	if err != nil {
+		return err
+	}
+
+	collectorData := map[string]interface{}{}
+	err = json.Unmarshal(data, &collectorData)
+
+	if err != nil {
+		return err
+	}
+
 	checkRuns := collectorData["runnerStats"].(map[string]interface{})["Checks"].(map[string]interface{})
 	for _, c := range cs {
 		s := runCheck(cliParams, c, printer)
-		checkMap := make(map[checkid.ID]*stats.Stats)
-		checkMap[c.ID()] = s
+		var checkResult map[string]interface{}
+		bytes, _ := json.Marshal(s)
+		json.Unmarshal(bytes, &checkResult)
+		checkMap := make(map[string]interface{})
+
+		checkMap[string(c.ID())] = checkResult
 		checkRuns[c.String()] = checkMap
 
 		// Sleep for a while to allow the aggregator to finish ingesting all the metrics/events/sc
@@ -506,9 +528,8 @@ func run(
 				checkFileOutput.WriteString(data + "\n")
 			}
 
-			statusJSON, _ := json.Marshal(collectorData)
-			checkStatus, _ := render.FormatCheckStats(statusJSON)
-			p(checkStatus)
+			checkStatus, _ := statusComponent.Render(status.CollectorSection, "text", collectorData)
+			p(string(checkStatus))
 
 			p("  Metadata\n  ========")
 

--- a/pkg/status/collector/collector.go
+++ b/pkg/status/collector/collector.go
@@ -117,6 +117,14 @@ func (provider) HTML(buffer io.Writer) error {
 	return render.RenderHTMLStatusTemplate(buffer, "/collectorHTML.tmpl", GetStatusInfo())
 }
 
+func (provider) TextWithData(buffer io.Writer, data any) error {
+	return render.RenderStatusTemplate(buffer, "/collector.tmpl", data)
+}
+
+func (provider) HTMLWithData(buffer io.Writer, data any) error {
+	return render.RenderHTMLStatusTemplate(buffer, "/collectorHTML.tmpl", data)
+}
+
 func StatusProvider() status.Provider {
 	return provider{}
 }

--- a/pkg/status/collector/collector.go
+++ b/pkg/status/collector/collector.go
@@ -10,6 +10,10 @@ package collector
 import (
 	"encoding/json"
 	"expvar"
+	"io"
+
+	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/pkg/status/render"
 )
 
 // GetStatusInfo retrives collector information
@@ -87,4 +91,33 @@ func PopulateStatus(stats map[string]interface{}) {
 		}
 	}
 	stats["inventories"] = checkMetadata
+}
+
+type provider struct{}
+
+func (provider) Name() string {
+	return "Collector"
+}
+
+func (provider) Section() string {
+	return status.CollectorSection
+}
+
+func (provider) JSON(stats map[string]interface{}) error {
+	PopulateStatus(stats)
+
+	return nil
+}
+
+func (provider) Text(buffer io.Writer) error {
+	render.RenderStatusTemplate(buffer, "/collector.tmpl", GetStatusInfo())
+	return nil
+}
+
+func (provider) HTML(buffer io.Writer) error {
+	return nil
+}
+
+func StatusProvider() status.Provider {
+	return provider{}
 }

--- a/pkg/status/collector/collector.go
+++ b/pkg/status/collector/collector.go
@@ -110,12 +110,11 @@ func (provider) JSON(stats map[string]interface{}) error {
 }
 
 func (provider) Text(buffer io.Writer) error {
-	render.RenderStatusTemplate(buffer, "/collector.tmpl", GetStatusInfo())
-	return nil
+	return render.RenderStatusTemplate(buffer, "/collector.tmpl", GetStatusInfo())
 }
 
 func (provider) HTML(buffer io.Writer) error {
-	return nil
+	return render.RenderHTMLStatusTemplate(buffer, "/collectorHTML.tmpl", GetStatusInfo())
 }
 
 func StatusProvider() status.Provider {

--- a/pkg/status/collector/collector.go
+++ b/pkg/status/collector/collector.go
@@ -93,38 +93,34 @@ func PopulateStatus(stats map[string]interface{}) {
 	stats["inventories"] = checkMetadata
 }
 
-type provider struct{}
+type Provider struct{}
 
-func (provider) Name() string {
+func (Provider) Name() string {
 	return "Collector"
 }
 
-func (provider) Section() string {
+func (Provider) Section() string {
 	return status.CollectorSection
 }
 
-func (provider) JSON(stats map[string]interface{}) error {
+func (Provider) JSON(stats map[string]interface{}) error {
 	PopulateStatus(stats)
 
 	return nil
 }
 
-func (provider) Text(buffer io.Writer) error {
+func (Provider) Text(buffer io.Writer) error {
 	return render.RenderStatusTemplate(buffer, "/collector.tmpl", GetStatusInfo())
 }
 
-func (provider) HTML(buffer io.Writer) error {
+func (Provider) HTML(buffer io.Writer) error {
 	return render.RenderHTMLStatusTemplate(buffer, "/collectorHTML.tmpl", GetStatusInfo())
 }
 
-func (provider) TextWithData(buffer io.Writer, data any) error {
+func (Provider) TextWithData(buffer io.Writer, data any) error {
 	return render.RenderStatusTemplate(buffer, "/collector.tmpl", data)
 }
 
-func (provider) HTMLWithData(buffer io.Writer, data any) error {
-	return render.RenderHTMLStatusTemplate(buffer, "/collectorHTML.tmpl", data)
-}
-
-func StatusProvider() status.Provider {
-	return provider{}
+func StatusProvider() Provider {
+	return Provider{}
 }

--- a/pkg/status/render/render.go
+++ b/pkg/status/render/render.go
@@ -30,25 +30,25 @@ func FormatStatus(data []byte) (string, error) {
 	stats["title"] = title
 
 	var b = new(bytes.Buffer)
-	headerFunc := func() error { return renderStatusTemplate(b, "/header.tmpl", stats) }
+	headerFunc := func() error { return RenderStatusTemplate(b, "/header.tmpl", stats) }
 	checkStatsFunc := func() error {
-		return renderStatusTemplate(b, "/collector.tmpl", stats)
+		return RenderStatusTemplate(b, "/collector.tmpl", stats)
 	}
-	jmxFetchFunc := func() error { return renderStatusTemplate(b, "/jmxfetch.tmpl", stats) }
-	forwarderFunc := func() error { return renderStatusTemplate(b, "/forwarder.tmpl", stats) }
-	endpointsFunc := func() error { return renderStatusTemplate(b, "/endpoints.tmpl", stats) }
-	logsAgentFunc := func() error { return renderStatusTemplate(b, "/logsagent.tmpl", stats) }
-	systemProbeFunc := func() error { return renderStatusTemplate(b, "/systemprobe.tmpl", stats) }
-	processAgentFunc := func() error { return renderStatusTemplate(b, "/process-agent.tmpl", stats) }
-	traceAgentFunc := func() error { return renderStatusTemplate(b, "/trace-agent.tmpl", stats) }
-	aggregatorFunc := func() error { return renderStatusTemplate(b, "/aggregator.tmpl", stats) }
-	dogstatsdFunc := func() error { return renderStatusTemplate(b, "/dogstatsd.tmpl", stats) }
-	clusterAgentFunc := func() error { return renderStatusTemplate(b, "/clusteragent.tmpl", stats) }
-	snmpTrapFunc := func() error { return renderStatusTemplate(b, "/snmp-traps.tmpl", stats) }
-	netflowFunc := func() error { return renderStatusTemplate(b, "/netflow.tmpl", stats) }
-	autodiscoveryFunc := func() error { return renderStatusTemplate(b, "/autodiscovery.tmpl", stats) }
-	remoteConfigFunc := func() error { return renderStatusTemplate(b, "/remoteconfig.tmpl", stats) }
-	otlpFunc := func() error { return renderStatusTemplate(b, "/otlp.tmpl", stats) }
+	jmxFetchFunc := func() error { return RenderStatusTemplate(b, "/jmxfetch.tmpl", stats) }
+	forwarderFunc := func() error { return RenderStatusTemplate(b, "/forwarder.tmpl", stats) }
+	endpointsFunc := func() error { return RenderStatusTemplate(b, "/endpoints.tmpl", stats) }
+	logsAgentFunc := func() error { return RenderStatusTemplate(b, "/logsagent.tmpl", stats) }
+	systemProbeFunc := func() error { return RenderStatusTemplate(b, "/systemprobe.tmpl", stats) }
+	processAgentFunc := func() error { return RenderStatusTemplate(b, "/process-agent.tmpl", stats) }
+	traceAgentFunc := func() error { return RenderStatusTemplate(b, "/trace-agent.tmpl", stats) }
+	aggregatorFunc := func() error { return RenderStatusTemplate(b, "/aggregator.tmpl", stats) }
+	dogstatsdFunc := func() error { return RenderStatusTemplate(b, "/dogstatsd.tmpl", stats) }
+	clusterAgentFunc := func() error { return RenderStatusTemplate(b, "/clusteragent.tmpl", stats) }
+	snmpTrapFunc := func() error { return RenderStatusTemplate(b, "/snmp-traps.tmpl", stats) }
+	netflowFunc := func() error { return RenderStatusTemplate(b, "/netflow.tmpl", stats) }
+	autodiscoveryFunc := func() error { return RenderStatusTemplate(b, "/autodiscovery.tmpl", stats) }
+	remoteConfigFunc := func() error { return RenderStatusTemplate(b, "/remoteconfig.tmpl", stats) }
+	otlpFunc := func() error { return RenderStatusTemplate(b, "/otlp.tmpl", stats) }
 
 	var renderFuncs []func() error
 	if config.IsCLCRunner() {
@@ -89,26 +89,26 @@ func FormatDCAStatus(data []byte) (string, error) {
 
 	var b = new(bytes.Buffer)
 	var errs []error
-	if err := renderStatusTemplate(b, "/header.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/header.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
-	if err := renderStatusTemplate(b, "/collector.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/collector.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
-	if err := renderStatusTemplate(b, "/forwarder.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/forwarder.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
-	if err := renderStatusTemplate(b, "/endpoints.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/endpoints.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
-	if err := renderStatusTemplate(b, "/logsagent.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/logsagent.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
-	if err := renderStatusTemplate(b, "/autodiscovery.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/autodiscovery.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
 
-	if err := renderStatusTemplate(b, "/orchestrator.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/orchestrator.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
 	if err := renderErrors(b, errs); err != nil {
@@ -126,7 +126,7 @@ func FormatHPAStatus(data []byte) (string, error) {
 	}
 	var b = new(bytes.Buffer)
 	var errs []error
-	if err := renderStatusTemplate(b, "/custommetricsprovider.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/custommetricsprovider.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
 	if err := renderErrors(b, errs); err != nil {
@@ -147,13 +147,13 @@ func FormatSecurityAgentStatus(data []byte) (string, error) {
 
 	var b = new(bytes.Buffer)
 	var errs []error
-	if err := renderStatusTemplate(b, "/header.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/header.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
-	if err := renderStatusTemplate(b, "/runtimesecurity.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/runtimesecurity.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
-	if err := renderStatusTemplate(b, "/compliance.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/compliance.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
 	if err := renderErrors(b, errs); err != nil {
@@ -171,7 +171,7 @@ func FormatProcessAgentStatus(data []byte) (string, error) {
 	}
 	var b = new(bytes.Buffer)
 	var errs []error
-	if err := renderStatusTemplate(b, "/process-agent.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/process-agent.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
 	if err := renderErrors(b, errs); err != nil {
@@ -189,7 +189,7 @@ func FormatMetadataMapCLI(data []byte) (string, error) {
 	}
 	var b = new(bytes.Buffer)
 	var errs []error
-	if err := renderStatusTemplate(b, "/metadatamapper.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/metadatamapper.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
 	if err := renderErrors(b, errs); err != nil {
@@ -207,7 +207,7 @@ func FormatCheckStats(data []byte) (string, error) {
 
 	var b = new(bytes.Buffer)
 	var errs []error
-	if err := renderStatusTemplate(b, "/collector.tmpl", stats); err != nil {
+	if err := RenderStatusTemplate(b, "/collector.tmpl", stats); err != nil {
 		errs = append(errs, err)
 	}
 	if err := renderErrors(b, errs); err != nil {
@@ -220,7 +220,8 @@ func FormatCheckStats(data []byte) (string, error) {
 //go:embed templates
 var templatesFS embed.FS
 
-func renderStatusTemplate(w io.Writer, templateName string, stats interface{}) error {
+// RenderStatusTemplate
+func RenderStatusTemplate(w io.Writer, templateName string, stats interface{}) error {
 	tmpl, tmplErr := templatesFS.ReadFile(path.Join("templates", templateName))
 	if tmplErr != nil {
 		return tmplErr
@@ -231,7 +232,7 @@ func renderStatusTemplate(w io.Writer, templateName string, stats interface{}) e
 
 func renderErrors(w io.Writer, errs []error) error {
 	if len(errs) > 0 {
-		return renderStatusTemplate(w, "/rendererrors.tmpl", errs)
+		return RenderStatusTemplate(w, "/rendererrors.tmpl", errs)
 	}
 	return nil
 }

--- a/pkg/status/render/render.go
+++ b/pkg/status/render/render.go
@@ -11,6 +11,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	htmlTemplate "html/template"
 	"io"
 	"path"
 	"text/template"
@@ -19,6 +20,7 @@ import (
 )
 
 var fmap = Textfmap()
+var htmlfmap = Fmap()
 
 // FormatStatus takes a json bytestring and prints out the formatted statuspage
 func FormatStatus(data []byte) (string, error) {
@@ -227,6 +229,16 @@ func RenderStatusTemplate(w io.Writer, templateName string, stats interface{}) e
 		return tmplErr
 	}
 	t := template.Must(template.New(templateName).Funcs(fmap).Parse(string(tmpl)))
+	return t.Execute(w, stats)
+}
+
+// RenderHTMLStatusTemplate
+func RenderHTMLStatusTemplate(w io.Writer, templateName string, stats interface{}) error {
+	tmpl, tmplErr := templatesFS.ReadFile(path.Join("templates", templateName))
+	if tmplErr != nil {
+		return tmplErr
+	}
+	t := htmlTemplate.Must(htmlTemplate.New(templateName).Funcs(htmlfmap).Parse(string(tmpl)))
 	return t.Execute(w, stats)
 }
 

--- a/pkg/status/render/templates/collector.tmpl
+++ b/pkg/status/render/templates/collector.tmpl
@@ -2,10 +2,7 @@
 NOTE: Changes made to this template should be reflected on the following templates, if applicable:
 * cmd/agent/gui/views/templates/collectorStatus.tmpl
 * cmd/agent/gui/views/templates/singleCheck.tmpl
-*/}}=========
-Collector
-=========
-
+*/}}
 {{- with .pythonInit -}}
   {{- if .Errors }}
   Error initializing Python

--- a/pkg/status/render/templates/collectorHTML.tmpl
+++ b/pkg/status/render/templates/collectorHTML.tmpl
@@ -1,0 +1,137 @@
+{{ with .pythonInit }}
+  {{- if .Errors }}
+  <div class="stat">
+    <span class="stat_title">Error initializing Python</span>
+    <span class="stat_data">
+    {{ range $err := .Errors -}}
+      <span class="stat_subdata">
+        {{ $err -}}
+      </span>
+    {{ end }}
+    </span>
+  {{- end -}}
+  </div>
+{{- end }}
+
+<div class="stat">
+  <span class="stat_title">Running Checks</span>
+  <span class="stat_data">
+    {{- with .runnerStats -}}
+      {{- if and (not .Runs) (not .Checks)}}
+        No checks have run yet
+      {{end -}}
+      {{- range $CheckName, $CheckInstances := .Checks}}
+        {{ $version := version $CheckInstances}}
+        <span class="stat_subtitle">{{$CheckName}}{{ if $version }} ({{$version}}){{ end }}</span>
+        {{- range $instance := $CheckInstances }}
+          <span class="stat_subdata">
+              Instance ID: {{.CheckID}} {{status .}}<br>
+              Total Runs: {{humanize .TotalRuns}}<br>
+              Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
+              Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
+              {{- range $k, $v := .TotalEventPlatformEvents }}
+              {{ $k }}: Last Run: {{humanize (index $instance.EventPlatformEvents $k) }}, Total: {{humanize $v}}<br>
+              {{- end -}}
+              Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
+              {{- if .TotalHistogramBuckets}}
+              Histogram Buckets: {{humanize .HistogramBuckets}}, Total: {{humanize .TotalHistogramBuckets}}<br>
+              {{- end -}}
+              Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}<br>
+              Last Execution Date : {{formatUnixTime .UpdateTimestamp}}<br>
+              Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}<br>
+              {{- if index $.inventories .CheckID }}
+              Metadata:<br>
+              <span class="stat_subdata">
+                {{- range $k, $v := index $.inventories .CheckID }}
+                  {{ $k }}: {{ $v }}<br>
+                {{- end }}
+              </span>
+              {{- end }}
+            {{- if .LastError}}
+              <span class="error">Error</span>: {{lastErrorMessage .LastError}}<br>
+                    {{lastErrorTraceback .LastError -}}
+            {{- end -}}
+            {{- if .LastWarnings}}
+              {{- range .LastWarnings }}
+                <span class="warning">Warning</span>: {{.}}<br>
+              {{- end -}}
+            {{- end -}}
+          </span>
+        {{ end }}
+      {{- end -}}
+    {{- end -}}
+    <span/>
+</div>
+
+{{- with .pyLoaderStats }}
+  {{- if .Py3Warnings }}
+  <div class="stat">
+    <span class="stat_title">Python 3 Linter Warnings</span>
+    <span class="stat_data">
+    {{ range $checkname, $warnings :=  .Py3Warnings }}
+        <span class="stat_subtitle">{{$checkname}}</span>
+        <span class="stat_subdata">
+          {{- range $idx, $warning := $warnings}}
+            {{pythonLoaderError $warning}}<br>
+          {{- end }}
+        </span>
+    {{- end}}
+    </span>
+  </div>
+  {{- end }}
+  {{- if .ConfigureErrors }}
+  <div class="stat">
+    <span class="stat_title">Check Initialization Errors</span>
+    <span class="stat_data">
+    {{ range $checkname, $errors :=  .ConfigureErrors }}
+        <span class="stat_subtitle">{{$checkname}}</span>
+        <span class="stat_subdata">
+          {{- range $idx, $err := $errors}}
+            <span class="stat_subtitle">Instance {{$idx}}</span>
+            <span class="stat_subdata">
+              {{ pythonLoaderError $err }}
+            </span>
+          {{- end }}
+        </span>
+    {{- end}}
+    </span>
+  </div>
+  {{- end }}
+{{- end }}
+
+{{- with .autoConfigStats -}}
+  {{- if .ConfigErrors}}
+    <div class="stat">
+      <span class="stat_title">Config Errors</span>
+      <span class="stat_data">
+        {{- range $checkname, $error := .ConfigErrors}}
+          <span class="stat_subtitle">{{$checkname}}</span>
+          <span class="stat_subdata">
+            {{ $error -}}
+          </span>
+        {{end -}}
+      </span>
+    </div>
+  {{- end}}
+{{- end}}
+{{- with .checkSchedulerStats }}
+  {{- if .LoaderErrors}}
+    <div class="stat">
+      <span class="stat_title">Loading Errors</span>
+      <span class="stat_data">
+        {{- range $checkname, $errors := .LoaderErrors}}
+          <span class="stat_subtitle">{{$checkname}}</span>
+          <span class="stat_subdata">
+            {{- range $kind, $err := $errors -}}
+              {{- if eq $kind "Python Check Loader"}}
+                <b>{{$kind}}</b>: {{ pythonLoaderError $err -}}<br>
+              {{- else}}
+                <b>{{$kind}}</b>: {{ $err -}}<br>
+              {{end -}}
+            {{end -}}
+          </span>
+        {{end -}}
+      </span>
+    </div>
+  {{- end}}
+{{end -}}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -321,14 +321,6 @@ func getCommonStatus(invAgent inventoryagent.Component) (map[string]interface{},
 
 func expvarStats(stats map[string]interface{}, invAgent inventoryagent.Component) (map[string]interface{}, error) {
 	var err error
-	forwarderStatsJSON := []byte(expvar.Get("forwarder").String())
-	forwarderStats := make(map[string]interface{})
-	json.Unmarshal(forwarderStatsJSON, &forwarderStats) //nolint:errcheck
-	forwarderStorageMaxSizeInBytes := config.Datadog.GetInt("forwarder_storage_max_size_in_bytes")
-	if forwarderStorageMaxSizeInBytes > 0 {
-		forwarderStats["forwarder_storage_max_size_in_bytes"] = strconv.Itoa(forwarderStorageMaxSizeInBytes)
-	}
-	stats["forwarderStats"] = forwarderStats
 
 	collector.PopulateStatus(stats)
 


### PR DESCRIPTION
THIS PR IS NOT INTENDED TO BE MERGE IS TO VALIDATE A PROOF OF CONCEPT

With these changes, we can validate the use of the status component for rendering the status output 

Steps to reproduce it locally:
1. Pull the branch to your machine
2. build the agent `invoke agent.build --build-exclude=systemd`
3. run the agent `./bin/agent/agent run -c dev/dist/datadog.yaml`
4. Request the status output 
  4.1 ` ./bin/agent/agent status -c dev/dist/datadog.yaml` Text format
  4.2 ` ./bin/agent/agent status -c -p dev/dist/datadog.yaml` JSON format
  4.3 Launch gui `./bin/agent/agent launch-gui -c dev/dist/datadog.yaml` Go the collector tab 
  4.4 Output a single check output  
      - `./bin/agent/agent check cpu -c dev/dist/datadog.yaml` Text format
      - `./bin/agent/agent check cpu -c --json dev/dist/datadog.yaml` JSON format