### PR TITLE
[usm] Improve perf event telemetry

### DIFF
--- a/pkg/network/ebpf/c/protocols/events-types.h
+++ b/pkg/network/ebpf/c/protocols/events-types.h
@@ -30,7 +30,8 @@ typedef struct {
     __u16 len;
     __u16 cap;
     __u16 event_size;
-    __u16 dropped_events;
+    __u32 dropped_events;
+    __u32 failed_flushes;
     char data[BATCH_BUFFER_SIZE];
 } batch_data_t;
 

--- a/pkg/network/ebpf/c/protocols/events.h
+++ b/pkg/network/ebpf/c/protocols/events.h
@@ -57,11 +57,13 @@
                 if (ret < 0) {                                                                          \
                     _LOG(name, "batch flush error: cpu: %d idx: %d err:%d",                             \
                          key.cpu, batch->idx, ret);                                                     \
+                    batch->failed_flushes++;                                                            \
                     return;                                                                             \
                 }                                                                                       \
                                                                                                         \
                 _LOG(name, "batch flushed: cpu: %d idx: %d", key.cpu, batch->idx);                      \
                 batch->dropped_events = 0;                                                              \
+                batch->failed_flushes = 0;                                                              \
                 batch->len = 0;                                                                         \
                 batch_state->idx_to_flush++;                                                            \
             }                                                                                           \

--- a/pkg/network/ebpf/c/protocols/events.h
+++ b/pkg/network/ebpf/c/protocols/events.h
@@ -1,9 +1,8 @@
 #ifndef __USM_EVENTS_H
 #define __USM_EVENTS_H
 
-#include "bpf_telemetry.h"
-
 #include "protocols/events-types.h"
+#define _STR(x) #x
 
 /* USM_EVENTS_INIT defines two functions used for the purposes of buffering and sending
    data to userspace:
@@ -39,7 +38,7 @@
             /* batch is not ready to be flushed */                                                      \
             return;                                                                                     \
         }                                                                                               \
-        _Pragma( STR(unroll(BATCH_PAGES_PER_CPU)) )                                                     \
+        _Pragma(_STR(unroll(BATCH_PAGES_PER_CPU)))                                                      \
             for (int i = 0; i < BATCH_PAGES_PER_CPU; i++) {                                             \
                 if (batch_state->idx_to_flush == batch_state->idx) return;                              \
                                                                                                         \
@@ -49,11 +48,11 @@
                     return;                                                                             \
                 }                                                                                       \
                                                                                                         \
-                long ret = bpf_perf_event_output_with_telemetry(ctx,                                    \
-                                                                &name##_batch_events,                   \
-                                                                key.cpu,                                \
-                                                                batch,                                  \
-                                                                sizeof(batch_data_t));                  \
+                long ret = bpf_perf_event_output(ctx,                                                   \
+                                                 &name##_batch_events,                                  \
+                                                 key.cpu,                                               \
+                                                 batch,                                                 \
+                                                 sizeof(batch_data_t));                                 \
                 if (ret < 0) {                                                                          \
                     _LOG(name, "batch flush error: cpu: %d idx: %d err:%d",                             \
                          key.cpu, batch->idx, ret);                                                     \
@@ -131,7 +130,6 @@ static __always_inline bool __enqueue_event(batch_data_t *batch, void *event, si
     return true;
 }
 
-#define _STR(x) #x
 #define _LOG(protocol, message, args...) \
     log_debug(_STR(protocol) " " message, args);
 

--- a/pkg/network/protocols/events/consumer.go
+++ b/pkg/network/protocols/events/consumer.go
@@ -13,8 +13,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"go.uber.org/atomic"
-
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -46,10 +44,9 @@ type Consumer[V any] struct {
 	// telemetry
 	metricGroup        *telemetry.MetricGroup
 	eventsCount        *telemetry.Counter
-	missesCount        *telemetry.Counter
+	failedFlushesCount *telemetry.Counter
 	kernelDropsCount   *telemetry.Counter
 	invalidEventsCount *telemetry.Counter
-	batchSize          *atomic.Int64
 }
 
 // NewConsumer instantiates a new event Consumer
@@ -88,9 +85,22 @@ func NewConsumer[V any](proto string, ebpf *manager.Manager, callback func([]V))
 	)
 
 	eventsCount := metricGroup.NewCounter("events_captured")
-	missesCount := metricGroup.NewCounter("events_missed")
 	kernelDropsCount := metricGroup.NewCounter("kernel_dropped_events")
 	invalidEventsCount := metricGroup.NewCounter("invalid_events")
+
+	// failedFlushesCount tracks the number of failed calls to
+	// `bpf_perf_event_output`. This is usually indicative of a slow-consumer
+	// problem, because flushing a perf event will fail when there is no space
+	// available in the perf ring. Having said that, in the context of this
+	// library a failed call to `bpf_perf_event_ouput` won't necessarily
+	// translate into data drop, because this library will retry flushing a
+	// given batch *until the call to `bpf_perf_event_output` succeeds*.  This
+	// is OK (in terms of no datapoints being dropped) as long as we have enough
+	// event "slots" in other batch pages.
+	//
+	// The exact number of events dropped can be obtained using the metric
+	// `kernel_dropped_events`.
+	failedFlushesCount := metricGroup.NewCounter("failed_flushes")
 
 	return &Consumer[V]{
 		proto:       proto,
@@ -103,10 +113,9 @@ func NewConsumer[V any](proto string, ebpf *manager.Manager, callback func([]V))
 		// telemetry
 		metricGroup:        metricGroup,
 		eventsCount:        eventsCount,
-		missesCount:        missesCount,
+		failedFlushesCount: failedFlushesCount,
 		kernelDropsCount:   kernelDropsCount,
 		invalidEventsCount: invalidEventsCount,
-		batchSize:          atomic.NewInt64(0),
 	}, nil
 }
 
