### PR TITLE
[CWS] Add ebpfless functional tests

### DIFF
--- a/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
+++ b/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
@@ -24,6 +24,8 @@ const (
 	uid = "uid"
 	// gid used to start the tracee
 	gid = "gid"
+	// async enable the traced program to start and run until we manage to connect to the GRPC endpoint
+	async = "async"
 )
 
 type traceCliParams struct {
@@ -31,6 +33,7 @@ type traceCliParams struct {
 	Verbose   bool
 	UID       int32
 	GID       int32
+	Async     bool
 }
 
 // Command returns the commands for the trace subcommand
@@ -50,7 +53,7 @@ func Command() []*cobra.Command {
 				gid := uint32(params.GID)
 				creds.GID = &gid
 			}
-			return ptracer.StartCWSPtracer(args, params.ProbeAddr, creds, params.Verbose)
+			return ptracer.StartCWSPtracer(args, params.ProbeAddr, creds, params.Verbose, params.Async)
 		},
 	}
 
@@ -58,6 +61,7 @@ func Command() []*cobra.Command {
 	traceCmd.Flags().BoolVar(&params.Verbose, verbose, false, "enable verbose output")
 	traceCmd.Flags().Int32Var(&params.UID, uid, -1, "uid used to start the tracee")
 	traceCmd.Flags().Int32Var(&params.GID, gid, -1, "gid used to start the tracee")
+	traceCmd.Flags().BoolVar(&params.Async, async, false, "enable async GRPC connection")
 
 	traceCmd.AddCommand(selftestscmd.Command()...)
 

--- a/pkg/security/resolvers/process/resolver_ebpfless.go
+++ b/pkg/security/resolvers/process/resolver_ebpfless.go
@@ -101,8 +101,12 @@ func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv 
 
 	entry.Process.ArgsEntry = &model.ArgsEntry{Values: argv}
 	if len(argv) > 0 {
-		entry.Process.Comm = argv[0]
 		entry.Process.Argv0 = argv[0]
+	}
+	entry.Process.Comm = filepath.Base(file)
+	if len(entry.Process.Comm) > 16 {
+		// truncate comm to max 16 chars to be ebpf ISO
+		entry.Process.Comm = entry.Process.Comm[:16]
 	}
 
 	entry.Process.EnvsEntry = &model.EnvsEntry{Values: envs}
@@ -113,6 +117,7 @@ func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv 
 
 	// TODO fix timestamp
 	entry.ExecTime = time.Now()
+	entry.CreatedAt = uint64(entry.ExecTime.UnixNano())
 
 	p.Lock()
 	defer p.Unlock()

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
@@ -59,12 +60,14 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0755)
-			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), false)
 
-			test.validateOpenSchema(t, event)
+			if !test.opts.staticOpts.enableEBPFLess {
+				// don't check some fields on ebpfless mode until they are implemented
+				assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+				test.validateOpenSchema(t, event)
+			}
 		})
 	}))
 
