### PR TITLE
[CWS][SEC-12049] autosuppression v2

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -225,6 +225,10 @@ CSM Threats logs have the following JSON schema:
                 "origin": {
                     "type": "string",
                     "description": "Origin of the event"
+                },
+                "suppressed": {
+                    "type": "boolean",
+                    "description": "True if the event has been suppressed"
                 }
             },
             "additionalProperties": false,
@@ -1766,6 +1770,10 @@ CSM Threats logs have the following JSON schema:
         "origin": {
             "type": "string",
             "description": "Origin of the event"
+        },
+        "suppressed": {
+            "type": "boolean",
+            "description": "True if the event has been suppressed"
         }
     },
     "additionalProperties": false,
@@ -1783,6 +1791,7 @@ CSM Threats logs have the following JSON schema:
 | `async` | True if the event was asynchronous |
 | `matched_rules` | The list of rules that the event matched (only valid in the context of an anomaly) |
 | `origin` | Origin of the event |
+| `suppressed` | True if the event has been suppressed |
 
 
 ## `ExitEvent`

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -209,6 +209,10 @@
         "origin": {
           "type": "string",
           "description": "Origin of the event"
+        },
+        "suppressed": {
+          "type": "boolean",
+          "description": "True if the event has been suppressed"
         }
       },
       "additionalProperties": false,

--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -142,6 +142,11 @@ func (ce *CustomEvent) GetActions() []*model.ActionTriggered {
 	return nil
 }
 
