### PR TITLE
render LastError on agent gui even when not JSON

### DIFF
--- a/cmd/agent/gui/render.go
+++ b/cmd/agent/gui/render.go
@@ -137,15 +137,15 @@ func lastErrorTraceback(value string) template.HTML {
 	return template.HTML(traceback)
 }
 
-func lastErrorMessage(value string) string {
+func lastErrorMessage(value string) template.HTML {
 	var lastErrorArray []map[string]string
 	err := json.Unmarshal([]byte(value), &lastErrorArray)
 	if err == nil && len(lastErrorArray) > 0 {
 		if msg, ok := lastErrorArray[0]["message"]; ok {
-			return msg
+			value = msg
 		}
 	}
-	return "UNKNOWN ERROR"
+	return template.HTML(template.HTMLEscapeString(value))
 }
 
 func displayStatus(check map[string]interface{}) template.HTML {

--- a/releasenotes/notes/show-go-check-error-in-agent-gui-fc4f1de1b942d710.yaml
+++ b/releasenotes/notes/show-go-check-error-in-agent-gui-fc4f1de1b942d710.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Error messages from Go checks are now shown on the Agent GUI status page
+    instead of ``UNKNOWN ERROR``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix display of go check errors in agent GUI, to match the `agent status` [command](https://github.com/DataDog/datadog-agent/blob/9f512d2849fa479f8e4fb5ab51ba5de9d06fdfe0/pkg/status/render/helpers.go#L101-L111)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Go checks that reported errors only displayed `Error: UNKNOWN ERROR` in the agent GUI. This happened because Python checks report errors as a JSON string, but Go checks don't.

https://datadoghq.atlassian.net/browse/WINA-521

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Create an error in a go check, for example, configure the `win32_event_log` check to monitor an event log that doesn't exist.

Then ensure that `agent status` command line, agent GUI collector status page, and the dashboard infra page, show the check error.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
