### PR TITLE
fix issue introduce by #21532 in the serveless agent

### DIFF
--- a/pkg/util/containers/metrics/provider/provider.go
+++ b/pkg/util/containers/metrics/provider/provider.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
@@ -128,6 +129,13 @@ func newProvider() *GenericProvider {
 	provider := &GenericProvider{
 		cache:         NewCache(cacheGCInterval),
 		metaCollector: newMetaCollector(),
+	}
+	if env.IsServerless() {
+		// TODO: quick fix to unblock some Serverless test.
+		// Serverless doesn't rely on the provider collector,
+		// so we avoid running the provider.collectorsUpdatedCallback.
+		// a proper fix should be to not register the collector if we are in the serveless agent.
+		return provider
 	}
 	registry.run(context.TODO(), provider.cache, provider.collectorsUpdatedCallback)
 


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

do not instantiate the provider.Collector if the provider is use in the serveless agent

this PR try to fix an issue introduced by #21532 for the serverless agent.

the errors that we see in the test are

```
2024-01-05 16:40:34 UTC | DD_EXTENSION | DEBUG | dogstatsd-udp: 127.0.0.1:8125 successfully initialized
2024-01-05 16:40:34 UTC | DD_EXTENSION | DEBUG | DogStatsD will run 2 workers
2024-01-05 16:40:34 UTC | DD_EXTENSION | ERROR | Unable to initialize cgroup provider (cgroups not mounted?), err: unable to detect cgroup version from detected mount points: map[]
2024-01-05 16:40:34 UTC | DD_EXTENSION | DEBUG | Metrics collector: system went into PermaFail, removed from candidates
```

### Motivation

Serverless agent should not try to initialise provider collectors,
To do so, we avoid running the provider.collectorsUpdatedCallback.
A proper fix should be to not register the collector if we are in
the serveless agent.



### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

the serveless tests ("Serverless Integration Tests")  should pass 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
