### PR TITLE
[CONTINT-3580] Safely acknowledge workloadmeta events

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -55,7 +55,10 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 				close(resultChan)
 				return
 
-			case eventBundle := <-imgEventsCh:
+			case eventBundle, ok := <-imgEventsCh:
+				if !ok {
+					return
+				}
 				eventBundle.Acknowledge()
 
 				for _, event := range eventBundle.Events {

--- a/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -56,7 +56,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 				return
 
 			case eventBundle := <-imgEventsCh:
-				close(eventBundle.Ch)
+				eventBundle.Acknowledge()
 
 				for _, event := range eventBundle.Events {
 					image := event.Entity.(*workloadmeta.ContainerImageMetadata)

--- a/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -57,6 +57,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 
 			case eventBundle, ok := <-imgEventsCh:
 				if !ok {
+					// closed channel case
 					return
 				}
 				eventBundle.Acknowledge()

--- a/comp/core/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -61,7 +61,10 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 			case <-ctx.Done():
 				return
 
-			case eventBundle := <-imgEventsCh:
+			case eventBundle, ok := <-imgEventsCh:
+				if !ok {
+					return
+				}
 				eventBundle.Acknowledge()
 
 				for _, event := range eventBundle.Events {

--- a/comp/core/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -62,7 +62,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 				return
 
 			case eventBundle := <-imgEventsCh:
-				close(eventBundle.Ch)
+				eventBundle.Acknowledge()
 
 				for _, event := range eventBundle.Events {
 					image := event.Entity.(*workloadmeta.ContainerImageMetadata)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -63,9 +63,7 @@ func testCollectEvent(t *testing.T, createResource func(*fake.Clientset) error, 
 	read := assert.Eventually(t, func() bool {
 		select {
 		case bundle = <-ch:
-			if bundle.Ch != nil {
-				close(bundle.Ch)
-			}
+			bundle.Acknowledge()
 			if len(bundle.Events) == 0 {
 				return false
 			}
@@ -80,9 +78,7 @@ func testCollectEvent(t *testing.T, createResource func(*fake.Clientset) error, 
 	// Retrieving the resource in an event bundle
 	if !read {
 		bundle = <-ch
-		if bundle.Ch != nil {
-			close(bundle.Ch)
-		}
+		bundle.Acknowledge()
 	}
 
 	// nil the bundle's Ch so we can

--- a/comp/core/workloadmeta/component.go
+++ b/comp/core/workloadmeta/component.go
@@ -47,7 +47,8 @@ type Component interface {
 	// for messages on this channel.
 	Subscribe(name string, priority SubscriberPriority, filter *Filter) chan EventBundle
 
-	// Unsubscribe reverses the effect of Subscribe.
+	// Unsubscribe closes the EventBundle channel. Note that it will emit a zero-value event.
+	// Thus, it is important to check that the channel is not closed.
 	Unsubscribe(ch chan EventBundle)
 
 	// GetContainer returns metadata about a container.  It fetches the entity

--- a/comp/core/workloadmeta/server/server.go
+++ b/comp/core/workloadmeta/server/server.go
@@ -51,7 +51,7 @@ func (s *Server) StreamEntities(in *pb.WorkloadmetaStreamRequest, out pb.AgentSe
 	for {
 		select {
 		case eventBundle := <-workloadmetaEventsChannel:
-			close(eventBundle.Ch)
+			eventBundle.Acknowledge()
 
 			var protobufEvents []*pb.WorkloadmetaEvent
 

--- a/comp/core/workloadmeta/server/server.go
+++ b/comp/core/workloadmeta/server/server.go
@@ -50,7 +50,10 @@ func (s *Server) StreamEntities(in *pb.WorkloadmetaStreamRequest, out pb.AgentSe
 
 	for {
 		select {
-		case eventBundle := <-workloadmetaEventsChannel:
+		case eventBundle, ok := <-workloadmetaEventsChannel:
+			if !ok {
+				return nil
+			}
 			eventBundle.Acknowledge()
 
 			var protobufEvents []*pb.WorkloadmetaEvent

--- a/comp/core/workloadmeta/store.go
+++ b/comp/core/workloadmeta/store.go
@@ -737,13 +737,10 @@ func (w *workloadmeta) notifyChannel(name string, ch chan EventBundle, events []
 	ch <- bundle
 
 	if wait {
-		timer := time.NewTimer(eventBundleChTimeout)
-
 		select {
 		case <-bundle.Ch:
-			timer.Stop()
 			telemetry.NotificationsSent.Inc(name, telemetry.StatusSuccess)
-		case <-timer.C:
+		case <-time.After(eventBundleChTimeout):
 			log.Warnf("collector %q did not close the event bundle channel in time, continuing with downstream collectors. bundle size: %d", name, len(bundle.Events))
 			telemetry.NotificationsSent.Inc(name, telemetry.StatusError)
 		}

--- a/comp/core/workloadmeta/store_example_test.go
+++ b/comp/core/workloadmeta/store_example_test.go
@@ -38,7 +38,7 @@ func TestExampleStoreSubscribe(t *testing.T) {
 	go func() {
 		for bundle := range ch {
 			// close Ch to indicate that the Store can proceed to the next subscriber
-			close(bundle.Ch)
+			bundle.Acknowledge()
 
 			for _, evt := range bundle.Events {
 				if evt.Type == EventTypeSet {

--- a/comp/core/workloadmeta/store_test.go
+++ b/comp/core/workloadmeta/store_test.go
@@ -605,7 +605,7 @@ func TestSubscribe(t *testing.T) {
 			actual := []EventBundle{}
 			go func() {
 				for bundle := range ch {
-					close(bundle.Ch)
+					bundle.Acknowledge()
 
 					// nil the bundle's Ch so we can
 					// deep-equal just the events later
@@ -1227,7 +1227,7 @@ func TestResetProcesses(t *testing.T) {
 
 			go func() {
 				for bundle := range ch {
-					close(bundle.Ch)
+					bundle.Acknowledge()
 
 					// nil the bundle's Ch so we can deep-equal just the events
 					// later
@@ -1427,7 +1427,7 @@ func TestReset(t *testing.T) {
 			var actualEventsReceived []EventBundle
 			go func() {
 				for bundle := range ch {
-					close(bundle.Ch)
+					bundle.Acknowledge()
 
 					// nil the bundle's Ch so we can deep-equal just the events
 					// later

--- a/comp/core/workloadmeta/types.go
+++ b/comp/core/workloadmeta/types.go
@@ -1027,6 +1027,13 @@ type EventBundle struct {
 	// Events gives the events in this bundle.
 	Events []Event
 
-	// Ch should be closed once the subscriber has handled the event.
+	// ch should be closed once the subscriber has handled the event.
 	Ch chan struct{}
+}
+
+// Acknowledge acknowledges that the subscriber has handled the event.
+func (e EventBundle) Acknowledge() {
+	if e.Ch != nil {
+		close(e.Ch)
+	}
 }

--- a/comp/core/workloadmeta/types.go
+++ b/comp/core/workloadmeta/types.go
@@ -1027,7 +1027,7 @@ type EventBundle struct {
 	// Events gives the events in this bundle.
 	Events []Event
 
-	// ch should be closed once the subscriber has handled the event.
+	// Ch should be closed once the subscriber has handled the event.
 	Ch chan struct{}
 }
 

--- a/comp/languagedetection/client/clientimpl/client.go
+++ b/comp/languagedetection/client/clientimpl/client.go
@@ -197,7 +197,7 @@ func (c *client) cleanUpProcesssesWithoutPod(now time.Time) {
 
 // handleEvent handles events from workloadmeta
 func (c *client) handleEvent(evBundle workloadmeta.EventBundle) {
-	close(evBundle.Ch)
+	evBundle.Acknowledge()
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	c.logger.Tracef("Processing %d events", len(evBundle.Events))

--- a/comp/languagedetection/client/clientimpl/client.go
+++ b/comp/languagedetection/client/clientimpl/client.go
@@ -175,7 +175,10 @@ func (c *client) run() {
 
 	for {
 		select {
-		case eventBundle := <-eventCh:
+		case eventBundle, ok := <-eventCh:
+			if !ok {
+				return
+			}
 			c.handleEvent(eventBundle)
 		case <-cleanupProcessesWithoutPodCleanupTicker.C:
 			c.cleanUpProcesssesWithoutPod(time.Now())

--- a/pkg/autodiscovery/listeners/workloadmeta.go
+++ b/pkg/autodiscovery/listeners/workloadmeta.go
@@ -166,9 +166,9 @@ func (l *workloadmetaListenerImpl) Stop() {
 }
 
 func (l *workloadmetaListenerImpl) processEvents(evBundle workloadmeta.EventBundle) {
-	// close the bundle channel asap since there are no downstream
+	// Acknowledge the bundle since there are no downstream
 	// collectors that depend on AD having up to date data.
-	close(evBundle.Ch)
+	evBundle.Acknowledge()
 
 	for _, ev := range evBundle.Events {
 		entity := ev.Entity

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -81,8 +81,7 @@ func (k *ContainerConfigProvider) Stream(ctx context.Context) <-chan integration
 				// need to signal that an event has been
 				// received, for flow control reasons
 				outCh <- k.processEvents(evBundle)
-
-				close(evBundle.Ch)
+				evBundle.Acknowledge()
 			}
 		}
 	}()

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -77,8 +77,8 @@ func (c *ContainerTagger) Start(ctx context.Context) {
 		for {
 			select {
 			case bundle := <-ch:
-				// close Ch to indicate that the Store can proceed to the next subscriber
-				close(bundle.Ch)
+				// Acknowledge the evBundle to indicate that the Store can proceed to the next subscriber
+				bundle.Acknowledge()
 
 				for _, evt := range bundle.Events {
 					err := c.processEvent(ctx, evt)

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -76,7 +76,11 @@ func (c *ContainerTagger) Start(ctx context.Context) {
 		defer c.store.Unsubscribe(ch)
 		for {
 			select {
-			case bundle := <-ch:
+			case bundle, ok := <-ch:
+				if !ok {
+					return
+				}
+
 				// Acknowledge the evBundle to indicate that the Store can proceed to the next subscriber
 				bundle.Acknowledge()
 

--- a/pkg/collector/corechecks/containerimage/check.go
+++ b/pkg/collector/corechecks/containerimage/check.go
@@ -147,18 +147,17 @@ func (c *Check) Run() error {
 
 	imgRefreshTicker := time.NewTicker(time.Duration(c.instance.PeriodicRefreshSeconds) * time.Second)
 
+	defer c.processor.stop()
 	for {
 		select {
 		case eventBundle, ok := <-imgEventsCh:
 			if !ok {
-				c.processor.stop()
 				return nil
 			}
 			c.processor.processEvents(eventBundle)
 		case <-imgRefreshTicker.C:
 			c.processor.processRefresh(c.workloadmetaStore.ListImages())
 		case <-c.stopCh:
-			c.processor.stop()
 			return nil
 		}
 	}

--- a/pkg/collector/corechecks/containerimage/check.go
+++ b/pkg/collector/corechecks/containerimage/check.go
@@ -149,7 +149,11 @@ func (c *Check) Run() error {
 
 	for {
 		select {
-		case eventBundle := <-imgEventsCh:
+		case eventBundle, ok := <-imgEventsCh:
+			if !ok {
+				c.processor.stop()
+				return nil
+			}
 			c.processor.processEvents(eventBundle)
 		case <-imgRefreshTicker.C:
 			c.processor.processRefresh(c.workloadmetaStore.ListImages())

--- a/pkg/collector/corechecks/containerimage/processor.go
+++ b/pkg/collector/corechecks/containerimage/processor.go
@@ -57,7 +57,7 @@ func newProcessor(sender sender.Sender, maxNbItem int, maxRetentionTime time.Dur
 }
 
 func (p *processor) processEvents(evBundle workloadmeta.EventBundle) {
-	close(evBundle.Ch)
+	evBundle.Acknowledge()
 
 	log.Tracef("Processing %d events", len(evBundle.Events))
 

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -122,9 +122,17 @@ func (c *Check) Run() error {
 
 	for {
 		select {
-		case eventBundle := <-contEventsCh:
+		case eventBundle, ok := <-contEventsCh:
+			if !ok {
+				stopProcessor()
+				return nil
+			}
 			c.processor.processEvents(eventBundle)
-		case eventBundle := <-podEventsCh:
+		case eventBundle, ok := <-podEventsCh:
+			if !ok {
+				stopProcessor()
+				return nil
+			}
 			c.processor.processEvents(eventBundle)
 		case <-c.stopCh:
 			stopProcessor()

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -120,11 +120,11 @@ func (c *Check) Run() error {
 	processorCtx, stopProcessor := context.WithCancel(context.Background())
 	c.processor.start(processorCtx, pollInterval)
 
+	defer stopProcessor()
 	for {
 		select {
 		case eventBundle, ok := <-contEventsCh:
 			if !ok {
-				stopProcessor()
 				return nil
 			}
 			c.processor.processEvents(eventBundle)
@@ -135,7 +135,6 @@ func (c *Check) Run() error {
 			}
 			c.processor.processEvents(eventBundle)
 		case <-c.stopCh:
-			stopProcessor()
 			return nil
 		}
 	}

--- a/pkg/collector/corechecks/containerlifecycle/processor.go
+++ b/pkg/collector/corechecks/containerlifecycle/processor.go
@@ -44,7 +44,7 @@ func (p *processor) start(ctx context.Context, pollInterval time.Duration) {
 
 // processEvents handles workloadmeta events, supports pods and container unset events.
 func (p *processor) processEvents(evBundle workloadmeta.EventBundle) {
-	close(evBundle.Ch)
+	evBundle.Acknowledge()
 
 	log.Tracef("Processing %d events", len(evBundle.Events))
 

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -193,11 +193,11 @@ func (c *Check) Run() error {
 	metricTicker := time.NewTicker(metricPeriod)
 	defer metricTicker.Stop()
 
+	defer c.processor.stop()
 	for {
 		select {
 		case eventBundle, ok := <-imgEventsCh:
 			if !ok {
-				c.processor.stop()
 				return nil
 			}
 			c.processor.processContainerImagesEvents(eventBundle)
@@ -208,7 +208,6 @@ func (c *Check) Run() error {
 		case <-metricTicker.C:
 			c.sendUsageMetrics()
 		case <-c.stopCh:
-			c.processor.stop()
 			return nil
 		}
 	}

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -195,7 +195,11 @@ func (c *Check) Run() error {
 
 	for {
 		select {
-		case eventBundle := <-imgEventsCh:
+		case eventBundle, ok := <-imgEventsCh:
+			if !ok {
+				c.processor.stop()
+				return nil
+			}
 			c.processor.processContainerImagesEvents(eventBundle)
 		case <-containerPeriodicRefreshTicker.C:
 			c.processor.processContainerImagesRefresh(c.workloadmetaStore.ListImages())

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -94,7 +94,7 @@ func newProcessor(workloadmetaStore workloadmeta.Component, sender sender.Sender
 }
 
 func (p *processor) processContainerImagesEvents(evBundle workloadmeta.EventBundle) {
-	close(evBundle.Ch)
+	evBundle.Acknowledge()
 
 	log.Tracef("Processing %d events", len(evBundle.Events))
 

--- a/pkg/process/metadata/workloadmeta/collector/process.go
+++ b/pkg/process/metadata/workloadmeta/collector/process.go
@@ -85,7 +85,11 @@ func (c *Collector) run(ctx context.Context, store workloadmeta.Component, conta
 
 	for {
 		select {
-		case evt := <-containerEvt:
+		case evt, ok := <-containerEvt:
+			if !ok {
+				log.Infof("The %s collector has stopped, workloadmeta channel is closed", collectorId)
+				return
+			}
 			c.handleContainerEvent(evt)
 		case <-collectionTicker.C:
 			err := c.processData.Fetch()

--- a/pkg/process/metadata/workloadmeta/collector/process.go
+++ b/pkg/process/metadata/workloadmeta/collector/process.go
@@ -104,7 +104,7 @@ func (c *Collector) run(ctx context.Context, store workloadmeta.Component, conta
 }
 
 func (c *Collector) handleContainerEvent(evt workloadmeta.EventBundle) {
-	evt.Acknowledge()
+	defer evt.Acknowledge()
 
 	for _, evt := range evt.Events {
 		ent := evt.Entity.(*workloadmeta.Container)

--- a/pkg/process/metadata/workloadmeta/collector/process.go
+++ b/pkg/process/metadata/workloadmeta/collector/process.go
@@ -100,11 +100,7 @@ func (c *Collector) run(ctx context.Context, store workloadmeta.Component, conta
 }
 
 func (c *Collector) handleContainerEvent(evt workloadmeta.EventBundle) {
-	defer func() {
-		if evt.Ch != nil {
-			close(evt.Ch)
-		}
-	}()
+	evt.Acknowledge()
 
 	for _, evt := range evt.Events {
 		ent := evt.Entity.(*workloadmeta.Container)

--- a/pkg/process/metadata/workloadmeta/collector/process_test.go
+++ b/pkg/process/metadata/workloadmeta/collector/process_test.go
@@ -134,9 +134,10 @@ func (c *collectorTest) setupProcs() {
 func (c *collectorTest) waitForContainerUpdate(t *testing.T, cont *workloadmeta.Container) {
 	t.Helper()
 
+	pid := cont.PID
 	c.store.Set(cont)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.Contains(t, c.collector.pidToCid, cont.PID)
+		assert.Contains(t, c.collector.pidToCid, pid)
 	}, 15*time.Second, 1*time.Second)
 }
 

--- a/pkg/process/metadata/workloadmeta/collector/process_test.go
+++ b/pkg/process/metadata/workloadmeta/collector/process_test.go
@@ -134,10 +134,9 @@ func (c *collectorTest) setupProcs() {
 func (c *collectorTest) waitForContainerUpdate(t *testing.T, cont *workloadmeta.Container) {
 	t.Helper()
 
-	pid := cont.PID
 	c.store.Set(cont)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.Contains(t, c.collector.pidToCid, pid)
+		assert.Contains(t, c.collector.pidToCid, cont.PID)
 	}, 15*time.Second, 1*time.Second)
 }
 

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -171,7 +171,7 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 		c.tagProcessor.ProcessTagInfo(tagInfos)
 	}
 
-	close(evBundle.Ch)
+	evBundle.Acknowledge()
 }
 
 func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*TagInfo {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR modifies the event acknowledgement logic of workloadmeta.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Internally, we've noticed some rare occurrence of panic because the channel was nil. It only occurs on shutdown.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Internally, check that we do not have any panic related to a subscriber closing a nil channel.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
