### PR TITLE
usm: http2: tests: Eliminate panic in tests

### DIFF
--- a/pkg/network/tracer/usm_grpc_monitor_test.go
+++ b/pkg/network/tracer/usm_grpc_monitor_test.go
@@ -125,6 +125,8 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 
 	cfg := s.getConfig()
 	tr := setupTracer(t, cfg)
+	require.NotNil(t, tr.usmMonitor)
+
 	if s.isTLS {
 		require.Eventuallyf(t, func() bool {
 			traced := utils.GetTracedPrograms("go-tls")
@@ -383,7 +385,7 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 				tt.runClients(t, clientCount)
 
 				res := make(map[http.Key]int)
-				require.Eventually(t, func() bool {
+				assert.Eventually(t, func() bool {
 					conns := getConnections(t, tr)
 					for key, stat := range conns.HTTP2 {
 						if key.DstPort == 5050 || key.SrcPort == 5050 {
@@ -417,6 +419,9 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 					return true
 				}, time.Second*5, time.Millisecond*100, "%v != %v", res, tt.expectedEndpoints)
 			})
+			if t.Failed() && tr.usmMonitor != nil {
+				ebpftest.DumpMapsTestHelper(t, tr.usmMonitor.DumpMaps, "http2_in_flight", "http2_dynamic_table")
+			}
 		}
 	}
 }
@@ -438,7 +443,7 @@ func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {
 
 	cfg := s.getConfig()
 	tr := setupTracer(t, cfg)
-	require.NoError(t, tr.ebpfTracer.Pause())
+	require.NotNil(t, tr.usmMonitor)
 
 	if s.isTLS {
 		require.Eventuallyf(t, func() bool {
@@ -554,7 +559,7 @@ func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {
 					return true
 				}, time.Second*5, time.Millisecond*100, "%v != %v", res, tt.expectedEndpoints)
 
-				if t.Failed() {
+				if t.Failed() && tr.usmMonitor != nil {
 					ebpftest.DumpMapsTestHelper(t, tr.usmMonitor.DumpMaps, "http2_in_flight", "http2_dynamic_table")
 				}
 			})


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

In a case where we have a bug in USM and it fails to start, we would run the test, but only at its end when we tried to dump maps, we would have caused a nil-deref wihle trying to access usm pointer.

Also removes redundant Pause method in TestLargeBodiesGRPCScenarios

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Failures in a different PR revealed the issue
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
