### PR TITLE
Skip TestWindowsTestSuite/TestManualProcessDiscoveryCheck

### DIFF
--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -58,10 +58,6 @@ func (s *windowsTestSuite) TestProcessCheck() {
 }
 
 func (s *windowsTestSuite) TestProcessDiscoveryCheck() {
-	// Skipping due to flakiness
-	// Responses with more than 100 processes end up being chunked, which fails JSON unmarshalling
-	s.T().Skip()
-
 	s.UpdateEnv(e2e.FakeIntakeStackDef(
 		e2e.WithAgentParams(agentparams.WithAgentConfig(processDiscoveryCheckConfigStr)),
 		e2e.WithVMParams(ec2params.WithOS(ec2os.WindowsOS)),
@@ -125,6 +121,10 @@ func (s *windowsTestSuite) TestManualProcessCheck() {
 }
 
 func (s *windowsTestSuite) TestManualProcessDiscoveryCheck() {
+	// Skipping due to flakiness
+	// Responses with more than 100 processes end up being chunked, which fails JSON unmarshalling
+	s.T().Skip()
+
 	check := s.Env().VM.
 		Execute("& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent\\process-agent.exe\" check process_discovery --json")
 	assertManualProcessDiscoveryCheck(s.T(), check, "MsMpEng.exe")


### PR DESCRIPTION

### What does this PR do?

Skip TestProcessDiscoveryCheck in the Process Agent Windows E2E test suite due to flakiness

https://github.com/DataDog/datadog-agent/pull/21842 skipped the wrong test

### Motivation

Test sometimes flakes when the number of processes returned is greater than 100. When this happens, two JSON objects are returned, which causes the following error during unmarshaling:

```
        	Error:      	Received unexpected error:
        	            	invalid character '{' after top-level value
        	Test:       	TestWindowsTestSuite/TestManualProcessDiscoveryCheck
        	Messages:   	failed to unmarshal process check output
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
