### PR TITLE
use different netns if the root is likely to fail guessing

### DIFF
--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -726,6 +726,12 @@ func getOrCreateNSForGuessing() (netns.NsHandle, error, func()) {
 		if err != nil {
 			return curNS, fmt.Errorf("error creating offsetguess netns: %w", err), cleanupFunc
 		}
+		cleanupFunc = func() {
+			err := newNS.Close()
+			if err != nil {
+				log.Debugf("error closing offsetguess netns: %v", err)
+			}
+		}
 		err = setupLoopbackInNS(newNS)
 		if err != nil {
 			return curNS, fmt.Errorf("error setting up lookback in offsetguess netns: %w", err), cleanupFunc
@@ -733,12 +739,6 @@ func getOrCreateNSForGuessing() (netns.NsHandle, error, func()) {
 		err = unix.Setns(int(curNS), unix.CLONE_NEWNET)
 		if err != nil {
 			return curNS, fmt.Errorf("error returning to original NS: %w", err), cleanupFunc
-		}
-		cleanupFunc = func() {
-			err := newNS.Close()
-			if err != nil {
-				log.Debugf("error closing offsetguess netns: %v", err)
-			}
 		}
 		return newNS, nil, cleanupFunc
 	}

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -756,8 +756,11 @@ func (t *tracerOffsetGuesser) Guess(cfg *config.Config) ([]manager.ConstantEdito
 	if err == nil && State(t.status.State) == StateReady {
 		return t.getConstantEditors(), nil
 	}
-
-	curNS, err := netns.Get()
+	var curNS netns.NsHandle
+	curNS, err = netns.Get()
+	if err != nil {
+		return nil, fmt.Errorf("error getting current netns: %w", err)
+	}
 	var eventGenerator *tracerEventGenerator
 	// the root NS is often 0xf0000000 which makes guessing likely to fail. If so, guess in a new NS with a different offset
 	if uintptr(curNS) == 0xf0000000 {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Sometimes the root NS offset value can be `0xF0000000`. This is not a very random value and is likely to be guessed incorrectly. In this case we create a new netNS to guess the netNS ino. My machine happens to have this exact case so I was able to validate this locally. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
