### PR TITLE
Imporve KMT destroy task

### DIFF
--- a/tasks/kernel_matrix_testing/README.md
+++ b/tasks/kernel_matrix_testing/README.md
@@ -1,13 +1,13 @@
 # Kernel Matrix Testing system
 
 ## Overview
-The Kernel Matrix Testing system is a new approach for testing system-probe. It uses libvirt and qemu to launch pre-provisioned VMs over a range of distributions and kernel versions. These VMs are used for running the test suite of system-probe.  
+The Kernel Matrix Testing system is a new approach for testing system-probe. It uses libvirt and qemu to launch pre-provisioned VMs over a range of distributions and kernel versions. These VMs are used for running the test suite of system-probe.
 
-Developers can check out this confluence page for more details about the system.   
+Developers can check out this confluence page for more details about the system.
 
 This file will document the invoke tasks provided to easily manage the lifecycle of the VMs launched using this system.
 
-The system works on the concept of `stacks`. A `stack` is a collection of VMs, both local and remote. A `stack` is given a unique name by the user.   
+The system works on the concept of `stacks`. A `stack` is a collection of VMs, both local and remote. A `stack` is given a unique name by the user.
 If no stack name is provided, a name is generated automatically from the current branch name. This allows the developers to couple `stacks` with their git workflow.
 A `stack` may be:
 - Created
@@ -24,12 +24,12 @@ A `stack` may be:
 
 ## Dependencies
 ### Linux
-Review and run `tasks/kernel_matrix_testing/env-setup.sh`   
-   
+Review and run `tasks/kernel_matrix_testing/env-setup.sh`
+
 
 - **You will have to run the following manually**
-Download [test-infra-definitions](https://github.com/DataDog/test-infra-definitions) repository.   
-From within the repository execute the following commands:  
+Download [test-infra-definitions](https://github.com/DataDog/test-infra-definitions) repository.
+From within the repository execute the following commands:
 ```bash
 go mod download
 export PULUMI_CONFIG_PASSPHRASE=dummy
@@ -43,8 +43,8 @@ brew install pulumi/tap/pulumi
 pulumi login --local
 ```
 
-Download [test-infra-definitions](https://github.com/DataDog/test-infra-definitions) repository.   
-From within the repository execute the following commands:  
+Download [test-infra-definitions](https://github.com/DataDog/test-infra-definitions) repository.
+From within the repository execute the following commands:
 ```bash
 go mod download
 export PULUMI_CONFIG_PASSPHRASE=dummy
@@ -57,7 +57,7 @@ pulumi --non-interactive plugin ls
 A straightforward flow to setup a collections of VMs is as follows:
 
 ### Initializing the environment
-This will download all the resources required to launch the VMs. This will not download the dependencies. See [above](#Dependencies) for that.   
+This will download all the resources required to launch the VMs. This will not download the dependencies. See [above](#Dependencies) for that.
 
 > This step should be done only once.
 
@@ -76,7 +76,7 @@ inv -e kmt.create-stack --stack=demo-stack
 ```
 
 ### Configure stack
-We will configure the stack to launch 
+We will configure the stack to launch
 - Remote x86_64 machine with ubuntu-jammy, ubuntu-focal VMs.
 - Remote arm64 machine with amazon linux 2 kernel 4.14, amazon linux 2 kernel 5.10 VMs.
 - Amazon linux 2 kernel 5.15, amazon linux 2 kernel 5.4 VMs on local machine.
@@ -111,12 +111,7 @@ Tear down the stack
 inv -e kmt.destroy-stack --stack=demo-stack
 ```
 
-If you run into any problems while destroying the stack, repeat with the following:
-```bash
-inv -e kmt.destroy-stack --force
-```
-
-This will attempt to manually teardown all resources. Primarily we care about cleaning the local libvirt environment and destroy remote ec2 instances. This flag takes care of these steps.
+This will attempt to manually teardown all resources. Primarily we care about cleaning the local libvirt environment and destroy remote ec2 instances.
 
 ## Tasks
 
@@ -136,12 +131,12 @@ In order to update the resources for launching VMs run:
 inv -e kmt.update-resources
 ```
 
-Updating will first destroy all running stacks, and then use checksums to decide which packages need to be updated from S3.   
+Updating will first destroy all running stacks, and then use checksums to decide which packages need to be updated from S3.
 If there is an error during update, original packages are restored from backup.
 
 
 ### Revert resources
-During the update process, all packages are first backed-up, incase there is an error during the update.   
+During the update process, all packages are first backed-up, incase there is an error during the update.
 This backup may be resotred manually if there is a problem with the new resources.
 
 ```bash
@@ -155,7 +150,7 @@ A stack can be created as follows:
 ```bash
 inv -e kmt.create-stack [--stack=<name>]
 ```
-The developer can provide a name to associate with the `stack`.    
+The developer can provide a name to associate with the `stack`.
 If no name is provided one is automatically generated from the current branch name.
 
 ### Listing possible VMs
@@ -184,9 +179,9 @@ The `vmsets` file contains the list of one or more sets of VMs to launch. A set 
 Sample VMSet file can be found [here](https://github.com/DataDog/test-infra-definitions/blob/f85e7eb2f003b6f9693c851549fbb7f3969b8ade/scenarios/aws/microVMs/sample-vm-config.json).
 
 
-The file can be generated for a particular `stack` with the `gen-config` task.   
+The file can be generated for a particular `stack` with the `gen-config` task.
 This task takes as parameters
-- The stack to target specified with [--stack=<name>] 
+- The stack to target specified with [--stack=<name>]
 - The list of VMS to generate specified by --vms=<list>. See [VMs list](#vms-list) for details on how to specify the list.
 - Optional paramenter `--init-stack` to automatically initialize the stack. This can be specified to automatically run the creating stack step.
 - Optional parameter `--new` to generate a fresh configuration file.
@@ -198,26 +193,26 @@ The file can be incrementally generated. This means a user may generate a vmset 
 # Setup configuration file to launch jammy and focal locally. Initialize a new stack corresponding to the current branch
 inv -e kmt.gen-config  --vms=jammy-local-distro,focal-local-distro --init-stack
 # Launch this stack. Since we are launching local VMs, there is no need to specify ssh key.
-inv -e kmt.launch-stack 
+inv -e kmt.launch-stack
 # Add amazon linux VMs to be launched locally
 inv -e kmt.gen-config  --vms=amazon4.14-local-distro,distro-local-amazon5.15,distro-local-amazon5.10
 # Launch the new VMs added. The previous VMs will keep running
-inv -e kmt.launch-stack 
+inv -e kmt.launch-stack
 # Remove all VMs except amazon linux 2 4.14 locally
 inv -e kmt.gen-config  --new --vms=amazon4.14-local-distro
 # Apply this configuration
-inv -e kmt.launch-stack 
+inv -e kmt.launch-stack
 ```
 
 #### Example 2
 ```bash
 # Setup configuration file to launch ubuntu VMs on remote x86_64 and arm64 machines
 inv -e kmt.gen-config  --vms=x86-ubuntu20-distro,distro-bionic-x86,distro-jammy-x86,distro-arm64-ubuntu22,arm64-ubuntu18-distro
-# Name of the ssh key to use 
+# Name of the ssh key to use
 inv -e kmt.launch-stack  --ssh-key=<ssh-key-name>
 # Add amazon linux
 inv -e kmt.gen-config  --vms=x86-amazon5.4-disto,arm64-distro-amazon5.4
-# Name of the ssh key to use 
+# Name of the ssh key to use
 inv -e kmt.launch-stack  --ssh-key=<ssh-key-name>
 ```
 
@@ -230,7 +225,7 @@ inv -e kmt.launch-stack  --ssh-key=<ssh-key-name>
 ```
 
 ### VMs List
-The vms list is a comma separated list of vm entries. These are the VMs to launch in the stack.   
+The vms list is a comma separated list of vm entries. These are the VMs to launch in the stack.
 Each entry comprises of three elemets seperate by a `-` (dash).
 1. Recipe. This is either `custom` or `distro`. `distro` is to be specified for distribution images and `custom` for custom kernels.
 2. Arch. Architecture is either `x86_64`, `arm64` or `local`.
@@ -260,10 +255,10 @@ All of the below resolve to [kernel 5.4, arm64, custom]
 ### Launching the stack
 If you are just launching local VMs you do not need to specify an ssh key
 ```bash
-inv -e kmt.launch-stack 
+inv -e kmt.launch-stack
 ```
 
-If you are launching remote instances then the ssh key used to access the machine is required.   
+If you are launching remote instances then the ssh key used to access the machine is required.
 Only the ssh key name is required. The program will automatically look in `~/.ssh/` directory for the key.
 ```bash
 inv -e kmt.launch-stack  --ssh-key=<ssh-key-name>
@@ -289,7 +284,7 @@ This resumes a previously paused stack. This is only applicable for VMs running 
 ### Syncing VMs
 The recommended workflow is to develop on the local machine, push changes to the target VMs, and then build and test there.
 
-To support this, a task for syncing the local datadog-agent repo with target VMs is provided.  
+To support this, a task for syncing the local datadog-agent repo with target VMs is provided.
 
 > We are working on providing tasks which will automatically sync with the target VMs, and build and run tests. However, this is a work in progress.
 

--- a/tasks/kernel_matrix_testing/libvirt.py
+++ b/tasks/kernel_matrix_testing/libvirt.py
@@ -1,8 +1,10 @@
+import os
 from .tool import info
+from .kmt_os import get_kmt_os
 
 
 def resource_in_stack(stack, resource):
-    return stack in resource
+    return f"-{stack}" in resource
 
 
 def get_resources_in_stack(stack, list_fn):

--- a/tasks/kernel_matrix_testing/libvirt.py
+++ b/tasks/kernel_matrix_testing/libvirt.py
@@ -1,6 +1,4 @@
-import os
 from .tool import info
-from .kmt_os import get_kmt_os
 
 
 def resource_in_stack(stack, resource):

--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -259,7 +259,7 @@ def remove_pool_directory(ctx, stack):
         for d in dirs:
             if resource_in_stack(stack, d):
                 rm_path = os.path.join(pools_dir, d)
-                ctx.run(f"sudo rm -r {rm_path}", hide=True)
+                ctx.run(f"sudo rm -r '{rm_path}'", hide=True)
                 info(f"[+] Removed libvirt pool directory {rm_path}")
 
 

--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -11,7 +11,7 @@ from .libvirt import (
     delete_volumes,
     pause_domains,
     resource_in_stack,
-    resume_domains
+    resume_domains,
 )
 from .tool import Exit, ask, error, info, warn
 

--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -4,7 +4,15 @@ import os
 
 from .init_kmt import VMCONFIG, check_and_get_stack
 from .kmt_os import get_kmt_os
-from .libvirt import delete_domains, delete_networks, delete_pools, delete_volumes, pause_domains, resume_domains, resource_in_stack
+from .libvirt import (
+    delete_domains,
+    delete_networks,
+    delete_pools,
+    delete_volumes,
+    pause_domains,
+    resource_in_stack,
+    resume_domains
+)
 from .tool import Exit, ask, error, info, warn
 
 try:
@@ -243,6 +251,7 @@ def destroy_ec2_instances(ctx, stack):
         info(f"[+] Instances {ids} terminated.")
 
     return
+
 
 def remove_pool_directory(ctx, stack):
     pools_dir = os.path.join(get_kmt_os().libvirt_dir, "pools")

--- a/tasks/kernel_matrix_testing/vmconfig.py
+++ b/tasks/kernel_matrix_testing/vmconfig.py
@@ -76,6 +76,7 @@ distributions = {
     "amazon_5.4": "amzn_5.4",
     "amazon_5.10": "amzn_5.10",
     "amzn_4.14": "amzn_4.14",
+    "amzn_414": "amzn_4.14",
     "amzn_5.4": "amzn_5.4",
     "amzn_5.10": "amzn_5.10",
     "amzn_2023": "amzn_2023",

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -70,9 +70,9 @@ def launch_stack(ctx, stack=None, ssh_key="", x86_ami=X86_AMI_ID_SANDBOX, arm_am
 
 
 @task
-def destroy_stack(ctx, stack=None, force=False, ssh_key=""):
+def destroy_stack(ctx, stack=None, pulumi=False, ssh_key=""):
     clean(ctx, stack)
-    stacks.destroy_stack(ctx, stack, force, ssh_key)
+    stacks.destroy_stack(ctx, stack, pulumi, ssh_key)
 
 
 @task
@@ -113,7 +113,7 @@ def update_resources(ctx, no_backup=False):
         raise Exit("[-] Update aborted")
 
     for stack in glob(f"{kmt_os.stacks_dir}/*"):
-        destroy_stack(ctx, stack=os.path.basename(stack), force=True)
+        destroy_stack(ctx, stack=os.path.basename(stack))
 
     update_kernel_packages(ctx, kmt_os.packages_dir, kmt_os.kheaders_dir, kmt_os.backup_dir, no_backup)
     update_rootfs(ctx, kmt_os.rootfs_dir, kmt_os.backup_dir, no_backup)
@@ -128,7 +128,7 @@ def revert_resources(ctx):
         raise Exit("[-] Revert aborted")
 
     for stack in glob(f"{kmt_os.stacks_dir}/*"):
-        destroy_stack(ctx, stack=stack, force=True)
+        destroy_stack(ctx, stack=stack)
 
     revert_kernel_packages(ctx, kmt_os.packages_dir, kmt_os.backup_dir)
     revert_rootfs(ctx, kmt_os.rootfs_dir, kmt_os.backup_dir)

--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -44,7 +44,7 @@ type handledError struct {
 	action      int
 }
 
-var errors = []handledError{
+var handledErrorsLs = []handledError{
 	// Retry if we failed to dial libvirt.
 	// Libvirt daemon on the server occasionally drops the connection established
 	// by the 'Provider'. If this happens we retry the stack to connect again.
@@ -99,7 +99,7 @@ func errorMetric(errType string) datadogV2.MetricPayload {
 
 func handleScenarioFailure(err error, changeRetryState func(handledError)) error {
 	errStr := err.Error()
-	for _, e := range errors {
+	for _, e := range handledErrorsLs {
 		if !strings.Contains(errStr, e.errorString) {
 			continue
 		}

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -11,7 +11,9 @@ package systemprobe
 import (
 	"context"
 	_ "embed" // embed files used in this scenario
+	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -97,7 +99,7 @@ func outputsToFile(output auto.OutputMap) error {
 		switch v := value.Value.(type) {
 		case string:
 			if _, err := f.WriteString(fmt.Sprintf("%s %s\n", key, v)); err != nil {
-				return fmt.Errorf("write string: %s", err)
+				return fmt.Errorf("failed to write string to file %q: %v", stackOutputs, err)
 			}
 		default:
 		}
@@ -211,18 +213,19 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *EnvOpts) (*
 	}
 
 	var upResult auto.UpResult
+	var pulumiStack *auto.Stack
 	ctx := context.Background()
 	currentAZ := 0 // PrimaryAZ
 	b := retry.NewConstant(3 * time.Second)
 	// Retry 4 times. This allows us to cycle through all AZs, and handle libvirt
 	// connection issues in the worst case.
 	b = retry.WithMaxRetries(4, b)
-	if retryErr := retry.Do(ctx, b, func(_ context.Context) error {
+	retryErr := retry.Do(ctx, b, func(_ context.Context) error {
 		if az := getAvailabilityZone(opts.InfraEnv, currentAZ); az != "" {
 			config["ddinfra:aws/defaultSubnets"] = auto.ConfigValue{Value: az}
 		}
 
-		_, upResult, err = stackManager.GetStackNoDeleteOnFailure(systemProbeTestEnv.context, systemProbeTestEnv.name, config, func(ctx *pulumi.Context) error {
+		pulumiStack, upResult, err = stackManager.GetStackNoDeleteOnFailure(systemProbeTestEnv.context, systemProbeTestEnv.name, config, func(ctx *pulumi.Context) error {
 			if err := microvms.Run(ctx); err != nil {
 				return fmt.Errorf("setup micro-vms in remote instance: %w", err)
 			}
@@ -239,13 +242,22 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *EnvOpts) (*
 		}
 
 		return nil
-	}); retryErr != nil {
-		return nil, fmt.Errorf("failed to create stack: %w", retryErr)
-	}
+	})
 
-	err = outputsToFile(upResult.Outputs)
+	outputs := upResult.Outputs
+	if retryErr != nil {
+		outputs, err = pulumiStack.Outputs(context.Background())
+		if err != nil {
+			outputs = nil
+			log.Printf("failed to get stack outputs: %v", err)
+		}
+	}
+	err = outputsToFile(outputs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to write stack output to file: %w", err)
+		err = fmt.Errorf("failed to write stack output to file: %w", err)
+	}
+	if retryErr != nil {
+		return nil, errors.Join(fmt.Errorf("failed to create stack: %w", retryErr), err)
 	}
 
 	systemProbeTestEnv.StackOutput = upResult

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -246,6 +246,8 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *EnvOpts) (*
 
 	outputs := upResult.Outputs
 	if retryErr != nil {
+		// pulumi does not populate `UpResult` with the stack output if the
+		// update process failed. In this case we must manually fetch the outputs.
 		outputs, err = pulumiStack.Outputs(context.Background())
 		if err != nil {
 			outputs = nil


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR makes the KMT destroy task more robust.
It does this by making sure that the remote ec2 instance is terminated even when the underlying scenario failed halfway.
It also removes some leftover artifacts created by libvirt.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
https://datadoghq.atlassian.net/browse/EBPF-370

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
