### PR TITLE
[AMLII-434] Add support for zstd compression in serializers

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -447,6 +447,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("serializer_max_series_points_per_payload", 10000)
 	config.BindEnvAndSetDefault("serializer_max_series_payload_size", 512000)
 	config.BindEnvAndSetDefault("serializer_max_series_uncompressed_payload_size", 5242880)
+	config.BindEnvAndSetDefault("serializer_compressor_kind", "zlib")
 
 	config.BindEnvAndSetDefault("use_v2_api.series", true)
 	// Serializer: allow user to blacklist any kind of payload to be sent

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -125,6 +125,7 @@ func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buff
 	maxPayloadSize := config.Datadog.GetInt("serializer_max_series_payload_size")
 	maxUncompressedSize := config.Datadog.GetInt("serializer_max_series_uncompressed_payload_size")
 	maxPointsPerPayload := config.Datadog.GetInt("serializer_max_series_points_per_payload")
+	compressorKind := config.Datadog.GetString("serializer_compressor_kind")
 
 	// constants for the protobuf data we will be writing, taken from MetricPayload in
 	// https://github.com/DataDog/agent-payload/blob/master/proto/metrics/agent_payload.proto
@@ -177,7 +178,7 @@ func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buff
 		compressor, err = stream.NewCompressor(
 			bufferContext.CompressorInput, bufferContext.CompressorOutput,
 			maxPayloadSize, maxUncompressedSize,
-			[]byte{}, []byte{}, []byte{})
+			[]byte{}, []byte{}, []byte{}, compressorKind)
 		if err != nil {
 			return err
 		}

--- a/pkg/serializer/internal/metrics/series_test.go
+++ b/pkg/serializer/internal/metrics/series_test.go
@@ -371,23 +371,36 @@ func makeSeries(numItems, numPoints int) *IterableSeries {
 }
 
 func TestMarshalSplitCompress(t *testing.T) {
-	series := makeSeries(10000, 50)
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			series := makeSeries(10000, 50)
 
-	payloads, err := series.MarshalSplitCompress(marshaler.NewBufferContext())
-	require.NoError(t, err)
-	// check that we got multiple payloads, so splitting occurred
-	require.Greater(t, len(payloads), 1)
-	for _, compressedPayload := range payloads {
-		payload, err := decompressPayload(compressedPayload.GetContent())
-		require.NoError(t, err)
+			payloads, err := series.MarshalSplitCompress(marshaler.NewBufferContext())
+			require.NoError(t, err)
+			// check that we got multiple payloads, so splitting occurred
+			require.Greater(t, len(payloads), 1)
+			for _, compressedPayload := range payloads {
+				payload, err := decompressPayload(compressedPayload.GetContent(), tc.kind)
+				require.NoError(t, err)
 
-		pl := new(gogen.MetricPayload)
-		err = pl.Unmarshal(payload)
-		for _, s := range pl.Series {
-			assert.Equal(t, []*gogen.MetricPayload_Resource{{Type: "host", Name: "localHost"}, {Type: "device", Name: "SomeDevice"}, {Type: "device", Name: "some_other_device"}, {Type: "database_instance", Name: "some_instance"}, {Type: "aws_rds_instance", Name: "some_endpoint"}}, s.Resources)
-			assert.Equal(t, []string{"tag1", "tag2:yes"}, s.Tags)
-		}
-		require.NoError(t, err)
+				pl := new(gogen.MetricPayload)
+				err = pl.Unmarshal(payload)
+				for _, s := range pl.Series {
+					assert.Equal(t, []*gogen.MetricPayload_Resource{{Type: "host", Name: "localHost"}, {Type: "device", Name: "SomeDevice"}, {Type: "device", Name: "some_other_device"}, {Type: "database_instance", Name: "some_instance"}, {Type: "aws_rds_instance", Name: "some_endpoint"}}, s.Resources)
+					assert.Equal(t, []string{"tag1", "tag2:yes"}, s.Tags)
+				}
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 
@@ -419,54 +432,67 @@ func TestMarshalSplitCompressPointsLimitTooBig(t *testing.T) {
 
 // test taken from the spliter
 func TestPayloadsSeries(t *testing.T) {
-	testSeries := metrics.Series{}
-	for i := 0; i < 30000; i++ {
-		point := metrics.Serie{
-			Points: []metrics.Point{
-				{Ts: 12345.0, Value: float64(21.21)},
-				{Ts: 67890.0, Value: float64(12.12)},
-				{Ts: 2222.0, Value: float64(22.12)},
-				{Ts: 333.0, Value: float64(32.12)},
-				{Ts: 444444.0, Value: float64(42.12)},
-				{Ts: 882787.0, Value: float64(52.12)},
-				{Ts: 99990.0, Value: float64(62.12)},
-				{Ts: 121212.0, Value: float64(72.12)},
-				{Ts: 222227.0, Value: float64(82.12)},
-				{Ts: 808080.0, Value: float64(92.12)},
-				{Ts: 9090.0, Value: float64(13.12)},
-			},
-			MType:    metrics.APIGaugeType,
-			Name:     fmt.Sprintf("test.metrics%d", i),
-			Interval: 1,
-			Host:     "localHost",
-			Tags:     tagset.CompositeTagsFromSlice([]string{"tag1", "tag2:yes"}),
-		}
-		testSeries = append(testSeries, &point)
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
 	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			testSeries := metrics.Series{}
+			for i := 0; i < 30000; i++ {
+				point := metrics.Serie{
+					Points: []metrics.Point{
+						{Ts: 12345.0, Value: float64(21.21)},
+						{Ts: 67890.0, Value: float64(12.12)},
+						{Ts: 2222.0, Value: float64(22.12)},
+						{Ts: 333.0, Value: float64(32.12)},
+						{Ts: 444444.0, Value: float64(42.12)},
+						{Ts: 882787.0, Value: float64(52.12)},
+						{Ts: 99990.0, Value: float64(62.12)},
+						{Ts: 121212.0, Value: float64(72.12)},
+						{Ts: 222227.0, Value: float64(82.12)},
+						{Ts: 808080.0, Value: float64(92.12)},
+						{Ts: 9090.0, Value: float64(13.12)},
+					},
+					MType:    metrics.APIGaugeType,
+					Name:     fmt.Sprintf("test.metrics%d", i),
+					Interval: 1,
+					Host:     "localHost",
+					Tags:     tagset.CompositeTagsFromSlice([]string{"tag1", "tag2:yes"}),
+				}
+				testSeries = append(testSeries, &point)
+			}
 
-	originalLength := len(testSeries)
-	builder := stream.NewJSONPayloadBuilder(true)
-	iterableSeries := CreateIterableSeries(CreateSerieSource(testSeries))
-	payloads, err := builder.BuildWithOnErrItemTooBigPolicy(iterableSeries, stream.DropItemOnErrItemTooBig)
-	require.Nil(t, err)
-	var splitSeries = []Series{}
-	for _, compressedPayload := range payloads {
-		payload, err := decompressPayload(compressedPayload.GetContent())
-		require.NoError(t, err)
+			originalLength := len(testSeries)
+			builder := stream.NewJSONPayloadBuilder(true)
+			iterableSeries := CreateIterableSeries(CreateSerieSource(testSeries))
+			payloads, err := builder.BuildWithOnErrItemTooBigPolicy(iterableSeries, stream.DropItemOnErrItemTooBig)
+			require.Nil(t, err)
+			var splitSeries = []Series{}
+			for _, compressedPayload := range payloads {
+				payload, err := decompressPayload(compressedPayload.GetContent(), tc.kind)
+				require.NoError(t, err)
 
-		var s = map[string]Series{}
-		err = json.Unmarshal(payload, &s)
-		require.NoError(t, err)
-		splitSeries = append(splitSeries, s["series"])
+				var s = map[string]Series{}
+				err = json.Unmarshal(payload, &s)
+				require.NoError(t, err)
+				splitSeries = append(splitSeries, s["series"])
+			}
+
+			unrolledSeries := Series{}
+			for _, series := range splitSeries {
+				unrolledSeries = append(unrolledSeries, series...)
+			}
+
+			newLength := len(unrolledSeries)
+			require.Equal(t, originalLength, newLength)
+		})
 	}
-
-	unrolledSeries := Series{}
-	for _, series := range splitSeries {
-		unrolledSeries = append(unrolledSeries, series...)
-	}
-
-	newLength := len(unrolledSeries)
-	require.Equal(t, originalLength, newLength)
 }
 
 var result transaction.BytesPayloads

--- a/pkg/serializer/internal/metrics/sketch_series_list.go
+++ b/pkg/serializer/internal/metrics/sketch_series_list.go
@@ -115,6 +115,7 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 	// sizes, but prefers small uncompressed payloads.
 	maxPayloadSize := config.Datadog.GetInt("serializer_max_payload_size")
 	maxUncompressedSize := config.Datadog.GetInt("serializer_max_uncompressed_payload_size")
+	compressorKind := config.Datadog.GetString("serializer_compressor_kind")
 
 	// Generate a footer containing an empty Metadata field.  The gogoproto
 	// generated serialization code includes this when marshaling the struct,
@@ -141,7 +142,7 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 		compressor, err = stream.NewCompressor(
 			bufferContext.CompressorInput, bufferContext.CompressorOutput,
 			maxPayloadSize, maxUncompressedSize,
-			[]byte{}, footer, []byte{})
+			[]byte{}, footer, []byte{}, compressorKind)
 		if err != nil {
 			return err
 		}

--- a/pkg/serializer/internal/metrics/sketch_series_test.go
+++ b/pkg/serializer/internal/metrics/sketch_series_test.go
@@ -8,9 +8,6 @@
 package metrics
 
 import (
-	"bytes"
-	"compress/zlib"
-	"io"
 	"testing"
 
 	"github.com/DataDog/agent-payload/v5/gogen"
@@ -91,160 +88,207 @@ func TestSketchSeriesSplitEmptyPayload(t *testing.T) {
 }
 
 func TestSketchSeriesMarshalSplitCompressEmpty(t *testing.T) {
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			sl := SketchSeriesList{SketchesSource: metrics.NewSketchesSourceTest()}
+			payload, _ := sl.Marshal()
+			payloads, err := sl.MarshalSplitCompress(marshaler.NewBufferContext())
 
-	sl := SketchSeriesList{SketchesSource: metrics.NewSketchesSourceTest()}
-	payload, _ := sl.Marshal()
-	payloads, err := sl.MarshalSplitCompress(marshaler.NewBufferContext())
+			assert.Nil(t, err)
 
-	assert.Nil(t, err)
+			firstPayload := payloads[0]
+			assert.Equal(t, 0, firstPayload.GetPointCount())
 
-	firstPayload := payloads[0]
-	assert.Equal(t, 0, firstPayload.GetPointCount())
-	reader := bytes.NewReader(firstPayload.GetContent())
-	r, _ := zlib.NewReader(reader)
-	decompressed, _ := io.ReadAll(r)
-	r.Close()
+			decompressed, err := decompressPayload(firstPayload.GetContent(), tc.kind)
+			assert.Nil(t, err)
 
-	// Check that we encoded the protobuf correctly
-	assert.Equal(t, decompressed, payload)
+			// Check that we encoded the protobuf correctly
+			assert.Equal(t, decompressed, payload)
+		})
+	}
 }
 
 func TestSketchSeriesMarshalSplitCompressItemTooBigIsDropped(t *testing.T) {
-
-	oldSetting := config.Datadog.Get("serializer_max_uncompressed_payload_size")
-	defer config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", oldSetting)
-	config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", 100)
-
-	sl := metrics.NewSketchesSourceTest()
-	// A big item (to be dropped)
-	sl.Append(Makeseries(0))
-
-	// A small item (no dropped)
-	sl.Append(&metrics.SketchSeries{
-		Name:     "small",
-		Tags:     tagset.CompositeTagsFromSlice([]string{}),
-		Host:     "",
-		Interval: 0,
-	})
-
-	serializer := SketchSeriesList{SketchesSource: sl}
-	payloads, err := serializer.MarshalSplitCompress(marshaler.NewBufferContext())
-
-	assert.Nil(t, err)
-
-	firstPayload := payloads[0]
-	require.Equal(t, 0, firstPayload.GetPointCount())
-	reader := bytes.NewReader(firstPayload.GetContent())
-	r, _ := zlib.NewReader(reader)
-	decompressed, _ := io.ReadAll(r)
-	r.Close()
-
-	pl := new(gogen.SketchPayload)
-	if err := pl.Unmarshal(decompressed); err != nil {
-		t.Fatal(err)
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
 	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldSetting := config.Datadog.Get("serializer_max_uncompressed_payload_size")
+			defer config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", oldSetting)
+			config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", 100)
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
 
-	// Should only have 1 sketch because the the larger one was dropped.
-	require.Len(t, pl.Sketches, 1)
+			sl := metrics.NewSketchesSourceTest()
+			// A big item (to be dropped)
+			sl.Append(Makeseries(0))
+
+			// A small item (no dropped)
+			sl.Append(&metrics.SketchSeries{
+				Name:     "small",
+				Tags:     tagset.CompositeTagsFromSlice([]string{}),
+				Host:     "",
+				Interval: 0,
+			})
+
+			serializer := SketchSeriesList{SketchesSource: sl}
+			payloads, err := serializer.MarshalSplitCompress(marshaler.NewBufferContext())
+
+			assert.Nil(t, err)
+
+			firstPayload := payloads[0]
+			require.Equal(t, 0, firstPayload.GetPointCount())
+
+			decompressed, err := decompressPayload(firstPayload.GetContent(), tc.kind)
+			assert.Nil(t, err)
+
+			pl := new(gogen.SketchPayload)
+			if err := pl.Unmarshal(decompressed); err != nil {
+				t.Fatal(err)
+			}
+
+			// Should only have 1 sketch because the the larger one was dropped.
+			require.Len(t, pl.Sketches, 1)
+		})
+	}
 }
 
 func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
-	sl := metrics.NewSketchesSourceTest()
-
-	for i := 0; i < 2; i++ {
-		sl.Append(Makeseries(i))
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
 	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
 
-	sl.Reset()
-	serializer2 := SketchSeriesList{SketchesSource: sl}
-	payloads, err := serializer2.MarshalSplitCompress(marshaler.NewBufferContext())
-	require.NoError(t, err)
+			sl := metrics.NewSketchesSourceTest()
 
-	firstPayload := payloads[0]
-	assert.Equal(t, 11, firstPayload.GetPointCount())
-	reader := bytes.NewReader(firstPayload.GetContent())
-	r, _ := zlib.NewReader(reader)
-	decompressed, _ := io.ReadAll(r)
-	r.Close()
+			for i := 0; i < 2; i++ {
+				sl.Append(Makeseries(i))
+			}
 
-	pl := new(gogen.SketchPayload)
-	err = pl.Unmarshal(decompressed)
-	require.NoError(t, err)
+			sl.Reset()
+			serializer2 := SketchSeriesList{SketchesSource: sl}
+			payloads, err := serializer2.MarshalSplitCompress(marshaler.NewBufferContext())
+			require.NoError(t, err)
 
-	require.Len(t, pl.Sketches, int(sl.Count()))
+			firstPayload := payloads[0]
+			assert.Equal(t, 11, firstPayload.GetPointCount())
+			decompressed, err := decompressPayload(firstPayload.GetContent(), tc.kind)
+			assert.Nil(t, err)
 
-	for i, pb := range pl.Sketches {
-		in := sl.Get(i)
-		require.Equal(t, Makeseries(i), in, "make sure we don't modify input")
+			pl := new(gogen.SketchPayload)
+			err = pl.Unmarshal(decompressed)
+			require.NoError(t, err)
 
-		assert.Equal(t, in.Host, pb.Host)
-		assert.Equal(t, in.Name, pb.Metric)
-		metrics.AssertCompositeTagsEqual(t, in.Tags, tagset.CompositeTagsFromSlice(pb.Tags))
-		assert.Len(t, pb.Distributions, 0)
+			require.Len(t, pl.Sketches, int(sl.Count()))
 
-		require.Len(t, pb.Dogsketches, len(in.Points))
-		for j, pointPb := range pb.Dogsketches {
+			for i, pb := range pl.Sketches {
+				in := sl.Get(i)
+				require.Equal(t, Makeseries(i), in, "make sure we don't modify input")
 
-			check(t, in.Points[j], pointPb)
-		}
+				assert.Equal(t, in.Host, pb.Host)
+				assert.Equal(t, in.Name, pb.Metric)
+				metrics.AssertCompositeTagsEqual(t, in.Tags, tagset.CompositeTagsFromSlice(pb.Tags))
+				assert.Len(t, pb.Distributions, 0)
+
+				require.Len(t, pb.Dogsketches, len(in.Points))
+				for j, pointPb := range pb.Dogsketches {
+
+					check(t, in.Points[j], pointPb)
+				}
+			}
+		})
 	}
 }
 
 func TestSketchSeriesMarshalSplitCompressSplit(t *testing.T) {
-	oldSetting := config.Datadog.Get("serializer_max_uncompressed_payload_size")
-	defer config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", oldSetting)
-	config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", 2000)
-
-	sl := metrics.NewSketchesSourceTest()
-
-	expectedPointCount := 0
-	for i := 0; i < 20; i++ {
-		sl.Append(Makeseries(i))
-		expectedPointCount += i + 5
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
 	}
 
-	serializer := SketchSeriesList{SketchesSource: sl}
-	payloads, err := serializer.MarshalSplitCompress(marshaler.NewBufferContext())
-	assert.Nil(t, err)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldSetting := config.Datadog.Get("serializer_max_uncompressed_payload_size")
+			defer config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", oldSetting)
+			config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", 2000)
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
 
-	recoveredSketches := []gogen.SketchPayload{}
-	recoveredCount := 0
-	pointCount := 0
-	for _, pld := range payloads {
-		reader := bytes.NewReader(pld.GetContent())
-		r, _ := zlib.NewReader(reader)
-		decompressed, _ := io.ReadAll(r)
-		r.Close()
+			sl := metrics.NewSketchesSourceTest()
 
-		pl := new(gogen.SketchPayload)
-		if err := pl.Unmarshal(decompressed); err != nil {
-			t.Fatal(err)
-		}
-		recoveredSketches = append(recoveredSketches, *pl)
-		recoveredCount += len(pl.Sketches)
-		pointCount += pld.GetPointCount()
-	}
-	assert.Equal(t, expectedPointCount, pointCount)
-	assert.Equal(t, recoveredCount, int(sl.Count()))
-	assert.Greater(t, len(recoveredSketches), 1)
-
-	i := 0
-	for _, pl := range recoveredSketches {
-		for _, pb := range pl.Sketches {
-			in := sl.Get(i)
-			require.Equal(t, Makeseries(i), in, "make sure we don't modify input")
-
-			assert.Equal(t, in.Host, pb.Host)
-			assert.Equal(t, in.Name, pb.Metric)
-			metrics.AssertCompositeTagsEqual(t, in.Tags, tagset.CompositeTagsFromSlice(pb.Tags))
-			assert.Len(t, pb.Distributions, 0)
-
-			require.Len(t, pb.Dogsketches, len(in.Points))
-			for j, pointPb := range pb.Dogsketches {
-
-				check(t, in.Points[j], pointPb)
+			expectedPointCount := 0
+			for i := 0; i < 20; i++ {
+				sl.Append(Makeseries(i))
+				expectedPointCount += i + 5
 			}
-			i++
-		}
+
+			serializer := SketchSeriesList{SketchesSource: sl}
+			payloads, err := serializer.MarshalSplitCompress(marshaler.NewBufferContext())
+			assert.Nil(t, err)
+
+			recoveredSketches := []gogen.SketchPayload{}
+			recoveredCount := 0
+			pointCount := 0
+			for _, pld := range payloads {
+				decompressed, err := decompressPayload(pld.GetContent(), tc.kind)
+				assert.Nil(t, err)
+
+				pl := new(gogen.SketchPayload)
+				if err := pl.Unmarshal(decompressed); err != nil {
+					t.Fatal(err)
+				}
+				recoveredSketches = append(recoveredSketches, *pl)
+				recoveredCount += len(pl.Sketches)
+				pointCount += pld.GetPointCount()
+			}
+			assert.Equal(t, expectedPointCount, pointCount)
+			assert.Equal(t, recoveredCount, int(sl.Count()))
+			assert.Greater(t, len(recoveredSketches), 1)
+
+			i := 0
+			for _, pl := range recoveredSketches {
+				for _, pb := range pl.Sketches {
+					in := sl.Get(i)
+					require.Equal(t, Makeseries(i), in, "make sure we don't modify input")
+
+					assert.Equal(t, in.Host, pb.Host)
+					assert.Equal(t, in.Name, pb.Metric)
+					metrics.AssertCompositeTagsEqual(t, in.Tags, tagset.CompositeTagsFromSlice(pb.Tags))
+					assert.Len(t, pb.Distributions, 0)
+
+					require.Len(t, pb.Dogsketches, len(in.Points))
+					for j, pointPb := range pb.Dogsketches {
+
+						check(t, in.Points[j], pointPb)
+					}
+					i++
+				}
+			}
+
+		})
 	}
 }

--- a/pkg/serializer/internal/stream/compressor.go
+++ b/pkg/serializer/internal/stream/compressor.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018-present Datadog, Inc.
 
-//go:build zlib
+//go:build zlib || zstd
 
 //nolint:revive // TODO(AML) Fix revive linter
 package stream
@@ -13,15 +13,39 @@ import (
 	"compress/zlib"
 	"errors"
 	"expvar"
+	"io"
 
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
+	"github.com/DataDog/zstd"
 )
 
 const (
 	// Available is true if the code is compiled in
 	Available = true
 )
+
+// Flusher is the interface that requires the Flush function
+type flusher interface {
+	Flush() error
+}
+
+// zipper is the interface that zlib and zstd should implement
+type zipper interface {
+	io.WriteCloser
+	flusher
+}
+
+// NewZipper returns a zipper of either zstd or zlib depending on the kind param
+func NewZipper(kind string, output *bytes.Buffer) (zipper, error) {
+	switch kind {
+	case "zlib":
+		return zlib.NewWriter(output), nil
+	case "zstd":
+		return zstd.NewWriter(output), nil
+	}
+	return nil, errors.New("invalid zipper kind. choose 'zlib' or 'zstd'")
+}
 
 var (
 	compressorExpvars    = expvar.NewMap("compressor")
@@ -63,12 +87,12 @@ func init() {
 type Compressor struct {
 	input               *bytes.Buffer // temporary buffer for data that has not been compressed yet
 	compressed          *bytes.Buffer // output buffer containing the compressed payload
-	zipper              *zlib.Writer
-	header              []byte // json header to print at the beginning of the payload
-	footer              []byte // json footer to append at the end of the payload
-	uncompressedWritten int    // uncompressed bytes written
-	firstItem           bool   // tells if the first item has been written
-	repacks             int    // numbers of time we had to pack this payload
+	zipper              zipper        // either zlib or zstd
+	header              []byte        // json header to print at the beginning of the payload
+	footer              []byte        // json footer to append at the end of the payload
+	uncompressedWritten int           // uncompressed bytes written
+	firstItem           bool          // tells if the first item has been written
+	repacks             int           // numbers of time we had to pack this payload
 	maxUnzippedItemSize int
 	maxZippedItemSize   int
 	maxPayloadSize      int
@@ -77,7 +101,7 @@ type Compressor struct {
 }
 
 // NewCompressor returns a new instance of a Compressor
-func NewCompressor(input, output *bytes.Buffer, maxPayloadSize, maxUncompressedSize int, header, footer []byte, separator []byte) (*Compressor, error) {
+func NewCompressor(input, output *bytes.Buffer, maxPayloadSize, maxUncompressedSize int, header, footer []byte, separator []byte, compressorKind string) (*Compressor, error) {
 	c := &Compressor{
 		header:              header,
 		footer:              footer,
@@ -91,7 +115,11 @@ func NewCompressor(input, output *bytes.Buffer, maxPayloadSize, maxUncompressedS
 		separator:           separator,
 	}
 
-	c.zipper = zlib.NewWriter(c.compressed)
+	var err error
+	c.zipper, err = NewZipper(compressorKind, c.compressed)
+	if err != nil {
+		return nil, err
+	}
 	n, err := c.zipper.Write(header)
 	c.uncompressedWritten += n
 

--- a/pkg/serializer/internal/stream/compressor_nozlib.go
+++ b/pkg/serializer/internal/stream/compressor_nozlib.go
@@ -30,7 +30,7 @@ var (
 type Compressor struct{}
 
 // NewCompressor not implemented
-func NewCompressor(input, output *bytes.Buffer, maxPayloadSize, maxUncompressedSize int, header, footer []byte, separator []byte) (*Compressor, error) {
+func NewCompressor(input, output *bytes.Buffer, maxPayloadSize, maxUncompressedSize int, header, footer []byte, separator []byte, compressorKind string) (*Compressor, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/serializer/internal/stream/compressor_test.go
+++ b/pkg/serializer/internal/stream/compressor_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+	"github.com/DataDog/zstd"
 )
 
 var (
@@ -30,13 +31,19 @@ func resetDefaults() {
 	config.Datadog.SetDefault("serializer_max_payload_size", maxPayloadSizeDefault)
 }
 
-func decompressPayload(payload []byte) ([]byte, error) {
-	r, err := zlib.NewReader(bytes.NewReader(payload))
+func decompressPayload(payload []byte, kind string) ([]byte, error) {
+	var r io.ReadCloser
+	var err error
+	switch kind {
+	case "zlib":
+		r, err = zlib.NewReader(bytes.NewReader(payload))
+	case "zstd":
+		r = zstd.NewReader(bytes.NewReader(payload))
+	}
 	if err != nil {
 		return nil, err
 	}
 	defer r.Close()
-
 	dst, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -44,8 +51,8 @@ func decompressPayload(payload []byte) ([]byte, error) {
 	return dst, nil
 }
 
-func payloadToString(payload []byte) string {
-	p, err := decompressPayload(payload)
+func payloadToString(payload []byte, kind string) string {
+	p, err := decompressPayload(payload, kind)
 	if err != nil {
 		return err.Error()
 	}
@@ -53,32 +60,44 @@ func payloadToString(payload []byte) string {
 }
 
 func TestCompressorSimple(t *testing.T) {
-	maxPayloadSize := config.Datadog.GetInt("serializer_max_payload_size")
-	maxUncompressedSize := config.Datadog.GetInt("serializer_max_uncompressed_payload_size")
-	c, err := NewCompressor(
-		&bytes.Buffer{}, &bytes.Buffer{},
-		maxPayloadSize, maxUncompressedSize,
-		[]byte("{["), []byte("]}"), []byte(","))
-	require.NoError(t, err)
-
-	for i := 0; i < 5; i++ {
-		c.AddItem([]byte("A"))
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
 	}
 
-	p, err := c.Close()
-	require.NoError(t, err)
-	require.Equal(t, "{[A,A,A,A,A]}", payloadToString(p))
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			maxPayloadSize := config.Datadog.GetInt("serializer_max_payload_size")
+			maxUncompressedSize := config.Datadog.GetInt("serializer_max_uncompressed_payload_size")
+			c, err := NewCompressor(
+				&bytes.Buffer{}, &bytes.Buffer{},
+				maxPayloadSize, maxUncompressedSize,
+				[]byte("{["), []byte("]}"), []byte(","), tc.kind)
+
+			require.NoError(t, err)
+
+			for i := 0; i < 5; i++ {
+				c.AddItem([]byte("A"))
+			}
+
+			p, err := c.Close()
+			require.NoError(t, err)
+			require.Equal(t, "{[A,A,A,A,A]}", payloadToString(p, tc.kind))
+		})
+	}
 }
 
 // With an empty payload, AddItem should never return "ErrPayloadFull"
 // ErrItemTooBig is a more appropriate error code if the item cannot
 // be added to an empty compressor
 func TestCompressorAddItemErrCodeWithEmptyCompressor(t *testing.T) {
-	checkAddItemErrCode := func(maxPayloadSize, maxUncompressedSize, dataLen int) {
+	checkAddItemErrCode := func(maxPayloadSize, maxUncompressedSize, dataLen int, kind string) {
 		c, err := NewCompressor(
 			&bytes.Buffer{}, &bytes.Buffer{},
 			maxPayloadSize, maxUncompressedSize,
-			[]byte("{["), []byte("]}"), []byte(","))
+			[]byte("{["), []byte("]}"), []byte(","), kind)
 		require.NoError(t, err)
 
 		payload := strings.Repeat("A", dataLen)
@@ -90,110 +109,187 @@ func TestCompressorAddItemErrCodeWithEmptyCompressor(t *testing.T) {
 		}
 	}
 
-	// While some of these values may look like they should fit, they currently don't due to a combination
-	// of due to overhead in the payload (header and footer) and the CompressBound calculation
-	t.Run("Edge Case from real world", func(t *testing.T) {
-		checkAddItemErrCode(2_621_440, 4_194_304, 2_620_896)
-	})
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {
+			kind: "zlib"},
+		"zstd": {
+			kind: "zstd"},
+	}
 
-	t.Run("Other values from iterative testing", func(t *testing.T) {
-		checkAddItemErrCode(17, 32, 1)
-		checkAddItemErrCode(19, 35, 4)
-		checkAddItemErrCode(23, 43, 12)
-		checkAddItemErrCode(44, 71, 39)
-		checkAddItemErrCode(1110, 1129, 1098)
-		checkAddItemErrCode(11100, 11119, 11085)
-	})
+	for name, tc := range tests {
+		oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+		defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+		config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+
+		// While some of these values may look like they should fit, they currently don't due to a combination
+		// of due to overhead in the payload (header and footer) and the CompressBound calculation
+		t.Run("Edge Case from real world"+name, func(t *testing.T) {
+			checkAddItemErrCode(2_621_440, 4_194_304, 2_620_896, tc.kind)
+		})
+
+		t.Run("Other values from iterative testing"+name, func(t *testing.T) {
+			checkAddItemErrCode(17, 32, 1, tc.kind)
+			checkAddItemErrCode(19, 35, 4, tc.kind)
+			checkAddItemErrCode(23, 43, 12, tc.kind)
+			checkAddItemErrCode(44, 71, 39, tc.kind)
+			checkAddItemErrCode(1110, 1129, 1098, tc.kind)
+			checkAddItemErrCode(11100, 11119, 11085, tc.kind)
+		})
+	}
+
 }
 
 func TestOnePayloadSimple(t *testing.T) {
-	m := &marshaler.DummyMarshaller{
-		Items:  []string{"A", "B", "C"},
-		Header: "{[",
-		Footer: "]}",
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {
+			kind: "zlib"},
+		"zstd": {
+			kind: "zstd"},
 	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			m := &marshaler.DummyMarshaller{
+				Items:  []string{"A", "B", "C"},
+				Header: "{[",
+				Footer: "]}",
+			}
 
-	builder := NewJSONPayloadBuilder(true)
-	payloads, err := BuildJSONPayload(builder, m)
-	require.NoError(t, err)
-	require.Len(t, payloads, 1)
-
-	require.Equal(t, "{[A,B,C]}", payloadToString(payloads[0].GetContent()))
+			builder := NewJSONPayloadBuilder(true)
+			payloads, err := BuildJSONPayload(builder, m)
+			require.NoError(t, err)
+			require.Len(t, payloads, 1)
+			require.Equal(t, "{[A,B,C]}", payloadToString(payloads[0].GetContent(), tc.kind))
+		})
+	}
 }
 
 func TestMaxCompressedSizePayload(t *testing.T) {
-	m := &marshaler.DummyMarshaller{
-		Items:  []string{"A", "B", "C"},
-		Header: "{[",
-		Footer: "]}",
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
 	}
-	config.Datadog.SetDefault("serializer_max_payload_size", 22)
-	defer resetDefaults()
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			m := &marshaler.DummyMarshaller{
+				Items:  []string{"A", "B", "C"},
+				Header: "{[",
+				Footer: "]}",
+			}
+			config.Datadog.SetDefault("serializer_max_payload_size", 22)
+			defer resetDefaults()
 
-	builder := NewJSONPayloadBuilder(true)
-	payloads, err := BuildJSONPayload(builder, m)
-	require.NoError(t, err)
-	require.Len(t, payloads, 1)
-
-	require.Equal(t, "{[A,B,C]}", payloadToString(payloads[0].GetContent()))
+			builder := NewJSONPayloadBuilder(true)
+			payloads, err := BuildJSONPayload(builder, m)
+			require.NoError(t, err)
+			require.Len(t, payloads, 1)
+			require.Equal(t, "{[A,B,C]}", payloadToString(payloads[0].GetContent(), tc.kind))
+		})
+	}
 }
 
 func TestTwoPayload(t *testing.T) {
-	m := &marshaler.DummyMarshaller{
-		Items:  []string{"A", "B", "C", "D", "E", "F"},
-		Header: "{[",
-		Footer: "]}",
+	tests := map[string]struct {
+		kind           string
+		maxPayloadSize int
+	}{
+		"zlib": {kind: "zlib", maxPayloadSize: 22},
+		"zstd": {kind: "zstd", maxPayloadSize: 20}, // zstd more efficient
 	}
-	config.Datadog.SetDefault("serializer_max_payload_size", 22)
-	defer resetDefaults()
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			m := &marshaler.DummyMarshaller{
+				Items:  []string{"A", "B", "C", "D", "E", "F"},
+				Header: "{[",
+				Footer: "]}",
+			}
+			config.Datadog.SetDefault("serializer_max_payload_size", tc.maxPayloadSize)
+			defer resetDefaults()
 
-	builder := NewJSONPayloadBuilder(true)
-	payloads, err := BuildJSONPayload(builder, m)
-	require.NoError(t, err)
-	require.Len(t, payloads, 2)
-
-	require.Equal(t, "{[A,B,C]}", payloadToString(payloads[0].GetContent()))
-	require.Equal(t, "{[D,E,F]}", payloadToString(payloads[1].GetContent()))
+			builder := NewJSONPayloadBuilder(true)
+			payloads, err := BuildJSONPayload(builder, m)
+			require.NoError(t, err)
+			require.Len(t, payloads, 2)
+			require.Equal(t, "{[A,B,C]}", payloadToString(payloads[0].GetContent(), tc.kind))
+			require.Equal(t, "{[D,E,F]}", payloadToString(payloads[1].GetContent(), tc.kind))
+		})
+	}
 }
 
 func TestLockedCompressorProducesSamePayloads(t *testing.T) {
-	m := &marshaler.DummyMarshaller{
-		Items:  []string{"A", "B", "C", "D", "E", "F"},
-		Header: "{[",
-		Footer: "]}",
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
 	}
-	defer resetDefaults()
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := &marshaler.DummyMarshaller{
+				Items:  []string{"A", "B", "C", "D", "E", "F"},
+				Header: "{[",
+				Footer: "]}",
+			}
+			defer resetDefaults()
 
-	builderLocked := NewJSONPayloadBuilder(true)
-	builderUnLocked := NewJSONPayloadBuilder(false)
-	payloads1, err := BuildJSONPayload(builderLocked, m)
-	require.NoError(t, err)
-	payloads2, err := BuildJSONPayload(builderUnLocked, m)
-	require.NoError(t, err)
-
-	require.Equal(t, payloadToString(payloads1[0].GetContent()), payloadToString(payloads2[0].GetContent()))
+			builderLocked := NewJSONPayloadBuilder(true)
+			builderUnLocked := NewJSONPayloadBuilder(false)
+			payloads1, err := BuildJSONPayload(builderLocked, m)
+			require.NoError(t, err)
+			payloads2, err := BuildJSONPayload(builderUnLocked, m)
+			require.NoError(t, err)
+			require.Equal(t, payloadToString(payloads1[0].GetContent(), tc.kind), payloadToString(payloads2[0].GetContent(), tc.kind))
+		})
+	}
 }
 
 func TestBuildWithOnErrItemTooBigPolicyMetadata(t *testing.T) {
-	config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", 40)
-	defer config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", nil)
-	marshaler := &IterableStreamJSONMarshalerMock{index: 0, maxIndex: 100}
-	builder := NewJSONPayloadBuilder(false)
-	payloads, err := builder.BuildWithOnErrItemTooBigPolicy(
-		marshaler,
-		DropItemOnErrItemTooBig)
-	r := require.New(t)
-	r.NoError(err)
-
-	// Make sure there are at least few payloads
-	r.Greater(len(payloads), 3)
-
-	pointCount := 0
-	for _, payload := range payloads {
-		pointCount += payload.GetPointCount()
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
 	}
-	maxValue := marshaler.maxIndex - 1
-	r.Equal((maxValue*(maxValue+1))/2, pointCount)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", 40)
+			defer config.Datadog.SetWithoutSource("serializer_max_uncompressed_payload_size", nil)
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			mshr := &IterableStreamJSONMarshalerMock{index: 0, maxIndex: 100}
+			builder := NewJSONPayloadBuilder(false)
+			payloads, err := builder.BuildWithOnErrItemTooBigPolicy(
+				mshr,
+				DropItemOnErrItemTooBig)
+			r := require.New(t)
+			r.NoError(err)
+
+			// Make sure there are at least few payloads
+			r.Greater(len(payloads), 3)
+
+			pointCount := 0
+			for _, payload := range payloads {
+				pointCount += payload.GetPointCount()
+			}
+			maxValue := mshr.maxIndex - 1
+			r.Equal((maxValue*(maxValue+1))/2, pointCount)
+		})
+	}
 }
 
 type IterableStreamJSONMarshalerMock struct {

--- a/pkg/serializer/internal/stream/json_payload_builder.go
+++ b/pkg/serializer/internal/stream/json_payload_builder.go
@@ -108,6 +108,7 @@ func (b *JSONPayloadBuilder) BuildWithOnErrItemTooBigPolicy(
 	// sizes, but prefers small uncompressed payloads.
 	maxPayloadSize := config.Datadog.GetInt("serializer_max_payload_size")
 	maxUncompressedSize := config.Datadog.GetInt("serializer_max_uncompressed_payload_size")
+	compressorKind := config.Datadog.GetString("serializer_compressor_kind")
 
 	if b.shareAndLockBuffers {
 		defer b.mu.Unlock()
@@ -154,7 +155,7 @@ func (b *JSONPayloadBuilder) BuildWithOnErrItemTooBigPolicy(
 	compressor, err := NewCompressor(
 		input, output,
 		maxPayloadSize, maxUncompressedSize,
-		header.Bytes(), footer.Bytes(), []byte(","))
+		header.Bytes(), footer.Bytes(), []byte(","), compressorKind)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (b *JSONPayloadBuilder) BuildWithOnErrItemTooBigPolicy(
 			compressor, err = NewCompressor(
 				input, output,
 				maxPayloadSize, maxUncompressedSize,
-				header.Bytes(), footer.Bytes(), []byte(","))
+				header.Bytes(), footer.Bytes(), []byte(","), compressorKind)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -8,7 +8,10 @@
 package serializer
 
 import (
+	"bytes"
+	"compress/zlib"
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -20,6 +23,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/zstd"
+
 	forwarder "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -29,20 +34,24 @@ import (
 	metricsserializer "github.com/DataDog/datadog-agent/pkg/serializer/internal/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var initialContentEncoding = compression.ContentEncoding
 
 func resetContentEncoding() {
 	compression.ContentEncoding = initialContentEncoding
-	initExtraHeaders()
 }
 
 func TestInitExtraHeadersNoopCompression(t *testing.T) {
 	compression.ContentEncoding = ""
 	defer resetContentEncoding()
 
-	initExtraHeaders()
+	jsonExtraHeaders := make(http.Header)
+	protobufExtraHeaders := make(http.Header)
+	jsonExtraHeadersWithCompression := make(http.Header)
+	protobufExtraHeadersWithCompression := make(http.Header)
+	initExtraHeaders(jsonExtraHeaders, protobufExtraHeaders, jsonExtraHeadersWithCompression, protobufExtraHeadersWithCompression)
 
 	expected := make(http.Header)
 	expected.Set("Content-Type", jsonContentType)
@@ -65,31 +74,48 @@ func TestInitExtraHeadersNoopCompression(t *testing.T) {
 }
 
 func TestInitExtraHeadersWithCompression(t *testing.T) {
-	compression.ContentEncoding = "zstd"
-	defer resetContentEncoding()
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			originalCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", originalCompressorKind)
 
-	initExtraHeaders()
+			contentEncoding := getContentEncoding(tc.kind)
 
-	expected := make(http.Header)
-	expected.Set("Content-Type", jsonContentType)
-	assert.Equal(t, expected, jsonExtraHeaders)
+			jsonExtraHeaders := make(http.Header)
+			protobufExtraHeaders := make(http.Header)
+			jsonExtraHeadersWithCompression := make(http.Header)
+			protobufExtraHeadersWithCompression := make(http.Header)
+			initExtraHeaders(jsonExtraHeaders, protobufExtraHeaders, jsonExtraHeadersWithCompression, protobufExtraHeadersWithCompression)
 
-	expected = make(http.Header)
-	expected.Set("Content-Type", protobufContentType)
-	expected.Set(payloadVersionHTTPHeader, AgentPayloadVersion)
-	assert.Equal(t, expected, protobufExtraHeaders)
+			expected := make(http.Header)
+			expected.Set("Content-Type", jsonContentType)
+			assert.Equal(t, expected, jsonExtraHeaders)
 
-	// "Content-Encoding" header present with correct value
-	expected = make(http.Header)
-	expected.Set("Content-Type", jsonContentType)
-	expected.Set("Content-Encoding", compression.ContentEncoding)
-	assert.Equal(t, expected, jsonExtraHeadersWithCompression)
+			expected = make(http.Header)
+			expected.Set("Content-Type", protobufContentType)
+			expected.Set(payloadVersionHTTPHeader, AgentPayloadVersion)
+			assert.Equal(t, expected, protobufExtraHeaders)
 
-	expected = make(http.Header)
-	expected.Set("Content-Type", protobufContentType)
-	expected.Set("Content-Encoding", compression.ContentEncoding)
-	expected.Set(payloadVersionHTTPHeader, AgentPayloadVersion)
-	assert.Equal(t, expected, protobufExtraHeadersWithCompression)
+			// "Content-Encoding" header present with correct value
+			expected = make(http.Header)
+			expected.Set("Content-Type", jsonContentType)
+			expected.Set("Content-Encoding", contentEncoding)
+			assert.Equal(t, expected, jsonExtraHeadersWithCompression)
+
+			expected = make(http.Header)
+			expected.Set("Content-Type", protobufContentType)
+			expected.Set("Content-Encoding", contentEncoding)
+			expected.Set(payloadVersionHTTPHeader, AgentPayloadVersion)
+			assert.Equal(t, expected, protobufExtraHeadersWithCompression)
+		})
+	}
 }
 
 func TestAgentPayloadVersion(t *testing.T) {
@@ -122,7 +148,18 @@ func (p *testPayload) Marshal() ([]byte, error) { return protobufString, nil }
 //nolint:revive // TODO(AML) Fix revive linter
 func (p *testPayload) MarshalSplitCompress(bufferContext *marshaler.BufferContext) (transaction.BytesPayloads, error) {
 	payloads := transaction.BytesPayloads{}
-	payload, err := compression.Compress(protobufString)
+	kind := config.Datadog.GetString("serializer_compressor_kind")
+	var payload []byte
+	var err error
+	switch kind {
+	case "zstd":
+		log.Info("compressing metadata with zstd")
+		payload, err = zstd.Compress(nil, payload)
+	case "zlib":
+		payload, err = compression.Compress(payload)
+	default:
+		return nil, fmt.Errorf("invalid serailizer_compressor kind. use zstd or zlib")
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +232,15 @@ func mkPayloads(payload []byte, compress bool) (transaction.BytesPayloads, error
 	payloads := transaction.BytesPayloads{}
 	var err error
 	if compress {
-		payload, err = compression.Compress(payload)
+		kind := config.Datadog.GetString("serializer_compressor_kind")
+		switch kind {
+		case "zstd":
+			payload, err = zstd.Compress(nil, payload)
+		case "zlib":
+			payload, err = compression.Compress(payload)
+		default:
+			return nil, fmt.Errorf("invalid serializer_compressor_kind. use zstd or zlib")
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -212,7 +257,18 @@ func createJSONPayloadMatcher(prefix string) interface{} {
 
 func doPayloadsMatch(payloads transaction.BytesPayloads, prefix string) bool {
 	for _, compressedPayload := range payloads {
-		if payload, err := compression.Decompress(compressedPayload.GetContent()); err != nil {
+		kind := config.Datadog.GetString("serializer_compressor_kind")
+		var payload []byte
+		var err error
+		switch kind {
+		case "zstd":
+			payload, err = zstd.Decompress(nil, compressedPayload.GetContent())
+		case "zlib":
+			payload, err = compression.Decompress(compressedPayload.GetContent())
+		default:
+			return false
+		}
+		if err != nil {
 			return false
 		} else { //nolint:revive // TODO(AML) Fix revive linter
 			if strings.HasPrefix(string(payload), prefix) {
@@ -229,10 +285,26 @@ func createJSONBytesPayloadMatcher(prefix string) interface{} {
 	})
 }
 
-func createProtoscopeMatcher(protoscopeDef string) interface{} {
+func createProtoscopeMatcher(protoscopeDef, compressorKind string) interface{} {
 	return mock.MatchedBy(func(payloads transaction.BytesPayloads) bool {
 		for _, compressedPayload := range payloads {
-			if payload, err := compression.Decompress(compressedPayload.GetContent()); err != nil {
+			originalCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", "zstd")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", originalCompressorKind)
+			var r io.ReadCloser
+			var err error
+			switch compressorKind {
+			case "zlib":
+				r, err = zlib.NewReader(bytes.NewReader(compressedPayload.GetContent()))
+			case "zstd":
+				r = zstd.NewReader(bytes.NewReader(compressedPayload.GetContent()))
+			}
+			if err != nil {
+				return false
+			}
+			defer r.Close()
+			payload, err := io.ReadAll(r)
+			if err != nil {
 				return false
 			} else { //nolint:revive // TODO(AML) Fix revive linter
 				res, err := protoscope.NewScanner(protoscopeDef).Exec()
@@ -251,189 +323,344 @@ func createProtoscopeMatcher(protoscopeDef string) interface{} {
 }
 
 func TestSendV1Events(t *testing.T) {
-	config.Datadog.SetWithoutSource("enable_events_stream_payload_serialization", false)
-	defer config.Datadog.SetWithoutSource("enable_events_stream_payload_serialization", nil)
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			config.Datadog.SetWithoutSource("enable_events_stream_payload_serialization", false)
+			defer config.Datadog.SetWithoutSource("enable_events_stream_payload_serialization", nil)
 
-	f := &forwarder.MockedForwarder{}
+			originalCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", originalCompressorKind)
 
-	matcher := createJSONPayloadMatcher(`{"apiKey":"","events":{},"internalHostname"`)
-	f.On("SubmitV1Intake", matcher, jsonExtraHeadersWithCompression).Return(nil).Times(1)
+			f := &forwarder.MockedForwarder{}
 
-	s := NewSerializer(f, nil)
-	err := s.SendEvents([]*event.Event{})
-	require.Nil(t, err)
-	f.AssertExpectations(t)
+			jsonExtraHeaders := make(http.Header)
+			protobufExtraHeaders := make(http.Header)
+			jsonExtraHeadersWithCompression := make(http.Header)
+			protobufExtraHeadersWithCompression := make(http.Header)
+			initExtraHeaders(jsonExtraHeaders, protobufExtraHeaders, jsonExtraHeadersWithCompression, protobufExtraHeadersWithCompression)
+
+			matcher := createJSONPayloadMatcher(`{"apiKey":"","events":{},"internalHostname"`)
+			f.On("SubmitV1Intake", matcher, jsonExtraHeadersWithCompression).Return(nil).Times(1)
+
+			s := NewSerializer(f, nil)
+			err := s.SendEvents([]*event.Event{})
+			require.Nil(t, err)
+			f.AssertExpectations(t)
+		})
+	}
 }
 
 func TestSendV1EventsCreateMarshalersBySourceType(t *testing.T) {
-	config.Datadog.SetWithoutSource("enable_events_stream_payload_serialization", true)
-	defer config.Datadog.SetWithoutSource("enable_events_stream_payload_serialization", nil)
-	f := &forwarder.MockedForwarder{}
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			config.Datadog.SetWithoutSource("enable_events_stream_payload_serialization", true)
+			defer config.Datadog.SetWithoutSource("enable_events_stream_payload_serialization", nil)
+			f := &forwarder.MockedForwarder{}
 
-	s := NewSerializer(f, nil)
+			s := NewSerializer(f, nil)
 
-	events := event.Events{&event.Event{SourceTypeName: "source1"}, &event.Event{SourceTypeName: "source2"}, &event.Event{SourceTypeName: "source3"}}
-	payloadsCountMatcher := func(payloadCount int) interface{} {
-		return mock.MatchedBy(func(payloads transaction.BytesPayloads) bool {
-			return len(payloads) == payloadCount
+			events := event.Events{&event.Event{SourceTypeName: "source1"}, &event.Event{SourceTypeName: "source2"}, &event.Event{SourceTypeName: "source3"}}
+			payloadsCountMatcher := func(payloadCount int) interface{} {
+				return mock.MatchedBy(func(payloads transaction.BytesPayloads) bool {
+					return len(payloads) == payloadCount
+				})
+			}
+
+			f.On("SubmitV1Intake", payloadsCountMatcher(1), s.jsonExtraHeadersWithCompression).Return(nil)
+			err := s.SendEvents(events)
+			assert.NoError(t, err)
+			f.AssertExpectations(t)
+
+			config.Datadog.SetWithoutSource("serializer_max_payload_size", 20)
+			defer config.Datadog.SetWithoutSource("serializer_max_payload_size", nil)
+
+			f.On("SubmitV1Intake", payloadsCountMatcher(3), s.jsonExtraHeadersWithCompression).Return(nil)
+			err = s.SendEvents(events)
+			assert.NoError(t, err)
+			f.AssertExpectations(t)
 		})
 	}
-
-	f.On("SubmitV1Intake", payloadsCountMatcher(1), jsonExtraHeadersWithCompression).Return(nil)
-	err := s.SendEvents(events)
-	assert.NoError(t, err)
-	f.AssertExpectations(t)
-
-	config.Datadog.SetWithoutSource("serializer_max_payload_size", 20)
-	defer config.Datadog.SetWithoutSource("serializer_max_payload_size", nil)
-
-	f.On("SubmitV1Intake", payloadsCountMatcher(3), jsonExtraHeadersWithCompression).Return(nil)
-	err = s.SendEvents(events)
-	assert.NoError(t, err)
-	f.AssertExpectations(t)
 }
 
 func TestSendV1ServiceChecks(t *testing.T) {
-	f := &forwarder.MockedForwarder{}
-	matcher := createJSONPayloadMatcher(`[{"check":"","host_name":"","timestamp":0,"status":0,"message":"","tags":null}]`)
-	f.On("SubmitV1CheckRuns", matcher, jsonExtraHeadersWithCompression).Return(nil).Times(1)
-	config.Datadog.SetWithoutSource("enable_service_checks_stream_payload_serialization", false)
-	defer config.Datadog.SetWithoutSource("enable_service_checks_stream_payload_serialization", nil)
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			f := &forwarder.MockedForwarder{}
+			jsonExtraHeaders := make(http.Header)
+			protobufExtraHeaders := make(http.Header)
+			jsonExtraHeadersWithCompression := make(http.Header)
+			protobufExtraHeadersWithCompression := make(http.Header)
+			initExtraHeaders(jsonExtraHeaders, protobufExtraHeaders, jsonExtraHeadersWithCompression, protobufExtraHeadersWithCompression)
+			matcher := createJSONPayloadMatcher(`[{"check":"","host_name":"","timestamp":0,"status":0,"message":"","tags":null}]`)
+			f.On("SubmitV1CheckRuns", matcher, jsonExtraHeadersWithCompression).Return(nil).Times(1)
+			config.Datadog.SetWithoutSource("enable_service_checks_stream_payload_serialization", false)
+			defer config.Datadog.SetWithoutSource("enable_service_checks_stream_payload_serialization", nil)
 
-	s := NewSerializer(f, nil)
-	err := s.SendServiceChecks(servicecheck.ServiceChecks{&servicecheck.ServiceCheck{}})
-	require.Nil(t, err)
-	f.AssertExpectations(t)
+			s := NewSerializer(f, nil)
+			err := s.SendServiceChecks(servicecheck.ServiceChecks{&servicecheck.ServiceCheck{}})
+			require.Nil(t, err)
+			f.AssertExpectations(t)
+		})
+	}
 }
 
 func TestSendV1Series(t *testing.T) {
-	f := &forwarder.MockedForwarder{}
-	matcher := createJSONBytesPayloadMatcher(`{"series":[]}`)
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			f := &forwarder.MockedForwarder{}
+			jsonExtraHeaders := make(http.Header)
+			protobufExtraHeaders := make(http.Header)
+			jsonExtraHeadersWithCompression := make(http.Header)
+			protobufExtraHeadersWithCompression := make(http.Header)
+			initExtraHeaders(jsonExtraHeaders, protobufExtraHeaders, jsonExtraHeadersWithCompression, protobufExtraHeadersWithCompression)
+			matcher := createJSONBytesPayloadMatcher(`{"series":[]}`)
 
-	f.On("SubmitV1Series", matcher, jsonExtraHeadersWithCompression).Return(nil).Times(1)
-	config.Datadog.SetWithoutSource("enable_stream_payload_serialization", false)
-	defer config.Datadog.SetWithoutSource("enable_stream_payload_serialization", nil)
-	config.Datadog.SetWithoutSource("use_v2_api.series", false)
-	defer config.Datadog.SetWithoutSource("use_v2_api.series", true)
+			f.On("SubmitV1Series", matcher, jsonExtraHeadersWithCompression).Return(nil).Times(1)
+			config.Datadog.SetWithoutSource("enable_stream_payload_serialization", false)
+			defer config.Datadog.SetWithoutSource("enable_stream_payload_serialization", nil)
+			config.Datadog.SetWithoutSource("use_v2_api.series", false)
+			defer config.Datadog.SetWithoutSource("use_v2_api.series", true)
 
-	s := NewSerializer(f, nil)
+			s := NewSerializer(f, nil)
 
-	err := s.SendIterableSeries(metricsserializer.CreateSerieSource(metrics.Series{}))
-	require.Nil(t, err)
-	f.AssertExpectations(t)
+			err := s.SendIterableSeries(metricsserializer.CreateSerieSource(metrics.Series{}))
+			require.Nil(t, err)
+			f.AssertExpectations(t)
+		})
+	}
 }
 
 func TestSendSeries(t *testing.T) {
-	f := &forwarder.MockedForwarder{}
-	matcher := createProtoscopeMatcher(`1: {
-		1: { 1: {"host"} }
-		5: 3
-		9: { 1: { 4: 10 }}
-	  }`)
-	f.On("SubmitSeries", matcher, protobufExtraHeadersWithCompression).Return(nil).Times(1)
-	config.Datadog.SetWithoutSource("use_v2_api.series", true) // default value, but just to be sure
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			f := &forwarder.MockedForwarder{}
+			matcher := createProtoscopeMatcher(`1: {
+				1: { 1: {"host"} }
+				5: 3
+				9: { 1: { 4: 10 }}
+			}`, tc.kind)
+			jsonExtraHeaders := make(http.Header)
+			protobufExtraHeaders := make(http.Header)
+			jsonExtraHeadersWithCompression := make(http.Header)
+			protobufExtraHeadersWithCompression := make(http.Header)
+			initExtraHeaders(jsonExtraHeaders, protobufExtraHeaders, jsonExtraHeadersWithCompression, protobufExtraHeadersWithCompression)
+			f.On("SubmitSeries", matcher, protobufExtraHeadersWithCompression).Return(nil).Times(1)
+			config.Datadog.SetWithoutSource("use_v2_api.series", true) // default value, but just to be sure
 
-	s := NewSerializer(f, nil)
+			s := NewSerializer(f, nil)
 
-	err := s.SendIterableSeries(metricsserializer.CreateSerieSource(metrics.Series{&metrics.Serie{}}))
-	require.Nil(t, err)
-	f.AssertExpectations(t)
+			err := s.SendIterableSeries(metricsserializer.CreateSerieSource(metrics.Series{&metrics.Serie{}}))
+			require.Nil(t, err)
+			f.AssertExpectations(t)
+		})
+	}
 }
 
 func TestSendSketch(t *testing.T) {
-	f := &forwarder.MockedForwarder{}
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			f := &forwarder.MockedForwarder{}
 
-	matcher := createProtoscopeMatcher(`
-		1: { 1: {"fakename"} 2: {"fakehost"} 8: { 1: { 4: 10 }}}
-		2: {}
-		`)
-	f.On("SubmitSketchSeries", matcher, protobufExtraHeadersWithCompression).Return(nil).Times(1)
+			matcher := createProtoscopeMatcher(`2: {}`, tc.kind)
+			jsonExtraHeaders := make(http.Header)
+			protobufExtraHeaders := make(http.Header)
+			jsonExtraHeadersWithCompression := make(http.Header)
+			protobufExtraHeadersWithCompression := make(http.Header)
+			initExtraHeaders(jsonExtraHeaders, protobufExtraHeaders, jsonExtraHeadersWithCompression, protobufExtraHeadersWithCompression)
+			f.On("SubmitSketchSeries", matcher, protobufExtraHeadersWithCompression).Return(nil).Times(1)
 
-	s := NewSerializer(f, nil)
-	err := s.SendSketch(metrics.NewSketchesSourceTestWithSketch())
-	require.Nil(t, err)
-	f.AssertExpectations(t)
+			s := NewSerializer(f, nil)
+			err := s.SendSketch(metrics.NewSketchesSourceTest())
+			require.Nil(t, err)
+			f.AssertExpectations(t)
+		})
+	}
 }
 
 func TestSendMetadata(t *testing.T) {
-	f := &forwarder.MockedForwarder{}
-	f.On("SubmitMetadata", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			f := &forwarder.MockedForwarder{}
+			jsonExtraHeaders := make(http.Header)
+			protobufExtraHeaders := make(http.Header)
+			jsonExtraHeadersWithCompression := make(http.Header)
+			protobufExtraHeadersWithCompression := make(http.Header)
+			initExtraHeaders(jsonExtraHeaders, protobufExtraHeaders, jsonExtraHeadersWithCompression, protobufExtraHeadersWithCompression)
+			jsonPayloads, err := mkPayloads(jsonString, true)
+			require.Nil(t, err)
+			protobufPayloads, err = mkPayloads(protobufString, true)
+			require.Nil(t, err)
+			f.On("SubmitMetadata", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 
-	s := NewSerializer(f, nil)
+			s := NewSerializer(f, nil)
 
-	payload := &testPayload{}
-	err := s.SendMetadata(payload)
-	require.Nil(t, err)
-	f.AssertExpectations(t)
+			payload := &testPayload{}
+			err = s.SendMetadata(payload)
+			require.Nil(t, err)
+			f.AssertExpectations(t)
 
-	f.On("SubmitMetadata", jsonPayloads, jsonExtraHeadersWithCompression).Return(fmt.Errorf("some error")).Times(1)
-	err = s.SendMetadata(payload)
-	require.NotNil(t, err)
-	f.AssertExpectations(t)
+			f.On("SubmitMetadata", jsonPayloads, jsonExtraHeadersWithCompression).Return(fmt.Errorf("some error")).Times(1)
+			err = s.SendMetadata(payload)
+			require.NotNil(t, err)
+			f.AssertExpectations(t)
 
-	errPayload := &testErrorPayload{}
-	err = s.SendMetadata(errPayload)
-	require.NotNil(t, err)
+			errPayload := &testErrorPayload{}
+			err = s.SendMetadata(errPayload)
+			require.NotNil(t, err)
+		})
+	}
 }
 
 func TestSendProcessesMetadata(t *testing.T) {
-	f := &forwarder.MockedForwarder{}
-	payload := []byte("\"test\"")
-	payloads, _ := mkPayloads(payload, true)
-	f.On("SubmitV1Intake", payloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			f := &forwarder.MockedForwarder{}
+			jsonExtraHeaders := make(http.Header)
+			protobufExtraHeaders := make(http.Header)
+			jsonExtraHeadersWithCompression := make(http.Header)
+			protobufExtraHeadersWithCompression := make(http.Header)
+			initExtraHeaders(jsonExtraHeaders, protobufExtraHeaders, jsonExtraHeadersWithCompression, protobufExtraHeadersWithCompression)
+			payload := []byte("\"test\"")
+			payloads, _ := mkPayloads(payload, true)
+			f.On("SubmitV1Intake", payloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 
-	s := NewSerializer(f, nil)
+			s := NewSerializer(f, nil)
 
-	err := s.SendProcessesMetadata("test")
-	require.Nil(t, err)
-	f.AssertExpectations(t)
+			err := s.SendProcessesMetadata("test")
+			require.Nil(t, err)
+			f.AssertExpectations(t)
 
-	f.On("SubmitV1Intake", payloads, jsonExtraHeadersWithCompression).Return(fmt.Errorf("some error")).Times(1)
-	err = s.SendProcessesMetadata("test")
-	require.NotNil(t, err)
-	f.AssertExpectations(t)
+			f.On("SubmitV1Intake", payloads, jsonExtraHeadersWithCompression).Return(fmt.Errorf("some error")).Times(1)
+			err = s.SendProcessesMetadata("test")
+			require.NotNil(t, err)
+			f.AssertExpectations(t)
 
-	errPayload := &testErrorPayload{}
-	err = s.SendProcessesMetadata(errPayload)
-	require.NotNil(t, err)
+			errPayload := &testErrorPayload{}
+			err = s.SendProcessesMetadata(errPayload)
+			require.NotNil(t, err)
+		})
+	}
 }
 
 func TestSendWithDisabledKind(t *testing.T) {
-	mockConfig := config.Mock(t)
+	tests := map[string]struct {
+		kind string
+	}{
+		"zlib": {kind: "zlib"},
+		"zstd": {kind: "zstd"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldCompressorKind := config.Datadog.GetString("serializer_compressor_kind")
+			defer config.Datadog.SetWithoutSource("serializer_compressor_kind", oldCompressorKind)
+			config.Datadog.SetWithoutSource("serializer_compressor_kind", tc.kind)
+			mockConfig := config.Mock(t)
 
-	mockConfig.SetWithoutSource("enable_payloads.events", false)
-	mockConfig.SetWithoutSource("enable_payloads.series", false)
-	mockConfig.SetWithoutSource("enable_payloads.service_checks", false)
-	mockConfig.SetWithoutSource("enable_payloads.sketches", false)
-	mockConfig.SetWithoutSource("enable_payloads.json_to_v1_intake", false)
+			mockConfig.SetWithoutSource("enable_payloads.events", false)
+			mockConfig.SetWithoutSource("enable_payloads.series", false)
+			mockConfig.SetWithoutSource("enable_payloads.service_checks", false)
+			mockConfig.SetWithoutSource("enable_payloads.sketches", false)
+			mockConfig.SetWithoutSource("enable_payloads.json_to_v1_intake", false)
 
-	// restore default values
-	defer func() {
-		mockConfig.SetWithoutSource("enable_payloads.events", true)
-		mockConfig.SetWithoutSource("enable_payloads.series", true)
-		mockConfig.SetWithoutSource("enable_payloads.service_checks", true)
-		mockConfig.SetWithoutSource("enable_payloads.sketches", true)
-		mockConfig.SetWithoutSource("enable_payloads.json_to_v1_intake", true)
-	}()
+			// restore default values
+			defer func() {
+				mockConfig.SetWithoutSource("enable_payloads.events", true)
+				mockConfig.SetWithoutSource("enable_payloads.series", true)
+				mockConfig.SetWithoutSource("enable_payloads.service_checks", true)
+				mockConfig.SetWithoutSource("enable_payloads.sketches", true)
+				mockConfig.SetWithoutSource("enable_payloads.json_to_v1_intake", true)
+			}()
 
-	f := &forwarder.MockedForwarder{}
-	s := NewSerializer(f, nil)
+			f := &forwarder.MockedForwarder{}
+			s := NewSerializer(f, nil)
 
-	payload := &testPayload{}
+			payload := &testPayload{}
 
-	s.SendEvents(make(event.Events, 0))
-	s.SendIterableSeries(metricsserializer.CreateSerieSource(metrics.Series{}))
-	s.SendSketch(metrics.NewSketchesSourceTest())
-	s.SendServiceChecks(make(servicecheck.ServiceChecks, 0))
-	s.SendProcessesMetadata("test")
+			s.SendEvents(make(event.Events, 0))
+			s.SendIterableSeries(metricsserializer.CreateSerieSource(metrics.Series{}))
+			s.SendSketch(metrics.NewSketchesSourceTest())
+			s.SendServiceChecks(make(servicecheck.ServiceChecks, 0))
+			s.SendProcessesMetadata("test")
 
-	f.AssertNotCalled(t, "SubmitMetadata")
-	f.AssertNotCalled(t, "SubmitV1CheckRuns")
-	f.AssertNotCalled(t, "SubmitV1Series")
-	f.AssertNotCalled(t, "SubmitSketchSeries")
+			f.AssertNotCalled(t, "SubmitMetadata")
+			f.AssertNotCalled(t, "SubmitV1CheckRuns")
+			f.AssertNotCalled(t, "SubmitV1Series")
+			f.AssertNotCalled(t, "SubmitSketchSeries")
 
-	// We never disable metadata
-	f.On("SubmitMetadata", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
-	s.SendMetadata(payload)
-	f.AssertNumberOfCalls(t, "SubmitMetadata", 1) // called once for the metadata
+			// We never disable metadata
+			f.On("SubmitMetadata", jsonPayloads, s.jsonExtraHeadersWithCompression).Return(nil).Times(1)
+			s.SendMetadata(payload)
+			f.AssertNumberOfCalls(t, "SubmitMetadata", 1) // called once for the metadata
+		})
+	}
 }

--- a/pkg/serializer/split/split_test.go
+++ b/pkg/serializer/split/split_test.go
@@ -14,7 +14,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/zstd"
+
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
@@ -83,7 +86,14 @@ func testSplitPayloadsSeries(t *testing.T, numPoints int, compress bool) {
 		localPayload := payload.GetContent()
 
 		if compress {
-			localPayload, err = compression.Decompress(localPayload)
+			kind := config.Datadog.GetString("serializer_compressor_kind")
+			var err error
+			switch kind {
+			case "zstd":
+				localPayload, err = zstd.Decompress(nil, localPayload)
+			case "zlib":
+				localPayload, err = compression.Decompress(localPayload)
+			}
 			require.Nil(t, err)
 		}
 
@@ -193,7 +203,14 @@ func testSplitPayloadsEvents(t *testing.T, numPoints int, compress bool) {
 		var s map[string]interface{}
 		localPayload := payload.GetContent()
 		if compress {
-			localPayload, err = compression.Decompress(localPayload)
+			kind := config.Datadog.GetString("serializer_compressor_kind")
+			var err error
+			switch kind {
+			case "zstd":
+				localPayload, err = zstd.Decompress(nil, localPayload)
+			case "zlib":
+				localPayload, err = compression.Decompress(localPayload)
+			}
 			require.Nil(t, err)
 		}
 
@@ -258,7 +275,14 @@ func testSplitPayloadsServiceChecks(t *testing.T, numPoints int, compress bool) 
 		var s []interface{}
 		localPayload := payload.GetContent()
 		if compress {
-			localPayload, err = compression.Decompress(localPayload)
+			kind := config.Datadog.GetString("serializer_compressor_kind")
+			var err error
+			switch kind {
+			case "zstd":
+				localPayload, err = zstd.Decompress(nil, localPayload)
+			case "zlib":
+				localPayload, err = compression.Decompress(localPayload)
+			}
 			require.Nil(t, err)
 		}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
