### PR TITLE
tasks: compare uncompressed package sizes

### DIFF
--- a/tasks/package.py
+++ b/tasks/package.py
@@ -1,5 +1,4 @@
 import glob
-import os
 
 from invoke import task
 from invoke.exceptions import Exit
@@ -17,12 +16,26 @@ def get_package_path(glob_pattern):
     return package_paths[0]
 
 
+def _get_deb_uncompressed_size(ctx, package):
+    # the size returned by dpkg is a number of bytes divided by 1024
+    # so we multiply it back to get the same unit as RPM or stat
+    return int(ctx.run(f'dpkg-deb --info {package} | grep Installed-Size | cut -d : -f 2 | xargs').stdout) * 1024
+
+
+def _get_rpm_uncompressed_size(ctx, package):
+    return int(ctx.run(f'rpm -qip {package} | grep Size | cut -d : -f 2 | xargs').stdout)
+
+
 @task
-def compare_size(_, new_package, stable_package, package_type, last_stable, threshold):
+def compare_size(ctx, new_package, stable_package, package_type, last_stable, threshold):
     mb = 1000000
 
-    new_package_size = os.path.getsize(get_package_path(new_package))
-    stable_package_size = os.path.getsize(get_package_path(stable_package))
+    if package_type.endswith('deb'):
+        new_package_size = _get_deb_uncompressed_size(ctx, get_package_path(new_package))
+        stable_package_size = _get_deb_uncompressed_size(ctx, get_package_path(stable_package))
+    else:
+        new_package_size = _get_rpm_uncompressed_size(ctx, get_package_path(new_package))
+        stable_package_size = _get_rpm_uncompressed_size(ctx, get_package_path(stable_package))
 
     threshold = int(threshold)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR switches from checking the package compressed size to checking the installed (or uncompressed) size.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We will soon use a different compression level for deploy and "regular" pipelines, which makes comparing the compressed size risky. The uncompressed size is however safe to use regardless of the type of pipeline we're running

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
