### PR TITLE
[SVLS-3533][SLES-1431] Register the extension even when an API key fails

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -119,7 +119,13 @@ func runAgent() {
 
 	debug.OutputDatadogEnvVariablesForDebugging()
 
-	if !apikey.HasAPIKey() {
+	config.Datadog.SetConfigFile(datadogConfigPath)
+	// Load datadog.yaml file into the config, so that metricAgent can pick these configurations
+	if _, err := config.LoadWithoutSecret(); err != nil {
+		log.Errorf("Error happened when loading configuration from datadog.yaml for metric agent: %s", err)
+	}
+
+	if err := apikey.HandleEnv(); err != nil {
 		log.Errorf("Can't start the Datadog extension as no API Key has been detected, or API Key could not be decrypted. Data will not be sent to Datadog.")
 		// we still need to register the extension but let's return after (no-op)
 		id, _, registrationError := registration.RegisterExtension(extensionRegistrationRoute, extensionRegistrationTimeout)
@@ -170,14 +176,6 @@ func runAgent() {
 	} else {
 		serverlessDaemon.UseAdaptiveFlush(true) // already initialized to true, but let's be explicit just in case
 	}
-
-	config.Datadog.SetConfigFile(datadogConfigPath)
-	// Load datadog.yaml file into the config, so that metricAgent can pick these configurations
-	if _, err := config.LoadWithoutSecret(); err != nil {
-		log.Errorf("Error happened when loading configuration from datadog.yaml for metric agent: %s", err)
-	}
-
-	apikey.HandleEnv()
 
 	logChannel := make(chan *logConfig.ChannelMessage)
 	// Channels for ColdStartCreator

--- a/pkg/serverless/apikey/api_key.go
+++ b/pkg/serverless/apikey/api_key.go
@@ -176,15 +176,6 @@ func extractRegionFromSecretsManagerArn(secretsManagerArn string) (string, error
 	return arnObject.Region, nil
 }
 
-// HasAPIKey returns true if an API key has been set in any of the supported ways.
-func HasAPIKey() bool {
-	return config.Datadog.IsSet("api_key") ||
-		len(os.Getenv(apiKeyKmsEncryptedEnvVar)) > 0 ||
-		len(os.Getenv(apiKeyKmsEnvVar)) > 0 ||
-		len(os.Getenv(apiKeySecretManagerEnvVar)) > 0 ||
-		len(os.Getenv(apiKeyEnvVar)) > 0
-}
-
 // checkForSingleAPIKey checks if an API key has been set in multiple places and logs a warning if so.
 func checkForSingleAPIKey() {
 	var apikeySetIn = []string{}

--- a/pkg/serverless/apikey/api_key_test.go
+++ b/pkg/serverless/apikey/api_key_test.go
@@ -101,36 +101,3 @@ func TestExtractRegionFromMalformedPrefixSecretsManagerArnPrefix(t *testing.T) {
 	assert.Equal(t, result, "")
 	assert.Error(t, err, "could not extract region from arn: aws:secretsmanager:us-west-2:123456789012:secret:DatadogAPIKeySecret. arn: invalid prefix")
 }
-
-func TestDDApiKey(t *testing.T) {
-	t.Setenv("DD_API_KEY", "abc")
-	assert.True(t, HasAPIKey())
-}
-
-func TestHasDDApiKeySecretArn(t *testing.T) {
-	t.Setenv("DD_API_KEY_SECRET_ARN", "abc")
-	assert.True(t, HasAPIKey())
-}
-
-func TestHasDDKmsApiKeyEncrypted(t *testing.T) {
-	t.Setenv("DD_API_KEY_KMS_ENCRYPTED", "abc")
-	assert.True(t, HasAPIKey())
-}
-
-func TestHasDDKmspiKey(t *testing.T) {
-	t.Setenv("DD_KMS_API_KEY", "abc")
-	assert.True(t, HasAPIKey())
-}
-
-func TestHasAPIKey(t *testing.T) {
-	t.Setenv("DD_API_KEY", "abc")
-	assert.True(t, HasAPIKey())
-}
-
-func TestHasNoKeys(t *testing.T) {
-	t.Setenv("DD_API_KEY_KMS_ENCRYPTED", "")
-	t.Setenv("DD_API_KEY_SECRET_ARN", "")
-	t.Setenv("DD_KMS_API_KEY", "")
-	t.Setenv("DD_API_KEY", "")
-	assert.False(t, HasAPIKey())
-}

--- a/pkg/serverless/apikey/env.go
+++ b/pkg/serverless/apikey/env.go
@@ -24,6 +24,9 @@ func getSecretEnvVars(envVars []string, kmsFunc decryptFunc, smFunc decryptFunc)
 		if !ok {
 			continue
 		}
+		if len(envVal) == 0 {
+			continue
+		}
 		if strings.HasSuffix(envKey, kmsKeySuffix) {
 			log.Debugf("Decrypting %v", envVar)
 			secretVal, err := kmsFunc(envVal)
@@ -69,7 +72,7 @@ func setSecretsFromEnv(envVars []string) {
 }
 
 // HandleEnv sets the API key from environment variables
-func HandleEnv() {
+func HandleEnv() error {
 	// API key reading
 	// ---------------
 
@@ -88,6 +91,7 @@ func HandleEnv() {
 		// we're not reporting the error to AWS because we don't want the function
 		// execution to be stopped. TODO(remy): discuss with AWS if there is way
 		// of reporting non-critical init errors.
-		log.Error("No API key configured")
+		return log.Error("No API key configured")
 	}
+	return nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Bumps up the order of when the DD API key is set from a source (e.g. datadog.yaml, plaintext, KMS or Secrets Manager key) so that we can register a no-op Extension and return early, instead of crashing the runtime or waiting for a response from the key service, ultimately leading to a timeout.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The Extension will kill the runtime when it fails to register during the INIT phase if the Extension lacks a permissions to access a Secret or KMS key, or when the Secret or KMS key does not exist. The function can also time out when it lacks the correct permissions.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Unit tests updated and tested manually with both Secrets Manager and KMS keys and permissions.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
