### PR TITLE
Revert "[APL-2624] run package build on file changes"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1010,15 +1010,3 @@ workflow:
 
 .if_run_e2e_tests:
   - <<: *if_run_e2e
-
-.on_omnibus_change:
-  - changes:
-      paths:
-        - omnibus/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
-
-.on_go-version_change:
-  - changes:
-      paths:
-        - .go-version
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -41,69 +41,51 @@
 agent_deb-x64-a6:
   extends: .agent_build_common_deb
   rules:
-    - !reference [.on_a6]
+    !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: "2,3"
+    PYTHON_RUNTIMES: '2,3'
     PACKAGE_ARCH: amd64
-    DESTINATION_DEB: "datadog-agent_6_amd64.deb"
-    DESTINATION_DBG_DEB: "datadog-agent-dbg_6_amd64.deb"
+    DESTINATION_DEB: 'datadog-agent_6_amd64.deb'
+    DESTINATION_DBG_DEB: 'datadog-agent-dbg_6_amd64.deb'
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_6
 
 agent_deb-x64-a7:
   extends: .agent_build_common_deb
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
+    PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: amd64
-    DESTINATION_DEB: "datadog-agent_7_amd64.deb"
-    DESTINATION_DBG_DEB: "datadog-agent-dbg_7_amd64.deb"
+    DESTINATION_DEB: 'datadog-agent_7_amd64.deb'
+    DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_amd64.deb'
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
 agent_deb-x64-a7-auto:
   extends: .agent_build_common_deb
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
+    PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: amd64
-    DESTINATION_DEB: "datadog-agent_7_auto_amd64.deb"
-    DESTINATION_DBG_DEB: "datadog-agent-dbg_7_auto_amd64.deb"
+    DESTINATION_DEB: 'datadog-agent_7_auto_amd64.deb'
+    DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_auto_amd64.deb'
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
     - export INSTALL_DIR=/opt/datadog/agents/$RELEASE_VERSION_7
@@ -111,48 +93,34 @@ agent_deb-x64-a7-auto:
 agent_deb-arm64-a6:
   extends: .agent_build_common_deb
   rules:
