### PR TITLE
[Serverless] Always create REPORT log message when logs enabled.

### DIFF
--- a/pkg/serverless/logs/logs_collector.go
+++ b/pkg/serverless/logs/logs_collector.go
@@ -251,6 +251,10 @@ func (lc *LambdaLogsCollector) processMessage(
 		lc.executionContext.UpdateStartTime(lc.invocationStartTime)
 	}
 
+	if message.logType == logTypePlatformReport {
+		message.stringRecord = createStringRecordForReportLog(lc.invocationStartTime, lc.invocationEndTime, message)
+	}
+
 	if lc.enhancedMetricsEnabled {
 		proactiveInit := false
 		coldStart := false
@@ -292,7 +296,6 @@ func (lc *LambdaLogsCollector) processMessage(
 				outOfMemoryRequestId = message.objectRecord.requestID
 			}
 			serverlessMetrics.GenerateEnhancedMetricsFromReportLog(args)
-			message.stringRecord = createStringRecordForReportLog(lc.invocationStartTime, lc.invocationEndTime, message)
 		}
 		if message.logType == logTypePlatformRuntimeDone {
 			serverlessMetrics.GenerateEnhancedMetricsFromRuntimeDoneLog(

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -665,64 +665,69 @@ func TestProcessLogMessageLogsNotEnabled(t *testing.T) {
 }
 
 func TestProcessLogMessagesTimeoutLogFromReportLog(t *testing.T) {
-	logChannel := make(chan *config.ChannelMessage)
-	demux := createDemultiplexer(t)
-	defer demux.Stop(false)
+	for _, enhancedMetricsEnabled := range []bool{true, false} {
+		t.Run(fmt.Sprint(enhancedMetricsEnabled), func(t *testing.T) {
 
-	mockExecutionContext := &executioncontext.ExecutionContext{}
-	lc := &LambdaLogsCollector{
-		arn:                    "my-arn",
-		lastRequestID:          "myRequestID",
-		logsEnabled:            true,
-		enhancedMetricsEnabled: true,
-		out:                    logChannel,
-		extraTags: &Tags{
-			Tags: []string{"tag0:value0,tag1:value1"},
-		},
-		executionContext:    mockExecutionContext,
-		demux:               demux,
-		invocationStartTime: time.Now(),
-		invocationEndTime:   time.Now().Add(10 * time.Millisecond),
-	}
+			logChannel := make(chan *config.ChannelMessage)
+			demux := createDemultiplexer(t)
+			defer demux.Stop(false)
 
-	reportLogMessage := LambdaLogAPIMessage{
-		objectRecord: platformObjectRecord{
-			requestID: "myRequestID",
-			reportLogItem: reportLogMetrics{
-				durationMs:       100.00,
-				billedDurationMs: 100,
-				memorySizeMB:     128,
-				maxMemoryUsedMB:  128,
-				initDurationMs:   50.00,
-			},
-			status: timeoutStatus,
-		},
-		logType:      logTypePlatformReport,
-		stringRecord: "contents to be overwritten",
-	}
+			mockExecutionContext := &executioncontext.ExecutionContext{}
+			lc := &LambdaLogsCollector{
+				arn:                    "my-arn",
+				lastRequestID:          "myRequestID",
+				logsEnabled:            true,
+				enhancedMetricsEnabled: enhancedMetricsEnabled,
+				out:                    logChannel,
+				extraTags: &Tags{
+					Tags: []string{"tag0:value0,tag1:value1"},
+				},
+				executionContext:    mockExecutionContext,
+				demux:               demux,
+				invocationStartTime: time.Now(),
+				invocationEndTime:   time.Now().Add(10 * time.Millisecond),
+			}
 
-	logMessages := []LambdaLogAPIMessage{
-		reportLogMessage,
-	}
+			reportLogMessage := LambdaLogAPIMessage{
+				objectRecord: platformObjectRecord{
+					requestID: "myRequestID",
+					reportLogItem: reportLogMetrics{
+						durationMs:       100.00,
+						billedDurationMs: 100,
+						memorySizeMB:     128,
+						maxMemoryUsedMB:  128,
+						initDurationMs:   50.00,
+					},
+					status: timeoutStatus,
+				},
+				logType:      logTypePlatformReport,
+				stringRecord: "contents to be overwritten",
+			}
 
-	go lc.processLogMessages(logMessages)
+			logMessages := []LambdaLogAPIMessage{
+				reportLogMessage,
+			}
 
-	expectedStringRecord := []string{
-		createStringRecordForReportLog(lc.invocationStartTime, lc.invocationEndTime, &reportLogMessage),
-		createStringRecordForTimeoutLog(&reportLogMessage),
-	}
-	expectedErrors := []bool{false, true}
-	for i := 0; i < len(expectedStringRecord); i++ {
-		select {
-		case received := <-logChannel:
-			assert.NotNil(t, received)
-			assert.Equal(t, "my-arn", received.Lambda.ARN)
-			assert.Equal(t, "myRequestID", received.Lambda.RequestID)
-			assert.Equal(t, expectedStringRecord[i], string(received.Content))
-			assert.Equal(t, expectedErrors[i], received.IsError)
-		case <-time.After(100 * time.Millisecond):
-			assert.Fail(t, "We should have received logs")
-		}
+			go lc.processLogMessages(logMessages)
+
+			expectedStringRecord := []string{
+				createStringRecordForReportLog(lc.invocationStartTime, lc.invocationEndTime, &reportLogMessage),
+				createStringRecordForTimeoutLog(&reportLogMessage),
+			}
+			expectedErrors := []bool{false, true}
+			for i := 0; i < len(expectedStringRecord); i++ {
+				select {
+				case received := <-logChannel:
+					assert.NotNil(t, received)
+					assert.Equal(t, "my-arn", received.Lambda.ARN)
+					assert.Equal(t, "myRequestID", received.Lambda.RequestID)
+					assert.Equal(t, expectedStringRecord[i], string(received.Content))
+					assert.Equal(t, expectedErrors[i], received.IsError)
+				case <-time.After(100 * time.Millisecond):
+					assert.Fail(t, "We should have received logs")
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Ensures that the REPORT log message is sent even when enhanced metrics are disabled.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Customer reported issue, not seeing REPORT log when adding `DD_ENHANCED_METRICS=false`.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.

https://datadoghq.atlassian.net/browse/SVLS-4311