### PR TITLE
[oracle] Fix broken query metrics test (DBMON-3379)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/statements_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements_test.go
@@ -83,15 +83,14 @@ func TestQueryMetrics(t *testing.T) {
 	var statementExecutions float64
 	var queryExecutions float64
 	for _, r := range c.lastOracleRows {
-		// null in PL/SQL block is falsely  obfuscated to ?
-		if r.QueryHash == "7wm4bk66d7zbj" {
+		if r.SQLText == testStatement {
 			statementExecutions = r.Executions
 		} else if r.SQLText == "select ? from dual" {
 			queryExecutions = r.Executions
 		}
 	}
-
-	assert.Equal(t, float64(1), statementExecutions)
+	fmt.Printf("exec %+v", c.lastOracleRows)
+	assert.Equal(t, float64(1), statementExecutions, "PL/SQL execution not captured")
 	assert.Equal(t, float64(10), queryExecutions)
 }
 

--- a/pkg/collector/corechecks/oracle-dbm/statements_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements_test.go
@@ -89,7 +89,6 @@ func TestQueryMetrics(t *testing.T) {
 			queryExecutions = r.Executions
 		}
 	}
-	fmt.Printf("exec %+v", c.lastOracleRows)
 	assert.Equal(t, float64(1), statementExecutions, "PL/SQL execution not captured")
 	assert.Equal(t, float64(10), queryExecutions)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
