### PR TITLE
Kacper murzyn/7.50.bugfixes changelog backport

### DIFF
--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -2,6 +2,19 @@
 Release Notes
 =============
 
+.. _Release Notes_7.50.1:
+
+7.50.1 / 6.50.1
+======
+
+.. _Release Notes_7.50.1_Bug Fixes:
+
+Bug Fixes
+---------
+
+- Fixes a bug introduced in `7.50.0` preventing `DD_TAGS` to be added to `kubernetes_state.*` metrics.
+
+
 .. _Release Notes_7.50.0:
 
 7.50.0 / 6.50.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,42 @@
 Release Notes
 =============
 
+.. _Release Notes_7.50.2:
+
+7.50.2 / 6.50.2
+======
+
+.. _Release Notes_7.50.2_Prelude:
+
+Prelude
+-------
+
+Release on: 2024-01-04
+
+- Please refer to the `7.50.2 tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7502>`_ for the list of changes on the Core Checks
+
+
+.. _Release Notes_7.50.2_Enhancement Notes:
+
+Enhancement Notes
+-----------------
+
+- Agents are now built with Go ``1.20.12``.
+
+
+.. _Release Notes_7.50.2_Bug Fixes:
+
+Bug Fixes
+---------
+
+- The CWS configuration parameter to enable anomaly detection is now working and taken
+  into account by the Agent.
+
+- Fix issue introduced in 7.47 that allowed all users to start/stop the
+  Windows Datadog Agent services. The Windows installer now, as in versions
+  before 7.47, grants this permission explicitly to ddagentuser.
+
+
 .. _Release Notes_7.50.1:
 
 7.50.1 / 6.50.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,24 @@
 Release Notes
 =============
 
+.. _Release Notes_7.50.1:
+
+7.50.1 / 6.50.1
+======
+
+.. _Release Notes_7.50.1_Prelude:
+
+Prelude
+-------
+
+Release on: 2023-12-21
+
+Bug Fixes
+---------
+
+- Fixes a bug introduced in `7.50.0` preventing `DD_TAGS` to be added to `kubernetes_state.*` metrics.
+
+
 .. _Release Notes_7.50.0:
 
 7.50.0 / 6.50.0


### PR DESCRIPTION
Backport of changelog updates from Agent 7.50.1 and 7.50.2 releases.