### PR TITLE
Replace builtin encoding/json with the faster github.com/json-iterator/go

### DIFF
--- a/pkg/serverless/appsec/appsec.go
+++ b/pkg/serverless/appsec/appsec.go
@@ -8,16 +8,16 @@
 package appsec
 
 import (
-	"encoding/json"
 	"math/rand"
 	"time"
 
 	appsecLog "github.com/DataDog/appsec-internal-go/log"
+	waf "github.com/DataDog/go-libddwaf/v2"
+	json "github.com/json-iterator/go"
+
 	"github.com/DataDog/datadog-agent/pkg/serverless/appsec/config"
 	"github.com/DataDog/datadog-agent/pkg/serverless/appsec/httpsec"
 	"github.com/DataDog/datadog-agent/pkg/serverless/proxy"
-	waf "github.com/DataDog/go-libddwaf/v2"
-
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 

--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -12,7 +12,6 @@ package httpsec
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -25,6 +24,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	waf "github.com/DataDog/go-libddwaf/v2"
+	json "github.com/json-iterator/go"
 )
 
 // Monitorer is the interface type expected by the httpsec invocation

--- a/pkg/serverless/appsec/httpsec/proxy.go
+++ b/pkg/serverless/appsec/httpsec/proxy.go
@@ -7,7 +7,6 @@ package httpsec
 
 import (
 	"bytes"
-	"encoding/json"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/appsec/config"
@@ -17,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/aws/aws-lambda-go/events"
+	json "github.com/json-iterator/go"
 )
 
 // ProxyLifecycleProcessor is an implementation of the invocationlifecycle.InvocationProcessor

--- a/pkg/serverless/appsec/httpsec/tags.go
+++ b/pkg/serverless/appsec/httpsec/tags.go
@@ -8,11 +8,12 @@
 package httpsec
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/appsec-internal-go/httpsec"
 	"github.com/DataDog/datadog-agent/pkg/util/log"

--- a/pkg/serverless/executioncontext/executioncontext.go
+++ b/pkg/serverless/executioncontext/executioncontext.go
@@ -7,11 +7,12 @@
 package executioncontext
 
 import (
-	"encoding/json"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	json "github.com/json-iterator/go"
 )
 
 const persistedStateFilePath = "/tmp/dd-lambda-extension-cache.json"

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -6,10 +6,11 @@
 package invocationlifecycle
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -7,10 +7,11 @@ package invocationlifecycle
 
 import (
 	"bytes"
-	"encoding/json"
 	"os"
 	"strings"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -7,13 +7,14 @@ package invocationlifecycle
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"regexp"
 	"strconv"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"

--- a/pkg/serverless/logs/parse.go
+++ b/pkg/serverless/logs/parse.go
@@ -6,10 +6,11 @@
 package logs
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )

--- a/pkg/serverless/registration/extension_api.go
+++ b/pkg/serverless/registration/extension_api.go
@@ -9,12 +9,13 @@ package registration
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/trigger"
 	"github.com/DataDog/datadog-agent/pkg/util/log"

--- a/pkg/serverless/registration/telemetry_api.go
+++ b/pkg/serverless/registration/telemetry_api.go
@@ -7,12 +7,11 @@ package registration
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
-
-	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )

--- a/pkg/serverless/registration/telemetry_api.go
+++ b/pkg/serverless/registration/telemetry_api.go
@@ -7,11 +7,12 @@ package registration
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )

--- a/pkg/serverless/registration/telemetry_api_payload.go
+++ b/pkg/serverless/registration/telemetry_api_payload.go
@@ -6,7 +6,7 @@
 package registration
 
 import (
-	"encoding/json"
+	json "github.com/json-iterator/go"
 )
 
 type destination struct {

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -8,12 +8,13 @@ package serverless
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/daemon"
 	"github.com/DataDog/datadog-agent/pkg/serverless/flush"

--- a/pkg/serverless/trace/inferredspan/propagation.go
+++ b/pkg/serverless/trace/inferredspan/propagation.go
@@ -7,13 +7,14 @@ package inferredspan
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"regexp"
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/aws/aws-lambda-go/events"
+	json "github.com/json-iterator/go"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (

--- a/pkg/serverless/trace/propagation/carriers.go
+++ b/pkg/serverless/trace/propagation/carriers.go
@@ -8,12 +8,13 @@ package propagation
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"

--- a/pkg/serverless/trace/propagation/carriers_test.go
+++ b/pkg/serverless/trace/propagation/carriers_test.go
@@ -133,7 +133,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		name   string
 		event  events.SQSMessage
 		expMap map[string]string
-		expErr error
+		expErr string
 	}{
 		{
 			name: "empty-string-body",
@@ -141,7 +141,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 				Body: "",
 			},
 			expMap: nil,
-			expErr: errors.New("Error unmarshaling message body: unexpected end of JSON input"),
+			expErr: "Error unmarshaling message body:",
 		},
 		{
 			name: "empty-map-body",
@@ -149,7 +149,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 				Body: "{}",
 			},
 			expMap: nil,
-			expErr: errors.New("No Datadog trace context found"),
+			expErr: "No Datadog trace context found",
 		},
 		{
 			name: "no-msg-attrs",
@@ -159,7 +159,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 				}`,
 			},
 			expMap: nil,
-			expErr: errors.New("No Datadog trace context found"),
+			expErr: "No Datadog trace context found",
 		},
 		{
 			name: "wrong-type-msg-attrs",
@@ -169,7 +169,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 				}`,
 			},
 			expMap: nil,
-			expErr: errors.New("Error unmarshaling message body: json: cannot unmarshal string into Go struct field snsBody.MessageAttributes of type map[string]interface {}"),
+			expErr: "Error unmarshaling message body:",
 		},
 		{
 			name: "non-binary-type",
@@ -184,7 +184,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 				}`,
 			},
 			expMap: nil,
-			expErr: errors.New("Unsupported Type in _datadog payload"),
+			expErr: "Unsupported Type in _datadog payload",
 		},
 		{
 			name: "cannot-decode",
@@ -199,7 +199,7 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 				}`,
 			},
 			expMap: nil,
