### PR TITLE
logs: Correct `use_compression` default

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1161,8 +1161,8 @@ api_key:
   #
   # force_use_tcp: true
 
-  ## @param use_compression - boolean - optional - default: false
-  ## @env DD_LOGS_CONFIG_USE_COMPRESSION - boolean - optional - default: false
+  ## @param use_compression - boolean - optional - default: true
+  ## @env DD_LOGS_CONFIG_USE_COMPRESSION - boolean - optional - default: true
   ## This parameter is available when sending logs with HTTPS. If enabled, the Agent
   ## compresses logs before sending them.
   #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1582,17 +1582,17 @@ api_key:
 
   ## @param trace_buffer - integer - optional - default: 0
   ## @env DD_APM_TRACE_BUFFER - integer - optional - default: 0
-  ## 
+  ##
   ## WARNING: Do not use this config. It is here for debugging and
   ## as a temporary fix in certain load scenarios. Setting this
   ## results in a performance deterioration and an increase in memory
   ## usage when the Trace Agent is under load. This config may be
   ## removed in a future version.
-  ## 
+  ##
   ## Specifies the number of trace payloads to buffer after decoding.
   ## Traces can be buffered when receiving traces faster than the
   ## processor can process them.
-  ## 
+  ##
   #
   # trace_buffer: 0
 
@@ -3915,8 +3915,8 @@ api_key:
 
     ## @param resource_attributes_as_tags - boolean - optional - default: false
     ## @env DD_OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS - boolean - optional - default: false
-    ## Set to true to add resource attributes of a metric to its metric tags. Please note that any of 
-    ## the subset of resource attributes in this list https://docs.datadoghq.com/opentelemetry/guide/semantic_mapping/ 
+    ## Set to true to add resource attributes of a metric to its metric tags. Please note that any of
+    ## the subset of resource attributes in this list https://docs.datadoghq.com/opentelemetry/guide/semantic_mapping/
     ## are converted to Datadog conventions and set to to metric tags whether this option is enabled or not.
     #
     # resource_attributes_as_tags: false


### PR DESCRIPTION
### What does this PR do?

Reflect the true default value of `logs.use_compression`, which is `true`.  Described my verification process in https://github.com/DataDog/datadog-agent/issues/21940. Fixes #21940.


### Motivation

I spent some time trying to tweak settings that turned out to be the way i wanted them by default.

### Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] ~Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.~
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] ~Changed code has automated tests for its functionality.~
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
