### PR TITLE
[USM] Rate limit process monitor debug logs

### DIFF
--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -37,6 +38,8 @@ var (
 		processExecCallbacks: make(map[*ProcessCallback]struct{}, 0),
 		processExitCallbacks: make(map[*ProcessCallback]struct{}, 0),
 	}
+
+	oversizedLogLimit = util.NewLogLimit(10, 10*time.Minute)
 )
 
 // processMonitorTelemetry
@@ -170,7 +173,7 @@ func (pm *ProcessMonitor) handleProcessExec(pid uint32) {
 			continue
 		default:
 			pm.tel.processExecChannelIsFull.Add(1)
-			if log.ShouldLog(seelog.DebugLvl) {
+			if log.ShouldLog(seelog.DebugLvl) && oversizedLogLimit.ShouldLog() {
 				log.Debug("can't send exec callback to callbackRunner, channel is full")
 			}
 		}
@@ -190,7 +193,7 @@ func (pm *ProcessMonitor) handleProcessExit(pid uint32) {
 			continue
 		default:
 			pm.tel.processExitChannelIsFull.Add(1)
-			if log.ShouldLog(seelog.DebugLvl) {
+			if log.ShouldLog(seelog.DebugLvl) && oversizedLogLimit.ShouldLog() {
 				log.Debug("can't send exit callback to callbackRunner, channel is full")
 			}
 		}

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -37,9 +37,8 @@ var (
 		// Must initialize the sets, as we can register callbacks prior to calling Initialize.
 		processExecCallbacks: make(map[*ProcessCallback]struct{}, 0),
 		processExitCallbacks: make(map[*ProcessCallback]struct{}, 0),
+		oversizedLogLimit:    util.NewLogLimit(10, 10*time.Minute),
 	}
-
-	oversizedLogLimit = util.NewLogLimit(10, 10*time.Minute)
 )
 
 // processMonitorTelemetry
@@ -124,6 +123,8 @@ type ProcessMonitor struct {
 	callbackRunner chan func()
 
 	tel processMonitorTelemetry
+
+	oversizedLogLimit *util.LogLimit
 }
 
 // ProcessCallback is a callback function that is called on a given pid that represents a new process.
@@ -173,7 +174,7 @@ func (pm *ProcessMonitor) handleProcessExec(pid uint32) {
 			continue
 		default:
 			pm.tel.processExecChannelIsFull.Add(1)
-			if log.ShouldLog(seelog.DebugLvl) && oversizedLogLimit.ShouldLog() {
+			if log.ShouldLog(seelog.DebugLvl) && pm.oversizedLogLimit.ShouldLog() {
 				log.Debug("can't send exec callback to callbackRunner, channel is full")
 			}
 		}
@@ -193,7 +194,7 @@ func (pm *ProcessMonitor) handleProcessExit(pid uint32) {
 			continue
 		default:
 			pm.tel.processExitChannelIsFull.Add(1)
-			if log.ShouldLog(seelog.DebugLvl) && oversizedLogLimit.ShouldLog() {
+			if log.ShouldLog(seelog.DebugLvl) && pm.oversizedLogLimit.ShouldLog() {
 				log.Debug("can't send exit callback to callbackRunner, channel is full")
 			}
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Limit the number of debug logs the process monitor can generate, as they are currently spamming our logs in case the callback channels are full (we have seen number in the 9k logs per 5 minutes). Not only does it spam the logs, it causes massive allocations in the range of 150+MB when it happens.

This PR fixes this by introducing a log limiter so only 10 logs are allowed in a 10 minutes span.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Reduce log spam & memory consumption in case of callback channels being full, when debug logs are enabled.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
