### PR TITLE
ignore ebpf check metrics for unknown modules

### DIFF
--- a/pkg/collector/corechecks/ebpf/ebpf.go
+++ b/pkg/collector/corechecks/ebpf/ebpf.go
@@ -103,6 +103,12 @@ func (m *EBPFCheck) Run() error {
 	totalMapMaxSize, totalMapRSS := uint64(0), uint64(0)
 	moduleTotalMapMaxSize, moduleTotalMapRSS := make(map[string]uint64), make(map[string]uint64)
 	reportBaseMap := func(mapStats ebpfcheck.EBPFMapStats) {
+		totalMapMaxSize += mapStats.MaxSize
+		totalMapRSS += mapStats.RSS
+		if mapStats.Module == "unknown" {
+			return
+		}
+
 		tags := []string{
 			"map_name:" + mapStats.Name,
 			"map_type:" + mapStats.Type.String(),
@@ -113,8 +119,6 @@ func (m *EBPFCheck) Run() error {
 		if mapStats.RSS > 0 {
 			sender.Gauge("ebpf.maps.memory_rss", float64(mapStats.RSS), "", tags)
 		}
-		totalMapMaxSize += mapStats.MaxSize
-		totalMapRSS += mapStats.RSS
 		moduleTotalMapMaxSize[mapStats.Module] += mapStats.MaxSize
 		moduleTotalMapRSS[mapStats.Module] += mapStats.RSS
 
@@ -132,9 +136,15 @@ func (m *EBPFCheck) Run() error {
 		sender.Gauge("ebpf.maps.memory_rss_total", float64(totalMapRSS), "", nil)
 	}
 	for mod, max := range moduleTotalMapMaxSize {
+		if mod == "unknown" {
+			continue
+		}
 		sender.Gauge("ebpf.maps.memory_max_permodule_total", float64(max), "", []string{"module:" + mod})
 	}
 	for mod, rss := range moduleTotalMapRSS {
+		if mod == "unknown" {
+			continue
+		}
 		sender.Gauge("ebpf.maps.memory_rss_permodule_total", float64(rss), "", []string{"module:" + mod})
 	}
 
@@ -143,6 +153,11 @@ func (m *EBPFCheck) Run() error {
 	moduleTotalXlatedLen := make(map[string]uint64)
 	moduleTotalVerifiedCount := make(map[string]uint64)
 	for _, progInfo := range stats.Programs {
+		totalProgRSS += progInfo.RSS
+		if progInfo.Module == "unknown" {
+			continue
+		}
+
 		tags := []string{
 			"program_name:" + progInfo.Name,
 			"program_type:" + progInfo.Type.String(),
@@ -167,7 +182,6 @@ func (m *EBPFCheck) Run() error {
 				debuglogs = append(debuglogs, fmt.Sprintf("%s=%.0f", k, v))
 			}
 		}
-		totalProgRSS += progInfo.RSS
 		moduleTotalProgRSS[progInfo.Module] += progInfo.RSS
 		moduleTotalXlatedLen[progInfo.Module] += uint64(progInfo.XlatedProgLen)
 		moduleTotalVerifiedCount[progInfo.Module] += uint64(progInfo.VerifiedInsns)
@@ -195,14 +209,23 @@ func (m *EBPFCheck) Run() error {
 		sender.Gauge("ebpf.programs.memory_rss_total", float64(totalProgRSS), "", nil)
 	}
 	for mod, rss := range moduleTotalProgRSS {
+		if mod == "unknown" {
+			continue
+		}
 		sender.Gauge("ebpf.programs.memory_rss_permodule_total", float64(rss), "", []string{"module:" + mod})
 	}
 	for mod, xlatedLen := range moduleTotalXlatedLen {
+		if mod == "unknown" {
+			continue
+		}
 		if xlatedLen > 0 {
 			sender.Gauge("ebpf.programs.xlated_instruction_len_permodule_total", float64(xlatedLen), "", []string{"module:" + mod})
 		}
 	}
 	for mod, verifiedCount := range moduleTotalVerifiedCount {
+		if mod == "unknown" {
+			continue
+		}
 		if verifiedCount > 0 {
 			sender.Gauge("ebpf.programs.verified_instruction_count_permodule_total", float64(verifiedCount), "", []string{"module:" + mod})
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Ignores metrics for programs/maps coming from `unknown` module.

### Motivation

The metric cardinality is too high.

### Additional Notes

The totals still include values from unknown modules.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
