### PR TITLE
Use sysprobeconfig in inventory agent

### DIFF
--- a/cmd/dogstatsd/subcommands/start/command.go
+++ b/cmd/dogstatsd/subcommands/start/command.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 
 	//nolint:revive // TODO(AML) Fix revive linter
 	logComponent "github.com/DataDog/datadog-agent/comp/core/log/logimpl"
@@ -154,6 +155,8 @@ func RunDogstatsdFct(cliParams *CLIParams, defaultConfPath string, defaultLogFil
 		resourcesimpl.Module(),
 		hostimpl.Module(),
 		inventoryagent.Module(),
+		// sysprobeconfig is optionally required by inventoryagent
+		sysprobeconfig.NoneModule(),
 		inventoryhostimpl.Module(),
 	)
 }

--- a/cmd/system-probe/api/module/factory_linux.go
+++ b/cmd/system-probe/api/module/factory_linux.go
@@ -7,12 +7,14 @@
 
 package module
 
-import "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+import (
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
+)
 
 // Factory encapsulates the initialization of a Module
 type Factory struct {
-	Name             config.ModuleName
+	Name             sysconfigtypes.ModuleName
 	ConfigNamespaces []string
-	Fn               func(cfg *config.Config) (Module, error)
+	Fn               func(cfg *sysconfigtypes.Config) (Module, error)
 	NeedsEBPF        func() bool
 }

--- a/cmd/system-probe/api/module/factory_others.go
+++ b/cmd/system-probe/api/module/factory_others.go
@@ -7,11 +7,13 @@
 
 package module
 
-import "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+import (
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
+)
 
 // Factory encapsulates the initialization of a Module
 type Factory struct {
-	Name             config.ModuleName
+	Name             sysconfigtypes.ModuleName
 	ConfigNamespaces []string
-	Fn               func(cfg *config.Config) (Module, error)
+	Fn               func(cfg *sysconfigtypes.Config) (Module, error)
 }

--- a/cmd/system-probe/api/module/loader_linux.go
+++ b/cmd/system-probe/api/module/loader_linux.go
@@ -8,7 +8,7 @@
 package module
 
 import (
-	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 )
 
@@ -21,14 +21,14 @@ func isEBPFRequired(factories []Factory) bool {
 	return false
 }
 