@@ -134,8 +143,8 @@ func (c *Consumer[V]) Start() {
 					return
 				}
 
-				missedEvents := c.batchSize.Load()
-				c.missesCount.Add(missedEvents)
+				// we have our own telemetry to track failed flushes so we don't
+				// do anything here other than draining this channel
 			case done, ok := <-c.syncRequest:
 				if !ok {
 					return
@@ -206,10 +215,15 @@ func (c *Consumer[V]) process(cpu int, b *batch, syncing bool) {
 		return
 	}
 
-	// telemetry stuff
-	c.batchSize.Store(int64(b.Cap))
 	c.eventsCount.Add(int64(end - begin))
-	c.kernelDropsCount.Add(int64(b.Dropped_events))
+
+	// Only track these bits of telemetry when we're reading the batch off the
+	// perf ring. In other words, if we're fetching the batch data via a Sync()
+	// call, skip this otherwise we'll double report the telemetry.
+	if !syncing {
+		c.failedFlushesCount.Add(int64(b.Failed_flushes))
+		c.kernelDropsCount.Add(int64(b.Dropped_events))
+	}
 
 	// generate a slice of type []V from the batch
 	ptr := pointerToElement[V](b, begin)

--- a/pkg/network/protocols/events/consumer.go
+++ b/pkg/network/protocols/events/consumer.go
@@ -92,11 +92,11 @@ func NewConsumer[V any](proto string, ebpf *manager.Manager, callback func([]V))
 	// `bpf_perf_event_output`. This is usually indicative of a slow-consumer
 	// problem, because flushing a perf event will fail when there is no space
 	// available in the perf ring. Having said that, in the context of this
-	// library a failed call to `bpf_perf_event_ouput` won't necessarily
+	// library a failed call to `bpf_perf_event_output` won't necessarily
 	// translate into data drop, because this library will retry flushing a
 	// given batch *until the call to `bpf_perf_event_output` succeeds*.  This
 	// is OK (in terms of no datapoints being dropped) as long as we have enough
-	// event "slots" in other batch pages.
+	// event "slots" in other batch pages while the retrying happens.
 	//
 	// The exact number of events dropped can be obtained using the metric
 	// `kernel_dropped_events`.

--- a/pkg/network/protocols/events/consumer_test.go
+++ b/pkg/network/protocols/events/consumer_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	bpftelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -133,8 +132,7 @@ func newEBPFProgram(c *config.Config) (*manager.Manager, error) {
 	}
 	defer bc.Close()
 
-	bpfTelemetry := bpftelemetry.NewEBPFTelemetry()
-	m := bpftelemetry.NewManager(&manager.Manager{
+	m := &manager.Manager{
 		Probes: []*manager.Probe{
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
@@ -142,7 +140,7 @@ func newEBPFProgram(c *config.Config) (*manager.Manager, error) {
 				},
 			},
 		},
-	}, bpfTelemetry)
+	}
 	options := manager.Options{
 		RLimit: &unix.Rlimit{
 			Cur: math.MaxUint64,
@@ -163,11 +161,11 @@ func newEBPFProgram(c *config.Config) (*manager.Manager, error) {
 		},
 	}
 
-	Configure("test", m.Manager, &options)
+	Configure("test", m, &options)
 	err = m.InitWithOptions(bc, options)
 	if err != nil {
 		return nil, err
 	}
 
-	return m.Manager, nil
+	return m, nil
 }

--- a/pkg/network/protocols/events/types_linux.go
+++ b/pkg/network/protocols/events/types_linux.go
@@ -8,7 +8,8 @@ type batch struct {
 	Len            uint16
 	Cap            uint16
 	Event_size     uint16
-	Dropped_events uint16
+	Dropped_events uint32
+	Failed_flushes uint32
 	Data           [4096]int8
 }
 type batchKey struct {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Improve perf event telemetry emitted by our `protocols/events` library.

* Remove `events_missed` metric which can be misleading;
* Add `failed_flushes` metrics which will represent the number of failed `bpf_perf_event_output` calls. This will be based on kernel-side telemetry as opposed to the `LostChannel` messages (sourced from `PERF_RECORD_LOST` messages). The motivation for this is that `PERF_RECORD_LOST` events representa only a subset of all possible errors;
* Ensure that neither `kernel_dropped_events` nor `failed_flushes` are accounted for when calling `Sync()`. This is a current bug that may result in overcounting errors, though I would expect the error margin nearly negligible;

### Motivation

Currently we have a metric `usm.<protocol>.events_missed` that tracks the number of "missed" perf events for a given protocol. In the context of our `events` library, a perf event is actually a batch of USM events, represented by the `batch_data_t` type, which is shared across all protocols. So in order for this metric to represent the actual number of USM events supposedly lost, we multiply it by the batch size.

The main problem with the approach is the fact that `bpf_perf_event_output` failures won't necessarily lead to data loss due to the way that our library works, so the name of the metric (`events_missed`) is definitely misleading.

The metric that should accurately represent data loss is `usm.<protocol>.kernel_dropped_events`. This will happen whenever we fail to *enqueue* an event to a `batch_data_t` map entry. Once an event is enqueued, it will eventually be sent to userspace, even if it takes multiple attempts to flush it.

An event will fail to be enqueued whenever _all_ batch pages for a given CPU are completely full.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
