### PR TITLE
feat(ci): decommission old container-integrations e2e tests

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -14,51 +14,6 @@
     - export DOCKER_REGISTRY_PWD=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
 
-k8s-e2e-dev:
-  extends: .k8s_e2e_template
-  rules: !reference [.on_dev_branch_manual]
-  # Note: pupernetes-dev requires the below jobs to work. However,
-  # we can't explicitly define the dependencies because a job cannot depend on other manual jobs.
-  # Adding the following lines would result in pipelines remaining in a "Running" state forever,
-  # as the pupernetes-dev job waits for manual jobs that may never be triggered.
-  # needs:
-  #   - dev_branch_docker_hub-a6
-  #   - dev_branch_docker_hub-a7
-  # We still want to make the job available as soon as possible. In this case, since it's manual
-  # and requires other manual jobs, it's reasonable make it available from the beginning and let
-  # engineers trigger the correct sequence of jobs when needed.
-  needs: []
-  script:
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py2 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=default
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=default
-
-k8s-e2e-main:
-  extends: .k8s_e2e_template
-  allow_failure: true # temporary while investigating
-  rules: !reference [.on_main]
-  # needs:
-  #   - dev_master-a6
-  #   - dev_master-a7
-  script:
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py2 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=default
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=default
-
-k8s-e2e-tags-6:
-  extends: .k8s_e2e_template
-  rules: !reference [.on_deploy_stable_or_beta_repo_branch_a6_manual]
-  script:
-    - AGENT_VERSION=$(inv agent.version --major-version 6)
-    - DCA_VERSION=$(inv -e cluster-agent.version)
-    - inv -e e2e-tests --agent-image=datadog/agent:${AGENT_VERSION} --dca-image=datadog/cluster-agent:${DCA_VERSION} --argo-workflow=default
-
-k8s-e2e-tags-7:
-  extends: .k8s_e2e_template
-  rules: !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
-  script:
-    - AGENT_VERSION=$(inv agent.version --major-version 7)
-    - DCA_VERSION=$(inv -e cluster-agent.version)
-    - inv -e e2e-tests --agent-image=datadog/agent:${AGENT_VERSION} --dca-image=datadog/cluster-agent:${DCA_VERSION} --argo-workflow=default
-
 .k8s-e2e-cws-cspm-init:
   - set +x
   - export DATADOG_AGENT_SITE=datadoghq.com
@@ -107,7 +62,7 @@ k8s-e2e-cspm-main:
 k8s-e2e-otlp-dev:
   extends: .k8s_e2e_template
   rules: !reference [.on_dev_branch_manual]
-  needs: [] # See note on k8s-e2e-dev above
+  needs: [] # we can't explicitly define the dependencies because a job cannot depend on other manual jobs.
   script:
     - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=otlp
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Remove `k8s-e2e-*` gitlab jobs own by @DataDog/container-integrations. 
This jobs were replaced by the new `new-e2e-containers*` gitlab jobs.

### Motivation

Remove useless jobs since the new jobs cover more use cases and should be less flacky 🤞 

### Additional Notes

Monitors needs to be updated/remove to not trigger if we received "no data" information for these jobs execution.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

No need to do QA for this change, the CI is handling it.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
