### PR TITLE
add internal telemetry for CO-RE loads

### DIFF
--- a/pkg/ebpf/btf.go
+++ b/pkg/ebpf/btf.go
@@ -288,7 +288,7 @@ func (b *orderedBTFLoader) searchEmbeddedCollection(filename string) []string {
 	return matchingPaths
 }
 
-func getBTFPlatform() (string, error) {
+var getBTFPlatform = funcs.Memoize(func() (string, error) {
 	platform, err := kernel.Platform()
 	if err != nil {
 		return "", fmt.Errorf("kernel platform: %s", err)
@@ -309,7 +309,7 @@ func getBTFPlatform() (string, error) {
 	default:
 		return "", fmt.Errorf("%s unsupported", platform)
 	}
-}
+})
 
 func loadBTFFrom(path string) (*btf.Spec, error) {
 	data, err := os.Open(path)

--- a/pkg/ebpf/ebpf.go
+++ b/pkg/ebpf/ebpf.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 
 	"github.com/cilium/ebpf/rlimit"
+
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
 
 var core struct {
@@ -43,6 +45,13 @@ func coreLoader(cfg *Config) (*coreAssetLoader, error) {
 	core.loader = &coreAssetLoader{
 		coreDir:   filepath.Join(cfg.BPFDir, "co-re"),
 		btfLoader: initBTFLoader(cfg),
+		telemetry: struct {
+			success telemetry.Counter
+			error   telemetry.Counter
+		}{
+			success: telemetry.NewCounter("ebpf__core__load", "success", []string{"platform", "platform_version", "kernel", "arch", "asset", "btf_type"}, "gauge of CO-RE load successes"),
+			error:   telemetry.NewCounter("ebpf__core__load", "error", []string{"platform", "platform_version", "kernel", "arch", "asset", "error_type"}, "gauge of CO-RE load errors"),
+		},
 	}
 	return core.loader, nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds internal telemetry on CO-RE loading for successes and failures. 

### Motivation

This will allow us to identify the specific hosts that experience errors and investigate. It will also provide a better early warning for any potential regressions during the QA process.

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-317

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
