### PR TITLE
Fix `deploy_containers-a7-rc` GitLab jobs

### DIFF
--- a/.gitlab/deploy_containers/conditions.yml
+++ b/.gitlab/deploy_containers/conditions.yml
@@ -32,8 +32,16 @@
 .on_rc:
   - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
     when: manual
+    variables:
+      AGENT_REPOSITORY: agent
+      DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
   - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
     when: on_success
+    variables:
+      AGENT_REPOSITORY: agent
+      DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
 
 # Rule for job that can be triggered manually on final build, deploy to prod repository on stable branch deploy, else to dev repository
 .on_final:


### PR DESCRIPTION
### What does this PR do?

Ensure `AGENT_REPOSITORY`, `DSD_REPOSITORY` and `IMG_REGISTRIES` environment variables are set in the `deploy_containers-a7-rc` and `deploy_containers-a6-rc` jobs.

### Motivation

The `deploy_containers-a7-rc` are currently broken. See the [`7.51.0-rc.1` pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/26032705).
The [jobs](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/402812467) are failing with this error:
```
$ inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_VARIABLES,IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS,IMG_SIGNING"
Traceback (most recent call last):
  File "/root/miniconda3/envs/ddpy3/bin/inv", line 8, in <module>
    sys.exit(program.run())
  File "/root/miniconda3/envs/ddpy3/lib/python3.9/site-packages/invoke/program.py", line 398, in run
    self.execute()
  File "/root/miniconda3/envs/ddpy3/lib/python3.9/site-packages/invoke/program.py", line 583, in execute
    executor.execute(*self.tasks)
  File "/root/miniconda3/envs/ddpy3/lib/python3.9/site-packages/invoke/executor.py", line 140, in execute
    result = call.task(*args, **call.kwargs)
  File "/root/miniconda3/envs/ddpy3/lib/python3.9/site-packages/invoke/tasks.py", line 138, in __call__
    result = self.body(*args, **kwargs)
  File "/go/src/github.com/DataDog/datadog-agent/tasks/pipeline.py", line 455, in trigger_child_pipeline
    data['variables'][v] = os.environ[v]
  File "/root/miniconda3/envs/ddpy3/lib/python3.9/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'IMG_REGISTRIES'
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
