### PR TITLE
usm: gotls: add config option to control system-probe tests self-hooking

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -218,7 +218,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// For backward compatibility
 	cfg.BindEnv(join(smNS, "enable_go_tls_support"))
 	cfg.BindEnv(join(smNS, "tls", "go", "enabled"))
-	cfg.BindEnv(join(smNS, "tls", "go", "enable_self_hook"))
+	cfg.BindEnvAndSetDefault(join(smNS, "tls", "go", "exclude_self"), true)
 
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_http2_monitoring"), false)
 	cfg.BindEnvAndSetDefault(join(smNS, "tls", "istio", "enabled"), false)

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -218,6 +218,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// For backward compatibility
 	cfg.BindEnv(join(smNS, "enable_go_tls_support"))
 	cfg.BindEnv(join(smNS, "tls", "go", "enabled"))
+	cfg.BindEnv(join(smNS, "tls", "go", "test_self_hook"))
 
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_http2_monitoring"), false)
 	cfg.BindEnvAndSetDefault(join(smNS, "tls", "istio", "enabled"), false)

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -218,7 +218,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// For backward compatibility
 	cfg.BindEnv(join(smNS, "enable_go_tls_support"))
 	cfg.BindEnv(join(smNS, "tls", "go", "enabled"))
-	cfg.BindEnv(join(smNS, "tls", "go", "test_self_hook"))
+	cfg.BindEnv(join(smNS, "tls", "go", "enable_self_hook"))
 
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_http2_monitoring"), false)
 	cfg.BindEnvAndSetDefault(join(smNS, "tls", "istio", "enabled"), false)

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -95,9 +95,9 @@ type Config struct {
 	// traffic done through Go's standard library's TLS implementation
 	EnableGoTLSSupport bool
 
-	// EnableGoTLSTestSelfHook specifies whether USM's GoTLS module should hook the
+	// EnableGoTLSSelfHook specifies whether USM's GoTLS module should hook the
 	// system-probe test binary
-	EnableGoTLSTestSelfHook bool
+	EnableGoTLSSelfHook bool
 
 	// EnableJavaTLSSupport specifies whether the tracer should monitor HTTPS
 	// traffic done through Java's TLS implementation
@@ -359,7 +359,7 @@ func New() *Config {
 		JavaAgentAllowRegex:         cfg.GetString(join(smjtNS, "allow_regex")),
 		JavaAgentBlockRegex:         cfg.GetString(join(smjtNS, "block_regex")),
 		EnableGoTLSSupport:          cfg.GetBool(join(smNS, "tls", "go", "enabled")),
-		EnableGoTLSTestSelfHook:     cfg.GetBool(join(smNS, "tls", "go", "enable_self_hook")),
+		EnableGoTLSSelfHook:         cfg.GetBool(join(smNS, "tls", "go", "enable_self_hook")),
 		EnableHTTPStatsByStatusCode: cfg.GetBool(join(smNS, "enable_http_stats_by_status_code")),
 		EnableUSMQuantization:       cfg.GetBool(join(smNS, "enable_quantization")),
 	}

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -95,9 +95,9 @@ type Config struct {
 	// traffic done through Go's standard library's TLS implementation
 	EnableGoTLSSupport bool
 
-	// EnableGoTLSSelfHook specifies whether USM's GoTLS module should hook the
-	// system-probe test binary
-	EnableGoTLSSelfHook bool
+	// GoTLSExcludeSelf specifies whether USM's GoTLS module should avoid
+	// hooking the system-probe test binary. Defaults to true.
+	GoTLSExcludeSelf bool
 
 	// EnableJavaTLSSupport specifies whether the tracer should monitor HTTPS
 	// traffic done through Java's TLS implementation
@@ -359,7 +359,7 @@ func New() *Config {
 		JavaAgentAllowRegex:         cfg.GetString(join(smjtNS, "allow_regex")),
 		JavaAgentBlockRegex:         cfg.GetString(join(smjtNS, "block_regex")),
 		EnableGoTLSSupport:          cfg.GetBool(join(smNS, "tls", "go", "enabled")),
-		EnableGoTLSSelfHook:         cfg.GetBool(join(smNS, "tls", "go", "enable_self_hook")),
+		GoTLSExcludeSelf:            cfg.GetBool(join(smNS, "tls", "go", "exclude_self")),
 		EnableHTTPStatsByStatusCode: cfg.GetBool(join(smNS, "enable_http_stats_by_status_code")),
 		EnableUSMQuantization:       cfg.GetBool(join(smNS, "enable_quantization")),
 	}

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -95,6 +95,10 @@ type Config struct {
 	// traffic done through Go's standard library's TLS implementation
 	EnableGoTLSSupport bool
 
+	// EnableGoTLSTestSelfHook specifies whether USM's GoTLS module should hook the
+	// system-probe test binary
+	EnableGoTLSTestSelfHook bool
+
 	// EnableJavaTLSSupport specifies whether the tracer should monitor HTTPS
 	// traffic done through Java's TLS implementation
 	EnableJavaTLSSupport bool
@@ -355,6 +359,7 @@ func New() *Config {
 		JavaAgentAllowRegex:         cfg.GetString(join(smjtNS, "allow_regex")),
 		JavaAgentBlockRegex:         cfg.GetString(join(smjtNS, "block_regex")),
 		EnableGoTLSSupport:          cfg.GetBool(join(smNS, "tls", "go", "enabled")),
+		EnableGoTLSTestSelfHook:     cfg.GetBool(join(smNS, "tls", "go", "test_self_hook")),
 		EnableHTTPStatsByStatusCode: cfg.GetBool(join(smNS, "enable_http_stats_by_status_code")),
 		EnableUSMQuantization:       cfg.GetBool(join(smNS, "enable_quantization")),
 	}

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -359,7 +359,7 @@ func New() *Config {
 		JavaAgentAllowRegex:         cfg.GetString(join(smjtNS, "allow_regex")),
 		JavaAgentBlockRegex:         cfg.GetString(join(smjtNS, "block_regex")),
 		EnableGoTLSSupport:          cfg.GetBool(join(smNS, "tls", "go", "enabled")),
-		EnableGoTLSTestSelfHook:     cfg.GetBool(join(smNS, "tls", "go", "test_self_hook")),
+		EnableGoTLSTestSelfHook:     cfg.GetBool(join(smNS, "tls", "go", "enable_self_hook")),
 		EnableHTTPStatsByStatusCode: cfg.GetBool(join(smNS, "enable_http_stats_by_status_code")),
 		EnableUSMQuantization:       cfg.GetBool(join(smNS, "enable_quantization")),
 	}

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1447,6 +1447,35 @@ service_monitoring_config:
 	})
 }
 
