### PR TITLE
[CWS] Close ebpfless gaps v2

### DIFF
--- a/pkg/security/probe/model_ebpfless.go
+++ b/pkg/security/probe/model_ebpfless.go
@@ -29,6 +29,8 @@ func NewEBPFLessModel() *model.Model {
 				!strings.HasPrefix(field, "setgid.") &&
 				!strings.HasPrefix(field, "setreuid.") &&
 				!strings.HasPrefix(field, "setregid.") &&
+				!strings.HasPrefix(field, "setfsuid.") &&
+				!strings.HasPrefix(field, "setfsgid.") &&
 				!strings.HasPrefix(field, "container.") {
 				return rules.ErrEventTypeNotEnabled
 			}

--- a/pkg/security/probe/model_ebpfless.go
+++ b/pkg/security/probe/model_ebpfless.go
@@ -34,6 +34,7 @@ func NewEBPFLessModel() *model.Model {
 				!strings.HasPrefix(field, "capset.") &&
 				!strings.HasPrefix(field, "rmdir.") &&
 				!strings.HasPrefix(field, "unlink.") &&
+				!strings.HasPrefix(field, "rename.") &&
 				!strings.HasPrefix(field, "container.") {
 				return rules.ErrEventTypeNotEnabled
 			}

--- a/pkg/security/probe/model_ebpfless.go
+++ b/pkg/security/probe/model_ebpfless.go
@@ -32,6 +32,8 @@ func NewEBPFLessModel() *model.Model {
 				!strings.HasPrefix(field, "setfsuid.") &&
 				!strings.HasPrefix(field, "setfsgid.") &&
 				!strings.HasPrefix(field, "capset.") &&
+				!strings.HasPrefix(field, "rmdir.") &&
+				!strings.HasPrefix(field, "unlink.") &&
 				!strings.HasPrefix(field, "container.") {
 				return rules.ErrEventTypeNotEnabled
 			}

--- a/pkg/security/probe/model_ebpfless.go
+++ b/pkg/security/probe/model_ebpfless.go
@@ -31,6 +31,7 @@ func NewEBPFLessModel() *model.Model {
 				!strings.HasPrefix(field, "setregid.") &&
 				!strings.HasPrefix(field, "setfsuid.") &&
 				!strings.HasPrefix(field, "setfsgid.") &&
+				!strings.HasPrefix(field, "capset.") &&
 				!strings.HasPrefix(field, "container.") {
 				return rules.ErrEventTypeNotEnabled
 			}

--- a/pkg/security/probe/model_ebpfless.go
+++ b/pkg/security/probe/model_ebpfless.go
@@ -25,6 +25,10 @@ func NewEBPFLessModel() *model.Model {
 				!strings.HasPrefix(field, "exit.") &&
 				!strings.HasPrefix(field, "open.") &&
 				!strings.HasPrefix(field, "process.") &&
+				!strings.HasPrefix(field, "setuid.") &&
+				!strings.HasPrefix(field, "setgid.") &&
+				!strings.HasPrefix(field, "setreuid.") &&
+				!strings.HasPrefix(field, "setregid.") &&
 				!strings.HasPrefix(field, "container.") {
 				return rules.ErrEventTypeNotEnabled
 			}

--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -157,6 +157,11 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 	case ebpfless.SyscallTypeSetFSGID:
 		event.Type = uint32(model.SetgidEventType)
 		event.SetGID.FSGID = uint32(syscallMsg.SetFSGID.FSGID)
+
+	case ebpfless.SyscallTypeCapset:
+		event.Type = uint32(model.CapsetEventType)
+		event.Capset.CapEffective = syscallMsg.Capset.Effective
+		event.Capset.CapPermitted = syscallMsg.Capset.Permitted
 	}
 
 	// container context

--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -165,6 +165,32 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 		event.Type = uint32(model.CapsetEventType)
 		event.Capset.CapEffective = syscallMsg.Capset.Effective
 		event.Capset.CapPermitted = syscallMsg.Capset.Permitted
+
+	case ebpfless.SyscallTypeUnlink:
+		event.Type = uint32(model.FileUnlinkEventType)
+		event.Unlink.Retval = syscallMsg.Retval
+		event.Unlink.File.PathnameStr = syscallMsg.Unlink.File.Filename
+		event.Unlink.File.BasenameStr = filepath.Base(syscallMsg.Unlink.File.Filename)
+		event.Unlink.File.MTime = syscallMsg.Unlink.File.MTime
+		event.Unlink.File.CTime = syscallMsg.Unlink.File.CTime
+		event.Unlink.File.Mode = uint16(syscallMsg.Unlink.File.Mode)
+		if syscallMsg.Unlink.File.Credentials != nil {
+			event.Unlink.File.UID = syscallMsg.Unlink.File.Credentials.UID
+			event.Unlink.File.GID = syscallMsg.Unlink.File.Credentials.GID
+		}
+
+	case ebpfless.SyscallTypeRmdir:
+		event.Type = uint32(model.FileRmdirEventType)
+		event.Rmdir.Retval = syscallMsg.Retval
+		event.Rmdir.File.PathnameStr = syscallMsg.Rmdir.File.Filename
+		event.Rmdir.File.BasenameStr = filepath.Base(syscallMsg.Rmdir.File.Filename)
+		event.Rmdir.File.MTime = syscallMsg.Rmdir.File.MTime
+		event.Rmdir.File.CTime = syscallMsg.Rmdir.File.CTime
+		event.Rmdir.File.Mode = uint16(syscallMsg.Rmdir.File.Mode)
+		if syscallMsg.Rmdir.File.Credentials != nil {
+			event.Rmdir.File.UID = syscallMsg.Rmdir.File.Credentials.UID
+			event.Rmdir.File.GID = syscallMsg.Rmdir.File.Credentials.GID
+		}
 	}
 
 	// container context

--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -191,6 +191,28 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 			event.Rmdir.File.UID = syscallMsg.Rmdir.File.Credentials.UID
 			event.Rmdir.File.GID = syscallMsg.Rmdir.File.Credentials.GID
 		}
+
+	case ebpfless.SyscallTypeRename:
+		event.Type = uint32(model.FileRenameEventType)
+		event.Rename.Retval = syscallMsg.Retval
+		event.Rename.Old.PathnameStr = syscallMsg.Rename.OldFile.Filename
+		event.Rename.Old.BasenameStr = filepath.Base(syscallMsg.Rename.OldFile.Filename)
+		event.Rename.Old.MTime = syscallMsg.Rename.OldFile.MTime
+		event.Rename.Old.CTime = syscallMsg.Rename.OldFile.CTime
+		event.Rename.Old.Mode = uint16(syscallMsg.Rename.OldFile.Mode)
+		if syscallMsg.Rename.OldFile.Credentials != nil {
+			event.Rename.Old.UID = syscallMsg.Rename.OldFile.Credentials.UID
+			event.Rename.Old.GID = syscallMsg.Rename.OldFile.Credentials.GID
+		}
+		event.Rename.New.PathnameStr = syscallMsg.Rename.NewFile.Filename
+		event.Rename.New.BasenameStr = filepath.Base(syscallMsg.Rename.NewFile.Filename)
+		event.Rename.New.MTime = syscallMsg.Rename.NewFile.MTime
+		event.Rename.New.CTime = syscallMsg.Rename.NewFile.CTime
+		event.Rename.New.Mode = uint16(syscallMsg.Rename.NewFile.Mode)
+		if syscallMsg.Rename.NewFile.Credentials != nil {
+			event.Rename.New.UID = syscallMsg.Rename.NewFile.Credentials.UID
+			event.Rename.New.GID = syscallMsg.Rename.NewFile.Credentials.GID
+		}
 	}
 
 	// container context

--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -140,9 +140,15 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 		}
 	case ebpfless.SyscallTypeSetUID:
 		p.Resolvers.ProcessResolver.UpdateUID(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: cl.nsID}, syscallMsg.SetUID.UID, syscallMsg.SetUID.EUID)
