### PR TITLE
Handle writes to current directory when it is read-only

### DIFF
--- a/pkg/network/protocols/tls/java/hotspot.go
+++ b/pkg/network/protocols/tls/java/hotspot.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"golang.org/x/sys/unix"
 )
 
 // Hotspot java has a specific protocol, described here:
@@ -98,6 +99,22 @@ func getPathOwner(path string) (uint32, uint32, error) {
 	return stat.Uid, stat.Gid, nil
 }
 
+func findWritableDest(cwd, root, agent string) (string, error) {
+	if unix.Access(cwd, unix.W_OK) == nil {
+		return filepath.Join(cwd, filepath.Base(agent)), nil
+	}
+
+	log.Debugf("Current working directory %s is not writable", cwd)
+
+	if unix.Access(filepath.Join(root, "tmp"), unix.W_OK) == nil {
+		dstPath := filepath.Join(root, "tmp", filepath.Base(agent))
+		log.Debugf("Writing agent jar file to %s", dstPath)
+		return dstPath, nil
+	}
+
+	return "", fmt.Errorf("unable to find writable destionation")
+}
+
 // copyAgent copy the agent-usm.jar to a directory where the running java process can load it.
 // the agent-usm.jar file must be readable from java process point of view
 // copyAgent return :
@@ -105,7 +122,11 @@ func getPathOwner(path string) (uint32, uint32, error) {
 //	o dstPath is path to the copy of agent-usm.jar (from container perspective), this would be pass to the hotspot command
 //	o cleanup must be called to remove the created file
 func (h *Hotspot) copyAgent(agent string, uid int, gid int) (string, func(), error) {
-	dstPath := filepath.Join(h.cwd, filepath.Base(agent))
+	dstPath, err := findWritableDest(h.cwd, h.root, agent)
+	if err != nil {
+		return "", nil, err
+	}
+
 	// path from the host point of view pointing to the process root namespace (/proc/pid/root/usr/...)
 	nsDstPath := h.root + dstPath
 	if dst, err := os.Stat(nsDstPath); err == nil {

--- a/pkg/network/protocols/tls/java/hotspot.go
+++ b/pkg/network/protocols/tls/java/hotspot.go
@@ -99,20 +99,23 @@ func getPathOwner(path string) (uint32, uint32, error) {
 	return stat.Uid, stat.Gid, nil
 }
 
+// findWritableDest looks for a writable destination for agent-usm.jar file.
+// The default is to write this file into the working directory of the agent.
+// If this is not possible then we try 'root/tmp', and finally fail.
 func findWritableDest(cwd, root, agent string) (string, error) {
 	if unix.Access(cwd, unix.W_OK) == nil {
 		return filepath.Join(cwd, filepath.Base(agent)), nil
 	}
 
-	log.Debugf("Current working directory %s is not writable", cwd)
+	log.Debugf("Current working directory %q is not writable", cwd)
 
 	if unix.Access(filepath.Join(root, "tmp"), unix.W_OK) == nil {
 		dstPath := filepath.Join(root, "tmp", filepath.Base(agent))
-		log.Debugf("Writing agent jar file to %s", dstPath)
+		log.Debugf("Writing agent jar file to %q", dstPath)
 		return dstPath, nil
 	}
 
-	return "", fmt.Errorf("unable to find writable destionation")
+	return "", errors.New("unable to find writable destionation")
 }
 
 // copyAgent copy the agent-usm.jar to a directory where the running java process can load it.

--- a/pkg/network/protocols/tls/java/jattach_test.go
+++ b/pkg/network/protocols/tls/java/jattach_test.go
@@ -8,7 +8,6 @@
 package java
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -110,7 +109,6 @@ func TestInjectInReadOnlyFS(t *testing.T) {
 		}
 	}()
 
-	fmt.Println(rodir)
 	err = syscall.Mount(curDir, rodir, "auto", syscall.MS_BIND|syscall.MS_RDONLY, "")
 	require.NoError(t, err)
 	err = syscall.Mount("none", rodir, "", syscall.MS_RDONLY|syscall.MS_REMOUNT|syscall.MS_BIND, "")

--- a/pkg/network/protocols/tls/java/jattach_test.go
+++ b/pkg/network/protocols/tls/java/jattach_test.go
@@ -8,7 +8,9 @@
 package java
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
@@ -51,7 +53,7 @@ func testInject(t *testing.T, prefix string) {
 	require.NoError(t, tfile.Close())
 	require.NoError(t, os.Remove(tfile.Name()))
 	// equivalent to jattach <pid> load instrument false testdata/TestAgentLoaded.jar=<tempfile>
-	require.NoError(t, InjectAgent(pids[0], "testdata/TestAgentLoaded.jar", "testfile="+tfile.Name()))
+	require.NoError(t, InjectAgent(pids[0], filepath.Join("testdata", "TestAgentLoaded.jar"), "testfile="+tfile.Name()))
 	require.Eventually(t, func() bool {
 		_, err = os.Stat(tfile.Name())
 		return err == nil
@@ -62,7 +64,7 @@ func testInject(t *testing.T, prefix string) {
 //
 //	o on the host
 //	o in the container, _simulated_ by running java in his own PID namespace
-func TestInject(t *testing.T) {
+func runTestInject(t *testing.T) {
 	currKernelVersion, err := kernel.HostVersion()
 	require.NoError(t, err)
 	if currKernelVersion < kernel.VersionCode(4, 14, 0) {
@@ -88,4 +90,45 @@ func TestInject(t *testing.T) {
 		// and testing if the test/platform give enough permission to do that
 		testInject(t, p)
 	})
+}
+
+func TestInject(t *testing.T) {
+	runTestInject(t)
+}
+
+func TestInjectInReadOnlyFS(t *testing.T) {
+	curDir, err := os.Getwd()
+	require.NoError(t, err)
+	rodir := filepath.Join(curDir, "rodir")
+
+	err = os.Mkdir(rodir, 0766)
+	require.NoError(t, err)
+	defer func() {
+		err = os.RemoveAll(rodir)
+		if err != nil {
+			t.Log(err)
+		}
+	}()
+
+	fmt.Println(rodir)
+	err = syscall.Mount(curDir, rodir, "auto", syscall.MS_BIND|syscall.MS_RDONLY, "")
+	require.NoError(t, err)
+	err = syscall.Mount("none", rodir, "", syscall.MS_RDONLY|syscall.MS_REMOUNT|syscall.MS_BIND, "")
+	require.NoError(t, err)
+	defer func() {
+		// without the sleep the unmount fails with a 'resource busy' error
+		time.Sleep(1 * time.Second)
+		err = syscall.Unmount(rodir, 0)
+		if err != nil {
+			t.Log(err)
+		}
+	}()
+
+	err = os.Chdir(rodir)
+	require.NoError(t, err)
+
+	runTestInject(t)
+
+	err = os.Chdir(curDir)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR handles the case in the java inject functions when the current working directory is read-only.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
KMT intends to mount read-only test directories to VMs. Since the java injection code does not handle the case when the process's working directory is read-only, the tests fail.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
