### PR TITLE
guess conntrack netns ino independently of tracer netns ino

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -370,6 +370,7 @@ static __always_inline int guess_conntrack_offsets(conntrack_status_t* status, c
     bpf_probe_read_kernel(&new_status, sizeof(conntrack_status_t), status);
     new_status.state = STATE_CHECKED;
     bpf_probe_read_kernel(&new_status.proc.comm, sizeof(proc.comm), proc.comm);
+    long ret;
 
     possible_net_t* possible_ct_net = NULL;
     u32 possible_netns = 0;
@@ -385,7 +386,19 @@ static __always_inline int guess_conntrack_offsets(conntrack_status_t* status, c
     case GUESS_CT_NET:
         new_status.offset_netns = aligned_offset(subject, status->offset_netns, SIZEOF_CT_NET);
         bpf_probe_read_kernel(&possible_ct_net, sizeof(possible_net_t*), subject + new_status.offset_netns);
-        bpf_probe_read_kernel(&possible_netns, sizeof(possible_netns), ((char*)possible_ct_net) + status->offset_ino);
+        if (!possible_ct_net) {
+            new_status.err = 1;
+            break;
+        }
+        // if we get a kernel fault, it means possible_ct_net
+        // is an invalid pointer, signal an error so we can go
+        // to the next offset_netns
+        new_status.offset_ino = aligned_offset(subject, status->offset_ino, SIZEOF_NETNS_INO);
+        ret = bpf_probe_read_kernel(&possible_netns, sizeof(possible_netns), ((char*)possible_ct_net) + status->offset_ino);
+        if (ret == -EFAULT) {
+            new_status.err = 1;
+            break;
+        }
         new_status.netns = possible_netns;
         break;
     default:

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -153,6 +153,7 @@ static __always_inline int guess_offsets(tracer_status_t* status, char* subject)
             new_status.err = 1;
             break;
         }
+        //log_debug("netns: off=%u ino=%u val=%u\n", status->offset_netns, status->offset_ino, possible_netns);
         new_status.netns = possible_netns;
         break;
     case GUESS_RTT:

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.h
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.h
@@ -152,5 +152,6 @@ static const __u8 SIZEOF_SK_BUFF_HEAD = sizeof((void*)0); // char*
 static const __u8 SIZEOF_CT_TUPLE_ORIGIN = sizeof_member(conntrack_status_t, saddr);
 static const __u8 SIZEOF_CT_TUPLE_REPLY = sizeof_member(conntrack_status_t, saddr);
 static const __u8 SIZEOF_CT_NET = sizeof((void*)0); // possible_net_t*
+static const __u8 SIZEOF_CT_NETNS_INO = sizeof_member(conntrack_status_t, netns);
 
 #endif //__OFFSET_GUESS_H

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.h
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.h
@@ -118,6 +118,8 @@ typedef struct {
     __u64 offset_netns;
     __u64 offset_ino;
 
+    __u64 err;
+
     __u32 saddr;
     __u32 netns;
 } conntrack_status_t;

--- a/pkg/network/tracer/offsetguess/conntrack.go
+++ b/pkg/network/tracer/offsetguess/conntrack.go
@@ -48,14 +48,8 @@ type conntrackOffsetGuesser struct {
 
 //nolint:revive // TODO(NET) Fix revive linter
 func NewConntrackOffsetGuesser(cfg *config.Config) (OffsetGuesser, error) {
-	tcpv6Enabled, udpv6Enabled := setIpv6Configuration(cfg)
-	var tcpv6EnabledConst, udpv6EnabledConst uint64
-	if tcpv6Enabled {
-		tcpv6EnabledConst = 1
-	}
-	if udpv6Enabled {
-		udpv6EnabledConst = 1
-	}
+	tcpv6Enabled, udpv6Enabled := getIpv6Configuration(cfg)
+	tcpv6EnabledConst, udpv6EnabledConst := boolToUint64(tcpv6Enabled), boolToUint64(udpv6Enabled)
 	return &conntrackOffsetGuesser{
 		m: &manager.Manager{
 			Maps: []*manager.Map{

--- a/pkg/network/tracer/offsetguess/conntrack.go
+++ b/pkg/network/tracer/offsetguess/conntrack.go
@@ -53,7 +53,6 @@ func NewConntrackOffsetGuesser(cfg *config.Config) (OffsetGuesser, error) {
 		return nil, err
 	}
 
-	var offsetIno uint64
 	var tcpv6Enabled, udpv6Enabled uint64
 	for _, c := range consts {
 		switch c.Name {
@@ -62,10 +61,6 @@ func NewConntrackOffsetGuesser(cfg *config.Config) (OffsetGuesser, error) {
 		case "udpv6_enabled":
 			udpv6Enabled = c.Value.(uint64)
 		}
-	}
-
-	if offsetIno == 0 {
-		return nil, fmt.Errorf("ino offset is 0")
 	}
 
 	return &conntrackOffsetGuesser{
@@ -82,7 +77,7 @@ func NewConntrackOffsetGuesser(cfg *config.Config) (OffsetGuesser, error) {
 				// so explicitly disabled, and the manager won't load it
 				{ProbeIdentificationPair: idPair(probes.NetDevQueue)}},
 		},
-		status:       &ConntrackStatus{Offset_ino: offsetIno},
+		status:       &ConntrackStatus{},
 		tcpv6Enabled: tcpv6Enabled,
 		udpv6Enabled: udpv6Enabled,
 	}, nil
@@ -184,6 +179,7 @@ func (c *conntrackOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expec
 
 		if c.status.Netns == expected.netns {
 			c.logAndAdvance(c.status.Offset_netns, GuessNotApplicable)
+			log.Debugf("Successfully guessed %v with offset of %d bytes", "ino", c.status.Offset_ino)
 			return c.setReadyState(mp)
 		}
 		c.status.Offset_ino++

--- a/pkg/network/tracer/offsetguess/offsetguess.go
+++ b/pkg/network/tracer/offsetguess/offsetguess.go
@@ -138,9 +138,7 @@ func setIpv6Configuration(c *config.Config) (bool, bool) {
 				return
 			}
 			if kv >= kernel.VersionCode(5, 18, 0) {
-				_cfg := *c
-				_cfg.CollectUDPv6Conns = false
-				c = &_cfg
+				udpv6Enabled = false
 			}
 		}
 	})

--- a/pkg/network/tracer/offsetguess/offsetguess.go
+++ b/pkg/network/tracer/offsetguess/offsetguess.go
@@ -26,6 +26,7 @@ import (
 )
 
 var zero uint64
+var tcpv6Enabled, udpv6Enabled bool
 
 // These constants should be in sync with the equivalent definitions in the ebpf program.
 const (
@@ -40,7 +41,7 @@ const (
 	notApplicable = 99999 // An arbitrary large number to indicate that the value should be ignored
 )
 
-var ipv6Variable sync.Once
+var ipv6Config sync.Once
 
 var stateString = map[State]string{
 	StateUninitialized: "uninitialized",
@@ -128,11 +129,9 @@ func enableProbe(enabled map[probes.ProbeFuncName]struct{}, name probes.ProbeFun
 }
 
 func setIpv6Configuration(c *config.Config) (bool, bool) {
-	var tcpv6Enabled, udpv6Enabled bool
-	ipv6Variable.Do(func() {
+	ipv6Config.Do(func() {
 		tcpv6Enabled = c.CollectTCPv6Conns
 		udpv6Enabled = c.CollectUDPv6Conns
-
 		if c.CollectUDPv6Conns {
 			kv, err := kernel.HostVersion()
 			if err != nil {

--- a/pkg/network/tracer/offsetguess/offsetguess.go
+++ b/pkg/network/tracer/offsetguess/offsetguess.go
@@ -128,7 +128,14 @@ func enableProbe(enabled map[probes.ProbeFuncName]struct{}, name probes.ProbeFun
 	enabled[name] = struct{}{}
 }
 
-func setIpv6Configuration(c *config.Config) (bool, bool) {
+func boolToUint64(in bool) uint64 {
+	if in {
+		return 1
+	}
+	return 0
+}
+
+func getIpv6Configuration(c *config.Config) (bool, bool) {
 	ipv6Config.Do(func() {
 		tcpv6Enabled = c.CollectTCPv6Conns
 		udpv6Enabled = c.CollectUDPv6Conns

--- a/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
+++ b/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
@@ -84,6 +84,7 @@ type ConntrackStatus struct {
 	Offset_status uint64
 	Offset_netns  uint64
 	Offset_ino    uint64
+	Err           uint64
 	Saddr         uint32
 	Netns         uint32
 }

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -1102,7 +1102,8 @@ func (o *tracerOffsets) Offsets(cfg *config.Config) ([]manager.ConstantEditor, e
 		return nil, o.err
 	}
 	defer offsetBuf.Close()
-	return RunOffsetGuessing(cfg, offsetBuf, NewTracerOffsetGuesser)
+	o.offsets, o.err = RunOffsetGuessing(cfg, offsetBuf, NewTracerOffsetGuesser)
+	return o.offsets, o.err
 }
 
 func (o *tracerOffsets) Reset() {

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -792,6 +792,13 @@ func (t *tracerOffsetGuesser) Guess(cfg *config.Config) ([]manager.ConstantEdito
 }
 
 func (t *tracerOffsetGuesser) getConstantEditors() []manager.ConstantEditor {
+	var tcpv6EnabledConst, udpv6EnabledConst uint64
+	if tcpv6Enabled {
+		tcpv6EnabledConst = 1
+	}
+	if udpv6Enabled {
+		udpv6EnabledConst = 1
+	}
 	return []manager.ConstantEditor{
 		{Name: "offset_saddr", Value: t.status.Offset_saddr},
 		{Name: "offset_daddr", Value: t.status.Offset_daddr},
@@ -817,8 +824,8 @@ func (t *tracerOffsetGuesser) getConstantEditors() []manager.ConstantEditor {
 		{Name: "offset_sk_buff_sock", Value: t.status.Offset_sk_buff_sock},
 		{Name: "offset_sk_buff_transport_header", Value: t.status.Offset_sk_buff_transport_header},
 		{Name: "offset_sk_buff_head", Value: t.status.Offset_sk_buff_head},
-		{Name: "tcpv6_enabled", Value: t.guessTCPv6},
-		{Name: "udpv6_enabled", Value: t.guessUDPv6},
+		{Name: "tcpv6_enabled", Value: tcpv6EnabledConst},
+		{Name: "udpv6_enabled", Value: udpv6EnabledConst},
 	}
 }
 

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -1089,18 +1089,6 @@ type tracerOffsets struct {
 	err     error
 }
 
-func boolConst(name string, value bool) manager.ConstantEditor {
-	c := manager.ConstantEditor{
-		Name:  name,
-		Value: uint64(1),
-	}
-	if !value {
-		c.Value = uint64(0)
-	}
-
-	return c
-}
-
 func (o *tracerOffsets) Offsets(cfg *config.Config) ([]manager.ConstantEditor, error) {
 	if o.err != nil {
 		return nil, o.err
@@ -1112,7 +1100,6 @@ func (o *tracerOffsets) Offsets(cfg *config.Config) ([]manager.ConstantEditor, e
 		return nil, o.err
 	}
 	defer offsetBuf.Close()
-
 	return RunOffsetGuessing(cfg, offsetBuf, NewTracerOffsetGuesser)
 }
 

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -725,7 +725,7 @@ func (t *tracerOffsetGuesser) Guess(cfg *config.Config) ([]manager.ConstantEdito
 		cProcName[i] = int8(ch)
 	}
 
-	t.guessTCPv6, t.guessUDPv6 = setIpv6Configuration(cfg)
+	t.guessTCPv6, t.guessUDPv6 = getIpv6Configuration(cfg)
 	t.status = &TracerStatus{
 		State: uint64(StateChecking),
 		Proc:  Proc{Comm: cProcName},
@@ -792,13 +792,6 @@ func (t *tracerOffsetGuesser) Guess(cfg *config.Config) ([]manager.ConstantEdito
 }
 
 func (t *tracerOffsetGuesser) getConstantEditors() []manager.ConstantEditor {
-	var tcpv6EnabledConst, udpv6EnabledConst uint64
-	if tcpv6Enabled {
-		tcpv6EnabledConst = 1
-	}
-	if udpv6Enabled {
-		udpv6EnabledConst = 1
-	}
 	return []manager.ConstantEditor{
 		{Name: "offset_saddr", Value: t.status.Offset_saddr},
 		{Name: "offset_daddr", Value: t.status.Offset_daddr},
@@ -824,8 +817,8 @@ func (t *tracerOffsetGuesser) getConstantEditors() []manager.ConstantEditor {
 		{Name: "offset_sk_buff_sock", Value: t.status.Offset_sk_buff_sock},
 		{Name: "offset_sk_buff_transport_header", Value: t.status.Offset_sk_buff_transport_header},
 		{Name: "offset_sk_buff_head", Value: t.status.Offset_sk_buff_head},
-		{Name: "tcpv6_enabled", Value: tcpv6EnabledConst},
-		{Name: "udpv6_enabled", Value: udpv6EnabledConst},
+		{Name: "tcpv6_enabled", Value: boolToUint64(t.guessTCPv6)},
+		{Name: "udpv6_enabled", Value: boolToUint64(t.guessUDPv6)},
 	}
 }
 

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -817,6 +817,8 @@ func (t *tracerOffsetGuesser) getConstantEditors() []manager.ConstantEditor {
 		{Name: "offset_sk_buff_sock", Value: t.status.Offset_sk_buff_sock},
 		{Name: "offset_sk_buff_transport_header", Value: t.status.Offset_sk_buff_transport_header},
 		{Name: "offset_sk_buff_head", Value: t.status.Offset_sk_buff_head},
+		{Name: "tcpv6_enabled", Value: t.guessTCPv6},
+		{Name: "udpv6_enabled", Value: t.guessUDPv6},
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Currently the `ct_netns_ino` offset value in conntrack offset guessing is set to the one that is guessed via tracer offset guessing since it should be the same offset. In reality this means that even when running the CO-RE tracer, tracer offset guessing is still required to support conntrack (which is always prebuilt). This PR removes that link between the two modules.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/NPM-3143

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
