### PR TITLE
[CWS] ebpfless: fix ECS container image tag

### DIFF
--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -131,7 +131,8 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 	event.ContainerContext.ID = cl.containerContext.ID
 	event.ContainerContext.CreatedAt = cl.containerContext.CreatedAt
 	event.ContainerContext.Tags = []string{
-		"image_name:" + cl.containerContext.Name,
+		"image_name:" + cl.containerContext.ImageShortName,
+		"image_tag:" + cl.containerContext.ImageTag,
 	}
 
 	// use ProcessCacheEntry process context as process context

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -44,9 +44,11 @@ const (
 
 // ContainerContext defines a container context
 type ContainerContext struct {
-	ID        string
-	Name      string
-	CreatedAt uint64
+	ID             string
+	Name           string
+	ImageShortName string
+	ImageTag       string
+	CreatedAt      uint64
 }
 
 // FcntlSyscallMsg defines a fcntl message

--- a/pkg/security/ptracer/container_context.go
+++ b/pkg/security/ptracer/container_context.go
@@ -10,16 +10,19 @@ package ptracer
 import (
 	"encoding/json"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
 )
 
-// ECSMetadata defines ECS metadatas
+// ECSMetadata defines ECS metadata
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html
 type ECSMetadata struct {
 	DockerID   string `json:"DockerId"`
 	DockerName string `json:"DockerName"`
 	Name       string `json:"Name"`
+	Image      string `json:"Image"`
 }
 
 func retrieveECSMetadata(url string) (*ECSMetadata, error) {
@@ -63,6 +66,23 @@ func newContainerContext(containerID string) (*ebpfless.ContainerContext, error)
 			}
 			if data.DockerName != "" {
 				ctx.Name = data.DockerName
+			}
+			if data.Image != "" {
+				image := data.Image
+				lastSlash := strings.LastIndex(image, "/")
+				lastColon := strings.LastIndex(image, ":")
+				if lastColon > -1 && lastColon > lastSlash {
+					ctx.ImageTag = image[lastColon+1:]
+					image = image[:lastColon]
+				}
+				if lastSlash > -1 {
+					ctx.ImageShortName = image[lastSlash+1:]
+				} else {
+					ctx.ImageShortName = image
+				}
+				if ctx.ImageShortName != "" && ctx.ImageTag == "" {
+					ctx.ImageTag = "latest"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes ECS container image tags.
Before this change the container name was used as the image name and the image tag was always empty.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
