### PR TITLE
[CSPM] Fix race on shutdown of compliance agent

### DIFF
--- a/cmd/cluster-agent/subcommands/start/compliance.go
+++ b/cmd/cluster-agent/subcommands/start/compliance.go
@@ -88,7 +88,7 @@ func startCompliance(senderManager sender.SenderManager, stopper startstop.Stopp
 		return err
 	}
 
-	reporter, err := compliance.NewLogReporter(hname, stopper, "compliance-agent", "compliance", runPath, endpoints, ctx)
+	reporter, err := compliance.NewLogReporter(hname, "compliance-agent", "compliance", runPath, endpoints, ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cluster-agent/subcommands/start/compliance.go
+++ b/cmd/cluster-agent/subcommands/start/compliance.go
@@ -88,14 +88,10 @@ func startCompliance(senderManager sender.SenderManager, stopper startstop.Stopp
 		return err
 	}
 
-	reporter, err := compliance.NewLogReporter(hname, "compliance-agent", "compliance", runPath, endpoints, ctx)
-	if err != nil {
-		return err
-	}
-
 	runner := runner.NewRunner(senderManager)
 	stopper.Add(runner)
 
+	reporter := compliance.NewLogReporter(hname, "compliance-agent", "compliance", runPath, endpoints, ctx)
 	agent := compliance.NewAgent(senderManager, compliance.AgentOptions{
 		ConfigDir:     configDir,
 		Reporter:      reporter,

--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -42,7 +42,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
 // CliParams needs to be exported because the compliance subcommand is tightly coupled to this subcommand and tests need to be able to access this type.
@@ -250,18 +249,16 @@ func reportComplianceEvents(log log.Component, config config.Component, events [
 	if err != nil {
 		return log.Errorf("Error while getting hostname, exiting: %v", err)
 	}
-
-	stopper := startstop.NewSerialStopper()
-	defer stopper.Stop()
 	runPath := config.GetString("compliance_config.run_path")
 	endpoints, context, err := common.NewLogContextCompliance()
 	if err != nil {
 		return fmt.Errorf("reporter: could not reate log context for compliance: %w", err)
 	}
-	reporter, err := compliance.NewLogReporter(hostnameDetected, stopper, "compliance-agent", "compliance", runPath, endpoints, context)
+	reporter, err := compliance.NewLogReporter(hostnameDetected, "compliance-agent", "compliance", runPath, endpoints, context)
 	if err != nil {
 		return fmt.Errorf("reporter: could not create: %w", err)
 	}
+	defer reporter.Stop()
 	for _, event := range events {
 		reporter.ReportEvent(event)
 	}

--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -254,10 +254,7 @@ func reportComplianceEvents(log log.Component, config config.Component, events [
 	if err != nil {
 		return fmt.Errorf("reporter: could not reate log context for compliance: %w", err)
 	}
-	reporter, err := compliance.NewLogReporter(hostnameDetected, "compliance-agent", "compliance", runPath, endpoints, context)
-	if err != nil {
-		return fmt.Errorf("reporter: could not create: %w", err)
-	}
+	reporter := compliance.NewLogReporter(hostnameDetected, "compliance-agent", "compliance", runPath, endpoints, context)
 	defer reporter.Stop()
 	for _, event := range events {
 		reporter.ReportEvent(event)

--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -8,7 +8,6 @@ package compliance
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -95,10 +94,7 @@ func eventRun(log log.Component, config config.Component, eventArgs *cliParams) 
 	}
 
 	runPath := config.GetString("compliance_config.run_path")
-	reporter, err := compliance.NewLogReporter(hostnameDetected, eventArgs.sourceName, eventArgs.sourceType, runPath, endpoints, dstContext)
-	if err != nil {
-		return fmt.Errorf("failed to set up compliance log reporter: %w", err)
-	}
+	reporter := compliance.NewLogReporter(hostnameDetected, eventArgs.sourceName, eventArgs.sourceType, runPath, endpoints, dstContext)
 	defer reporter.Stop()
 
 	eventData := make(map[string]interface{})

--- a/cmd/security-agent/subcommands/compliance/compliance.go
+++ b/cmd/security-agent/subcommands/compliance/compliance.go
@@ -44,11 +44,6 @@ func StartCompliance(log log.Component, config config.Component, sysprobeconfig 
 	}
 	stopper.Add(context)
 
-	reporter, err := compliance.NewLogReporter(hostname, "compliance-agent", "compliance", runPath, endpoints, context)
-	if err != nil {
-		return nil, err
-	}
-
 	resolverOptions := compliance.ResolverOptions{
 		Hostname:           hostname,
 		HostRoot:           os.Getenv("HOST_ROOT"),
@@ -73,6 +68,7 @@ func StartCompliance(log log.Component, config config.Component, sysprobeconfig 
 		enabledConfigurationsExporters = append(enabledConfigurationsExporters, compliance.DBExporter)
 	}
 
+	reporter := compliance.NewLogReporter(hostname, "compliance-agent", "compliance", runPath, endpoints, context)
 	runner := runner.NewRunner(senderManager)
 	stopper.Add(runner)
 	agent := compliance.NewAgent(senderManager, compliance.AgentOptions{

--- a/cmd/security-agent/subcommands/compliance/compliance.go
+++ b/cmd/security-agent/subcommands/compliance/compliance.go
@@ -44,7 +44,7 @@ func StartCompliance(log log.Component, config config.Component, sysprobeconfig 
 	}
 	stopper.Add(context)
 
-	reporter, err := compliance.NewLogReporter(hostname, stopper, "compliance-agent", "compliance", runPath, endpoints, context)
+	reporter, err := compliance.NewLogReporter(hostname, "compliance-agent", "compliance", runPath, endpoints, context)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -283,6 +283,7 @@ func (a *Agent) Stop() {
 	case <-time.After(10 * time.Second):
 	case <-a.finish:
 	}
+	a.opts.Reporter.Stop()
 	log.Infof("compliance agent shut down")
 }
 

--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -23,20 +23,21 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
 // LogReporter is responsible for sending compliance logs to DataDog backends.
 type LogReporter struct {
-	hostname  string
-	logSource *sources.LogSource
-	logChan   chan *message.Message
-	endpoints *config.Endpoints
-	tags      []string
+	hostname         string
+	pipelineProvider pipeline.Provider
+	auditor          *auditor.RegistryAuditor
+	logSource        *sources.LogSource
+	logChan          chan *message.Message
+	endpoints        *config.Endpoints
+	tags             []string
 }
 
 // NewLogReporter instantiates a new log LogReporter
-func NewLogReporter(hostname string, stopper startstop.Stopper, sourceName, sourceType, runPath string, endpoints *config.Endpoints, dstcontext *client.DestinationsContext) (*LogReporter, error) {
+func NewLogReporter(hostname string, sourceName, sourceType, runPath string, endpoints *config.Endpoints, dstcontext *client.DestinationsContext) (*LogReporter, error) {
 	health := health.RegisterLiveness(sourceType)
 
 	// setup the auditor
@@ -46,9 +47,6 @@ func NewLogReporter(hostname string, stopper startstop.Stopper, sourceName, sour
 	// setup the pipeline provider that provides pairs of processor and sender
 	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, auditor, &diagnostic.NoopMessageReceiver{}, nil, endpoints, dstcontext)
 	pipelineProvider.Start()
-
-	stopper.Add(pipelineProvider)
-	stopper.Add(auditor)
 
 	logSource := sources.NewLogSource(
 		sourceName,
@@ -74,12 +72,19 @@ func NewLogReporter(hostname string, stopper startstop.Stopper, sourceName, sour
 	}
 
 	return &LogReporter{
-		hostname:  hostname,
-		logSource: logSource,
-		logChan:   logChan,
-		endpoints: endpoints,
-		tags:      tags,
+		hostname:         hostname,
+		pipelineProvider: pipelineProvider,
+		auditor:          auditor,
+		logSource:        logSource,
+		logChan:          logChan,
+		endpoints:        endpoints,
+		tags:             tags,
 	}, nil
+}
+
+func (r *LogReporter) Stop() {
+	r.pipelineProvider.Stop()
+	r.auditor.Stop()
 }
 
 // Endpoints returns the endpoints associated with the log reporter.

--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -37,7 +37,7 @@ type LogReporter struct {
 }
 
 // NewLogReporter instantiates a new log LogReporter
-func NewLogReporter(hostname string, sourceName, sourceType, runPath string, endpoints *config.Endpoints, dstcontext *client.DestinationsContext) (*LogReporter, error) {
+func NewLogReporter(hostname string, sourceName, sourceType, runPath string, endpoints *config.Endpoints, dstcontext *client.DestinationsContext) *LogReporter {
 	health := health.RegisterLiveness(sourceType)
 
 	// setup the auditor
@@ -79,7 +79,7 @@ func NewLogReporter(hostname string, sourceName, sourceType, runPath string, end
 		logChan:          logChan,
 		endpoints:        endpoints,
 		tags:             tags,
-	}, nil
+	}
 }
 
 // Stop stops the LogReporter

--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -82,6 +82,7 @@ func NewLogReporter(hostname string, sourceName, sourceType, runPath string, end
 	}, nil
 }
 
+// Stop stops the LogReporter
 func (r *LogReporter) Stop() {
 	r.pipelineProvider.Stop()
 	r.auditor.Stop()


### PR DESCRIPTION
### What does this PR do?

Fix a race on shutdown of the compliance agent. The LogReporter was closed before the agent was notified about the shutdown causing logs to be emitted after the reporter had been closed.

### Motivation

Fix a rare panic on shutdown of the security-agent.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
