### PR TITLE
Improve error handling for the Windows registry check

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2978,3 +2978,5 @@ core,sigs.k8s.io/structured-merge-diff/v4/schema,Apache-2.0,Copyright 2017 The K
 core,sigs.k8s.io/structured-merge-diff/v4/typed,Apache-2.0,Copyright 2017 The Kubernetes Authors.
 core,sigs.k8s.io/structured-merge-diff/v4/value,Apache-2.0,Copyright 2017 The Kubernetes Authors.
 core,sigs.k8s.io/yaml,MIT,Copyright 2017 The Kubernetes Authors.
+core,github.com/swaggest/jsonschema-go,MIT,Copyright (c) 2019 swaggest
+core,github.com/swaggest/refl,MIT,Copyright (c) 2020 swaggest

--- a/comp/checks/winregistry/impl/winregistryimpl.go
+++ b/comp/checks/winregistry/impl/winregistryimpl.go
@@ -10,30 +10,32 @@ package winregistryimpl
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-
 	"github.com/DataDog/datadog-agent/comp/checks/winregistry"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
 	logsConfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
-	"github.com/DataDog/datadog-agent/pkg/logs/message"
-	"github.com/DataDog/datadog-agent/pkg/logs/sources"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
-
-	"io/fs"
-	"strconv"
-	"strings"
-
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	agentLog "github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
+	yy "github.com/ghodss/yaml"
+	"github.com/swaggest/jsonschema-go"
+	"github.com/xeipuuv/gojsonschema"
 	"go.uber.org/fx"
 	"golang.org/x/sys/windows/registry"
 	"gopkg.in/yaml.v2"
