### PR TITLE
usm: tls: Fix wrong classification

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -55,7 +55,13 @@ static __always_inline void classify_decrypted_payload(protocol_stack_t *stack, 
 }
 
 static __always_inline void tls_process(struct pt_regs *ctx, conn_tuple_t *t, void *buffer_ptr, size_t len, __u64 tags) {
-    protocol_stack_t *stack = get_protocol_stack(t);
+    conn_tuple_t final_tuple = {0};
+    conn_tuple_t normalized_tuple = *t;
+    normalize_tuple(&normalized_tuple);
+    normalized_tuple.pid = 0;
+    normalized_tuple.netns = 0;
+
+    protocol_stack_t *stack = get_protocol_stack(&normalized_tuple);
     if (!stack) {
         return;
     }
@@ -69,20 +75,14 @@ static __always_inline void tls_process(struct pt_regs *ctx, conn_tuple_t *t, vo
         }
         read_into_user_buffer_classification(request_fragment, buffer_ptr);
 
-        classify_decrypted_payload(stack, t, request_fragment, len);
+        classify_decrypted_payload(stack, &normalized_tuple, request_fragment, len);
         protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
     }
     tls_prog_t prog;
     switch (protocol) {
     case PROTOCOL_HTTP:
         prog = TLS_HTTP_PROCESS;
-        // HTTP implementation relies on the assumption of having a normalized tuple (as we're sharing implementation
-        // with the socket_filter program).
-        normalize_tuple(t);
-        // HTTP implementation relies on the assumption of not having pid and netns (as we're sharing implementation
-        // with the socket_filter program which does not have access to such fields).
-        t->pid = 0;
-        t->netns = 0;
+        final_tuple = normalized_tuple;
         break;
     default:
         return;
@@ -94,14 +94,20 @@ static __always_inline void tls_process(struct pt_regs *ctx, conn_tuple_t *t, vo
         return;
     }
     bpf_memset(args, 0, sizeof(tls_dispatcher_arguments_t));
-    bpf_memcpy(&args->tup, t, sizeof(conn_tuple_t));
+    bpf_memcpy(&args->tup, &final_tuple, sizeof(conn_tuple_t));
     args->buffer_ptr = buffer_ptr;
     args->tags = tags;
     bpf_tail_call_compat(ctx, &tls_process_progs, prog);
 }
 
 static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t) {
-    protocol_stack_t *stack = get_protocol_stack(t);
+    conn_tuple_t final_tuple = {0};
+    conn_tuple_t normalized_tuple = *t;
+    normalize_tuple(&normalized_tuple);
+    normalized_tuple.pid = 0;
+    normalized_tuple.netns = 0;
+
+    protocol_stack_t *stack = get_protocol_stack(&normalized_tuple);
     if (!stack) {
         return;
     }
@@ -111,13 +117,7 @@ static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t) {
     switch (protocol) {
     case PROTOCOL_HTTP:
         prog = TLS_HTTP_TERMINATION;
-        // HTTP implementation relies on the assumption of having a normalized tuple (as we're sharing implementation
-        // with the socket_filter program).
-        normalize_tuple(t);
-        // HTTP implementation relies on the assumption of not having pid and netns (as we're sharing implementation
-        // with the socket_filter program which does not have access to such fields).
-        t->pid = 0;
-        t->netns = 0;
+        final_tuple = normalized_tuple;
         break;
     default:
         return;
@@ -130,7 +130,7 @@ static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t) {
         return;
     }
     bpf_memset(args, 0, sizeof(tls_dispatcher_arguments_t));
-    bpf_memcpy(&args->tup, t, sizeof(conn_tuple_t));
+    bpf_memcpy(&args->tup, &final_tuple, sizeof(conn_tuple_t));
     bpf_tail_call_compat(ctx, &tls_process_progs, prog);
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixed a leak introduced in https://github.com/DataDog/datadog-agent/pull/21686

On the first call to TLS_read (or TLS_write) - we have an unclassified buffer
We're trying to classify the protocol associate with tuple t
After my original change t wasn't normalized, and had netns and pid
if we were able to classify the protocol we would save it in the classification map
if the protocol was HTTP, I normalized t (a pointer to a map value) and zeroed netns and pid
We would insert an entry into http_in_flight map with the normalized t.
on the second call for TLS_read or TLS_write, we would have normalized t rather than the original t

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Lower capturing rate while dogfooding

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
