### PR TITLE
usm: http2: tests: Improve gRPC TLS test managment

### DIFF
--- a/pkg/network/tracer/testutil/grpc/builder.go
+++ b/pkg/network/tracer/testutil/grpc/builder.go
@@ -32,7 +32,12 @@ func NewGRPCTLSServer(t *testing.T, addr string, useTLS bool) (*exec.Cmd, contex
 	c, _, err := nettestutil.StartCommandCtx(cancelCtx, commandLine)
 
 	require.NoError(t, err)
-	return c, cancel
+	return c, func() {
+		cancel()
+		if c.Process != nil {
+			_, _ = c.Process.Wait()
+		}
+	}
 }
 
 const (

--- a/pkg/network/tracer/usm_grpc_monitor_test.go
+++ b/pkg/network/tracer/usm_grpc_monitor_test.go
@@ -121,7 +121,6 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 
 	srv, cancel := grpc.NewGRPCTLSServer(t, srvAddr, s.isTLS)
 	t.Cleanup(cancel)
-	srv.Run()
 	defaultCtx := context.Background()
 
 	cfg := s.getConfig()
@@ -430,7 +429,6 @@ func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {
 
 	srv, cancel := grpc.NewGRPCTLSServer(t, srvAddr, s.isTLS)
 	t.Cleanup(cancel)
-	srv.Run()
 	defaultCtx := context.Background()
 
 	// Random string generation is an heavy operation, and it's proportional for the length (30MB)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Avoiding calling 'Run' method on the process as we already call it in 'StartCommandCtx', also, the cancel function is blocking until the process is terminated

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Avoiding flakiness in the CI, as the server being launched multiple times, and without proper cleanup we can fail with "address already in use"

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
