### PR TITLE
Bugfix: GUI status output do not display Netflow and SNTP if disable 

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -535,57 +535,58 @@
     </span>
   </div>
 
-  <div class="stat">
-    <span class="stat_title">SNMP Traps</span>
-    <span class="stat_data">
-      {{- with .snmpTrapsStats -}}
-        {{- if .error }}
-          Error: {{.error}}<br>
-        {{- end }}
-        {{- range $key, $value := .metrics}}
-          {{formatTitle $key}}: {{humanize $value}}<br>
-        {{- end }}
-      {{- end -}}
-    </span>
-  </div>
+  {{- with .snmpTrapsStats -}}
+    <div class="stat">
+      <span class="stat_title">SNMP Traps</span>
+      <span class="stat_data">
+          {{- if .error }}
+            Error: {{.error}}<br>
+          {{- end }}
+          {{- range $key, $value := .metrics}}
+            {{formatTitle $key}}: {{humanize $value}}<br>
+          {{- end }}
+      </span>
+    </div>
+  {{- end -}}
 
-  <div class="stat">
-    <span class="stat_title">NetFlow</span>
-    <span class="stat_data">
-        Total Listeners: {{.netflowStats.TotalListeners}}
-        <br>Open Listeners: {{.netflowStats.OpenListeners}}
-        <br>Closed Listeners: {{.netflowStats.ClosedListeners}}
-        {{ if .netflowStats.OpenListeners }}
-        <span class="stat_subtitle">Open Listener Details</span>
-        {{- range $index, $NetflowListenerStatus := .netflowStats.WorkingListenerDetails }}
-        BindHost: {{$NetflowListenerStatus.Config.BindHost}}
-        <br>FlowType: {{$NetflowListenerStatus.Config.FlowType}}
-        <br>Port: {{$NetflowListenerStatus.Config.Port}}
-        <br>Workers: {{$NetflowListenerStatus.Config.Workers}}
-        <br>Namespace: {{$NetflowListenerStatus.Config.Namespace}}
-        <br>Flows Received: {{$NetflowListenerStatus.FlowCount}}
-        <br>
-        <br>
-        {{- end }}
-        {{ end }}
-        <br>
-        {{ if .netflowStats.ClosedListeners }}
-        <br>
-        <span class="stat_subtitle">Closed Listener Details</span>
-        {{- range $index, $NetflowListenerStatus := .netflowStats.ClosedListenerDetails }}
-        BindHost: {{$NetflowListenerStatus.Config.BindHost}}
-        <br>FlowType: {{$NetflowListenerStatus.Config.FlowType}}
-        <br>Port: {{$NetflowListenerStatus.Config.Port}}
-        <br>Workers: {{$NetflowListenerStatus.Config.Workers}}
-        <br>Namespace: {{$NetflowListenerStatus.Config.Namespace}}
-        <br>Error: {{$NetflowListenerStatus.Error}}
-        <br>
-        <br>
-        {{- end }}
-        {{ end }}
-    </span>
-   </div>
-
+  {{- with .netflowStats -}}
+    <div class="stat">
+      <span class="stat_title">NetFlow</span>
+      <span class="stat_data">
+          Total Listeners: {{.TotalListeners}}
+          <br>Open Listeners: {{.OpenListeners}}
+          <br>Closed Listeners: {{.ClosedListeners}}
+          {{ if .OpenListeners }}
+          <span class="stat_subtitle">Open Listener Details</span>
+          {{- range $index, $NetflowListenerStatus := .WorkingListenerDetails }}
+          BindHost: {{$NetflowListenerStatus.Config.BindHost}}
+          <br>FlowType: {{$NetflowListenerStatus.Config.FlowType}}
+          <br>Port: {{$NetflowListenerStatus.Config.Port}}
+          <br>Workers: {{$NetflowListenerStatus.Config.Workers}}
+          <br>Namespace: {{$NetflowListenerStatus.Config.Namespace}}
+          <br>Flows Received: {{$NetflowListenerStatus.FlowCount}}
+          <br>
+          <br>
+          {{- end }}
+          {{ end }}
+          <br>
+          {{ if .ClosedListeners }}
+          <br>
+          <span class="stat_subtitle">Closed Listener Details</span>
+          {{- range $index, $NetflowListenerStatus := .ClosedListenerDetails }}
+          BindHost: {{$NetflowListenerStatus.Config.BindHost}}
+          <br>FlowType: {{$NetflowListenerStatus.Config.FlowType}}
+          <br>Port: {{$NetflowListenerStatus.Config.Port}}
+          <br>Workers: {{$NetflowListenerStatus.Config.Workers}}
+          <br>Namespace: {{$NetflowListenerStatus.Config.Namespace}}
+          <br>Error: {{$NetflowListenerStatus.Error}}
+          <br>
+          <br>
+          {{- end }}
+          {{ end }}
+      </span>
+    </div>
+  {{- end -}}
 
 
   <div class="stat">

