### PR TITLE
feat(CI): Add a new task to automatically assign a team label on a dependabot PR

### DIFF
--- a/.github/workflows/assign-dependabot.yml
+++ b/.github/workflows/assign-dependabot.yml
@@ -1,0 +1,28 @@
+name: Assign Dependabot PRs
+
+on:
+  pull_request:
+
+jobs:
+  label_pr:
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_ID: ${{ github.event.number }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Add label according to modified dependency
+        run: |
+          invoke add-team-label --pr-id $PR_ID

--- a/.github/workflows/assign-dependabot.yml
+++ b/.github/workflows/assign-dependabot.yml
@@ -1,7 +1,9 @@
+---
 name: Assign Dependabot PRs
 
 on:
   pull_request:
+    types: [opened, reopened]
 
 jobs:
   label_pr:
@@ -10,7 +12,6 @@ jobs:
       pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
-      PR_ID: ${{ github.event.number }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -25,4 +26,4 @@ jobs:
           pip install -r requirements.txt
       - name: Add label according to modified dependency
         run: |
-          invoke add-team-label --pr-id $PR_ID
+          invoke add-team-label --pr-id ${{ github.event.number }} --pr-title ${{ github.event.pull_request.title }}

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -53,7 +53,7 @@ from tasks import (
     trace_agent,
     vscode,
 )
-from tasks.assign_pr import add_team_labels
+from tasks.assign_pr import add_labels_and_reviewers
 from tasks.build_tags import audit_tag_impact, print_default_build_tags
 from tasks.codecov import apply_missing_coverage, codecov, upload_coverage_to_s3
 from tasks.components import lint_components, lint_fxutil_oneshot_test
@@ -144,7 +144,7 @@ ns.add_task(go_fix)
 ns.add_task(build_messagetable)
 ns.add_task(get_impacted_packages)
 ns.add_task(modules.go_work)
-ns.add_task(add_team_labels)
+ns.add_task(add_labels_and_reviewers)
 ns.add_task(get_modified_packages)
 ns.add_task(send_unit_tests_stats)
 # To deprecate

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -53,6 +53,7 @@ from tasks import (
     trace_agent,
     vscode,
 )
+from tasks.assign_pr import add_team_labels
 from tasks.build_tags import audit_tag_impact, print_default_build_tags
 from tasks.codecov import apply_missing_coverage, codecov, upload_coverage_to_s3
 from tasks.components import lint_components, lint_fxutil_oneshot_test
@@ -142,6 +143,8 @@ ns.add_task(fuzz)
 ns.add_task(go_fix)
 ns.add_task(build_messagetable)
 ns.add_task(get_impacted_packages)
+ns.add_task(modules.go_work)
+ns.add_task(add_team_labels)
 ns.add_task(get_modified_packages)
 ns.add_task(send_unit_tests_stats)
 # To deprecate

--- a/tasks/assign_pr.py
+++ b/tasks/assign_pr.py
@@ -1,0 +1,79 @@
+import json
+import os
+import re
+from collections import Counter
+
+from invoke import task
+
+from tasks.libs.pipeline_notifications import read_owners
+
+
+@task
+def add_team_labels(ctx, pr_id):
+    """
+    Add team labels to a PR based on the changed dependencies
+    """
+
+    codeowners = read_owners(".github/CODEOWNERS")
+
+    # Get what was changed according to PR title
+    title_words = ctx.run(f"gh pr view {pr_id} | head -n 1", hide=True).stdout.split()
+    dependency = title_words[2]
+    if "group" in title_words:  # dependabot defines group. Currently dep name is part of the group name
+        group_index = title_words.index("group")
+        dependency = title_words[group_index - 1]
+    import_module = re.compile(rf"^[ \t]*\"{dependency}.*$")
+    folder = f"./{title_words[-1][1:]}" if title_words[-2] == "in" else "."
+
+    # Find the responsible person for each file
+    owners = []
+    for root, _, files in os.walk(folder):
+        if root == "./.git" or any(root.startswith(prefix) for prefix in ["./venv", "./.git/"]):
+            continue
+        for file in files:
+            file_path = os.path.join(root, file)
+            if "doc" in file_path.casefold():
+                continue
+            with open(file_path, "r") as f:
+                try:
+                    for line in f:
+                        if is_go_module(dependency):
+                            if import_module.match(line):
+                                owners.extend([owner[1] for owner in codeowners.of(file_path[2:])])
+                                break
+                        elif dependency in line:
+                            owners.extend([owner[1] for owner in codeowners.of(file_path[2:])])
+                            break
+                except UnicodeDecodeError:
+                    continue
+    c = Counter(owners)
+    responsible = c.most_common(1)[0][0].replace('@Datadog/', '').replace('@DataDog/', '')
+    # Hardcode for USM as owner name does not match team label name
+    if responsible == "universal-service-monitoring":
+        responsible = "usm"
+
+    # Retrieve & assign labels
+    team_labels = [team["name"] for team in json.loads(ctx.run("gh label list -S team --json name", hide=True).stdout)]
+    try:
+        label = next(label for label in team_labels if responsible in label)
+    except StopIteration:
+        label = "team/agent-platform"
+    ctx.run(f"gh pr edit {pr_id} --remove-label \"team/triage\"")
+    ctx.run(f"gh pr edit {pr_id} --add-label \"{label}\"")
+
+
+def is_go_module(module):
+    starts = [
+        "github.com",
+        "k8s.io",
+        "go.opentelemetry.io",
+        "golang.org",
+        "google.golang.org",
+        "gopkg.in",
+        "gotest.tools",
+        "go.uber.org",
+        "sigs.k8s.io",
+    ]
+    if any(module.startswith(start) for start in starts):
+        return True
+    return False

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -307,7 +307,7 @@ def lint_components(_, fix=False):
         current = f.read()
     codeowners = '\n'.join(make_codeowners(current.splitlines(), bundles, components_without_bundle))
     if fix:
-        with open(".github/CODEOWNERS", "w") as f:
+        with open(filename, "w") as f:
             f.write(codeowners)
     elif current != codeowners:
         print(f"** {filename} differs")


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
- Add a new task to automatically assign a team label on a dependabot PR
- Add an associated workflow to assign at PR creation

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Remove manual actions
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Assignment is based on the occurrence of dependency found in repository files. This heuristic is basic and prevents the PR from being unassigned. It does not prevent a manual redirection.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
