### PR TITLE
Adds explicit service for trace-agent's profiler configuration

### DIFF
--- a/comp/trace/agent/run.go
+++ b/comp/trace/agent/run.go
@@ -194,6 +194,7 @@ func profilingConfig(tracecfg *tracecfg.AgentConfig) *profiling.Settings {
 
 		// remaining configuration parameters use the top-level `internal_profiling` config
 		Period:               coreconfig.Datadog.GetDuration("internal_profiling.period"),
+		Service:              "trace-agent",
 		CPUDuration:          coreconfig.Datadog.GetDuration("internal_profiling.cpu_duration"),
 		MutexProfileFraction: coreconfig.Datadog.GetInt("internal_profiling.mutex_profile_fraction"),
 		BlockProfileRate:     coreconfig.Datadog.GetInt("internal_profiling.block_profile_rate"),


### PR DESCRIPTION

### What does this PR do?
Sets the `Service` value for the trace-agent's profiler configuration to disambiguate trace-agent's profiles from core-agent's profiles.

### Motivation
Disambiguate trace-agent's profiles from core-agent's profiles.

### Additional Notes
Similar to other agents, eg [security-agent](https://github.com/DataDog/datadog-agent/blob/0f20b9de8872f362919fec9fa2666c38d32bad95/cmd/security-agent/subcommands/start/command.go#L369)

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes


### Reviewer's Checklist


- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
