### PR TITLE
[test/new-e2e/ecs] Add Fargate tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,7 +181,7 @@ variables:
   # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: d3e7838354a5
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: f69f46f8ca43
   DATADOG_AGENT_BUILDERS: v22276738-b36b132
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -24,7 +24,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240117145649-d3e7838354a5
+	github.com/DataDog/test-infra-definitions v0.0.0-20240118142854-f69f46f8ca43
 	github.com/aws/aws-sdk-go-v2 v1.24.0
 	github.com/aws/aws-sdk-go-v2/config v1.25.10
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -14,8 +14,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20240117145649-d3e7838354a5 h1:i7DhVXrF94e4zqfRKc0VJRCKfMZoY3MYOUuRD/fqyo0=
-github.com/DataDog/test-infra-definitions v0.0.0-20240117145649-d3e7838354a5/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
+github.com/DataDog/test-infra-definitions v0.0.0-20240118142854-f69f46f8ca43 h1:OwRfZxSAXBYSanYXcehZBkHXNaVxAfo5IivJ1F1O4Ks=
+github.com/DataDog/test-infra-definitions v0.0.0-20240118142854-f69f46f8ca43/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -174,12 +174,13 @@ func (suite *ecsSuite) Test00UpAndRunning() {
 	})
 }
 
-func (suite *ecsSuite) TestNginx() {
+func (suite *ecsSuite) TestNginxECS() {
 	// `nginx` check is configured via docker labels
 	// Test it is properly scheduled
 	suite.testMetric(&testMetricArgs{
 		Filter: testMetricFilterArgs{
 			Name: "nginx.net.request_per_s",
+			Tags: []string{"ecs_launch_type:ec2"},
 		},
 		Expect: testMetricExpectArgs{
 			Tags: &[]string{
@@ -189,6 +190,7 @@ func (suite *ecsSuite) TestNginx() {
 				`^docker_image:ghcr.io/datadog/apps-nginx-server:main$`,
 				`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
 				`^ecs_container_name:nginx$`,
+				`^ecs_launch_type:ec2$`,
 				`^git.commit.sha:`,                                                       // org.opencontainers.image.revision docker image label
 				`^git.repository_url:https://github.com/DataDog/test-infra-definitions$`, // org.opencontainers.image.source   docker image label
 				`^image_id:sha256:`,
@@ -207,6 +209,7 @@ func (suite *ecsSuite) TestNginx() {
 	suite.testLog(&testLogArgs{
 		Filter: testLogFilterArgs{
 			Service: "apps-nginx-server",
+			Tags:    []string{"ecs_launch_type:ec2"},
 		},
 		Expect: testLogExpectArgs{
 			Tags: &[]string{
@@ -216,6 +219,7 @@ func (suite *ecsSuite) TestNginx() {
 				`^docker_image:ghcr.io/datadog/apps-nginx-server:main$`,
 				`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
 				`^ecs_container_name:nginx$`,
+				`^ecs_launch_type:ec2$`,
 				`^git.commit.sha:`,                                                       // org.opencontainers.image.revision docker image label
 				`^git.repository_url:https://github.com/DataDog/test-infra-definitions$`, // org.opencontainers.image.source   docker image label
 				`^image_id:sha256:`,
@@ -232,12 +236,13 @@ func (suite *ecsSuite) TestNginx() {
 	})
 }
 
-func (suite *ecsSuite) TestRedis() {
+func (suite *ecsSuite) TestRedisECS() {
 	// `redis` check is auto-configured due to image name
 	// Test it is properly scheduled
 	suite.testMetric(&testMetricArgs{
 		Filter: testMetricFilterArgs{
 			Name: "redis.net.instantaneous_ops_per_sec",
+			Tags: []string{"ecs_launch_type:ec2"},
 		},
 		Expect: testMetricExpectArgs{
 			Tags: &[]string{
@@ -247,6 +252,7 @@ func (suite *ecsSuite) TestRedis() {
 				`^docker_image:redis:latest$`,
 				`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
 				`^ecs_container_name:redis$`,
+				`^ecs_launch_type:ec2$`,
 				`^image_id:sha256:`,
 				`^image_name:redis$`,
 				`^image_tag:latest$`,
@@ -265,6 +271,7 @@ func (suite *ecsSuite) TestRedis() {
 	suite.testLog(&testLogArgs{
 		Filter: testLogFilterArgs{
 			Service: "redis",
+			Tags:    []string{"ecs_launch_type:ec2"},
 		},
 		Expect: testLogExpectArgs{
 			Tags: &[]string{
@@ -274,6 +281,7 @@ func (suite *ecsSuite) TestRedis() {
 				`^docker_image:redis:latest$`,
 				`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
 				`^ecs_container_name:redis$`,
+				`^ecs_launch_type:ec2$`,
 				`^image_id:sha256:`,
 				`^image_name:redis$`,
 				`^image_tag:latest$`,
@@ -284,6 +292,74 @@ func (suite *ecsSuite) TestRedis() {
 				`^task_version:[[:digit:]]+$`,
 			},
 			Message: `Accepted`,
+		},
+	})
+}
+
+func (suite *ecsSuite) TestNginxFargate() {
+	// `nginx` check is configured via docker labels
+	// Test it is properly scheduled
+	suite.testMetric(&testMetricArgs{
+		Filter: testMetricFilterArgs{
+			Name: "nginx.net.request_per_s",
+			Tags: []string{"ecs_launch_type:fargate"},
+		},
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{
+				`^availability_zone:`,
+				`^availability-zone:`,
+				`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
+				`^container_id:`,
+				`^container_name:nginx$`,
+				`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
+				`^ecs_container_name:nginx$`,
+				`^ecs_launch_type:fargate$`,
+				`^image_id:sha256:`,
+				`^image_name:ghcr.io/datadog/apps-nginx-server$`,
+				`^image_tag:main$`,
+				`^nginx_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
+				`^region:us-east-1$`,
+				`^short_image:apps-nginx-server$`,
+				`^task_arn:`,
+				`^task_family:.*-nginx-fg$`,
+				`^task_name:.*-nginx-fg$`,
+				`^task_version:[[:digit:]]+$`,
+			},
+		},
+	})
+}
+
+func (suite *ecsSuite) TestRedisFargate() {
+	// `redis` check is auto-configured due to image name
+	// Test it is properly scheduled
+	suite.testMetric(&testMetricArgs{
+		Filter: testMetricFilterArgs{
+			Name: "redis.net.instantaneous_ops_per_sec",
+			Tags: []string{"ecs_launch_type:fargate"},
+		},
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{
+				`^availability_zone:`,
+				`^availability-zone:`,
+				`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
+				`^container_id:`,
+				`^container_name:redis$`,
+				`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
+				`^ecs_container_name:redis$`,
+				`^ecs_launch_type:fargate`,
+				`^image_id:sha256:`,
+				`^image_name:redis$`,
+				`^image_tag:latest$`,
+				`^redis_host:`,
+				`^redis_port:6379$`,
+				`^redis_role:master$`,
+				`^region:us-east-1$`,
+				`^short_image:redis$`,
+				`^task_arn:`,
+				`^task_family:.*-redis-fg$`,
+				`^task_name:.*-redis-fg*`,
+				`^task_version:[[:digit:]]+$`,
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add ECS Fargate E2E tests.

### Motivation

We want to do E2E tests of the agent to verify that's it's working as intended.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
