### PR TITLE
[CONTINT-3592] Backport fix sbom scan from filesystem (#21767)

### DIFF
--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -209,6 +209,8 @@ func (c *Collector) CleanCache() error {
 	return nil
 }
 
+// getCache returns the cache with the cache Cleaner. It should initializes the cache
+// only once to avoid blocking the CLI with the `flock` file system.
 func (c *Collector) getCache() (cache.Cache, CacheCleaner, error) {
 	var err error
 	c.cacheInitialized.Do(func() {
@@ -309,8 +311,14 @@ func (c *Collector) ScanFilesystem(ctx context.Context, path string, scanOptions
 }
 
 func (c *Collector) scan(ctx context.Context, artifact artifact.Artifact, applier applier.Applier, imgMeta *workloadmeta.ContainerImageMetadata) (*types.Report, error) {
-	if imgMeta != nil {
-		artifactReference, err := artifact.Inspect(ctx) // called by the scanner as well
+	// The cacheCleaner can be nil if `getCache` is not called previously. At the moment, we initialize the cache
+	// in the `scanImage`, which is not called in the `ScanImageFromFilesystem` method.
+	// Filesystem scans use a memory cache that is not returned by the cacheProvider.
+	// Todo: refactor the cache initialization to avoid this.
+	if imgMeta != nil && c.cacheCleaner != nil {
+		// The artifact reference is only needed to clean up the blobs after the scan.
+		// It is re-generated from cached partial results during the scan.
+		artifactReference, err := artifact.Inspect(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Fix panic when using SBOM from fs
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
#21767
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
#21767
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
#21767
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
#21767
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
