### PR TITLE
USMON-689: Fix HTTP2 Kernel Telemetry Update in User Mode

### DIFF
--- a/pkg/network/protocols/http2/telemetry.go
+++ b/pkg/network/protocols/http2/telemetry.go
@@ -80,6 +80,7 @@ func (t *kernelTelemetry) Log() {
 	log.Debugf("http2 kernel telemetry summary: %s", t.metricGroup.Summary())
 }
 
+// Sub generates a new HTTP2Telemetry object by subtracting the values of this HTTP2Telemetry object from the other
 func (t *HTTP2Telemetry) Sub(other HTTP2Telemetry) *HTTP2Telemetry {
 	return &HTTP2Telemetry{
 		Request_seen:                     t.Request_seen - other.Request_seen,
@@ -89,15 +90,15 @@ func (t *HTTP2Telemetry) Sub(other HTTP2Telemetry) *HTTP2Telemetry {
 		Path_exceeds_frame:               t.Path_exceeds_frame - other.Path_exceeds_frame,
 		Exceeding_max_interesting_frames: t.Exceeding_max_interesting_frames - other.Exceeding_max_interesting_frames,
 		Exceeding_max_frames_to_filter:   t.Exceeding_max_frames_to_filter - other.Exceeding_max_frames_to_filter,
-		Path_size_bucket:                 computeDifferences(t.Path_size_bucket, other.Path_size_bucket),
+		Path_size_bucket:                 computePathSizeBucketDifferences(t.Path_size_bucket, other.Path_size_bucket),
 	}
 }
 
-func computeDifferences(arr1, arr2 [8]uint64) [8]uint64 {
+func computePathSizeBucketDifferences(pathSizeBucket, otherPathSizeBucket [8]uint64) [8]uint64 {
 	var result [8]uint64
 
 	for i := 0; i < 8; i++ {
-		result[i] = arr1[i] - arr2[i]
+		result[i] = pathSizeBucket[i] - otherPathSizeBucket[i]
 	}
 
 	return result

--- a/pkg/network/protocols/http2/telemetry.go
+++ b/pkg/network/protocols/http2/telemetry.go
@@ -57,15 +57,15 @@ func newHTTP2KernelTelemetry() *kernelTelemetry {
 
 // update updates the kernel metrics with the given telemetry.
 func (t *kernelTelemetry) update(tel *HTTP2Telemetry) {
-	t.http2requests.Add(int64(tel.Request_seen))
-	t.http2responses.Add(int64(tel.Response_seen))
-	t.endOfStream.Add(int64(tel.End_of_stream))
-	t.endOfStreamRST.Add(int64(tel.End_of_stream_rst))
-	t.pathExceedsFrame.Add(int64(tel.Path_exceeds_frame))
-	t.exceedingMaxInterestingFrames.Add(int64(tel.Exceeding_max_interesting_frames))
-	t.exceedingMaxFramesToFilter.Add(int64(tel.Exceeding_max_frames_to_filter))
+	t.http2requests.UpdateCounterWithDifference(int64(tel.Request_seen))
+	t.http2responses.UpdateCounterWithDifference(int64(tel.Response_seen))
+	t.endOfStream.UpdateCounterWithDifference(int64(tel.End_of_stream))
+	t.endOfStreamRST.UpdateCounterWithDifference(int64(tel.End_of_stream_rst))
+	t.pathExceedsFrame.UpdateCounterWithDifference(int64(tel.Path_exceeds_frame))
+	t.exceedingMaxInterestingFrames.UpdateCounterWithDifference(int64(tel.Exceeding_max_interesting_frames))
+	t.exceedingMaxFramesToFilter.UpdateCounterWithDifference(int64(tel.Exceeding_max_frames_to_filter))
 	for bucketIndex := range t.pathSizeBucket {
-		t.pathSizeBucket[bucketIndex].Add(int64(tel.Path_size_bucket[bucketIndex]))
+		t.pathSizeBucket[bucketIndex].UpdateCounterWithDifference(int64(tel.Path_size_bucket[bucketIndex]))
 	}
 }
 

--- a/pkg/network/protocols/http2/telemetry.go
+++ b/pkg/network/protocols/http2/telemetry.go
@@ -19,21 +19,24 @@ type kernelTelemetry struct {
 	metricGroup *libtelemetry.MetricGroup
 
 	// http2requests Count of HTTP/2 requests seen
-	http2requests *libtelemetry.Gauge
+	http2requests *libtelemetry.Counter
 	// http2responses Count of HTTP/2 responses seen
-	http2responses *libtelemetry.Gauge
+	http2responses *libtelemetry.Counter
 	// endOfStream Count of END_OF_STREAM flags seen
-	endOfStream *libtelemetry.Gauge
+	endOfStream *libtelemetry.Counter
 	// endOfStreamRST Count of RST flags seen
-	endOfStreamRST *libtelemetry.Gauge
+	endOfStreamRST *libtelemetry.Counter
 	// pathSizeBucket Count of path sizes divided into buckets.
-	pathSizeBucket [http2PathBuckets + 1]*libtelemetry.Gauge
+	pathSizeBucket [http2PathBuckets + 1]*libtelemetry.Counter
 	// pathExceedsFrame Count of times we couldn't retrieve the path due to reaching the end of the frame.
-	pathExceedsFrame *libtelemetry.Gauge
+	pathExceedsFrame *libtelemetry.Counter
 	// exceedingMaxInterestingFrames Count of times we reached the max number of frames per iteration.
-	exceedingMaxInterestingFrames *libtelemetry.Gauge
+	exceedingMaxInterestingFrames *libtelemetry.Counter
 	// exceedingMaxFramesToFilter Count of times we have left with more frames to filter than the max number of frames to filter.
-	exceedingMaxFramesToFilter *libtelemetry.Gauge
+	exceedingMaxFramesToFilter *libtelemetry.Counter
+
+	// telemetryLastState represents the latest HTTP2 eBPF Kernel telemetry observed from the kernel
+	telemetryLastState HTTP2Telemetry
 }
 
 // newHTTP2KernelTelemetry hold HTTP/2 kernel metrics.
@@ -41,15 +44,15 @@ func newHTTP2KernelTelemetry() *kernelTelemetry {
 	metricGroup := libtelemetry.NewMetricGroup("usm.http2", libtelemetry.OptPrometheus)
 	http2KernelTel := &kernelTelemetry{
 		metricGroup:                   metricGroup,
-		http2requests:                 metricGroup.NewGauge("requests"),
-		http2responses:                metricGroup.NewGauge("responses"),
-		endOfStream:                   metricGroup.NewGauge("eos"),
-		endOfStreamRST:                metricGroup.NewGauge("rst"),
-		pathExceedsFrame:              metricGroup.NewGauge("path_exceeds_frame"),
-		exceedingMaxInterestingFrames: metricGroup.NewGauge("exceeding_max_interesting_frames"),
-		exceedingMaxFramesToFilter:    metricGroup.NewGauge("exceeding_max_frames_to_filter")}
+		http2requests:                 metricGroup.NewCounter("requests"),
+		http2responses:                metricGroup.NewCounter("responses"),
+		endOfStream:                   metricGroup.NewCounter("eos"),
+		endOfStreamRST:                metricGroup.NewCounter("rst"),
+		pathExceedsFrame:              metricGroup.NewCounter("path_exceeds_frame"),
+		exceedingMaxInterestingFrames: metricGroup.NewCounter("exceeding_max_interesting_frames"),
+		exceedingMaxFramesToFilter:    metricGroup.NewCounter("exceeding_max_frames_to_filter")}
 	for bucketIndex := range http2KernelTel.pathSizeBucket {
-		http2KernelTel.pathSizeBucket[bucketIndex] = metricGroup.NewGauge("path_size_bucket_" + (strconv.Itoa(bucketIndex + 1)))
+		http2KernelTel.pathSizeBucket[bucketIndex] = metricGroup.NewCounter("path_size_bucket_" + (strconv.Itoa(bucketIndex + 1)))
 	}
 
 	return http2KernelTel
@@ -57,18 +60,45 @@ func newHTTP2KernelTelemetry() *kernelTelemetry {
 
 // update updates the kernel metrics with the given telemetry.
 func (t *kernelTelemetry) update(tel *HTTP2Telemetry) {
-	t.http2requests.Set(int64(tel.Request_seen))
-	t.http2responses.Set(int64(tel.Response_seen))
-	t.endOfStream.Set(int64(tel.End_of_stream))
-	t.endOfStreamRST.Set(int64(tel.End_of_stream_rst))
-	t.pathExceedsFrame.Set(int64(tel.Path_exceeds_frame))
-	t.exceedingMaxInterestingFrames.Set(int64(tel.Exceeding_max_interesting_frames))
-	t.exceedingMaxFramesToFilter.Set(int64(tel.Exceeding_max_frames_to_filter))
+	// We should only add the delta between the current eBPF map state and the last seen eBPF map state
+	telemetryDelta := tel.Sub(t.telemetryLastState)
+	t.http2requests.Add(int64(telemetryDelta.Request_seen))
+	t.http2responses.Add(int64(telemetryDelta.Response_seen))
+	t.endOfStream.Add(int64(telemetryDelta.End_of_stream))
+	t.endOfStreamRST.Add(int64(telemetryDelta.End_of_stream_rst))
+	t.pathExceedsFrame.Add(int64(telemetryDelta.Path_exceeds_frame))
+	t.exceedingMaxInterestingFrames.Add(int64(telemetryDelta.Exceeding_max_interesting_frames))
+	t.exceedingMaxFramesToFilter.Add(int64(telemetryDelta.Exceeding_max_frames_to_filter))
 	for bucketIndex := range t.pathSizeBucket {
-		t.pathSizeBucket[bucketIndex].Set(int64(tel.Path_size_bucket[bucketIndex]))
+		t.pathSizeBucket[bucketIndex].Add(int64(telemetryDelta.Path_size_bucket[bucketIndex]))
 	}
+	// Create a deep copy of the 'tel' parameter to prevent changes from the outer scope affecting the last state
+	t.telemetryLastState = *tel
 }
 
 func (t *kernelTelemetry) Log() {
 	log.Debugf("http2 kernel telemetry summary: %s", t.metricGroup.Summary())
+}
+
+func (t *HTTP2Telemetry) Sub(other HTTP2Telemetry) *HTTP2Telemetry {
+	return &HTTP2Telemetry{
+		Request_seen:                     t.Request_seen - other.Request_seen,
+		Response_seen:                    t.Response_seen - other.Response_seen,
+		End_of_stream:                    t.End_of_stream - other.End_of_stream,
+		End_of_stream_rst:                t.End_of_stream_rst - other.End_of_stream_rst,
+		Path_exceeds_frame:               t.Path_exceeds_frame - other.Path_exceeds_frame,
+		Exceeding_max_interesting_frames: t.Exceeding_max_interesting_frames - other.Exceeding_max_interesting_frames,
+		Exceeding_max_frames_to_filter:   t.Exceeding_max_frames_to_filter - other.Exceeding_max_frames_to_filter,
+		Path_size_bucket:                 computeDifferences(t.Path_size_bucket, other.Path_size_bucket),
+	}
+}
+
+func computeDifferences(arr1, arr2 [8]uint64) [8]uint64 {
+	var result [8]uint64
+
+	for i := 0; i < 8; i++ {
+		result[i] = arr1[i] - arr2[i]
+	}
+
+	return result
 }

--- a/pkg/network/protocols/http2/telemetry.go
+++ b/pkg/network/protocols/http2/telemetry.go
@@ -19,21 +19,21 @@ type kernelTelemetry struct {
 	metricGroup *libtelemetry.MetricGroup
 
 	// http2requests Count of HTTP/2 requests seen
-	http2requests *libtelemetry.Counter
+	http2requests *libtelemetry.Gauge
 	// http2responses Count of HTTP/2 responses seen
-	http2responses *libtelemetry.Counter
+	http2responses *libtelemetry.Gauge
 	// endOfStream Count of END_OF_STREAM flags seen
-	endOfStream *libtelemetry.Counter
+	endOfStream *libtelemetry.Gauge
 	// endOfStreamRST Count of RST flags seen
-	endOfStreamRST *libtelemetry.Counter
+	endOfStreamRST *libtelemetry.Gauge
 	// pathSizeBucket Count of path sizes divided into buckets.
-	pathSizeBucket [http2PathBuckets + 1]*libtelemetry.Counter
+	pathSizeBucket [http2PathBuckets + 1]*libtelemetry.Gauge
 	// pathExceedsFrame Count of times we couldn't retrieve the path due to reaching the end of the frame.
-	pathExceedsFrame *libtelemetry.Counter
+	pathExceedsFrame *libtelemetry.Gauge
 	// exceedingMaxInterestingFrames Count of times we reached the max number of frames per iteration.
-	exceedingMaxInterestingFrames *libtelemetry.Counter
+	exceedingMaxInterestingFrames *libtelemetry.Gauge
 	// exceedingMaxFramesToFilter Count of times we have left with more frames to filter than the max number of frames to filter.
-	exceedingMaxFramesToFilter *libtelemetry.Counter
+	exceedingMaxFramesToFilter *libtelemetry.Gauge
 }
 
 // newHTTP2KernelTelemetry hold HTTP/2 kernel metrics.
@@ -41,15 +41,15 @@ func newHTTP2KernelTelemetry() *kernelTelemetry {
 	metricGroup := libtelemetry.NewMetricGroup("usm.http2", libtelemetry.OptPrometheus)
 	http2KernelTel := &kernelTelemetry{
 		metricGroup:                   metricGroup,
-		http2requests:                 metricGroup.NewCounter("requests"),
-		http2responses:                metricGroup.NewCounter("responses"),
-		endOfStream:                   metricGroup.NewCounter("eos"),
-		endOfStreamRST:                metricGroup.NewCounter("rst"),
-		pathExceedsFrame:              metricGroup.NewCounter("path_exceeds_frame"),
-		exceedingMaxInterestingFrames: metricGroup.NewCounter("exceeding_max_interesting_frames"),
-		exceedingMaxFramesToFilter:    metricGroup.NewCounter("exceeding_max_frames_to_filter")}
+		http2requests:                 metricGroup.NewGauge("requests"),
+		http2responses:                metricGroup.NewGauge("responses"),
+		endOfStream:                   metricGroup.NewGauge("eos"),
+		endOfStreamRST:                metricGroup.NewGauge("rst"),
+		pathExceedsFrame:              metricGroup.NewGauge("path_exceeds_frame"),
+		exceedingMaxInterestingFrames: metricGroup.NewGauge("exceeding_max_interesting_frames"),
+		exceedingMaxFramesToFilter:    metricGroup.NewGauge("exceeding_max_frames_to_filter")}
 	for bucketIndex := range http2KernelTel.pathSizeBucket {
-		http2KernelTel.pathSizeBucket[bucketIndex] = metricGroup.NewCounter("path_size_bucket_" + (strconv.Itoa(bucketIndex + 1)))
+		http2KernelTel.pathSizeBucket[bucketIndex] = metricGroup.NewGauge("path_size_bucket_" + (strconv.Itoa(bucketIndex + 1)))
 	}
 
 	return http2KernelTel
@@ -57,15 +57,15 @@ func newHTTP2KernelTelemetry() *kernelTelemetry {
 
 // update updates the kernel metrics with the given telemetry.
 func (t *kernelTelemetry) update(tel *HTTP2Telemetry) {
-	t.http2requests.UpdateCounterWithDifference(int64(tel.Request_seen))
-	t.http2responses.UpdateCounterWithDifference(int64(tel.Response_seen))
-	t.endOfStream.UpdateCounterWithDifference(int64(tel.End_of_stream))
-	t.endOfStreamRST.UpdateCounterWithDifference(int64(tel.End_of_stream_rst))
-	t.pathExceedsFrame.UpdateCounterWithDifference(int64(tel.Path_exceeds_frame))
-	t.exceedingMaxInterestingFrames.UpdateCounterWithDifference(int64(tel.Exceeding_max_interesting_frames))
-	t.exceedingMaxFramesToFilter.UpdateCounterWithDifference(int64(tel.Exceeding_max_frames_to_filter))
+	t.http2requests.Set(int64(tel.Request_seen))
+	t.http2responses.Set(int64(tel.Response_seen))
+	t.endOfStream.Set(int64(tel.End_of_stream))
+	t.endOfStreamRST.Set(int64(tel.End_of_stream_rst))
+	t.pathExceedsFrame.Set(int64(tel.Path_exceeds_frame))
+	t.exceedingMaxInterestingFrames.Set(int64(tel.Exceeding_max_interesting_frames))
+	t.exceedingMaxFramesToFilter.Set(int64(tel.Exceeding_max_frames_to_filter))
 	for bucketIndex := range t.pathSizeBucket {
-		t.pathSizeBucket[bucketIndex].UpdateCounterWithDifference(int64(tel.Path_size_bucket[bucketIndex]))
+		t.pathSizeBucket[bucketIndex].Set(int64(tel.Path_size_bucket[bucketIndex]))
 	}
 }
 

--- a/pkg/network/protocols/http2/telemetry_test.go
+++ b/pkg/network/protocols/http2/telemetry_test.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package http2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKernelTelemetryUpdate(t *testing.T) {
+	kTelemetry := newHTTP2KernelTelemetry()
+
+	// Populating values to simulate the eBPF map's HTTP2 telemetry
+	http2Telemetry := HTTP2Telemetry{
+		Request_seen:                     5,
+		Response_seen:                    5,
+		End_of_stream:                    10,
+		End_of_stream_rst:                11,
+		Path_exceeds_frame:               20,
+		Exceeding_max_interesting_frames: 30,
+		Exceeding_max_frames_to_filter:   40,
+		Path_size_bucket:                 [8]uint64{1, 2, 3, 4, 5, 6, 7, 8},
+	}
+	kTelemetry.update(&HTTP2Telemetry{
+		Request_seen:                     5,
+		Response_seen:                    5,
+		End_of_stream:                    10,
+		End_of_stream_rst:                11,
+		Path_exceeds_frame:               20,
+		Exceeding_max_interesting_frames: 30,
+		Exceeding_max_frames_to_filter:   40,
+		Path_size_bucket:                 [8]uint64{1, 2, 3, 4, 5, 6, 7, 8},
+	})
+	assertTelemetryEquality(t, &http2Telemetry, kTelemetry)
+
+	// Increasing the values to simulate more data coming from the eBPF map's HTTP2 telemetry
+	newHTTP2Telemetry := HTTP2Telemetry{
+		Request_seen:                     10,
+		Response_seen:                    10,
+		End_of_stream:                    11,
+		End_of_stream_rst:                18,
+		Path_exceeds_frame:               26,
+		Exceeding_max_interesting_frames: 32,
+		Exceeding_max_frames_to_filter:   45,
+		Path_size_bucket:                 [8]uint64{2, 3, 4, 5, 6, 7, 8, 9},
+	}
+	kTelemetry.update(&newHTTP2Telemetry)
+	assertTelemetryEquality(t, &newHTTP2Telemetry, kTelemetry)
+}
+
+func assertTelemetryEquality(t *testing.T, http2Telemetry *HTTP2Telemetry, kTelemetry *kernelTelemetry) {
+	assert.Equal(t, http2Telemetry.Request_seen, uint64(kTelemetry.http2requests.Get()))
+	assert.Equal(t, http2Telemetry.Response_seen, uint64(kTelemetry.http2responses.Get()))
+	assert.Equal(t, http2Telemetry.End_of_stream, uint64(kTelemetry.endOfStream.Get()))
+	assert.Equal(t, http2Telemetry.End_of_stream_rst, uint64(kTelemetry.endOfStreamRST.Get()))
+	assert.Equal(t, http2Telemetry.Path_exceeds_frame, uint64(kTelemetry.pathExceedsFrame.Get()))
+	assert.Equal(t, http2Telemetry.Exceeding_max_interesting_frames, uint64(kTelemetry.exceedingMaxInterestingFrames.Get()))
+	assert.Equal(t, http2Telemetry.Exceeding_max_frames_to_filter, uint64(kTelemetry.exceedingMaxFramesToFilter.Get()))
+	for i, bucket := range kTelemetry.pathSizeBucket {
+		assert.Equal(t, http2Telemetry.Path_size_bucket[i], uint64(bucket.Get()))
+	}
+}

--- a/pkg/network/protocols/http2/telemetry_test.go
+++ b/pkg/network/protocols/http2/telemetry_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestKernelTelemetryUpdate(t *testing.T) {
-	kTelemetry := newHTTP2KernelTelemetry()
+	kernelTelemetryGroup := newHTTP2KernelTelemetry()
 
 	// Populating values to simulate the eBPF map's HTTP2 telemetry
 	http2Telemetry := HTTP2Telemetry{
@@ -27,7 +27,7 @@ func TestKernelTelemetryUpdate(t *testing.T) {
 		Exceeding_max_frames_to_filter:   40,
 		Path_size_bucket:                 [8]uint64{1, 2, 3, 4, 5, 6, 7, 8},
 	}
-	kTelemetry.update(&HTTP2Telemetry{
+	kernelTelemetryGroup.update(&HTTP2Telemetry{
 		Request_seen:                     5,
 		Response_seen:                    5,
 		End_of_stream:                    10,
@@ -37,7 +37,7 @@ func TestKernelTelemetryUpdate(t *testing.T) {
 		Exceeding_max_frames_to_filter:   40,
 		Path_size_bucket:                 [8]uint64{1, 2, 3, 4, 5, 6, 7, 8},
 	})
-	assertTelemetryEquality(t, &http2Telemetry, kTelemetry)
+	assertTelemetryEquality(t, &http2Telemetry, kernelTelemetryGroup)
 
 	// Increasing the values to simulate more data coming from the eBPF map's HTTP2 telemetry
 	newHTTP2Telemetry := HTTP2Telemetry{
@@ -50,19 +50,19 @@ func TestKernelTelemetryUpdate(t *testing.T) {
 		Exceeding_max_frames_to_filter:   45,
 		Path_size_bucket:                 [8]uint64{2, 3, 4, 5, 6, 7, 8, 9},
 	}
-	kTelemetry.update(&newHTTP2Telemetry)
-	assertTelemetryEquality(t, &newHTTP2Telemetry, kTelemetry)
+	kernelTelemetryGroup.update(&newHTTP2Telemetry)
+	assertTelemetryEquality(t, &newHTTP2Telemetry, kernelTelemetryGroup)
 }
 
-func assertTelemetryEquality(t *testing.T, http2Telemetry *HTTP2Telemetry, kTelemetry *kernelTelemetry) {
-	assert.Equal(t, http2Telemetry.Request_seen, uint64(kTelemetry.http2requests.Get()))
-	assert.Equal(t, http2Telemetry.Response_seen, uint64(kTelemetry.http2responses.Get()))
-	assert.Equal(t, http2Telemetry.End_of_stream, uint64(kTelemetry.endOfStream.Get()))
-	assert.Equal(t, http2Telemetry.End_of_stream_rst, uint64(kTelemetry.endOfStreamRST.Get()))
-	assert.Equal(t, http2Telemetry.Path_exceeds_frame, uint64(kTelemetry.pathExceedsFrame.Get()))
-	assert.Equal(t, http2Telemetry.Exceeding_max_interesting_frames, uint64(kTelemetry.exceedingMaxInterestingFrames.Get()))
-	assert.Equal(t, http2Telemetry.Exceeding_max_frames_to_filter, uint64(kTelemetry.exceedingMaxFramesToFilter.Get()))
-	for i, bucket := range kTelemetry.pathSizeBucket {
+func assertTelemetryEquality(t *testing.T, http2Telemetry *HTTP2Telemetry, kernelTelemetryGroup *kernelTelemetry) {
+	assert.Equal(t, http2Telemetry.Request_seen, uint64(kernelTelemetryGroup.http2requests.Get()))
+	assert.Equal(t, http2Telemetry.Response_seen, uint64(kernelTelemetryGroup.http2responses.Get()))
+	assert.Equal(t, http2Telemetry.End_of_stream, uint64(kernelTelemetryGroup.endOfStream.Get()))
+	assert.Equal(t, http2Telemetry.End_of_stream_rst, uint64(kernelTelemetryGroup.endOfStreamRST.Get()))
+	assert.Equal(t, http2Telemetry.Path_exceeds_frame, uint64(kernelTelemetryGroup.pathExceedsFrame.Get()))
+	assert.Equal(t, http2Telemetry.Exceeding_max_interesting_frames, uint64(kernelTelemetryGroup.exceedingMaxInterestingFrames.Get()))
+	assert.Equal(t, http2Telemetry.Exceeding_max_frames_to_filter, uint64(kernelTelemetryGroup.exceedingMaxFramesToFilter.Get()))
+	for i, bucket := range kernelTelemetryGroup.pathSizeBucket {
 		assert.Equal(t, http2Telemetry.Path_size_bucket[i], uint64(bucket.Get()))
 	}
 }

--- a/pkg/network/protocols/telemetry/metric.go
+++ b/pkg/network/protocols/telemetry/metric.go
@@ -29,7 +29,7 @@ func NewCounter(name string, tagsAndOptions ...string) *Counter {
 // Add value atomically
 func (c *Counter) Add(v int64) {
 	if v < 0 {
-		// Counters are always monotonic so we don't allow negative numbers. We
+		// Counters are always monotonic, so we don't allow negative numbers. We
 		// could enforce this by using an unsigned type, but that would make the
 		// API a little bit more cumbersome to use.
 		return
@@ -40,8 +40,8 @@ func (c *Counter) Add(v int64) {
 
 func (c *Counter) UpdateCounterWithDifference(v int64) {
 	differenceValue := v - c.Get()
-	if v < 0 || (differenceValue <= 0) {
-		// Counters are always monotonic so we don't allow negative numbers. We
+	if v < 0 || differenceValue <= 0 {
+		// Counters are always monotonic, so we don't allow negative numbers. We
 		// could enforce this by using an unsigned type, but that would make the
 		// API a little bit more cumbersome to use.
 		return

--- a/pkg/network/protocols/telemetry/metric.go
+++ b/pkg/network/protocols/telemetry/metric.go
@@ -29,7 +29,7 @@ func NewCounter(name string, tagsAndOptions ...string) *Counter {
 // Add value atomically
 func (c *Counter) Add(v int64) {
 	if v < 0 {
-		// Counters are always monotonic, so we don't allow negative numbers. We
+		// Counters are always monotonic so we don't allow negative numbers. We
 		// could enforce this by using an unsigned type, but that would make the
 		// API a little bit more cumbersome to use.
 		return

--- a/pkg/network/protocols/telemetry/metric.go
+++ b/pkg/network/protocols/telemetry/metric.go
@@ -38,18 +38,6 @@ func (c *Counter) Add(v int64) {
 	c.value.Add(v)
 }
 
-func (c *Counter) UpdateCounterWithDifference(v int64) {
-	differenceValue := v - c.Get()
-	if v < 0 || differenceValue <= 0 {
-		// Counters are always monotonic, so we don't allow negative numbers. We
-		// could enforce this by using an unsigned type, but that would make the
-		// API a little bit more cumbersome to use.
-		return
-	}
-
-	c.value.Add(differenceValue)
-}
-
 func (c *Counter) base() *metricBase {
 	return c.metricBase
 }

--- a/pkg/network/protocols/telemetry/metric.go
+++ b/pkg/network/protocols/telemetry/metric.go
@@ -38,6 +38,18 @@ func (c *Counter) Add(v int64) {
 	c.value.Add(v)
 }
 
+func (c *Counter) UpdateCounterWithDifference(v int64) {
+	differenceValue := v - c.Get()
+	if v < 0 || (differenceValue <= 0) {
+		// Counters are always monotonic so we don't allow negative numbers. We
+		// could enforce this by using an unsigned type, but that would make the
+		// API a little bit more cumbersome to use.
+		return
+	}
+
+	c.value.Add(differenceValue)
+}
+
 func (c *Counter) base() *metricBase {
 	return c.metricBase
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR addresses the issue with updating HTTP2 Kernel telemetry in user mode. Previously, we consistently added values from the eBPF map, leading to overcounting in the metrics. With this modification, we maintain the correct state of the map in user mode.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
I can't use the `Gauge` type as it behaves differently from the `Counter` type.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
