### PR TITLE
usm: http2: Remove redundant static table

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -240,9 +240,9 @@ static __always_inline __u8 filter_relevant_headers(struct __sk_buff *skb, skb_i
         bpf_skb_load_bytes(skb, skb_info->data_off, &current_ch, sizeof(current_ch));
         skb_info->data_off++;
 
-        // To determine the size of the dynamic table update, we read an integer representation byte by byte. 
-        // We continue reading bytes until we encounter a byte without the Most Significant Bit (MSB) set, 
-        // indicating that we've consumed the complete integer. While in the context of the dynamic table 
+        // To determine the size of the dynamic table update, we read an integer representation byte by byte.
+        // We continue reading bytes until we encounter a byte without the Most Significant Bit (MSB) set,
+        // indicating that we've consumed the complete integer. While in the context of the dynamic table
         // update, we set the state as true if the MSB is set, and false otherwise. Then, we proceed to the next byte.
         // More on the feature - https://httpwg.org/specs/rfc7541.html#rfc.section.6.3.
         if (is_dynamic_table_update) {
@@ -313,18 +313,13 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
         current_header = &headers_to_process[iteration];
 
         if (current_header->type == kStaticHeader) {
-            static_table_value_t *static_value = bpf_map_lookup_elem(&http2_static_table, &current_header->index);
-            if (static_value == NULL) {
-                break;
-            }
-
             if (current_header->index == kPOST || current_header->index == kGET) {
                 // TODO: mark request
                 current_stream->request_started = bpf_ktime_get_ns();
-                current_stream->request_method = *static_value;
+                current_stream->request_method = current_header->index;
                 __sync_fetch_and_add(&http2_tel->request_seen, 1);
             } else if (current_header->index >= k200 && current_header->index <= k500) {
-                current_stream->response_status_code = *static_value;
+                current_stream->response_status_code = current_header->index;
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
             } else if (current_header->index == kEmptyPath) {
                 current_stream->path_size = HTTP2_ROOT_PATH_LEN;

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -6,9 +6,6 @@
 // packet, to the current one.
 BPF_HASH_MAP(http2_remainder, conn_tuple_t, frame_header_remainder_t, 2048)
 
-// http2_static_table is the map that holding the supported static values by index and its static value.
-BPF_ARRAY_MAP(http2_static_table, static_table_value_t, 15)
-
 /* http2_dynamic_table is the map that holding the supported dynamic values - the index is the static index and the
    conn tuple and it is value is the buffer which contains the dynamic string. */
 BPF_HASH_MAP(http2_dynamic_table, dynamic_table_index_t, dynamic_table_entry_t, 0)

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -8,7 +8,6 @@
 package http2
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -21,7 +20,6 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
@@ -53,7 +51,6 @@ const (
 	dynamicTable              = "http2_dynamic_table"
 	dynamicTableCounter       = "http2_dynamic_counter_table"
 	http2IterationsTable      = "http2_iterations"
-	staticTable               = "http2_static_table"
 	firstFrameHandlerTailCall = "socket__http2_handle_first_frame"
 	filterTailCall            = "socket__http2_filter"
 	headersParserTailCall     = "socket__http2_headers_parser"
@@ -71,9 +68,6 @@ var Spec = &protocols.ProtocolSpec{
 		},
 		{
 			Name: dynamicTable,
-		},
-		{
-			Name: staticTable,
 		},
 		{
 			Name: dynamicTableCounter,
@@ -208,10 +202,6 @@ func (p *Protocol) PreStart(mgr *manager.Manager) (err error) {
 	p.statkeeper = http.NewStatkeeper(p.cfg, p.telemetry, http.NewIncompleteBuffer(p.cfg, p.telemetry))
 	p.eventsConsumer.Start()
 
-	if err = p.createStaticTable(mgr); err != nil {
-		return fmt.Errorf("error creating a static table for http2 monitoring: %w", err)
-	}
-
 	return
 }
 
@@ -345,41 +335,6 @@ func (p *Protocol) GetStats() *protocols.ProtocolStats {
 		Type:  protocols.HTTP2,
 		Stats: p.statkeeper.GetAndResetAllStats(),
 	}
-}
-
-// The following map contains a list of static table entries that are used by the http2 monitor.
-// The full list of static table entries can be found here: https://httpwg.org/specs/rfc7541.html#static.table.definition.
-var (
-	staticTableEntries = map[uint64]StaticTableEnumValue{
-		2:  GetValue,
-		3:  PostValue,
-		4:  EmptyPathValue,
-		5:  IndexPathValue,
-		8:  K200Value,
-		9:  K204Value,
-		10: K206Value,
-		11: K304Value,
-		12: K400Value,
-		13: K404Value,
-		14: K500Value,
-	}
-)
-
-// createStaticTable creates a static table for http2 monitor.
-func (p *Protocol) createStaticTable(mgr *manager.Manager) error {
-	staticTable, _, _ := mgr.GetMap(probes.StaticTableMap)
-	if staticTable == nil {
-		return errors.New("http2 static table is null")
-	}
-
-	for key, value := range staticTableEntries {
-		err := staticTable.Put(unsafe.Pointer(&key), unsafe.Pointer(&value))
-
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // IsBuildModeSupported returns always true, as http2 module is supported by all modes.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Removes the static table from http2 implementation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The map was redundant and mapped key `x` to the value `x`. Also, the only use of the map, was to verify the index does exist in the static table, but we reached to the verification after calling the method `is_interesting_index` which does the same
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
