### PR TITLE
Fix deadlock with inventory metadata

### DIFF
--- a/comp/metadata/internal/util/inventory_payload.go
+++ b/comp/metadata/internal/util/inventory_payload.go
@@ -59,6 +59,8 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/atomic"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/comp/core/log"
@@ -96,7 +98,7 @@ type InventoryPayload struct {
 	LastCollect   time.Time
 	MinInterval   time.Duration
 	MaxInterval   time.Duration
-	ForceRefresh  bool
+	forceRefresh  atomic.Bool
 	FlareFileName string
 }
 
@@ -147,11 +149,11 @@ func (i *InventoryPayload) collect(_ context.Context) time.Duration {
 
 	// Collect will be called every MinInterval second. We send a new payload if a refresh was trigger or if it's
 	// been at least MaxInterval seconds since the last payload.
-	if !i.ForceRefresh && i.MaxInterval-timeSince(i.LastCollect) > 0 {
+	if !i.forceRefresh.Load() && i.MaxInterval-timeSince(i.LastCollect) > 0 {
 		return i.MinInterval
 	}
 
-	i.ForceRefresh = false
+	i.forceRefresh.Store(false)
 	i.LastCollect = time.Now()
 
 	p := i.getPayload()
@@ -167,13 +169,18 @@ func (i *InventoryPayload) Refresh() {
 		return
 	}
 
-	i.m.Lock()
-	defer i.m.Unlock()
-
 	// For a refresh we want to resend a new payload as soon as possible but still respect MinInterval second
-	// since the last update. The Refresh method set ForceRefresh to true which will trigger a new payload when
+	// since the last update. The Refresh method set forceRefresh to true which will trigger a new payload when
 	// Collect is called every MinInterval.
-	i.ForceRefresh = true
+	i.forceRefresh.Store(true)
+}
+
+// RefreshTriggered returns true if a refresh was trigger but not yet done.
+func (i *InventoryPayload) RefreshTriggered() bool {
+	if !i.Enabled {
+		return false
+	}
+	return i.forceRefresh.Load()
 }
 
 // GetAsJSON returns the payload as a JSON string. Useful to be displayed in the CLI or added to a flare.

--- a/comp/metadata/internal/util/inventory_payload_test.go
+++ b/comp/metadata/internal/util/inventory_payload_test.go
@@ -164,10 +164,10 @@ func TestCollect(t *testing.T) {
 	i.collect(context.Background())
 	i.serializer.(*serializer.MockSerializer).AssertExpectations(t)
 
-	// testing collect with LastCollect between MinInterval and MaxInterval with ForceRefresh being trigger
+	// testing collect with LastCollect between MinInterval and MaxInterval with forceRefresh being trigger
 
 	i.Refresh()
-	assert.True(t, i.ForceRefresh)
+	assert.True(t, i.forceRefresh.Load())
 
 	serializerMock.On(
 		"SendMetadata",
@@ -180,5 +180,5 @@ func TestCollect(t *testing.T) {
 
 	i.collect(context.Background())
 	i.serializer.(*serializer.MockSerializer).AssertExpectations(t)
-	assert.False(t, i.ForceRefresh)
+	assert.False(t, i.forceRefresh.Load())
 }

--- a/comp/metadata/inventoryagent/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagent_test.go
@@ -237,7 +237,7 @@ func TestFlareProviderFilename(t *testing.T) {
 func TestConfigRefresh(t *testing.T) {
 	ia := getTestInventoryPayload(t, nil)
 
-	assert.False(t, ia.ForceRefresh)
+	assert.False(t, ia.RefreshTriggered())
 	pkgconfig.Datadog.Set("inventories_max_interval", 10*time.Minute, pkgconfigmodel.SourceAgentRuntime)
-	assert.True(t, ia.ForceRefresh)
+	assert.True(t, ia.RefreshTriggered())
 }


### PR DESCRIPTION
### What does this PR do?

Some 'Refresh' can be triggered by the configuration. So if any inventory payload modify the configuration while generating a payload it creates a deadlock.

### Describe how to test/QA your changes

Change the log_level or any other setting at runtime and check that inventory payload are still sent and the config in `inventory-agent` is accurate.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