-			expErr: errors.New("Error decoding binary: illegal base64 data at input byte 4"),
+			expErr: "Error decoding binary:",
 		},
 		{
 			name: "empty-string-encoded",
@@ -214,19 +214,19 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 				}`,
 			},
 			expMap: nil,
-			expErr: errors.New("Error unmarshaling the decoded binary: unexpected end of JSON input"),
+			expErr: "Error unmarshaling the decoded binary:",
 		},
 		{
 			name:   "empty-map-encoded",
 			event:  eventSqsMessage(headersNone, headersEmpty, headersNone),
 			expMap: headersMapEmpty,
-			expErr: nil,
+			expErr: "",
 		},
 		{
 			name:   "datadog-map",
 			event:  eventSqsMessage(headersNone, headersAll, headersNone),
 			expMap: headersMapAll,
-			expErr: nil,
+			expErr: "",
 		},
 	}
 
@@ -234,9 +234,9 @@ func TestSnsSqsMessageCarrier(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tm, err := snsSqsMessageCarrier(tc.event)
 			t.Logf("snsSqsMessageCarrier returned TextMapReader=%#v error=%#v", tm, err)
-			assert.Equal(t, tc.expErr != nil, err != nil)
-			if tc.expErr != nil && err != nil {
-				assert.Equal(t, tc.expErr.Error(), err.Error())
+			assert.Equal(t, tc.expErr != "", err != nil)
+			if tc.expErr != "" {
+				assert.ErrorContains(t, err, tc.expErr)
 			}
 			assert.Equal(t, tc.expMap, getMapFromCarrier(tm))
 		})
@@ -248,13 +248,13 @@ func TestSnsEntityCarrier(t *testing.T) {
 		name   string
 		event  events.SNSEntity
 		expMap map[string]string
-		expErr error
+		expErr string
 	}{
 		{
 			name:   "no-msg-attrs",
 			event:  events.SNSEntity{},
 			expMap: nil,
-			expErr: errors.New("No Datadog trace context found"),
+			expErr: "No Datadog trace context found",
 		},
 		{
 			name: "wrong-type-msg-attrs",
@@ -264,7 +264,7 @@ func TestSnsEntityCarrier(t *testing.T) {
 				},
 			},
 			expMap: nil,
-			expErr: errors.New("Unsupported type for _datadog payload"),
+			expErr: "Unsupported type for _datadog payload",
 		},
 		{
 			name: "wrong-type-type",
@@ -277,7 +277,7 @@ func TestSnsEntityCarrier(t *testing.T) {
 				},
 			},
 			expMap: nil,
-			expErr: errors.New("Unsupported type in _datadog payload"),
+			expErr: "Unsupported type in _datadog payload",
 		},
 		{
 			name: "wrong-value-type",
@@ -290,7 +290,7 @@ func TestSnsEntityCarrier(t *testing.T) {
 				},
 			},
 			expMap: nil,
-			expErr: errors.New("Unsupported value type in _datadog payload"),
+			expErr: "Unsupported value type in _datadog payload",
 		},
 		{
 			name: "cannot-decode",
@@ -303,7 +303,7 @@ func TestSnsEntityCarrier(t *testing.T) {
 				},
 			},
 			expMap: nil,
-			expErr: errors.New("Error decoding binary: illegal base64 data at input byte 4"),
+			expErr: "Error decoding binary: illegal base64 data at input byte 4",
 		},
 		{
 			name: "unknown-type",
@@ -316,7 +316,7 @@ func TestSnsEntityCarrier(t *testing.T) {
 				},
 			},
 			expMap: nil,
-			expErr: errors.New("Unsupported Type in _datadog payload"),
+			expErr: "Unsupported Type in _datadog payload",
 		},
 		{
 			name: "empty-string-encoded",
@@ -329,7 +329,7 @@ func TestSnsEntityCarrier(t *testing.T) {
 				},
 			},
 			expMap: nil,
-			expErr: errors.New("Error unmarshaling the decoded binary: unexpected end of JSON input"),
+			expErr: "Error unmarshaling the decoded binary:",
 		},
 		{
 			name: "binary-type",
@@ -342,7 +342,7 @@ func TestSnsEntityCarrier(t *testing.T) {
 				},
 			},
 			expMap: headersMapAll,
-			expErr: nil,
+			expErr: "",
 		},
 		{
 			name: "string-type",
@@ -355,7 +355,7 @@ func TestSnsEntityCarrier(t *testing.T) {
 				},
 			},
 			expMap: headersMapAll,
-			expErr: nil,
+			expErr: "",
 		},
 	}
 
@@ -363,9 +363,9 @@ func TestSnsEntityCarrier(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tm, err := snsEntityCarrier(tc.event)
 			t.Logf("snsEntityCarrier returned TextMapReader=%#v error=%#v", tm, err)
-			assert.Equal(t, tc.expErr != nil, err != nil)
-			if tc.expErr != nil && err != nil {
-				assert.Equal(t, tc.expErr.Error(), err.Error())
+			assert.Equal(t, tc.expErr != "", err != nil)
+			if tc.expErr != "" {
+				assert.ErrorContains(t, err, tc.expErr)
 			}
 			assert.Equal(t, tc.expMap, getMapFromCarrier(tm))
 		})

--- a/pkg/serverless/trigger/events.go
+++ b/pkg/serverless/trigger/events.go
@@ -7,8 +7,9 @@
 package trigger
 
 import (
-	jsonEncoder "encoding/json"
 	"strings"
+
+	jsonEncoder "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/util/json"
 )

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -14,10 +14,10 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"encoding/json"
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
+	json "github.com/json-iterator/go"
 )
 
 // APIGatewayProxyRequest mirrors events.APIGatewayProxyRequest type, removing

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -6,12 +6,12 @@
 package trigger
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
 )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Replaces `encoding/json` with `github.com/json-iterator/go`, which according to their [documentation](https://github.com/json-iterator/go) is vastly more performant.

![687474703a2f2f6a736f6e697465722e636f6d2f62656e63686d61726b732f676f2d62656e63686d61726b2e706e67](https://github.com/DataDog/datadog-agent/assets/1383216/14f1cf09-f7f9-4b1e-876e-dce3394621c8)



<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The need for speed.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Using a simple hello world java app, we can see the difference this makes: decrease in runtime duration of more than 6%.

<img width="670" alt="Screenshot 2023-12-28 at 10 46 09 AM" src="https://github.com/DataDog/datadog-agent/assets/1383216/ab53c8ea-e112-45d9-8f6e-c4aa11f04d2f">

See https://ddserverless.datadoghq.com/s/61ba5v0dnxcpd8dm/q7s-czi-ga6.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
