### PR TITLE
usm: tls: Flip read/recv conn tuples

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/native-tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls.h
@@ -128,7 +128,11 @@ int uretprobe__SSL_read(struct pt_regs *ctx) {
 
     char *buffer_ptr = args->buf;
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
-    tls_process(ctx, t, buffer_ptr, len, LIBSSL);
+    // The read tuple should be flipped (compared to the write tuple).
+    // tls_process and the appropriate parsers will flip it back if needed.
+    conn_tuple_t copy = *t;
+    flip_tuple(&copy);
+    tls_process(ctx, &copy, buffer_ptr, len, LIBSSL);
     return 0;
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
@@ -222,7 +226,11 @@ int uretprobe__SSL_read_ex(struct pt_regs* ctx) {
 
     char *buffer_ptr = args->buf;
     bpf_map_delete_elem(&ssl_read_ex_args, &pid_tgid);
-    tls_process(ctx, conn_tuple, buffer_ptr, bytes_count, LIBSSL);
+    // The read tuple should be flipped (compared to the write tuple).
+    // tls_process and the appropriate parsers will flip it back if needed.
+    conn_tuple_t copy = *conn_tuple;
+    flip_tuple(&copy);
+    tls_process(ctx, &copy, buffer_ptr, bytes_count, LIBSSL);
     return 0;
 cleanup:
     bpf_map_delete_elem(&ssl_read_ex_args, &pid_tgid);
@@ -401,7 +409,11 @@ int uretprobe__gnutls_record_recv(struct pt_regs *ctx) {
 
     char *buffer_ptr = args->buf;
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
-    tls_process(ctx, t, buffer_ptr, read_len, LIBGNUTLS);
+    // The read tuple should be flipped (compared to the write tuple).
+    // tls_process and the appropriate parsers will flip it back if needed.
+    conn_tuple_t copy = *t;
+    flip_tuple(&copy);
+    tls_process(ctx, &copy, buffer_ptr, read_len, LIBGNUTLS);
     return 0;
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -265,7 +265,11 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
     char *buffer_ptr = (char*)call_data_ptr->b_data;
     bpf_map_delete_elem(&go_tls_read_args, (go_tls_function_args_key_t*)&call_key);
 
-    tls_process(ctx, t, buffer_ptr, bytes_read, GO);
+    // The read tuple should be flipped (compared to the write tuple).
+    // tls_process and the appropriate parsers will flip it back if needed.
+    conn_tuple_t copy = *t;
+    flip_tuple(&copy);
+    tls_process(ctx, &copy, buffer_ptr, bytes_read, GO);
     return 0;
 }
 


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Flip conn tuple for read-tls calls.

Complementary work of https://github.com/DataDog/datadog-agent/pull/21686

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We need to distinguish between read/write TLS conn tuples for the different protocols (for example http2). Inside tls_process the protocols will be responsible to normalize/flip it back if needed
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
