### PR TITLE
[CWS] Close ebpfless gaps v3

### DIFF
--- a/pkg/security/probe/model_ebpfless.go
+++ b/pkg/security/probe/model_ebpfless.go
@@ -35,6 +35,8 @@ func NewEBPFLessModel() *model.Model {
 				!strings.HasPrefix(field, "rmdir.") &&
 				!strings.HasPrefix(field, "unlink.") &&
 				!strings.HasPrefix(field, "rename.") &&
+				!strings.HasPrefix(field, "mkdir.") &&
+				!strings.HasPrefix(field, "utimes.") &&
 				!strings.HasPrefix(field, "container.") {
 				return rules.ErrEventTypeNotEnabled
 			}

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -38,8 +38,6 @@ const (
 	SyscallTypeOpen
 	// SyscallTypeExit exit type
 	SyscallTypeExit
-	// SyscallTypeFcntl fcntl type
-	SyscallTypeFcntl
 	// SyscallTypeSetUID setuid/setreuid type
 	SyscallTypeSetUID
 	// SyscallTypeSetGID setgid/setregid type
@@ -56,6 +54,10 @@ const (
 	SyscallTypeRmdir
 	// SyscallTypeRename rename/renameat/renameat2 type
 	SyscallTypeRename
+	// SyscallTypeMkdir mkdir/mkdirat type
+	SyscallTypeMkdir
+	// SyscallTypeUtimes utime/utimes/utimensat/futimesat type
+	SyscallTypeUtimes
 )
 
 // ContainerContext defines a container context
@@ -167,6 +169,19 @@ type RenameSyscallMsg struct {
 	NewFile OpenSyscallMsg
 }
 
+// MkdirSyscallMsg defines a mkdir/mkdirat message
+type MkdirSyscallMsg struct {
+	Dir  OpenSyscallMsg
+	Mode uint32
+}
+
+// UtimesSyscallMsg defines a utime/utimes/utimensat/futimesat message
+type UtimesSyscallMsg struct {
+	File  OpenSyscallMsg
+	ATime uint64 // in nanoseconds
+	MTime uint64 // in nanoseconds
+}
+
 // SyscallMsg defines a syscall message
 type SyscallMsg struct {
 	Type      SyscallType
@@ -186,6 +201,8 @@ type SyscallMsg struct {
 	Unlink    *UnlinkSyscallMsg   `json:",omitempty"`
 	Rmdir     *RmdirSyscallMsg    `json:",omitempty"`
 	Rename    *RenameSyscallMsg   `json:",omitempty"`
+	Mkdir     *MkdirSyscallMsg    `json:",omitempty"`
+	Utimes    *UtimesSyscallMsg   `json:",omitempty"`
 
 	// internals
 	Dup   *DupSyscallFakeMsg   `json:",omitempty"`

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -15,9 +15,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -31,670 +29,26 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/native"
 )
 
-func fillProcessCwd(process *Process) error {
-	cwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", process.Pid))
-	if err != nil {
-		return err
-	}
-	process.Res.Cwd = cwd
-	return nil
+type syscallHandlerFunc func(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error
+
+type shouldSendFunc func(ret int64) bool
+
+type syscallID struct {
+	ID   int
+	Name string
 }
 
-func getFullPathFromFd(process *Process, filename string, fd int32) (string, error) {
-	if len(filename) > 0 && filename[0] != '/' {
-		if fd == unix.AT_FDCWD { // if use current dir, try to prefix it
-			if process.Res.Cwd != "" || fillProcessCwd(process) == nil {
-				filename = filepath.Join(process.Res.Cwd, filename)
-			} else {
-				return "", errors.New("fillProcessCwd failed")
-			}
-		} else { // if using another dir, prefix it, we should have it in cache
-			if path, exists := process.Res.Fd[fd]; exists {
-				filename = filepath.Join(path, filename)
-			} else {
-				return "", errors.New("process FD cache incomplete during path resolution")
-			}
-		}
-	}
-	return filename, nil
+type syscallHandler struct {
+	IDs        []syscallID        // IDs defines the list of syscall IDs related to this handler
+	Func       syscallHandlerFunc // Func defines the entrance handler for those syscalls, can be nil
+	ShouldSend shouldSendFunc     // ShouldSend checks if we should send the event regarding the syscall return value. If nil, acts as false
+	RetFunc    syscallHandlerFunc // RetFunc defines the return handler for those syscalls, can be nil
 }
 
-func getFullPathFromFilename(process *Process, filename string) (string, error) {
-	if filename[0] != '/' {
-		if process.Res.Cwd != "" || fillProcessCwd(process) == nil {
-			filename = filepath.Join(process.Res.Cwd, filename)
-		} else {
-			return "", errors.New("fillProcessCwd failed")
-		}
-	}
-	return filename, nil
-}
-
-func fillFileMetadata(filepath string, openMsg *ebpfless.OpenSyscallMsg, disableStats bool) error {
-	if disableStats || strings.HasPrefix(filepath, "memfd:") {
-		return nil
-	}
-
-	// NB: Here we use Lstat to not follow the link, because we don't do it yet globally.
-	//     Once we'll follow them, we may want to replace it by a Stat().
-	fileInfo, err := os.Lstat(filepath)
-	if err != nil {
-		return nil
-	}
-	stat := fileInfo.Sys().(*syscall.Stat_t)
-	openMsg.MTime = uint64(stat.Mtim.Nano())
-	openMsg.CTime = uint64(stat.Ctim.Nano())
-	openMsg.Credentials = &ebpfless.Credentials{
-		UID: stat.Uid,
-		GID: stat.Gid,
-	}
-	if openMsg.Mode == 0 { // here, mode can be already set by handler of open syscalls
-		openMsg.Mode = stat.Mode // useful for exec handlers
-	}
-	return nil
-}
-
-func handleOpenAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	fd := tracer.ReadArgInt32(regs, 0)
-
-	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
-	if err != nil {
-		return err
-	}
-
-	filename, err = getFullPathFromFd(process, filename, fd)
-	if err != nil {
-		return err
-	}
-
-	msg.Type = ebpfless.SyscallTypeOpen
-	msg.Open = &ebpfless.OpenSyscallMsg{
-		Filename: filename,
-		Flags:    uint32(tracer.ReadArgUint64(regs, 2)),
-		Mode:     uint32(tracer.ReadArgUint64(regs, 3)),
-	}
-
-	return fillFileMetadata(filename, msg.Open, disableStats)
-}
-
-func handleOpenAt2(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	fd := tracer.ReadArgInt32(regs, 0)
-
-	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
-	if err != nil {
-		return err
-	}
-
-	filename, err = getFullPathFromFd(process, filename, fd)
-	if err != nil {
-		return err
-	}
-
-	howData, err := tracer.ReadArgData(process.Pid, regs, 2, 16 /*sizeof uint64 + sizeof uint64*/) // flags, mode
-	if err != nil {
-		return err
-	}
-
-	msg.Type = ebpfless.SyscallTypeOpen
-	msg.Open = &ebpfless.OpenSyscallMsg{
-		Filename: filename,
-		Flags:    uint32(binary.NativeEndian.Uint64(howData[:8])),
-		Mode:     uint32(binary.NativeEndian.Uint64(howData[8:16])),
-	}
-
-	return fillFileMetadata(filename, msg.Open, disableStats)
-}
-
-func handleOpen(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
-	if err != nil {
-		return err
-	}
-
-	filename, err = getFullPathFromFilename(process, filename)
-	if err != nil {
-		return err
-	}
-
-	msg.Type = ebpfless.SyscallTypeOpen
-	msg.Open = &ebpfless.OpenSyscallMsg{
-		Filename: filename,
-		Flags:    uint32(tracer.ReadArgUint64(regs, 1)),
-		Mode:     uint32(tracer.ReadArgUint64(regs, 2)),
-	}
-
-	return fillFileMetadata(filename, msg.Open, disableStats)
-}
-
-func handleCreat(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
-	if err != nil {
-		return err
-	}
-
-	filename, err = getFullPathFromFilename(process, filename)
-	if err != nil {
-		return err
-	}
-
-	msg.Type = ebpfless.SyscallTypeOpen
-	msg.Open = &ebpfless.OpenSyscallMsg{
-		Filename: filename,
-		Flags:    unix.O_CREAT | unix.O_WRONLY | unix.O_TRUNC,
-		Mode:     uint32(tracer.ReadArgUint64(regs, 1)),
-	}
-
-	return fillFileMetadata(filename, msg.Open, disableStats)
-}
-
-func handleMemfdCreate(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
-	if err != nil {
-		return err
-	}
-	filename = "memfd:" + filename
-
-	msg.Type = ebpfless.SyscallTypeOpen
-	msg.Open = &ebpfless.OpenSyscallMsg{
-		Filename: filename,
-		Flags:    uint32(tracer.ReadArgUint64(regs, 1)),
-	}
-	return nil
-}
-
-func handleNameToHandleAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	fd := tracer.ReadArgInt32(regs, 0)
-
-	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
-	if err != nil {
-		return err
-	}
-
-	filename, err = getFullPathFromFd(process, filename, fd)
-	if err != nil {
-		return err
-	}
-
-	msg.Type = ebpfless.SyscallTypeOpen
-	msg.Open = &ebpfless.OpenSyscallMsg{
-		Filename: filename,
-	}
-	return nil
-}
-
-func handleNameToHandleAtRet(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) {
-	if msg.Open == nil {
-		return
-	}
-
-	if ret := tracer.ReadRet(regs); ret < 0 {
-		return
-	}
-
-	pFileHandleData, err := tracer.ReadArgData(process.Pid, regs, 2, 8 /*sizeof uint32 + sizeof int32*/)
-	if err != nil {
-		return
-	}
-
-	key := fileHandleKey{
-		handleBytes: binary.BigEndian.Uint32(pFileHandleData[:4]),
-		handleType:  int32(binary.BigEndian.Uint32(pFileHandleData[4:8])),
-	}
-	process.Res.FileHandleCache[key] = &fileHandleVal{
-		pathName: msg.Open.Filename,
-	}
-}
-
-func handleOpenByHandleAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	pFileHandleData, err := tracer.ReadArgData(process.Pid, regs, 1, 8 /*sizeof uint32 + sizeof int32*/)
-	if err != nil {
-		return err
-	}
-
-	key := fileHandleKey{
-		handleBytes: binary.BigEndian.Uint32(pFileHandleData[:4]),
-		handleType:  int32(binary.BigEndian.Uint32(pFileHandleData[4:8])),
-	}
-	val, ok := process.Res.FileHandleCache[key]
-	if !ok {
-		return errors.New("didn't find correspondance in the file handle cache")
-	}
-	msg.Type = ebpfless.SyscallTypeOpen
-	msg.Open = &ebpfless.OpenSyscallMsg{
-		Filename: val.pathName,
-		Flags:    uint32(tracer.ReadArgUint64(regs, 2)),
-	}
-	return fillFileMetadata(val.pathName, msg.Open, disableStats)
-}
-
-func handleUnlinkat(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	fd := tracer.ReadArgInt32(regs, 0)
-
-	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
-	if err != nil {
-		return err
-	}
-
-	flags := tracer.ReadArgInt32(regs, 2)
-
-	filename, err = getFullPathFromFd(process, filename, fd)
-	if err != nil {
-		return err
-	}
-
-	if flags == unix.AT_REMOVEDIR {
-		msg.Type = ebpfless.SyscallTypeRmdir
-		msg.Rmdir = &ebpfless.RmdirSyscallMsg{
-			File: ebpfless.OpenSyscallMsg{
-				Filename: filename,
-			},
-		}
-		err = fillFileMetadata(filename, &msg.Rmdir.File, disableStats)
-	} else {
-		msg.Type = ebpfless.SyscallTypeUnlink
-		msg.Unlink = &ebpfless.UnlinkSyscallMsg{
-			File: ebpfless.OpenSyscallMsg{
-				Filename: filename,
-			},
-		}
-		err = fillFileMetadata(filename, &msg.Unlink.File, disableStats)
-	}
-	return err
-}
-
-func handleUnlink(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
-	if err != nil {
-		return err
-	}
-
-	filename, err = getFullPathFromFilename(process, filename)
-	if err != nil {
-		return err
-	}
-
-	msg.Type = ebpfless.SyscallTypeUnlink
-	msg.Unlink = &ebpfless.UnlinkSyscallMsg{
-		File: ebpfless.OpenSyscallMsg{
-			Filename: filename,
-		},
-	}
-	return fillFileMetadata(filename, &msg.Unlink.File, disableStats)
-}
-
-func handleRmdir(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
-	if err != nil {
-		return err
-	}
-
-	filename, err = getFullPathFromFilename(process, filename)
-	if err != nil {
-		return err
-	}
-
-	msg.Type = ebpfless.SyscallTypeRmdir
-	msg.Rmdir = &ebpfless.RmdirSyscallMsg{
-		File: ebpfless.OpenSyscallMsg{
-			Filename: filename,
-		},
-	}
-	return fillFileMetadata(filename, &msg.Rmdir.File, disableStats)
-}
-
-func handleRename(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	oldFilename, err := tracer.ReadArgString(process.Pid, regs, 0)
-	if err != nil {
-		return err
-	}
-
-	oldFilename, err = getFullPathFromFilename(process, oldFilename)
-	if err != nil {
-		return err
-	}
-
-	newFilename, err := tracer.ReadArgString(process.Pid, regs, 1)
-	if err != nil {
-		return err
-	}
-
-	newFilename, err = getFullPathFromFilename(process, newFilename)
-	if err != nil {
-		return err
-	}
-
-	msg.Type = ebpfless.SyscallTypeRename
-	msg.Rename = &ebpfless.RenameSyscallMsg{
-		OldFile: ebpfless.OpenSyscallMsg{
-			Filename: oldFilename,
-		},
-		NewFile: ebpfless.OpenSyscallMsg{
-			Filename: newFilename,
-		},
-	}
-	return fillFileMetadata(oldFilename, &msg.Rename.OldFile, disableStats)
-}
-
-func handleRenameAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	oldFD := tracer.ReadArgInt32(regs, 0)
-
-	oldFilename, err := tracer.ReadArgString(process.Pid, regs, 1)
-	if err != nil {
-		return err
-	}
-
-	oldFilename, err = getFullPathFromFd(process, oldFilename, oldFD)
-	if err != nil {
-		return err
-	}
-
-	newFD := tracer.ReadArgInt32(regs, 2)
-
-	newFilename, err := tracer.ReadArgString(process.Pid, regs, 3)
-	if err != nil {
-		return err
-	}
-
-	newFilename, err = getFullPathFromFd(process, newFilename, newFD)
-	if err != nil {
-		return err
-	}
-
-	msg.Type = ebpfless.SyscallTypeRename
-	msg.Rename = &ebpfless.RenameSyscallMsg{
-		OldFile: ebpfless.OpenSyscallMsg{
-			Filename: oldFilename,
-		},
-		NewFile: ebpfless.OpenSyscallMsg{
-			Filename: newFilename,
-		},
-	}
-	return fillFileMetadata(oldFilename, &msg.Rename.OldFile, disableStats)
-}
-
-func getPidTTY(pid int) string {
-	tty, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/0", pid))
-	if err != nil {
-		return ""
-	}
-	if !strings.HasPrefix(tty, "/dev/pts") {
-		return ""
-	}
-	return "pts" + path.Base(tty)
-}
-
-func truncateArgs(list []string) ([]string, bool) {
-	truncated := false
-	if len(list) > model.MaxArgsEnvsSize {
-		list = list[:model.MaxArgsEnvsSize]
-		truncated = true
-	}
-	for i, l := range list {
-		if len(l) > model.MaxArgEnvSize {
-			list[i] = l[:model.MaxArgEnvSize-4] + "..."
-			truncated = true
-		}
-	}
-	return list, truncated
-}
-
-// list copied from default value of env_with_value system-probe config
-var priorityEnvs = []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE", "GLIBC_TUNABLES"}
-
-func truncateEnvs(list []string) ([]string, bool) {
-	truncated := false
-	if len(list) > model.MaxArgsEnvsSize {
-		// walk over all envs and put priority ones asides
-		var priorityList []string
-		var secondaryList []string
-		for _, l := range list {
-			found := false
-			for _, prio := range priorityEnvs {
-				if strings.HasPrefix(l, prio) {
-					priorityList = append(priorityList, l)
-					found = true
-					break
-				}
-			}
-			if !found {
-				secondaryList = append(secondaryList, l)
-			}
-		}
-		// build the result by first taking the priority envs if found
-		list = append(priorityList, secondaryList[:model.MaxArgsEnvsSize-len(priorityList)]...)
-		truncated = true
-	}
-	for i, l := range list {
-		if len(l) > model.MaxArgEnvSize {
-			list[i] = l[:model.MaxArgEnvSize-4] + "..."
-			truncated = true
-		}
-	}
-	return list, truncated
-}
-
-func handleExecveAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	fd := tracer.ReadArgInt32(regs, 0)
-
-	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
-	if err != nil {
-		return err
-	}
-
-	if filename == "" { // in this case, dirfd defines directly the file's FD
-		var exists bool
-		if filename, exists = process.Res.Fd[fd]; !exists || filename == "" {
-			return errors.New("can't find related file path")
-		}
-	} else {
-		filename, err = getFullPathFromFd(process, filename, fd)
-		if err != nil {
-			return err
-		}
-	}
-
-	args, err := tracer.ReadArgStringArray(process.Pid, regs, 2)
-	if err != nil {
-		return err
-	}
-	args, argsTruncated := truncateArgs(args)
-
-	envs, err := tracer.ReadArgStringArray(process.Pid, regs, 3)
-	if err != nil {
-		return err
-	}
-	envs, envsTruncated := truncateEnvs(envs)
-
-	msg.Type = ebpfless.SyscallTypeExec
-	msg.Exec = &ebpfless.ExecSyscallMsg{
-		File: ebpfless.OpenSyscallMsg{
-			Filename: filename,
-		},
-		Args:          args,
-		ArgsTruncated: argsTruncated,
-		Envs:          envs,
-		EnvsTruncated: envsTruncated,
-		TTY:           getPidTTY(process.Pid),
-	}
-	err = fillFileMetadata(filename, &msg.Exec.File, disableStats)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func handleFcntl(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	msg.Type = ebpfless.SyscallTypeFcntl
-	msg.Fcntl = &ebpfless.FcntlSyscallMsg{
-		Fd:  tracer.ReadArgUint32(regs, 0),
-		Cmd: tracer.ReadArgUint32(regs, 1),
-	}
-	return nil
-}
-
-func handleExecve(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
-	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
-	if err != nil {
-		return err
-	}
-
-	filename, err = getFullPathFromFilename(process, filename)
-	if err != nil {
-		return err
-	}
-
-	args, err := tracer.ReadArgStringArray(process.Pid, regs, 1)
-	if err != nil {
-		return err
-	}
-	args, argsTruncated := truncateArgs(args)
-
-	envs, err := tracer.ReadArgStringArray(process.Pid, regs, 2)
-	if err != nil {
-		return err
-	}
-	envs, envsTruncated := truncateEnvs(envs)
-
-	msg.Type = ebpfless.SyscallTypeExec
-	msg.Exec = &ebpfless.ExecSyscallMsg{
-		File: ebpfless.OpenSyscallMsg{
-			Filename: filename,
-		},
-		Args:          args,
-		ArgsTruncated: argsTruncated,
-		Envs:          envs,
-		EnvsTruncated: envsTruncated,
-		TTY:           getPidTTY(process.Pid),
-	}
-	err = fillFileMetadata(filename, &msg.Exec.File, disableStats)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func handleDup(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	// using msg to temporary store arg0, as it will be erased by the return value on ARM64
-	msg.Dup = &ebpfless.DupSyscallFakeMsg{
-		OldFd: tracer.ReadArgInt32(regs, 0),
-	}
-	return nil
-}
-
-func handleChdir(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	// using msg to temporary store arg0, as it will be erased by the return value on ARM64
-	dirname, err := tracer.ReadArgString(process.Pid, regs, 0)
-	if err != nil {
-		return err
-	}
-
-	dirname, err = getFullPathFromFilename(process, dirname)
-	if err != nil {
-		process.Res.Cwd = ""
-		return err
-	}
-
-	msg.Chdir = &ebpfless.ChdirSyscallFakeMsg{
-		Path: dirname,
-	}
-	return nil
-}
-
-func handleFchdir(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	fd := tracer.ReadArgInt32(regs, 0)
-	dirname, ok := process.Res.Fd[fd]
-	if !ok {
-		process.Res.Cwd = ""
-		return nil
-	}
-
-	// using msg to temporary store arg0, as it will be erased by the return value on ARM64
-	msg.Chdir = &ebpfless.ChdirSyscallFakeMsg{
-		Path: dirname,
-	}
-	return nil
-}
-
-func handleSetuid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	msg.Type = ebpfless.SyscallTypeSetUID
-	msg.SetUID = &ebpfless.SetUIDSyscallMsg{
-		UID:  tracer.ReadArgInt32(regs, 0),
-		EUID: -1,
-	}
-	return nil
-}
-
-func handleSetgid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	msg.Type = ebpfless.SyscallTypeSetGID
-	msg.SetGID = &ebpfless.SetGIDSyscallMsg{
-		GID:  tracer.ReadArgInt32(regs, 0),
-		EGID: -1,
-	}
-	return nil
-}
-
-func handleSetreuid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	msg.Type = ebpfless.SyscallTypeSetUID
-	msg.SetUID = &ebpfless.SetUIDSyscallMsg{
-		UID:  tracer.ReadArgInt32(regs, 0),
-		EUID: tracer.ReadArgInt32(regs, 1),
-	}
-	return nil
-}
-
-func handleSetregid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	msg.Type = ebpfless.SyscallTypeSetGID
-	msg.SetGID = &ebpfless.SetGIDSyscallMsg{
-		GID:  tracer.ReadArgInt32(regs, 0),
-		EGID: tracer.ReadArgInt32(regs, 1),
-	}
-	return nil
-}
-
-func handleSetfsuid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	msg.Type = ebpfless.SyscallTypeSetFSUID
-	msg.SetFSUID = &ebpfless.SetFSUIDSyscallMsg{
-		FSUID: tracer.ReadArgInt32(regs, 0),
-	}
-	return nil
-}
-
-func handleSetfsgid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	msg.Type = ebpfless.SyscallTypeSetFSGID
-	msg.SetFSGID = &ebpfless.SetFSGIDSyscallMsg{
-		FSGID: tracer.ReadArgInt32(regs, 0),
-	}
-	return nil
-}
-
-func handleClose(tracer *Tracer, process *Process, _ *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	fd := tracer.ReadArgInt32(regs, 0)
-	delete(process.Res.Fd, fd)
-	return nil
-}
-
-func handleCapset(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs) error {
-	pCapsData, err := tracer.ReadArgData(process.Pid, regs, 1, 24 /*sizeof uint32 x3 x2*/)
-	if err != nil {
-		return err
-	}
-
-	// extract low bytes of effective caps
-	effective := uint64(binary.NativeEndian.Uint32(pCapsData[0:4]))
-	// extract high bytes of effective caps, merge them together
-	effective |= uint64(binary.NativeEndian.Uint32(pCapsData[12:16])) << 32
-
-	// extract low bytes of permitted caps
-	permitted := uint64(binary.NativeEndian.Uint32(pCapsData[4:8]))
-	// extract high bytes of permitted caps,  merge them together
-	permitted |= uint64(binary.NativeEndian.Uint32(pCapsData[16:20])) << 32
-
-	msg.Type = ebpfless.SyscallTypeCapset
-	msg.Capset = &ebpfless.CapsetSyscallMsg{
-		Effective: uint64(effective),
-		Permitted: uint64(permitted),
-	}
-	return nil
+// defaults funcs for ShouldSend:
+func shouldSendAlways(_ int64) bool { return true }
+func isAcceptedRetval(retval int64) bool {
+	return retval >= 0 || retval == -int64(syscall.EACCES) || retval == -int64(syscall.EPERM)
 }
 
 func checkEntryPoint(path string) (string, error) {
@@ -722,10 +76,6 @@ func checkEntryPoint(path string) (string, error) {
 	}
 
 	return name, nil
-}
-
-func isAcceptedRetval(retval int64) bool {
-	return retval >= 0 || retval == -int64(syscall.EACCES) || retval == -int64(syscall.EPERM) || retval == -int64(syscall.ENOSYS)
 }
 
 func initConn(probeAddr string, nbAttempts uint) (net.Conn, error) {
@@ -816,6 +166,10 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 	if err != nil {
 		return err
 	}
+
+	syscallHandlers := make(map[int]syscallHandler)
+	PtracedSyscalls := registerFIMHandlers(syscallHandlers)
+	PtracedSyscalls = append(PtracedSyscalls, registerProcessHandlers(syscallHandlers)...)
 
 	opts := Opts{
 		Syscalls: PtracedSyscalls,
@@ -925,43 +279,17 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 				process.Nr[nr] = syscallMsg
 			}
 
-			switch nr {
-			case OpenNr:
-				if err := handleOpen(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle open: %v", err)
+			handler, found := syscallHandlers[nr]
+			if found && handler.Func != nil {
+				err := handler.Func(tracer, process, syscallMsg, regs, disableStats)
+				if err != nil {
 					return
 				}
-			case OpenatNr:
-				if err := handleOpenAt(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle openat: %v", err)
-					return
-				}
-			case Openat2Nr:
-				if err := handleOpenAt2(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle openat: %v", err)
-					return
-				}
-			case CreatNr:
-				if err = handleCreat(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle creat: %v", err)
-					return
-				}
-			case NameToHandleAtNr:
-				if err = handleNameToHandleAt(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle name_to_handle_at: %v", err)
-					return
-				}
-			case OpenByHandleAtNr:
-				if err = handleOpenByHandleAt(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle open_by_handle_at: %v", err)
-					return
-				}
-			case ExecveNr:
-				if err = handleExecve(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle execve: %v", err)
-					return
-				}
+			}
 
+			/* internal special cases */
+			switch nr {
+			case ExecveNr:
 				// Top level pid, add creds. For the other PIDs the creds will be propagated at the probe side
 				if process.Pid == tracer.PID {
 					var uid, gid uint32
@@ -991,141 +319,36 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 					pc.Add(process.Tgid, process)
 				}
 			case ExecveatNr:
-				if err = handleExecveAt(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle execveat: %v", err)
-					return
-				}
-
 				// special case for exec since the pre reports the pid while the post reports the tgid
 				if process.Pid != process.Tgid {
 					pc.Add(process.Tgid, process)
 				}
-			case FcntlNr:
-				_ = handleFcntl(tracer, process, syscallMsg, regs)
-			case DupNr, Dup2Nr, Dup3Nr:
-				if err = handleDup(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle dup: %v", err)
-					return
-				}
-			case ChdirNr:
-				if err = handleChdir(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle chdir: %v", err)
-					return
-				}
-			case FchdirNr:
-				if err = handleFchdir(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle fchdir: %v", err)
-					return
-				}
-			case SetuidNr:
-				if err = handleSetuid(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle fchdir: %v", err)
-					return
-				}
-			case SetgidNr:
-				if err = handleSetgid(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle fchdir: %v", err)
-					return
-				}
-			case SetreuidNr, SetresuidNr:
-				if err = handleSetreuid(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle fchdir: %v", err)
-					return
-				}
-			case SetregidNr, SetresgidNr:
-				if err = handleSetregid(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle fchdir: %v", err)
-					return
-				}
-			case SetfsuidNr:
-				if err = handleSetfsuid(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle fchdir: %v", err)
-					return
-				}
-			case SetfsgidNr:
-				if err = handleSetfsgid(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle fchdir: %v", err)
-					return
-				}
-			case CloseNr:
-				if err = handleClose(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle close: %v", err)
-					return
-				}
-			case MemfdCreateNr:
-				if err = handleMemfdCreate(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle memfd_create: %v", err)
-					return
-				}
-			case CapsetNr:
-				if err = handleCapset(tracer, process, syscallMsg, regs); err != nil {
-					logger.Errorf("unable to handle capset: %v", err)
-					return
-				}
-			case UnlinkNr:
-				if err := handleUnlink(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle unlink: %v", err)
-					return
-				}
-			case UnlinkatNr:
-				if err := handleUnlinkat(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle unlinkat: %v", err)
-					return
-				}
-			case RmdirNr:
-				if err := handleRmdir(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle rmdir: %v", err)
-					return
-				}
-			case RenameNr:
-				if err := handleRename(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle rename: %v", err)
-					return
-				}
-			case RenameAtNr, RenameAt2Nr:
-				if err := handleRenameAt(tracer, process, syscallMsg, regs, disableStats); err != nil {
-					logger.Errorf("unable to handle renameat: %v", err)
-					return
-				}
+
 			}
 		case CallbackPostType:
-			switch nr {
-			case CloseNr:
-				// nothing to do
-			case ExecveNr, ExecveatNr:
-				if ret := tracer.ReadRet(regs); isAcceptedRetval(ret) {
-					sendSyscallMsg(process.Nr[ExecveNr]) // special case for execveat: we store the msg in execve bucket (see upper)
+			syscallMsg, msgExists := process.Nr[nr]
+			handler, handlerFound := syscallHandlers[nr]
+			if handlerFound && msgExists && (handler.ShouldSend != nil || handler.RetFunc != nil) {
+				if handler.RetFunc != nil {
+					err := handler.RetFunc(tracer, process, syscallMsg, regs, disableStats)
+					if err != nil {
+						return
+					}
 				}
+				if handler.ShouldSend != nil {
+					ret := tracer.ReadRet(regs)
+					if handler.ShouldSend(ret) && syscallMsg.Type != ebpfless.SyscallTypeUnknown {
+						syscallMsg.Retval = ret
+						sendSyscallMsg(syscallMsg)
+					}
+				}
+			}
 
+			/* internal special cases */
+			switch nr {
+			case ExecveNr, ExecveatNr:
 				// now the pid is the tgid
 				process.Pid = process.Tgid
-			case NameToHandleAtNr:
-				syscallMsg, exists := process.Nr[nr]
-				if !exists || syscallMsg.Open == nil {
-					return
-				}
-				handleNameToHandleAtRet(tracer, process, syscallMsg, regs)
-			case OpenNr, OpenatNr, Openat2Nr, CreatNr, OpenByHandleAtNr, MemfdCreateNr:
-				if ret := tracer.ReadRet(regs); isAcceptedRetval(ret) {
-					syscallMsg, exists := process.Nr[nr]
-					if !exists || syscallMsg.Open == nil {
-						return
-					}
-					syscallMsg.Retval = ret
-
-					sendSyscallMsg(syscallMsg)
-
-					// maintain fd/path mapping
-					process.Res.Fd[int32(ret)] = syscallMsg.Open.Filename
-				}
-			case SetuidNr, SetgidNr, SetreuidNr, SetregidNr, SetresuidNr, SetresgidNr, SetfsuidNr, SetfsgidNr:
-				if ret := tracer.ReadRet(regs); isAcceptedRetval(ret) || nr == SetfsuidNr || nr == SetfsgidNr {
-					syscallMsg, exists := process.Nr[nr]
-					if !exists {
-						return
-					}
-					sendSyscallMsg(syscallMsg)
-				}
 			case CloneNr:
 				if flags := tracer.ReadArgUint64(regs, 0); flags&uint64(unix.SIGCHLD) == 0 {
 					pc.SetAsThreadOf(process, ppid)
@@ -1161,73 +384,8 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, creds Creds
 						},
 					})
 				}
-			case FcntlNr:
-				if ret := tracer.ReadRet(regs); ret >= 0 {
-					syscallMsg, exists := process.Nr[nr]
-					if !exists {
-						return
-					}
-
-					// maintain fd/path mapping
-					if syscallMsg.Fcntl.Cmd == unix.F_DUPFD || syscallMsg.Fcntl.Cmd == unix.F_DUPFD_CLOEXEC {
-						if path, exists := process.Res.Fd[int32(syscallMsg.Fcntl.Fd)]; exists {
-							process.Res.Fd[int32(ret)] = path
-						}
-					}
-				}
-			case DupNr, Dup2Nr, Dup3Nr:
-				if ret := tracer.ReadRet(regs); ret >= 0 {
-					syscallMsg, exists := process.Nr[nr]
-					if !exists {
-						return
-					}
-					path, ok := process.Res.Fd[syscallMsg.Dup.OldFd]
-					if ok {
-						// maintain fd/path in case of dups
-						process.Res.Fd[int32(ret)] = path
-					}
-				}
-			case ChdirNr, FchdirNr:
-				if ret := tracer.ReadRet(regs); ret >= 0 {
-					syscallMsg, exists := process.Nr[nr]
-					if !exists || syscallMsg.Chdir == nil {
-						return
-					}
-					process.Res.Cwd = syscallMsg.Chdir.Path
-				}
-			case CapsetNr:
-				if ret := tracer.ReadRet(regs); isAcceptedRetval(ret) {
-					syscallMsg, exists := process.Nr[nr]
-					if !exists || syscallMsg.Capset == nil {
-						return
-					}
-					syscallMsg.Retval = ret
-					sendSyscallMsg(syscallMsg)
-				}
-
-			case UnlinkNr, UnlinkatNr, RmdirNr:
-				if ret := tracer.ReadRet(regs); isAcceptedRetval(ret) {
-					syscallMsg, exists := process.Nr[nr]
-					if !exists {
-						return
-					}
-					syscallMsg.Retval = ret
-					sendSyscallMsg(syscallMsg)
-				}
-
-			case RenameNr, RenameAtNr, RenameAt2Nr:
-				if ret := tracer.ReadRet(regs); isAcceptedRetval(ret) {
-					syscallMsg, exists := process.Nr[nr]
-					if !exists {
-						return
-					}
-					syscallMsg.Retval = ret
-					err := fillFileMetadata(syscallMsg.Rename.NewFile.Filename, &syscallMsg.Rename.NewFile, disableStats)
-					if err == nil {
-						sendSyscallMsg(syscallMsg)
-					}
-				}
 			}
+
 		case CallbackExitType:
 			// send exit only for process not threads
 			if process.Pid == process.Tgid && waitStatus != nil {

--- a/pkg/security/ptracer/fim_handlers.go
+++ b/pkg/security/ptracer/fim_handlers.go
@@ -1,0 +1,740 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package ptracer holds the start command of CWS injector
+package ptracer
+
+import (
+	"encoding/binary"
+	"errors"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
+)
+
+func registerFIMHandlers(handlers map[int]syscallHandler) []string {
+	fimHandlers := []syscallHandler{
+		{
+			IDs:        []syscallID{{ID: OpenNr, Name: "open"}},
+			Func:       handleOpen,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    handleOpensRet,
+		},
+		{
+			IDs:        []syscallID{{ID: OpenatNr, Name: "openat"}},
+			Func:       handleOpenAt,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    handleOpensRet,
+		},
+		{
+			IDs:        []syscallID{{ID: Openat2Nr, Name: "openat2"}},
+			Func:       handleOpenAt2,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    handleOpensRet,
+		},
+		{
+			IDs:        []syscallID{{ID: CreatNr, Name: "creat"}},
+			Func:       handleCreat,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    handleOpensRet,
+		},
+		{
+			IDs:        []syscallID{{ID: NameToHandleAtNr, Name: "name_to_handle_at"}},
+			Func:       handleNameToHandleAt,
+			ShouldSend: nil,
+			RetFunc:    handleNameToHandleAtRet,
+		},
+		{
+			IDs:        []syscallID{{ID: OpenByHandleAtNr, Name: "open_by_handle_at"}},
+			Func:       handleOpenByHandleAt,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    handleOpensRet,
+		},
+		{
+			IDs:        []syscallID{{ID: MemfdCreateNr, Name: "memfd_create"}},
+			Func:       handleMemfdCreate,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    handleOpensRet,
+		},
+		{
+			IDs:        []syscallID{{ID: FcntlNr, Name: "fcntl"}},
+			Func:       handleFcntl,
+			ShouldSend: nil,
+			RetFunc:    handleFcntlRet,
+		},
+		{
+			IDs:        []syscallID{{ID: DupNr, Name: "dup"}, {ID: Dup2Nr, Name: "dup2"}, {ID: Dup3Nr, Name: "dup3"}},
+			Func:       handleDup,
+			ShouldSend: nil,
+			RetFunc:    handleDupRet,
+		},
+		{
+			IDs:        []syscallID{{ID: CloseNr, Name: "close"}},
+			Func:       handleClose,
+			ShouldSend: nil,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: UnlinkNr, Name: "unlink"}},
+			Func:       handleUnlink,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: UnlinkatNr, Name: "unlinkat"}},
+			Func:       handleUnlinkat,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: RmdirNr, Name: "rmdir"}},
+			Func:       handleRmdir,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: RenameNr, Name: "rename"}},
+			Func:       handleRename,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    handleRenamesRet,
+		},
+		{
+			IDs:        []syscallID{{ID: RenameAtNr, Name: "renameat"}, {ID: RenameAt2Nr, Name: "renameat2"}},
+			Func:       handleRenameAt,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    handleRenamesRet,
+		},
+		{
+			IDs:        []syscallID{{ID: MkdirNr, Name: "mkdir"}},
+			Func:       handleMkdir,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    handleMkdirRet,
+		},
+		{
+			IDs:        []syscallID{{ID: MkdirAtNr, Name: "mkdirat"}},
+			Func:       handleMkdirAt,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    handleMkdirRet,
+		},
+		{
+			IDs:        []syscallID{{ID: UtimeNr, Name: "utime"}},
+			Func:       handleUtime,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: UtimesNr, Name: "utimes"}},
+			Func:       handleUtimes,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: UtimensAtNr, Name: "utimensat"}, {ID: FutimesAtNr, Name: "futimesat"}},
+			Func:       handleUtimensAt,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    nil,
+		},
+	}
+
+	syscallList := []string{}
+	for _, h := range fimHandlers {
+		for _, id := range h.IDs {
+			if id.ID >= 0 { // insert only available syscalls
+				handlers[id.ID] = h
+				syscallList = append(syscallList, id.Name)
+			}
+		}
+	}
+	return syscallList
+}
+
+//
+// handlers called on syscall entrance
+//
+
+func handleOpenAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	fd := tracer.ReadArgInt32(regs, 0)
+
+	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFd(process, filename, fd)
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeOpen
+	msg.Open = &ebpfless.OpenSyscallMsg{
+		Filename: filename,
+		Flags:    uint32(tracer.ReadArgUint64(regs, 2)),
+		Mode:     uint32(tracer.ReadArgUint64(regs, 3)),
+	}
+
+	return fillFileMetadata(filename, msg.Open, disableStats)
+}
+
+func handleOpenAt2(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	fd := tracer.ReadArgInt32(regs, 0)
+
+	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFd(process, filename, fd)
+	if err != nil {
+		return err
+	}
+
+	howData, err := tracer.ReadArgData(process.Pid, regs, 2, 16 /*sizeof uint64 + sizeof uint64*/) // flags, mode
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeOpen
+	msg.Open = &ebpfless.OpenSyscallMsg{
+		Filename: filename,
+		Flags:    uint32(binary.NativeEndian.Uint64(howData[:8])),
+		Mode:     uint32(binary.NativeEndian.Uint64(howData[8:16])),
+	}
+
+	return fillFileMetadata(filename, msg.Open, disableStats)
+}
+
+func handleOpen(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFilename(process, filename)
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeOpen
+	msg.Open = &ebpfless.OpenSyscallMsg{
+		Filename: filename,
+		Flags:    uint32(tracer.ReadArgUint64(regs, 1)),
+		Mode:     uint32(tracer.ReadArgUint64(regs, 2)),
+	}
+
+	return fillFileMetadata(filename, msg.Open, disableStats)
+}
+
+func handleCreat(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFilename(process, filename)
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeOpen
+	msg.Open = &ebpfless.OpenSyscallMsg{
+		Filename: filename,
+		Flags:    unix.O_CREAT | unix.O_WRONLY | unix.O_TRUNC,
+		Mode:     uint32(tracer.ReadArgUint64(regs, 1)),
+	}
+
+	return fillFileMetadata(filename, msg.Open, disableStats)
+}
+
+func handleMemfdCreate(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
+	if err != nil {
+		return err
+	}
+	filename = "memfd:" + filename
+
+	msg.Type = ebpfless.SyscallTypeOpen
+	msg.Open = &ebpfless.OpenSyscallMsg{
+		Filename: filename,
+		Flags:    uint32(tracer.ReadArgUint64(regs, 1)),
+	}
+	return nil
+}
+
+func handleNameToHandleAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	fd := tracer.ReadArgInt32(regs, 0)
+
+	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFd(process, filename, fd)
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeOpen
+	msg.Open = &ebpfless.OpenSyscallMsg{
+		Filename: filename,
+	}
+	return nil
+}
+
+func handleOpenByHandleAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	pFileHandleData, err := tracer.ReadArgData(process.Pid, regs, 1, 8 /*sizeof uint32 + sizeof int32*/)
+	if err != nil {
+		return err
+	}
+
+	key := fileHandleKey{
+		handleBytes: binary.BigEndian.Uint32(pFileHandleData[:4]),
+		handleType:  int32(binary.BigEndian.Uint32(pFileHandleData[4:8])),
+	}
+	val, ok := process.Res.FileHandleCache[key]
+	if !ok {
+		return errors.New("didn't find correspondance in the file handle cache")
+	}
+	msg.Type = ebpfless.SyscallTypeOpen
+	msg.Open = &ebpfless.OpenSyscallMsg{
+		Filename: val.pathName,
+		Flags:    uint32(tracer.ReadArgUint64(regs, 2)),
+	}
+	return fillFileMetadata(val.pathName, msg.Open, disableStats)
+}
+
+func handleUnlinkat(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	fd := tracer.ReadArgInt32(regs, 0)
+
+	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
+	if err != nil {
+		return err
+	}
+
+	flags := tracer.ReadArgInt32(regs, 2)
+
+	filename, err = getFullPathFromFd(process, filename, fd)
+	if err != nil {
+		return err
+	}
+
+	if flags == unix.AT_REMOVEDIR {
+		msg.Type = ebpfless.SyscallTypeRmdir
+		msg.Rmdir = &ebpfless.RmdirSyscallMsg{
+			File: ebpfless.OpenSyscallMsg{
+				Filename: filename,
+			},
+		}
+		err = fillFileMetadata(filename, &msg.Rmdir.File, disableStats)
+	} else {
+		msg.Type = ebpfless.SyscallTypeUnlink
+		msg.Unlink = &ebpfless.UnlinkSyscallMsg{
+			File: ebpfless.OpenSyscallMsg{
+				Filename: filename,
+			},
+		}
+		err = fillFileMetadata(filename, &msg.Unlink.File, disableStats)
+	}
+	return err
+}
+
+func handleUnlink(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFilename(process, filename)
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeUnlink
+	msg.Unlink = &ebpfless.UnlinkSyscallMsg{
+		File: ebpfless.OpenSyscallMsg{
+			Filename: filename,
+		},
+	}
+	return fillFileMetadata(filename, &msg.Unlink.File, disableStats)
+}
+
+func handleRmdir(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFilename(process, filename)
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeRmdir
+	msg.Rmdir = &ebpfless.RmdirSyscallMsg{
+		File: ebpfless.OpenSyscallMsg{
+			Filename: filename,
+		},
+	}
+	return fillFileMetadata(filename, &msg.Rmdir.File, disableStats)
+}
+
+func handleRename(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	oldFilename, err := tracer.ReadArgString(process.Pid, regs, 0)
+	if err != nil {
+		return err
+	}
+
+	oldFilename, err = getFullPathFromFilename(process, oldFilename)
+	if err != nil {
+		return err
+	}
+
+	newFilename, err := tracer.ReadArgString(process.Pid, regs, 1)
+	if err != nil {
+		return err
+	}
+
+	newFilename, err = getFullPathFromFilename(process, newFilename)
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeRename
+	msg.Rename = &ebpfless.RenameSyscallMsg{
+		OldFile: ebpfless.OpenSyscallMsg{
+			Filename: oldFilename,
+		},
+		NewFile: ebpfless.OpenSyscallMsg{
+			Filename: newFilename,
+		},
+	}
+	return fillFileMetadata(oldFilename, &msg.Rename.OldFile, disableStats)
+}
+
+func handleRenameAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	oldFD := tracer.ReadArgInt32(regs, 0)
+
+	oldFilename, err := tracer.ReadArgString(process.Pid, regs, 1)
+	if err != nil {
+		return err
+	}
+
+	oldFilename, err = getFullPathFromFd(process, oldFilename, oldFD)
+	if err != nil {
+		return err
+	}
+
+	newFD := tracer.ReadArgInt32(regs, 2)
+
+	newFilename, err := tracer.ReadArgString(process.Pid, regs, 3)
+	if err != nil {
+		return err
+	}
+
+	newFilename, err = getFullPathFromFd(process, newFilename, newFD)
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeRename
+	msg.Rename = &ebpfless.RenameSyscallMsg{
+		OldFile: ebpfless.OpenSyscallMsg{
+			Filename: oldFilename,
+		},
+		NewFile: ebpfless.OpenSyscallMsg{
+			Filename: newFilename,
+		},
+	}
+	return fillFileMetadata(oldFilename, &msg.Rename.OldFile, disableStats)
+}
+
+func handleFcntl(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	msg.Fcntl = &ebpfless.FcntlSyscallMsg{
+		Fd:  tracer.ReadArgUint32(regs, 0),
+		Cmd: tracer.ReadArgUint32(regs, 1),
+	}
+	return nil
+}
+
+func handleDup(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	// using msg to temporary store arg0, as it will be erased by the return value on ARM64
+	msg.Dup = &ebpfless.DupSyscallFakeMsg{
+		OldFd: tracer.ReadArgInt32(regs, 0),
+	}
+	return nil
+}
+
+func handleClose(tracer *Tracer, process *Process, _ *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	fd := tracer.ReadArgInt32(regs, 0)
+	delete(process.Res.Fd, fd)
+	return nil
+}
+
+func handleMkdirAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	fd := tracer.ReadArgInt32(regs, 0)
+
+	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFd(process, filename, fd)
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeMkdir
+	msg.Mkdir = &ebpfless.MkdirSyscallMsg{
+		Dir: ebpfless.OpenSyscallMsg{
+			Filename: filename,
+		},
+		Mode: uint32(tracer.ReadArgUint64(regs, 2)),
+	}
+	return nil
+}
+
+func handleMkdir(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFilename(process, filename)
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeMkdir
+	msg.Mkdir = &ebpfless.MkdirSyscallMsg{
+		Dir: ebpfless.OpenSyscallMsg{
+			Filename: filename,
+		},
+		Mode: uint32(tracer.ReadArgUint64(regs, 1)),
+	}
+	return nil
+}
+
+func handleUtime(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFilename(process, filename)
+	if err != nil {
+		return err
+	}
+
+	var atime, mtime uint64
+	pTimes := tracer.ReadArgUint64(regs, 1)
+	// first, check the given pointer. if null, apply current time
+	if pTimes == 0 {
+		atime = uint64(time.Now().UnixNano())
+		mtime = atime
+	} else {
+		times, err := tracer.ReadArgData(process.Pid, regs, 1, 16 /*sizeof uint64 *2*/) // ATime,CTime
+		if err != nil {
+			return err
+		}
+		atime = secsToNanosecs(binary.NativeEndian.Uint64(times[:8]))
+		mtime = secsToNanosecs(binary.NativeEndian.Uint64(times[8:16]))
+	}
+
+	msg.Type = ebpfless.SyscallTypeUtimes
+	msg.Utimes = &ebpfless.UtimesSyscallMsg{
+		File: ebpfless.OpenSyscallMsg{
+			Filename: filename,
+		},
+		ATime: atime,
+		MTime: mtime,
+	}
+	return fillFileMetadata(msg.Utimes.File.Filename, &msg.Utimes.File, disableStats)
+}
+
+func handleUtimes(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFilename(process, filename)
+	if err != nil {
+		return err
+	}
+
+	var atime, mtime uint64
+	pTimes := tracer.ReadArgUint64(regs, 1)
+	// first, check the given pointer. if null, apply current time
+	if pTimes == 0 {
+		atime = uint64(time.Now().UnixNano())
+		mtime = atime
+	} else {
+		times, err := tracer.ReadArgData(process.Pid, regs, 1, 32 /*sizeof uint64 *4*/) // ATime,CTime
+		if err != nil {
+			return err
+		}
+		atime = secsToNanosecs(binary.NativeEndian.Uint64(times[:8]))
+		atime += microsecsToNanosecs(binary.NativeEndian.Uint64(times[8:16]))
+		mtime = secsToNanosecs(binary.NativeEndian.Uint64(times[16:24]))
+		mtime += microsecsToNanosecs(binary.NativeEndian.Uint64(times[24:32]))
+	}
+
+	msg.Type = ebpfless.SyscallTypeUtimes
+	msg.Utimes = &ebpfless.UtimesSyscallMsg{
+		File: ebpfless.OpenSyscallMsg{
+			Filename: filename,
+		},
+		ATime: atime,
+		MTime: mtime,
+	}
+	return fillFileMetadata(msg.Utimes.File.Filename, &msg.Utimes.File, disableStats)
+}
+
+func handleUtimensAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	fd := tracer.ReadArgInt32(regs, 0)
+
+	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFd(process, filename, fd)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFilename(process, filename)
+	if err != nil {
+		return err
+	}
+
+	var now uint64
+	getCurrentTimestamp := func() uint64 {
+		if now == 0 {
+			now = uint64(time.Now().UnixNano())
+		}
+		return now
+	}
+
+	var atime, mtime uint64
+	pTimes := tracer.ReadArgUint64(regs, 2)
+	// first, check the given pointer. if null, apply current time
+	if pTimes == 0 {
+		atime = getCurrentTimestamp()
+		mtime = getCurrentTimestamp()
+	} else {
+		times, err := tracer.ReadArgData(process.Pid, regs, 2, 32 /*sizeof uint64 *4*/) // ATime,CTime
+		if err != nil {
+			return err
+		}
+		atime = secsToNanosecs(binary.NativeEndian.Uint64(times[:8]))
+		if atime == unix.UTIME_NOW {
+			atime = getCurrentTimestamp()
+		} else {
+			nsecs := binary.NativeEndian.Uint64(times[8:16])
+			if nsecs == unix.UTIME_OMIT {
+				atime = 0
+			} else {
+				atime += nsecs
+			}
+		}
+		mtime = secsToNanosecs(binary.NativeEndian.Uint64(times[16:24]))
+		if mtime == unix.UTIME_NOW {
+			mtime = getCurrentTimestamp()
+		} else {
+			nsecs := binary.NativeEndian.Uint64(times[24:32])
+			if nsecs == unix.UTIME_OMIT {
+				mtime = 0
+			} else {
+				mtime += nsecs
+			}
+		}
+	}
+
+	msg.Type = ebpfless.SyscallTypeUtimes
+	msg.Utimes = &ebpfless.UtimesSyscallMsg{
+		File: ebpfless.OpenSyscallMsg{
+			Filename: filename,
+		},
+		ATime: atime,
+		MTime: mtime,
+	}
+	return fillFileMetadata(msg.Utimes.File.Filename, &msg.Utimes.File, disableStats)
+}
+
+//
+// handlers called on syscall return
+//
+
+func handleNameToHandleAtRet(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	if msg.Open == nil {
+		return errors.New("msg empty")
+	}
+
+	if ret := tracer.ReadRet(regs); ret < 0 {
+		return errors.New("syscall failed")
+	}
+
+	pFileHandleData, err := tracer.ReadArgData(process.Pid, regs, 2, 8 /*sizeof uint32 + sizeof int32*/)
+	if err != nil {
+		return err
+	}
+
+	key := fileHandleKey{
+		handleBytes: binary.BigEndian.Uint32(pFileHandleData[:4]),
+		handleType:  int32(binary.BigEndian.Uint32(pFileHandleData[4:8])),
+	}
+	process.Res.FileHandleCache[key] = &fileHandleVal{
+		pathName: msg.Open.Filename,
+	}
+	return nil
+}
+
+func handleOpensRet(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	if ret := tracer.ReadRet(regs); msg.Open != nil && ret > 0 {
+		process.Res.Fd[int32(ret)] = msg.Open.Filename
+	}
+	return nil
+}
+
+func handleFcntlRet(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	if ret := tracer.ReadRet(regs); msg.Fcntl != nil && ret >= 0 {
+		// maintain fd/path mapping
+		if msg.Fcntl.Cmd == unix.F_DUPFD || msg.Fcntl.Cmd == unix.F_DUPFD_CLOEXEC {
+			if path, exists := process.Res.Fd[int32(msg.Fcntl.Fd)]; exists {
+				process.Res.Fd[int32(ret)] = path
+			}
+		}
+	}
+	return nil
+}
+
+func handleDupRet(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	if ret := tracer.ReadRet(regs); msg.Dup != nil && ret >= 0 {
+		if path, ok := process.Res.Fd[msg.Dup.OldFd]; ok {
+			// maintain fd/path in case of dups
+			process.Res.Fd[int32(ret)] = path
+		}
+	}
+	return nil
+}
+
+func handleRenamesRet(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	if ret := tracer.ReadRet(regs); msg.Rename != nil && ret == 0 {
+		return fillFileMetadata(msg.Rename.NewFile.Filename, &msg.Rename.NewFile, disableStats)
+	}
+	return nil
+}
+
+func handleMkdirRet(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	if ret := tracer.ReadRet(regs); msg.Mkdir != nil && ret == 0 {
+		return fillFileMetadata(msg.Mkdir.Dir.Filename, &msg.Mkdir.Dir, disableStats)
+	}
+	return nil
+}

