### PR TITLE
Fix logs agent flaky file tailer tests

### DIFF
--- a/pkg/logs/tailers/file/tailer_nix.go
+++ b/pkg/logs/tailers/file/tailer_nix.go
@@ -55,7 +55,7 @@ func (t *Tailer) read() (int, error) {
 	if n == 0 {
 		return 0, nil
 	}
-	t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
 	t.lastReadOffset.Add(int64(n))
+	t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
 	return n, nil
 }

--- a/pkg/logs/tailers/file/tailer_windows.go
+++ b/pkg/logs/tailers/file/tailer_windows.go
@@ -92,6 +92,9 @@ func (t *Tailer) readAvailable() (int, error) {
 			return bytes, err
 		}
 
+		// record these bytes as having been read
+		t.lastReadOffset.Add(int64(n))
+
 		// First, try to send the data to the decoder, but only wait for
 		// windowsOpenFileTimeout.  This short-term blocking send allows this
 		// component to hold a file open over any short-term blockages in the
@@ -113,9 +116,6 @@ func (t *Tailer) readAvailable() (int, error) {
 			// blocking send to the decoder
 			t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
 		}
-
-		// record these bytes as having been read
-		t.lastReadOffset.Add(int64(n))
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes some very rare failures in our CI tests, that seemingly randomly affect file launcher/tailer tests. 

The fix is to update `tailer.lastReadOffset` before we write the bytes to the pipeline channel instead of after. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix CI

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

To understand whats going on there, let's take a look at a part of [`TestLauncherScanWithLogRotationCopyTruncate()`](https://github.com/DataDog/datadog-agent/blob/ea902644e2ea3b2e31c54e88049a188fd23b2e2d/pkg/logs/launchers/file/launcher_test.go#L146)

with comments added to give context:

```go
tailer, _ = s.tailers.Get(getScanKey(suite.testPath, suite.source)) // Create a new tailer
_, err = suite.testFile.WriteString("hello world\n") // write 12 bytes to the file
suite.Nil(err)
msg = <-suite.outputChan // Ask the logs pipeline for what it read and assert that it is correct
suite.Equal("hello world", string(msg.GetContent()))

// At this point, what is the value of `tailer.lastReadOffset`?
```

The agent assumed that `tailer.lastReadOffset` would be correctly and atomically updated to reflect the number of bytes read. However, since the tailer reads a file on it's own goroutine, if the test is too fast, or the pipeline is to slow (blocked). It is possible to receive the bytes in `msg = <-suite.outputChan` before the byte count is updated in the tailer thread. 

A few lines later in our tests we truncate and re-write to the file to simulate a rotation:
```go
// Simulate rotation
suite.Nil(suite.testFile.Truncate(0))
_, err = suite.testFile.Seek(0, 0)
suite.Nil(err)
suite.Nil(suite.testFile.Sync())
_, err = suite.testFile.WriteString("third\n")
suite.Nil(err)
suite.Nil(suite.testFile.Sync())

// Make sure the agent detects it
s.scan() 

// Check to ensure we got a new tailer instance and detected the file rotation
newTailer, _ = s.tailers.Get(getScanKey(suite.testPath, suite.source))
suite.True(tailer != newTailer) // Test would fail here because we missed the rotation
```

If the above condition occurs where the byte count is not yet updated by the tailer thread we will fail to detect the rotation and the test will fail.

This could happen in a real agent. However I believe the worst possible outcome is simply missing the rotation until the next scan interval (10 seconds by default). However this PR should improve our test stability overall, and prevent future issues like this from happening. 


<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

This is very tricky to reproduce, so it's impossible to know if this is 100% fixed. So instead of QAing that the CI is fixed, please QA basic file rotation behavior for linux and windows to ensure there are no regressions with this fix. 


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
