### PR TITLE
Set the first trace tags separately for each service

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -2298,6 +2298,20 @@ func TestSetFirstTraceTags(t *testing.T) {
 		assert.False(t, ok)
 		_, ok = anotherRoot.Meta[tagInstallTime]
 		assert.False(t, ok)
+
+		// However, calling setFirstTraceTags on another span from a different service should set the tags again
+		differentServiceRoot := &pb.Span{
+			Service:  "discombobulator",
+			Name:     "parent",
+			TraceID:  2,
+			SpanID:   2,
+			Start:    time.Now().Add(-time.Second).UnixNano(),
+			Duration: time.Millisecond.Nanoseconds(),
+		}
+		traceAgent.setFirstTraceTags(differentServiceRoot)
+		assert.Equal(t, cfg.InstallSignature.InstallID, differentServiceRoot.Meta[tagInstallID])
+		assert.Equal(t, cfg.InstallSignature.InstallType, differentServiceRoot.Meta[tagInstallType])
+		assert.Equal(t, fmt.Sprintf("%v", cfg.InstallSignature.InstallTime), differentServiceRoot.Meta[tagInstallTime])
 	})
 
 	traceAgent = NewTestAgent(ctx, cfg, telemetry.NewNoopCollector())


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This implements the 2nd option from [this RFC](https://docs.google.com/document/d/1c9R8ayo2wskbRDyctiyBahksIajMeE9A0UncTmcJjjw/edit), which was to have the trace agent tag the first trace that it receives for each service, as opposed to the first trace overall.

Basically, we are interested in measuring the time from the tracer agent install to the first trace received at the service granularity. If every tracer lib also did the work of tagging the first trace, then we would not need any additional changes in the trace agent. But since we decided to have tracer libs not keep track of which trace is first, and since we want to correctly handle the scenario where one and the same instance of the agent processes traces for multiple services, this change is necessary.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Jira: [Tag the first trace for each service, not just the first trace overall, with install info](https://datadoghq.atlassian.net/browse/AIT-9206)

Also see [this RFC](https://docs.google.com/document/d/1c9R8ayo2wskbRDyctiyBahksIajMeE9A0UncTmcJjjw/edit) and [this thread on Slack](https://dd.slack.com/archives/CLWN64GAW/p1703067649531709)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

It is theoretically possible for an org to change their service name erratically and fill a lot of memory in the trace agent with random service names. I think the cost of starting up a Kubernetes pod is high enough that this is either not going to cause the trace agent to OOM, or the OOMs will be acceptably infrequent.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Make sure the unit tests pass, including the updated one, and that circle CI is green.

For an end-to-end test, compile and run the trace agent locally as described in the test plan on https://github.com/DataDog/datadog-agent/pull/20733 . Run an instrumented service locally and make sure the first trace sent to the backend [gets tagged with the first trace tags](https://dd.datad0g.com/api/ui/trace/7396991593477631547). Change the name of your local service, restart the service without restarting the agent, and make sure the first trace [once again gets tagged with the install information](https://dd.datad0g.com/api/ui/trace/8548656064905241328). Make sure any traces other than the first one [do not get tagged with the install tags](https://dd.datad0g.com/api/ui/trace/7760435107867785260).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