--- a/pkg/security/ptracer/process_handlers.go
+++ b/pkg/security/ptracer/process_handlers.go
@@ -1,0 +1,309 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package ptracer holds the start command of CWS injector
+package ptracer
+
+import (
+	"encoding/binary"
+	"errors"
+	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
+)
+
+func registerProcessHandlers(handlers map[int]syscallHandler) []string {
+	processHandlers := []syscallHandler{
+		{
+			IDs:        []syscallID{{ID: ExecveNr, Name: "execve"}},
+			Func:       handleExecve,
+			ShouldSend: shouldSendAlways,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: ExecveatNr, Name: "execveat"}},
+			Func:       handleExecveAt,
+			ShouldSend: shouldSendAlways,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: ChdirNr, Name: "chdir"}},
+			Func:       handleChdir,
+			ShouldSend: nil,
+			RetFunc:    handleChdirRet,
+		},
+		{
+			IDs:        []syscallID{{ID: FchdirNr, Name: "fchdir"}},
+			Func:       handleFchdir,
+			ShouldSend: nil,
+			RetFunc:    handleChdirRet,
+		},
+		{
+			IDs:        []syscallID{{ID: SetuidNr, Name: "setuid"}},
+			Func:       handleSetuid,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: SetgidNr, Name: "setgid"}},
+			Func:       handleSetgid,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: SetreuidNr, Name: "setreuid"}, {ID: SetresuidNr, Name: "setresuid"}},
+			Func:       handleSetreuid,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: SetregidNr, Name: "setregid"}, {ID: SetresgidNr, Name: "setresgid"}},
+			Func:       handleSetregid,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: SetfsuidNr, Name: "setfsuid"}},
+			Func:       handleSetfsuid,
+			ShouldSend: shouldSendAlways,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: SetfsgidNr, Name: "setfsgid"}},
+			Func:       handleSetfsgid,
+			ShouldSend: shouldSendAlways,
+			RetFunc:    nil,
+		},
+		{
+			IDs:        []syscallID{{ID: CapsetNr, Name: "capset"}},
+			Func:       handleCapset,
+			ShouldSend: isAcceptedRetval,
+			RetFunc:    nil,
+		},
+	}
+
+	syscallList := []string{}
+	for _, h := range processHandlers {
+		for _, id := range h.IDs {
+			if id.ID >= 0 { // insert only available syscalls
+				handlers[id.ID] = h
+				syscallList = append(syscallList, id.Name)
+			}
+		}
+	}
+	return syscallList
+}
+
+//
+// handlers called on syscall entrance
+//
+
+func handleExecveAt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	fd := tracer.ReadArgInt32(regs, 0)
+
+	filename, err := tracer.ReadArgString(process.Pid, regs, 1)
+	if err != nil {
+		return err
+	}
+
+	if filename == "" { // in this case, dirfd defines directly the file's FD
+		var exists bool
+		if filename, exists = process.Res.Fd[fd]; !exists || filename == "" {
+			return errors.New("can't find related file path")
+		}
+	} else {
+		filename, err = getFullPathFromFd(process, filename, fd)
+		if err != nil {
+			return err
+		}
+	}
+
+	args, err := tracer.ReadArgStringArray(process.Pid, regs, 2)
+	if err != nil {
+		return err
+	}
+	args, argsTruncated := truncateArgs(args)
+
+	envs, err := tracer.ReadArgStringArray(process.Pid, regs, 3)
+	if err != nil {
+		return err
+	}
+	envs, envsTruncated := truncateEnvs(envs)
+
+	msg.Type = ebpfless.SyscallTypeExec
+	msg.Exec = &ebpfless.ExecSyscallMsg{
+		File: ebpfless.OpenSyscallMsg{
+			Filename: filename,
+		},
+		Args:          args,
+		ArgsTruncated: argsTruncated,
+		Envs:          envs,
+		EnvsTruncated: envsTruncated,
+		TTY:           getPidTTY(process.Pid),
+	}
+	// special case for execveat: we store ALSO the msg in execve bucket (see cws.go)
+	process.Nr[ExecveNr] = msg
+	return fillFileMetadata(filename, &msg.Exec.File, disableStats)
+}
+
+func handleExecve(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error {
+	filename, err := tracer.ReadArgString(process.Pid, regs, 0)
+	if err != nil {
+		return err
+	}
+
+	filename, err = getFullPathFromFilename(process, filename)
+	if err != nil {
+		return err
+	}
+
+	args, err := tracer.ReadArgStringArray(process.Pid, regs, 1)
+	if err != nil {
+		return err
+	}
+	args, argsTruncated := truncateArgs(args)
+
+	envs, err := tracer.ReadArgStringArray(process.Pid, regs, 2)
+	if err != nil {
+		return err
+	}
+	envs, envsTruncated := truncateEnvs(envs)
+
+	msg.Type = ebpfless.SyscallTypeExec
+	msg.Exec = &ebpfless.ExecSyscallMsg{
+		File: ebpfless.OpenSyscallMsg{
+			Filename: filename,
+		},
+		Args:          args,
+		ArgsTruncated: argsTruncated,
+		Envs:          envs,
+		EnvsTruncated: envsTruncated,
+		TTY:           getPidTTY(process.Pid),
+	}
+	return fillFileMetadata(filename, &msg.Exec.File, disableStats)
+}
+
+func handleChdir(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	// using msg to temporary store arg0, as it will be erased by the return value on ARM64
+	dirname, err := tracer.ReadArgString(process.Pid, regs, 0)
+	if err != nil {
+		return err
+	}
+
+	dirname, err = getFullPathFromFilename(process, dirname)
+	if err != nil {
+		process.Res.Cwd = ""
+		return err
+	}
+
+	msg.Chdir = &ebpfless.ChdirSyscallFakeMsg{
+		Path: dirname,
+	}
+	return nil
+}
+
+func handleFchdir(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	fd := tracer.ReadArgInt32(regs, 0)
+	dirname, ok := process.Res.Fd[fd]
+	if !ok {
+		process.Res.Cwd = ""
+		return nil
+	}
+
+	// using msg to temporary store arg0, as it will be erased by the return value on ARM64
+	msg.Chdir = &ebpfless.ChdirSyscallFakeMsg{
+		Path: dirname,
+	}
+	return nil
+}
+
+func handleSetuid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	msg.Type = ebpfless.SyscallTypeSetUID
+	msg.SetUID = &ebpfless.SetUIDSyscallMsg{
+		UID:  tracer.ReadArgInt32(regs, 0),
+		EUID: -1,
+	}
+	return nil
+}
+
+func handleSetgid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	msg.Type = ebpfless.SyscallTypeSetGID
+	msg.SetGID = &ebpfless.SetGIDSyscallMsg{
+		GID:  tracer.ReadArgInt32(regs, 0),
+		EGID: -1,
+	}
+	return nil
+}
+
+func handleSetreuid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	msg.Type = ebpfless.SyscallTypeSetUID
+	msg.SetUID = &ebpfless.SetUIDSyscallMsg{
+		UID:  tracer.ReadArgInt32(regs, 0),
+		EUID: tracer.ReadArgInt32(regs, 1),
+	}
+	return nil
+}
+
+func handleSetregid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	msg.Type = ebpfless.SyscallTypeSetGID
+	msg.SetGID = &ebpfless.SetGIDSyscallMsg{
+		GID:  tracer.ReadArgInt32(regs, 0),
+		EGID: tracer.ReadArgInt32(regs, 1),
+	}
+	return nil
+}
+
+func handleSetfsuid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	msg.Type = ebpfless.SyscallTypeSetFSUID
+	msg.SetFSUID = &ebpfless.SetFSUIDSyscallMsg{
+		FSUID: tracer.ReadArgInt32(regs, 0),
+	}
+	return nil
+}
+
+func handleSetfsgid(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	msg.Type = ebpfless.SyscallTypeSetFSGID
+	msg.SetFSGID = &ebpfless.SetFSGIDSyscallMsg{
+		FSGID: tracer.ReadArgInt32(regs, 0),
+	}
+	return nil
+}
+
+func handleCapset(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	pCapsData, err := tracer.ReadArgData(process.Pid, regs, 1, 24 /*sizeof uint32 x3 x2*/)
+	if err != nil {
+		return err
+	}
+
+	// extract low bytes of effective caps
+	effective := uint64(binary.NativeEndian.Uint32(pCapsData[0:4]))
+	// extract high bytes of effective caps, merge them together
+	effective |= uint64(binary.NativeEndian.Uint32(pCapsData[12:16])) << 32
+
+	// extract low bytes of permitted caps
+	permitted := uint64(binary.NativeEndian.Uint32(pCapsData[4:8]))
+	// extract high bytes of permitted caps,  merge them together
+	permitted |= uint64(binary.NativeEndian.Uint32(pCapsData[16:20])) << 32
+
+	msg.Type = ebpfless.SyscallTypeCapset
+	msg.Capset = &ebpfless.CapsetSyscallMsg{
+		Effective: uint64(effective),
+		Permitted: uint64(permitted),
+	}
+	return nil
+}
+
+//
+// handlers called on syscall return
+//
+
+func handleChdirRet(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	if ret := tracer.ReadRet(regs); msg.Chdir != nil && ret >= 0 {
+		process.Res.Cwd = msg.Chdir.Path
+	}
+	return nil
+}

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -9,86 +9,53 @@ package ptracer
 
 import (
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
-	OpenNr           = 2   // OpenNr defines the syscall ID for amd64
-	OpenatNr         = 257 // OpenatNr defines the syscall ID for amd64
-	Openat2Nr        = 437 // Openat2Nr defines the syscall ID for amd64
-	CreatNr          = 85  // CreatNr defines the syscall ID for amd64
-	NameToHandleAtNr = 303 // NameToHandleAtNr defines the syscall ID for amd64
-	OpenByHandleAtNr = 304 // OpenByHandleAtNr defines the syscall ID for amd64
-	ExecveNr         = 59  // ExecveNr defines the syscall ID for amd64
-	ExecveatNr       = 322 // ExecveatNr defines the syscall ID for amd64
-	CloneNr          = 56  // CloneNr defines the syscall ID for amd64
-	ForkNr           = 57  // ForkNr defines the syscall ID for amd64
-	VforkNr          = 58  // VforkNr defines the syscall ID for amd64
-	ExitNr           = 60  // ExitNr defines the syscall ID for amd64
-	FcntlNr          = 72  // FcntlNr defines the syscall ID for amd64
-	DupNr            = 32  // DupNr defines the syscall ID for amd64
-	Dup2Nr           = 33  // Dup2Nr defines the syscall ID for amd64
-	Dup3Nr           = 292 // Dup3Nr defines the syscall ID for amd64
-	ChdirNr          = 80  // ChdirNr defines the syscall ID for amd64
-	FchdirNr         = 81  // FchdirNr defines the syscall ID for amd64
-	SetuidNr         = 105 // SetuidNr defines the syscall ID for amd64
-	SetgidNr         = 106 // SetgidNr defines the syscall ID for amd64
-	SetreuidNr       = 113 // SetreuidNr defines the syscall ID for amd64
-	SetregidNr       = 114 // SetregidNr defines the syscall ID for amd64
-	SetresuidNr      = 117 // SetresuidNr defines the syscall ID for amd64
-	SetresgidNr      = 119 // SetresgidNr defines the syscall ID for amd64
-	SetfsuidNr       = 122 // SetfsuidNr defines the syscall ID for amd64
-	SetfsgidNr       = 123 // SetfsgidNr defines the syscall ID for amd64
-	CloseNr          = 3   // CloseNr defines the syscall ID for amd64
-	MemfdCreateNr    = 319 // MemfdCreateNr defines the syscall ID for amd64
-	CapsetNr         = 126 // CapsetNr defines the syscall ID for amd64
-	UnlinkNr         = 87  // UnlinkNr defines the syscall ID for amd64
-	UnlinkatNr       = 263 // UnlinkatNr defines the syscall ID for amd64
-	RmdirNr          = 84  // RmdirNr defines the syscall ID for amd64
-	RenameNr         = 82  // RenameNr defines the syscall ID for amd64
-	RenameAtNr       = 264 // RenameAtNr defines the syscall ID for amd64
-	RenameAt2Nr      = 316 // RenameAt2Nr defines the syscall ID for amd64
-	Clone3Nr         = 435 // Clone3Nr defines the syscall ID for amd64
-)
-
-var (
-	// PtracedSyscalls defines the list of syscall we want to ptrace
-	PtracedSyscalls = []string{
-		"open",
-		"openat",
-		"openat2",
-		"creat",
-		"name_to_handle_at",
-		"open_by_handle_at",
-		"fork",
-		"vfork",
-		"clone",
-		"execve",
-		"execveat",
-		"exit",
-		"fcntl",
-		"dup",
-		"dup2",
-		"dup3",
-		"chdir",
-		"fchdir",
-		"setuid",
-		"setgid",
-		"setreuid",
-		"setregid",
-		"setresuid",
-		"setresgid",
-		"setfsuid",
-		"setfsgid",
-		"close",
-		"memfd_create",
-		"capset",
-		"unlink",
-		"unlinkat",
-		"rmdir",
-		"rename",
-		"renameat",
-		"renameat2",
-	}
+	OpenNr           = unix.SYS_OPEN              // OpenNr defines the syscall ID for amd64
+	OpenatNr         = unix.SYS_OPENAT            // OpenatNr defines the syscall ID for amd64
+	Openat2Nr        = unix.SYS_OPENAT2           // Openat2Nr defines the syscall ID for amd64
+	CreatNr          = unix.SYS_CREAT             // CreatNr defines the syscall ID for amd64
+	NameToHandleAtNr = unix.SYS_NAME_TO_HANDLE_AT // NameToHandleAtNr defines the syscall ID for amd64
+	OpenByHandleAtNr = unix.SYS_OPEN_BY_HANDLE_AT // OpenByHandleAtNr defines the syscall ID for amd64
+	ExecveNr         = unix.SYS_EXECVE            // ExecveNr defines the syscall ID for amd64
+	ExecveatNr       = unix.SYS_EXECVEAT          // ExecveatNr defines the syscall ID for amd64
+	CloneNr          = unix.SYS_CLONE             // CloneNr defines the syscall ID for amd64
+	Clone3Nr         = unix.SYS_CLONE3            // Clone3Nr defines the syscall ID for amd64
+	ForkNr           = unix.SYS_FORK              // ForkNr defines the syscall ID for amd64
+	VforkNr          = unix.SYS_VFORK             // VforkNr defines the syscall ID for amd64
+	ExitNr           = unix.SYS_EXIT              // ExitNr defines the syscall ID for amd64
+	FcntlNr          = unix.SYS_FCNTL             // FcntlNr defines the syscall ID for amd64
+	DupNr            = unix.SYS_DUP               // DupNr defines the syscall ID for amd64
+	Dup2Nr           = unix.SYS_DUP2              // Dup2Nr defines the syscall ID for amd64
+	Dup3Nr           = unix.SYS_DUP3              // Dup3Nr defines the syscall ID for amd64
+	ChdirNr          = unix.SYS_CHDIR             // ChdirNr defines the syscall ID for amd64
+	FchdirNr         = unix.SYS_FCHDIR            // FchdirNr defines the syscall ID for amd64
+	SetuidNr         = unix.SYS_SETUID            // SetuidNr defines the syscall ID for amd64
+	SetgidNr         = unix.SYS_SETGID            // SetgidNr defines the syscall ID for amd64
+	SetreuidNr       = unix.SYS_SETREUID          // SetreuidNr defines the syscall ID for amd64
+	SetregidNr       = unix.SYS_SETREGID          // SetregidNr defines the syscall ID for amd64
+	SetresuidNr      = unix.SYS_SETRESUID         // SetresuidNr defines the syscall ID for amd64
+	SetresgidNr      = unix.SYS_SETRESGID         // SetresgidNr defines the syscall ID for amd64
+	SetfsuidNr       = unix.SYS_SETFSUID          // SetfsuidNr defines the syscall ID for amd64
+	SetfsgidNr       = unix.SYS_SETFSGID          // SetfsgidNr defines the syscall ID for amd64
+	CloseNr          = unix.SYS_CLOSE             // CloseNr defines the syscall ID for amd64
+	MemfdCreateNr    = unix.SYS_MEMFD_CREATE      // MemfdCreateNr defines the syscall ID for amd64
+	CapsetNr         = unix.SYS_CAPSET            // CapsetNr defines the syscall ID for amd64
+	UnlinkNr         = unix.SYS_UNLINK            // UnlinkNr defines the syscall ID for amd64
+	UnlinkatNr       = unix.SYS_UNLINKAT          // UnlinkatNr defines the syscall ID for amd64
+	RmdirNr          = unix.SYS_RMDIR             // RmdirNr defines the syscall ID for amd64
+	RenameNr         = unix.SYS_RENAME            // RenameNr defines the syscall ID for amd64
+	RenameAtNr       = unix.SYS_RENAMEAT          // RenameAtNr defines the syscall ID for amd64
+	RenameAt2Nr      = unix.SYS_RENAMEAT2         // RenameAt2Nr defines the syscall ID for amd64
+	MkdirNr          = unix.SYS_MKDIR             // MkdirNr defines the syscall ID for amd64
+	MkdirAtNr        = unix.SYS_MKDIRAT           // MkdirAtNr defines the syscall ID for amd64
+	UtimeNr          = unix.SYS_UTIME             // UtimeNr defines the syscall ID for amd64
+	UtimesNr         = unix.SYS_UTIMES            // UtimesNr defines the syscall ID for amd64
+	UtimensAtNr      = unix.SYS_UTIMENSAT         // UtimensAtNr defines the syscall ID for amd64
+	FutimesAtNr      = unix.SYS_FUTIMESAT         // FutimesAtNr defines the syscall ID for amd64
 )
 
 // https://github.com/torvalds/linux/blob/v5.0/arch/x86/entry/entry_64.S#L126

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -9,81 +9,54 @@ package ptracer
 
 import (
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
-	OpenatNr         = 56  // OpenatNr defines the syscall ID for arm64
-	Openat2Nr        = 437 // Openat2Nr defines the syscall ID for amd64
-	NameToHandleAtNr = 264 // NameToHandleAtNr defines the syscall ID for amd64
-	OpenByHandleAtNr = 265 // OpenByHandleAtNr defines the syscall ID for amd64
-	ExecveNr         = 221 // ExecveNr defines the syscall ID for arm64
-	ExecveatNr       = 281 // ExecveatNr defines the syscall ID for arm64
-	CloneNr          = 220 // CloneNr defines the syscall ID for arm64
-	ExitNr           = 93  // ExitNr defines the syscall ID for arm64
-	FcntlNr          = 25  // FcntlNr defines the syscall ID for arm64
-	DupNr            = 23  // DupNr defines the syscall ID for arm64
-	Dup3Nr           = 24  // Dup3Nr defines the syscall ID for arm64
-	ChdirNr          = 49  // ChdirNr defines the syscall ID for arm64
-	FchdirNr         = 50  // FchdirNr defines the syscall ID for arm64
-	SetuidNr         = 146 // SetuidNr defines the syscall ID for arm64
-	SetgidNr         = 144 // SetgidNr defines the syscall ID for arm64
-	SetreuidNr       = 145 // SetreuidNr defines the syscall ID for arm64
-	SetregidNr       = 143 // SetregidNr defines the syscall ID for arm64
-	SetresuidNr      = 147 // SetresuidNr defines the syscall ID for arm64
-	SetresgidNr      = 149 // SetresgidNr defines the syscall ID for arm64
-	SetfsuidNr       = 151 // SetfsuidNr defines the syscall ID for arm64
-	SetfsgidNr       = 152 // SetfsgidNr defines the syscall ID for arm64
-	CloseNr          = 57  // CloseNr defines the syscall ID for arm64
-	MemfdCreateNr    = 279 // MemfdCreateNr defines the syscall ID for arm64
-	CapsetNr         = 91  // CapsetNr defines the syscall ID for arm64
-	UnlinkatNr       = 35  // UnlinkatNr defines the syscall ID for arm64
-	RenameAtNr       = 38  // RenameAtNr defines the syscall ID for arm64
-	RenameAt2Nr      = 276 // RenameAt2Nr defines the syscall ID for arm64
-	Clone3Nr         = 435 // Clone3Nr defines the syscall ID for amd64
+	OpenatNr         = unix.SYS_OPENAT            // OpenatNr defines the syscall ID for arm64
+	Openat2Nr        = unix.SYS_OPENAT2           // Openat2Nr defines the syscall ID for amd64
+	NameToHandleAtNr = unix.SYS_NAME_TO_HANDLE_AT // NameToHandleAtNr defines the syscall ID for amd64
+	OpenByHandleAtNr = unix.SYS_OPEN_BY_HANDLE_AT // OpenByHandleAtNr defines the syscall ID for amd64
+	ExecveNr         = unix.SYS_EXECVE            // ExecveNr defines the syscall ID for arm64
+	ExecveatNr       = unix.SYS_EXECVEAT          // ExecveatNr defines the syscall ID for arm64
+	CloneNr          = unix.SYS_CLONE             // CloneNr defines the syscall ID for arm64
+	Clone3Nr         = unix.SYS_CLONE3            // Clone3Nr defines the syscall ID for arm64
+	ExitNr           = unix.SYS_EXIT              // ExitNr defines the syscall ID for arm64
+	FcntlNr          = unix.SYS_FCNTL             // FcntlNr defines the syscall ID for arm64
+	DupNr            = unix.SYS_DUP               // DupNr defines the syscall ID for arm64
+	Dup3Nr           = unix.SYS_DUP3              // Dup3Nr defines the syscall ID for arm64
+	ChdirNr          = unix.SYS_CHDIR             // ChdirNr defines the syscall ID for arm64
+	FchdirNr         = unix.SYS_FCHDIR            // FchdirNr defines the syscall ID for arm64
+	SetuidNr         = unix.SYS_SETUID            // SetuidNr defines the syscall ID for arm64
+	SetgidNr         = unix.SYS_SETGID            // SetgidNr defines the syscall ID for arm64
+	SetreuidNr       = unix.SYS_SETREUID          // SetreuidNr defines the syscall ID for arm64
+	SetregidNr       = unix.SYS_SETREGID          // SetregidNr defines the syscall ID for arm64
+	SetresuidNr      = unix.SYS_SETRESUID         // SetresuidNr defines the syscall ID for arm64
+	SetresgidNr      = unix.SYS_SETRESGID         // SetresgidNr defines the syscall ID for arm64
+	SetfsuidNr       = unix.SYS_SETFSUID          // SetfsuidNr defines the syscall ID for arm64
+	SetfsgidNr       = unix.SYS_SETFSGID          // SetfsgidNr defines the syscall ID for arm64
+	CloseNr          = unix.SYS_CLOSE             // CloseNr defines the syscall ID for arm64
+	MemfdCreateNr    = unix.SYS_MEMFD_CREATE      // MemfdCreateNr defines the syscall ID for arm64
+	CapsetNr         = unix.SYS_CAPSET            // CapsetNr defines the syscall ID for arm64
+	UnlinkatNr       = unix.SYS_UNLINKAT          // UnlinkatNr defines the syscall ID for arm64
+	RenameAtNr       = unix.SYS_RENAMEAT          // RenameAtNr defines the syscall ID for arm64
+	RenameAt2Nr      = unix.SYS_RENAMEAT2         // RenameAt2Nr defines the syscall ID for arm64
+	MkdirAtNr        = unix.SYS_MKDIRAT           // MkdirAtNr defines the syscall ID for arm64
+	UtimensAtNr      = unix.SYS_UTIMENSAT         // UtimensAtNr defines the syscall ID for arm64
 
-	OpenNr   = -1 // OpenNr not available on arm64
-	ForkNr   = -2 // ForkNr not available on arm64
-	VforkNr  = -3 // VforkNr not available on arm64
-	Dup2Nr   = -4 // Dup2Nr not available on arm64
-	CreatNr  = -5 // CreatNr not available on arm64
-	UnlinkNr = -6 // UnlinkNr not available on arm64
-	RmdirNr  = -7 // RmdirNr not available on arm64
-	RenameNr = -8 // RenameNr not available on arm64
-)
-
-var (
-	// PtracedSyscalls defines the list of syscall we want to ptrace
-	PtracedSyscalls = []string{
-		"openat",
-		"openat2",
-		"name_to_handle_at",
-		"open_by_handle_at",
-		"clone",
-		"execve",
-		"execveat",
-		"exit",
-		"fcntl",
-		"dup",
-		"dup3",
-		"chdir",
-		"fchdir",
-		"setuid",
-		"setgid",
-		"setuid",
-		"setgid",
-		"setreuid",
-		"setregid",
-		"setresuid",
-		"setresgid",
-		"setfsuid",
-		"setfsgid",
-		"close",
-		"memfd_create",
-		"capset",
-		"unlinkat",
-		"renameat",
-		"renameat2",
-	}
+	OpenNr      = -1  // OpenNr not available on arm64
+	ForkNr      = -2  // ForkNr not available on arm64
+	VforkNr     = -3  // VforkNr not available on arm64
+	Dup2Nr      = -4  // Dup2Nr not available on arm64
+	CreatNr     = -5  // CreatNr not available on arm64
+	UnlinkNr    = -6  // UnlinkNr not available on arm64
+	RmdirNr     = -7  // RmdirNr not available on arm64
+	RenameNr    = -8  // RenameNr not available on arm64
+	MkdirNr     = -9  // MkdirNr not available on arm64
+	UtimeNr     = -10 // UtimeNr not available on arm64
+	UtimesNr    = -11 // UtimesNr not available on arm64
+	FutimesAtNr = -12 // FutimesAtNr not available on arm64
 )
 
 func (t *Tracer) argToRegValue(regs syscall.PtraceRegs, arg int) uint64 {

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -56,7 +56,9 @@ func TestUtimes(t *testing.T) {
 			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(123), event.Utimes.Atime.Unix())
 			assert.Equal(t, int64(456), event.Utimes.Mtime.Unix())
-			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode, "wrong inode")
+			if !test.opts.staticOpts.enableEBPFLess {
+				assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode, "wrong inode")
+			}
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
@@ -95,7 +97,9 @@ func TestUtimes(t *testing.T) {
 			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(111), event.Utimes.Atime.Unix())
 			assert.Equal(t, int64(222), event.Utimes.Atime.UnixNano()%int64(time.Second)/int64(time.Microsecond))