@@ -81,7 +84,10 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
-			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+
+			if !test.opts.staticOpts.enableEBPFLess {
+				assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			}
 
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), false)
@@ -94,6 +100,14 @@ func TestOpen(t *testing.T) {
 	}
 
 	t.Run("openat2", func(t *testing.T) {
+		kv, err := kernel.NewKernelVersion()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if test.opts.staticOpts.enableEBPFLess && kv.Code < kernel.Kernel6_0 {
+			t.Skip("openat2 is not supported")
+		}
+
 		defer os.Remove(testFile)
 
 		test.WaitSignal(t, func() error {
@@ -117,6 +131,10 @@ func TestOpen(t *testing.T) {
 	})
 
 	t.Run("creat", ifSyscallSupported("SYS_CREAT", func(t *testing.T, syscallNB uintptr) {
+		if test.opts.staticOpts.enableEBPFLess {
+			t.Skip("SYS_CREAT not supported yet")
+		}
+
 		defer os.Remove(testFile)
 
 		test.WaitSignal(t, func() error {
@@ -137,6 +155,10 @@ func TestOpen(t *testing.T) {
 	}))
 
 	t.Run("truncate", func(t *testing.T) {
+		if test.opts.staticOpts.enableEBPFLess {
+			t.Skip("SYS_TRUNCATE not supported yet")
+		}
+
 		defer os.Remove(testFile)
 
 		test.WaitSignal(t, func() error {
@@ -171,6 +193,10 @@ func TestOpen(t *testing.T) {
 	})
 
 	t.Run("open_by_handle_at", func(t *testing.T) {
+		if test.opts.staticOpts.enableEBPFLess {
+			t.Skip("open_by_handle_at not supported yet")
+		}
+
 		defer os.Remove(testFile)
 
 		// wait for this first event
@@ -217,6 +243,10 @@ func TestOpen(t *testing.T) {
 	})
 
 	t.Run("io_uring", func(t *testing.T) {
+		if test.opts.staticOpts.enableEBPFLess {
+			t.Skip("io_uring not supported yet")
+		}
+
 		defer os.Remove(testFile)
 
 		err = test.GetSignal(t, func() error {
@@ -342,6 +372,9 @@ func TestOpenMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
+	if test.opts.staticOpts.enableEBPFLess {
+		t.Skip("some metadata not supported yet")
+	}
 
 	fileMode := 0o447
 	expectedMode := uint16(applyUmask(fileMode))
@@ -388,6 +421,10 @@ func TestOpenDiscarded(t *testing.T) {
 	}
 	defer test.Close()
 
+	if test.opts.staticOpts.enableEBPFLess == true {
+		t.Skip("not supported yet")
+	}
+
 	t.Run("pipefs", func(t *testing.T) {
 		var pipeFDs [2]int
 		if err := unix.Pipe(pipeFDs[:]); err != nil {
@@ -398,7 +435,7 @@ func TestOpenDiscarded(t *testing.T) {
 
 		path := fmt.Sprintf("/proc/self/fd/%d", pipeFDs[1])
 
-		test.GetSignal(t, func() error {
+		err := test.GetSignal(t, func() error {
 			fd, err := unix.Open(path, unix.O_WRONLY, 0o0)
 			if err != nil {
 				return err
@@ -407,6 +444,9 @@ func TestOpenDiscarded(t *testing.T) {
 		}, func(e *model.Event, r *rules.Rule) {
 			t.Error("shouldn't have received an event")
 		})
+		if err == nil {
+			t.Error("shouldn't have received an event")
+		}
 	})
 }
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -33,12 +33,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
+	"golang.org/x/sys/unix"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/oliveagle/jsonpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/syndtr/gocapability/capability"
-	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -53,8 +54,12 @@ func TestProcess(t *testing.T) {
 	}
 
 	ruleDef := &rules.RuleDefinition{
-		ID:         "test_rule",
-		Expression: fmt.Sprintf(`process.user != "" && process.file.name == "%s" && open.file.path == "{{.Root}}/test-process"`, path.Base(executable)),
+		ID: "test_rule",
+	}
+	if os.Getenv("EBPFLESS") != "" {
+		ruleDef.Expression = fmt.Sprintf(`process.file.name == "%s" && open.file.path == "{{.Root}}/test-process"`, path.Base(executable))
+	} else {
+		ruleDef.Expression = fmt.Sprintf(`process.user != "" && process.file.name == "%s" && open.file.path == "{{.Root}}/test-process"`, path.Base(executable))
 	}
 
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef})
@@ -95,11 +100,11 @@ func TestProcessContext(t *testing.T) {
 		},
 		{
 			ID:         "test_rule_ancestors",
-			Expression: `open.file.path == "{{.Root}}/test-process-ancestors" && process.ancestors[_].file.name in ["dash", "bash"]`,
+			Expression: `open.file.path == "{{.Root}}/test-process-ancestors" && process.ancestors[_].file.name in ["sh", "dash", "bash"]`,
 		},
 		{
 			ID:         "test_rule_parent",
-			Expression: `open.file.path == "{{.Root}}/test-process-parent" && process.parent.file.name in ["dash", "bash"]`,
+			Expression: `open.file.path == "{{.Root}}/test-process-parent" && process.parent.file.name in ["sh", "dash", "bash"]`,
 		},
 		{
 			ID:         "test_rule_pid1",
@@ -139,11 +144,11 @@ func TestProcessContext(t *testing.T) {
 		},
 		{
 			ID:         "test_rule_ancestors_glob",
-			Expression: `exec.file.name == "ls" && exec.argv == "glob" && process.ancestors.file.path =~ "/usr/**"`,
+			Expression: `exec.file.name == "ls" && exec.argv == "glob" && process.ancestors.file.path in [~"/tmp/**"]`,
 		},
 		{
 			ID:         "test_self_exec",
-			Expression: `exec.file.name == "syscall_tester" && exec.argv0 == "selfexec123" && process.comm == "exe"`,
+			Expression: `exec.file.name in ["syscall_tester", "exe"] && exec.argv0 == "selfexec123" && process.comm == "exe"`,
 		},
 		{
 			ID:         "test_rule_ctx_1",
@@ -179,6 +184,10 @@ func TestProcessContext(t *testing.T) {
 	}
 
 	t.Run("exec-time", func(t *testing.T) {
+		if test.opts.staticOpts.enableEBPFLess {
+			t.Skip("create_at not supported yet")
+		}
+
 		testFile, _, err := test.Path("test-exec-time-1")
 		if err != nil {
 			t.Fatal(err)
@@ -220,6 +229,10 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	t.Run("inode", func(t *testing.T) {
+		if test.opts.staticOpts.enableEBPFLess {
+			t.Skip("inode not supported yet")
+		}
+
 		testFile, _, err := test.Path("test-process-context")
 		if err != nil {
 			t.Fatal(err)
@@ -245,9 +258,12 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "args-envs", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
+
 		args := []string{"-al", "--password", "secret", "--custom", "secret"}
 		envs := []string{"LD_LIBRARY_PATH=/tmp/lib", "DD_API_KEY=dd-api-key"}
-
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("ls", args, envs)
 			// we need to ignore the error because "--password" is not a valid option for ls
@@ -315,6 +331,10 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "envp", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
+
 		args := []string{"-al", "http://example.com"}
 		envs := []string{"ENVP=test"}
 
@@ -361,6 +381,13 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "args-overflow-single", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
+		if test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("args not yet truncated")
+		}
+
 		args := []string{"-al"}
 		envs := []string{"LD_LIBRARY_PATH=/tmp/lib"}
 
@@ -405,6 +432,12 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "args-overflow-list-50", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
+		if test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("args not yet truncated")
+		}
 		envs := []string{"LD_LIBRARY_PATH=/tmp/lib"}
 
 		// force seed to have something we can reproduce
@@ -416,7 +449,7 @@ func TestProcessContext(t *testing.T) {
 			args = append(args, utils.RandString(50))
 		}
 
-		test.GetSignal(t, func() error {
+		err := test.GetSignal(t, func() error {
 			cmd := cmdFunc("ls", args, envs)
 			// we need to ignore the error because the string of "a" generates a "File name too long" error
 			_ = cmd.Run()
@@ -443,9 +476,19 @@ func TestProcessContext(t *testing.T) {
 				t.Errorf("arg not truncated: %s", execArgs.(string))
 			}
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	test.Run(t, "args-overflow-list-500", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
+		if test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("args not yet truncated")
+		}
+
 		envs := []string{"LD_LIBRARY_PATH=/tmp/lib"}
 
 		// force seed to have something we can reproduce
@@ -457,7 +500,7 @@ func TestProcessContext(t *testing.T) {
 			args = append(args, utils.RandString(500))
 		}
 
-		test.GetSignal(t, func() error {
+		err := test.GetSignal(t, func() error {
 			cmd := cmdFunc("ls", args, envs)
 			// we need to ignore the error because the string of "a" generates a "File name too long" error
 			_ = cmd.Run()
@@ -488,9 +531,16 @@ func TestProcessContext(t *testing.T) {
 				t.Errorf("arg not truncated: %s", execArgs.(string))
 			}
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	test.Run(t, "envs-overflow-single", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("envs truncate not supported yet")
+		}
+
 		args := []string{"-al"}
 		envs := []string{"LD_LIBRARY_PATH=/tmp/lib"}
 
@@ -538,6 +588,10 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "envs-overflow-list-50", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("envs truncate not supported yet")
+		}
+
 		args := []string{"-al"}
 
 		// force seed to have something we can reproduce
@@ -557,7 +611,7 @@ func TestProcessContext(t *testing.T) {
 			args = []string{"-u", "PATH", "-u", "HOSTNAME", "-u", "HOME", "ls", "-al"}
 		}
 
-		test.GetSignal(t, func() error {
+		err := test.GetSignal(t, func() error {
 			bin := "ls"
 			if kind == dockerWrapperType {
 				bin = "env"
@@ -586,9 +640,16 @@ func TestProcessContext(t *testing.T) {
 				t.Errorf("envs not truncated: %s", execEnvp.([]string))
 			}
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	test.Run(t, "envs-overflow-list-500", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("envs truncate not supported yet")
+		}
+
 		args := []string{"-al"}
 
 		// force seed to have something we can reproduce
@@ -608,7 +669,7 @@ func TestProcessContext(t *testing.T) {
 			args = []string{"-u", "PATH", "-u", "HOSTNAME", "-u", "HOME", "ls", "-al"}
 		}
 
-		test.GetSignal(t, func() error {
+		err := test.GetSignal(t, func() error {
 			bin := "ls"
 			if kind == dockerWrapperType {
 				bin = "env"
@@ -643,9 +704,16 @@ func TestProcessContext(t *testing.T) {
 				t.Errorf("envs not truncated: %s", execEnvp.([]string))
 			}
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("tty", func(t *testing.T) {
+		if test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("not supported yet")
+		}
+
 		testFile, _, err := test.Path("test-process-tty")
 		if err != nil {
 			t.Fatal(err)
@@ -717,6 +785,9 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "ancestors", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
 		testFile, _, err := test.Path("test-process-ancestors")
 		if err != nil {
 			t.Fatal(err)
@@ -741,6 +812,10 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "parent", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
+
 		testFile, _, err := test.Path("test-process-parent")
 		if err != nil {
 			t.Fatal(err)
@@ -766,6 +841,10 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "pid1", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("in ebpfless we don't have complete lineage context")
+		}
+
 		testFile, _, err := test.Path("test-process-pid1")
 		if err != nil {
 			t.Fatal(err)
@@ -789,6 +868,9 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "service-tag", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
 		testFile, _, err := test.Path("test-process-context")
 		if err != nil {
 			t.Fatal(err)
@@ -816,6 +898,9 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "ancestors-args", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
 		testFile, _, err := test.Path("test-ancestors-args")
 		if err != nil {
 			t.Fatal(err)
@@ -836,6 +921,10 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "args-envs-dedup", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
+
 		shell, args, envs := "sh", []string{"-x", "-c", "ls -al test123456; echo"}, []string{"DEDUP=dedup123"}
 
 		test.WaitSignal(t, func() error {
@@ -877,7 +966,8 @@ func TestProcessContext(t *testing.T) {
 		lsExecutable := which(t, "ls")
 
 		test.WaitSignal(t, func() error {
-			cmd := exec.Command(lsExecutable, "glob")
+			args := []string{"exec-in-pthread", lsExecutable, "glob"}
+			cmd := exec.Command(syscallTester, args...)
 			_ = cmd.Run()
 			return nil
 		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
@@ -886,6 +976,10 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "self-exec", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
+
 		args := []string{"self-exec", "selfexec123", "abc"}
 		envs := []string{}
 
@@ -900,6 +994,9 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "container-id", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		if kind == dockerWrapperType && test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("docker tests not supported")
+		}
 		testFile, _, err := test.Path("test-container")
 		if err != nil {
 			t.Fatal(err)
@@ -1001,6 +1098,9 @@ func TestProcessExecCTime(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
+	if test.opts.staticOpts.enableEBPFLess == true {
+		t.Skip("ctime not supported yet")
+	}
 
 	test.WaitSignal(t, func() error {
 		testFile, _, err := test.Path("touch")
@@ -1036,12 +1136,9 @@ func TestProcessPIDVariable(t *testing.T) {
 	}, func(event *model.Event, rule *rules.Rule) {
 		assert.Equal(t, "test_rule_var", rule.ID, "wrong rule triggered")
 	})
-	if err != nil {
-		t.Error(err)
-	}
 }
 
-func TestProcessScopedVariable(t *testing.T) {
+func TestProcessScopedVariable(t *testing.T) { // TODO: should work on ebpfless, but it doesnt
 	ruleDefs := []*rules.RuleDefinition{{
 		ID:         "test_rule_set_mutable_vars",
 		Expression: `open.file.path == "{{.Root}}/test-open"`,
@@ -1150,7 +1247,7 @@ func TestProcessScopedVariable(t *testing.T) {
 	defer os.Remove(filename3)
 }
 
-func TestTimestampVariable(t *testing.T) {
+func TestTimestampVariable(t *testing.T) { // TODO: should work on ebpfless, but it doesnt
 	ruleDefs := []*rules.RuleDefinition{{
 		ID:         "test_rule_set_timestamp_var",
 		Expression: `open.file.path == "{{.Root}}/test-open"`,
@@ -1256,6 +1353,9 @@ func TestProcessMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
+	if test.opts.staticOpts.enableEBPFLess == true {
+		t.Skip("not supported yet")
+	}
 
 	fileMode := uint16(0o777)
 	testFile, _, err := test.CreateWithOptions("test-exec", 98, 99, int(fileMode))
@@ -1281,8 +1381,10 @@ func TestProcessMetadata(t *testing.T) {
 		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
 			assertRights(t, event.Exec.FileEvent.Mode, fileMode)
-			assertNearTime(t, event.Exec.FileEvent.MTime)
-			assertNearTime(t, event.Exec.FileEvent.CTime)
+			if test.opts.staticOpts.enableEBPFLess != true {
+				assertNearTime(t, event.Exec.FileEvent.MTime)
+				assertNearTime(t, event.Exec.FileEvent.CTime)
+			}
 		}))
 	})
 
@@ -1302,9 +1404,9 @@ func TestProcessMetadata(t *testing.T) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
 			assert.Equal(t, 1001, int(event.Exec.Credentials.UID), "wrong uid")
 			assert.Equal(t, 1001, int(event.Exec.Credentials.EUID), "wrong euid")
-			assert.Equal(t, 1001, int(event.Exec.Credentials.FSUID), "wrong fsuid")
 			assert.Equal(t, 2001, int(event.Exec.Credentials.GID), "wrong gid")
 			assert.Equal(t, 2001, int(event.Exec.Credentials.EGID), "wrong egid")
+			assert.Equal(t, 1001, int(event.Exec.Credentials.FSUID), "wrong fsuid")
 			assert.Equal(t, 2001, int(event.Exec.Credentials.FSGID), "wrong fsgid")
 		}))
 	})
@@ -1324,12 +1426,8 @@ func TestProcessExecExit(t *testing.T) {
 	}
 	defer test.Close()
 
-	p, ok := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-	if !ok {
-		t.Skip("not supported")
-	}
-
 	var execPid uint32
+	var nsId uint64
 
 	err = test.GetProbeEvent(func() error {
 		cmd := exec.Command(executable, "-t", "01010101", "/dev/null")
@@ -1340,7 +1438,6 @@ func TestProcessExecExit(t *testing.T) {
 			if basename, err := event.GetFieldValue("exec.file.name"); err != nil || basename.(string) != "touch" {
 				return false
 			}
-
 			if args, err := event.GetFieldValue("exec.args"); err != nil || !strings.Contains(args.(string), "01010101") {
 				return false
 			}
@@ -1355,6 +1452,9 @@ func TestProcessExecExit(t *testing.T) {
 			validate(event, nil)
 
 			execPid = event.ProcessContext.Pid
+			if test.opts.staticOpts.enableEBPFLess == true {
+				nsId = event.NSID
+			}
 
 		case model.ExitEventType:
 			// assert that exit time >= exec time
@@ -1373,14 +1473,27 @@ func TestProcessExecExit(t *testing.T) {
 
 	// make sure that the process cache entry of the process was properly deleted from the cache
 	err = retry.Do(func() error {
-		entry := p.Resolvers.ProcessResolver.Get(execPid)
-		if entry != nil {
-			return errors.New("the process cache entry was not deleted from the user space cache")
+		if test.opts.staticOpts.enableEBPFLess != true {
+			p, ok := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
+			if !ok {
+				t.Skip("not supported")
+			}
+			entry := p.Resolvers.ProcessResolver.Get(execPid)
+			if entry != nil {
+				return errors.New("the process cache entry was not deleted from the user space cache")
+			}
+		} else {
+			p, ok := test.probe.PlatformProbe.(*sprobe.EBPFLessProbe)
+			if !ok {
+				t.Skip("not supported")
+			}
+			entry := p.Resolvers.ProcessResolver.Resolve(process.CacheResolverKey{Pid: execPid, NSID: nsId})
+			if entry != nil {
+				return errors.New("the process cache entry was not deleted from the user space cache")
+			}
 		}
-
 		return nil
 	})
-
 	if err != nil {
 		t.Error(err)
 	}
@@ -1423,6 +1536,9 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
+	if test.opts.staticOpts.enableEBPFLess == true {
+		t.Skip("not supported")
+	}
 
 	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
 	if err != nil {
@@ -1578,6 +1694,9 @@ func TestProcessIsThread(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
+	if test.opts.staticOpts.enableEBPFLess == true {
+		t.Skip("not immplemented")
+	}
 
 	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
 	if err != nil {
@@ -1666,7 +1785,9 @@ func TestProcessExit(t *testing.T) {
 			cmd.Env = envp
 			return cmd.Run()
 		}, func(event *model.Event, rule *rules.Rule) {
-			test.validateExitSchema(t, event)
+			if test.opts.staticOpts.enableEBPFLess != true {
+				test.validateExitSchema(t, event)
+			}
 			assertTriggeredRule(t, rule, "test_exit_ok")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
@@ -1676,6 +1797,10 @@ func TestProcessExit(t *testing.T) {
 	})
 
 	t.Run("exit-error", func(t *testing.T) {
+		if test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("not supported yet")
+		}
+
 		test.WaitSignal(t, func() error {
 			args := []string{} // sleep with no argument should exit with return code 1
 			envp := []string{envpExitSleep}
@@ -1695,6 +1820,10 @@ func TestProcessExit(t *testing.T) {
 	})
 
 	t.Run("exit-coredumped", func(t *testing.T) {
+		if test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("not supported yet")
+		}
+
 		test.WaitSignal(t, func() error {
 			args := []string{"--preserve-status", "--signal=SIGQUIT", "2", sleepExec, "9"}
 			envp := []string{envpExitSleep}
@@ -1714,6 +1843,10 @@ func TestProcessExit(t *testing.T) {
 	})
 
 	t.Run("exit-signaled", func(t *testing.T) {
+		if test.opts.staticOpts.enableEBPFLess == true {
+			t.Skip("not supported yet")
+		}
+
 		test.WaitSignal(t, func() error {
 			args := []string{"--preserve-status", "--signal=SIGKILL", "2", sleepExec, "9"}
 			envp := []string{envpExitSleep}
@@ -1741,7 +1874,9 @@ func TestProcessExit(t *testing.T) {
 			cmd.Env = envp
 			return cmd.Run()
 		}, func(event *model.Event, rule *rules.Rule) {
-			test.validateExitSchema(t, event)
+			if test.opts.staticOpts.enableEBPFLess != true {
+				test.validateExitSchema(t, event)
+			}
 			assertTriggeredRule(t, rule, "test_exit_time_1")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
@@ -1759,7 +1894,9 @@ func TestProcessExit(t *testing.T) {
 			cmd.Env = envp
 			return cmd.Run()
 		}, func(event *model.Event, rule *rules.Rule) {
-			test.validateExitSchema(t, event)
+			if test.opts.staticOpts.enableEBPFLess != true {
+				test.validateExitSchema(t, event)
+			}
 			assertTriggeredRule(t, rule, "test_exit_time_2")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
@@ -1794,6 +1931,9 @@ func TestProcessBusybox(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
+	if test.opts.staticOpts.enableEBPFLess == true {
+		t.Skip("not supported")
+	}
 
 	wrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), "alpine")
 	if err != nil {
@@ -2242,6 +2382,10 @@ func TestProcessFilelessExecution(t *testing.T) {
 					t.Fatal("shouldn't get an event")
 				}
 			} else {
+				if testModule.opts.staticOpts.enableEBPFLess == true {
+					t.Skip("memfd unsupported yet")
+				}
+
 				testModule.WaitSignal(t, func() error {
 					return runSyscallTesterFunc(context.Background(), t, syscallTester, test.syscallTesterToRun, test.syscallTesterScriptFilenameToRun)
 				}, func(event *model.Event, rule *rules.Rule) {
@@ -2261,7 +2405,7 @@ func TestKillAction(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID: "kill_action",
 		// using a wilcard to avoid approvers on basename. events will not match thus will be noisy
-		Expression: `process.file.name == "syscall_tester" && mkdir.file.path == "{{.Root}}/test-kill-action"`,
+		Expression: `process.file.name == "syscall_tester" && open.file.path == "{{.Root}}/test-kill-action"`,
 		Actions: []*rules.ActionDefinition{
 			{
 				Kill: &rules.KillDefinition{
@@ -2276,6 +2420,9 @@ func TestKillAction(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
+	if test.opts.staticOpts.enableEBPFLess == true {
+		t.Skip("kill action not supported")
+	}
 
 	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
 	if err != nil {
@@ -2297,7 +2444,7 @@ func TestKillAction(t *testing.T) {
 		if err := runSyscallTesterFunc(
 			timeoutCtx, t, syscallTester,
 			"set-signal-handler", ";",
-			"mkdirat", testFile, ";",
+			"open", testFile, ";",
 			"sleep", "2", ";",
 			"wait-signal", ";",
 			"signal", "sigusr2", strconv.Itoa(int(os.Getpid())),

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -190,6 +190,25 @@ def run_functional_tests(ctx, testsuite, verbose=False, testflags='', fentry=Fal
     ctx.run(cmd.format(**args))
 
 
+@task
+def run_ebpfless_functional_tests(ctx, cws_instrumentation, testsuite, verbose=False, testflags=''):
+    cmd = 'EBPFLESS=true {cws_instrumentation} trace --async -- {testsuite} {verbose_opt} {testflags} {tests}'
+
+    if os.getuid() != 0:
+        cmd = 'sudo -E PATH={path} ' + cmd
+
+    args = {
+        "cws_instrumentation": cws_instrumentation,
+        "testsuite": testsuite,
+        "verbose_opt": "-test.v" if verbose else "",
+        "testflags": testflags,
+        "path": os.environ['PATH'],
+        "tests": "-test.run '^(TestOpen|TestProcess|TimestampVariable|KillAction)'",
+    }
+
+    ctx.run(cmd.format(**args))
+
+
 def ninja_ebpf_probe_syscall_tester(nw, build_dir):
     c_dir = os.path.join("pkg", "security", "tests", "syscall_tester", "c")
     c_file = os.path.join(c_dir, "ebpf_probe.c")
@@ -476,6 +495,40 @@ def functional_tests(
         verbose=verbose,
         testflags=testflags,
         fentry=fentry,
+    )
+
+
+@task
+def ebpfless_functional_tests(
+    ctx,
+    verbose=False,
+    race=False,
+    arch=CURRENT_ARCH,
+    major_version='7',
+    output='pkg/security/tests/testsuite',
+    bundle_ebpf=True,
+    testflags='',
+    skip_linters=False,
+    kernel_release=None,
+    cws_instrumentation='bin/cws-instrumentation/cws-instrumentation',
+):
+    build_functional_tests(
+        ctx,
+        arch=arch,
+        major_version=major_version,
+        output=output,
+        bundle_ebpf=bundle_ebpf,
+        skip_linters=skip_linters,
+        race=race,
+        kernel_release=kernel_release,
+    )
+
+    run_ebpfless_functional_tests(
+        ctx,
+        cws_instrumentation,
+        testsuite=output,
+        verbose=verbose,
+        testflags=testflags,
     )
 
 


### PR DESCRIPTION
### What does this PR do?

It bootstraps the functional tests for ebpfless mode.

Tl;dr:
* Added ebpfless tests:
- * 30 tests are passing.
- * 36 are skipped because we lack some support.
- * 1 is failing (but should not).
* Test fixed: 6
* Ebpfless fixes: 4
* Gaps identified: 25


To do so:
* I've added an async connection mode to the ptracer (aka `cws-instrumentation trace` cmd). Now with a `--async`, it will directly start to trace the program, and wait for a client to start sending pending messages.
* module_tester was also adapted: it could globally be configured in ebpfless mode if env `EBPFLESS` env variable is set; allowing to run the already existing epbf tests in ebpfless mode (but a new config option is also avaible to build specific ebpfless tests if needed).
* Test module reloading (between tests) has been disable, only the first instance will be up. This is an ~hard limitation: if we reload the module, we'll reset the ptracer connection and lose the process cache. Depending of future tests, this could become an issue.

Functional tests fixed:
* By checking the timeout error:
- * TestOpenDiscarded
- * TestProcessContext/args-overflow-list-50
- * TestProcessContext/args-overflow-list-500
- * TestProcessContext/envs-overflow-list-50
- * TestProcessContext/args-overflow-list-500
* TestProcessPIDVariable: remove wrong error check

Ebpfless other fixes/improvements:
* Exit events were caught but not sent. Now they are. This is a first basic implementation and lacks of context (cause, exit code and timestamp)
* Fix `execveat` segfault when passing an empty path (special case that was not handled)
* Fix chained exec events no different threads (where only the last exec was sent multiple times)
* Fix create_at field wich was missing (to handle secl rules based on it)

Remaining gaps to have a full open/exec coverage:
* Add proper timestamps to exec/exit events
* Add more context to exits (cause and return code)
* Checks on lineage were skipped (the fact to always have parent/ancestors and finish on PID 1). We may want to let them skipped, or revisit more globally ebpfless process contexts.
* Same for "hostname", as we can't determine it.
* Event (exec/exit/open) schema validation were also skipped (because a lot of fields are actually missing). We could either wait to add them all, or work with another temporary ebpfless schema. TODO: ask backend if receiving ebpfless events with unvalid schema trigger errors.
* Inodes checks are skipped. We should consider providing them and add the checks back
* Support SYS_CREAT
* Support SYS_TRUNCATE
* Support open_by_handle_at
* Support io_uring (maybe impossible?)
* MTime/CTime
* uid/gid for open files events
* Add user/group
* Follow links?
* args/envs truncation
* tty
* scoped variable and event timestamp (which should had work ootb)
* fsuid/fsgid
* be able to wrote rules on setuid/setgid (should work except for fs[ug]id).
* capset rules
* is_thread
* busybox special cases
* fileless / memfd
* other easy FIM syscalls: mkdir, rename, unlink, close, ...
* kill action


TODO: add a gitlab job


### Motivation

* Validate what we already built
* Have automatic tests for future improvements

### Additional Notes

Also, while trying to make most of the open/exec tests pass in ebpfless, I encountered some tests that were broken.
I guess that if we take a closer look on all other existing tests we shall have more surprises.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

First, build the cws-instrumentation tool:

> inv -e cws-instrumentation.build

Then launch the ebpf testsuite:

> inv -e security-agent.ebpfless-functional-tests --skip-linters --testflags "-test.v"


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
