### PR TITLE
Fix panic in KSM check when nil map set as annotations as tags value

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -704,8 +704,9 @@ func (k *KSMCheck) mergeAnnotationsAsTags(extra map[string]map[string]string) {
 		k.instance.AnnotationsAsTags = make(map[string]map[string]string)
 	}
 	for resource, mapping := range extra {
-		_, found := k.instance.AnnotationsAsTags[resource]
-		if !found {
+		val, found := k.instance.AnnotationsAsTags[resource]
+		// In the case of a misconfiguration issue, the value could be explicitly set to nil
+		if !found || val == nil {
 			k.instance.AnnotationsAsTags[resource] = make(map[string]string)
 			k.instance.AnnotationsAsTags[resource] = mapping
 			continue

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -703,10 +703,18 @@ func (k *KSMCheck) mergeAnnotationsAsTags(extra map[string]map[string]string) {
 	if k.instance.AnnotationsAsTags == nil {
 		k.instance.AnnotationsAsTags = make(map[string]map[string]string)
 	}
+	// In the case of a misconfiguration issue, the value could be explicitly set to nil
+	for resource, mapping := range k.instance.AnnotationsAsTags {
+		if mapping == nil {
+			delete(k.instance.AnnotationsAsTags, resource)
+		}
+	}
 	for resource, mapping := range extra {
-		val, found := k.instance.AnnotationsAsTags[resource]
-		// In the case of a misconfiguration issue, the value could be explicitly set to nil
-		if !found || val == nil {
+		_, found := k.instance.AnnotationsAsTags[resource]
+		if mapping == nil {
+			continue
+		}
+		if !found {
 			k.instance.AnnotationsAsTags[resource] = make(map[string]string)
 			k.instance.AnnotationsAsTags[resource] = mapping
 			continue

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -711,9 +711,6 @@ func (k *KSMCheck) mergeAnnotationsAsTags(extra map[string]map[string]string) {
 	}
 	for resource, mapping := range extra {
 		_, found := k.instance.AnnotationsAsTags[resource]
-		if mapping == nil {
-			continue
-		}
 		if !found {
 			k.instance.AnnotationsAsTags[resource] = make(map[string]string)
 			k.instance.AnnotationsAsTags[resource] = mapping

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -1465,10 +1465,10 @@ func TestKSMCheck_mergeAnnotationsAsTags(t *testing.T) {
 			expected: map[string]map[string]string{"pod": {"common_key": "in_val"}},
 		},
 		{
-			name:     "conf nil value",
-			conf:     map[string]map[string]string{"pod": nil},
-			extra:    map[string]map[string]string{"pod": {"common_key": "extra_val", "foo": "bar"}},
-			expected: map[string]map[string]string{"pod": {"common_key": "extra_val", "foo": "bar"}},
+			name:     "conf nil values",
+			conf:     map[string]map[string]string{"job": nil, "deployment": nil, "statefulset": nil, "daemonset": nil},
+			extra:    defaultAnnotationsAsTags(),
+			expected: defaultAnnotationsAsTags(),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -1464,6 +1464,12 @@ func TestKSMCheck_mergeAnnotationsAsTags(t *testing.T) {
 			extra:    nil,
 			expected: map[string]map[string]string{"pod": {"common_key": "in_val"}},
 		},
+		{
+			name:     "conf nil value",
+			conf:     map[string]map[string]string{"pod": nil},
+			extra:    map[string]map[string]string{"pod": {"common_key": "extra_val", "foo": "bar"}},
+			expected: map[string]map[string]string{"pod": {"common_key": "extra_val", "foo": "bar"}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR checks if the value of the annotations as tags map is set to nil due to misconfiguration, and reinitializes an empty map if so.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

If the value is accidentally misconfigured it may cause a panic in the code.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

A unit test was added to cover this case. To test on a cluster:
1. Start up an agent, cluster agent and cluster worker locally; modify the cluster agent configuration with the following:
```
...
clusterAgent:
  ...
  confd:
    kubernetes_state_core.yaml: |-
      init_config:
      instances:
        - collectors:
          - secrets
          - configmaps
          - nodes
          - pods
          - services
          - resourcequotas
          - replicationcontrollers
          - limitranges
          - persistentvolumeclaims
          - persistentvolumes
          - namespaces
          - endpoints
          - daemonsets
          - deployments
          - replicasets
          - statefulsets
          - cronjobs
          - jobs
          - horizontalpodautoscalers
          - poddisruptionbudgets
          - storageclasses
          - volumeattachments
          - ingresses
          tags:
            - "test_ksm_panic:true"
          labels_as_tags:
            {}
          annotations_as_tags:
            pod:
            deployment:
              service: service
            statefulset:
              service: service
            daemonset:
              service: service
...
```
2. Verify that this causes the cluster agent to panic
3. Pull this change then re-deploy; verify that the agent no longer panics and that ksm metrics are reported

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
