### PR TITLE
Fix secret resolving for string slices

### DIFF
--- a/comp/core/secrets/secretsimpl/secrets_test.go
+++ b/comp/core/secrets/secretsimpl/secrets_test.go
@@ -45,6 +45,23 @@ slice:
 - 123
 `)
 
+	testSimpleConf = []byte(`secret_backend_arguments:
+- ENC[pass1]
+`)
+
+	testSimpleConfResolved = `secret_backend_arguments:
+- password1
+`
+
+	testSimpleConfOrigin = handleToContext{
+		"pass1": []secretContext{
+			{
+				origin: "test",
+				path:   []string{"secret_backend_arguments", "0"},
+			},
+		},
+	}
+
 	testConf = []byte(`---
 instances:
 - password: ENC[pass1]
@@ -271,6 +288,23 @@ func TestResolve(t *testing.T) {
 
 	currentTest := t
 	testCases := []testCase{
+		{
+			name:                 "simple",
+			testConf:             testSimpleConf,
+			resolvedConf:         testSimpleConfResolved,
+			expectedSecretOrigin: testSimpleConfOrigin,
+			expectedScrubbedKey:  []string{"secret_backend_arguments"},
+			secretFetchCB: func(secrets []string) (map[string]string, error) {
+				sort.Strings(secrets)
+				assert.Equal(currentTest, []string{
+					"pass1",
+				}, secrets)
+
+				return map[string]string{
+					"pass1": "password1",
+				}, nil
+			},
+		},
 		{
 			// TestResolve/map_with_dash_value checks that a nested string config value
 			// that can be interpreted as YAML (such as a "-") is not interpreted as YAML by the secrets

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1867,6 +1867,19 @@ func configAssignAtPath(config pkgconfigmodel.Config, settingPath []string, newV
 			} else {
 				iterateValue = modifyValue[elem]
 			}
+		case []string:
+			index, err := strconv.Atoi(elem)
+			if err != nil {
+				return err
+			}
+			if index >= len(modifyValue) {
+				return fmt.Errorf("index out of range %d >= %d", index, len(modifyValue))
+			}
+			if k == len(trailingElements)-1 {
+				modifyValue[index] = fmt.Sprintf("%s", newValue)
+			} else {
+				iterateValue = modifyValue[index]
+			}
 		case []interface{}:
 			index, err := strconv.Atoi(elem)
 			if err != nil {


### PR DESCRIPTION
### What does this PR do?

Under certain circumstances, the yaml config will unmarshal the config to use []string instead of []interface{}, so that case needs to be handled as well

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Create this script for resolving secrets, name it `secret-script.py`:
```
#!/usr/bin/env python
import datetime
import json
import os
import sys

def log(fout, msg):
  dt = datetime.datetime.now()
  if not msg.endswith('\n'):
    msg += '\n'
  fout.write('[%s] %s' % (dt, msg))

def main():
  fout = open('secret-script.log', 'a')
  content = sys.stdin.read()
  obj = json.loads(content)
  log(fout, 'request: %s' % content)
  handles = obj['secrets']
  log(fout, 'num handles = %d' % len(handles))
  result = {}
  resolved = []
  for h in handles:
    resolved.append(h)
    result[h] = {
      'value': 'decoded_%s' % h,
    }
  print(json.dumps(result))
  log(fout, '%s => %s\n' % (','.join(resolved), result))
  fout.close()

if __name__ == '__main__':
  main()
```

In `datadog.yaml` configure the secret backend:

```
secret_backend_command: secret-script.py
secret_backend_arguments: 
- ENC[arg]
```

Start the agent, then run this command `agent secret`. You should see that `arg` was decoded (the value is scrubbed and is not viewable). Run `agent config` and look for `secret_backend_arguments`. You should see that the argument is now a resolved secret (but only `"********"` should be visible due to the scrubber).

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
