### PR TITLE
[trace-agent] CLI support added for unofficially supported deprecated flags/switches

### DIFF
--- a/cmd/trace-agent/command/deprecated.go
+++ b/cmd/trace-agent/command/deprecated.go
@@ -32,6 +32,7 @@ func FixDeprecatedFlags(args []string, w io.Writer) []string {
 		"-info":     replaceInfo,
 		"--info":    replaceInfo,
 		"-pid":      replacePid,
+		"--pid":     replacePid,
 		// Profiling flags
 		"-cpuprofile": replaceCPUProfile,
 		"-memprofile": replaceMemProfile,

--- a/cmd/trace-agent/command/deprecated.go
+++ b/cmd/trace-agent/command/deprecated.go
@@ -34,8 +34,10 @@ func FixDeprecatedFlags(args []string, w io.Writer) []string {
 		"-pid":      replacePid,
 		"--pid":     replacePid,
 		// Profiling flags
-		"-cpuprofile": replaceCPUProfile,
-		"-memprofile": replaceMemProfile,
+		"-cpuprofile":  replaceCpuProfile,
+		"--cpuprofile": replaceCpuProfile,
+		"-memprofile":  replaceMemProfile,
+		"--memprofile": replaceMemProfile,
 		// Windows flags
 		"-start-service": cli.ReplaceFlagPosix,
 		"-stop-service":  cli.ReplaceFlagPosix,

--- a/cmd/trace-agent/command/deprecated_test.go
+++ b/cmd/trace-agent/command/deprecated_test.go
@@ -45,6 +45,41 @@ func TestFixDeprecatedFlags(t *testing.T) {
 			},
 		},
 		{
+			cli: "--pid pidfile",
+			expectArgs: []string{
+				"--pidfile",
+				"pidfile",
+			},
+		},
+		{
+			cli: "-cpuprofile file",
+			expectArgs: []string{
+				"--cpu-profile",
+				"file",
+			},
+		},
+		{
+			cli: "--cpuprofile file",
+			expectArgs: []string{
+				"--cpu-profile",
+				"file",
+			},
+		},
+		{
+			cli: "-memprofile file",
+			expectArgs: []string{
+				"--mem-profile",
+				"file",
+			},
+		},
+		{
+			cli: "--memprofile file",
+			expectArgs: []string{
+				"--mem-profile",
+				"file",
+			},
+		},
+		{
 			cli: "-info",
 			expectArgs: []string{
 				"info",

--- a/releasenotes/notes/trace-agent-cli-support-deprecated-bc3feadf07d5aed8.yaml
+++ b/releasenotes/notes/trace-agent-cli-support-deprecated-bc3feadf07d5aed8.yaml
@@ -10,4 +10,4 @@ fixes:
   - |
     Adds support for previously unofficially supported deprecated flags
     in the Datadog Trace Agent ``trace-agent`` that were broken when the
-    CLI compatibility layer was first added for new flags.
+    CLI compatibility layer was first added for new flags in v7.48.0.

--- a/releasenotes/notes/trace-agent-cli-support-deprecated-bc3feadf07d5aed8.yaml
+++ b/releasenotes/notes/trace-agent-cli-support-deprecated-bc3feadf07d5aed8.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add support for previously unofficially supported deprecated flags
+    in the Datadog Trace Agent ``trace-agent`` that were broken when the
+    CLI compatibility layer was first added for new flags.

--- a/releasenotes/notes/trace-agent-cli-support-deprecated-bc3feadf07d5aed8.yaml
+++ b/releasenotes/notes/trace-agent-cli-support-deprecated-bc3feadf07d5aed8.yaml
@@ -8,6 +8,6 @@
 ---
 fixes:
   - |
-    Add support for previously unofficially supported deprecated flags
+    Adds support for previously unofficially supported deprecated flags
     in the Datadog Trace Agent ``trace-agent`` that were broken when the
     CLI compatibility layer was first added for new flags.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
In PR https://github.com/DataDog/datadog-agent/pull/18492 we added backward-compatibility support for official flags that were now deprecated. Unfortunately, the unofficially supported `--pid` (single hyphen were the documented switches `-pid`) was left out. This PR adds support for it once again.  

We also take the opportunity to fix a couple other flags so they remain backward-compatible even if only unofficially supported previously. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Customer was impacted by using the unofficial `--pid` flag instead of `-pid` (both now deprecated).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Manually launch the trace-agent and make sure the old flags are still well supported:
- `-pid <file>`
- `--pid <file>`
- `-cpuprofile <file>`
- `--cpuprofile <file>`
- `-memprofile <file>`
- `--memprofile <file>`

As well as the newer ones:
- `--pidfile <file>`
- `--cpu-profile <file>`
- `--mem-profile <file>`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