+		event.Type = uint32(model.SetuidEventType)
+		event.SetUID.UID = uint32(syscallMsg.SetUID.UID)
+		event.SetUID.EUID = uint32(syscallMsg.SetUID.EUID)
 
 	case ebpfless.SyscallTypeSetGID:
 		p.Resolvers.ProcessResolver.UpdateGID(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: cl.nsID}, syscallMsg.SetGID.GID, syscallMsg.SetGID.EGID)
+		event.Type = uint32(model.SetgidEventType)
+		event.SetGID.GID = uint32(syscallMsg.SetGID.GID)
+		event.SetGID.EGID = uint32(syscallMsg.SetGID.EGID)
 	}
 
 	// container context

--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -149,6 +149,14 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 		event.Type = uint32(model.SetgidEventType)
 		event.SetGID.GID = uint32(syscallMsg.SetGID.GID)
 		event.SetGID.EGID = uint32(syscallMsg.SetGID.EGID)
+
+	case ebpfless.SyscallTypeSetFSUID:
+		event.Type = uint32(model.SetuidEventType)
+		event.SetUID.FSUID = uint32(syscallMsg.SetFSUID.FSUID)
+
+	case ebpfless.SyscallTypeSetFSGID:
+		event.Type = uint32(model.SetgidEventType)
+		event.SetGID.FSGID = uint32(syscallMsg.SetFSGID.FSGID)
 	}
 
 	// container context

