### PR TITLE
[USMON-669] fix interesting_frame_index verifier issue

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -530,8 +530,8 @@ static __always_inline bool get_first_frame(struct __sk_buff *skb, skb_info_t *s
 }
 
 // find_relevant_frames iterates over the packet and finds frames that are
-// relevant for us. The frames info and location are stored in the `frames_array` array,
-// and the number of frames found is returned.
+// relevant for us. The frames info and location are stored in the `iteration_value->frames_array` array,
+// and the number of frames found is being stored at iteration_value->frames_count.
 //
 // We consider frames as relevant if they are either:
 // - HEADERS frames
@@ -542,6 +542,7 @@ static __always_inline void find_relevant_frames(struct __sk_buff *skb, skb_info
     http2_frame_t current_frame = {};
 
    // If we have found enough interesting frames, we should not process any new frame.
+   // We want to validate that we don't have more than HTTP2_MAX_FRAMES_ITERATIONS frames in a single packet.
    if (iteration_value->frames_count >= HTTP2_MAX_FRAMES_ITERATIONS) {
        return;
    }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -542,8 +542,8 @@ static __always_inline void find_relevant_frames(struct __sk_buff *skb, skb_info
     http2_frame_t current_frame = {};
 
    // If we have found enough interesting frames, we should not process any new frame.
-    // This check accounts for a future change where the value of iteration_value->frames_count may potentially be greater than 0.
-    // It's essential to validate that this increase doesn't surpass the maximum number of frames we can process.
+   // This check accounts for a future change where the value of iteration_value->frames_count may potentially be greater than 0.
+   // It's essential to validate that this increase doesn't surpass the maximum number of frames we can process.
    if (iteration_value->frames_count >= HTTP2_MAX_FRAMES_ITERATIONS) {
        return;
    }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -542,7 +542,8 @@ static __always_inline void find_relevant_frames(struct __sk_buff *skb, skb_info
     http2_frame_t current_frame = {};
 
    // If we have found enough interesting frames, we should not process any new frame.
-   // We want to validate that we don't have more than HTTP2_MAX_FRAMES_ITERATIONS frames in a single packet.
+    // This check accounts for a future change where the value of iteration_value->frames_count may potentially be greater than 0.
+    // It's essential to validate that this increase doesn't surpass the maximum number of frames we can process.
    if (iteration_value->frames_count >= HTTP2_MAX_FRAMES_ITERATIONS) {
        return;
    }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -537,16 +537,14 @@ static __always_inline bool get_first_frame(struct __sk_buff *skb, skb_info_t *s
 // - HEADERS frames
 // - RST_STREAM frames
 // - DATA frames with the END_STREAM flag set
-static __always_inline __u16 find_relevant_frames(struct __sk_buff *skb, skb_info_t *skb_info, http2_frame_with_offset *frames_array, __u8 original_index, http2_telemetry_t *http2_tel) {
+static __always_inline void find_relevant_frames(struct __sk_buff *skb, skb_info_t *skb_info, http2_tail_call_state_t *iteration_value, http2_telemetry_t *http2_tel) {
     bool is_headers_or_rst_frame, is_data_end_of_stream;
     http2_frame_t current_frame = {};
 
-    // We may have found a relevant frame already in http2_handle_first_frame,
-    // so we need to adjust the index accordingly. We do not set
-    // interesting_frame_index to original_index directly, as this will confuse
-    // the verifier, leading it into thinking the index could have an arbitrary
-    // value.
-    __u16 interesting_frame_index = original_index == 1;
+   // If we have found enough interesting frames, we should not process any new frame.
+   if (iteration_value->frames_count >= HTTP2_MAX_FRAMES_ITERATIONS) {
+       return;
+   }
 
     __u32 iteration = 0;
 #pragma unroll(HTTP2_MAX_FRAMES_TO_FILTER)
@@ -567,12 +565,17 @@ static __always_inline __u16 find_relevant_frames(struct __sk_buff *skb, skb_inf
         // https://datatracker.ietf.org/doc/html/rfc7540#section-6.2 for headers frame.
         is_headers_or_rst_frame = current_frame.type == kHeadersFrame || current_frame.type == kRSTStreamFrame;
         is_data_end_of_stream = ((current_frame.flags & HTTP2_END_OF_STREAM) == HTTP2_END_OF_STREAM) && (current_frame.type == kDataFrame);
-        if (interesting_frame_index < HTTP2_MAX_FRAMES_ITERATIONS && (is_headers_or_rst_frame || is_data_end_of_stream)) {
-            frames_array[interesting_frame_index].frame = current_frame;
-            frames_array[interesting_frame_index].offset = skb_info->data_off;
-            interesting_frame_index++;
+        if (iteration_value->frames_count < HTTP2_MAX_FRAMES_ITERATIONS && (is_headers_or_rst_frame || is_data_end_of_stream)) {
+            iteration_value->frames_array[iteration_value->frames_count].frame = current_frame;
+            iteration_value->frames_array[iteration_value->frames_count].offset = skb_info->data_off;
+            iteration_value->frames_count++;
         }
         skb_info->data_off += current_frame.length;
+
+        // If we have found enough interesting frames, we can stop iterating.
+        if (iteration_value->frames_count >= HTTP2_MAX_FRAMES_ITERATIONS) {
+            break;
+        }
     }
 
     // Checking we can read HTTP2_FRAME_HEADER_SIZE from the skb - if we can, update telemetry to indicate we have
@@ -580,11 +583,10 @@ static __always_inline __u16 find_relevant_frames(struct __sk_buff *skb, skb_inf
         __sync_fetch_and_add(&http2_tel->exceeding_max_frames_to_filter, 1);
     }
 
-    if (interesting_frame_index == HTTP2_MAX_FRAMES_ITERATIONS) {
+    if (iteration_value->frames_count == HTTP2_MAX_FRAMES_ITERATIONS) {
         __sync_fetch_and_add(&http2_tel->exceeding_max_interesting_frames, 1);
     }
 
-    return interesting_frame_index;
 }
 
 SEC("socket/http2_handle_first_frame")
@@ -691,10 +693,7 @@ int socket__http2_filter(struct __sk_buff *skb) {
     // in a map, we cannot allow it to be modified. Thus, having a local copy of skb_info.
     skb_info_t local_skb_info = dispatcher_args_copy.skb_info;
 
-    // The verifier cannot tell if `iteration_value->frames_count` is 0 or 1, so we have to help it. The value is
-    // 1 if we have found an interesting frame in `socket__http2_handle_first_frame`, otherwise it is 0.
-    // filter frames
-    iteration_value->frames_count = find_relevant_frames(skb, &local_skb_info, iteration_value->frames_array, iteration_value->frames_count, http2_tel);
+    find_relevant_frames(skb, &local_skb_info, iteration_value, http2_tel);
 
     frame_header_remainder_t new_frame_state = { 0 };
     if (local_skb_info.data_off > local_skb_info.data_end) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR fixes the issue we had with the verifier. The solution was to set value directly to `interesting_frame_index`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This PR removes the dependency on directly setting `interesting_frame_index`. Consequently, we'll have the ability to set it arbitrarily, a crucial capability for us. This change sets the stage for a future PR, where we aim to enhance our filtering capacity by increasing the number of frames we can handle.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
