### PR TITLE
[ASCII-976] split `pkg/status` into sub packages 

### DIFF
--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -27,7 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/DataDog/datadog-agent/pkg/flare"
-	"github.com/DataDog/datadog-agent/pkg/status"
+	clusteragentStatus "github.com/DataDog/datadog-agent/pkg/status/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
@@ -58,7 +58,7 @@ func SetupHandlers(r *mux.Router, wmeta workloadmeta.Component, senderManager se
 func getStatus(w http.ResponseWriter, r *http.Request) {
 	log.Info("Got a request for the status. Making status.")
 	verbose := r.URL.Query().Get("verbose") == "true"
-	s, err := status.GetDCAStatus(verbose)
+	s, err := clusteragentStatus.GetStatus(verbose)
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		log.Errorf("Error getting status. Error: %v, Status: %v", err, s)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -32,6 +32,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	processagentStatus "github.com/DataDog/datadog-agent/pkg/status/processagent"
+	systemprobeStatus "github.com/DataDog/datadog-agent/pkg/status/systemprobe"
 	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -181,7 +183,7 @@ func getExpVar(fb flaretypes.FlareBuilder) error {
 }
 
 func getSystemProbeStats() ([]byte, error) {
-	sysProbeStats := status.GetSystemProbeStats(config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
+	sysProbeStats := systemprobeStatus.GetStatus(config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
 	sysProbeBuf, err := yaml.Marshal(sysProbeStats)
 	if err != nil {
 		return nil, err
@@ -199,7 +201,7 @@ func getProcessAgentFullConfig() ([]byte, error) {
 
 	procStatusURL := fmt.Sprintf("http://%s/config/all", addressPort)
 
-	cfgB := status.GetProcessAgentRuntimeConfig(procStatusURL)
+	cfgB := processagentStatus.GetRuntimeConfig(procStatusURL)
 	return cfgB, nil
 }
 

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -20,7 +20,7 @@ import (
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/status"
+	clusteragentStatus "github.com/DataDog/datadog-agent/pkg/status/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/status/render"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -52,7 +52,7 @@ func createDCAArchive(fb flaretypes.FlareBuilder, confSearchPaths map[string]str
 	} else {
 		// The Status will be unavailable unless the agent is running.
 		// Only zip it up if the agent is running
-		err := fb.AddFileFromFunc("cluster-agent-status.log", status.GetAndFormatDCAStatus)
+		err := fb.AddFileFromFunc("cluster-agent-status.log", clusteragentStatus.GetAndFormatStatus)
 		if err != nil {
 			log.Errorf("Error getting the status of the DCA, %q", err)
 			return

--- a/pkg/status/aggregator/aggregator.go
+++ b/pkg/status/aggregator/aggregator.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package aggregator fetch information needed to render the 'aggregator' section of the status page.
+package aggregator
+
+import (
+	"encoding/json"
+	"expvar"
+
+	checkstats "github.com/DataDog/datadog-agent/pkg/collector/check/stats"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// PopulateStatus populates the status stats
+func PopulateStatus(stats map[string]interface{}) {
+	aggregatorStatsJSON := []byte(expvar.Get("aggregator").String())
+	aggregatorStats := make(map[string]interface{})
+	json.Unmarshal(aggregatorStatsJSON, &aggregatorStats) //nolint:errcheck
+	stats["aggregatorStats"] = aggregatorStats
+	s, err := checkstats.TranslateEventPlatformEventTypes(stats["aggregatorStats"])
+	if err != nil {
+		log.Debugf("failed to translate event platform event types in aggregatorStats: %s", err.Error())
+	} else {
+		stats["aggregatorStats"] = s
+	}
+}

--- a/pkg/status/aggregator/aggregator.go
+++ b/pkg/status/aggregator/aggregator.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package aggregator fetch information needed to render the 'aggregator' section of the status page.
 package aggregator

--- a/pkg/status/autodiscovery/autodicovery.go
+++ b/pkg/status/autodiscovery/autodicovery.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package autodiscovery fetch information needed to render the 'autodiscovery' section of the status page.
+package autodiscovery
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+)
+
+// PopulateStatus populates the status stats
+func PopulateStatus(stats map[string]interface{}) {
+	stats["adEnabledFeatures"] = config.GetDetectedFeatures()
+	if common.AC != nil {
+		stats["adConfigErrors"] = common.AC.GetAutodiscoveryErrors()
+	}
+	stats["filterErrors"] = containers.GetFilterErrors()
+}

--- a/pkg/status/autodiscovery/autodicovery.go
+++ b/pkg/status/autodiscovery/autodicovery.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package autodiscovery fetch information needed to render the 'autodiscovery' section of the status page.
 package autodiscovery

--- a/pkg/status/clusteragent/clusteragent.go
+++ b/pkg/status/clusteragent/clusteragent.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package clusteragent implements the status of the cluster agent
+package clusteragent
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/externalmetrics"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/orchestrator"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	logsStatus "github.com/DataDog/datadog-agent/pkg/logs/status"
+	"github.com/DataDog/datadog-agent/pkg/status/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/status/common"
+	"github.com/DataDog/datadog-agent/pkg/status/endpoints"
+	"github.com/DataDog/datadog-agent/pkg/status/render"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// GetStatus grabs the status from expvar and puts it into a map
+func GetStatus(verbose bool) (map[string]interface{}, error) {
+	// inventory is not enabled for the clusteragent/DCA so we pass nil to GetStatus
+	stats, err := common.GetStatus(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	stats["config"] = getDCAPartialConfig()
+	stats["leaderelection"] = getLeaderElectionDetails()
+
+	if config.Datadog.GetBool("compliance_config.enabled") {
+		stats["logsStats"] = logsStatus.Get(verbose)
+	}
+
+	endpoints.PopulateStatus(stats)
+
+	apiCl, apiErr := apiserver.GetAPIClient()
+	if apiErr != nil {
+		stats["custommetrics"] = map[string]string{"Error": apiErr.Error()}
+		stats["admissionWebhook"] = map[string]string{"Error": apiErr.Error()}
+	} else {
+		stats["custommetrics"] = custommetrics.GetStatus(apiCl.Cl)
+		stats["admissionWebhook"] = admission.GetStatus(apiCl.Cl)
+	}
+
+	if config.Datadog.GetBool("external_metrics_provider.use_datadogmetric_crd") {
+		stats["externalmetrics"] = externalmetrics.GetStatus()
+	} else {
+		stats["externalmetrics"] = apiserver.GetStatus()
+	}
+
+	if config.Datadog.GetBool("cluster_checks.enabled") {
+		cchecks, err := clusterchecks.GetStats()
+		if err != nil {
+			log.Errorf("Error grabbing clusterchecks stats: %s", err)
+		} else {
+			stats["clusterchecks"] = cchecks
+		}
+	}
+
+	autodiscovery.PopulateStatus(stats)
+
+	if config.Datadog.GetBool("orchestrator_explorer.enabled") {
+		if apiErr != nil {
+			stats["orchestrator"] = map[string]string{"Error": apiErr.Error()}
+		} else {
+			orchestratorStats := orchestrator.GetStatus(context.TODO(), apiCl.Cl)
+			stats["orchestrator"] = orchestratorStats
+		}
+	}
+
+	return stats, nil
+}
+
+// getDCAPartialConfig returns config parameters of interest for the status page.
+func getDCAPartialConfig() map[string]string {
+	conf := make(map[string]string)
+	conf["log_level"] = config.Datadog.GetString("log_level")
+	conf["confd_path"] = config.Datadog.GetString("confd_path")
+	return conf
+}
+
+// GetAndFormatStatus gets and formats the status all in one go
+func GetAndFormatStatus() ([]byte, error) {
+	s, err := GetStatus(true)
+	if err != nil {
+		log.Infof("Error while getting status %q", err)
+		return nil, err
+	}
+	statusJSON, err := json.Marshal(s)
+	if err != nil {
+		log.Infof("Error while marshalling %q", err)
+		return nil, err
+	}
+	st, err := render.FormatDCAStatus(statusJSON)
+	if err != nil {
+		log.Infof("Error formatting the status %q", err)
+		return nil, err
+	}
+	return []byte(st), nil
+}

--- a/pkg/status/clusteragent/clusteragent.go
+++ b/pkg/status/clusteragent/clusteragent.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package clusteragent implements the status of the cluster agent
 package clusteragent

--- a/pkg/status/clusteragent/status_apiserver.go
+++ b/pkg/status/clusteragent/status_apiserver.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 //go:build kubeapiserver
 

--- a/pkg/status/clusteragent/status_apiserver.go
+++ b/pkg/status/clusteragent/status_apiserver.go
@@ -1,11 +1,11 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2023-present Datadog, Inc.
 
 //go:build kubeapiserver
 
-package status
+package clusteragent
 
 import (
 	"fmt"
@@ -32,7 +32,8 @@ func getLeaderElectionDetails() map[string]string {
 	return leaderElectionStats
 }
 
-func getDCAStatus() map[string]string {
+// GetDCAStatus collect the DCA agent information and return it in a map
+func GetDCAStatus() map[string]string {
 	clusterAgentDetails := make(map[string]string)
 
 	dcaCl, err := clusteragent.GetClusterAgentClient()

--- a/pkg/status/clusteragent/status_no_apiserver.go
+++ b/pkg/status/clusteragent/status_no_apiserver.go
@@ -1,11 +1,11 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2023-present Datadog, Inc.
 
 //go:build !kubeapiserver
 
-package status
+package clusteragent
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -16,7 +16,8 @@ func getLeaderElectionDetails() map[string]string {
 	return nil
 }
 
-func getDCAStatus() map[string]string {
+// GetDCAStatus empty function for agents not running in a  k8s environment
+func GetDCAStatus() map[string]string {
 	log.Info("Not implemented")
 	return nil
 }

--- a/pkg/status/clusteragent/status_no_apiserver.go
+++ b/pkg/status/clusteragent/status_no_apiserver.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 //go:build !kubeapiserver
 

--- a/pkg/status/collector/collector.go
+++ b/pkg/status/collector/collector.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package collector fetch information needed to render the 'collector' section of the status page.
 // This will, in time, be migrated to the collector package/comp.

--- a/pkg/status/common/common.go
+++ b/pkg/status/common/common.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package common provides a functoin to get the status elements common to all Agent flavors.
+package common
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"time"
+
+	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl/utils"
+	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/status/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/status/collector"
+	"github.com/DataDog/datadog-agent/pkg/status/compliance"
+	"github.com/DataDog/datadog-agent/pkg/status/dogstatsd"
+	"github.com/DataDog/datadog-agent/pkg/status/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/status/hostname"
+	"github.com/DataDog/datadog-agent/pkg/status/netflow"
+	"github.com/DataDog/datadog-agent/pkg/status/ntp"
+	"github.com/DataDog/datadog-agent/pkg/status/snmptraps"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// GetStatus grabs the status from expvar and puts it into a map.
+func GetStatus(invAgent inventoryagent.Component) (map[string]interface{}, error) {
+	stats := make(map[string]interface{})
+	stats, err := expvarStats(stats, invAgent)
+	if err != nil {
+		log.Errorf("Error Getting ExpVar Stats: %v", err)
+	}
+
+	stats["version"] = version.AgentVersion
+	stats["flavor"] = flavor.GetFlavor()
+	stats["metadata"] = hostMetadataUtils.GetFromCache(context.TODO(), config.Datadog)
+	stats["conf_file"] = config.Datadog.ConfigFileUsed()
+	stats["pid"] = os.Getpid()
+	stats["go_version"] = runtime.Version()
+	stats["agent_start_nano"] = config.StartTime.UnixNano()
+	stats["build_arch"] = runtime.GOARCH
+	now := time.Now()
+	stats["time_nano"] = now.UnixNano()
+
+	return stats, nil
+}
+
+func expvarStats(stats map[string]interface{}, invAgent inventoryagent.Component) (map[string]interface{}, error) {
+	var err error
+	forwarder.PopulateStatus(stats)
+	collector.PopulateStatus(stats)
+	aggregator.PopulateStatus(stats)
+	dogstatsd.PopulateStatus(stats)
+	hostname.PopulateStatus(stats)
+	err = ntp.PopulateStatus(stats)
+	// invAgent can be nil when generating a status page for some agent where inventory is not enabled
+	// (clusteragent, security-agent, ...).
+	//
+	// todo: (component) remove this condition once status is a component.
+	if invAgent != nil {
+		stats["agent_metadata"] = invAgent.Get()
+	} else {
+		stats["agent_metadata"] = map[string]string{}
+	}
+
+	snmptraps.PopulateStatus(stats)
+
+	netflow.PopulateStatus(stats)
+
+	compliance.PopulateStatus(stats)
+
+	return stats, err
+}

--- a/pkg/status/common/common.go
+++ b/pkg/status/common/common.go
@@ -1,9 +1,9 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
-// Package common provides a functoin to get the status elements common to all Agent flavors.
+// Package common provides a function to get the status elements common to all Agent flavors.
 package common
 
 import (

--- a/pkg/status/compliance/compliance.go
+++ b/pkg/status/compliance/compliance.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package compliance fetch information needed to render the 'compliance' section of the status page.
 package compliance

--- a/pkg/status/compliance/compliance.go
+++ b/pkg/status/compliance/compliance.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package compliance fetch information needed to render the 'compliance' section of the status page.
+package compliance
+
+import (
+	"encoding/json"
+	"expvar"
+)
+
+// PopulateStatus populates the status stats
+func PopulateStatus(stats map[string]interface{}) {
+	complianceVar := expvar.Get("compliance")
+	if complianceVar != nil {
+		complianceStatusJSON := []byte(complianceVar.String())
+		complianceStatus := make(map[string]interface{})
+		json.Unmarshal(complianceStatusJSON, &complianceStatus) //nolint:errcheck
+		stats["complianceChecks"] = complianceStatus["Checks"]
+	} else {
+		stats["complianceChecks"] = map[string]interface{}{}
+	}
+}

--- a/pkg/status/dogstatsd/dogstatsd.go
+++ b/pkg/status/dogstatsd/dogstatsd.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package dogstatsd fetch information needed to render the 'dogstatsd' section of the status page.
 package dogstatsd

--- a/pkg/status/dogstatsd/dogstatsd.go
+++ b/pkg/status/dogstatsd/dogstatsd.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package dogstatsd fetch information needed to render the 'dogstatsd' section of the status page.
+package dogstatsd
+
+import (
+	"encoding/json"
+	"expvar"
+)
+
+// PopulateStatus populates the status stats
+func PopulateStatus(stats map[string]interface{}) {
+	if expvar.Get("dogstatsd") != nil {
+		dogstatsdStatsJSON := []byte(expvar.Get("dogstatsd").String())
+		dogstatsdUdsStatsJSON := []byte(expvar.Get("dogstatsd-uds").String())
+		dogstatsdUDPStatsJSON := []byte(expvar.Get("dogstatsd-udp").String())
+		dogstatsdStats := make(map[string]interface{})
+		json.Unmarshal(dogstatsdStatsJSON, &dogstatsdStats) //nolint:errcheck
+		dogstatsdUdsStats := make(map[string]interface{})
+		json.Unmarshal(dogstatsdUdsStatsJSON, &dogstatsdUdsStats) //nolint:errcheck
+		for name, value := range dogstatsdUdsStats {
+			dogstatsdStats["Uds"+name] = value
+		}
+		dogstatsdUDPStats := make(map[string]interface{})
+		json.Unmarshal(dogstatsdUDPStatsJSON, &dogstatsdUDPStats) //nolint:errcheck
+		for name, value := range dogstatsdUDPStats {
+			dogstatsdStats["Udp"+name] = value
+		}
+		stats["dogstatsdStats"] = dogstatsdStats
+	}
+}

--- a/pkg/status/endpoints/endpoints.go
+++ b/pkg/status/endpoints/endpoints.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package endpoints fetch information needed to render the 'endpoints' section of the status page.
 package endpoints

--- a/pkg/status/endpoints/endpoints.go
+++ b/pkg/status/endpoints/endpoints.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package endpoints fetch information needed to render the 'endpoints' section of the status page.
+package endpoints
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/utils"
+)
+
+// PopulateStatus populates the status stats
+func PopulateStatus(stats map[string]interface{}) {
+	endpoints, err := utils.GetMultipleEndpoints(config.Datadog)
+	if err != nil {
+		stats["endpointsInfos"] = nil
+		return
+	}
+
+	endpointsInfos := make(map[string]interface{})
+
+	// obfuscate the api keys
+	for endpoint, keys := range endpoints {
+		for i, key := range keys {
+			if len(key) > 5 {
+				keys[i] = key[len(key)-5:]
+			}
+		}
+		endpointsInfos[endpoint] = keys
+	}
+	stats["endpointsInfos"] = endpointsInfos
+}

--- a/pkg/status/forwarder/forwarder.go
+++ b/pkg/status/forwarder/forwarder.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package forwarder fetch information needed to render the 'forwarder' section of the status page.
 package forwarder

--- a/pkg/status/forwarder/forwarder.go
+++ b/pkg/status/forwarder/forwarder.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package forwarder fetch information needed to render the 'forwarder' section of the status page.
+package forwarder
+
+import (
+	"encoding/json"
+	"expvar"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// PopulateStatus populates the status stats
+func PopulateStatus(stats map[string]interface{}) {
+	forwarderStatsJSON := []byte(expvar.Get("forwarder").String())
+	forwarderStats := make(map[string]interface{})
+	json.Unmarshal(forwarderStatsJSON, &forwarderStats) //nolint:errcheck
+	forwarderStorageMaxSizeInBytes := config.Datadog.GetInt("forwarder_storage_max_size_in_bytes")
+	if forwarderStorageMaxSizeInBytes > 0 {
+		forwarderStats["forwarder_storage_max_size_in_bytes"] = strconv.Itoa(forwarderStorageMaxSizeInBytes)
+	}
+	stats["forwarderStats"] = forwarderStats
+}

--- a/pkg/status/hostname/hostname.go
+++ b/pkg/status/hostname/hostname.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package hostname fetch information needed to render the 'hostname' section of the status page.
 package hostname

--- a/pkg/status/hostname/hostname.go
+++ b/pkg/status/hostname/hostname.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package hostname fetch information needed to render the 'hostname' section of the status page.
+package hostname
+
+import (
+	"encoding/json"
+	"expvar"
+)
+
+// PopulateStatus populates the status stats
+func PopulateStatus(stats map[string]interface{}) {
+	hostnameStatsJSON := []byte(expvar.Get("hostname").String())
+	hostnameStats := make(map[string]interface{})
+	json.Unmarshal(hostnameStatsJSON, &hostnameStats) //nolint:errcheck
+	stats["hostnameStats"] = hostnameStats
+}

--- a/pkg/status/netflow/netflow.go
+++ b/pkg/status/netflow/netflow.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package netflow fetch information needed to render the 'netflow' section of the status page.
+package netflow
+
+import netflowServer "github.com/DataDog/datadog-agent/comp/netflow/server"
+
+// PopulateStatus populates the status stats
+func PopulateStatus(stats map[string]interface{}) {
+	if netflowServer.IsEnabled() {
+		stats["netflowStats"] = netflowServer.GetStatus()
+	}
+}

--- a/pkg/status/netflow/netflow.go
+++ b/pkg/status/netflow/netflow.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package netflow fetch information needed to render the 'netflow' section of the status page.
 package netflow

--- a/pkg/status/ntp/ntp.go
+++ b/pkg/status/ntp/ntp.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package ntp fetch information needed to render the 'ntp' section of the status page.
+package ntp
+
+import (
+	"expvar"
+	"strconv"
+)
+
+// PopulateStatus populates the status stats
+func PopulateStatus(stats map[string]interface{}) error {
+	ntpOffset := expvar.Get("ntpOffset")
+	if ntpOffset != nil && ntpOffset.String() != "" {
+		float, err := strconv.ParseFloat(expvar.Get("ntpOffset").String(), 64)
+		stats["ntpOffset"] = float
+
+		return err
+	}
+
+	return nil
+}

--- a/pkg/status/ntp/ntp.go
+++ b/pkg/status/ntp/ntp.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package ntp fetch information needed to render the 'ntp' section of the status page.
 package ntp

--- a/pkg/status/processagent/processagent.go
+++ b/pkg/status/processagent/processagent.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package status
+// Package processagent fetch information about the process agent
+package processagent
 
 import (
 	"encoding/json"
@@ -33,8 +34,8 @@ func getHTTPClient() *http.Client {
 	return httpClient
 }
 
-// GetProcessAgentStatus fetches the process-agent status from the process-agent API server
-func GetProcessAgentStatus() map[string]interface{} {
+// GetStatus fetches the process-agent status from the process-agent API server
+func GetStatus() map[string]interface{} {
 	s := make(map[string]interface{})
 	addressPort, err := config.GetProcessAPIAddressPort()
 	if err != nil {
@@ -74,11 +75,11 @@ func marshalError(err error) []byte {
 	return b
 }
 
-// GetProcessAgentRuntimeConfig fetches the process-agent runtime settings.
+// GetRuntimeConfig fetches the process-agent runtime settings.
 // The API server in process-agent already scrubs and marshals the runtime settings as YAML.
 // Since the api_key has been obfuscated with *, we're not able to unmarshal the response as YAML because *
 // is not a valid YAML character
-func GetProcessAgentRuntimeConfig(statusURL string) []byte {
+func GetRuntimeConfig(statusURL string) []byte {
 	client := getHTTPClient()
 	b, err := apiutil.DoGet(client, statusURL, apiutil.CloseConnection)
 	if err != nil {

--- a/pkg/status/remoteconfiguration/remoteconfiguration.go
+++ b/pkg/status/remoteconfiguration/remoteconfiguration.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package remoteconfiguration fetch information needed to render the 'remoteconfiguration' section of the status page.
+package remoteconfiguration
+
+import (
+	"encoding/json"
+	"expvar"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// PopulateStatus populates the status stats
+func PopulateStatus(stats map[string]interface{}) {
+	status := make(map[string]interface{})
+
+	if config.IsRemoteConfigEnabled(config.Datadog) && expvar.Get("remoteConfigStatus") != nil {
+		remoteConfigStatusJSON := expvar.Get("remoteConfigStatus").String()
+		json.Unmarshal([]byte(remoteConfigStatusJSON), &status) //nolint:errcheck
+	} else {
+		if !config.Datadog.GetBool("remote_configuration.enabled") {
+			status["disabledReason"] = "it is explicitly disabled in the agent configuration. (`remote_configuration.enabled: false`)"
+		} else if config.Datadog.GetBool("fips.enabled") {
+			status["disabledReason"] = "it is not supported when FIPS is enabled. (`fips.enabled: true`)"
+		} else if config.Datadog.GetString("site") == "ddog-gov.com" {
+			status["disabledReason"] = "it is not supported on GovCloud. (`site: \"ddog-gov.com\"`)"
+		}
+	}
+
+	stats["remoteConfiguration"] = status
+}

--- a/pkg/status/remoteconfiguration/remoteconfiguration.go
+++ b/pkg/status/remoteconfiguration/remoteconfiguration.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package remoteconfiguration fetch information needed to render the 'remoteconfiguration' section of the status page.
 package remoteconfiguration

--- a/pkg/status/snmptraps/snmptraps.go
+++ b/pkg/status/snmptraps/snmptraps.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package snmptraps fetch information needed to render the 'snmptraps' section of the status page.
 package snmptraps

--- a/pkg/status/snmptraps/snmptraps.go
+++ b/pkg/status/snmptraps/snmptraps.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package snmptraps fetch information needed to render the 'snmptraps' section of the status page.
+package snmptraps
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/snmp/traps"
+)
+
+// PopulateStatus populates the status stats
+func PopulateStatus(stats map[string]interface{}) {
+	if traps.IsEnabled(config.Datadog) {
+		stats["snmpTrapsStats"] = traps.GetStatus()
+	}
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -7,46 +7,32 @@
 package status
 
 import (
-	"context"
 	"encoding/json"
 	"expvar"
-	"os"
-	"runtime"
-	"strconv"
 	"strings"
-	"time"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl/utils"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
-	netflowServer "github.com/DataDog/datadog-agent/comp/netflow/server"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/externalmetrics"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/orchestrator"
-	checkstats "github.com/DataDog/datadog-agent/pkg/collector/check/stats"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	logsStatus "github.com/DataDog/datadog-agent/pkg/logs/status"
-	"github.com/DataDog/datadog-agent/pkg/snmp/traps"
 	"github.com/DataDog/datadog-agent/pkg/status/apm"
-	"github.com/DataDog/datadog-agent/pkg/status/collector"
+	"github.com/DataDog/datadog-agent/pkg/status/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/status/clusteragent"
+	commonStatus "github.com/DataDog/datadog-agent/pkg/status/common"
+	"github.com/DataDog/datadog-agent/pkg/status/endpoints"
 	"github.com/DataDog/datadog-agent/pkg/status/jmx"
 	"github.com/DataDog/datadog-agent/pkg/status/otlp"
+	"github.com/DataDog/datadog-agent/pkg/status/processagent"
+	"github.com/DataDog/datadog-agent/pkg/status/remoteconfiguration"
 	"github.com/DataDog/datadog-agent/pkg/status/render"
-	"github.com/DataDog/datadog-agent/pkg/util/containers"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/status/systemprobe"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 // GetStatus grabs the status from expvar and puts it into a map
 func GetStatus(verbose bool, invAgent inventoryagent.Component) (map[string]interface{}, error) {
-	stats, err := getCommonStatus(invAgent)
+	stats, err := commonStatus.GetStatus(invAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -68,22 +54,17 @@ func GetStatus(verbose bool, invAgent inventoryagent.Component) (map[string]inte
 
 	otlp.PopulateStatus(stats)
 
-	endpointsInfos, err := getEndpointsInfos()
-	if endpointsInfos != nil && err == nil {
-		stats["endpointsInfos"] = endpointsInfos
-	} else {
-		stats["endpointsInfos"] = nil
-	}
+	endpoints.PopulateStatus(stats)
 
 	if config.Datadog.GetBool("cluster_agent.enabled") || config.Datadog.GetBool("cluster_checks.enabled") {
-		stats["clusterAgentStatus"] = getDCAStatus()
+		stats["clusterAgentStatus"] = clusteragent.GetDCAStatus()
 	}
 
 	if config.SystemProbe.GetBool("system_probe_config.enabled") {
-		stats["systemProbeStats"] = GetSystemProbeStats(config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
+		stats["systemProbeStats"] = systemprobe.GetStatus(config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
 	}
 
-	stats["processAgentStatus"] = GetProcessAgentStatus()
+	stats["processAgentStatus"] = processagent.GetStatus()
 	stats["apmStats"] = apm.GetAPMStatus()
 
 	if !config.Datadog.GetBool("no_proxy_nonexact_match") {
@@ -94,14 +75,10 @@ func GetStatus(verbose bool, invAgent inventoryagent.Component) (map[string]inte
 	}
 
 	if config.IsContainerized() {
-		stats["adEnabledFeatures"] = config.GetDetectedFeatures()
-		if common.AC != nil {
-			stats["adConfigErrors"] = common.AC.GetAutodiscoveryErrors()
-		}
-		stats["filterErrors"] = containers.GetFilterErrors()
+		autodiscovery.PopulateStatus(stats)
 	}
 
-	stats["remoteConfiguration"] = getRemoteConfigStatus()
+	remoteconfiguration.PopulateStatus(stats)
 	return stats, nil
 }
 
@@ -122,90 +99,6 @@ func GetAndFormatStatus(invAgent inventoryagent.Component) ([]byte, error) {
 		return nil, err
 	}
 
-	return []byte(st), nil
-}
-
-// GetDCAStatus grabs the status from expvar and puts it into a map
-func GetDCAStatus(verbose bool) (map[string]interface{}, error) {
-	// inventory is not enabled for the clusteragent/DCA so we pass nil to getCommonStatus
-	stats, err := getCommonStatus(nil)
-	if err != nil {
-		return nil, err
-	}
-
-	stats["config"] = getDCAPartialConfig()
-	stats["leaderelection"] = getLeaderElectionDetails()
-
-	if config.Datadog.GetBool("compliance_config.enabled") {
-		stats["logsStats"] = logsStatus.Get(verbose)
-	}
-
-	endpointsInfos, err := getEndpointsInfos()
-	if endpointsInfos != nil && err == nil {
-		stats["endpointsInfos"] = endpointsInfos
-	} else {
-		stats["endpointsInfos"] = nil
-	}
-
-	apiCl, apiErr := apiserver.GetAPIClient()
-	if apiErr != nil {
-		stats["custommetrics"] = map[string]string{"Error": apiErr.Error()}
-		stats["admissionWebhook"] = map[string]string{"Error": apiErr.Error()}
-	} else {
-		stats["custommetrics"] = custommetrics.GetStatus(apiCl.Cl)
-		stats["admissionWebhook"] = admission.GetStatus(apiCl.Cl)
-	}
-
-	if config.Datadog.GetBool("external_metrics_provider.use_datadogmetric_crd") {
-		stats["externalmetrics"] = externalmetrics.GetStatus()
-	} else {
-		stats["externalmetrics"] = apiserver.GetStatus()
-	}
-
-	if config.Datadog.GetBool("cluster_checks.enabled") {
-		cchecks, err := clusterchecks.GetStats()
-		if err != nil {
-			log.Errorf("Error grabbing clusterchecks stats: %s", err)
-		} else {
-			stats["clusterchecks"] = cchecks
-		}
-	}
-
-	stats["adEnabledFeatures"] = config.GetDetectedFeatures()
-	if common.AC != nil {
-		stats["adConfigErrors"] = common.AC.GetAutodiscoveryErrors()
-	}
-	stats["filterErrors"] = containers.GetFilterErrors()
-
-	if config.Datadog.GetBool("orchestrator_explorer.enabled") {
-		if apiErr != nil {
-			stats["orchestrator"] = map[string]string{"Error": apiErr.Error()}
-		} else {
-			orchestratorStats := orchestrator.GetStatus(context.TODO(), apiCl.Cl)
-			stats["orchestrator"] = orchestratorStats
-		}
-	}
-
-	return stats, nil
-}
-
-// GetAndFormatDCAStatus gets and formats the DCA status all in one go.
-func GetAndFormatDCAStatus() ([]byte, error) {
-	s, err := GetDCAStatus(true)
-	if err != nil {
-		log.Infof("Error while getting status %q", err)
-		return nil, err
-	}
-	statusJSON, err := json.Marshal(s)
-	if err != nil {
-		log.Infof("Error while marshalling %q", err)
-		return nil, err
-	}
-	st, err := render.FormatDCAStatus(statusJSON)
-	if err != nil {
-		log.Infof("Error formatting the status %q", err)
-		return nil, err
-	}
 	return []byte(st), nil
 }
 
@@ -232,14 +125,6 @@ func GetAndFormatSecurityAgentStatus(runtimeStatus, complianceStatus map[string]
 	return []byte(st), nil
 }
 
-// getDCAPartialConfig returns config parameters of interest for the status page.
-func getDCAPartialConfig() map[string]string {
-	conf := make(map[string]string)
-	conf["log_level"] = config.Datadog.GetString("log_level")
-	conf["confd_path"] = config.Datadog.GetString("confd_path")
-	return conf
-}
-
 // getPartialConfig returns config parameters of interest for the status page
 func getPartialConfig() map[string]string {
 	conf := make(map[string]string)
@@ -253,154 +138,6 @@ func getPartialConfig() map[string]string {
 	conf["fips_port_range_start"] = config.Datadog.GetString("fips.port_range_start")
 
 	return conf
-}
-
-func getEndpointsInfos() (map[string]interface{}, error) {
-	endpoints, err := utils.GetMultipleEndpoints(config.Datadog)
-	if err != nil {
-		return nil, err
-	}
-
-	endpointsInfos := make(map[string]interface{})
-
-	// obfuscate the api keys
-	for endpoint, keys := range endpoints {
-		for i, key := range keys {
-			if len(key) > 5 {
-				keys[i] = key[len(key)-5:]
-			}
-		}
-		endpointsInfos[endpoint] = keys
-	}
-
-	return endpointsInfos, nil
-}
-
-// getRemoteConfigStatus return the current status of remote config
-func getRemoteConfigStatus() map[string]interface{} {
-	status := make(map[string]interface{})
-
-	if config.IsRemoteConfigEnabled(config.Datadog) && expvar.Get("remoteConfigStatus") != nil {
-		remoteConfigStatusJSON := expvar.Get("remoteConfigStatus").String()
-		json.Unmarshal([]byte(remoteConfigStatusJSON), &status) //nolint:errcheck
-	} else {
-		if !config.Datadog.GetBool("remote_configuration.enabled") {
-			status["disabledReason"] = "it is explicitly disabled in the agent configuration. (`remote_configuration.enabled: false`)"
-		} else if config.Datadog.GetBool("fips.enabled") {
-			status["disabledReason"] = "it is not supported when FIPS is enabled. (`fips.enabled: true`)"
-		} else if config.Datadog.GetString("site") == "ddog-gov.com" {
-			status["disabledReason"] = "it is not supported on GovCloud. (`site: \"ddog-gov.com\"`)"
-		}
-	}
-
-	return status
-}
-
-// getCommonStatus grabs the status from expvar and puts it into a map.
-// It gets the status elements common to all Agent flavors.
-func getCommonStatus(invAgent inventoryagent.Component) (map[string]interface{}, error) {
-	stats := make(map[string]interface{})
-	stats, err := expvarStats(stats, invAgent)
-	if err != nil {
-		log.Errorf("Error Getting ExpVar Stats: %v", err)
-	}
-
-	stats["version"] = version.AgentVersion
-	stats["flavor"] = flavor.GetFlavor()
-	stats["metadata"] = hostMetadataUtils.GetFromCache(context.TODO(), config.Datadog)
-	stats["conf_file"] = config.Datadog.ConfigFileUsed()
-	stats["pid"] = os.Getpid()
-	stats["go_version"] = runtime.Version()
-	stats["agent_start_nano"] = config.StartTime.UnixNano()
-	stats["build_arch"] = runtime.GOARCH
-	now := time.Now()
-	stats["time_nano"] = now.UnixNano()
-
-	return stats, nil
-}
-
-func expvarStats(stats map[string]interface{}, invAgent inventoryagent.Component) (map[string]interface{}, error) {
-	var err error
-	forwarderStatsJSON := []byte(expvar.Get("forwarder").String())
-	forwarderStats := make(map[string]interface{})
-	json.Unmarshal(forwarderStatsJSON, &forwarderStats) //nolint:errcheck
-	forwarderStorageMaxSizeInBytes := config.Datadog.GetInt("forwarder_storage_max_size_in_bytes")
-	if forwarderStorageMaxSizeInBytes > 0 {
-		forwarderStats["forwarder_storage_max_size_in_bytes"] = strconv.Itoa(forwarderStorageMaxSizeInBytes)
-	}
-	stats["forwarderStats"] = forwarderStats
-
-	collector.PopulateStatus(stats)
-
-	aggregatorStatsJSON := []byte(expvar.Get("aggregator").String())
-	aggregatorStats := make(map[string]interface{})
-	json.Unmarshal(aggregatorStatsJSON, &aggregatorStats) //nolint:errcheck
-	stats["aggregatorStats"] = aggregatorStats
-	s, err := checkstats.TranslateEventPlatformEventTypes(stats["aggregatorStats"])
-	if err != nil {
-		log.Debugf("failed to translate event platform event types in aggregatorStats: %s", err.Error())
-	} else {
-		stats["aggregatorStats"] = s
-	}
-
-	if expvar.Get("dogstatsd") != nil {
-		dogstatsdStatsJSON := []byte(expvar.Get("dogstatsd").String())
-		dogstatsdUdsStatsJSON := []byte(expvar.Get("dogstatsd-uds").String())
-		dogstatsdUDPStatsJSON := []byte(expvar.Get("dogstatsd-udp").String())
-		dogstatsdStats := make(map[string]interface{})
-		json.Unmarshal(dogstatsdStatsJSON, &dogstatsdStats) //nolint:errcheck
-		dogstatsdUdsStats := make(map[string]interface{})
-		json.Unmarshal(dogstatsdUdsStatsJSON, &dogstatsdUdsStats) //nolint:errcheck
-		for name, value := range dogstatsdUdsStats {
-			dogstatsdStats["Uds"+name] = value
-		}
-		dogstatsdUDPStats := make(map[string]interface{})
-		json.Unmarshal(dogstatsdUDPStatsJSON, &dogstatsdUDPStats) //nolint:errcheck
-		for name, value := range dogstatsdUDPStats {
-			dogstatsdStats["Udp"+name] = value
-		}
-		stats["dogstatsdStats"] = dogstatsdStats
-	}
-
-	hostnameStatsJSON := []byte(expvar.Get("hostname").String())
-	hostnameStats := make(map[string]interface{})
-	json.Unmarshal(hostnameStatsJSON, &hostnameStats) //nolint:errcheck
-	stats["hostnameStats"] = hostnameStats
-
-	ntpOffset := expvar.Get("ntpOffset")
-	if ntpOffset != nil && ntpOffset.String() != "" {
-		stats["ntpOffset"], err = strconv.ParseFloat(expvar.Get("ntpOffset").String(), 64)
-	}
-
-	// invAgent can be nil when generating a status page for some agent where inventory is not enabled
-	// (clusteragent, security-agent, ...).
-	//
-	// todo: (component) remove this condition once status is a component.
-	if invAgent != nil {
-		stats["agent_metadata"] = invAgent.Get()
-	} else {
-		stats["agent_metadata"] = map[string]string{}
-	}
-
-	if traps.IsEnabled(config.Datadog) {
-		stats["snmpTrapsStats"] = traps.GetStatus()
-	}
-
-	if netflowServer.IsEnabled() {
-		stats["netflowStats"] = netflowServer.GetStatus()
-	}
-
-	complianceVar := expvar.Get("compliance")
-	if complianceVar != nil {
-		complianceStatusJSON := []byte(complianceVar.String())
-		complianceStatus := make(map[string]interface{})
-		json.Unmarshal(complianceStatusJSON, &complianceStatus) //nolint:errcheck
-		stats["complianceChecks"] = complianceStatus["Checks"]
-	} else {
-		stats["complianceChecks"] = map[string]interface{}{}
-	}
-
-	return stats, err
 }
 
 // GetExpvarRunnerStats grabs the status of the runner from expvar

--- a/pkg/status/systemprobe/systemprobe.go
+++ b/pkg/status/systemprobe/systemprobe.go
@@ -5,7 +5,8 @@
 
 //go:build process
 
-package status
+// Package systemprobe fetch information about the system probe
+package systemprobe
 
 import (
 	"fmt"
@@ -13,8 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 )
 
-// GetSystemProbeStats returns the expvar stats of the system probe
-func GetSystemProbeStats(socketPath string) map[string]interface{} {
+// GetStatus returns the expvar stats of the system probe
+func GetStatus(socketPath string) map[string]interface{} {
 	probeUtil, err := net.GetRemoteSystemProbeUtil(socketPath)
 
 	if err != nil {

--- a/pkg/status/systemprobe/systemprobe_unsupported.go
+++ b/pkg/status/systemprobe/systemprobe_unsupported.go
@@ -5,10 +5,11 @@
 
 //go:build !process
 
-package status
+// Package systemprobe fetch information about the system probe
+package systemprobe
 
-// GetSystemProbeStats returns a notice that it is not supported on systems that do not at least build the process agent
-func GetSystemProbeStats(_ string) map[string]interface{} {
+// GetStatus returns a notice that it is not supported on systems that do not at least build the process agent
+func GetStatus(_ string) map[string]interface{} {
 	return map[string]interface{}{
 		"Errors": "System Probe is not supported on this system",
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Organize the `pkg/status` into separate subpackages.

This work is part of the ongoing work to enable the use of the new status component `comp/core/status`. Here is a POC that shows how we would use the status component in the future https://github.com/DataDog/datadog-agent/pull/21723

The work to separate functionality into subpackages would help us during the migration. 


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The output of the status commands works as expected.

Normal agent

- `agent status`
- `agent launch-gui`

Cluster agent

- `agent status`

Process agent

- `/opt/datadog-agent/embedded/bin/process-agent status`

Security Agent

- `agent status`


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
