### PR TITLE
usm: http2: Fix external grpc server

### DIFF
--- a/pkg/network/protocols/http/testutil/testutil.go
+++ b/pkg/network/protocols/http/testutil/testutil.go
@@ -164,6 +164,17 @@ func StatusFromPath(path string) uint16 {
 	return 0
 }
 
+// GetCertsPaths returns the absolute paths to the certs located in the testdata
+// directory, so they can be used in test throughout the project
+func GetCertsPaths() (string, string, error) {
+	curDir, err := CurDir()
+	if err != nil {
+		return "", "", err
+	}
+
+	return filepath.Join(curDir, "testdata/cert.pem.0"), filepath.Join(curDir, "testdata/server.key"), nil
+}
+
 // CurDir returns the current directory of the caller.
 func CurDir() (string, error) {
 	_, file, _, ok := runtime.Caller(1)

--- a/pkg/network/tracer/testutil/grpc/builder.go
+++ b/pkg/network/tracer/testutil/grpc/builder.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,11 +21,15 @@ import (
 
 // NewGRPCTLSServer triggers an external go tls client that runs `numRequests` HTTPs requests to `serverAddr`.
 // Returns the command executed and a callback to start sending requests.
-func NewGRPCTLSServer(t *testing.T) (*exec.Cmd, context.CancelFunc) {
+func NewGRPCTLSServer(t *testing.T, addr string, useTLS bool) (*exec.Cmd, context.CancelFunc) {
 	serverBin := buildGRPCServerBin(t)
-
+	args := []string{serverBin, "-addr", addr}
+	if useTLS {
+		args = append(args, "-tls")
+	}
 	cancelCtx, cancel := context.WithCancel(context.Background())
-	c, _, err := nettestutil.StartCommandCtx(cancelCtx, serverBin)
+	commandLine := strings.Join(args, " ")
+	c, _, err := nettestutil.StartCommandCtx(cancelCtx, commandLine)
 
 	require.NoError(t, err)
 	return c, cancel

--- a/pkg/network/tracer/testutil/grpc/server.go
+++ b/pkg/network/tracer/testutil/grpc/server.go
@@ -13,7 +13,6 @@ import (
 	"log"
 	"math"
 	"net"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -233,9 +232,10 @@ func NewServer(addr string, enableTLS bool) (*Server, error) {
 
 	creds := insecure.NewCredentials()
 	if enableTLS {
-		curDir, _ := testutil.CurDir()
-		crtPath := filepath.Join(curDir, "testdata/cert.pem.0")
-		keyPath := filepath.Join(curDir, "testdata/server.key")
+		crtPath, keyPath, err := testutil.GetCertsPaths()
+		if err != nil {
+			return nil, err
+		}
 		creds, err = credentials.NewServerTLSFromFile(crtPath, keyPath)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes certificates retrieval in tests, and allows to configure grpc-external server

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
