### PR TITLE
Fix slice aliasing bug in secrets resolver

### DIFF
--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -170,6 +170,10 @@ func (r *secretResolver) registerSecretOrigin(handle string, origin string, path
 		}
 	}
 
+	// clone the path to take ownership of it, otherwise callers may
+	// modify the original object and corrupt data in the origin map
+	path = slices.Clone(path)
+
 	r.origin[handle] = append(
 		r.origin[handle],
 		secretContext{


### PR DESCRIPTION
### What does this PR do?

Before this change, a path to a secret (like `some.encoded.0.data` in `testConfSibling` in secrets_test.go) could be accidentally modified after being registered. This is because the walker reuses the same slice value while traversing a configuration. By cloning the slice before registering it, we avoid this aliasing bug.

### Motivation

Broke cluster-agent's config on nightly

### Additional Notes
### Possible Drawbacks / Trade-offs
### Describe how to test/QA your changes
### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
