### PR TITLE
hardcode netns struct offset to 48 bytes 

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -153,7 +153,7 @@ static __always_inline int guess_offsets(tracer_status_t* status, char* subject)
             new_status.err = 1;
             break;
         }
-        log_debug("netns: off=%u ino=%u val=%u\n", status->offset_netns, status->offset_ino, possible_netns);
+        //log_debug("netns: off=%u ino=%u val=%u\n", status->offset_netns, status->offset_ino, possible_netns);
         new_status.netns = possible_netns;
         break;
     case GUESS_RTT:

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -153,7 +153,7 @@ static __always_inline int guess_offsets(tracer_status_t* status, char* subject)
             new_status.err = 1;
             break;
         }
-        //log_debug("netns: off=%u ino=%u val=%u\n", status->offset_netns, status->offset_ino, possible_netns);
+        log_debug("netns: off=%u ino=%u val=%u\n", status->offset_netns, status->offset_ino, possible_netns);
         new_status.netns = possible_netns;
         break;
     case GUESS_RTT:

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.h
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.h
@@ -104,6 +104,8 @@ typedef struct {
     __u8 fl4_offsets;
     __u8 fl6_offsets;
 
+    __u8 seen_failure;
+
 } tracer_status_t;
 
 typedef struct {

--- a/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
+++ b/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
@@ -63,7 +63,8 @@ type TracerStatus struct {
 	Mac_header                      uint16
 	Fl4_offsets                     uint8
 	Fl6_offsets                     uint8
-	Pad_cgo_0                       [4]byte
+	Seen_failure                    uint8
+	Pad_cgo_0                       [3]byte
 }
 
 type State uint8

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -44,6 +44,7 @@ const (
 
 	tcpGetSockOptKProbeNotCalled uint64 = 0
 	tcpGetSockOptKProbeCalled    uint64 = 1
+	netNsDefaultOffsetBytes             = 48
 )
 
 var tcpKprobeCalledString = map[uint64]string{
@@ -740,7 +741,7 @@ func (t *tracerOffsetGuesser) Guess(cfg *config.Config) ([]manager.ConstantEdito
 		State:        uint64(StateChecking),
 		Proc:         Proc{Comm: cProcName},
 		What:         uint64(GuessSAddr),
-		Offset_netns: 48,
+		Offset_netns: netNsDefaultOffsetBytes,
 	}
 
 	// if we already have the offsets, just return

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -554,7 +554,6 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 				t.status.Offset_netns = t.status.Offset_family
 				t.status.Seen_failure = 1
 			}
-			t.status.Offset_netns = t.status.Offset_family
 			t.status.Offset_netns, _ = skipOverlaps(t.status.Offset_netns, t.sockRanges())
 		}
 	case GuessRTT:

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -528,6 +528,7 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 			t.status.Fl6_offsets = disabled
 			break
 		}
+	// This case guesses for both the net namespace struct and the inode field within it
 	case GuessNetNS:
 		t.status.Offset_netns, overlapped = skipOverlaps(t.status.Offset_netns, t.sockRanges())
 		if overlapped {
@@ -535,16 +536,24 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 			break
 		}
 
+		// compare the netns INO to the expected (usually the root NS of this machine)
 		if t.status.Netns == expected.netns {
 			t.logAndAdvance(t.status.Offset_netns, GuessRTT)
 			log.Debugf("Successfully guessed %v with offset of %d bytes", "ino", t.status.Offset_ino)
 			break
 		}
 		t.status.Offset_ino++
-		// go to the next offset_netns if we get an error
+		// go to the next offset_netns if we get an error in kernelspace or if we pass the threshold
 		if t.status.Err != 0 || t.status.Offset_ino >= threshold {
 			t.status.Offset_ino = 0
-			t.status.Offset_netns++
+			// if we have already seen a failure, we need to increment the offset_netns otherwise set it to offset_family
+			if t.status.Seen_failure != 0 {
+				t.status.Offset_netns++
+			} else {
+				t.status.Offset_netns = t.status.Offset_family
+				t.status.Seen_failure = 1
+			}
+			t.status.Offset_netns = t.status.Offset_family
 			t.status.Offset_netns, _ = skipOverlaps(t.status.Offset_netns, t.sockRanges())
 		}
 	case GuessRTT:
@@ -728,9 +737,10 @@ func (t *tracerOffsetGuesser) Guess(cfg *config.Config) ([]manager.ConstantEdito
 	t.guessUDPv6 = cfg.CollectUDPv6Conns
 	t.guessTCPv6 = cfg.CollectTCPv6Conns
 	t.status = &TracerStatus{
-		State: uint64(StateChecking),
-		Proc:  Proc{Comm: cProcName},
-		What:  uint64(GuessSAddr),
+		State:        uint64(StateChecking),
+		Proc:         Proc{Comm: cProcName},
+		What:         uint64(GuessSAddr),
+		Offset_netns: 48,
 	}
 
 	// if we already have the offsets, just return


### PR DESCRIPTION
all kernels I tested had a netns offset of 48 bytes so there isn't a reason to guess for it. This may help to resolve some flakyness in guessing we have seen in conntrack as well, as it relies on a properly guessed netns inode offset to function properly.
research: https://docs.google.com/spreadsheets/d/1Sug6g4VbnwNJhSmAKeIdqHpGZpQY9oH6DOJnF7hebG8/edit#gid=0

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
