### PR TITLE
remove postgresql dependencies

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2-dependencies.rb
@@ -11,19 +11,10 @@ if arm_target?
 end
 
 if osx_target?
-  dependency 'postgresql'
   dependency 'unixodbc'
 end
 
 if linux_target?
-  # * Psycopg2 doesn't come with pre-built wheel on the arm architecture.
-  #   to compile from source, it requires the `pg_config` executable present on the $PATH
-  # * We also need it to build psycopg[c] Python dependency
-  # * Note: because having unixodbc already built breaks postgresql build,
-  #   we made unixodbc depend on postgresql to ensure proper build order.
-  #   If we're ever removing/changing one of these dependencies, we need to
-  #   take this into account.
-  dependency 'postgresql'
   # add nfsiostat script
   dependency 'unixodbc'
   dependency 'freetds'  # needed for SQL Server integration

--- a/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
@@ -14,19 +14,10 @@ if arm_target?
 end
 
 if osx_target?
-  dependency 'postgresql'
   dependency 'unixodbc'
 end
 
 if linux_target?
-  # * Psycopg2 doesn't come with pre-built wheel on the arm architecture.
-  #   to compile from source, it requires the `pg_config` executable present on the $PATH
-  # * We also need it to build psycopg[c] Python dependency
-  # * Note: because having unixodbc already built breaks postgresql build,
-  #   we made unixodbc depend on postgresql to ensure proper build order.
-  #   If we're ever removing/changing one of these dependencies, we need to
-  #   take this into account.
-  dependency 'postgresql'
   # add nfsiostat script
   dependency 'unixodbc'
   dependency 'freetds'  # needed for SQL Server integration

--- a/releasenotes/notes/remove-postgresql-dependency-36757c0a86ccf48a.yaml
+++ b/releasenotes/notes/remove-postgresql-dependency-36757c0a86ccf48a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    Removes ``postgresql`` dependency after upgrading ``psycopg2`` to v2.9 in integrations-core.
+    ``psycopg2`` now comes with pre-built wheel for arm architecture.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR removes `postgresql` dependency after upgrading [psycopg2](https://github.com/DataDog/integrations-core/blob/master/postgres/pyproject.toml#L45) to 2.9 in `integrations-core`. `psycopg2` now comes with pre-built wheel for arm architecture start [v2.9](https://github.com/psycopg/psycopg2/releases/tag/2_9) (macos arm support started from [v2.9.3](https://github.com/psycopg/psycopg2/releases/tag/2_9_3-macos-arm64)). 

Test with the build
![image](https://github.com/DataDog/datadog-agent/assets/4964070/cd248569-b11b-4b0c-bf01-d0ac3db5fdb2)


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We have been reached out by customers questioning why we bundled `postgresql` in the agent. We will have to keep `postgresql` updated to fix CVEs. 
Now that we don't need `postgresql` for arm, we can safely remove the dependency. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Follow up PR will be made to remove [postgresql](https://github.com/DataDog/omnibus-software/blob/master/config/software/postgresql.rb) from omnibus-software.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