--- a/pkg/security/probe/probe_epbfless.go
+++ b/pkg/security/probe/probe_epbfless.go
@@ -101,7 +101,10 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 	switch syscallMsg.Type {
 	case ebpfless.SyscallTypeExec:
 		event.Type = uint32(model.ExecEventType)
-		entry := p.Resolvers.ProcessResolver.AddExecEntry(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: cl.nsID}, syscallMsg.Exec.File.Filename, syscallMsg.Exec.Args, syscallMsg.Exec.Envs, cl.containerContext.ID, syscallMsg.Timestamp, syscallMsg.Exec.TTY)
+		entry := p.Resolvers.ProcessResolver.AddExecEntry(
+			process.CacheResolverKey{Pid: syscallMsg.PID, NSID: cl.nsID}, syscallMsg.Exec.File.Filename,
+			syscallMsg.Exec.Args, syscallMsg.Exec.ArgsTruncated, syscallMsg.Exec.Envs, syscallMsg.Exec.EnvsTruncated,
+			cl.containerContext.ID, syscallMsg.Timestamp, syscallMsg.Exec.TTY)
 		if syscallMsg.Exec.Credentials != nil {
 			entry.Credentials.UID = syscallMsg.Exec.Credentials.UID
 			entry.Credentials.EUID = syscallMsg.Exec.Credentials.EUID

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -54,6 +54,8 @@ const (
 	SyscallTypeUnlink
 	// SyscallTypeRmdir rmdir type
 	SyscallTypeRmdir
+	// SyscallTypeRename rename/renameat/renameat2 type
+	SyscallTypeRename
 )
 
 // ContainerContext defines a container context
@@ -149,14 +151,20 @@ type CapsetSyscallMsg struct {
 	Permitted uint64
 }
 
-// UnlinkSyscallMsg defines a setfsgid message
+// UnlinkSyscallMsg defines a unlink message
 type UnlinkSyscallMsg struct {
 	File OpenSyscallMsg
 }
 
-// RmdirSyscallMsg defines a setfsgid message
+// RmdirSyscallMsg defines a rmdir message
 type RmdirSyscallMsg struct {
 	File OpenSyscallMsg
+}
+
+// RenameSyscallMsg defines a rename/renameat/renameat2 message
+type RenameSyscallMsg struct {
+	OldFile OpenSyscallMsg
+	NewFile OpenSyscallMsg
 }
 
 // SyscallMsg defines a syscall message
@@ -177,6 +185,7 @@ type SyscallMsg struct {
 	Capset    *CapsetSyscallMsg   `json:",omitempty"`
 	Unlink    *UnlinkSyscallMsg   `json:",omitempty"`
 	Rmdir     *RmdirSyscallMsg    `json:",omitempty"`
+	Rename    *RenameSyscallMsg   `json:",omitempty"`
 
 	// internals
 	Dup   *DupSyscallFakeMsg   `json:",omitempty"`

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -50,6 +50,10 @@ const (
 	SyscallTypeSetFSGID
 	// SyscallTypeCapset capset type
 	SyscallTypeCapset
+	// SyscallTypeUnlink unlink/unlinkat type
+	SyscallTypeUnlink
+	// SyscallTypeRmdir rmdir type
+	SyscallTypeRmdir
 )
 
 // ContainerContext defines a container context
@@ -77,7 +81,7 @@ type Credentials struct {
 
 // ExecSyscallMsg defines an exec message
 type ExecSyscallMsg struct {
-	File          *OpenSyscallMsg
+	File          OpenSyscallMsg
 	Args          []string
 	ArgsTruncated bool
 	Envs          []string
@@ -145,6 +149,16 @@ type CapsetSyscallMsg struct {
 	Permitted uint64
 }
 
+// UnlinkSyscallMsg defines a setfsgid message
+type UnlinkSyscallMsg struct {
+	File OpenSyscallMsg
+}
+
+// RmdirSyscallMsg defines a setfsgid message
+type RmdirSyscallMsg struct {
+	File OpenSyscallMsg
+}
+
 // SyscallMsg defines a syscall message
 type SyscallMsg struct {
 	Type      SyscallType
@@ -161,6 +175,8 @@ type SyscallMsg struct {
 	SetFSUID  *SetFSUIDSyscallMsg `json:",omitempty"`
 	SetFSGID  *SetFSGIDSyscallMsg `json:",omitempty"`
 	Capset    *CapsetSyscallMsg   `json:",omitempty"`
+	Unlink    *UnlinkSyscallMsg   `json:",omitempty"`
+	Rmdir     *RmdirSyscallMsg    `json:",omitempty"`
 
 	// internals
 	Dup   *DupSyscallFakeMsg   `json:",omitempty"`

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -145,7 +145,7 @@ type SetFSGIDSyscallMsg struct {
 	FSGID int32
 }
 
-// CapsetSyscallMsg defines a setfsgid message
+// CapsetSyscallMsg defines a capset message
 type CapsetSyscallMsg struct {
 	Effective uint64
 	Permitted uint64

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -77,11 +77,13 @@ type Credentials struct {
 
 // ExecSyscallMsg defines an exec message
 type ExecSyscallMsg struct {
-	File        *OpenSyscallMsg
-	Args        []string
-	Envs        []string
-	TTY         string
-	Credentials *Credentials
+	File          *OpenSyscallMsg
+	Args          []string
+	ArgsTruncated bool
+	Envs          []string
+	EnvsTruncated bool
+	TTY           string
+	Credentials   *Credentials
 }
 
 // ForkSyscallMsg defines a fork message

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -44,6 +44,10 @@ const (
 	SyscallTypeSetUID
 	// SyscallTypeSetGID setgid/setregid type
 	SyscallTypeSetGID
+	// SyscallTypeSetFSUID setfsuid type
+	SyscallTypeSetFSUID
+	// SyscallTypeSetFSGID setfsgid type
+	SyscallTypeSetFSGID
 )
 
 // ContainerContext defines a container context
@@ -121,19 +125,31 @@ type SetGIDSyscallMsg struct {
 	EGID int32
 }
 
+// SetFSUIDSyscallMsg defines a setfsuid message
+type SetFSUIDSyscallMsg struct {
+	FSUID int32
+}
+
+// SetFSGIDSyscallMsg defines a setfsgid message
+type SetFSGIDSyscallMsg struct {
+	FSGID int32
+}
+
 // SyscallMsg defines a syscall message
 type SyscallMsg struct {
 	Type      SyscallType
 	PID       uint32
 	Timestamp uint64
 	Retval    int64
-	Exec      *ExecSyscallMsg   `json:",omitempty"`
-	Open      *OpenSyscallMsg   `json:",omitempty"`
-	Fork      *ForkSyscallMsg   `json:",omitempty"`
-	Exit      *ExitSyscallMsg   `json:",omitempty"`
-	Fcntl     *FcntlSyscallMsg  `json:",omitempty"`
-	SetUID    *SetUIDSyscallMsg `json:",omitempty"`
-	SetGID    *SetGIDSyscallMsg `json:",omitempty"`
+	Exec      *ExecSyscallMsg     `json:",omitempty"`
+	Open      *OpenSyscallMsg     `json:",omitempty"`
+	Fork      *ForkSyscallMsg     `json:",omitempty"`
+	Exit      *ExitSyscallMsg     `json:",omitempty"`
+	Fcntl     *FcntlSyscallMsg    `json:",omitempty"`
+	SetUID    *SetUIDSyscallMsg   `json:",omitempty"`
+	SetGID    *SetGIDSyscallMsg   `json:",omitempty"`
+	SetFSUID  *SetFSUIDSyscallMsg `json:",omitempty"`
+	SetFSGID  *SetFSGIDSyscallMsg `json:",omitempty"`
 
 	// internals
 	Dup   *DupSyscallFakeMsg   `json:",omitempty"`

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -48,6 +48,8 @@ const (
 	SyscallTypeSetFSUID
 	// SyscallTypeSetFSGID setfsgid type
 	SyscallTypeSetFSGID
+	// SyscallTypeCapset capset type
+	SyscallTypeCapset
 )
 
 // ContainerContext defines a container context
@@ -135,6 +137,12 @@ type SetFSGIDSyscallMsg struct {
 	FSGID int32
 }
 
+// CapsetSyscallMsg defines a setfsgid message
+type CapsetSyscallMsg struct {
+	Effective uint64
+	Permitted uint64
+}
+
 // SyscallMsg defines a syscall message
 type SyscallMsg struct {
 	Type      SyscallType
@@ -150,6 +158,7 @@ type SyscallMsg struct {
 	SetGID    *SetGIDSyscallMsg   `json:",omitempty"`
 	SetFSUID  *SetFSUIDSyscallMsg `json:",omitempty"`
 	SetFSGID  *SetFSGIDSyscallMsg `json:",omitempty"`
+	Capset    *CapsetSyscallMsg   `json:",omitempty"`
 
 	// internals
 	Dup   *DupSyscallFakeMsg   `json:",omitempty"`

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -1223,8 +1223,10 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 						return
 					}
 					syscallMsg.Retval = ret
-					fillFileMetadata(syscallMsg.Rename.NewFile.Filename, &syscallMsg.Rename.NewFile, disableStats)
-					sendSyscallMsg(syscallMsg)
+					err := fillFileMetadata(syscallMsg.Rename.NewFile.Filename, &syscallMsg.Rename.NewFile, disableStats)
+					if err == nil {
+						sendSyscallMsg(syscallMsg)
+					}
 				}
 			}
 		case CallbackExitType:

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -798,12 +798,12 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 					logErrorf("unable to handle fchdir: %v", err)
 					return
 				}
-			case SetreuidNr:
+			case SetreuidNr, SetresuidNr:
 				if err = handleSetreuid(tracer, process, syscallMsg, regs); err != nil {
 					logErrorf("unable to handle fchdir: %v", err)
 					return
 				}
-			case SetregidNr:
+			case SetregidNr, SetresgidNr:
 				if err = handleSetregid(tracer, process, syscallMsg, regs); err != nil {
 					logErrorf("unable to handle fchdir: %v", err)
 					return
@@ -847,7 +847,7 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 					// maintain fd/path mapping
 					process.Res.Fd[int32(ret)] = syscallMsg.Open.Filename
 				}
-			case SetuidNr, SetgidNr, SetreuidNr, SetregidNr:
+			case SetuidNr, SetgidNr, SetreuidNr, SetregidNr, SetresuidNr, SetresgidNr:
 				if ret := tracer.ReadRet(regs); ret >= 0 {
 					syscallMsg, exists := process.Nr[nr]
 					if !exists {

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -36,6 +36,8 @@ const (
 	SetgidNr         = 106 // SetgidNr defines the syscall ID for amd64
 	SetreuidNr       = 113 // SetreuidNr defines the syscall ID for amd64
 	SetregidNr       = 114 // SetregidNr defines the syscall ID for amd64
+	SetresuidNr      = 117 // SetreuidNr defines the syscall ID for amd64
+	SetresgidNr      = 119 // SetregidNr defines the syscall ID for amd64
 	CloseNr          = 3   // CloseNr defines the syscall ID for amd64
 	MemfdCreateNr    = 319 // MemfdCreateNr defines the syscall ID for amd64
 
@@ -73,6 +75,8 @@ var (
 		"setgid",
 		"setreuid",
 		"setregid",
+		"setresuid",
+		"setresgid",
 		"close",
 		"memfd_create",
 	}

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -46,6 +46,9 @@ const (
 	UnlinkNr         = 87  // UnlinkNr defines the syscall ID for amd64
 	UnlinkatNr       = 263 // UnlinkatNr defines the syscall ID for amd64
 	RmdirNr          = 84  // RmdirNr defines the syscall ID for amd64
+	RenameNr         = 82  // RenameNr defines the syscall ID for amd64
+	RenameAtNr       = 264 // RenameAtNr defines the syscall ID for amd64
+	RenameAt2Nr      = 316 // RenameAt2Nr defines the syscall ID for amd64
 
 	ptraceFlags = 0 |
 		syscall.PTRACE_O_TRACEVFORK |
@@ -91,6 +94,9 @@ var (
 		"unlink",
 		"unlinkat",
 		"rmdir",
+		"rename",
+		"renameat",
+		"renameat2",
 	}
 )
 

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -43,6 +43,9 @@ const (
 	CloseNr          = 3   // CloseNr defines the syscall ID for amd64
 	MemfdCreateNr    = 319 // MemfdCreateNr defines the syscall ID for amd64
 	CapsetNr         = 126 // CapsetNr defines the syscall ID for amd64
+	UnlinkNr         = 87  // UnlinkNr defines the syscall ID for amd64
+	UnlinkatNr       = 263 // UnlinkatNr defines the syscall ID for amd64
+	RmdirNr          = 84  // RmdirNr defines the syscall ID for amd64
 
 	ptraceFlags = 0 |
 		syscall.PTRACE_O_TRACEVFORK |
@@ -85,6 +88,9 @@ var (
 		"close",
 		"memfd_create",
 		"capset",
+		"unlink",
+		"unlinkat",
+		"rmdir",
 	}
 )
 

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -38,6 +38,8 @@ const (
 	SetregidNr       = 114 // SetregidNr defines the syscall ID for amd64
 	SetresuidNr      = 117 // SetreuidNr defines the syscall ID for amd64
 	SetresgidNr      = 119 // SetregidNr defines the syscall ID for amd64
+	SetfsuidNr       = 122 // SetreuidNr defines the syscall ID for amd64
+	SetfsgidNr       = 123 // SetregidNr defines the syscall ID for amd64
 	CloseNr          = 3   // CloseNr defines the syscall ID for amd64
 	MemfdCreateNr    = 319 // MemfdCreateNr defines the syscall ID for amd64
 
@@ -77,6 +79,8 @@ var (
 		"setregid",
 		"setresuid",
 		"setresgid",
+		"setfsuid",
+		"setfsgid",
 		"close",
 		"memfd_create",
 	}

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -42,6 +42,7 @@ const (
 	SetfsgidNr       = 123 // SetregidNr defines the syscall ID for amd64
 	CloseNr          = 3   // CloseNr defines the syscall ID for amd64
 	MemfdCreateNr    = 319 // MemfdCreateNr defines the syscall ID for amd64
+	CapsetNr         = 126 // CapsetNr defines the syscall ID for amd64
 
 	ptraceFlags = 0 |
 		syscall.PTRACE_O_TRACEVFORK |
@@ -83,6 +84,7 @@ var (
 		"setfsgid",
 		"close",
 		"memfd_create",
+		"capset",
 	}
 )
 

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -36,10 +36,10 @@ const (
 	SetgidNr         = 106 // SetgidNr defines the syscall ID for amd64
 	SetreuidNr       = 113 // SetreuidNr defines the syscall ID for amd64
 	SetregidNr       = 114 // SetregidNr defines the syscall ID for amd64
-	SetresuidNr      = 117 // SetreuidNr defines the syscall ID for amd64
-	SetresgidNr      = 119 // SetregidNr defines the syscall ID for amd64
-	SetfsuidNr       = 122 // SetreuidNr defines the syscall ID for amd64
-	SetfsgidNr       = 123 // SetregidNr defines the syscall ID for amd64
+	SetresuidNr      = 117 // SetresuidNr defines the syscall ID for amd64
+	SetresgidNr      = 119 // SetresgidNr defines the syscall ID for amd64
+	SetfsuidNr       = 122 // SetfsuidNr defines the syscall ID for amd64
+	SetfsgidNr       = 123 // SetfsgidNr defines the syscall ID for amd64
 	CloseNr          = 3   // CloseNr defines the syscall ID for amd64
 	MemfdCreateNr    = 319 // MemfdCreateNr defines the syscall ID for amd64
 	CapsetNr         = 126 // CapsetNr defines the syscall ID for amd64

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -31,10 +31,10 @@ const (
 	SetgidNr         = 144 // SetgidNr defines the syscall ID for arm64
 	SetreuidNr       = 145 // SetreuidNr defines the syscall ID for arm64
 	SetregidNr       = 143 // SetregidNr defines the syscall ID for arm64
-	SetresuidNr      = 147 // SetreuidNr defines the syscall ID for arm64
-	SetresgidNr      = 149 // SetregidNr defines the syscall ID for arm64
-	SetfsuidNr       = 151 // SetreuidNr defines the syscall ID for arm64
-	SetfsgidNr       = 152 // SetregidNr defines the syscall ID for arm64
+	SetresuidNr      = 147 // SetresuidNr defines the syscall ID for arm64
+	SetresgidNr      = 149 // SetresgidNr defines the syscall ID for arm64
+	SetfsuidNr       = 151 // SetfsuidNr defines the syscall ID for arm64
+	SetfsgidNr       = 152 // SetfsgidNr defines the syscall ID for arm64
 	CloseNr          = 57  // CloseNr defines the syscall ID for arm64
 	MemfdCreateNr    = 279 // MemfdCreateNr defines the syscall ID for arm64
 	CapsetNr         = 91  // CapsetNr defines the syscall ID for arm64

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -31,6 +31,8 @@ const (
 	SetgidNr         = 144 // SetgidNr defines the syscall ID for arm64
 	SetreuidNr       = 145 // SetreuidNr defines the syscall ID for arm64
 	SetregidNr       = 143 // SetregidNr defines the syscall ID for arm64
+	SetresuidNr      = 147 // SetreuidNr defines the syscall ID for arm64
+	SetresgidNr      = 149 // SetregidNr defines the syscall ID for arm64
 	CloseNr          = 57  // CloseNr defines the syscall ID for arm64
 	MemfdCreateNr    = 279 // MemfdCreateNr defines the syscall ID for arm64
 
@@ -69,6 +71,8 @@ var (
 		"setgid",
 		"setreuid",
 		"setregid",
+		"setresuid",
+		"setresgid",
 		"close",
 		"memfd_create",
 	}

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -33,6 +33,8 @@ const (
 	SetregidNr       = 143 // SetregidNr defines the syscall ID for arm64
 	SetresuidNr      = 147 // SetreuidNr defines the syscall ID for arm64
 	SetresgidNr      = 149 // SetregidNr defines the syscall ID for arm64
+	SetfsuidNr       = 151 // SetreuidNr defines the syscall ID for arm64
+	SetfsgidNr       = 152 // SetregidNr defines the syscall ID for arm64
 	CloseNr          = 57  // CloseNr defines the syscall ID for arm64
 	MemfdCreateNr    = 279 // MemfdCreateNr defines the syscall ID for arm64
 
@@ -73,6 +75,8 @@ var (
 		"setregid",
 		"setresuid",
 		"setresgid",
+		"setfsuid",
+		"setfsgid",
 		"close",
 		"memfd_create",
 	}

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -38,12 +38,15 @@ const (
 	CloseNr          = 57  // CloseNr defines the syscall ID for arm64
 	MemfdCreateNr    = 279 // MemfdCreateNr defines the syscall ID for arm64
 	CapsetNr         = 91  // CapsetNr defines the syscall ID for arm64
+	UnlinkatNr       = 35  // UnlinkatNr defines the syscall ID for arm64
 
-	OpenNr  = -1 // OpenNr not available on arm64
-	ForkNr  = -2 // ForkNr not available on arm64
-	VforkNr = -3 // VforkNr not available on arm64
-	Dup2Nr  = -4 // Dup2Nr not available on arm64
-	CreatNr = -5 // CreatNr not available on arm64
+	OpenNr   = -1 // OpenNr not available on arm64
+	ForkNr   = -2 // ForkNr not available on arm64
+	VforkNr  = -3 // VforkNr not available on arm64
+	Dup2Nr   = -4 // Dup2Nr not available on arm64
+	CreatNr  = -5 // CreatNr not available on arm64
+	UnlinkNr = -6 // UnlinkNr not available on arm64
+	RmdirNr  = -7 // RmdirNr not available on arm64
 
 	ptraceFlags = 0 |
 		syscall.PTRACE_O_TRACECLONE |
@@ -81,6 +84,7 @@ var (
 		"close",
 		"memfd_create",
 		"capset",
+		"unlinkat",
 	}
 )
 

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -37,6 +37,7 @@ const (
 	SetfsgidNr       = 152 // SetregidNr defines the syscall ID for arm64
 	CloseNr          = 57  // CloseNr defines the syscall ID for arm64
 	MemfdCreateNr    = 279 // MemfdCreateNr defines the syscall ID for arm64
+	CapsetNr         = 91  // CapsetNr defines the syscall ID for arm64
 
 	OpenNr  = -1 // OpenNr not available on arm64
 	ForkNr  = -2 // ForkNr not available on arm64
@@ -79,6 +80,7 @@ var (
 		"setfsgid",
 		"close",
 		"memfd_create",
+		"capset",
 	}
 )
 

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -39,6 +39,8 @@ const (
 	MemfdCreateNr    = 279 // MemfdCreateNr defines the syscall ID for arm64
 	CapsetNr         = 91  // CapsetNr defines the syscall ID for arm64
 	UnlinkatNr       = 35  // UnlinkatNr defines the syscall ID for arm64
+	RenameAtNr       = 38  // RenameAtNr defines the syscall ID for arm64
+	RenameAt2Nr      = 276 // RenameAt2Nr defines the syscall ID for arm64
 
 	OpenNr   = -1 // OpenNr not available on arm64
 	ForkNr   = -2 // ForkNr not available on arm64
@@ -47,6 +49,7 @@ const (
 	CreatNr  = -5 // CreatNr not available on arm64
 	UnlinkNr = -6 // UnlinkNr not available on arm64
 	RmdirNr  = -7 // RmdirNr not available on arm64
+	RenameNr = -8 // RenameNr not available on arm64
 
 	ptraceFlags = 0 |
 		syscall.PTRACE_O_TRACECLONE |
@@ -85,6 +88,8 @@ var (
 		"memfd_create",
 		"capset",
 		"unlinkat",
+		"renameat",
+		"renameat2",
 	}
 )
 

--- a/pkg/security/resolvers/process/resolver_ebpfless.go
+++ b/pkg/security/resolvers/process/resolver_ebpfless.go
@@ -87,6 +87,7 @@ func (p *EBPFLessResolver) AddForkEntry(key CacheResolverKey, ppid uint32, ts ui
 	entry.PIDContext.Pid = key.Pid
 	entry.PPid = ppid
 	entry.ForkTime = time.Unix(0, int64(ts))
+	entry.IsThread = true
 
 	p.Lock()
 	defer p.Unlock()

--- a/pkg/security/resolvers/process/resolver_ebpfless.go
+++ b/pkg/security/resolvers/process/resolver_ebpfless.go
@@ -98,11 +98,15 @@ func (p *EBPFLessResolver) AddForkEntry(key CacheResolverKey, ppid uint32, ts ui
 }
 
 // AddExecEntry adds an entry to the local cache and returns the newly created entry
-func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv []string, envs []string, ctrID string, ts uint64, tty string) *model.ProcessCacheEntry {
+func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv []string, argsTruncated bool,
+	envs []string, envsTruncated bool, ctrID string, ts uint64, tty string) *model.ProcessCacheEntry {
 	entry := p.processCacheEntryPool.Get()
 	entry.PIDContext.Pid = key.Pid
 
-	entry.Process.ArgsEntry = &model.ArgsEntry{Values: argv}
+	entry.Process.ArgsEntry = &model.ArgsEntry{
+		Values:    argv,
+		Truncated: argsTruncated,
+	}
 	if len(argv) > 0 {
 		entry.Process.Argv0 = argv[0]
 	}
@@ -113,7 +117,11 @@ func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv 
 	}
 	entry.Process.TTYName = tty
 
-	entry.Process.EnvsEntry = &model.EnvsEntry{Values: envs}
+	entry.Process.EnvsEntry = &model.EnvsEntry{
+		Values:    envs,
+		Truncated: envsTruncated,
+	}
+	// TODO: use env resolvers + config for priority envs
 
 	if strings.HasPrefix(file, "memfd:") {
 		entry.Process.FileEvent.PathnameStr = ""

--- a/pkg/security/resolvers/process/resolver_ebpfless.go
+++ b/pkg/security/resolvers/process/resolver_ebpfless.go
@@ -121,7 +121,6 @@ func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, file string, argv 
 		Values:    envs,
 		Truncated: envsTruncated,
 	}
-	// TODO: use env resolvers + config for priority envs
 
 	if strings.HasPrefix(file, "memfd:") {
 		entry.Process.FileEvent.PathnameStr = ""

--- a/pkg/security/secl/model/args_envs.go
+++ b/pkg/security/secl/model/args_envs.go
@@ -15,6 +15,8 @@ import (
 const (
 	// MaxArgEnvSize maximum size of one argument or environment variable
 	MaxArgEnvSize = 256
+	// MaxArgsEnvsSize maximum number of args and/or envs
+	MaxArgsEnvsSize = 128
 )
 
 // ArgsEnvs raw value for args and envs

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1502,10 +1502,10 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 			ID:         "test_setreuid",
 			Expression: `setuid.uid == 1002 && setuid.euid == 1003 && process.file.name == "syscall_tester"`,
 		},
-		// {
-		// 	ID:         "test_setfsuid",
-		// 	Expression: `setuid.fsuid == 1004 && process.file.name == "syscall_tester"`,
-		// },
+		{
+			ID:         "test_setfsuid",
+			Expression: `setuid.fsuid == 1004 && process.file.name == "syscall_tester"`,
+		},
 		{
 			ID:         "test_setgid",
 			Expression: `setgid.gid == 1005 && process.file.name == "syscall_tester"`,

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -183,10 +183,6 @@ func TestProcessContext(t *testing.T) {
 	}
 
 	t.Run("exec-time", func(t *testing.T) {
-		if test.opts.staticOpts.enableEBPFLess {
-			t.Skip("create_at not supported yet")
-		}
-
 		testFile, _, err := test.Path("test-exec-time-1")
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1502,10 +1502,10 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 			ID:         "test_setreuid",
 			Expression: `setuid.uid == 1002 && setuid.euid == 1003 && process.file.name == "syscall_tester"`,
 		},
-		{
-			ID:         "test_setfsuid",
-			Expression: `setuid.fsuid == 1004 && process.file.name == "syscall_tester"`,
-		},
+		// {
+		// 	ID:         "test_setfsuid",
+		// 	Expression: `setuid.fsuid == 1004 && process.file.name == "syscall_tester"`,
+		// },
 		{
 			ID:         "test_setgid",
 			Expression: `setgid.gid == 1005 && process.file.name == "syscall_tester"`,
@@ -1529,9 +1529,6 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
-	if test.opts.staticOpts.enableEBPFLess == true {
-		t.Skip("not supported")
-	}
 
 	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
 	if err != nil {

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -58,7 +58,9 @@ func TestRmdir(t *testing.T) {
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
-			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong inode")
+			if !test.opts.staticOpts.enableEBPFLess {
+				assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong inode")
+			}
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
@@ -88,7 +90,9 @@ func TestRmdir(t *testing.T) {
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
-			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong inode")
+			if !test.opts.staticOpts.enableEBPFLess {
+				assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong inode")
+			}
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
@@ -99,6 +103,9 @@ func TestRmdir(t *testing.T) {
 	})
 
 	t.Run("unlinkat-io_uring", func(t *testing.T) {
+		if test.opts.staticOpts.enableEBPFLess {
+			t.Skip("io_uring not supported")
+		}
 		testDir, _, err := test.Path("test-unlink-rmdir")
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -479,13 +479,13 @@ int test_forkexec(int argc, char **argv) {
             }
             return EXIT_SUCCESS;
         } else if (strcmp(subcmd, "mmap") == 0) {
-            mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+            open("/dev/null", O_RDONLY);
             return EXIT_SUCCESS;
         }
     } else if (argc == 1) {
         int child = fork();
         if (child == 0) {
-            mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+            open("/dev/null", O_RDONLY);
             return EXIT_SUCCESS;
         } else if (child > 0) {
             wait(NULL);

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -53,7 +53,9 @@ func TestUnlink(t *testing.T) {
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
-			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong inode")
+			if !test.opts.staticOpts.enableEBPFLess {
+				assert.Equal(t, inode, event.Unlink.File.Inode, "wrong inode")
+			}
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
@@ -79,7 +81,9 @@ func TestUnlink(t *testing.T) {
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
-			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong inode")
+			if !test.opts.staticOpts.enableEBPFLess {
+				assert.Equal(t, inode, event.Unlink.File.Inode, "wrong inode")
+			}
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
@@ -98,6 +102,9 @@ func TestUnlink(t *testing.T) {
 	inode = getInode(t, testAtFile)
 
 	t.Run("io_uring", func(t *testing.T) {
+		if test.opts.staticOpts.enableEBPFLess {
+			t.Skip("io_uring not supported")
+		}
 		iour, err := iouring.New(1)
 		if err != nil {
 			if errors.Is(err, unix.ENOTSUP) {

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -203,7 +203,7 @@ def run_ebpfless_functional_tests(ctx, cws_instrumentation, testsuite, verbose=F
         "verbose_opt": "-test.v" if verbose else "",
         "testflags": testflags,
         "path": os.environ['PATH'],
-        "tests": "-test.run '^(TestOpen|TestProcess|TimestampVariable|KillAction|TestRmdir|TestUnlink)'",
+        "tests": "-test.run '^(TestOpen|TestProcess|TimestampVariable|KillAction|TestRmdir|TestUnlink|TestRename)'",
     }
 
     ctx.run(cmd.format(**args))

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -203,7 +203,7 @@ def run_ebpfless_functional_tests(ctx, cws_instrumentation, testsuite, verbose=F
         "verbose_opt": "-test.v" if verbose else "",
         "testflags": testflags,
         "path": os.environ['PATH'],
-        "tests": "-test.run '^(TestOpen|TestProcess|TimestampVariable|KillAction)'",
+        "tests": "-test.run '^(TestOpen|TestProcess|TimestampVariable|KillAction|TestRmdir|TestUnlink)'",
     }
 
     ctx.run(cmd.format(**args))


### PR DESCRIPTION
### What does this PR do?

This PR closes more gaps from ebpfless:
* Adding the IsThread field
* Send events for set(re)[gu]id
* Add setres[gu]id and setfs[gu]id syscalls
* Add capset syscall
* Make the related functional tests to pass
* Reactivate the created_at test
* Args/Env truncation
* Added unlink/rmdir/rename

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
