### PR TITLE
[Invoke] Replace `List`, `Dict`, `Tuple` with the Python >= 3.9 equivalents

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -200,8 +200,8 @@ build_tags = {
 def compute_build_tags_for_flavor(
     build: str,
     arch: str,
-    build_include: List[str],
-    build_exclude: List[str],
+    build_include: list[str],
+    build_exclude: list[str],
     flavor: AgentFlavor = AgentFlavor.base,
 ):
     """

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -1,12 +1,8 @@
 """
 Utilities to manage build tags
 """
-# TODO: check if we really need the typing import.
-# Recent versions of Python should be able to use dict and list directly in type hints,
-# so we only need to check that we don't run this code with old Python versions.
 
 import sys
-from typing import List
 
 from invoke import task
 

--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -1,9 +1,6 @@
 """
 High level testing tasks
 """
-# TODO: check if we really need the typing import.
-# Recent versions of Python should be able to use dict and list directly in type hints,
-# so we only need to check that we don't run this code with old Python versions.
 
 import abc
 import json
@@ -15,7 +12,6 @@ import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Dict, List
 
 from invoke import task
 from invoke.exceptions import Exit

--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -154,7 +154,7 @@ def invoke_unit_tests(ctx):
 
 
 def test_core(
-    modules: List[GoModule],
+    modules: list[GoModule],
     flavor: AgentFlavor,
     module_class: GoModule,
     operation_name: str,
@@ -293,9 +293,9 @@ class ModuleTestResult(ModuleResult):
 
 def lint_flavor(
     ctx,
-    modules: List[GoModule],
+    modules: list[GoModule],
     flavor: AgentFlavor,
-    build_tags: List[str],
+    build_tags: list[str],
     arch: str,
     rtloader_root: bool,
     concurrency: int,
@@ -332,10 +332,10 @@ def lint_flavor(
 
 def build_stdlib(
     ctx,
-    build_tags: List[str],
+    build_tags: list[str],
     cmd: str,
-    env: Dict[str, str],
-    args: Dict[str, str],
+    env: dict[str, str],
+    args: dict[str, str],
     test_profiler: TestProfiler,
 ):
     """
@@ -358,11 +358,11 @@ def build_stdlib(
 def test_flavor(
     ctx,
     flavor: AgentFlavor,
-    build_tags: List[str],
-    modules: List[GoModule],
+    build_tags: list[str],
+    modules: list[GoModule],
     cmd: str,
-    env: Dict[str, str],
-    args: Dict[str, str],
+    env: dict[str, str],
+    args: dict[str, str],
     junit_tar: str,
     save_result_json: str,
     test_profiler: TestProfiler,
@@ -418,7 +418,7 @@ def test_flavor(
 def coverage_flavor(
     ctx,
     flavor: AgentFlavor,
-    modules: List[GoModule],
+    modules: list[GoModule],
 ):
     """
     Prints the code coverage of all modules for the given flavor.
@@ -436,7 +436,7 @@ def coverage_flavor(
 def codecov_flavor(
     ctx,
     flavor: AgentFlavor,
-    modules: List[GoModule],
+    modules: list[GoModule],
 ):
     """
     Uploads coverage data of all modules for the given flavor.
@@ -487,7 +487,7 @@ def process_input_args(input_module, input_targets, input_flavors, headless_mode
     return modules, flavors
 
 
-def process_module_results(module_results: Dict[str, Dict[str, List[ModuleResult]]]):
+def process_module_results(module_results: dict[str, dict[str, list[ModuleResult]]]):
     """
     Expects results in the format:
     {
@@ -1149,7 +1149,7 @@ def junit_macos_repack(_, infile, outfile):
 
 
 @task
-def get_modified_packages(ctx) -> List[GoModule]:
+def get_modified_packages(ctx) -> list[GoModule]:
     modified_files = get_modified_files(ctx)
     modified_go_files = [
         f"./{file}" for file in modified_files if file.endswith(".go") or file.endswith(".mod") or file.endswith(".sum")

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -3,7 +3,6 @@ import os
 import re
 import subprocess
 from collections import defaultdict
-from typing import Dict
 
 from .common.gitlab import Gitlab, get_gitlab_token
 from .types import FailedJobs, Test

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -134,7 +134,7 @@ def get_failed_tests(project_name, job, owners_file=".github/CODEOWNERS"):
     return failed_tests.values()
 
 
-def find_job_owners(failed_jobs: FailedJobs, owners_file: str = ".gitlab/JOBOWNERS") -> Dict[str, FailedJobs]:
+def find_job_owners(failed_jobs: FailedJobs, owners_file: str = ".gitlab/JOBOWNERS") -> dict[str, FailedJobs]:
     owners = read_owners(owners_file)
     owners_to_notify = defaultdict(FailedJobs)
 

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -206,8 +206,8 @@ def _clean_stacks(ctx: Context):
         _remove_stack(ctx, stack)
 
 
-def _get_existing_stacks(ctx: Context) -> List[str]:
-    e2e_stacks: List[str] = []
+def _get_existing_stacks(ctx: Context) -> list[str]:
+    e2e_stacks: list[str] = []
     output = ctx.run("PULUMI_SKIP_UPDATE_CHECK=true pulumi stack ls --all --project e2elocal --json", hide=True)
     if output is None or not output:
         return []

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -8,7 +8,6 @@ import os.path
 import shutil
 import tempfile
 from pathlib import Path
-from typing import List
 
 from invoke.context import Context
 from invoke.exceptions import Exit

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -6,7 +6,6 @@ import time
 import traceback
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Dict
 
 import yaml
 from invoke import task

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -410,7 +410,7 @@ Please check for typos in the JOBOWNERS file and/or add them to the Github <-> S
 """
 
 
-def generate_failure_messages(project_name: str, failed_jobs: FailedJobs) -> Dict[str, SlackMessage]:
+def generate_failure_messages(project_name: str, failed_jobs: FailedJobs) -> dict[str, SlackMessage]:
     all_teams = "@DataDog/agent-all"
 
     # Generate messages for each team

--- a/tasks/show_linters_issues/golangci_lint_parser.py
+++ b/tasks/show_linters_issues/golangci_lint_parser.py
@@ -133,7 +133,7 @@ def display_result(filtered_lints):
     return output
 
 
-def merge_results(results_per_os_x_arch: Dict[str, str]):
+def merge_results(results_per_os_x_arch: dict[str, str]):
     """
     Merge golangci-lint output
     """

--- a/tasks/show_linters_issues/golangci_lint_parser.py
+++ b/tasks/show_linters_issues/golangci_lint_parser.py
@@ -5,7 +5,6 @@ This module defines a parser for golangci-lint output.
 import os
 import re
 from collections import defaultdict
-from typing import Dict
 
 from ..libs.pipeline_notifications import read_owners
 

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -17,7 +17,7 @@ GO_VERSION_FILE = "./.go-version"
 # - path is the path of the file to update
 # - pre_pattern and post_pattern delimit the version to update
 # - is_bugfix is True if the version in the match is a bugfix version, False if it's a minor
-GO_VERSION_REFERENCES: List[Tuple[str, str, str, bool]] = [
+GO_VERSION_REFERENCES: list[tuple[str, str, str, bool]] = [
     (GO_VERSION_FILE, "", "", True),  # the version is the only content of the file
     ("./tools/gdb/Dockerfile", "https://go.dev/dl/go", ".linux-amd64.tar.gz", True),
     ("./test/fakeintake/Dockerfile", "FROM golang:", "-alpine", True),

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -1,5 +1,4 @@
 import re
-from typing import List, Tuple
 
 from invoke import exceptions
 from invoke.context import Context


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR replaces:
- List -> list
- Dict -> dict
- Tuple -> tuple

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Clearer code. We're using Python >= 3.9, meaning we don't need `typing` for those: https://mypy.readthedocs.io/en/stable/builtin_types.html#generic-types

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
