### PR TITLE
serializer: re-use marshaller buffers when possible

### DIFF
--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -112,6 +112,7 @@ func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buff
 	var err error
 	var compressor *stream.Compressor
 	buf := bufferContext.PrecompressionBuf
+	buf.Reset()
 	ps := molecule.NewProtoStream(buf)
 	payloads := transaction.BytesPayloads{}
 

--- a/pkg/serializer/internal/metrics/sketch_series_list.go
+++ b/pkg/serializer/internal/metrics/sketch_series_list.go
@@ -54,6 +54,7 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 	var err error
 	var compressor *stream.Compressor
 	buf := bufferContext.PrecompressionBuf
+	buf.Reset()
 	ps := molecule.NewProtoStream(buf)
 	payloads := transaction.BytesPayloads{}
 


### PR DESCRIPTION
### What does this PR do?
Changes the way memory is managed by the metrics serializer

### Motivation
In some profiles, I noticed that we seem to be needlessly re-allocating these buffers, when we could re-use the existing buffers without issue.

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes
Automated tests will cover this.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