+// IsSuppressed returns true if the event is suppressed
+func (ce *CustomEvent) IsSuppressed() bool {
+	return false
+}
+
 // GetWorkloadID returns the workload id
 func (ce *CustomEvent) GetWorkloadID() string {
 	return ""

--- a/pkg/security/events/event.go
+++ b/pkg/security/events/event.go
@@ -46,6 +46,7 @@ type Event interface {
 	GetTags() []string
 	GetType() string
 	GetActions() []*model.ActionTriggered
+	IsSuppressed() bool
 }
 
 // EventSender defines an event sender

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -33,6 +33,12 @@ var (
 	// Tags: rule_id
 	MetricRateLimiterAllow = newRuntimeMetric(".rules.rate_limiter.allow")
 
+	// Rule Suppression metrics
+
+	// MetricRulesSuppressed is the name of the metric used to count the number of events marked as suppressed
+	// Tags: rule_id
+	MetricRulesSuppressed = newRuntimeMetric(".rules.suppressed")
+
 	// Syscall monitoring metrics
 
 	// MetricSyscalls is the name of the metric used to count each syscall executed on the host

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -47,6 +47,9 @@ type CWSConsumer struct {
 	ruleEngine    *rulesmodule.RuleEngine
 	selfTester    *selftests.SelfTester
 	reloader      ReloaderInterface
+
+	eventSuppressionsLock  sync.Mutex
+	eventSuppressionsStats map[string]*int64
 }
 
 // NewCWSConsumer initializes the module with options
@@ -65,14 +68,15 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 		probe:        evm.Probe,
 		statsdClient: evm.StatsdClient,
 		// internals
-		ctx:           ctx,
-		cancelFnc:     cancelFnc,
-		apiServer:     NewAPIServer(cfg, evm.Probe, evm.StatsdClient, selfTester),
-		rateLimiter:   events.NewRateLimiter(cfg, evm.StatsdClient),
-		sendStatsChan: make(chan chan bool, 1),
-		grpcServer:    NewGRPCServer(family, address),
-		selfTester:    selfTester,
-		reloader:      NewReloader(),
+		ctx:                    ctx,
+		cancelFnc:              cancelFnc,
+		apiServer:              NewAPIServer(cfg, evm.Probe, evm.StatsdClient, selfTester),
+		rateLimiter:            events.NewRateLimiter(cfg, evm.StatsdClient),
+		sendStatsChan:          make(chan chan bool, 1),
+		grpcServer:             NewGRPCServer(family, address),
+		selfTester:             selfTester,
+		reloader:               NewReloader(),
+		eventSuppressionsStats: make(map[string]*int64),
 	}
 
 	// set sender
@@ -232,6 +236,10 @@ func (c *CWSConsumer) HandleCustomEvent(rule *rules.Rule, event *events.CustomEv
 
 // SendEvent sends an event to the backend after checking that the rate limiter allows it for the provided rule
 func (c *CWSConsumer) SendEvent(rule *rules.Rule, event events.Event, extTagsCb func() []string, service string) {
+	if event.IsSuppressed() {
+		c.countEventSuppression(rule.ID)
+	}
+
 	if c.rateLimiter.Allow(rule.ID, event) {
 		c.apiServer.SendEvent(rule, event, extTagsCb, service)
 	} else {
@@ -258,6 +266,16 @@ func (c *CWSConsumer) sendStats() {
 	if err := c.apiServer.SendStats(); err != nil {
 		seclog.Debugf("failed to send api server stats: %s", err)
 	}
+
+	c.eventSuppressionsLock.Lock()
+	for ruleID, counter := range c.eventSuppressionsStats {
+		value := *counter
+		if value > 0 {
+			*counter = 0
+			_ = c.statsdClient.Count(metrics.MetricRulesSuppressed, value, []string{fmt.Sprintf("rule_id:%s", ruleID)}, 1.0)
+		}
+	}
+	c.eventSuppressionsLock.Unlock()
 }
 
 func (c *CWSConsumer) statsSender() {
@@ -282,4 +300,13 @@ func (c *CWSConsumer) statsSender() {
 // GetRuleEngine returns new current rule engine
 func (c *CWSConsumer) GetRuleEngine() *rulesmodule.RuleEngine {
 	return c.ruleEngine
+}
+
+func (c *CWSConsumer) countEventSuppression(ruleID string) {
+	c.eventSuppressionsLock.Lock()
+	defer c.eventSuppressionsLock.Unlock()
+	if _, ok := c.eventSuppressionsStats[ruleID]; !ok {
+		c.eventSuppressionsStats[ruleID] = new(int64)
+	}
+	*(c.eventSuppressionsStats[ruleID])++
 }

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -265,10 +265,12 @@ func (a *APIServer) GetConfig(_ context.Context, _ *api.GetConfigParams) (*api.S
 func (a *APIServer) SendEvent(rule *rules.Rule, e events.Event, extTagsCb func() []string, service string) {
 	var ruleActions []events.RuleActionContext
 
-	// report only kill action for now
-	for _, action := range e.GetActions() {
-		if action.Name == rules.KillAction {
-			ruleActions = append(ruleActions, events.RuleActionContext{Name: action.Name, Signal: action.Value})
+	if !e.IsSuppressed() {
+		// report only kill action for now
+		for _, action := range e.GetActions() {
+			if action.Name == rules.KillAction {
+				ruleActions = append(ruleActions, events.RuleActionContext{Name: action.Name, Signal: action.Value})
+			}
 		}
 	}
 

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strconv"
 	"sync"
 	"time"
 
@@ -390,8 +391,10 @@ func (e *RuleEngine) RuleMatch(rule *rules.Rule, event eval.Event) bool {
 	if e.config.SecurityProfileAutoSuppressionEnabled &&
 		ev.SecurityProfileContext.Status.IsEnabled(model.AutoSuppression) &&
 		ev.IsInProfile() {
-		if val, ok := rule.Definition.GetTag("allow_autosuppression"); ok && val == "true" {
-			ev.Suppressed = true
+		if val, ok := rule.Definition.GetTag("allow_autosuppression"); ok {
+			if b, err := strconv.ParseBool(val); err == nil && b {
+				ev.Suppressed = true
+			}
 		}
 	}
 

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -171,6 +171,7 @@ type BaseEvent struct {
 	Rules        []*MatchedRule     `field:"-"`
 	Actions      []*ActionTriggered `field:"-"`
 	Origin       string             `field:"-"`
+	Suppressed   bool               `field:"-"`
 
 	// context shared with all events
 	ProcessContext         *ProcessContext        `field:"process" event:"*"`

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -314,6 +314,11 @@ func (e *Event) GetActions() []*ActionTriggered {
 	return e.Actions
 }
 
+// IsSuppressed returns true if the event is suppressed
+func (e *Event) IsSuppressed() bool {
+	return e.Suppressed
+}
+
 // GetWorkloadID returns an ID that represents the workload
 func (e *Event) GetWorkloadID() string {
 	return e.SecurityProfileContext.Name

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -15,11 +15,12 @@ import (
 
 	"github.com/spf13/cast"
 
+	"github.com/hashicorp/go-multierror"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/log"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/hashicorp/go-multierror"
 )
 
 // MacroID represents the ID of a macro

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -51,6 +51,8 @@ type EventContextSerializer struct {
 	MatchedRules []MatchedRuleSerializer `json:"matched_rules,omitempty"`
 	// Origin of the event
 	Origin string `json:"origin,omitempty"`
+	// True if the event has been suppressed
+	Suppressed bool `json:"suppressed,omitempty"`
 }
 
 // ProcessContextSerializer serializes a process context to JSON
@@ -217,8 +219,9 @@ func NewBaseEventSerializer(event *model.Event) *BaseEventSerializer {
 
 	s := &BaseEventSerializer{
 		EventContextSerializer: EventContextSerializer{
-			Name:   eventType.String(),
-			Origin: event.Origin,
+			Name:       eventType.String(),
+			Origin:     event.Origin,
+			Suppressed: event.Suppressed,
 		},
 		ProcessContextSerializer: newProcessContextSerializer(pc, event),
 		Date:                     utils.NewEasyjsonTime(event.ResolveEventTime()),

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -952,6 +952,8 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 			}
 		case "origin":
 			out.Origin = string(in.String())
+		case "suppressed":
+			out.Suppressed = bool(in.Bool())
 		default:
 			in.SkipRecursive()
 		}
@@ -1030,6 +1032,16 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 			out.RawString(prefix)
 		}
 		out.String(string(in.Origin))
+	}
+	if in.Suppressed {
+		const prefix string = ",\"suppressed\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.Suppressed))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -15,13 +15,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/slices"
+
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/profile"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slices"
 )
 
 func TestSecurityProfile(t *testing.T) {
@@ -761,10 +762,12 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 		{
 			ID:         "test_autosuppression_exec",
 			Expression: `exec.file.name == "getconf"`,
+			Tags:       map[string]string{"allow_autosuppression": "true"},
 		},
 		{
 			ID:         "test_autosuppression_dns",
 			Expression: `dns.question.type == A && dns.question.name == "foo.bar"`,
+			Tags:       map[string]string{"allow_autosuppression": "true"},
 		},
 	}
 	test, err := newTestModule(t, nil, rulesDef, withStaticOpts(testOpts{
@@ -814,6 +817,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_autosuppression_exec")
 			assert.Equal(t, "getconf", event.ProcessContext.FileEvent.BasenameStr, "wrong exec file")
+			assert.False(t, event.IsSuppressed(), "exec event should not be marked as suppressed")
 		})
 	})
 
@@ -826,6 +830,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_autosuppression_dns")
 			assert.Equal(t, "nslookup", event.ProcessContext.Argv0, "wrong exec file")
+			assert.False(t, event.IsSuppressed(), "dns event should not be marked as suppressed")
 		})
 	})
 
@@ -846,33 +851,29 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 
 	t.Run("auto-suppression-process-suppression", func(t *testing.T) {
 		// check we autosuppres signals
-		err = test.GetSignal(t, func() error {
+		err = test.GetEventSent(t, func() error {
 			cmd := dockerInstance.Command("getconf", []string{"-a"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(event *model.Event, rule *rules.Rule) {
-			if event.ProcessContext.ContainerID == dump.ContainerID {
-				t.Fatal("Got a signal that should have been suppressed")
-			}
-		})
-		if err != nil && !strings.HasPrefix(err.Error(), "timeout") {
-			t.Fatal("Got an error different from timeout")
-		}
+		}, func(rule *rules.Rule, event *model.Event) bool {
+			assertTriggeredRule(t, rule, "test_autosuppression_exec")
+			assert.Equal(t, "getconf", event.ProcessContext.FileEvent.BasenameStr, "wrong exec file")
+			assert.True(t, event.IsSuppressed(), "exec event should be marked as suppressed")
+			return true
+		}, time.Second*3, "test_autosuppression_exec")
 	})
 
 	t.Run("auto-suppression-dns-suppression", func(t *testing.T) {
 		// check we autosuppres signals
-		err = test.GetSignal(t, func() error {
+		err = test.GetEventSent(t, func() error {
 			cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(event *model.Event, rule *rules.Rule) {
-			if event.ProcessContext.ContainerID == dump.ContainerID {
-				t.Fatal("Got a signal that should have been suppressed")
-			}
-		})
-		if err != nil && !strings.HasPrefix(err.Error(), "timeout") {
-			t.Fatal("Got an error different from timeout")
-		}
+		}, func(rule *rules.Rule, event *model.Event) bool {
+			assertTriggeredRule(t, rule, "test_autosuppression_dns")
+			assert.Equal(t, "nslookup", event.ProcessContext.Argv0, "wrong exec file")
+			assert.True(t, event.IsSuppressed(), "dns event should be marked as suppressed")
+			return true
+		}, time.Second*3, "test_autosuppression_dns")
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR changes the behavior of the autosuppression feature in the following way:
- Auto-suppressed events aren't dropped by the agent anymore
- Instead a suppressed flag is added to the event to indicate that it should be suppressed
- Only rules with an `allow_autosuppression` tag set to `true` can be auto-suppressed
- The `runtime_security.rules.suppressed` metric counts the number of auto-suppressed events and is tagged by rule ID (this metric is computed before applying any event rate limiting)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
