### PR TITLE
[CONTINT-567] Fix GetSelfContainerID on cgroupv2 using cgroup inode to resolve the ContainerID

### DIFF
--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -42,6 +42,7 @@ func init() {
 
 type systemCollector struct {
 	reader              *cgroups.Reader
+	selfReader          *cgroups.Reader
 	pidMapper           cgroups.StandalonePIDMapper
 	procPath            string
 	baseController      string
@@ -70,9 +71,20 @@ func newSystemCollector(cache *provider.Cache) (provider.CollectorMetadata, erro
 		return collectorMetadata, provider.ErrPermaFail
 	}
 
+	selfReader, err := cgroups.NewSelfReader(
+		procPath,
+		config.IsContainerized(),
+		cgroups.WithCgroupV1BaseController(cgroupV1BaseController),
+	)
+	if err != nil {
+		// Cgroup provider is pretty static. Except not having required mounts, it should always work.
+		log.Errorf("Unable to initialize self cgroup reader, err: %v", err)
+		return collectorMetadata, provider.ErrPermaFail
+	}
 	systemCollector := &systemCollector{
-		reader:   reader,
-		procPath: procPath,
+		reader:     reader,
+		selfReader: selfReader,
+		procPath:   procPath,
 	}
 
 	// Set base controller for cgroupV1 (remains empty for cgroupV2)
@@ -222,7 +234,27 @@ func (c *systemCollector) GetContainerIDForInode(inode uint64, cacheValidity tim
 }
 
 func (c *systemCollector) GetSelfContainerID() (string, error) {
+	cid, err := c.getSelfContainerIDFromInode()
+	if cid != "" {
+		return cid, nil
+	}
+	log.Debugf("unable to get self container ID from cgroup controller inode: %v", err)
+
 	return getSelfContainerID(c.hostCgroupNamespace, c.reader.CgroupVersion(), c.baseController)
+}
+
+// getSelfContainerIDFromInode returns the container ID of the current process by using the inode of the cgroup
+// controller. The `reader` must use a `cgroups.ContainerFilter`.
+func (c *systemCollector) getSelfContainerIDFromInode() (string, error) {
+	if c.selfReader == nil {
+		return "", fmt.Errorf("self reader is not initialized")
+	}
+	selfCgroup := c.selfReader.GetCgroup(cgroups.SelfCgroupIdentifier)
+	if selfCgroup == nil {
+		return "", fmt.Errorf("unable to get self cgroup")
+	}
+
+	return c.GetContainerIDForInode(selfCgroup.Inode(), 0)
 }
 
 func (c *systemCollector) getCgroup(containerID string, cacheValidity time.Duration) (cgroups.Cgroup, error) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR adds a fallback mechanism when the ContainerID can't be found from `/proc/mountinfo` or `/proc/self/cgroup`. It uses the cgroup controller inode to identify the ContainerID.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We want to support container tags for the agent on cgroupv2.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent with `basic_telemetry_add_container_tags` in a container on cgroupsv2. Make sure container tags are added to every metric emitted by the agent.
On my experiments, `parseMountinfo` was buggy on kind and returned a volume id instead of a containerid. So I commented out this function and simply added a debug log which seems to work fine:
```
❯ k logs -n datadog-agent-helm datadog-agent-linux-s89px | grep -i debugcontainerid
2023-12-14 17:18:06 UTC | CORE | INFO | (pkg/util/containers/metrics/system/collector_linux.go:241 in GetSelfContainerID) | debugcontainerid id: aac74beea589d9cb5f73622fbc315a7170cd7be27cc4a1af21fd2a6cb6867907, err <nil>
❯ k -n datadog-agent-helm get pod datadog-agent-linux-s89px -o yaml | grep -i aac74beea589d9cb5f73622fbc315a7170cd7be27cc4a1af21fd2a6cb6867907
  - containerID: containerd://aac74beea589d9cb5f73622fbc315a7170cd7be27cc4a1af21fd2a6cb6867907
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
[](url)