+	"io/fs"
+	"strconv"
+	"strings"
 )
 
 const (
@@ -60,20 +62,20 @@ type dependencies struct {
 }
 
 type registryValueCfg struct {
-	Name         string                   `yaml:"name"` // The metric name of the registry value
-	DefaultValue optional.Option[float64] `yaml:"default_value"`
-	Mappings     []map[string]float64     `yaml:"mapping"`
+	Name         string                   `json:"name" yaml:"name" required:"true"` // The metric name of the registry value
+	DefaultValue optional.Option[float64] `json:"default_value" yaml:"default_value"`
+	Mappings     []map[string]float64     `json:"mapping" yaml:"mapping"`
 }
 
 type registryKeyCfg struct {
-	Name           string                      `yaml:"name"`            // The metric name of the registry key
-	RegistryValues map[string]registryValueCfg `yaml:"registry_values"` // The map key is the registry value name
+	Name           string                      `json:"name" yaml:"name" required:"true"`                                                     // The metric name of the registry key
+	RegistryValues map[string]registryValueCfg `json:"registry_values" yaml:"registry_values" minItems:"1" nullable:"false" required:"true"` // The map key is the registry value name
 }
 
 // checkCfg is the config that is specific to each check instance
 type checkCfg struct {
-	RegistryKeys map[string]registryKeyCfg `yaml:"registry_keys"`
-	SendOnStart  optional.Option[bool]     `yaml:"send_on_start"`
+	RegistryKeys map[string]registryKeyCfg `json:"registry_keys" yaml:"registry_keys" nullable:"false" required:"true"`
+	SendOnStart  optional.Option[bool]     `json:"send_on_start" yaml:"send_on_start"`
 }
 
 // checkInitCfg is the config that is common to all check instances
@@ -106,6 +108,30 @@ type WindowsRegistryCheck struct {
 	integrationLogsDelegate *integrationLogsRegistryDelegate
 }
 
+func createSchema() ([]byte, error) {
+	reflector := jsonschema.Reflector{}
+
+	conf := checkCfg{}
+	conf.RegistryKeys = map[string]registryKeyCfg{
+		"test_key": {
+			Name: "test_key_name",
+			RegistryValues: map[string]registryValueCfg{
+				"test_value": {
+					Name:         "test_value_name",
+					DefaultValue: optional.Option[float64]{},
+					Mappings:     []map[string]float64{},
+				},
+			},
+		},
+	}
+	schema, err := reflector.Reflect(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.MarshalIndent(schema, "", " ")
+}
+
 // Configure configures the check
 func (c *WindowsRegistryCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
 	c.senderManager = senderManager
@@ -115,13 +141,39 @@ func (c *WindowsRegistryCheck) Configure(senderManager sender.SenderManager, int
 		return err
 	}
 
+	schemaString, err := createSchema()
+	if err != nil {
+		agentLog.Errorf("failed to create validation schema: %s", err)
+		return err
+	}
+	schemaLoader := gojsonschema.NewBytesLoader(schemaString)
+	rawDocument, err := yy.YAMLToJSON(data)
+	if err != nil {
+		agentLog.Errorf("failed to load the config to JSON: %s", err)
+		return err
+	}
+	documentLoader := gojsonschema.NewBytesLoader(rawDocument)
+	result, _ := gojsonschema.Validate(schemaLoader, documentLoader)
+	if !result.Valid() {
+		for _, err := range result.Errors() {
+			if err.Value() != nil {
+				agentLog.Errorf("configuration error: %s", err)
+			} else {
+				agentLog.Errorf("configuration error: %s (%v)", err, err.Value())
+			}
+		}
+		return fmt.Errorf("configuration validation failed")
+	}
+
 	var initCfg checkInitCfg
 	if err := yaml.Unmarshal(initConfig, &initCfg); err != nil {
+		agentLog.Errorf("cannot unmarshal shared configuration: %s", err)
 		return err
 	}
 
 	var conf checkCfg
 	if err := yaml.Unmarshal(data, &conf); err != nil {
+		agentLog.Errorf("cannot unmarshal configuration: %s", err)
 		return err
 	}
 
@@ -146,7 +198,9 @@ func (c *WindowsRegistryCheck) Configure(senderManager sender.SenderManager, int
 	for regKey, regKeyConfig := range conf.RegistryKeys {
 		splitKeypath := strings.SplitN(regKey, "\\", 2)
 		if len(splitKeypath) != 2 {
-			return fmt.Errorf("the key %s is too short to be a valid key", regKey)
+			err = fmt.Errorf("the key %s is too short to be a valid key", regKey)
+			agentLog.Errorf("configuration error: %s", err)
+			return err
 		}
 
 		if len(regKeyConfig.Name) == 0 {
@@ -171,13 +225,16 @@ func (c *WindowsRegistryCheck) Configure(senderManager sender.SenderManager, int
 				registryValues:  regValues,
 			})
 		} else {
-			return fmt.Errorf("unknown hive %s", splitKeypath[0])
+			err = fmt.Errorf("unknown hive %s", splitKeypath[0])
+			agentLog.Errorf("configuration error: %s", err)
+			return err
 		}
 	}
 
 	c.sender, err = c.GetSender()
 	if err != nil {
-		return fmt.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
+		agentLog.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
+		return err
 	}
 	c.sender.FinalizeCheckServiceTag()
 

--- a/comp/checks/winregistry/impl/winregistryimpl.go
+++ b/comp/checks/winregistry/impl/winregistryimpl.go
@@ -110,21 +110,7 @@ type WindowsRegistryCheck struct {
 
 func createSchema() ([]byte, error) {
 	reflector := jsonschema.Reflector{}
-
-	conf := checkCfg{}
-	conf.RegistryKeys = map[string]registryKeyCfg{
-		"test_key": {
-			Name: "test_key_name",
-			RegistryValues: map[string]registryValueCfg{
-				"test_value": {
-					Name:         "test_value_name",
-					DefaultValue: optional.Option[float64]{},
-					Mappings:     []map[string]float64{},
-				},
-			},
-		},
-	}
-	schema, err := reflector.Reflect(conf)
+	schema, err := reflector.Reflect(checkCfg{})
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -376,7 +376,7 @@ require (
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
@@ -651,6 +651,7 @@ require (
 	github.com/protocolbuffers/protoscope v0.0.0-20221109213918-8e7a6aafa2c9
 	github.com/sijms/go-ora/v2 v2.8.1
 	github.com/stormcat24/protodep v0.1.8
+	github.com/swaggest/jsonschema-go v0.3.64
 	go.opentelemetry.io/collector/extension v0.91.0
 	go.opentelemetry.io/collector/otelcol v0.91.0
 	go.opentelemetry.io/collector/processor v0.91.0
@@ -693,6 +694,7 @@ require (
 	github.com/skeema/knownhosts v1.2.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
+	github.com/swaggest/refl v1.3.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/zclconf/go-cty v1.13.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.91.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -395,6 +395,10 @@ github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQ
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40 h1:y4B3+GPxKlrigF1ha5FFErxK+sr6sWxQovRMzwMhejo=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
+github.com/bool64/dev v0.2.31 h1:OS57EqYaYe2M/2bw9uhDCIFiZZwywKFS/4qMLN6JUmQ=
+github.com/bool64/dev v0.2.31/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
+github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=
+github.com/bool64/shared v0.1.5/go.mod h1:081yz68YC9jeFB3+Bbmno2RFWvGKv1lPKkMP6MHJlPs=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4Pt2A=
@@ -1015,6 +1019,8 @@ github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
+github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJDkXXS7VoV7XGE=
 github.com/ianlancetaylor/cgosymbolizer v0.0.0-20221208003206-eaf69f594683 h1:K5WubDh+7FP4wf8HB+vOrUmeCoGMYmLv0QMfWYA4oCk=
 github.com/ianlancetaylor/cgosymbolizer v0.0.0-20221208003206-eaf69f594683/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -1602,6 +1608,12 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/swaggest/assertjson v1.9.0 h1:dKu0BfJkIxv/xe//mkCrK5yZbs79jL7OVf9Ija7o2xQ=
+github.com/swaggest/assertjson v1.9.0/go.mod h1:b+ZKX2VRiUjxfUIal0HDN85W0nHPAYUbYH5WkkSsFsU=
+github.com/swaggest/jsonschema-go v0.3.64 h1:HyB41fkA4XP0BZkqWfGap5i2JtRHQGXG/21dGDPbyLM=
+github.com/swaggest/jsonschema-go v0.3.64/go.mod h1:DYuKqdpms/edvywsX6p1zHXCZkdwB28wRaBdFCe3Duw=
+github.com/swaggest/refl v1.3.0 h1:PEUWIku+ZznYfsoyheF97ypSduvMApYyGkYF3nabS0I=
+github.com/swaggest/refl v1.3.0/go.mod h1:3Ujvbmh1pfSbDYjC6JGG7nMgPvpG0ehQL4iNonnLNbg=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
@@ -1713,6 +1725,10 @@ github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBe
 github.com/yashtewari/glob-intersection v0.2.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d h1:splanxYIlg+5LfHAM6xpdFEAYOk8iySO56hMFq6uLyA=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
+github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCOA=
+github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
+github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 h1:BHyfKlQyqbsFN5p3IfnEUduWvb9is428/nNb5L3U01M=
+github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR improves the error handling for the Windows registry check.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Clearer error messages.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Misconfigure the windows registry check, for example:
```
init_config:
instances:
  - 
      registry_keys:
      HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wuauserv:
        name: 12
        registry_values:
```
Check that the Windows registry integration did not load.

In Agent status:
```
windows_registry
Core Check Loader: Could not configure check windows_registry: configuration validation failed
```

In the Agent's logs:
```
2024-01-05 18:13:39 CET | CORE | ERROR | (comp/checks/winregistry/impl/winregistryimpl.go:160 in Configure) | configuration error: registry_keys.HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wuauserv.name: Invalid type. Expected: string, given: integer
2024-01-05 18:13:39 CET | CORE | ERROR | (comp/checks/winregistry/impl/winregistryimpl.go:162 in Configure) | configuration error: registry_keys.HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wuauserv.registry_values: Invalid type. Expected: object, given: null (<nil>)
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