-    - !reference [.on_all_builds_a6]
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
+    !reference [.on_all_builds_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-arm64",
-      "go_deps",
-      "generate_minimized_btfs_arm64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
   variables:
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: "2,3"
+    PYTHON_RUNTIMES: '2,3'
     PACKAGE_ARCH: arm64
-    DESTINATION_DEB: "datadog-agent_6_arm64.deb"
-    DESTINATION_DBG_DEB: "datadog-agent-dbg_6_arm64.deb"
+    DESTINATION_DEB: 'datadog-agent_6_arm64.deb'
+    DESTINATION_DBG_DEB: 'datadog-agent-dbg_6_arm64.deb'
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_6
 
 agent_deb-arm64-a7:
   extends: .agent_build_common_deb
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-arm64",
-      "go_deps",
-      "generate_minimized_btfs_arm64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
+    PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: arm64
-    DESTINATION_DEB: "datadog-agent_7_arm64.deb"
-    DESTINATION_DBG_DEB: "datadog-agent-dbg_7_arm64.deb"
+    DESTINATION_DEB: 'datadog-agent_7_arm64.deb'
+    DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_arm64.deb'
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
@@ -188,35 +156,31 @@ agent_deb-arm64-a7:
 iot_agent_deb-x64:
   extends: .iot_agent_build_common_deb
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_mod_tidy_check", "go_deps"]
   variables:
     PACKAGE_ARCH: amd64
-    DESTINATION_DEB: "datadog-iot-agent_7_amd64.deb"
+    DESTINATION_DEB: 'datadog-iot-agent_7_amd64.deb'
 
 iot_agent_deb-arm64:
   extends: .iot_agent_build_common_deb
   rules:
-    - !reference [.on_all_builds_a7]
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
+    !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
   needs: ["go_mod_tidy_check", "go_deps"]
   variables:
     PACKAGE_ARCH: arm64
-    DESTINATION_DEB: "datadog-iot-agent_7_arm64.deb"
+    DESTINATION_DEB: 'datadog-iot-agent_7_arm64.deb'
 
 iot_agent_deb-armhf:
   extends: .iot_agent_build_common_deb
   rules:
-    - !reference [.on_all_builds_a7]
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
+    !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   # Run with platform:arm64 since no platform:armhf exists and arm64 should be backwards compatible
@@ -224,11 +188,11 @@ iot_agent_deb-armhf:
   needs: ["go_mod_tidy_check", "go_deps"]
   variables:
     PACKAGE_ARCH: armhf
-    DESTINATION_DEB: "datadog-iot-agent_7_armhf.deb"
+    DESTINATION_DEB: 'datadog-iot-agent_7_armhf.deb'
 
 dogstatsd_deb-x64:
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -256,9 +220,7 @@ dogstatsd_deb-x64:
 
 dogstatsd_deb-arm64:
   rules:
-    - !reference [.on_all_builds_a7]
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
+    !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -286,13 +248,13 @@ dogstatsd_deb-arm64:
 agent_heroku_deb-x64-a6:
   extends: agent_deb-x64-a6
   variables:
-    DESTINATION_DEB: "datadog-heroku-agent_6_amd64.deb"
-    DESTINATION_DBG_DEB: "datadog-heroku-agent-dbg_6_amd64.deb"
+    DESTINATION_DEB: 'datadog-heroku-agent_6_amd64.deb'
+    DESTINATION_DBG_DEB: 'datadog-heroku-agent-dbg_6_amd64.deb'
     FLAVOR: heroku
 
 agent_heroku_deb-x64-a7:
   extends: agent_deb-x64-a7
   variables:
-    DESTINATION_DEB: "datadog-heroku-agent_7_amd64.deb"
-    DESTINATION_DBG_DEB: "datadog-heroku-agent-dbg_7_amd64.deb"
+    DESTINATION_DEB: 'datadog-heroku-agent_7_amd64.deb'
+    DESTINATION_DBG_DEB: 'datadog-heroku-agent-dbg_7_amd64.deb'
     FLAVOR: heroku

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -14,7 +14,7 @@
     - python3 -m pip install -r tasks/libs/requirements-github.txt
     - inv -e github.trigger-macos-build --datadog-agent-ref "$CI_COMMIT_SHA" --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --destination "$OMNIBUS_PACKAGE_DIR" --version-cache "$VERSION_CACHE_CONTENT"
     - !reference [.upload_sbom_artifacts]
-  timeout: 3h # MacOS builds can take 1h~2h, increase the timeout to avoid timeout flakes
+  timeout: 3h  # MacOS builds can take 1h~2h, increase the timeout to avoid timeout flakes
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -23,14 +23,14 @@
 agent_dmg-x64-a7:
   extends: .agent_build_common_dmg
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_mod_tidy_check"]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
+    PYTHON_RUNTIMES: '3'
   before_script:
     - source /root/.bashrc
     - export RELEASE_VERSION=$RELEASE_VERSION_7

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -36,20 +36,14 @@
 agent_rpm-x64-a6:
   extends: .agent_build_common_rpm
   rules:
-    - !reference [.on_a6]
+    !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: "2,3"
+    PYTHON_RUNTIMES: '2,3'
     PACKAGE_ARCH: amd64
   before_script:
     - source /root/.bashrc
@@ -59,20 +53,14 @@ agent_rpm-x64-a6:
 agent_rpm-x64-a7:
   extends: .agent_build_common_rpm
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
+    PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: amd64
   before_script:
     - source /root/.bashrc
@@ -82,22 +70,14 @@ agent_rpm-x64-a7:
 agent_rpm-arm64-a6:
   extends: .agent_build_common_rpm
   rules:
-    - !reference [.on_all_builds_a6]
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
+    !reference [.on_all_builds_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-arm64",
-      "go_deps",
-      "generate_minimized_btfs_arm64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
   variables:
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: "2,3"
+    PYTHON_RUNTIMES: '2,3'
     PACKAGE_ARCH: arm64
   before_script:
     - source /root/.bashrc
@@ -107,22 +87,14 @@ agent_rpm-arm64-a6:
 agent_rpm-arm64-a7:
   extends: .agent_build_common_rpm
   rules:
-    - !reference [.on_all_builds_a7]
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
+    !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-arm64",
-      "go_deps",
-      "generate_minimized_btfs_arm64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
+    PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: arm64
   before_script:
     - source /root/.bashrc
@@ -163,7 +135,7 @@ agent_rpm-arm64-a7:
 iot_agent_rpm-x64:
   extends: .iot_agent_build_common_rpm
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -172,9 +144,7 @@ iot_agent_rpm-x64:
 iot_agent_rpm-arm64:
   extends: .iot_agent_build_common_rpm
   rules:
-    - !reference [.on_all_builds_a7]
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
+    !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -183,9 +153,7 @@ iot_agent_rpm-arm64:
 iot_agent_rpm-armhf:
   extends: .iot_agent_build_common_rpm
   rules:
-    - !reference [.on_all_builds_a7]
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
+    !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_armhf$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   # Run with platform:arm64 since no platform:armhf exists and arm64 should be backwards compatible
@@ -197,7 +165,7 @@ iot_agent_rpm-armhf:
 
 dogstatsd_rpm-x64:
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -39,20 +39,14 @@
 agent_suse-x64-a6:
   extends: .agent_build_common_suse_rpm
   rules:
-    - !reference [.on_a6]
+    !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: "2,3"
+    PYTHON_RUNTIMES: '2,3'
     PACKAGE_ARCH: amd64
   before_script:
     - source /root/.bashrc
@@ -62,20 +56,14 @@ agent_suse-x64-a6:
 agent_suse-x64-a7:
   extends: .agent_build_common_suse_rpm
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
+    PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: amd64
   before_script:
     - source /root/.bashrc
@@ -86,31 +74,23 @@ agent_suse-x64-a7:
 agent_suse-arm64-a7:
   extends: .agent_build_common_suse_rpm
   rules:
-    - !reference [.on_all_builds_a7]
-    - !reference [.on_omnibus_change]
-    - !reference [.on_go-version_change]
+    !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-arm64",
-      "go_deps",
-      "generate_minimized_btfs_arm64",
-    ]
+  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
   variables:
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
+    PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: arm64
-    OMNIBUS_TASK_EXTRA_PARAMS: "--host-distribution=suse"
+    OMNIBUS_TASK_EXTRA_PARAMS: '--host-distribution=suse'
   before_script:
     - source /root/.bashrc
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
 iot_agent_suse-x64:
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -147,7 +127,7 @@ iot_agent_suse-x64:
 
 dogstatsd_suse-x64:
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -56,22 +56,22 @@
 windows_msi_and_bosh_zip_x64-a7:
   extends: .windows_main_agent_base
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   variables:
     ARCH: "x64"
     AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
+    PYTHON_RUNTIMES: '3'
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_7
 
 windows_msi_x64-a6:
   extends: .windows_main_agent_base
   rules:
-    - !reference [.on_a6]
+    !reference [.on_a6]
   variables:
     ARCH: "x64"
     AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: "2,3"
+    PYTHON_RUNTIMES: '2,3'
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_6
   timeout: 3h
@@ -79,7 +79,7 @@ windows_msi_x64-a6:
 # cloudfoundry IoT build for Windows
 windows_zip_agent_binaries_x64-a7:
   rules:
-    - !reference [.on_a7]
+    !reference [.on_a7]
   stage: package_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["go_mod_tidy_check", "go_deps"]


### PR DESCRIPTION
Reverts DataDog/datadog-agent#21697

The original PR seems to cause some "needs" jobs not to be run now: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/25814317