### PR TITLE
usm: tests: Modify gotls_client to support http2 as well

### DIFF
--- a/pkg/network/protocols/grpc/monitor_test.go
+++ b/pkg/network/protocols/grpc/monitor_test.go
@@ -64,7 +64,7 @@ func TestGRPCScenarios(t *testing.T) {
 func getClientsArray(t *testing.T, size int) ([]*grpc.Client, func()) {
 	res := make([]*grpc.Client, size)
 	for i := 0; i < size; i++ {
-		client, err := grpc.NewClient(srvAddr, grpc.Options{})
+		client, err := grpc.NewClient(srvAddr, grpc.Options{}, false)
 		require.NoError(t, err)
 		res[i] = &client
 	}

--- a/pkg/network/protocols/tls/gotls/testutil/gotls_client/gotls_client.go
+++ b/pkg/network/protocols/tls/gotls/testutil/gotls_client/gotls_client.go
@@ -31,7 +31,7 @@ func main() {
 	serverAddr := args[0]
 	reqCount, err := strconv.Atoi(args[1])
 	if err != nil || reqCount < 0 {
-		log.Fatalf("invalid value %q for number of request", args[1])
+		log.Fatalf("invalid value %q for number of requests", args[1])
 	}
 
 	var transport http.RoundTripper

--- a/pkg/network/protocols/tls/gotls/testutil/gotls_client/gotls_client.go
+++ b/pkg/network/protocols/tls/gotls/testutil/gotls_client/gotls_client.go
@@ -8,33 +8,51 @@ package main
 
 import (
 	"crypto/tls"
+	"flag"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"strconv"
+
+	"golang.org/x/net/http2"
 )
 
 func main() {
-	if len(os.Args) < 3 {
-		log.Fatalf("usage: %s <server_addr> <number_of_requests>", os.Args[0])
+	useHTTP2 := flag.Bool("http2", false, "enable HTTP2")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 2 {
+		log.Fatalf("usage: %s <server_addr> <number_of_requests> [optional -http2]", os.Args[0])
 	}
 
-	serverAddr := os.Args[1]
-	reqCount, err := strconv.Atoi(os.Args[2])
+	serverAddr := args[0]
+	reqCount, err := strconv.Atoi(args[1])
 	if err != nil || reqCount < 0 {
-		log.Fatalf("invalid value %q for number of request", os.Args[2])
+		log.Fatalf("invalid value %q for number of request", args[1])
 	}
 
-	client := http.Client{
-		Transport: &http.Transport{
-			ForceAttemptHTTP2: false,
-			TLSNextProto:      make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+	var transport http.RoundTripper
+	transport = &http.Transport{
+		ForceAttemptHTTP2: false,
+		TLSNextProto:      make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+
+	if *useHTTP2 {
+		transport = &http2.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},
-		},
+		}
+	}
+
+	client := http.Client{
+		Transport: transport,
 	}
 
 	defer client.CloseIdleConnections()

--- a/pkg/network/tracer/testutil/grpc/client.go
+++ b/pkg/network/tracer/testutil/grpc/client.go
@@ -8,8 +8,8 @@ package grpc
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
-	"google.golang.org/grpc/examples/route_guide/routeguide"
 	"io"
 	"math/rand"
 	"net"
@@ -17,8 +17,10 @@ import (
 
 	pbStream "github.com/pahanini/go-grpc-bidirectional-streaming-example/src/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
+	"google.golang.org/grpc/examples/route_guide/routeguide"
 )
 
 const (
@@ -147,10 +149,14 @@ type Options struct {
 }
 
 // NewClient returns a new gRPC client
-func NewClient(addr string, options Options) (Client, error) {
-	gRPCOptions := []grpc.DialOption{
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+func NewClient(addr string, options Options, withTLS bool) (Client, error) {
+	var gRPCOptions []grpc.DialOption
+	creds := grpc.WithTransportCredentials(insecure.NewCredentials())
+	if withTLS {
+		creds = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{ServerName: "", InsecureSkipVerify: true}))
 	}
+	gRPCOptions = append(gRPCOptions, creds)
+
 	if options.CustomDialer != nil {
 		gRPCOptions = append(gRPCOptions, grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			return options.CustomDialer.DialContext(ctx, "tcp", addr)

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1558,7 +1558,7 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 			postTracerSetup: func(t *testing.T, ctx testContext) {
 				c, err := grpc.NewClient(ctx.targetAddress, grpc.Options{
 					CustomDialer: defaultDialer,
-				})
+				}, false)
 				require.NoError(t, err)
 				defer c.Close()
 				timedContext, cancel := context.WithTimeout(context.Background(), defaultTimeout)
@@ -1573,7 +1573,7 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 			postTracerSetup: func(t *testing.T, ctx testContext) {
 				c, err := grpc.NewClient(ctx.targetAddress, grpc.Options{
 					CustomDialer: defaultDialer,
-				})
+				}, false)
 				require.NoError(t, err)
 				defer c.Close()
 				timedContext, cancel := context.WithTimeout(context.Background(), defaultTimeout)

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -656,7 +656,7 @@ func testProtocolConnectionProtocolMapCleanup(t *testing.T, tr *Tracer, clientHo
 
 		grpcClient, err := grpc.NewClient(targetAddr, grpc.Options{
 			CustomDialer: dialer,
-		})
+		}, false)
 		require.NoError(t, err)
 		defer grpcClient.Close()
 		_ = grpcClient.HandleUnary(context.Background(), "test")
@@ -842,7 +842,7 @@ func testHTTPGoTLSCaptureNewProcess(t *testing.T, cfg *config.Config) {
 	}
 
 	// spin-up goTLS client and issue requests after initialization
-	command, runRequests := gotlstestutil.NewGoTLSClient(t, serverAddr, expectedOccurrences)
+	command, runRequests := gotlstestutil.NewGoTLSClient(t, serverAddr, expectedOccurrences, false)
 	require.Eventuallyf(t, func() bool {
 		traced := utils.GetTracedPrograms("go-tls")
 		for _, prog := range traced {
@@ -870,7 +870,7 @@ func testHTTPGoTLSCaptureAlreadyRunning(t *testing.T, cfg *config.Config) {
 	t.Cleanup(closeServer)
 
 	// spin-up goTLS client but don't issue requests yet
-	command, issueRequestsFn := gotlstestutil.NewGoTLSClient(t, serverAddr, expectedOccurrences)
+	command, issueRequestsFn := gotlstestutil.NewGoTLSClient(t, serverAddr, expectedOccurrences, false)
 
 	cfg.EnableGoTLSSupport = true
 	cfg.EnableHTTPMonitoring = true


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Modifies the gotls_client to support also http2 (controlled via a flag)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Part of a bigger change to support http2-tls in USM.
Split the main giant PR into smaller manageable PRs
original code was written by @Yumasi in https://github.com/DataDog/datadog-agent/pull/21619 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