-			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode)
+			if !test.opts.staticOpts.enableEBPFLess {
+				assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode)
+			}
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
@@ -137,7 +141,9 @@ func TestUtimes(t *testing.T) {
 			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(555), event.Utimes.Mtime.Unix())
 			assert.Equal(t, int64(666), event.Utimes.Mtime.UnixNano()%int64(time.Second)/int64(time.Nanosecond))
-			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode)
+			if !test.opts.staticOpts.enableEBPFLess {
+				assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode)
+			}
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -218,7 +218,7 @@ def run_ebpfless_functional_tests(ctx, cws_instrumentation, testsuite, verbose=F
         "verbose_opt": "-test.v" if verbose else "",
         "testflags": testflags,
         "path": os.environ['PATH'],
-        "tests": "-test.run '^(TestOpen|TestProcess|TimestampVariable|KillAction|TestRmdir|TestUnlink|TestRename)'",
+        "tests": "-test.run '^(TestOpen|TestProcess|TimestampVariable|KillAction|TestRmdir|TestUnlink|TestRename|TestMkdir|TestUtimes)'",
     }
 
     ctx.run(cmd.format(**args))


### PR DESCRIPTION
### What does this PR do?

It continues to close eBPF-less gaps:
* rework of the syscall handlers
* mkdir
* utimes

Todo:
* users/groups
* chown
* chmod
* link
* mmap/mprotect
* mount
* splice
* removexattr/setxattr



<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