+func TestUSMTLSGoSelfHook(t *testing.T) {
+	t.Run("via YAML", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		cfg := configurationFromYAML(t, `
+service_monitoring_config:
+  tls:
+    go:
+      test_self_hook: true
+`)
+		require.True(t, cfg.EnableGoTLSTestSelfHook)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_TEST_SELF_HOOK", "true")
+
+		cfg := New()
+
+		require.True(t, cfg.EnableGoTLSTestSelfHook)
+	})
+
+	t.Run("Not enabled", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		cfg := New()
+		// Default value.
+		require.False(t, cfg.EnableGoTLSTestSelfHook)
+	})
+}
+
 func TestProcessServiceInference(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1454,14 +1454,14 @@ func TestUSMTLSGoSelfHook(t *testing.T) {
 service_monitoring_config:
   tls:
     go:
-      test_self_hook: true
+      enable_self_hook: true
 `)
 		require.True(t, cfg.EnableGoTLSTestSelfHook)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_TEST_SELF_HOOK", "true")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_ENABLE_SELF_HOOK", "true")
 
 		cfg := New()
 

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1456,7 +1456,7 @@ service_monitoring_config:
     go:
       enable_self_hook: true
 `)
-		require.True(t, cfg.EnableGoTLSTestSelfHook)
+		require.True(t, cfg.EnableGoTLSSelfHook)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
@@ -1465,14 +1465,14 @@ service_monitoring_config:
 
 		cfg := New()
 
-		require.True(t, cfg.EnableGoTLSTestSelfHook)
+		require.True(t, cfg.EnableGoTLSSelfHook)
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := New()
 		// Default value.
-		require.False(t, cfg.EnableGoTLSTestSelfHook)
+		require.False(t, cfg.EnableGoTLSSelfHook)
 	})
 }
 

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1447,32 +1447,32 @@ service_monitoring_config:
 	})
 }
 
