### PR TITLE
[metrics/system] Set cgroup init fail log level as `info`

### DIFF
--- a/pkg/util/containers/metrics/provider/provider.go
+++ b/pkg/util/containers/metrics/provider/provider.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
@@ -129,13 +128,6 @@ func newProvider() *GenericProvider {
 	provider := &GenericProvider{
 		cache:         NewCache(cacheGCInterval),
 		metaCollector: newMetaCollector(),
-	}
-	if env.IsServerless() {
-		// TODO: quick fix to unblock some Serverless test.
-		// Serverless doesn't rely on the provider collector,
-		// so we avoid running the provider.collectorsUpdatedCallback.
-		// a proper fix should be to not register the collector if we are in the serveless agent.
-		return provider
 	}
 	registry.run(context.TODO(), provider.cache, provider.collectorsUpdatedCallback)
 

--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -67,7 +67,7 @@ func newSystemCollector(cache *provider.Cache) (provider.CollectorMetadata, erro
 	)
 	if err != nil {
 		// Cgroup provider is pretty static. Except not having required mounts, it should always work.
-		log.Errorf("Unable to initialize cgroup provider (cgroups not mounted?), err: %v", err)
+		log.Infof("Unable to initialize cgroup provider (cgroups not mounted?), err: %v", err)
 		return collectorMetadata, provider.ErrPermaFail
 	}
 
@@ -78,7 +78,7 @@ func newSystemCollector(cache *provider.Cache) (provider.CollectorMetadata, erro
 	)
 	if err != nil {
 		// Cgroup provider is pretty static. Except not having required mounts, it should always work.
-		log.Errorf("Unable to initialize self cgroup reader, err: %v", err)
+		log.Infof("Unable to initialize self cgroup reader, err: %v", err)
 		return collectorMetadata, provider.ErrPermaFail
 	}
 	systemCollector := &systemCollector{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Revert quickfix (https://github.com/DataDog/datadog-agent/pull/21902) and set cgroup init fail log level as `info`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We want to revert our quickfix and make set the log level to `info` for now.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check if the serverless unittests output a valid info log without failure.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