-func preRegister(_ *config.Config, moduleFactories []Factory) error {
+func preRegister(_ *sysconfigtypes.Config, moduleFactories []Factory) error {
 	if isEBPFRequired(moduleFactories) {
 		return ebpf.Setup(ebpf.NewConfig())
 	}
 	return nil
 }
 
-func postRegister(_ *config.Config, moduleFactories []Factory) error {
+func postRegister(_ *sysconfigtypes.Config, moduleFactories []Factory) error {
 	if isEBPFRequired(moduleFactories) {
 		ebpf.FlushBTF()
 	}

--- a/cmd/system-probe/api/module/loader_unsupported.go
+++ b/cmd/system-probe/api/module/loader_unsupported.go
@@ -7,12 +7,12 @@
 
 package module
 
-import "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+import sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 
-func preRegister(_ *config.Config, _ []Factory) error {
+func preRegister(_ *sysconfigtypes.Config, _ []Factory) error {
 	return nil
 }
 
-func postRegister(_ *config.Config, _ []Factory) error {
+func postRegister(_ *sysconfigtypes.Config, _ []Factory) error {
 	return nil
 }

--- a/cmd/system-probe/api/module/loader_windows.go
+++ b/cmd/system-probe/api/module/loader_windows.go
@@ -8,19 +8,19 @@ package module
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/network/driver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func preRegister(cfg *config.Config, _ []Factory) error {
+func preRegister(cfg *sysconfigtypes.Config, _ []Factory) error {
 	if err := driver.Init(cfg); err != nil {
 		return fmt.Errorf("failed to load driver subsystem: %v", err)
 	}
 	return nil
 }
 
-func postRegister(_ *config.Config, _ []Factory) error {
+func postRegister(_ *sysconfigtypes.Config, _ []Factory) error {
 	if !driver.IsNeeded() {
 		// if running, shut it down
 		log.Debug("Shutting down the driver.  Upon successful initialization, it was not needed by the current configuration.")

--- a/cmd/system-probe/api/restart.go
+++ b/cmd/system-probe/api/restart.go
@@ -12,12 +12,13 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/modules"
 )
 
 func restartModuleHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	moduleName := config.ModuleName(vars["module-name"])
+	moduleName := sysconfigtypes.ModuleName(vars["module-name"])
 
 	if moduleName == config.EventMonitorModule {
 		w.WriteHeader(http.StatusOK)

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -19,7 +19,7 @@ import (
 	"google.golang.org/grpc/stats"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
-	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/modules"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
@@ -31,7 +31,7 @@ import (
 const maxGRPCServerMessage = 100 * 1024 * 1024
 
 // StartServer starts the HTTP and gRPC servers for the system-probe, which registers endpoints from all enabled modules.
-func StartServer(cfg *config.Config, telemetry telemetry.Component) error {
+func StartServer(cfg *sysconfigtypes.Config, telemetry telemetry.Component) error {
 	conn, err := net.NewListener(cfg.SocketAddress)
 	if err != nil {
 		return fmt.Errorf("error creating IPC socket: %s", err)

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -15,14 +15,12 @@ import (
 
 	"github.com/DataDog/viper"
 
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	aconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
-
-// ModuleName is a typed alias for string, used only for module names
-type ModuleName string
 
 const (
 	// Namespace is the top-level configuration key that all system-probe settings are nested underneath
@@ -31,51 +29,27 @@ const (
 
 // system-probe module names
 const (
-	NetworkTracerModule          ModuleName = "network_tracer"
-	OOMKillProbeModule           ModuleName = "oom_kill_probe"
-	TCPQueueLengthTracerModule   ModuleName = "tcp_queue_length_tracer"
-	ProcessModule                ModuleName = "process"
-	EventMonitorModule           ModuleName = "event_monitor"
-	DynamicInstrumentationModule ModuleName = "dynamic_instrumentation"
-	EBPFModule                   ModuleName = "ebpf"
-	LanguageDetectionModule      ModuleName = "language_detection"
-	WindowsCrashDetectModule     ModuleName = "windows_crash_detection"
-	ComplianceModule             ModuleName = "compliance"
+	NetworkTracerModule          types.ModuleName = "network_tracer"
+	OOMKillProbeModule           types.ModuleName = "oom_kill_probe"
+	TCPQueueLengthTracerModule   types.ModuleName = "tcp_queue_length_tracer"
+	ProcessModule                types.ModuleName = "process"
+	EventMonitorModule           types.ModuleName = "event_monitor"
+	DynamicInstrumentationModule types.ModuleName = "dynamic_instrumentation"
+	EBPFModule                   types.ModuleName = "ebpf"
+	LanguageDetectionModule      types.ModuleName = "language_detection"
+	WindowsCrashDetectModule     types.ModuleName = "windows_crash_detection"
+	ComplianceModule             types.ModuleName = "compliance"
 )
 
-// Config represents the configuration options for the system-probe
-type Config struct {
-	Enabled        bool
-	EnabledModules map[ModuleName]struct{}
-
-	// When the system-probe is enabled in a separate container, we need a way to also disable the system-probe
-	// packaged in the main agent container (without disabling network collection on the process-agent).
-	ExternalSystemProbe bool
-
-	SocketAddress      string
-	MaxConnsPerMessage int
-
-	LogFile          string
-	LogLevel         string
-	DebugPort        int
-	HealthPort       int
-	TelemetryEnabled bool
-
-	StatsdHost string
-	StatsdPort int
-
-	GRPCServerEnabled bool
-}
-
 // New creates a config object for system-probe. It assumes no configuration has been loaded as this point.
-func New(configPath string) (*Config, error) {
+func New(configPath string) (*types.Config, error) {
 	return newSysprobeConfig(configPath)
 }
 
-func newSysprobeConfig(configPath string) (*Config, error) {
+func newSysprobeConfig(configPath string) (*types.Config, error) {
 	// System probe is not supported on darwin, so we should fail gracefully in this case.
 	if runtime.GOOS == "darwin" {
-		return &Config{}, nil
+		return &types.Config{}, nil
 	}
 
 	aconfig.SystemProbe.SetConfigName("system-probe")
@@ -111,13 +85,13 @@ func newSysprobeConfig(configPath string) (*Config, error) {
 	return load()
 }
 
-func load() (*Config, error) {
+func load() (*types.Config, error) {
 	cfg := aconfig.SystemProbe
 	Adjust(cfg)
 
-	c := &Config{
+	c := &types.Config{
 		Enabled:             cfg.GetBool(spNS("enabled")),
-		EnabledModules:      make(map[ModuleName]struct{}),
+		EnabledModules:      make(map[types.ModuleName]struct{}),
 		ExternalSystemProbe: cfg.GetBool(spNS("external")),
 
 		SocketAddress:      cfg.GetString(spNS("sysprobe_socket")),
@@ -185,12 +159,6 @@ func load() (*Config, error) {
 	cfg.Set(spNS("enabled"), c.Enabled, model.SourceAgentRuntime)
 
 	return c, nil
-}
-
-// ModuleIsEnabled returns a bool indicating if the given module name is enabled.
-func (c Config) ModuleIsEnabled(modName ModuleName) bool {
-	_, ok := c.EnabledModules[modName]
-	return ok
 }
 
 // SetupOptionalDatadogConfigWithDir loads the datadog.yaml config file from a given config directory but will not fail on a missing file

--- a/cmd/system-probe/config/types/config.go
+++ b/cmd/system-probe/config/types/config.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package types contains the different types used by the system-probe config.
+//
+// This types are extracted to their own module so other can link against it without compiling with the entire
+// system-probe code base.
+package types
+
+// ModuleName is a typed alias for string, used only for module names
+type ModuleName string
+
+// Config represents the configuration options for the system-probe
+type Config struct {
+	Enabled        bool
+	EnabledModules map[ModuleName]struct{}
+
+	// When the system-probe is enabled in a separate container, we need a way to also disable the system-probe
+	// packaged in the main agent container (without disabling network collection on the process-agent).
+	ExternalSystemProbe bool
+
+	SocketAddress      string
+	MaxConnsPerMessage int
+
+	LogFile          string
+	LogLevel         string
+	DebugPort        int
+	HealthPort       int
+	TelemetryEnabled bool
+
+	StatsdHost string
+	StatsdPort int
+
+	GRPCServerEnabled bool
+}
+
+// ModuleIsEnabled returns a bool indicating if the given module name is enabled.
+func (c Config) ModuleIsEnabled(modName ModuleName) bool {
+	_, ok := c.EnabledModules[modName]
+	return ok
+}

--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/compliance/dbconfig"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -34,7 +35,7 @@ import (
 var ComplianceModule = module.Factory{
 	Name:             config.ComplianceModule,
 	ConfigNamespaces: []string{},
-	Fn: func(cfg *config.Config) (module.Module, error) {
+	Fn: func(cfg *sysconfigtypes.Config) (module.Module, error) {
 		return &complianceModule{}, nil
 	},
 	NeedsEBPF: func() bool {

--- a/cmd/system-probe/modules/crashdetect_windows.go
+++ b/cmd/system-probe/modules/crashdetect_windows.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/wincrashdetect/probe"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -24,7 +25,7 @@ import (
 var WinCrashProbe = module.Factory{
 	Name:             config.WindowsCrashDetectModule,
 	ConfigNamespaces: []string{"windows_crash_detection"},
-	Fn: func(cfg *config.Config) (module.Module, error) {
+	Fn: func(cfg *sysconfigtypes.Config) (module.Module, error) {
 		log.Infof("Starting the WinCrashProbe probe")
 		cp, err := probe.NewWinCrashProbe(cfg)
 		if err != nil {

--- a/cmd/system-probe/modules/dynamic_instrumentation.go
+++ b/cmd/system-probe/modules/dynamic_instrumentation.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	dynamicinstrumentation "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 )
@@ -20,7 +21,7 @@ import (
 var DynamicInstrumentation = module.Factory{
 	Name:             config.DynamicInstrumentationModule,
 	ConfigNamespaces: []string{},
-	Fn: func(agentConfiguration *config.Config) (module.Module, error) {
+	Fn: func(agentConfiguration *sysconfigtypes.Config) (module.Module, error) {
 		config, err := dynamicinstrumentation.NewConfig(agentConfiguration)
 		if err != nil {
 			return nil, fmt.Errorf("invalid dynamic instrumentation module configuration: %w", err)

--- a/cmd/system-probe/modules/ebpf.go
+++ b/cmd/system-probe/modules/ebpf.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -27,7 +28,7 @@ import (
 var EBPFProbe = module.Factory{
 	Name:             config.EBPFModule,
 	ConfigNamespaces: []string{},
-	Fn: func(cfg *config.Config) (module.Module, error) {
+	Fn: func(cfg *sysconfigtypes.Config) (module.Module, error) {
 		log.Infof("Starting the ebpf probe")
 		okp, err := ebpfcheck.NewProbe(ebpf.NewConfig())
 		if err != nil {

--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -9,7 +9,7 @@ package modules
 
 import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
-	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	emconfig "github.com/DataDog/datadog-agent/pkg/eventmonitor/config"
 	"github.com/DataDog/datadog-agent/pkg/network/events"
@@ -21,7 +21,7 @@ import (
 
 var eventMonitorModuleConfigNamespaces = []string{"event_monitoring_config", "runtime_security_config"}
 
-func createEventMonitorModule(sysProbeConfig *config.Config) (module.Module, error) {
+func createEventMonitorModule(sysProbeConfig *sysconfigtypes.Config) (module.Module, error) {
 	emconfig := emconfig.NewConfig(sysProbeConfig)
 
 	secconfig, err := secconfig.NewConfig()

--- a/cmd/system-probe/modules/language_detection.go
+++ b/cmd/system-probe/modules/language_detection.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/privileged"
 	languageDetectionProto "github.com/DataDog/datadog-agent/pkg/proto/pbgo/languagedetection"
@@ -27,7 +28,7 @@ import (
 var LanguageDetectionModule = module.Factory{
 	Name:             config.LanguageDetectionModule,
 	ConfigNamespaces: []string{"language_detection"},
-	Fn: func(cfg *config.Config) (module.Module, error) {
+	Fn: func(cfg *sysconfigtypes.Config) (module.Module, error) {
 		return &languageDetectionModule{
 			languageDetector: privileged.NewLanguageDetector(),
 		}, nil

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
-	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	networkconfig "github.com/DataDog/datadog-agent/pkg/network/config"
@@ -43,7 +43,7 @@ const inactivityRestartDuration = 20 * time.Minute
 
 var networkTracerModuleConfigNamespaces = []string{"network_config", "service_monitoring_config", "data_streams_config"}
 
-func createNetworkTracerModule(cfg *config.Config) (module.Module, error) {
+func createNetworkTracerModule(cfg *sysconfigtypes.Config) (module.Module, error) {
 	ncfg := networkconfig.New()
 
 	// Checking whether the current OS + kernel version is supported by the tracer
@@ -306,7 +306,7 @@ func writeConnections(w http.ResponseWriter, marshaler marshal.Marshaler, cs *ne
 	log.Tracef("/connections: %d connections", len(cs.Conns))
 }
 
-func startTelemetryReporter(_ *config.Config, done <-chan struct{}) {
+func startTelemetryReporter(_ *sysconfigtypes.Config, done <-chan struct{}) {
 	telemetry.SetStatsdClient(statsd.Client)
 	ticker := time.NewTicker(30 * time.Second)
 	go func() {

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/oomkill"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -27,7 +28,7 @@ import (
 var OOMKillProbe = module.Factory{
 	Name:             config.OOMKillProbeModule,
 	ConfigNamespaces: []string{},
-	Fn: func(cfg *config.Config) (module.Module, error) {
+	Fn: func(cfg *sysconfigtypes.Config) (module.Module, error) {
 		log.Infof("Starting the OOM Kill probe")
 		okp, err := oomkill.NewProbe(ebpf.NewConfig())
 		if err != nil {

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 
 	//nolint:revive // TODO(PROC) Fix revive linter
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
@@ -36,7 +37,7 @@ var ErrProcessUnsupported = errors.New("process module unsupported")
 var Process = module.Factory{
 	Name:             config.ProcessModule,
 	ConfigNamespaces: []string{},
-	Fn: func(cfg *config.Config) (module.Module, error) {
+	Fn: func(cfg *sysconfigtypes.Config) (module.Module, error) {
 		log.Infof("Creating process module for: %s", filepath.Base(os.Args[0]))
 
 		// we disable returning zero values for stats to reduce parsing work on process-agent side

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/tcpqueuelength"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -26,7 +27,7 @@ import (
 var TCPQueueLength = module.Factory{
 	Name:             config.TCPQueueLengthTracerModule,
 	ConfigNamespaces: []string{},
-	Fn: func(cfg *config.Config) (module.Module, error) {
+	Fn: func(cfg *sysconfigtypes.Config) (module.Module, error) {
 		t, err := tcpqueuelength.NewTracer(ebpf.NewConfig())
 		if err != nil {
 			return nil, fmt.Errorf("unable to start the TCP queue length tracer: %w", err)

--- a/comp/core/sysprobeconfig/component.go
+++ b/comp/core/sysprobeconfig/component.go
@@ -16,8 +16,11 @@
 package sysprobeconfig
 
 import (
-	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
+	"go.uber.org/fx"
 )
 
 // team: ebpf-platform
@@ -30,5 +33,15 @@ type Component interface {
 	Warnings() *config.Warnings
 
 	// SysProbeObject returns the wrapper sysconfig
-	SysProbeObject() *sysconfig.Config
+	SysProbeObject() *sysconfigtypes.Config
+}
+
+// NoneModule return a None optional type for sysprobeconfig.Component.
+//
+// This helper allows code that needs a disabled Optional type for sysprobeconfig to get it. The helper is split from
+// the implementation to avoid linking with the dependencies from sysprobeconfig.
+func NoneModule() fxutil.Module {
+	return fxutil.Component(fx.Provide(func() optional.Option[Component] {
+		return optional.NewNoneOption[Component]()
+	}))
 }

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
@@ -34,14 +34,25 @@ type cfg struct {
 	warnings *config.Warnings
 }
 
+// sysprobeconfigDependencies is an interface that mimics the fx-oriented dependencies struct (This is copied from the main agent configuration.)
+// The goal of this interface is to be able to call setupConfig with either 'dependencies' or 'mockDependencies'.
+// TODO: (components) investigate whether this interface is worth keeping, otherwise delete it and just use dependencies
+type sysprobeconfigDependencies interface {
+	getParams() *Params
+}
+
 type dependencies struct {
 	fx.In
 
 	Params Params
 }
 
-func setupConfig(deps dependencies) (*sysconfig.Config, error) {
-	return sysconfig.New(deps.Params.sysProbeConfFilePath)
+func (d dependencies) getParams() *Params {
+	return &d.Params
+}
+
+func setupConfig(deps sysprobeconfigDependencies) (*sysconfig.Config, error) {
+	return sysconfig.New(deps.getParams().sysProbeConfFilePath)
 }
 
 func newConfig(deps dependencies) (sysprobeconfig.Component, error) {

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
@@ -11,15 +11,21 @@ import (
 	"go.uber.org/fx"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fx.Provide(newConfig))
+		fx.Provide(newConfig),
+		fx.Provide(func(syscfg sysprobeconfig.Component) optional.Option[sysprobeconfig.Component] {
+			return optional.NewOption[sysprobeconfig.Component](syscfg)
+		}),
+	)
 }
 
 // cfg implements the Component.
@@ -28,7 +34,7 @@ type cfg struct {
 	// and uses globals in that package.
 	config.Config
 
-	syscfg *sysconfig.Config
+	syscfg *sysconfigtypes.Config
 
 	// warnings are the warnings generated during setup
 	warnings *config.Warnings
@@ -51,7 +57,7 @@ func (d dependencies) getParams() *Params {
 	return &d.Params
 }
 
-func setupConfig(deps sysprobeconfigDependencies) (*sysconfig.Config, error) {
+func setupConfig(deps sysprobeconfigDependencies) (*sysconfigtypes.Config, error) {
 	return sysconfig.New(deps.getParams().sysProbeConfFilePath)
 }
 
@@ -72,6 +78,6 @@ func (c *cfg) Object() config.Reader {
 	return c
 }
 
-func (c *cfg) SysProbeObject() *sysconfig.Config {
+func (c *cfg) SysProbeObject() *sysconfigtypes.Config {
 	return c.syscfg
 }

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/config_mock.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/config_mock.go
@@ -18,17 +18,30 @@ import (
 	"go.uber.org/fx"
 )
 
+type mockDependencies struct {
+	fx.In
+
+	Params MockParams
+}
+
+func (m mockDependencies) getParams() *Params {
+	p := m.Params.Params
+	return &p
+}
+
 // MockModule defines the fx options for the mock component.
 func MockModule() fxutil.Module {
 	return fxutil.Component(
-		fx.Provide(newMock))
+		fx.Provide(newMock),
+		fx.Supply(MockParams{}))
 }
 
-func newMock(deps dependencies, t testing.TB) sysprobeconfig.Component {
+func newMock(deps mockDependencies, t testing.TB) sysprobeconfig.Component {
 	old := config.SystemProbe
 	config.SystemProbe = config.NewConfig("mock", "XXXX", strings.NewReplacer())
 	c := &cfg{
 		warnings: &config.Warnings{},
+		Config:   config.SystemProbe,
 	}
 
 	// call InitSystemProbeConfig to set defaults.
@@ -50,6 +63,12 @@ func newMock(deps dependencies, t testing.TB) sysprobeconfig.Component {
 			os.Setenv(kvslice[0], kvslice[1])
 		}
 	})
+
+	// Overrides are explicit and will take precedence over any other
+	// setting
+	for k, v := range deps.Params.Overrides {
+		config.SystemProbe.SetWithoutSource(k, v)
+	}
 
 	// swap the existing config back at the end of the test.
 	t.Cleanup(func() { config.SystemProbe = old })

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/config_mock.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/config_mock.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"go.uber.org/fx"
 )
 
@@ -33,6 +34,9 @@ func (m mockDependencies) getParams() *Params {
 func MockModule() fxutil.Module {
 	return fxutil.Component(
 		fx.Provide(newMock),
+		fx.Provide(func(syscfg sysprobeconfig.Component) optional.Option[sysprobeconfig.Component] {
+			return optional.NewOption[sysprobeconfig.Component](syscfg)
+		}),
 		fx.Supply(MockParams{}))
 }
 

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/mock_params.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/mock_params.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+// +build test
+
+package sysprobeconfigimpl
+
+// MockParams defines the parameter for the mock config.
+// It is designed to be used with `fx.Replace` which replaces the default
+// empty value of `MockParams`.
+//
+//	fx.Replace(sysprobeconfigComponent.MockParams{Overrides: overrides})
+type MockParams struct {
+	Params
+
+	// Overrides is a parameter used to override values of the config
+	Overrides map[string]interface{}
+}

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/mock_params.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/mock_params.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build test
-// +build test
 
 package sysprobeconfigimpl
 

--- a/comp/metadata/inventoryagent/configuration_test.go
+++ b/comp/metadata/inventoryagent/configuration_test.go
@@ -14,7 +14,7 @@ import (
 func TestGetProvidedAgentConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
-	})
+	}, nil)
 
 	_, err := ia.getProvidedAgentConfiguration()
 	assert.Error(t, err)
@@ -23,7 +23,7 @@ func TestGetProvidedAgentConfigurationDisable(t *testing.T) {
 func TestGetProvidedAgentConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
-	})
+	}, nil)
 
 	data, err := ia.getProvidedAgentConfiguration()
 	assert.NoError(t, err)
@@ -33,7 +33,7 @@ func TestGetProvidedAgentConfiguration(t *testing.T) {
 func TestGetFullAgentConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
-	})
+	}, nil)
 
 	_, err := ia.getFullAgentConfiguration()
 	assert.Error(t, err)
@@ -42,7 +42,7 @@ func TestGetFullAgentConfigurationDisable(t *testing.T) {
 func TestGetFullAgentConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
-	})
+	}, nil)
 
 	data, err := ia.getFullAgentConfiguration()
 	assert.NoError(t, err)
@@ -52,7 +52,7 @@ func TestGetFullAgentConfiguration(t *testing.T) {
 func TestGetAgentFileConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
-	})
+	}, nil)
 
 	_, err := ia.getFullAgentConfiguration()
 	assert.Error(t, err)
@@ -61,7 +61,7 @@ func TestGetAgentFileConfigurationDisable(t *testing.T) {
 func TestGetAgentFileConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
-	})
+	}, nil)
 
 	data, err := ia.getAgentFileConfiguration()
 	assert.NoError(t, err)
@@ -71,7 +71,7 @@ func TestGetAgentFileConfiguration(t *testing.T) {
 func TestGetAgentEnvVarConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
-	})
+	}, nil)
 
 	_, err := ia.getAgentEnvVarConfiguration()
 	assert.Error(t, err)
@@ -80,7 +80,7 @@ func TestGetAgentEnvVarConfigurationDisable(t *testing.T) {
 func TestGetAgentEnvVarConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
-	})
+	}, nil)
 
 	data, err := ia.getAgentEnvVarConfiguration()
 	assert.NoError(t, err)
@@ -90,7 +90,7 @@ func TestGetAgentEnvVarConfiguration(t *testing.T) {
 func TestGetAgentRuntimeConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
-	})
+	}, nil)
 
 	_, err := ia.getAgentRuntimeConfiguration()
 	assert.Error(t, err)
@@ -99,7 +99,7 @@ func TestGetAgentRuntimeConfigurationDisable(t *testing.T) {
 func TestGetAgentRuntimeConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
-	})
+	}, nil)
 
 	data, err := ia.getAgentRuntimeConfiguration()
 	assert.NoError(t, err)
@@ -109,7 +109,7 @@ func TestGetAgentRuntimeConfiguration(t *testing.T) {
 func TestGetAgentRemoteConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
-	})
+	}, nil)
 
 	_, err := ia.getAgentRemoteConfiguration()
 	assert.Error(t, err)
@@ -118,7 +118,7 @@ func TestGetAgentRemoteConfigurationDisable(t *testing.T) {
 func TestGetAgentRemoteConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
-	})
+	}, nil)
 
 	data, err := ia.getAgentRemoteConfiguration()
 	assert.NoError(t, err)
@@ -128,7 +128,7 @@ func TestGetAgentRemoteConfiguration(t *testing.T) {
 func TestGetAgentCliConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
-	})
+	}, nil)
 
 	_, err := ia.getAgentCliConfiguration()
 	assert.Error(t, err)
@@ -137,7 +137,7 @@ func TestGetAgentCliConfigurationDisable(t *testing.T) {
 func TestGetAgentCliConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
-	})
+	}, nil)
 
 	data, err := ia.getAgentCliConfiguration()
 	assert.NoError(t, err)

--- a/comp/metadata/inventoryagent/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagent.go
@@ -18,9 +18,9 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/metadata/internal/util"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -60,19 +60,22 @@ func (p *Payload) SplitPayload(_ int) ([]marshaler.AbstractMarshaler, error) {
 type inventoryagent struct {
 	util.InventoryPayload
 
-	log      log.Component
-	conf     config.Component
-	m        sync.Mutex
-	data     agentMetadata
-	hostname string
+	log          log.Component
+	conf         config.Component
+	sysprobeConf sysprobeconfig.Component
+	m            sync.Mutex
+	data         agentMetadata
+	hostname     string
 }
 
 type dependencies struct {
 	fx.In
 
-	Log        log.Component
-	Config     config.Component
-	Serializer serializer.MetricSerializer
+	Log    log.Component
+	Config config.Component
+	// if sysprobeconfig was loaded we use it, if not the system probe metadata will default to false.
+	SysProbeConfig sysprobeconfig.Component `optional:"true"`
+	Serializer     serializer.MetricSerializer
 }
 
 type provides struct {
@@ -86,10 +89,11 @@ type provides struct {
 func newInventoryAgentProvider(deps dependencies) provides {
 	hname, _ := hostname.Get(context.Background())
 	ia := &inventoryagent{
-		conf:     deps.Config,
-		log:      deps.Log,
-		hostname: hname,
-		data:     make(agentMetadata),
+		conf:         deps.Config,
+		sysprobeConf: deps.SysProbeConfig,
+		log:          deps.Log,
+		hostname:     hname,
+		data:         make(agentMetadata),
 	}
 	ia.InventoryPayload = util.CreateInventoryPayload(deps.Config, deps.Log, deps.Serializer, ia.getPayload, "agent.json")
 
@@ -124,6 +128,20 @@ func (ia *inventoryagent) initData() {
 			return rv
 		}
 		return []string{}
+	}
+
+	// if system probe configuration was loaded we use it, if not we default to false
+	getBoolSysProbe := func(key string) bool {
+		if ia.sysprobeConf == nil {
+			return false
+		}
+		return ia.sysprobeConf.GetBool(key)
+	}
+	getIntSysProbe := func(key string) int {
+		if ia.sysprobeConf == nil {
+			return 0
+		}
+		return ia.sysprobeConf.GetInt(key)
 	}
 
 	tool := "undefined"
@@ -168,15 +186,15 @@ func (ia *inventoryagent) initData() {
 	ia.data["feature_cspm_host_benchmarks_enabled"] = ia.conf.GetBool("compliance_config.host_benchmarks.enabled")
 	ia.data["feature_apm_enabled"] = ia.conf.GetBool("apm_config.enabled")
 	ia.data["feature_imdsv2_enabled"] = ia.conf.GetBool("ec2_prefer_imdsv2")
-	ia.data["feature_dynamic_instrumentation_enabled"] = pkgconfig.SystemProbe.GetBool("dynamic_instrumentation.enabled")
+	ia.data["feature_dynamic_instrumentation_enabled"] = getBoolSysProbe("dynamic_instrumentation.enabled")
 	ia.data["feature_remote_configuration_enabled"] = ia.conf.GetBool("remote_configuration.enabled")
 
 	ia.data["feature_container_images_enabled"] = ia.conf.GetBool("container_image.enabled")
 
-	ia.data["feature_cws_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.enabled")
-	ia.data["feature_cws_network_enabled"] = pkgconfig.SystemProbe.GetBool("event_monitoring_config.network.enabled")
-	ia.data["feature_cws_security_profiles_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.activity_dump.enabled")
-	ia.data["feature_cws_remote_config_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.remote_configuration.enabled")
+	ia.data["feature_cws_enabled"] = getBoolSysProbe("runtime_security_config.enabled")
+	ia.data["feature_cws_network_enabled"] = getBoolSysProbe("event_monitoring_config.network.enabled")
+	ia.data["feature_cws_security_profiles_enabled"] = getBoolSysProbe("runtime_security_config.activity_dump.enabled")
+	ia.data["feature_cws_remote_config_enabled"] = getBoolSysProbe("runtime_security_config.remote_configuration.enabled")
 
 	ia.data["feature_csm_vm_containers_enabled"] = ia.conf.GetBool("sbom.enabled") && ia.conf.GetBool("container_image.enabled") && ia.conf.GetBool("sbom.container_image.enabled")
 	ia.data["feature_csm_vm_hosts_enabled"] = ia.conf.GetBool("sbom.enabled") && ia.conf.GetBool("sbom.host.enabled")
@@ -185,35 +203,35 @@ func (ia *inventoryagent) initData() {
 	ia.data["feature_process_language_detection_enabled"] = ia.conf.GetBool("language_detection.enabled")
 	ia.data["feature_processes_container_enabled"] = ia.conf.GetBool("process_config.container_collection.enabled")
 
-	ia.data["feature_networks_enabled"] = pkgconfig.SystemProbe.GetBool("network_config.enabled")
-	ia.data["feature_networks_http_enabled"] = pkgconfig.SystemProbe.GetBool("service_monitoring_config.enable_http_monitoring")
-	ia.data["feature_networks_https_enabled"] = pkgconfig.SystemProbe.GetBool("service_monitoring_config.tls.native.enabled")
+	ia.data["feature_networks_enabled"] = getBoolSysProbe("network_config.enabled")
+	ia.data["feature_networks_http_enabled"] = getBoolSysProbe("service_monitoring_config.enable_http_monitoring")
+	ia.data["feature_networks_https_enabled"] = getBoolSysProbe("service_monitoring_config.tls.native.enabled")
 
-	ia.data["feature_usm_enabled"] = pkgconfig.SystemProbe.GetBool("service_monitoring_config.enabled")
-	ia.data["feature_usm_kafka_enabled"] = pkgconfig.SystemProbe.GetBool("data_streams_config.enabled")
-	ia.data["feature_usm_java_tls_enabled"] = pkgconfig.SystemProbe.GetBool("service_monitoring_config.tls.java.enabled")
-	ia.data["feature_usm_http2_enabled"] = pkgconfig.SystemProbe.GetBool("service_monitoring_config.enable_http2_monitoring")
-	ia.data["feature_usm_istio_enabled"] = pkgconfig.SystemProbe.GetBool("service_monitoring_config.tls.istio.enabled")
-	ia.data["feature_usm_http_by_status_code_enabled"] = pkgconfig.SystemProbe.GetBool("service_monitoring_config.enable_http_stats_by_status_code")
-	ia.data["feature_usm_go_tls_enabled"] = pkgconfig.SystemProbe.GetBool("service_monitoring_config.tls.go.enabled")
+	ia.data["feature_usm_enabled"] = getBoolSysProbe("service_monitoring_config.enabled")
+	ia.data["feature_usm_kafka_enabled"] = getBoolSysProbe("data_streams_config.enabled")
+	ia.data["feature_usm_java_tls_enabled"] = getBoolSysProbe("service_monitoring_config.tls.java.enabled")
+	ia.data["feature_usm_http2_enabled"] = getBoolSysProbe("service_monitoring_config.enable_http2_monitoring")
+	ia.data["feature_usm_istio_enabled"] = getBoolSysProbe("service_monitoring_config.tls.istio.enabled")
+	ia.data["feature_usm_http_by_status_code_enabled"] = getBoolSysProbe("service_monitoring_config.enable_http_stats_by_status_code")
+	ia.data["feature_usm_go_tls_enabled"] = getBoolSysProbe("service_monitoring_config.tls.go.enabled")
 
-	ia.data["feature_tcp_queue_length_enabled"] = pkgconfig.SystemProbe.GetBool("system_probe_config.enable_tcp_queue_length")
-	ia.data["feature_oom_kill_enabled"] = pkgconfig.SystemProbe.GetBool("system_probe_config.enable_oom_kill")
-	ia.data["feature_windows_crash_detection_enabled"] = pkgconfig.SystemProbe.GetBool("windows_crash_detection.enabled")
+	ia.data["feature_tcp_queue_length_enabled"] = getBoolSysProbe("system_probe_config.enable_tcp_queue_length")
+	ia.data["feature_oom_kill_enabled"] = getBoolSysProbe("system_probe_config.enable_oom_kill")
+	ia.data["feature_windows_crash_detection_enabled"] = getBoolSysProbe("windows_crash_detection.enabled")
 
-	ia.data["system_probe_core_enabled"] = pkgconfig.SystemProbe.GetBool("system_probe_config.enable_co_re")
-	ia.data["system_probe_runtime_compilation_enabled"] = pkgconfig.SystemProbe.GetBool("system_probe_config.enable_runtime_compiler")
-	ia.data["system_probe_kernel_headers_download_enabled"] = pkgconfig.SystemProbe.GetBool("system_probe_config.enable_kernel_header_download")
-	ia.data["system_probe_prebuilt_fallback_enabled"] = pkgconfig.SystemProbe.GetBool("system_probe_config.allow_precompiled_fallback")
-	ia.data["system_probe_telemetry_enabled"] = pkgconfig.SystemProbe.GetBool("system_probe_config.telemetry_enabled")
-	ia.data["system_probe_max_connections_per_message"] = pkgconfig.SystemProbe.GetInt("system_probe_config.max_conns_per_message")
-	ia.data["system_probe_track_tcp_4_connections"] = pkgconfig.SystemProbe.GetBool("network_config.collect_tcp_v4")
-	ia.data["system_probe_track_tcp_6_connections"] = pkgconfig.SystemProbe.GetBool("network_config.collect_tcp_v6")
-	ia.data["system_probe_track_udp_4_connections"] = pkgconfig.SystemProbe.GetBool("network_config.collect_udp_v4")
-	ia.data["system_probe_track_udp_6_connections"] = pkgconfig.SystemProbe.GetBool("network_config.collect_udp_v6")
-	ia.data["system_probe_protocol_classification_enabled"] = pkgconfig.SystemProbe.GetBool("network_config.enable_protocol_classification")
-	ia.data["system_probe_gateway_lookup_enabled"] = pkgconfig.SystemProbe.GetBool("network_config.enable_gateway_lookup")
-	ia.data["system_probe_root_namespace_enabled"] = pkgconfig.SystemProbe.GetBool("network_config.enable_root_netns")
+	ia.data["system_probe_core_enabled"] = getBoolSysProbe("system_probe_config.enable_co_re")
+	ia.data["system_probe_runtime_compilation_enabled"] = getBoolSysProbe("system_probe_config.enable_runtime_compiler")
+	ia.data["system_probe_kernel_headers_download_enabled"] = getBoolSysProbe("system_probe_config.enable_kernel_header_download")
+	ia.data["system_probe_prebuilt_fallback_enabled"] = getBoolSysProbe("system_probe_config.allow_precompiled_fallback")
+	ia.data["system_probe_telemetry_enabled"] = getBoolSysProbe("system_probe_config.telemetry_enabled")
+	ia.data["system_probe_max_connections_per_message"] = getIntSysProbe("system_probe_config.max_conns_per_message")
+	ia.data["system_probe_track_tcp_4_connections"] = getBoolSysProbe("network_config.collect_tcp_v4")
+	ia.data["system_probe_track_tcp_6_connections"] = getBoolSysProbe("network_config.collect_tcp_v6")
+	ia.data["system_probe_track_udp_4_connections"] = getBoolSysProbe("network_config.collect_udp_v4")
+	ia.data["system_probe_track_udp_6_connections"] = getBoolSysProbe("network_config.collect_udp_v6")
+	ia.data["system_probe_protocol_classification_enabled"] = getBoolSysProbe("network_config.enable_protocol_classification")
+	ia.data["system_probe_gateway_lookup_enabled"] = getBoolSysProbe("network_config.enable_gateway_lookup")
+	ia.data["system_probe_root_namespace_enabled"] = getBoolSysProbe("network_config.enable_root_netns")
 }
 
 // Set updates a metadata value in the payload. The given value will be stored in the cache without being copied. It is

--- a/comp/metadata/inventoryagent/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagent_test.go
@@ -14,23 +14,27 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/stretchr/testify/assert"
 )
 
-func getTestInventoryPayload(t *testing.T, confOverrides map[string]any) *inventoryagent {
+func getTestInventoryPayload(t *testing.T, confOverrides map[string]any, sysprobeConfOverrides map[string]any) *inventoryagent {
 	p := newInventoryAgentProvider(
 		fxutil.Test[dependencies](
 			t,
 			logimpl.MockModule(),
 			config.MockModule(),
 			fx.Replace(config.MockParams{Overrides: confOverrides}),
+			sysprobeconfigimpl.MockModule(),
+			fx.Replace(sysprobeconfigimpl.MockParams{Overrides: sysprobeConfOverrides}),
 			fx.Provide(func() serializer.MetricSerializer { return &serializer.MockSerializer{} }),
 		),
 	)
@@ -38,14 +42,14 @@ func getTestInventoryPayload(t *testing.T, confOverrides map[string]any) *invent
 }
 
 func TestSet(t *testing.T) {
-	ia := getTestInventoryPayload(t, nil)
+	ia := getTestInventoryPayload(t, nil, nil)
 
 	ia.Set("test", 1234)
 	assert.Equal(t, 1234, ia.data["test"])
 }
 
 func TestGetPayload(t *testing.T) {
-	ia := getTestInventoryPayload(t, nil)
+	ia := getTestInventoryPayload(t, nil, nil)
 	ia.hostname = "hostname-for-test"
 
 	ia.Set("test", 1234)
@@ -65,7 +69,7 @@ func TestInitDataErrorInstallInfo(t *testing.T) {
 		return nil, fmt.Errorf("some error")
 	}
 
-	ia := getTestInventoryPayload(t, nil)
+	ia := getTestInventoryPayload(t, nil, nil)
 
 	ia.initData()
 	assert.Equal(t, "undefined", ia.data["install_method_tool"])
@@ -87,40 +91,41 @@ func TestInitDataErrorInstallInfo(t *testing.T) {
 }
 
 func TestInitData(t *testing.T) {
-	// TODO: (components) - until system probe configuration is migrated to a component we use the old mock here.
-	systemProbeMock := pkgconfig.MockSystemProbe(t)
-	systemProbeMock.SetWithoutSource("dynamic_instrumentation.enabled", true)
-	systemProbeMock.SetWithoutSource("remote_configuration.enabled", true)
-	systemProbeMock.SetWithoutSource("runtime_security_config.enabled", true)
-	systemProbeMock.SetWithoutSource("event_monitoring_config.network.enabled", true)
-	systemProbeMock.SetWithoutSource("runtime_security_config.activity_dump.enabled", true)
-	systemProbeMock.SetWithoutSource("runtime_security_config.remote_configuration.enabled", true)
-	systemProbeMock.SetWithoutSource("network_config.enabled", true)
-	systemProbeMock.SetWithoutSource("service_monitoring_config.enable_http_monitoring", true)
-	systemProbeMock.SetWithoutSource("service_monitoring_config.tls.native.enabled", true)
-	systemProbeMock.SetWithoutSource("service_monitoring_config.enabled", true)
-	systemProbeMock.SetWithoutSource("data_streams_config.enabled", true)
-	systemProbeMock.SetWithoutSource("service_monitoring_config.tls.java.enabled", true)
-	systemProbeMock.SetWithoutSource("service_monitoring_config.enable_http2_monitoring", true)
-	systemProbeMock.SetWithoutSource("service_monitoring_config.tls.istio.enabled", true)
-	systemProbeMock.SetWithoutSource("service_monitoring_config.enable_http_stats_by_status_code", true)
-	systemProbeMock.SetWithoutSource("service_monitoring_config.tls.go.enabled", true)
-	systemProbeMock.SetWithoutSource("system_probe_config.enable_tcp_queue_length", true)
-	systemProbeMock.SetWithoutSource("system_probe_config.enable_oom_kill", true)
-	systemProbeMock.SetWithoutSource("windows_crash_detection.enabled", true)
-	systemProbeMock.SetWithoutSource("system_probe_config.enable_co_re", true)
-	systemProbeMock.SetWithoutSource("system_probe_config.enable_runtime_compiler", true)
-	systemProbeMock.SetWithoutSource("system_probe_config.enable_kernel_header_download", true)
-	systemProbeMock.SetWithoutSource("system_probe_config.allow_precompiled_fallback", true)
-	systemProbeMock.SetWithoutSource("system_probe_config.telemetry_enabled", true)
-	systemProbeMock.SetWithoutSource("system_probe_config.max_conns_per_message", 10)
-	systemProbeMock.SetWithoutSource("network_config.collect_tcp_v4", true)
-	systemProbeMock.SetWithoutSource("network_config.collect_tcp_v6", true)
-	systemProbeMock.SetWithoutSource("network_config.collect_udp_v4", true)
-	systemProbeMock.SetWithoutSource("network_config.collect_udp_v6", true)
-	systemProbeMock.SetWithoutSource("network_config.enable_protocol_classification", true)
-	systemProbeMock.SetWithoutSource("network_config.enable_gateway_lookup", true)
-	systemProbeMock.SetWithoutSource("network_config.enable_root_netns", true)
+	sysprobeOverrides := map[string]any{
+		"dynamic_instrumentation.enabled":                            true,
+		"remote_configuration.enabled":                               true,
+		"runtime_security_config.enabled":                            true,
+		"event_monitoring_config.network.enabled":                    true,
+		"runtime_security_config.activity_dump.enabled":              true,
+		"runtime_security_config.remote_configuration.enabled":       true,
+		"network_config.enabled":                                     true,
+		"service_monitoring_config.enable_http_monitoring":           true,
+		"service_monitoring_config.tls.native.enabled":               true,
+		"service_monitoring_config.enabled":                          true,
+		"data_streams_config.enabled":                                true,
+		"service_monitoring_config.tls.java.enabled":                 true,
+		"service_monitoring_config.enable_http2_monitoring":          true,
+		"service_monitoring_config.tls.istio.enabled":                true,
+		"service_monitoring_config.enable_http_stats_by_status_code": true,
+		"service_monitoring_config.tls.go.enabled":                   true,
+		"system_probe_config.enable_tcp_queue_length":                true,
+		"system_probe_config.enable_oom_kill":                        true,
+		"windows_crash_detection.enabled":                            true,
+		"system_probe_config.enable_co_re":                           true,
+		"system_probe_config.enable_runtime_compiler":                true,
+		"system_probe_config.enable_kernel_header_download":          true,
+		"system_probe_config.allow_precompiled_fallback":             true,
+		"system_probe_config.telemetry_enabled":                      true,
+		"system_probe_config.max_conns_per_message":                  10,
+		"system_probe_config.disable_ipv6":                           false,
+		"network_config.collect_tcp_v4":                              true,
+		"network_config.collect_tcp_v6":                              true,
+		"network_config.collect_udp_v4":                              true,
+		"network_config.collect_udp_v6":                              true,
+		"network_config.enable_protocol_classification":              true,
+		"network_config.enable_gateway_lookup":                       true,
+		"network_config.enable_root_netns":                           true,
+	}
 
 	overrides := map[string]any{
 		"language_detection.enabled":       true,
@@ -148,7 +153,7 @@ func TestInitData(t *testing.T) {
 		"sbom.container_image.enabled":                true,
 		"sbom.host.enabled":                           true,
 	}
-	ia := getTestInventoryPayload(t, overrides)
+	ia := getTestInventoryPayload(t, overrides, sysprobeOverrides)
 
 	expected := map[string]any{
 		"agent_version":                    version.AgentVersion,
@@ -209,6 +214,11 @@ func TestInitData(t *testing.T) {
 		"system_probe_max_connections_per_message":     10,
 	}
 
+	if !kernel.IsIPv6Enabled() {
+		expected["system_probe_track_tcp_6_connections"] = false
+		expected["system_probe_track_udp_6_connections"] = false
+	}
+
 	for name, value := range expected {
 		assert.Equal(t, value, ia.data[name], "value for '%s' is wrong", name)
 	}
@@ -217,7 +227,7 @@ func TestInitData(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	ia := getTestInventoryPayload(t, nil)
+	ia := getTestInventoryPayload(t, nil, nil)
 
 	ia.Set("test", 1234)
 
@@ -230,12 +240,12 @@ func TestGet(t *testing.T) {
 }
 
 func TestFlareProviderFilename(t *testing.T) {
-	ia := getTestInventoryPayload(t, nil)
+	ia := getTestInventoryPayload(t, nil, nil)
 	assert.Equal(t, "agent.json", ia.FlareFileName)
 }
 
 func TestConfigRefresh(t *testing.T) {
-	ia := getTestInventoryPayload(t, nil)
+	ia := getTestInventoryPayload(t, nil, nil)
 
 	assert.False(t, ia.RefreshTriggered())
 	pkgconfig.Datadog.Set("inventories_max_interval", 10*time.Minute, pkgconfigmodel.SourceAgentRuntime)

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"golang.org/x/sys/windows/registry"
 )
@@ -22,7 +22,7 @@ type WinCrashProbe struct {
 }
 
 // NewWinCrashProbe returns an initialized WinCrashProbe
-func NewWinCrashProbe(_ *config.Config) (*WinCrashProbe, error) {
+func NewWinCrashProbe(_ *sysconfigtypes.Config) (*WinCrashProbe, error) {
 	return &WinCrashProbe{}, nil
 }
 

--- a/pkg/dynamicinstrumentation/config.go
+++ b/pkg/dynamicinstrumentation/config.go
@@ -7,6 +7,7 @@ package dynamicinstrumentation
 
 import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 )
 
@@ -17,7 +18,7 @@ type Config struct {
 }
 
 //nolint:revive // TODO(DEBUG) Fix revive linter
-func NewConfig(sysprobeConfig *config.Config) (*Config, error) {
+func NewConfig(sysprobeConfig *sysconfigtypes.Config) (*Config, error) {
 	_, diEnabled := sysprobeConfig.EnabledModules[config.DynamicInstrumentationModule]
 	return &Config{
 		Config:                        *ebpf.NewConfig(),

--- a/pkg/eventmonitor/config/config.go
+++ b/pkg/eventmonitor/config/config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -35,7 +36,7 @@ type Config struct {
 }
 
 // NewConfig creates a config for the event monitoring module
-func NewConfig(spConfig *config.Config) *Config {
+func NewConfig(spConfig *sysconfigtypes.Config) *Config {
 	return &Config{
 		// event server
 		SocketPath:       coreconfig.SystemProbe.GetString(join(evNS, "socket")),

--- a/pkg/network/driver/driver_windows.go
+++ b/pkg/network/driver/driver_windows.go
@@ -13,7 +13,7 @@ import (
 
 	"go.uber.org/atomic"
 
-	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 )
 
 // ErrDriverNotInitialized is returned when you attempt to use the driver without calling Init
@@ -27,7 +27,7 @@ type driver struct {
 }
 
 // Init configures the driver and will disable it if closed source is not allowed
-func Init(*config.Config) error {
+func Init(*sysconfigtypes.Config) error {
 	driverInit.Do(func() {
 		driverRef = &driver{
 			inuse: atomic.NewUint32(0),

--- a/pkg/network/tracer/tracer_windows_test.go
+++ b/pkg/network/tracer/tracer_windows_test.go
@@ -8,13 +8,13 @@
 package tracer
 
 import (
-	syscfg "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/driver"
 )
 
 func platformInit() {
-	_ = driver.Init(&syscfg.Config{})
+	_ = driver.Init(&sysconfigtypes.Config{})
 }
 
 func httpSupported() bool {

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -9,7 +9,7 @@ package checks
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
 
-	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -105,7 +105,7 @@ func (p CombinedRunResult) RealtimePayloads() []model.MessageBody {
 // All is a list of all runnable checks. Putting a check in here does not guarantee it will be run,
 // it just guarantees that the collector will be able to find the check.
 // If you want to add a check you MUST register it here.
-func All(config, sysprobeYamlCfg ddconfig.ReaderWriter, syscfg *sysconfig.Config) []Check {
+func All(config, sysprobeYamlCfg ddconfig.ReaderWriter, syscfg *sysconfigtypes.Config) []Check {
 	return []Check{
 		NewProcessCheck(config),
 		NewContainerCheck(config),

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -14,6 +14,7 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl/utils"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/network/dns"
@@ -38,7 +39,7 @@ var (
 )
 
 // NewConnectionsCheck returns an instance of the ConnectionsCheck.
-func NewConnectionsCheck(config, sysprobeYamlConfig config.Reader, syscfg *sysconfig.Config) *ConnectionsCheck {
+func NewConnectionsCheck(config, sysprobeYamlConfig config.Reader, syscfg *sysconfigtypes.Config) *ConnectionsCheck {
 	return &ConnectionsCheck{
 		config:             config,
 		syscfg:             syscfg,
@@ -48,7 +49,7 @@ func NewConnectionsCheck(config, sysprobeYamlConfig config.Reader, syscfg *sysco
 
 // ConnectionsCheck collects statistics about live TCP and UDP connections.
 type ConnectionsCheck struct {
-	syscfg             *sysconfig.Config
+	syscfg             *sysconfigtypes.Config
 	sysprobeYamlConfig config.Reader
 	config             config.Reader
 

--- a/pkg/process/net/check.go
+++ b/pkg/process/net/check.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	ebpfcheck "github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck/model"
 	oomkill "github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/oomkill/model"
 	tcpqueuelength "github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/model"
@@ -25,7 +26,7 @@ const (
 )
 
 // GetCheck returns the check output of the specified module
-func (r *RemoteSysProbeUtil) GetCheck(module sysconfig.ModuleName) (interface{}, error) {
+func (r *RemoteSysProbeUtil) GetCheck(module sysconfigtypes.ModuleName) (interface{}, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf(checksURL, module), nil)
 	if err != nil {
 		return nil, err

--- a/pkg/process/net/check_windows.go
+++ b/pkg/process/net/check_windows.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/wincrashdetect/probe"
 )
 
@@ -23,7 +24,7 @@ const (
 )
 
 // GetCheck returns the check output of the specified module
-func (r *RemoteSysProbeUtil) GetCheck(module sysconfig.ModuleName) (interface{}, error) {
+func (r *RemoteSysProbeUtil) GetCheck(module sysconfigtypes.ModuleName) (interface{}, error) {
 
 	switch module {
 	default:

--- a/pkg/process/runner/runner.go
+++ b/pkg/process/runner/runner.go
@@ -17,6 +17,7 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -93,7 +94,7 @@ func (l *CheckRunner) RunRealTime() bool {
 }
 
 // NewRunner creates a new CheckRunner
-func NewRunner(config ddconfig.Reader, sysCfg *sysconfig.Config, hostInfo *checks.HostInfo, enabledChecks []checks.Check, rtNotifierChan <-chan types.RTResponse) (*CheckRunner, error) {
+func NewRunner(config ddconfig.Reader, sysCfg *sysconfigtypes.Config, hostInfo *checks.HostInfo, enabledChecks []checks.Check, rtNotifierChan <-chan types.RTResponse) (*CheckRunner, error) {
 	runRealTime := !config.GetBool("process_config.disable_realtime_checks")
 
 	cfg := &checks.SysProbeConfig{}

--- a/test/new-e2e/tests/agent-shared-components/inventory/inventory_agent_test.go
+++ b/test/new-e2e/tests/agent-shared-components/inventory/inventory_agent_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,7 +19,7 @@ type inventoryAgentSuite struct {
 }
 
 func TestAgentDiagnoseEC2Suite(t *testing.T) {
-	e2e.Run(t, &inventoryAgentSuite{}, e2e.AgentStackDef(), params.WithDevMode())
+	e2e.Run(t, &inventoryAgentSuite{}, e2e.AgentStackDef())
 }
 
 func (v *inventoryAgentSuite) TestInventoryDefaultConfig() {

--- a/test/new-e2e/tests/agent-shared-components/inventory/inventory_agent_test.go
+++ b/test/new-e2e/tests/agent-shared-components/inventory/inventory_agent_test.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package inventory
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/stretchr/testify/assert"
+)
+
+type inventoryAgentSuite struct {
+	e2e.Suite[e2e.AgentEnv]
+}
+
+func TestAgentDiagnoseEC2Suite(t *testing.T) {
+	e2e.Run(t, &inventoryAgentSuite{}, e2e.AgentStackDef(), params.WithDevMode())
+}
+
+func (v *inventoryAgentSuite) TestInventoryDefaultConfig() {
+	inventory := v.Env().Agent.Diagnose(client.WithArgs([]string{"show-metadata", "inventory-agent"}))
+	assert.Contains(v.T(), inventory, `"feature_apm_enabled": true`)
+	assert.Contains(v.T(), inventory, `"feature_logs_enabled": false`)
+	assert.Contains(v.T(), inventory, `"feature_process_enabled": false`)
+	assert.Contains(v.T(), inventory, `"feature_networks_enabled": false`)
+	assert.Contains(v.T(), inventory, `"feature_cspm_enabled": false`)
+	assert.Contains(v.T(), inventory, `"feature_cws_enabled": false`)
+	assert.Contains(v.T(), inventory, `"feature_usm_enabled": false`)
+}
+
+func (v *inventoryAgentSuite) TestInventoryAllEnabled() {
+
+	agentConfig := `logs_enabled: true
+process_config:
+  enabled: true
+process_config:
+  process_collection:
+    enabled: true`
+
+	systemProbeConfiguration := `runtime_security_config:
+  enabled: true
+service_monitoring_config:
+  enabled: true
+network_config:
+  enabled: true`
+
+	securityAgentConfiguration := `compliance_config:
+  enabled: true`
+
+	agentOptions := []agentparams.Option{
+		agentparams.WithAgentConfig(string(agentConfig)),
+		agentparams.WithSystemProbeConfig(string(systemProbeConfiguration)),
+		agentparams.WithSecurityAgentConfig(string(securityAgentConfiguration)),
+	}
+
+	v.UpdateEnv(e2e.AgentStackDef(e2e.WithAgentParams(agentOptions...)))
+
+	inventory := v.Env().Agent.Diagnose(client.WithArgs([]string{"show-metadata", "inventory-agent"}))
+	assert.Contains(v.T(), inventory, `"feature_apm_enabled": true`)
+	assert.Contains(v.T(), inventory, `"feature_logs_enabled": true`)
+	assert.Contains(v.T(), inventory, `"feature_process_enabled": true`)
+	assert.Contains(v.T(), inventory, `"feature_networks_enabled": true`)
+	assert.Contains(v.T(), inventory, `"feature_cspm_enabled": true`)
+	assert.Contains(v.T(), inventory, `"feature_cws_enabled": true`)
+	assert.Contains(v.T(), inventory, `"feature_usm_enabled": true`)
+}


### PR DESCRIPTION
### What does this PR do?

Use sysprobeconfig component within the Inventory Agent. This also split the system-probe configuration in two so we can link with its types without pulling most of system-probe (This avoid adding 16MB to dogstatsd binary)

### Motivation

sysprobeconfig is a dependency of inventory-agent comp but it was the link was not done via Fx.
Because of this, the inventory-agent comp was created before the sysprobeconfig, and the fetched values ([example](https://github.com/DataDog/datadog-agent/blob/34922393ce47261da9835d7bf62fb5e090e5fa55/comp/metadata/inventoryagent/inventoryagent.go#L176-L179)) during inventory creation were wrong .

### Additional Notes


### Possible Drawbacks / Trade-offs

I had to add sysprobeconfig to the dogstatsd build because inventoryagent depends on it.
If this is an issue, we probably can make the sysprobeconfig component optional in the inventoryagent

### Describe how to test/QA your changes

Should be covered by unit tests and e2e tests 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