-func TestUSMTLSGoSelfHook(t *testing.T) {
+func TestUSMTLSGoExcludeSelf(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := configurationFromYAML(t, `
 service_monitoring_config:
   tls:
     go:
-      enable_self_hook: true
+      exclude_self: false
 `)
-		require.True(t, cfg.EnableGoTLSSelfHook)
+		require.False(t, cfg.GoTLSExcludeSelf)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_ENABLE_SELF_HOOK", "true")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_EXCLUDE_SELF", "false")
 
 		cfg := New()
 
-		require.True(t, cfg.EnableGoTLSSelfHook)
+		require.False(t, cfg.GoTLSExcludeSelf)
 	})
 
-	t.Run("Not enabled", func(t *testing.T) {
+	t.Run("Not disabled", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := New()
 		// Default value.
-		require.False(t, cfg.EnableGoTLSSelfHook)
+		require.True(t, cfg.GoTLSExcludeSelf)
 	})
 }
 

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -320,7 +320,7 @@ func registerCBCreator(mgr *manager.Manager, offsetsDataMap *ebpf.Map, probeIDs 
 }
 
 func (p *goTLSProgram) handleProcessStart(pid pid) {
-	if !p.cfg.EnableGoTLSTestSelfHook && pid == uint32(os.Getpid()) {
+	if !p.cfg.EnableGoTLSSelfHook && pid == uint32(os.Getpid()) {
 		return
 	}
 

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -320,7 +320,7 @@ func registerCBCreator(mgr *manager.Manager, offsetsDataMap *ebpf.Map, probeIDs 
 }
 
 func (p *goTLSProgram) handleProcessStart(pid pid) {
-	if !p.cfg.EnableGoTLSSelfHook && pid == uint32(os.Getpid()) {
+	if p.cfg.GoTLSExcludeSelf && pid == uint32(os.Getpid()) {
 		return
 	}
 

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -320,6 +320,10 @@ func registerCBCreator(mgr *manager.Manager, offsetsDataMap *ebpf.Map, probeIDs 
 }
 
 func (p *goTLSProgram) handleProcessStart(pid pid) {
+	if !p.cfg.EnableGoTLSTestSelfHook && pid == uint32(os.Getpid()) {
+		return
+	}
+
 	pidAsStr := strconv.FormatUint(uint64(pid), 10)
 	exePath := filepath.Join(p.procRoot, pidAsStr, "exe")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds adds a new configuration option, `GoTLSExcludeSelf`, to allow us to control if the Go TLS module should hook the system-probe test binaries. This only affects unit tests, as we already are not hooking agent binaries when running system-probe, including system-probe itself.

The option can be changed via the `service_monitoring_config.tls.go.exclude_self` yaml option, or the `DD_SERVICE_MONITORING_CONFIG_TLS_GO_EXCLUDE_SELF` environment variable.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Some of our unit tests, like the gRPC+TLS tests, expect the test binary to not be hooked (to prevent duplicate stats).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Config option covered by unit tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
