### PR TITLE
Fix process agent status output

### DIFF
--- a/cmd/process-agent/subcommands/status/status.go
+++ b/cmd/process-agent/subcommands/status/status.go
@@ -116,7 +116,7 @@ func fetchStatus(statusURL string) ([]byte, error) {
 }
 
 // getAndWriteStatus calls the status server and writes it to `w`
-func getAndWriteStatus(log log.Component, statusURL string, w io.Writer, options ...status.StatusOption) {
+func getAndWriteStatus(log log.Component, statusURL string, w io.Writer) {
 	body, err := fetchStatus(statusURL)
 	if err != nil {
 		switch err.(type) {
@@ -134,10 +134,6 @@ func getAndWriteStatus(log log.Component, statusURL string, w io.Writer, options
 	if err != nil {
 		writeError(log, w, err)
 		return
-	}
-
-	for _, option := range options {
-		option(&s)
 	}
 
 	statusMap["processAgentStatus"] = s

--- a/cmd/process-agent/subcommands/status/status.go
+++ b/cmd/process-agent/subcommands/status/status.go
@@ -128,27 +128,24 @@ func getAndWriteStatus(log log.Component, statusURL string, w io.Writer, options
 		return
 	}
 
-	// If options to override the status are provided, we need to deserialize and serialize it again
-	if len(options) > 0 {
-		var s status.Status
-		err = json.Unmarshal(body, &s)
-		if err != nil {
-			writeError(log, w, err)
-			return
-		}
+	statusMap := map[string]interface{}{}
+	var s status.Status
+	err = json.Unmarshal(body, &s)
+	if err != nil {
+		writeError(log, w, err)
+		return
+	}
 
-		for _, option := range options {
-			option(&s)
-		}
+	for _, option := range options {
+		option(&s)
+	}
 
-		status := map[string]interface{}{}
-		status["processAgentStatus"] = s
+	statusMap["processAgentStatus"] = s
 
-		body, err = json.Marshal(status)
-		if err != nil {
-			writeError(log, w, err)
-			return
-		}
+	body, err = json.Marshal(statusMap)
+	if err != nil {
+		writeError(log, w, err)
+		return
 	}
 
 	stats, err := render.FormatProcessAgentStatus(body)

--- a/cmd/process-agent/subcommands/status/status_test.go
+++ b/cmd/process-agent/subcommands/status/status_test.go
@@ -65,7 +65,7 @@ func TestStatus(t *testing.T) {
 
 	// Build the actual status
 	var statusBuilder strings.Builder
-	getAndWriteStatus(log.NoopLogger, server.URL, &statusBuilder, status.OverrideTime(testTime))
+	getAndWriteStatus(log.NoopLogger, server.URL, &statusBuilder)
 
 	assert.Equal(t, expectedOutput, statusBuilder.String())
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

During the QA week for `7.51.0` we found that the process agent status is not correctly displayed. The initial PR that introduced the bug here https://github.com/DataDog/datadog-agent/pull/21106/commits/8155a18be67570e934bdf0bfaee6ed8f566bc521

The solution was to make sure that the `statusMap["processAgentStatus"` gets computed not only if there were additional options to `getAndWriteStatus` function. Later, I realized that that function used the optional `...status.StatusOption` just for testing. Looking at the test, there is no need to pass those options around since we are stubbing the server response. In the second commit, I remove that code entirely: https://github.com/DataDog/datadog-agent/commit/93ac7576773317cbe459e00b7b2950ec83bd8bbd

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The output of the process agent status commands works as expected.

`/opt/datadog-agent/embedded/bin/process-agent status`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