--- a/pkg/status/render/fixtures/agent_status.text
+++ b/pkg/status/render/fixtures/agent_status.text
@@ -484,11 +484,13 @@ Datadog Cluster Agent
     - Datadog Cluster Agent endpoint detected: https://10.122.58.252:5005
     Successfully connected to the Datadog Cluster Agent.
     - Running: x.y.z+commit.9b0b54b
+
 ==========
 SNMP Traps
 ==========
   Packets: 0
   Packets Auth Errors: 0
+
 =============
 Autodiscovery
 =============

--- a/pkg/status/render/templates/clusteragent.tmpl
+++ b/pkg/status/render/templates/clusteragent.tmpl
@@ -16,4 +16,4 @@ Datadog Cluster Agent
     Successfully connected to the Datadog Cluster Agent.
     - Running: {{ .Version }}
   {{- end }}
-{{- end -}}
+{{- end }}

--- a/pkg/status/render/templates/netflow.tmpl
+++ b/pkg/status/render/templates/netflow.tmpl
@@ -1,4 +1,4 @@
-{{- with .netflowStats -}}
+{{- with .netflowStats }}
 =========
 NetFlow
 =========
@@ -32,4 +32,4 @@ NetFlow
   ---------
   {{- end }}
   {{ end }}
-{{- end -}}
+{{- end }}

--- a/pkg/status/render/templates/snmp-traps.tmpl
+++ b/pkg/status/render/templates/snmp-traps.tmpl
@@ -12,4 +12,4 @@ SNMP Traps
 {{- range $key, $value := .metrics}}
   {{formatTitle $key}}: {{humanize $value}}
 {{- end }}
-{{- end }}
+{{- end -}}

--- a/pkg/status/render/templates/snmp-traps.tmpl
+++ b/pkg/status/render/templates/snmp-traps.tmpl
@@ -12,4 +12,4 @@ SNMP Traps
 {{- range $key, $value := .metrics}}
   {{formatTitle $key}}: {{humanize $value}}
 {{- end }}
-{{- end -}}
+{{- end }}


### PR DESCRIPTION
- Text version make sure to add new lines between some sections
- GUI do not display SNMP or NetFlow sections if no infomration is available

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

During the QA process, we noticed that the information in GUI between 7.50.2 and the RC changed. In the 7.50.2 version even when SNMP or Netflow are disabled we still see them displayed in the GUI
<img width="424" alt="image" src="https://github.com/DataDog/datadog-agent/assets/4672858/3a27d16a-a589-4f39-90d8-82ff94286c51">

In the RC we still see the header but no information:
<img width="395" alt="image" src="https://github.com/DataDog/datadog-agent/assets/4672858/3b387f36-4a63-44a9-bba1-dd8ae28bfbbe">

The problems originated here https://github.com/DataDog/datadog-agent/pull/20824/files#diff-1deea3647518183ee4915dd3c10ccfc7bb60e1ed860673c99eefaf5cfeefaa6bL379-L381

Before that change, we collected the data even if those services were not enabled. The default information is 0. After the change, we only collected the data that were enabled. 

In the PR above, we made sure of the text version.  does not display the information if not present; in the HTML, we always display the information, even when the service was not enabled. 

This PR changes so it only renders information if present. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Validate the status output and the GUI output are correct.

#### With SNMP and NetFlow configured 
- modify the config to include:
```
network_devices:
  netflow:
    enabled: true
    listeners:
      - flow_type: netflow9   # choices: netflow5, netflow9, ipfix, sflow5
        port: 2055            # devices must send traffic to this port
      - flow_type: netflow5
        port: 2056
      - flow_type: ipfix
        port: 4739
      - flow_type: sflow5
        port: 6343
  snmp_traps:
    enabled: true
    port: 9162 # on which ports to listen for traps
    community_strings: # which community strings to allow for v2 traps
      - <STRING_1>
      - <STRING_2>
    bind_host: 0.0.0.0
    users: # limited to only a single v3 user
      - username: 'user'
        authKey: 'fakeKey'
        authProtocol: 'SHA' # choices: MD5, SHA, SHA224, SHA256, SHA384, SHA512
        privKey: 'fakePrivKey'
        privProtocol: 'AES' # choices: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
```

- Start the agent 
- Get the status output `agent status`. Validate that SNMP and Netflow information is displayed 
- Launch the GUI.  `agent launch-gui`. Validate that in the General Status section SNMP and Netflow information is displayed 

#### With SNMP and NetFlow **not** configured 
- Remove the `network_devices` configuration for NetFlow and SNMP from the configuration 
- Start the agent 
- Get the status output `agent status`. Validate that SNMP and Netflow information is **not** displayed 
- Launch the GUI.  `agent launch-gui`. Validate that in the General Status section SNMP and Netflow information is *not* displayed 


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
