### PR TITLE
serverless: appsec: send aws.lambda.enhanced.asm.invocations metric

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -257,7 +257,7 @@ func runAgent() {
 	go func() {
 		defer wg.Done()
 		var err error
-		appsecProxyProcessor, err = appsec.New()
+		appsecProxyProcessor, err = appsec.New(serverlessDaemon.MetricAgent.Demux)
 		if err != nil {
 			log.Error("appsec: could not start: ", err)
 		}

--- a/pkg/serverless/appsec/appsec.go
+++ b/pkg/serverless/appsec/appsec.go
@@ -15,6 +15,7 @@ import (
 	waf "github.com/DataDog/go-libddwaf/v2"
 	json "github.com/json-iterator/go"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/serverless/appsec/config"
 	"github.com/DataDog/datadog-agent/pkg/serverless/appsec/httpsec"
 	"github.com/DataDog/datadog-agent/pkg/serverless/proxy"
@@ -22,7 +23,7 @@ import (
 )
 
 //nolint:revive // TODO(ASM) Fix revive linter
-func New() (*httpsec.ProxyLifecycleProcessor, error) {
+func New(demux aggregator.Demultiplexer) (*httpsec.ProxyLifecycleProcessor, error) {
 	appsecInstance, err := newAppSec() // note that the assigned variable is in the parent scope
 	if err != nil {
 		return nil, err
@@ -32,7 +33,7 @@ func New() (*httpsec.ProxyLifecycleProcessor, error) {
 	}
 
 	// AppSec monitors the invocations by acting as a proxy of the AWS Lambda Runtime API.
-	lp := httpsec.NewProxyLifecycleProcessor(appsecInstance)
+	lp := httpsec.NewProxyLifecycleProcessor(appsecInstance, demux)
 	proxy.Start(
 		"127.0.0.1:9000",
 		"127.0.0.1:9001",

--- a/pkg/serverless/appsec/appsec_test.go
+++ b/pkg/serverless/appsec/appsec_test.go
@@ -26,7 +26,7 @@ func TestNew(t *testing.T) {
 		appsecEnabledStr := strconv.FormatBool(appsecEnabled)
 		t.Run(fmt.Sprintf("DD_SERVERLESS_APPSEC_ENABLED=%s", appsecEnabledStr), func(t *testing.T) {
 			t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", appsecEnabledStr)
-			lp, err := New()
+			lp, err := New(nil)
 			if err := wafHealth(); err != nil {
 				if ok, _ := waf.SupportsTarget(); ok {
 					// host should be supported by appsec, error is unexpected

--- a/pkg/serverless/appsec/httpsec/proxy.go
+++ b/pkg/serverless/appsec/httpsec/proxy.go
@@ -34,7 +34,7 @@ type ProxyLifecycleProcessor struct {
 	// Parsed invocation event value
 	invocationEvent interface{}
 
-	Demux aggregator.Demultiplexer
+	demux aggregator.Demultiplexer
 }
 
 // NewProxyLifecycleProcessor returns a new httpsec proxy processor monitored with the
@@ -42,7 +42,7 @@ type ProxyLifecycleProcessor struct {
 func NewProxyLifecycleProcessor(appsec Monitorer, demux aggregator.Demultiplexer) *ProxyLifecycleProcessor {
 	return &ProxyLifecycleProcessor{
 		appsec: appsec,
-		Demux:  demux,
+		demux:  demux,
 	}
 }
 
@@ -88,7 +88,7 @@ func (lp *ProxyLifecycleProcessor) OnInvokeStart(startDetails *invocationlifecyc
 	case trigger.LambdaFunctionURLEvent:
 		event = &events.LambdaFunctionURLRequest{}
 	}
-	serverlessMetrics.SendASMInvocationEnhancedMetric(nil, lp.Demux)
+	serverlessMetrics.SendASMInvocationEnhancedMetric(nil, lp.demux)
 
 	if err := json.Unmarshal(payloadBytes, event); err != nil {
 		log.Errorf("appsec: proxy-lifecycle: unexpected lambda event parsing error: %v", err)

--- a/pkg/serverless/appsec/httpsec/proxy.go
+++ b/pkg/serverless/appsec/httpsec/proxy.go
@@ -88,7 +88,9 @@ func (lp *ProxyLifecycleProcessor) OnInvokeStart(startDetails *invocationlifecyc
 	case trigger.LambdaFunctionURLEvent:
 		event = &events.LambdaFunctionURLRequest{}
 	}
-	serverlessMetrics.SendASMInvocationEnhancedMetric(nil, lp.demux)
+	if lp.demux != nil {
+		serverlessMetrics.SendASMInvocationEnhancedMetric(nil, lp.demux)
+	}
 
 	if err := json.Unmarshal(payloadBytes, event); err != nil {
 		log.Errorf("appsec: proxy-lifecycle: unexpected lambda event parsing error: %v", err)

--- a/pkg/serverless/appsec/httpsec/proxy_test.go
+++ b/pkg/serverless/appsec/httpsec/proxy_test.go
@@ -26,7 +26,7 @@ func init() {
 
 func TestProxyLifecycleProcessor(t *testing.T) {
 	t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", "true")
-	lp, err := appsec.New()
+	lp, err := appsec.New(nil)
 	if err != nil {
 		t.Skipf("appsec disabled: %v", err)
 	}


### PR DESCRIPTION
### What does this PR do?

JIRA: APPSEC-38167

This change does two things:
1 - Allow to force sending enhanced metrics regardless of configuration
2 - Force send an enhanced metric when a serverless invocation handled by appsec is detected.
      This new metric is `aws.lambda.enhanced.asm.invocations`, and will always be present if ASM is enabled (hence the need to ignore configuration and force the metric send)

### Motivation

This metric will be used to correctly track billing of all ASM serverless invocations while keeping out any unsupported invocation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
