### PR TITLE
add new log writer to http server in dca to avoid tls flood

### DIFF
--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -92,7 +92,7 @@ func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error
 	server := &http.Server{
 		Addr:     fmt.Sprintf(":%d", config.Datadog.GetInt("admission_controller.port")),
 		Handler:  s.mux,
-		ErrorLog: stdLog.New(logWriter, "Error from DCA http API server: ", 0),
+		ErrorLog: stdLog.New(logWriter, "Error from the admission controller http API server: ", 0),
 		TLSConfig: &tls.Config{
 			GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				secretNs := common.GetResourcesNamespace()

--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	stdLog "log"
 	"net/http"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/cihub/seelog"
 
 	admiv1 "k8s.io/api/admission/v1"
 	admiv1beta1 "k8s.io/api/admission/v1beta1"
@@ -86,9 +88,11 @@ func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error
 		tlsMinVersion = tls.VersionTLS10
 	}
 
+	logWriter, _ := config.NewTlsHandshakeErrorWriter(4, seelog.WarnLvl)
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", config.Datadog.GetInt("admission_controller.port")),
-		Handler: s.mux,
+		Addr:     fmt.Sprintf(":%d", config.Datadog.GetInt("admission_controller.port")),
+		Handler:  s.mux,
+		ErrorLog: stdLog.New(logWriter, "Error from DCA http API server: ", 0),
 		TLSConfig: &tls.Config{
 			GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				secretNs := common.GetResourcesNamespace()

--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -88,7 +88,7 @@ func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error
 		tlsMinVersion = tls.VersionTLS10
 	}
 
-	logWriter, _ := config.NewTlsHandshakeErrorWriter(4, seelog.WarnLvl)
+	logWriter, _ := config.NewTLSHandshakeErrorWriter(4, seelog.WarnLvl)
 	server := &http.Server{
 		Addr:     fmt.Sprintf(":%d", config.Datadog.GetInt("admission_controller.port")),
 		Handler:  s.mux,

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -106,7 +106,7 @@ func StartServer(w workloadmeta.Component, senderManager sender.DiagnoseSenderMa
 	}
 
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
-	logWriter, _ := config.NewLogWriter(4, seelog.WarnLvl)
+	logWriter, _ := config.NewTlsHandshakeErrorWriter(4, seelog.WarnLvl)
 
 	authInterceptor := grpcutil.AuthInterceptor(func(token string) (interface{}, error) {
 		if token != util.GetDCAAuthToken() {

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -106,7 +106,7 @@ func StartServer(w workloadmeta.Component, senderManager sender.DiagnoseSenderMa
 	}
 
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
-	logWriter, _ := config.NewTlsHandshakeErrorWriter(4, seelog.WarnLvl)
+	logWriter, _ := config.NewTLSHandshakeErrorWriter(4, seelog.WarnLvl)
 
 	authInterceptor := grpcutil.AuthInterceptor(func(token string) (interface{}, error) {
 		if token != util.GetDCAAuthToken() {

--- a/pkg/config/aliases.go
+++ b/pkg/config/aliases.go
@@ -102,8 +102,9 @@ type LoggerName = logs.LoggerName
 
 // Aliases for  logs
 var (
-	NewLogWriter   = logs.NewLogWriter
-	ChangeLogLevel = logs.ChangeLogLevel
+	NewLogWriter               = logs.NewLogWriter
+	ChangeLogLevel             = logs.ChangeLogLevel
+	NewTlsHandshakeErrorWriter = logs.NewTlsHandshakeErrorWriter
 )
 
 // SetupLogger Alias using Datadog config

--- a/pkg/config/aliases.go
+++ b/pkg/config/aliases.go
@@ -104,7 +104,7 @@ type LoggerName = logs.LoggerName
 var (
 	NewLogWriter               = logs.NewLogWriter
 	ChangeLogLevel             = logs.ChangeLogLevel
-	NewTlsHandshakeErrorWriter = logs.NewTlsHandshakeErrorWriter
+	NewTLSHandshakeErrorWriter = logs.NewTLSHandshakeErrorWriter
 )
 
 // SetupLogger Alias using Datadog config

--- a/pkg/config/logs/log.go
+++ b/pkg/config/logs/log.go
@@ -259,6 +259,30 @@ func (s *logWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
+const tlsHandshakeErrorPrefix = "http: TLS handshake error"
+
+// tlsHandshakeErrorWriter writes TLS handshake errors to log with
+// debug level, to avoid flooding of tls handshake errors.
+type tlsHandshakeErrorWriter struct {
+	writer logWriter
+}
+
+// NewTlsHandshakeErrorWriter is a wrapper function which creates a new logWriter.
+func NewTlsHandshakeErrorWriter(additionalDepth int, logLevel seelog.LogLevel) (io.Writer, error) {
+	return NewLogWriter(additionalDepth, logLevel)
+}
+
+// Write writes TLS handshake errors to log with debug level.
+func (t *tlsHandshakeErrorWriter) Write(p []byte) (n int, err error) {
+	tlsWriter := &t.writer
+	if strings.HasPrefix(string(p), tlsHandshakeErrorPrefix) {
+		log.DebugStackDepth(2, strings.TrimSpace(string(p)))
+	} else {
+		tlsWriter.logFunc(tlsWriter.additionalDepth, strings.TrimSpace(string(p)))
+	}
+	return len(p), nil
+}
+
 var levelToSyslogSeverity = map[seelog.LogLevel]int{
 	// Mapping to RFC 5424 where possible
 	seelog.TraceLvl:    7,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
[CONS-6014](https://datadoghq.atlassian.net/browse/CONS-6014)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
DCA sometimes generates lots of TLS handshake error EOFs. The error is harmless but might cause expensive log cost. Some of the logs are not in standard format, 
for example: `2024/01/04 03:42:07 http: TLS handshake error from 10.128.113.72:40802: EOF` 
and could not be found in the flare logs either. To fix the spamming logs, we need to 1) add a logging wrapper so that it can be filtered by agent log filter 2) downgrade log level to debug to avoid flood.  

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[CONS-6014]: https://datadoghq.atlassian.net/browse/CONS-6014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