### PR TITLE
[CWS] Close ebpfless gaps

### DIFF
--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -146,8 +146,8 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 		event.Type = uint32(model.ExitEventType)
 		event.ProcessContext.ExitTime = time.Unix(0, int64(syscallMsg.Timestamp))
 		event.Exit.Process = &event.ProcessCacheEntry.Process
-		event.Exit.Cause = uint32(model.ExitExited) // TODO: fix cause
-		event.Exit.Code = 0                         // TODO: fix code
+		event.Exit.Cause = uint32(syscallMsg.Exit.Cause)
+		event.Exit.Code = syscallMsg.Exit.Code
 		defer p.Resolvers.ProcessResolver.DeleteEntry(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: cl.nsID}, event.ProcessContext.ExitTime)
 	}
 

--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -100,7 +100,7 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 	switch syscallMsg.Type {
 	case ebpfless.SyscallTypeExec:
 		event.Type = uint32(model.ExecEventType)
-		entry := p.Resolvers.ProcessResolver.AddExecEntry(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: cl.nsID}, syscallMsg.Exec.File.Filename, syscallMsg.Exec.Args, syscallMsg.Exec.Envs, cl.containerContext.ID, syscallMsg.Timestamp)
+		entry := p.Resolvers.ProcessResolver.AddExecEntry(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: cl.nsID}, syscallMsg.Exec.File.Filename, syscallMsg.Exec.Args, syscallMsg.Exec.Envs, cl.containerContext.ID, syscallMsg.Timestamp, syscallMsg.Exec.TTY)
 		if syscallMsg.Exec.Credentials != nil {
 			entry.Credentials.UID = syscallMsg.Exec.Credentials.UID
 			entry.Credentials.EUID = syscallMsg.Exec.Credentials.EUID

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -71,7 +71,7 @@ type Credentials struct {
 
 // ExecSyscallMsg defines an exec message
 type ExecSyscallMsg struct {
-	Filename    string
+	File        *OpenSyscallMsg
 	Args        []string
 	Envs        []string
 	Credentials *Credentials
@@ -90,9 +90,12 @@ type ExitSyscallMsg struct {
 
 // OpenSyscallMsg defines an open message
 type OpenSyscallMsg struct {
-	Filename string
-	Flags    uint32
-	Mode     uint32
+	Filename    string
+	CTime       uint64
+	MTime       uint64
+	Flags       uint32
+	Mode        uint32
+	Credentials *Credentials
 }
 
 // DupSyscallFakeMsg defines a dup message

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -74,6 +74,7 @@ type ExecSyscallMsg struct {
 	File        *OpenSyscallMsg
 	Args        []string
 	Envs        []string
+	TTY         string
 	Credentials *Credentials
 }
 

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -112,16 +112,17 @@ type SetGIDSyscallMsg struct {
 
 // SyscallMsg defines a syscall message
 type SyscallMsg struct {
-	Type   SyscallType
-	PID    uint32
-	Retval int64
-	Exec   *ExecSyscallMsg   `json:",omitempty"`
-	Open   *OpenSyscallMsg   `json:",omitempty"`
-	Fork   *ForkSyscallMsg   `json:",omitempty"`
-	Exit   *ExitSyscallMsg   `json:",omitempty"`
-	Fcntl  *FcntlSyscallMsg  `json:",omitempty"`
-	SetUID *SetUIDSyscallMsg `json:",omitempty"`
-	SetGID *SetGIDSyscallMsg `json:",omitempty"`
+	Type      SyscallType
+	PID       uint32
+	Timestamp uint64
+	Retval    int64
+	Exec      *ExecSyscallMsg   `json:",omitempty"`
+	Open      *OpenSyscallMsg   `json:",omitempty"`
+	Fork      *ForkSyscallMsg   `json:",omitempty"`
+	Exit      *ExitSyscallMsg   `json:",omitempty"`
+	Fcntl     *FcntlSyscallMsg  `json:",omitempty"`
+	SetUID    *SetUIDSyscallMsg `json:",omitempty"`
+	SetGID    *SetGIDSyscallMsg `json:",omitempty"`
 
 	// internals
 	Dup   *DupSyscallFakeMsg   `json:",omitempty"`

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -6,7 +6,11 @@
 // Package ebpfless holds msgpack messages
 package ebpfless
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
 
 // MessageType defines the type of a message
 type MessageType int32
@@ -79,7 +83,10 @@ type ForkSyscallMsg struct {
 }
 
 // ExitSyscallMsg defines an exit message
-type ExitSyscallMsg struct{}
+type ExitSyscallMsg struct {
+	Code  uint32
+	Cause model.ExitCause
+}
 
 // OpenSyscallMsg defines an open message
 type OpenSyscallMsg struct {

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/native"
 )
 
+// CwsInstrumentationEnvDisableStats defines the environ variable to set to disable aviodable stats
 const CwsInstrumentationEnvDisableStats = "CWS_INSTRUMENTATION_DISABLE_STATS"
 
 type fileHandleKey struct {
@@ -239,7 +240,6 @@ func handleNameToHandleAtRet(tracer *Tracer, process *Process, msg *ebpfless.Sys
 	fileHandleCache[key] = &fileHandleVal{
 		pathName: msg.Open.Filename,
 	}
-	return
 }
 
 func handleOpenByHandleAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
@@ -461,7 +461,7 @@ func handleSetregid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs s
 	return nil
 }
 
-func handleClose(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
+func handleClose(tracer *Tracer, process *Process, _ *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
 	fd := tracer.ReadArgInt32(regs, 0)
 	delete(process.Res.Fd, fd)
 	return nil

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -29,22 +29,9 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/util/native"
 )
-
-// CwsInstrumentationEnvDisableStats defines the environ variable to set to disable aviodable stats
-const CwsInstrumentationEnvDisableStats = "CWS_INSTRUMENTATION_DISABLE_STATS"
-
-type fileHandleKey struct {
-	handleBytes uint32
-	handleType  int32
-}
-
-type fileHandleVal struct {
-	pathName string
-}
-
-var fileHandleCache map[fileHandleKey]*fileHandleVal
 
 func fillProcessCwd(process *Process) error {
 	cwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", process.Pid))
@@ -85,12 +72,8 @@ func getFullPathFromFilename(process *Process, filename string) (string, error) 
 	return filename, nil
 }
 
-func fillFileMetadata(filepath string, openMsg *ebpfless.OpenSyscallMsg) error {
-	// Lookup option to disable avoidable usage of stats to reduce the induced overhead
-	if os.Getenv(CwsInstrumentationEnvDisableStats) != "" {
-		return nil
-	}
-	if strings.HasPrefix(filepath, "memfd:") {
+func fillFileMetadata(filepath string, openMsg *ebpfless.OpenSyscallMsg, disableStats bool) error {
+	if disableStats || strings.HasPrefix(filepath, "memfd:") {
 		return nil
 	}
 
@@ -113,7 +96,7 @@ func fillFileMetadata(filepath string, openMsg *ebpfless.OpenSyscallMsg) error {
 	return nil
 }
 
-func handleOpenAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
+func handleOpenAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
 	fd := tracer.ReadArgInt32(regs, 0)
 
 	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
@@ -133,14 +116,14 @@ func handleOpenAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, re
 		Mode:     uint32(tracer.ReadArgUint64(regs, 3)),
 	}
 
-	err = fillFileMetadata(filename, msg.Open)
+	err = fillFileMetadata(filename, msg.Open, disableStats)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func handleOpen(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
+func handleOpen(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
 	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
 	if err != nil {
 		return err
@@ -158,14 +141,14 @@ func handleOpen(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs
 		Mode:     uint32(tracer.ReadArgUint64(regs, 2)),
 	}
 
-	err = fillFileMetadata(filename, msg.Open)
+	err = fillFileMetadata(filename, msg.Open, disableStats)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func handleCreat(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
+func handleCreat(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
 	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
 	if err != nil {
 		return err
@@ -183,7 +166,7 @@ func handleCreat(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, reg
 		Mode:     uint32(tracer.ReadArgUint64(regs, 1)),
 	}
 
-	err = fillFileMetadata(filename, msg.Open)
+	err = fillFileMetadata(filename, msg.Open, disableStats)
 	if err != nil {
 		return err
 	}
@@ -255,12 +238,12 @@ func handleNameToHandleAtRet(tracer *Tracer, process *Process, msg *ebpfless.Sys
 		handleBytes: handleBytes,
 		handleType:  handleType,
 	}
-	fileHandleCache[key] = &fileHandleVal{
+	process.Res.FileHandleCache[key] = &fileHandleVal{
 		pathName: msg.Open.Filename,
 	}
 }
 
-func handleOpenByHandleAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
+func handleOpenByHandleAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
 	pFileHandleData, err := tracer.ReadArgData(process.Pid, regs, 1, 8 /*sizeof uint32 + sizeof int32*/)
 	if err != nil {
 		return err
@@ -282,16 +265,16 @@ func handleOpenByHandleAt(tracer *Tracer, process *Process, msg *ebpfless.Syscal
 		handleBytes: handleBytes,
 		handleType:  handleType,
 	}
-	val, ok := fileHandleCache[key]
+	val, ok := process.Res.FileHandleCache[key]
 	if !ok {
-		return errors.New("didnt find correspondance in the file handle cache")
+		return errors.New("didn't find correspondance in the file handle cache")
 	}
 	msg.Type = ebpfless.SyscallTypeOpen
 	msg.Open = &ebpfless.OpenSyscallMsg{
 		Filename: val.pathName,
 		Flags:    uint32(tracer.ReadArgUint64(regs, 2)),
 	}
-	err = fillFileMetadata(val.pathName, msg.Open)
+	err = fillFileMetadata(val.pathName, msg.Open, disableStats)
 	if err != nil {
 		return err
 	}
@@ -309,7 +292,7 @@ func getPidTTY(pid int) string {
 	return "pts" + path.Base(tty)
 }
 
-func handleExecveAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
+func handleExecveAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
 	fd := tracer.ReadArgInt32(regs, 0)
 
 	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
@@ -348,7 +331,7 @@ func handleExecveAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, 
 		Envs: envs,
 		TTY:  getPidTTY(process.Pid),
 	}
-	err = fillFileMetadata(filename, msg.Exec.File)
+	err = fillFileMetadata(filename, msg.Exec.File, disableStats)
 	if err != nil {
 		return err
 	}
@@ -364,7 +347,7 @@ func handleFcntl(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs sysc
 	return nil
 }
 
-func handleExecve(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
+func handleExecve(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
 	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
 	if err != nil {
 		return err
@@ -394,7 +377,7 @@ func handleExecve(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, re
 		Envs: envs,
 		TTY:  getPidTTY(process.Pid),
 	}
-	err = fillFileMetadata(filename, msg.Exec.File)
+	err = fillFileMetadata(filename, msg.Exec.File, disableStats)
 	if err != nil {
 		return err
 	}
@@ -556,7 +539,7 @@ func sendMsg(client net.Conn, msg *ebpfless.Message) error {
 }
 
 // StartCWSPtracer start the ptracer
-func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds, verbose bool, async bool) error {
+func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds, verbose bool, async bool, disableStats bool) error {
 	if len(args) == 0 {
 		return fmt.Errorf("an executable is required")
 	}
@@ -688,9 +671,7 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 		},
 	})
 
-	fileHandleCache = make(map[fileHandleKey]*fileHandleVal)
-
-	cb := func(cbType CallbackType, nr int, pid int, ppid int, regs syscall.PtraceRegs, exitCtx *ebpfless.ExitSyscallMsg) {
+	cb := func(cbType CallbackType, nr int, pid int, ppid int, regs syscall.PtraceRegs, waitStatus *syscall.WaitStatus) {
 		process := pc.Get(pid)
 		if process == nil {
 			process = NewProcess(pid)
@@ -722,17 +703,17 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 
 			switch nr {
 			case OpenNr:
-				if err := handleOpen(tracer, process, syscallMsg, regs); err != nil {
+				if err := handleOpen(tracer, process, syscallMsg, regs, disableStats); err != nil {
 					logErrorf("unable to handle open: %v", err)
 					return
 				}
 			case OpenatNr, Openat2Nr:
-				if err := handleOpenAt(tracer, process, syscallMsg, regs); err != nil {
+				if err := handleOpenAt(tracer, process, syscallMsg, regs, disableStats); err != nil {
 					logErrorf("unable to handle openat: %v", err)
 					return
 				}
 			case CreatNr:
-				if err = handleCreat(tracer, process, syscallMsg, regs); err != nil {
+				if err = handleCreat(tracer, process, syscallMsg, regs, disableStats); err != nil {
 					logErrorf("unable to handle creat: %v", err)
 					return
 				}
@@ -742,12 +723,12 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 					return
 				}
 			case OpenByHandleAtNr:
-				if err = handleOpenByHandleAt(tracer, process, syscallMsg, regs); err != nil {
+				if err = handleOpenByHandleAt(tracer, process, syscallMsg, regs, disableStats); err != nil {
 					logErrorf("unable to handle open_by_handle_at: %v", err)
 					return
 				}
 			case ExecveNr:
-				if err = handleExecve(tracer, process, syscallMsg, regs); err != nil {
+				if err = handleExecve(tracer, process, syscallMsg, regs, disableStats); err != nil {
 					logErrorf("unable to handle execve: %v", err)
 					return
 				}
@@ -781,7 +762,7 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 					pc.Add(process.Tgid, process)
 				}
 			case ExecveatNr:
-				if err = handleExecveAt(tracer, process, syscallMsg, regs); err != nil {
+				if err = handleExecveAt(tracer, process, syscallMsg, regs, disableStats); err != nil {
 					logErrorf("unable to handle execveat: %v", err)
 					return
 				}
@@ -849,7 +830,7 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 				process.Pid = process.Tgid
 			case NameToHandleAtNr:
 				syscallMsg, exists := process.Nr[nr]
-				if !exists {
+				if !exists || syscallMsg.Open == nil {
 					return
 				}
 				handleNameToHandleAtRet(tracer, process, syscallMsg, regs)
@@ -925,7 +906,18 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 			}
 		case CallbackExitType:
 			// send exit only for process not threads
-			if process.Pid == process.Tgid && exitCtx != nil {
+			if process.Pid == process.Tgid && waitStatus != nil {
+				exitCtx := &ebpfless.ExitSyscallMsg{}
+				if waitStatus.Exited() {
+					exitCtx.Cause = model.ExitExited
+					exitCtx.Code = uint32(waitStatus.ExitStatus())
+				} else if waitStatus.CoreDump() {
+					exitCtx.Cause = model.ExitCoreDumped
+					exitCtx.Code = uint32(waitStatus.Signal())
+				} else if waitStatus.Signaled() {
+					exitCtx.Cause = model.ExitSignaled
+					exitCtx.Code = uint32(waitStatus.Signal())
+				}
 				sendSyscallMsg(&ebpfless.SyscallMsg{
 					Type: ebpfless.SyscallTypeExit,
 					Exit: exitCtx,

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -30,6 +30,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/native"
 )
 
+const CwsInstrumentationEnvDisableStats = "CWS_INSTRUMENTATION_DISABLE_STATS"
+
 type fileHandleKey struct {
 	handleBytes uint32
 	handleType  int32
@@ -81,6 +83,11 @@ func getFullPathFromFilename(process *Process, filename string) (string, error) 
 }
 
 func fillFileMetadata(filepath string, openMsg *ebpfless.OpenSyscallMsg) error {
+	// Lookup option to disable avoidable usage of stats to reduce the induced overhead
+	if os.Getenv(CwsInstrumentationEnvDisableStats) != "" {
+		return nil
+	}
+
 	// NB: Here we use Lstat to not follow the link, because we don't do it yet globally.
 	//     Once we'll follow them, we may want to replace it by a Stat().
 	fileInfo, err := os.Lstat(filepath)

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -614,6 +614,7 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 				return
 			}
 			msg.PID = uint32(process.Tgid)
+			msg.Timestamp = uint64(time.Now().UnixNano())
 			send(&ebpfless.Message{
 				Type:    ebpfless.MessageTypeSyscall,
 				Syscall: msg,

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -602,7 +602,7 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 
 	fileHandleCache = make(map[fileHandleKey]*fileHandleVal)
 
-	cb := func(cbType CallbackType, nr int, pid int, ppid int, regs syscall.PtraceRegs) {
+	cb := func(cbType CallbackType, nr int, pid int, ppid int, regs syscall.PtraceRegs, exitCtx *ebpfless.ExitSyscallMsg) {
 		process := pc.Get(pid)
 		if process == nil {
 			process = NewProcess(pid)
@@ -826,9 +826,10 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 			}
 		case CallbackExitType:
 			// send exit only for process not threads
-			if process.Pid == process.Tgid {
+			if process.Pid == process.Tgid && exitCtx != nil {
 				sendSyscallMsg(&ebpfless.SyscallMsg{
 					Type: ebpfless.SyscallTypeExit,
+					Exit: exitCtx,
 				})
 			}
 

--- a/pkg/security/ptracer/process.go
+++ b/pkg/security/ptracer/process.go
@@ -13,10 +13,20 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+type fileHandleKey struct {
+	handleBytes uint32
+	handleType  int32
+}
+
+type fileHandleVal struct {
+	pathName string
+}
+
 // Resources defines shared process resources
 type Resources struct {
-	Fd  map[int32]string
-	Cwd string
+	Fd              map[int32]string
+	Cwd             string
+	FileHandleCache map[fileHandleKey]*fileHandleVal
 }
 
 // Process represents a process context
@@ -34,7 +44,8 @@ func NewProcess(pid int) *Process {
 		Tgid: pid,
 		Nr:   make(map[int]*ebpfless.SyscallMsg),
 		Res: &Resources{
-			Fd: make(map[int32]string),
+			Fd:              make(map[int32]string),
+			FileHandleCache: make(map[fileHandleKey]*fileHandleVal),
 		},
 	}
 }

--- a/pkg/security/ptracer/ptracer.go
+++ b/pkg/security/ptracer/ptracer.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/net/bpf"
 	"golang.org/x/sys/unix"
 
+	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/util/native"
 )
 
@@ -222,7 +224,7 @@ func (t *Tracer) ReadArgStringArray(pid int, regs syscall.PtraceRegs, arg int) (
 }
 
 // Trace traces a process
-func (t *Tracer) Trace(cb func(cbType CallbackType, nr int, pid int, ppid int, regs syscall.PtraceRegs)) error {
+func (t *Tracer) Trace(cb func(cbType CallbackType, nr int, pid int, ppid int, regs syscall.PtraceRegs, exitCtx *ebpfless.ExitSyscallMsg)) error {
 	var waitStatus syscall.WaitStatus
 
 	if err := syscall.PtraceCont(t.PID, 0); err != nil {
@@ -237,11 +239,36 @@ func (t *Tracer) Trace(cb func(cbType CallbackType, nr int, pid int, ppid int, r
 			break
 		}
 
-		if waitStatus.Exited() || waitStatus.Signaled() {
+		if waitStatus.Exited() {
 			if pid == t.PID {
 				break
 			}
-			cb(CallbackExitType, ExitNr, pid, 0, regs)
+			cb(CallbackExitType, ExitNr, pid, 0, regs, &ebpfless.ExitSyscallMsg{
+				Cause: model.ExitExited,
+				Code:  uint32(waitStatus.ExitStatus()),
+			})
+			continue
+		}
+
+		if waitStatus.CoreDump() {
+			if pid == t.PID {
+				break
+			}
+			cb(CallbackExitType, ExitNr, pid, 0, regs, &ebpfless.ExitSyscallMsg{
+				Cause: model.ExitCoreDumped,
+				Code:  uint32(waitStatus.Signal()),
+			})
+			continue
+		}
+
+		if waitStatus.Signaled() {
+			if pid == t.PID {
+				break
+			}
+			cb(CallbackExitType, ExitNr, pid, 0, regs, &ebpfless.ExitSyscallMsg{
+				Cause: model.ExitSignaled,
+				Code:  uint32(waitStatus.Signal()),
+			})
 			continue
 		}
 
@@ -262,14 +289,14 @@ func (t *Tracer) Trace(cb func(cbType CallbackType, nr int, pid int, ppid int, r
 			switch waitStatus.TrapCause() {
 			case syscall.PTRACE_EVENT_CLONE, syscall.PTRACE_EVENT_FORK, syscall.PTRACE_EVENT_VFORK:
 				if npid, err := syscall.PtraceGetEventMsg(pid); err == nil {
-					cb(CallbackPostType, nr, int(npid), pid, regs)
+					cb(CallbackPostType, nr, int(npid), pid, regs, nil)
 				}
 			case unix.PTRACE_EVENT_SECCOMP:
 				switch nr {
 				case ForkNr, VforkNr, CloneNr:
 					// already handled
 				default:
-					cb(CallbackPreType, nr, pid, 0, regs)
+					cb(CallbackPreType, nr, pid, 0, regs, nil)
 
 					// force a ptrace syscall in order to get to return value
 					if err := syscall.PtraceSyscall(pid, 0); err != nil {
@@ -283,11 +310,11 @@ func (t *Tracer) Trace(cb func(cbType CallbackType, nr int, pid int, ppid int, r
 				case ExecveNr, ExecveatNr:
 					// does not return on success, thus ret value stay at syscall.ENOSYS
 					if ret := -t.ReadRet(regs); ret == int64(syscall.ENOSYS) {
-						cb(CallbackPostType, nr, pid, 0, regs)
+						cb(CallbackPostType, nr, pid, 0, regs, nil)
 					}
 				default:
 					if ret := -t.ReadRet(regs); ret != int64(syscall.ENOSYS) {
-						cb(CallbackPostType, nr, pid, 0, regs)
+						cb(CallbackPostType, nr, pid, 0, regs, nil)
 					}
 				}
 			}

--- a/pkg/security/ptracer/ptracer.go
+++ b/pkg/security/ptracer/ptracer.go
@@ -168,7 +168,7 @@ func (t *Tracer) ReadArgInt32Ptr(pid int, regs syscall.PtraceRegs, arg int) (int
 	return t.readInt32(pid, ptr)
 }
 
-// ReadArgString reads the regs and returns the wanted arg as byte array
+// ReadArgData reads the regs and returns the wanted arg as byte array
 func (t *Tracer) ReadArgData(pid int, regs syscall.PtraceRegs, arg int, size uint) ([]byte, error) {
 	ptr := t.argToRegValue(regs, arg)
 	return t.readData(pid, ptr, size)

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -37,6 +37,7 @@ const (
 	SetreuidNr       = 113 // SetreuidNr defines the syscall ID for amd64
 	SetregidNr       = 114 // SetregidNr defines the syscall ID for amd64
 	CloseNr          = 3   // CloseNr defines the syscall ID for amd64
+	MemfdCreateNr    = 319 // MemfdCreateNr defines the syscall ID for amd64
 
 	ptraceFlags = 0 |
 		syscall.PTRACE_O_TRACEVFORK |
@@ -73,6 +74,7 @@ var (
 		"setreuid",
 		"setregid",
 		"close",
+		"memfd_create",
 	}
 )
 

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -14,26 +14,28 @@ import (
 )
 
 const (
-	OpenNr     = 2   // OpenNr defines the syscall ID for amd64
-	OpenatNr   = 257 // OpenatNr defines the syscall ID for amd64
-	Openat2Nr  = 437 // Openat2Nr defines the syscall ID for amd64
-	ExecveNr   = 59  // ExecveNr defines the syscall ID for amd64
-	ExecveatNr = 322 // ExecveatNr defines the syscall ID for amd64
-	CloneNr    = 56  // CloneNr defines the syscall ID for amd64
-	ForkNr     = 57  // ForkNr defines the syscall ID for amd64
-	VforkNr    = 58  // VforkNr defines the syscall ID for amd64
-	ExitNr     = 60  // ExitNr defines the syscall ID for amd64
-	FcntlNr    = 72  // FcntlNr defines the syscall ID for amd64
-	DupNr      = 32  // DupNr defines the syscall ID for amd64
-	Dup2Nr     = 33  // Dup2Nr defines the syscall ID for amd64
-	Dup3Nr     = 292 // Dup3Nr defines the syscall ID for amd64
-	ChdirNr    = 80  // ChdirNr defines the syscall ID for amd64
-	FchdirNr   = 81  // FchdirNr defines the syscall ID for amd64
-	SetuidNr   = 105 // SetuidNr defines the syscall ID for amd64
-	SetgidNr   = 106 // SetgidNr defines the syscall ID for amd64
-	SetreuidNr = 113 // SetreuidNr defines the syscall ID for amd64
-	SetregidNr = 114 // SetregidNr defines the syscall ID for amd64
-	CreatNr    = 85  // CreatNr defines the syscall ID for amd64
+	OpenNr           = 2   // OpenNr defines the syscall ID for amd64
+	OpenatNr         = 257 // OpenatNr defines the syscall ID for amd64
+	Openat2Nr        = 437 // Openat2Nr defines the syscall ID for amd64
+	CreatNr          = 85  // CreatNr defines the syscall ID for amd64
+	NameToHandleAtNr = 303 // NameToHandleAtNr defines the syscall ID for amd64
+	OpenByHandleAtNr = 304 // OpenByHandleAtNr defines the syscall ID for amd64
+	ExecveNr         = 59  // ExecveNr defines the syscall ID for amd64
+	ExecveatNr       = 322 // ExecveatNr defines the syscall ID for amd64
+	CloneNr          = 56  // CloneNr defines the syscall ID for amd64
+	ForkNr           = 57  // ForkNr defines the syscall ID for amd64
+	VforkNr          = 58  // VforkNr defines the syscall ID for amd64
+	ExitNr           = 60  // ExitNr defines the syscall ID for amd64
+	FcntlNr          = 72  // FcntlNr defines the syscall ID for amd64
+	DupNr            = 32  // DupNr defines the syscall ID for amd64
+	Dup2Nr           = 33  // Dup2Nr defines the syscall ID for amd64
+	Dup3Nr           = 292 // Dup3Nr defines the syscall ID for amd64
+	ChdirNr          = 80  // ChdirNr defines the syscall ID for amd64
+	FchdirNr         = 81  // FchdirNr defines the syscall ID for amd64
+	SetuidNr         = 105 // SetuidNr defines the syscall ID for amd64
+	SetgidNr         = 106 // SetgidNr defines the syscall ID for amd64
+	SetreuidNr       = 113 // SetreuidNr defines the syscall ID for amd64
+	SetregidNr       = 114 // SetregidNr defines the syscall ID for amd64
 
 	ptraceFlags = 0 |
 		syscall.PTRACE_O_TRACEVFORK |
@@ -50,6 +52,9 @@ var (
 		"open",
 		"openat",
 		"openat2",
+		"creat",
+		"name_to_handle_at",
+		"open_by_handle_at",
 		"fork",
 		"vfork",
 		"clone",
@@ -66,7 +71,6 @@ var (
 		"setgid",
 		"setreuid",
 		"setregid",
-		"creat",
 	}
 )
 

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -33,6 +33,7 @@ const (
 	SetgidNr   = 106 // SetgidNr defines the syscall ID for amd64
 	SetreuidNr = 113 // SetreuidNr defines the syscall ID for amd64
 	SetregidNr = 114 // SetregidNr defines the syscall ID for amd64
+	CreatNr    = 85  // CreatNr defines the syscall ID for amd64
 
 	ptraceFlags = 0 |
 		syscall.PTRACE_O_TRACEVFORK |
@@ -65,6 +66,7 @@ var (
 		"setgid",
 		"setreuid",
 		"setregid",
+		"creat",
 	}
 )
 

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -36,6 +36,7 @@ const (
 	SetgidNr         = 106 // SetgidNr defines the syscall ID for amd64
 	SetreuidNr       = 113 // SetreuidNr defines the syscall ID for amd64
 	SetregidNr       = 114 // SetregidNr defines the syscall ID for amd64
+	CloseNr          = 3   // CloseNr defines the syscall ID for amd64
 
 	ptraceFlags = 0 |
 		syscall.PTRACE_O_TRACEVFORK |
@@ -71,6 +72,7 @@ var (
 		"setgid",
 		"setreuid",
 		"setregid",
+		"close",
 	}
 )
 

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -31,6 +31,7 @@ const (
 	SetgidNr         = 144 // SetgidNr defines the syscall ID for arm64
 	SetreuidNr       = 145 // SetreuidNr defines the syscall ID for arm64
 	SetregidNr       = 143 // SetregidNr defines the syscall ID for arm64
+	CloseNr          = 57  // CloseNr defines the syscall ID for arm64
 
 	OpenNr  = -1 // OpenNr not available on arm64
 	ForkNr  = -2 // ForkNr not available on arm64
@@ -67,6 +68,7 @@ var (
 		"setgid",
 		"setreuid",
 		"setregid",
+		"close",
 	}
 )
 

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -34,6 +34,7 @@ const (
 	ForkNr  = -2 // ForkNr not available on arm64
 	VforkNr = -3 // VforkNr not available on arm64
 	Dup2Nr  = -4 // Dup2Nr not available on arm64
+	CreatNr = -5 // CreatNr not available on arm64
 
 	ptraceFlags = 0 |
 		syscall.PTRACE_O_TRACECLONE |

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -14,21 +14,23 @@ import (
 )
 
 const (
-	OpenatNr   = 56  // OpenatNr defines the syscall ID for arm64
-	Openat2Nr  = 437 // Openat2Nr defines the syscall ID for amd64
-	ExecveNr   = 221 // ExecveNr defines the syscall ID for arm64
-	ExecveatNr = 281 // ExecveatNr defines the syscall ID for arm64
-	CloneNr    = 220 // CloneNr defines the syscall ID for arm64
-	ExitNr     = 93  // ExitNr defines the syscall ID for arm64
-	FcntlNr    = 25  // FcntlNr defines the syscall ID for arm64
-	DupNr      = 23  // DupNr defines the syscall ID for arm64
-	Dup3Nr     = 24  // Dup3Nr defines the syscall ID for arm64
-	ChdirNr    = 49  // ChdirNr defines the syscall ID for arm64
-	FchdirNr   = 50  // FchdirNr defines the syscall ID for arm64
-	SetuidNr   = 146 // SetuidNr defines the syscall ID for arm64
-	SetgidNr   = 144 // SetgidNr defines the syscall ID for arm64
-	SetreuidNr = 145 // SetreuidNr defines the syscall ID for arm64
-	SetregidNr = 143 // SetregidNr defines the syscall ID for arm64
+	OpenatNr         = 56  // OpenatNr defines the syscall ID for arm64
+	Openat2Nr        = 437 // Openat2Nr defines the syscall ID for amd64
+	NameToHandleAtNr = 264 // NameToHandleAtNr defines the syscall ID for amd64
+	OpenByHandleAtNr = 265 // OpenByHandleAtNr defines the syscall ID for amd64
+	ExecveNr         = 221 // ExecveNr defines the syscall ID for arm64
+	ExecveatNr       = 281 // ExecveatNr defines the syscall ID for arm64
+	CloneNr          = 220 // CloneNr defines the syscall ID for arm64
+	ExitNr           = 93  // ExitNr defines the syscall ID for arm64
+	FcntlNr          = 25  // FcntlNr defines the syscall ID for arm64
+	DupNr            = 23  // DupNr defines the syscall ID for arm64
+	Dup3Nr           = 24  // Dup3Nr defines the syscall ID for arm64
+	ChdirNr          = 49  // ChdirNr defines the syscall ID for arm64
+	FchdirNr         = 50  // FchdirNr defines the syscall ID for arm64
+	SetuidNr         = 146 // SetuidNr defines the syscall ID for arm64
+	SetgidNr         = 144 // SetgidNr defines the syscall ID for arm64
+	SetreuidNr       = 145 // SetreuidNr defines the syscall ID for arm64
+	SetregidNr       = 143 // SetregidNr defines the syscall ID for arm64
 
 	OpenNr  = -1 // OpenNr not available on arm64
 	ForkNr  = -2 // ForkNr not available on arm64
@@ -48,6 +50,8 @@ var (
 	PtracedSyscalls = []string{
 		"openat",
 		"openat2",
+		"name_to_handle_at",
+		"open_by_handle_at",
 		"clone",
 		"execve",
 		"execveat",

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -32,6 +32,7 @@ const (
 	SetreuidNr       = 145 // SetreuidNr defines the syscall ID for arm64
 	SetregidNr       = 143 // SetregidNr defines the syscall ID for arm64
 	CloseNr          = 57  // CloseNr defines the syscall ID for arm64
+	MemfdCreateNr    = 279 // MemfdCreateNr defines the syscall ID for arm64
 
 	OpenNr  = -1 // OpenNr not available on arm64
 	ForkNr  = -2 // ForkNr not available on arm64
@@ -69,6 +70,7 @@ var (
 		"setreuid",
 		"setregid",
 		"close",
+		"memfd_create",
 	}
 )
 

--- a/pkg/security/resolvers/process/resolver_ebpfless.go
+++ b/pkg/security/resolvers/process/resolver_ebpfless.go
@@ -96,7 +96,7 @@ func (p *EBPFLessResolver) AddForkEntry(key CacheResolverKey, ppid uint32, ts ui
 }
 
 // AddExecEntry adds an entry to the local cache and returns the newly created entry
-func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv []string, envs []string, ctrID string, ts uint64) *model.ProcessCacheEntry {
+func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv []string, envs []string, ctrID string, ts uint64, tty string) *model.ProcessCacheEntry {
 	entry := p.processCacheEntryPool.Get()
 	entry.PIDContext.Pid = key.Pid
 
@@ -109,6 +109,7 @@ func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv 
 		// truncate comm to max 16 chars to be ebpf ISO
 		entry.Process.Comm = entry.Process.Comm[:16]
 	}
+	entry.Process.TTYName = tty
 
 	entry.Process.EnvsEntry = &model.EnvsEntry{Values: envs}
 

--- a/pkg/security/resolvers/process/resolver_ebpfless.go
+++ b/pkg/security/resolvers/process/resolver_ebpfless.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -113,8 +114,13 @@ func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv 
 
 	entry.Process.EnvsEntry = &model.EnvsEntry{Values: envs}
 
-	entry.Process.FileEvent.PathnameStr = file
-	entry.Process.FileEvent.BasenameStr = filepath.Base(entry.Process.FileEvent.PathnameStr)
+	if strings.HasPrefix(file, "memfd:") {
+		entry.Process.FileEvent.PathnameStr = ""
+		entry.Process.FileEvent.BasenameStr = file
+	} else {
+		entry.Process.FileEvent.PathnameStr = file
+		entry.Process.FileEvent.BasenameStr = filepath.Base(entry.Process.FileEvent.PathnameStr)
+	}
 	entry.Process.ContainerID = ctrID
 
 	entry.ExecTime = time.Unix(0, int64(ts))

--- a/pkg/security/resolvers/process/resolver_ebpfless.go
+++ b/pkg/security/resolvers/process/resolver_ebpfless.go
@@ -81,10 +81,11 @@ func (p *EBPFLessResolver) DeleteEntry(key CacheResolverKey, exitTime time.Time)
 }
 
 // AddForkEntry adds an entry to the local cache and returns the newly created entry
-func (p *EBPFLessResolver) AddForkEntry(key CacheResolverKey, ppid uint32) *model.ProcessCacheEntry {
+func (p *EBPFLessResolver) AddForkEntry(key CacheResolverKey, ppid uint32, ts uint64) *model.ProcessCacheEntry {
 	entry := p.processCacheEntryPool.Get()
 	entry.PIDContext.Pid = key.Pid
 	entry.PPid = ppid
+	entry.ForkTime = time.Unix(0, int64(ts))
 
 	p.Lock()
 	defer p.Unlock()
@@ -95,7 +96,7 @@ func (p *EBPFLessResolver) AddForkEntry(key CacheResolverKey, ppid uint32) *mode
 }
 
 // AddExecEntry adds an entry to the local cache and returns the newly created entry
-func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv []string, envs []string, ctrID string) *model.ProcessCacheEntry {
+func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv []string, envs []string, ctrID string, ts uint64) *model.ProcessCacheEntry {
 	entry := p.processCacheEntryPool.Get()
 	entry.PIDContext.Pid = key.Pid
 
@@ -115,8 +116,7 @@ func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv 
 	entry.Process.FileEvent.BasenameStr = filepath.Base(entry.Process.FileEvent.PathnameStr)
 	entry.Process.ContainerID = ctrID
 
-	// TODO fix timestamp
-	entry.ExecTime = time.Now()
+	entry.ExecTime = time.Unix(0, int64(ts))
 
 	p.Lock()
 	defer p.Unlock()

--- a/pkg/security/tests/main_test.go
+++ b/pkg/security/tests/main_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 		envs := os.Environ()
 		envs = append(envs, "EBPFLESS=true")
 
-		err := ptracer.StartCWSPtracer(args, envs, setup.DefaultEBPFLessProbeAddr, ptracer.Creds{}, false, true)
+		err := ptracer.StartCWSPtracer(args, envs, setup.DefaultEBPFLessProbeAddr, ptracer.Creds{}, false /* verbose */, true /* async */, false /* disableStats */)
 		if err != nil {
 			fmt.Printf("unable to trace [%v]: %s", args, err)
 			os.Exit(-1)

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -191,10 +191,6 @@ func TestOpen(t *testing.T) {
 	})
 
 	t.Run("open_by_handle_at", func(t *testing.T) {
-		if test.opts.staticOpts.enableEBPFLess {
-			t.Skip("open_by_handle_at not supported yet")
-		}
-
 		defer os.Remove(testFile)
 
 		// wait for this first event
@@ -233,7 +229,9 @@ func TestOpen(t *testing.T) {
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
-			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			if !test.opts.staticOpts.enableEBPFLess {
+				assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			}
 
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), false)

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1797,10 +1797,6 @@ func TestProcessExit(t *testing.T) {
 	})
 
 	t.Run("exit-error", func(t *testing.T) {
-		if test.opts.staticOpts.enableEBPFLess == true {
-			t.Skip("not supported yet")
-		}
-
 		test.WaitSignal(t, func() error {
 			args := []string{} // sleep with no argument should exit with return code 1
 			envp := []string{envpExitSleep}
@@ -1810,7 +1806,9 @@ func TestProcessExit(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
-			test.validateExitSchema(t, event)
+			if !test.opts.staticOpts.enableEBPFLess {
+				test.validateExitSchema(t, event)
+			}
 			assertTriggeredRule(t, rule, "test_exit_error")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
@@ -1820,10 +1818,6 @@ func TestProcessExit(t *testing.T) {
 	})
 
 	t.Run("exit-coredumped", func(t *testing.T) {
-		if test.opts.staticOpts.enableEBPFLess == true {
-			t.Skip("not supported yet")
-		}
-
 		test.WaitSignal(t, func() error {
 			args := []string{"--preserve-status", "--signal=SIGQUIT", "2", sleepExec, "9"}
 			envp := []string{envpExitSleep}
@@ -1833,7 +1827,9 @@ func TestProcessExit(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
-			test.validateExitSchema(t, event)
+			if !test.opts.staticOpts.enableEBPFLess {
+				test.validateExitSchema(t, event)
+			}
 			assertTriggeredRule(t, rule, "test_exit_coredump")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitCoreDumped), event.Exit.Cause, "wrong exit cause")
@@ -1843,10 +1839,6 @@ func TestProcessExit(t *testing.T) {
 	})
 
 	t.Run("exit-signaled", func(t *testing.T) {
-		if test.opts.staticOpts.enableEBPFLess == true {
-			t.Skip("not supported yet")
-		}
-
 		test.WaitSignal(t, func() error {
 			args := []string{"--preserve-status", "--signal=SIGKILL", "2", sleepExec, "9"}
 			envp := []string{envpExitSleep}
@@ -1856,7 +1848,9 @@ func TestProcessExit(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
-			test.validateExitSchema(t, event)
+			if !test.opts.staticOpts.enableEBPFLess {
+				test.validateExitSchema(t, event)
+			}
 			assertTriggeredRule(t, rule, "test_exit_signal")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitSignaled), event.Exit.Cause, "wrong exit cause")

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1098,9 +1098,6 @@ func TestProcessExecCTime(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
-	if test.opts.staticOpts.enableEBPFLess == true {
-		t.Skip("ctime not supported yet")
-	}
 
 	test.WaitSignal(t, func() error {
 		testFile, _, err := test.Path("touch")
@@ -1353,9 +1350,6 @@ func TestProcessMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
-	if test.opts.staticOpts.enableEBPFLess == true {
-		t.Skip("not supported yet")
-	}
 
 	fileMode := uint16(0o777)
 	testFile, _, err := test.CreateWithOptions("test-exec", 98, 99, int(fileMode))
@@ -1403,11 +1397,13 @@ func TestProcessMetadata(t *testing.T) {
 		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
 			assert.Equal(t, 1001, int(event.Exec.Credentials.UID), "wrong uid")
-			assert.Equal(t, 1001, int(event.Exec.Credentials.EUID), "wrong euid")
 			assert.Equal(t, 2001, int(event.Exec.Credentials.GID), "wrong gid")
-			assert.Equal(t, 2001, int(event.Exec.Credentials.EGID), "wrong egid")
-			assert.Equal(t, 1001, int(event.Exec.Credentials.FSUID), "wrong fsuid")
-			assert.Equal(t, 2001, int(event.Exec.Credentials.FSGID), "wrong fsgid")
+			if !test.opts.staticOpts.enableEBPFLess {
+				assert.Equal(t, 1001, int(event.Exec.Credentials.EUID), "wrong euid")
+				assert.Equal(t, 1001, int(event.Exec.Credentials.FSUID), "wrong fsuid")
+				assert.Equal(t, 2001, int(event.Exec.Credentials.EGID), "wrong egid")
+				assert.Equal(t, 2001, int(event.Exec.Credentials.FSGID), "wrong fsgid")
+			}
 		}))
 	})
 }

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2370,8 +2370,8 @@ func TestProcessFilelessExecution(t *testing.T) {
 					t.Fatal("shouldn't get an event")
 				}
 			} else {
-				if testModule.opts.staticOpts.enableEBPFLess == true {
-					t.Skip("memfd unsupported yet")
+				if testModule.opts.staticOpts.enableEBPFLess == true && test.rule.ID == "test_fileless_with_interpreter" {
+					t.Skip("interpreter detection unsupported")
 				}
 
 				testModule.WaitSignal(t, func() error {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -710,10 +710,6 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	t.Run("tty", func(t *testing.T) {
-		if test.opts.staticOpts.enableEBPFLess == true {
-			t.Skip("not supported yet")
-		}
-
 		testFile, _, err := test.Path("test-process-tty")
 		if err != nil {
 			t.Fatal(err)
@@ -769,8 +765,10 @@ func TestProcessContext(t *testing.T) {
 				t.Errorf("not able to get a tty name: %s\n", name)
 			}
 
-			if inode := getInode(t, executable); inode != event.ProcessContext.FileEvent.Inode {
-				t.Errorf("expected inode %d, got %d => %+v", event.ProcessContext.FileEvent.Inode, inode, event)
+			if !test.opts.staticOpts.enableEBPFLess {
+				if inode := getInode(t, executable); inode != event.ProcessContext.FileEvent.Inode {
+					t.Errorf("expected inode %d, got %d => %+v", event.ProcessContext.FileEvent.Inode, inode, event)
+				}
 			}
 
 			str, err := test.marshalEvent(event)


### PR DESCRIPTION
### What does this PR do?

This PR adds:
* opens with creat syscall
* name_to_handle_at/open_by_handle_at support
* close (to cleanup process fd cache)
* Fork/Exec/Exit timestamps
* Exit code and cause (exited, signaled or core dumped)
* UID/GID/CTime/MTime for open and exec files. And as this support came with a cost of a stats syscall, an option was added to disable it.
* Process TTY
* Fileless execs with memfd_create

### Motivation

Close the gaps of ebpfless implementation of files/processes over ebpf one

### Additional Notes



### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

The teststuite has been updated to not skip anymore related tests

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
