### PR TITLE
[PROCS-3306] Implement basic e2e test for Process Agent on Windows

### DIFF
--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -108,14 +108,14 @@ func (s *linuxTestSuite) TestManualProcessCheck() {
 	check := s.Env().VM.
 		Execute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
 
-	assertManualProcessCheck(s.T(), check, false)
+	assertManualProcessCheck(s.T(), check, false, "stress")
 }
 
 func (s *linuxTestSuite) TestManualProcessDiscoveryCheck() {
 	check := s.Env().VM.
 		Execute("sudo /opt/datadog-agent/embedded/bin/process-agent check process_discovery --json")
 
-	assertManualProcessDiscoveryCheck(s.T(), check)
+	assertManualProcessDiscoveryCheck(s.T(), check, "stress")
 }
 
 func (s *linuxTestSuite) TestManualProcessCheckWithIO() {
@@ -127,5 +127,5 @@ func (s *linuxTestSuite) TestManualProcessCheckWithIO() {
 	check := s.Env().VM.
 		Execute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
 
-	assertManualProcessCheck(s.T(), check, true)
+	assertManualProcessCheck(s.T(), check, true, "stress")
 }

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -39,7 +39,7 @@ func (s *linuxTestSuite) TestProcessCheck() {
 	t := s.T()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().VM, []string{"process", "rtprocess"}, false)
+		assertRunningChecks(collect, s.Env().VM, []string{"process", "rtprocess"}, false, "sudo datadog-agent status --json")
 	}, 1*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessPayload
@@ -52,7 +52,7 @@ func (s *linuxTestSuite) TestProcessCheck() {
 		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
 	}, 2*time.Minute, 10*time.Second)
 
-	assertStressProcessCollected(t, payloads, false)
+	assertProcessCollected(t, payloads, false, "stress")
 }
 
 func (s *linuxTestSuite) TestProcessDiscoveryCheck() {
@@ -62,7 +62,7 @@ func (s *linuxTestSuite) TestProcessDiscoveryCheck() {
 	t := s.T()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().VM, []string{"process_discovery"}, false)
+		assertRunningChecks(collect, s.Env().VM, []string{"process_discovery"}, false, "sudo datadog-agent status --json")
 	}, 1*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessDiscoveryPayload
@@ -73,7 +73,7 @@ func (s *linuxTestSuite) TestProcessDiscoveryCheck() {
 		assert.NotEmpty(c, payloads, "no process discovery payloads returned")
 	}, 2*time.Minute, 10*time.Second)
 
-	assertStressProcessDiscoveryCollected(t, payloads)
+	assertStressProcessDiscoveryCollected(t, payloads, "stress")
 }
 
 func (s *linuxTestSuite) TestProcessCheckWithIO() {
@@ -88,7 +88,7 @@ func (s *linuxTestSuite) TestProcessCheckWithIO() {
 	t := s.T()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().VM, []string{"process", "rtprocess"}, true)
+		assertRunningChecks(collect, s.Env().VM, []string{"process", "rtprocess"}, true, "sudo datadog-agent status --json")
 	}, 1*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessPayload
@@ -101,7 +101,7 @@ func (s *linuxTestSuite) TestProcessCheckWithIO() {
 		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
 	}, 2*time.Minute, 10*time.Second)
 
-	assertStressProcessCollected(t, payloads, true)
+	assertProcessCollected(t, payloads, true, "stress")
 }
 
 func (s *linuxTestSuite) TestManualProcessCheck() {

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -73,7 +73,7 @@ func (s *linuxTestSuite) TestProcessDiscoveryCheck() {
 		assert.NotEmpty(c, payloads, "no process discovery payloads returned")
 	}, 2*time.Minute, 10*time.Second)
 
-	assertStressProcessDiscoveryCollected(t, payloads, "stress")
+	assertProcessDiscoveryCollected(t, payloads, "stress")
 }
 
 func (s *linuxTestSuite) TestProcessCheckWithIO() {

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -105,7 +105,7 @@ func processHasData(process *agentmodel.Process) bool {
 
 // processHasIOStats asserts that the given process has the expected IO stats populated
 func processHasIOStats(process *agentmodel.Process) bool {
-	// the given process only writes to disk, does not read from it
+	// The processes we currently use to test can only read or write, not both 
 	return process.IoStat.WriteRate > 0 && process.IoStat.WriteBytesRate > 0 ||  process.IoStat.ReadRate > 0 && process.IoStat.ReadBytesRate > 0 
 }
 

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -98,7 +98,7 @@ func findProcess(
 
 // processHasData asserts that the given process has the expected data populated
 func processHasData(process *agentmodel.Process) bool {
-	return process.Pid != 0 && process.NsPid != 0 && len(process.User.Name) > 0 &&
+	return process.Pid != 0 && len(process.User.Name) > 0 &&
 		process.Cpu.TotalPct > 0 && process.Cpu.SystemPct > 0 &&
 		process.Memory.Rss > 0 && process.Memory.Vms > 0
 }
@@ -109,7 +109,7 @@ func processHasIOStats(process *agentmodel.Process) bool {
 	return process.IoStat.WriteRate > 0 && process.IoStat.WriteBytesRate > 0
 }
 
-// assertStressProcessDiscoveryCollected asserts that the stress process is collected by the process
+// assertStressProcessDiscoveryCollected asserts that the given process is collected by the process
 // discovery check and that it has the expected data populated
 func assertStressProcessDiscoveryCollected(
 	t *testing.T, payloads []*aggregator.ProcessDiscoveryPayload, process string,
@@ -152,12 +152,12 @@ func findProcessDiscovery(
 
 // processDiscoveryHasData asserts that the given process discovery has the expected data populated
 func processDiscoveryHasData(disc *agentmodel.ProcessDiscovery) bool {
-	return disc.Pid != 0 && disc.NsPid != 0 && len(disc.User.Name) > 0
+	return disc.Pid != 0 && len(disc.User.Name) > 0
 }
 
 // assertManualProcessCheck asserts that the stress process is collected and reported in the output
 // of the manual process check
-func assertManualProcessCheck(t *testing.T, check string, withIOStats bool) {
+func assertManualProcessCheck(t *testing.T, check string, withIOStats bool, process string) {
 	defer func() {
 		if t.Failed() {
 			t.Logf("Check output:\n%s\n", check)
@@ -170,15 +170,15 @@ func assertManualProcessCheck(t *testing.T, check string, withIOStats bool) {
 	err := json.Unmarshal([]byte(check), &checkOutput)
 	require.NoError(t, err, "failed to unmarshal process check output")
 
-	found, populated := findProcess("stress", checkOutput.Processes, withIOStats)
+	found, populated := findProcess(process, checkOutput.Processes, withIOStats)
 
-	require.True(t, found, "stress process not found")
-	assert.True(t, populated, "no stress process had all data populated")
+	require.True(t, found, process + " process not found")
+	assert.True(t, populated, "no " + process + " process had all data populated")
 }
 
-// assertManualProcessDiscoveryCheck asserts that the stress process is collected and reported in
+// assertManualProcessDiscoveryCheck asserts that the given process is collected and reported in
 // the output of the manual process_discovery check
-func assertManualProcessDiscoveryCheck(t *testing.T, check string) {
+func assertManualProcessDiscoveryCheck(t *testing.T, check string, process string) {
 	defer func() {
 		if t.Failed() {
 			t.Logf("Check output:\n%s\n", check)
@@ -191,8 +191,8 @@ func assertManualProcessDiscoveryCheck(t *testing.T, check string) {
 	err := json.Unmarshal([]byte(check), &checkOutput)
 	require.NoError(t, err, "failed to unmarshal process check output")
 
-	found, populated := findProcessDiscovery("stress", checkOutput.ProcessDiscoveries)
+	found, populated := findProcessDiscovery(process, checkOutput.ProcessDiscoveries)
 
-	require.True(t, found, "stress process not found")
-	assert.True(t, populated, "no stress process had all data populated")
+	require.True(t, found, process + " process not found")
+	assert.True(t, populated, "no " + process + " process had all data populated")
 }

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -70,7 +70,7 @@ func assertProcessCollected(
 	}
 
 	require.True(t, found, process + " process not found")
-	assert.True(t, populated, process + "no process had all data populated")
+	assert.True(t, populated, "no " + process + " process had all data populated")
 }
 
 // findProcess returns whether the process with the given name exists in the given list of
@@ -129,7 +129,7 @@ func assertStressProcessDiscoveryCollected(
 	}
 
 	require.True(t, found, process + " process not found")
-	assert.True(t, populated, process + "no stress process had all data populated")
+	assert.True(t, populated, "no " + process + " process had all data populated")
 }
 
 // findProcessDiscovery returns whether the process with the given name exists in the given list of

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -29,8 +29,8 @@ var processDiscoveryCheckConfigStr string
 var systemProbeConfigStr string
 
 // assertRunningChecks asserts that the given process agent checks are running on the given VM
-func assertRunningChecks(t *assert.CollectT, vm client.VM, checks []string, withSystemProbe bool) {
-	status := vm.Execute("sudo datadog-agent status --json")
+func assertRunningChecks(t *assert.CollectT, vm client.VM, checks []string, withSystemProbe bool, command string) {
+	status := vm.Execute(command)
 	var statusMap struct {
 		ProcessAgentStatus struct {
 			Expvars struct {
@@ -50,10 +50,10 @@ func assertRunningChecks(t *assert.CollectT, vm client.VM, checks []string, with
 	}
 }
 
-// assertStressProcessCollected asserts that the stress process is collected by the process check
+// assertStressProcessCollected asserts that the given process is collected by the process check
 // and that it has the expected data populated
-func assertStressProcessCollected(
-	t *testing.T, payloads []*aggregator.ProcessPayload, withIOStats bool,
+func assertProcessCollected(
+	t *testing.T, payloads []*aggregator.ProcessPayload, withIOStats bool, process string,
 ) {
 	defer func() {
 		if t.Failed() {
@@ -63,14 +63,14 @@ func assertStressProcessCollected(
 
 	var found, populated bool
 	for _, payload := range payloads {
-		found, populated = findProcess("stress", payload.Processes, withIOStats)
+		found, populated = findProcess(process, payload.Processes, withIOStats)
 		if found && populated {
 			break
 		}
 	}
 
-	require.True(t, found, "stress process not found")
-	assert.True(t, populated, "no stress process had all data populated")
+	require.True(t, found, process + " process not found")
+	assert.True(t, populated, process + "no process had all data populated")
 }
 
 // findProcess returns whether the process with the given name exists in the given list of
@@ -112,7 +112,7 @@ func processHasIOStats(process *agentmodel.Process) bool {
 // assertStressProcessDiscoveryCollected asserts that the stress process is collected by the process
 // discovery check and that it has the expected data populated
 func assertStressProcessDiscoveryCollected(
-	t *testing.T, payloads []*aggregator.ProcessDiscoveryPayload,
+	t *testing.T, payloads []*aggregator.ProcessDiscoveryPayload, process string,
 ) {
 	defer func() {
 		if t.Failed() {
@@ -122,14 +122,14 @@ func assertStressProcessDiscoveryCollected(
 
 	var found, populated bool
 	for _, payload := range payloads {
-		found, populated = findProcessDiscovery("stress", payload.ProcessDiscoveries)
+		found, populated = findProcessDiscovery(process, payload.ProcessDiscoveries)
 		if found && populated {
 			break
 		}
 	}
 
-	require.True(t, found, "stress process not found")
-	assert.True(t, populated, "no stress process had all data populated")
+	require.True(t, found, process + " process not found")
+	assert.True(t, populated, process + "no stress process had all data populated")
 }
 
 // findProcessDiscovery returns whether the process with the given name exists in the given list of

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -69,8 +69,8 @@ func assertProcessCollected(
 		}
 	}
 
-	require.True(t, found, process + " process not found")
-	assert.True(t, populated, "no " + process + " process had all data populated")
+	require.True(t, found, "%s process not found", process)
+	assert.True(t, populated, "no %s process had all data populated", process)
 }
 
 // findProcess returns whether the process with the given name exists in the given list of
@@ -105,8 +105,8 @@ func processHasData(process *agentmodel.Process) bool {
 
 // processHasIOStats asserts that the given process has the expected IO stats populated
 func processHasIOStats(process *agentmodel.Process) bool {
-	// The processes we currently use to test can only read or write, not both 
-	return process.IoStat.WriteRate > 0 && process.IoStat.WriteBytesRate > 0 ||  process.IoStat.ReadRate > 0 && process.IoStat.ReadBytesRate > 0 
+	// The processes we currently use to test can only read or write, not both
+	return process.IoStat.WriteRate > 0 && process.IoStat.WriteBytesRate > 0 || process.IoStat.ReadRate > 0 && process.IoStat.ReadBytesRate > 0
 }
 
 // assertProcessDiscoveryCollected asserts that the given process is collected by the process
@@ -128,8 +128,8 @@ func assertProcessDiscoveryCollected(
 		}
 	}
 
-	require.True(t, found, process + " process not found")
-	assert.True(t, populated, "no " + process + " process had all data populated")
+	require.True(t, found, "%s process not found", process)
+	assert.True(t, populated, "no %s process had all data populated", process)
 }
 
 // findProcessDiscovery returns whether the process with the given name exists in the given list of
@@ -172,8 +172,8 @@ func assertManualProcessCheck(t *testing.T, check string, withIOStats bool, proc
 
 	found, populated := findProcess(process, checkOutput.Processes, withIOStats)
 
-	require.True(t, found, process + " process not found")
-	assert.True(t, populated, "no " + process + " process had all data populated")
+	require.True(t, found, "%s process not found", process)
+	assert.True(t, populated, "no %s process had all data populated", process)
 }
 
 // assertManualProcessDiscoveryCheck asserts that the given process is collected and reported in
@@ -193,6 +193,6 @@ func assertManualProcessDiscoveryCheck(t *testing.T, check string, process strin
 
 	found, populated := findProcessDiscovery(process, checkOutput.ProcessDiscoveries)
 
-	require.True(t, found, process + " process not found")
-	assert.True(t, populated, "no " + process + " process had all data populated")
+	require.True(t, found, "%s process not found", process)
+	assert.True(t, populated, "no %s process had all data populated", process)
 }

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -50,7 +50,7 @@ func assertRunningChecks(t *assert.CollectT, vm client.VM, checks []string, with
 	}
 }
 
-// assertStressProcessCollected asserts that the given process is collected by the process check
+// assertProcessCollected asserts that the given process is collected by the process check
 // and that it has the expected data populated
 func assertProcessCollected(
 	t *testing.T, payloads []*aggregator.ProcessPayload, withIOStats bool, process string,
@@ -105,13 +105,13 @@ func processHasData(process *agentmodel.Process) bool {
 
 // processHasIOStats asserts that the given process has the expected IO stats populated
 func processHasIOStats(process *agentmodel.Process) bool {
-	// the stress process only writes to disk, does not read from it
+	// the given process only writes to disk, does not read from it
 	return process.IoStat.WriteRate > 0 && process.IoStat.WriteBytesRate > 0 ||  process.IoStat.ReadRate > 0 && process.IoStat.ReadBytesRate > 0 
 }
 
-// assertStressProcessDiscoveryCollected asserts that the given process is collected by the process
+// assertProcessDiscoveryCollected asserts that the given process is collected by the process
 // discovery check and that it has the expected data populated
-func assertStressProcessDiscoveryCollected(
+func assertProcessDiscoveryCollected(
 	t *testing.T, payloads []*aggregator.ProcessDiscoveryPayload, process string,
 ) {
 	defer func() {
@@ -155,7 +155,7 @@ func processDiscoveryHasData(disc *agentmodel.ProcessDiscovery) bool {
 	return disc.Pid != 0 && disc.Command.Ppid != 0 && len(disc.User.Name) > 0
 }
 
-// assertManualProcessCheck asserts that the stress process is collected and reported in the output
+// assertManualProcessCheck asserts that the given process is collected and reported in the output
 // of the manual process check
 func assertManualProcessCheck(t *testing.T, check string, withIOStats bool, process string) {
 	defer func() {

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -98,7 +98,7 @@ func findProcess(
 
 // processHasData asserts that the given process has the expected data populated
 func processHasData(process *agentmodel.Process) bool {
-	return process.Pid != 0 && len(process.User.Name) > 0 &&
+	return process.Pid != 0 && process.Command.Ppid != 0 && len(process.User.Name) > 0 &&
 		process.Cpu.TotalPct > 0 && process.Cpu.SystemPct > 0 &&
 		process.Memory.Rss > 0 && process.Memory.Vms > 0
 }
@@ -106,7 +106,7 @@ func processHasData(process *agentmodel.Process) bool {
 // processHasIOStats asserts that the given process has the expected IO stats populated
 func processHasIOStats(process *agentmodel.Process) bool {
 	// the stress process only writes to disk, does not read from it
-	return process.IoStat.WriteRate > 0 && process.IoStat.WriteBytesRate > 0
+	return process.IoStat.WriteRate > 0 && process.IoStat.WriteBytesRate > 0 ||  process.IoStat.ReadRate > 0 && process.IoStat.ReadBytesRate > 0 
 }
 
 // assertStressProcessDiscoveryCollected asserts that the given process is collected by the process
@@ -152,7 +152,7 @@ func findProcessDiscovery(
 
 // processDiscoveryHasData asserts that the given process discovery has the expected data populated
 func processDiscoveryHasData(disc *agentmodel.ProcessDiscovery) bool {
-	return disc.Pid != 0 && len(disc.User.Name) > 0
+	return disc.Pid != 0 && disc.Command.Ppid != 0 && len(disc.User.Name) > 0
 }
 
 // assertManualProcessCheck asserts that the stress process is collected and reported in the output

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -32,8 +32,7 @@ func TestWindowsTestSuite(t *testing.T) {
 
 func (s *windowsTestSuite) SetupSuite() {
 	s.Suite.SetupSuite()
-	//s.Env().VM.Execute("fsutil file createnew big 107374182400")
-	//s.Env().VM.Execute("Start-Process -WindowStyle hidden -FilePath tar.exe -ArgumentList \"czvf\",\"test.tar.gz\",\"big\"")
+	s.Env().VM.Execute("Start-MpScan -ScanType FullScan -AsJob")
 }
 
 func (s *windowsTestSuite) TestProcessCheck() {
@@ -98,6 +97,8 @@ func (s *windowsTestSuite) TestProcessCheckIO() {
 		assertRunningChecks(collect, s.Env().VM, []string{"process", "rtprocess"}, true, command)
 	}, 1*time.Minute, 5*time.Second)
 
+	//s.Env().VM.Execute("Start-MpScan -ScanType FullScan")
+
 	var payloads []*aggregator.ProcessPayload
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		var err error
@@ -107,7 +108,7 @@ func (s *windowsTestSuite) TestProcessCheckIO() {
 		// Wait for two payloads, as processes must be detected in two check runs to be returned
 		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
 	}, 2*time.Minute, 10*time.Second)
-
+	
 	assertProcessCollected(t, payloads, true, "MsMpEng.exe")
 }
 

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
 )
 
 type windowsTestSuite struct {

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -32,6 +32,7 @@ func TestWindowsTestSuite(t *testing.T) {
 
 func (s *windowsTestSuite) SetupSuite() {
 	s.Suite.SetupSuite()
+	// Start an antivirus scan to use as process for testing
 	s.Env().VM.Execute("Start-MpScan -ScanType FullScan -AsJob")
 }
 

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -109,7 +109,7 @@ func (s *windowsTestSuite) TestProcessCheckIO() {
 		// Wait for two payloads, as processes must be detected in two check runs to be returned
 		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
 	}, 2*time.Minute, 10*time.Second)
-	
+
 	assertProcessCollected(t, payloads, true, "MsMpEng.exe")
 }
 

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package process
+
+import (
+	"testing"
+
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+)
+
+type windowsTestSuite struct {
+	e2e.Suite[e2e.FakeIntakeEnv]
+}
+
+func TestWindowsTestSuite(t *testing.T) {
+	e2e.Run(t, &windowsTestSuite{},
+		e2e.FakeIntakeStackDef(
+			e2e.WithAgentParams(agentparams.WithAgentConfig(processCheckConfigStr)),
+		))
+}
+
+func (s *linuxTestSuite) SetupSuite() {
+	s.Suite.SetupSuite()
+}

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -7,10 +7,16 @@ package process
 
 import (
 	"testing"
+	"time"
 
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
 )
 
 type windowsTestSuite struct {
@@ -21,9 +27,83 @@ func TestWindowsTestSuite(t *testing.T) {
 	e2e.Run(t, &windowsTestSuite{},
 		e2e.FakeIntakeStackDef(
 			e2e.WithAgentParams(agentparams.WithAgentConfig(processCheckConfigStr)),
-		))
+			e2e.WithVMParams(ec2params.WithOS(ec2os.WindowsOS)),
+		), params.WithDevMode())
 }
 
-func (s *linuxTestSuite) SetupSuite() {
+func (s *windowsTestSuite) SetupSuite() {
 	s.Suite.SetupSuite()
+	s.Env().VM.Execute("ForEach ($p in 1..200){ Start-Process -WindowStyle hidden -FilePath cmd.exe }")
+}
+
+func (s *windowsTestSuite) TestProcessCheck() {
+	t := s.T()
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		command := "& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe\" status --json"
+		assertRunningChecks(collect, s.Env().VM, []string{"process", "rtprocess"}, false, command)
+	}, 1*time.Minute, 5*time.Second)
+
+	var payloads []*aggregator.ProcessPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().Fakeintake.GetProcesses()
+		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+
+		// Wait for two payloads, as processes must be detected in two check runs to be returned
+		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+	}, 2*time.Minute, 10*time.Second)
+	
+	assertProcessCollected(t, payloads, false, "cmd.exe")
+}
+
+func (s *windowsTestSuite) TestProcessDiscoveryCheck() {
+	s.UpdateEnv(e2e.FakeIntakeStackDef(
+		e2e.WithAgentParams(agentparams.WithAgentConfig(processDiscoveryCheckConfigStr))))
+
+	t := s.T()
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		command := "& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe\" status --json"
+		assertRunningChecks(collect, s.Env().VM, []string{"process_discovery"}, false, command)
+	}, 1*time.Minute, 5*time.Second)
+
+	var payloads []*aggregator.ProcessDiscoveryPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().Fakeintake.GetProcessDiscoveries()
+		assert.NoError(c, err, "failed to get process discovery payloads from fakeintake")
+		assert.NotEmpty(c, payloads, "no process discovery payloads returned")
+	}, 2*time.Minute, 10*time.Second)
+
+	assertStressProcessDiscoveryCollected(t, payloads, "cmd.exe")
+}
+
+func (s *windowsTestSuite) TestProcessCheckWithIO() {
+	s.UpdateEnv(e2e.FakeIntakeStackDef(e2e.WithAgentParams(
+		agentparams.WithAgentConfig(processCheckConfigStr),
+		agentparams.WithSystemProbeConfig(systemProbeConfigStr),
+	)))
+
+	// Flush fake intake to remove payloads that won't have IO stats
+	s.Env().Fakeintake.FlushServerAndResetAggregators()
+
+	t := s.T()
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		command := "& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe\" status --json"
+		assertRunningChecks(collect, s.Env().VM, []string{"process", "rtprocess"}, true, command)
+	}, 1*time.Minute, 5*time.Second)
+
+	var payloads []*aggregator.ProcessPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().Fakeintake.GetProcesses()
+		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+
+		// Wait for two payloads, as processes must be detected in two check runs to be returned
+		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+	}, 2*time.Minute, 10*time.Second)
+
+	assertProcessCollected(t, payloads, true, "cmd.exe")
 }

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -78,7 +78,7 @@ func (s *windowsTestSuite) TestProcessDiscoveryCheck() {
 		assert.NotEmpty(c, payloads, "no process discovery payloads returned")
 	}, 2*time.Minute, 10*time.Second)
 
-	assertStressProcessDiscoveryCollected(t, payloads, "MsMpEng.exe")
+	assertProcessDiscoveryCollected(t, payloads, "MsMpEng.exe")
 }
 
 func (s *windowsTestSuite) TestProcessCheckIO() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Adds basic end-to-end tests for process checks in a Windows environment.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Finding command-line utilities to start processes that could generate load was surprisingly difficult. As of now, these tests start with running an antivirus scan as it will last the entire time and have some IO stats. One possible drawback of this is that the user for this process is SYSTEM and not Administrator. An alternative would be to start compressing a very large file using `tar.exe` as it's already included in Windows.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
