### PR TITLE
Fix incorrect metadata about system-probe

### DIFF
--- a/releasenotes/notes/fix-inventory-agent-metadata-sysprobe-18961f4a24e88b0d.yaml
+++ b/releasenotes/notes/fix-inventory-agent-metadata-sysprobe-18961f4a24e88b0d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix incorrect metadata about system-probe being sent to Inventory and Fleet Automation products.


### PR DESCRIPTION
### What does this PR do?

With the move to component, we now load system-probe information before loading the file. This means we would send default values.

This fix is meant for '7.50.1', a real fix has already been merge for 7.51.0+.

### Describe how to test/QA your changes

Configure system-probe.yaml and check that the payload sent to the backend correctly reflect its value (use the `datadog-agent diagnose show-metadata inventory-agent` command).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
