### PR TITLE
Add workflow to add the community label on external contributor PRs

### DIFF
--- a/.github/workflows/external-contributor.yml
+++ b/.github/workflows/external-contributor.yml
@@ -16,13 +16,13 @@ jobs:
           script: |
             const { data: isMember } = await github.orgs.checkMembershipForUser({
               org: context.repo.owner,
-              username: github.event.pull_request.user.login
+              username: context.payload.sender.login
             })
             if (!isMember) {
               await github.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: github.event.pull_request.number,
+                issue_number: context.issue.number,
                 labels: ['community']
               })
             }

--- a/.github/workflows/external-contributor.yml
+++ b/.github/workflows/external-contributor.yml
@@ -1,7 +1,8 @@
 name: Handle External Contributor PRs
 
 on:
-  pull_request:
+  # run in the context of the base branch, so that it still works in PR from forks
+  pull_request_target:
     types: [opened, reopened]
 
 jobs:

--- a/.github/workflows/external-contributor.yml
+++ b/.github/workflows/external-contributor.yml
@@ -6,23 +6,16 @@ on:
 
 jobs:
   external-contributor-prs:
-    name: Handle External Contributor PRs
+    name: Handle Fork PRs
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Set label on external contributor PRs
-        uses: actions/github-script@v4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { data: isMember } = await github.orgs.checkMembershipForUser({
-              org: context.repo.owner,
-              username: context.payload.sender.login
-            })
-            if (!isMember) {
-              await github.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                labels: ['community']
-              })
-            }
+        run: gh issue edit "$NUMBER" --add-label "$LABELS" --milestone "$MILESTONE"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          # labels is a comma-separated list of tags
+          LABELS: community,team/triage
+          MILESTONE: Triage

--- a/.github/workflows/external-contributor.yml
+++ b/.github/workflows/external-contributor.yml
@@ -15,7 +15,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number }}
+          NUMBER: ${{ github.event.number }}
           # labels is a comma-separated list of tags
           LABELS: community,team/triage
           MILESTONE: Triage

--- a/.github/workflows/external-contributor.yml
+++ b/.github/workflows/external-contributor.yml
@@ -1,0 +1,28 @@
+name: Handle External Contributor PRs
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  external-contributor-prs:
+    name: Handle External Contributor PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set label on external contributor PRs
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: isMember } = await github.orgs.checkMembershipForUser({
+              org: context.repo.owner,
+              username: github.event.pull_request.user.login
+            })
+            if (!isMember) {
+              await github.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: github.event.pull_request.number,
+                labels: ['community']
+              })
+            }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Create a github workflow to automatically add the `community` and `team/triage` labels as well as `Triage` milestone on PRs from forks.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Have a clearer view of external contributor PRs.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Initially tried to use author organization membership, but it would require a Github Token with access to the DataDog org.

Example opened from a fork (labels and milestone added): https://github.com/DataDog/datadog-agent/pull/22009
Example from this repo (job skipped): https://github.com/DataDog/datadog-agent/pull/22011

Note that in the first one the job appears failed on the PR but it's actually an older run, the run which added the labels succeeded (the event type changed from `pull_request` to `pull_request_target` so it doesn't override it).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
