### PR TITLE
[clusterchecks] Take into account utilization of excluded checks

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -228,14 +228,6 @@ func (d *dispatcher) updateRunnersStats() {
 				checkStats.IsClusterCheck = true
 				stats[idStr] = checkStats
 			}
-
-			checkName := checkid.IDToCheckName(id)
-			if _, found := d.excludedChecksFromDispatching[checkName]; found {
-				// TODO: We are abusing the IsClusterCheck field to mark checks that should be excluded from rebalancing decisions.
-				// It behaves the same way as we want to count them in rebalance decisions but we don't want to move them.
-				checkStats.IsClusterCheck = false
-				stats[idStr] = checkStats
-			}
 		}
 		node.clcRunnerStats = stats
 		log.Tracef("Updated CLC Runner stats on node: %s, node IP: %s, stats: %v", name, node.clientIP, stats)


### PR DESCRIPTION
### What does this PR do?

Takes into account the utilization of cluster checks excluded by the `cluster_checks.exclude_checks_from_dispatching` option when rebalancing. We do not want to move these checks, but we still need to take into account their utilization so that the checks are distributed evenly across the runner pods.


### Describe how to test/QA your changes

Can be skipped. If this is not working, we'll realize when we check our dashboards.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
