### PR TITLE
[RC-1440] gate logs metadata inventory payload with the inventories_checks_configuration_enabled config

### DIFF
--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
@@ -176,13 +176,14 @@ func (ic *inventorychecksImpl) GetInstanceMetadata(instanceID string) map[string
 
 func (ic *inventorychecksImpl) getPayload() marshaler.JSONMarshaler {
 	payloadData := make(checksMetadata)
+	invChecksEnabled := ic.conf.GetBool("inventories_checks_configuration_enabled")
 
 	if coll, isSet := ic.coll.Get(); isSet {
 		foundInCollector := map[string]struct{}{}
 
 		coll.MapOverChecks(func(checks []check.Info) {
 			for _, c := range checks {
-				cm := check.GetMetadata(c, ic.conf.GetBool("inventories_checks_configuration_enabled"))
+				cm := check.GetMetadata(c, invChecksEnabled)
 
 				if checkData, found := ic.data[string(c.ID())]; found {
 					for key, val := range checkData.metadata {
@@ -208,7 +209,7 @@ func (ic *inventorychecksImpl) getPayload() marshaler.JSONMarshaler {
 	}
 
 	logsMetadata := make(map[string][]metadata)
-	if sources, isSet := ic.sources.Get(); isSet {
+	if sources, isSet := ic.sources.Get(); isSet && invChecksEnabled {
 		if sources != nil {
 			for _, logSource := range sources.GetSources() {
 				if _, found := logsMetadata[logSource.Name]; !found {

--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
@@ -97,116 +97,140 @@ func TestGetInstanceMetadata(t *testing.T) {
 }
 
 func TestGetPayload(t *testing.T) {
-	cInfo := []check.Info{
-		check.MockInfo{
-			Name:         "check1",
-			CheckID:      checkid.ID("check1_instance1"),
-			Source:       "provider1",
-			InitConf:     "",
-			InstanceConf: "{\"test\":21}",
-		},
-		check.MockInfo{
-			Name:         "check1",
-			CheckID:      checkid.ID("check1_instance2"),
-			Source:       "provider1",
-			InitConf:     "",
-			InstanceConf: "{\"test\":22}",
-		},
-		check.MockInfo{
-			Name:         "check2",
-			CheckID:      checkid.ID("check2_instance1"),
-			Source:       "provider2",
-			InitConf:     "{}",
-			InstanceConf: "{}",
-		},
+	for _, invChecksCfgEnabled := range []bool{true, false} {
+		cInfo := []check.Info{
+			check.MockInfo{
+				Name:         "check1",
+				CheckID:      checkid.ID("check1_instance1"),
+				Source:       "provider1",
+				InitConf:     "",
+				InstanceConf: "{\"test\":21}",
+			},
+			check.MockInfo{
+				Name:         "check1",
+				CheckID:      checkid.ID("check1_instance2"),
+				Source:       "provider1",
+				InitConf:     "",
+				InstanceConf: "{\"test\":22}",
+			},
+			check.MockInfo{
+				Name:         "check2",
+				CheckID:      checkid.ID("check2_instance1"),
+				Source:       "provider2",
+				InitConf:     "{}",
+				InstanceConf: "{}",
+			},
+		}
+
+		mockColl := collector.NewMock(cInfo)
+		mockColl.On("AddEventReceiver", mock.AnythingOfType("EventReceiver")).Return()
+		mockColl.On("MapOverChecks", mock.AnythingOfType("func([]check.Info)")).Return()
+
+		// Setup log sources
+		logSources := sources.NewLogSources()
+		src := sources.NewLogSource("redisdb", &logConfig.LogsConfig{
+			Type:       logConfig.FileType,
+			Path:       "/var/log/redis/redis.log",
+			Identifier: "redisdb",
+			Service:    "awesome_cache",
+			Source:     "redis",
+			Tags:       []string{"env:prod"},
+		})
+		// Register an error
+		src.Status.Error(fmt.Errorf("No such file or directory"))
+		logSources.AddSource(src)
+		mockLogAgent := fxutil.Test[optional.Option[logagent.Mock]](
+			t, logagent.MockModule(), core.MockBundle(), inventoryagent.MockModule(),
+		)
+		logsAgent, _ := mockLogAgent.Get()
+		logsAgent.SetSources(logSources)
+
+		testName := fmt.Sprintf("inventories_checks_configuration_enabled=%t", invChecksCfgEnabled)
+		t.Run(testName, func(t *testing.T) {
+			overrides := map[string]any{
+				"inventories_configuration_enabled":        true,
+				"inventories_checks_configuration_enabled": invChecksCfgEnabled,
+			}
+
+			ic := getTestInventoryChecks(t,
+				optional.NewOption[collector.Collector](mockColl),
+				optional.NewOption[logagent.Component](logsAgent),
+				overrides,
+			)
+
+			ic.hostname = "test-hostname"
+
+			ic.Set("check1_instance1", "check_provided_key1", 123)
+			ic.Set("check1_instance1", "check_provided_key2", "Hi")
+			ic.Set("non_running_checkid", "check_provided_key1", "this_should_not_be_kept")
+
+			p := ic.getPayload().(*Payload)
+
+			assert.Equal(t, "test-hostname", p.Hostname)
+
+			assert.Len(t, p.Metadata, 2)           // 'non_running_checkid' should have been cleaned
+			assert.Len(t, p.Metadata["check1"], 2) // check1 has two instances
+
+			check1Instance1 := p.Metadata["check1"][0]
+			assert.Equal(t, "check1_instance1", check1Instance1["config.hash"])
+			assert.Equal(t, "provider1", check1Instance1["config.provider"])
+			assert.Equal(t, 123, check1Instance1["check_provided_key1"])
+			assert.Equal(t, "Hi", check1Instance1["check_provided_key2"])
+			if invChecksCfgEnabled {
+				assert.Equal(t, "", check1Instance1["init_config"])
+				assert.Equal(t, "test: 21", check1Instance1["instance_config"])
+			} else {
+				assert.Nil(t, check1Instance1["init_config"])
+				assert.Nil(t, check1Instance1["instance_config"])
+			}
+
+			check1Instance2 := p.Metadata["check1"][1]
+			assert.Equal(t, "check1_instance2", check1Instance2["config.hash"])
+			assert.Equal(t, "provider1", check1Instance2["config.provider"])
+			if invChecksCfgEnabled {
+				assert.Equal(t, "", check1Instance2["init_config"])
+				assert.Equal(t, "test: 22", check1Instance2["instance_config"])
+			} else {
+				assert.Nil(t, check1Instance2["init_config"])
+				assert.Nil(t, check1Instance2["instance_config"])
+			}
+
+			assert.Len(t, p.Metadata["check2"], 1) // check2 has one instance
+			check2Instance1 := p.Metadata["check2"][0]
+			assert.Equal(t, "check2_instance1", check2Instance1["config.hash"])
+			assert.Equal(t, "provider2", check2Instance1["config.provider"])
+			if invChecksCfgEnabled {
+				assert.Equal(t, "{}", check2Instance1["init_config"])
+				assert.Equal(t, "{}", check2Instance1["instance_config"])
+			} else {
+				assert.Nil(t, check2Instance1["init_config"])
+				assert.Nil(t, check2Instance1["instance_config"])
+			}
+
+			// Check that metadata linked to non-existing check were deleted
+			assert.NotContains(t, "non_running_checkid", ic.data)
+
+			// Check the log sources part of the metadata
+			if invChecksCfgEnabled {
+				assert.Len(t, p.LogsMetadata, 1)
+				actualSource, found := p.LogsMetadata["redisdb"]
+				assert.True(t, found)
+				assert.Len(t, actualSource, 1)
+				expectedSourceConfig := `{"type":"file","path":"/var/log/redis/redis.log","service":"awesome_cache","source":"redis","tags":["env:prod"]}`
+				assert.Equal(t, expectedSourceConfig, actualSource[0]["config"])
+				expectedSourceStatus := map[string]string{
+					"status": "error",
+					"error":  "Error: No such file or directory",
+				}
+				assert.Equal(t, expectedSourceStatus, actualSource[0]["state"])
+				assert.Equal(t, "awesome_cache", actualSource[0]["service"])
+				assert.Equal(t, "redis", actualSource[0]["source"])
+				assert.Equal(t, []string{"env:prod"}, actualSource[0]["tags"])
+			} else {
+				assert.Len(t, p.LogsMetadata, 0)
+			}
+		})
 	}
-
-	overrides := map[string]any{
-		"inventories_configuration_enabled":        true,
-		"inventories_checks_configuration_enabled": true,
-	}
-
-	mockColl := collector.NewMock(cInfo)
-	mockColl.On("AddEventReceiver", mock.AnythingOfType("EventReceiver")).Return()
-	mockColl.On("MapOverChecks", mock.AnythingOfType("func([]check.Info)")).Return()
-
-	// Setup log sources
-	logSources := sources.NewLogSources()
-	src := sources.NewLogSource("redisdb", &logConfig.LogsConfig{
-		Type:       logConfig.FileType,
-		Path:       "/var/log/redis/redis.log",
-		Identifier: "redisdb",
-		Service:    "awesome_cache",
-		Source:     "redis",
-		Tags:       []string{"env:prod"},
-	})
-	// Register an error
-	src.Status.Error(fmt.Errorf("No such file or directory"))
-	logSources.AddSource(src)
-	mockLogAgent := fxutil.Test[optional.Option[logagent.Mock]](
-		t, logagent.MockModule(), core.MockBundle(), inventoryagent.MockModule(),
-	)
-	logsAgent, _ := mockLogAgent.Get()
-	logsAgent.SetSources(logSources)
-
-	ic := getTestInventoryChecks(t,
-		optional.NewOption[collector.Collector](mockColl),
-		optional.NewOption[logagent.Component](logsAgent),
-		overrides,
-	)
-
-	ic.hostname = "test-hostname"
-
-	ic.Set("check1_instance1", "check_provided_key1", 123)
-	ic.Set("check1_instance1", "check_provided_key2", "Hi")
-	ic.Set("non_running_checkid", "check_provided_key1", "this_should_not_be_kept")
-
-	p := ic.getPayload().(*Payload)
-
-	assert.Equal(t, "test-hostname", p.Hostname)
-
-	assert.Len(t, p.Metadata, 2)           // 'non_running_checkid' should have been cleaned
-	assert.Len(t, p.Metadata["check1"], 2) // check1 has two instances
-
-	check1Instance1 := p.Metadata["check1"][0]
-	assert.Equal(t, "check1_instance1", check1Instance1["config.hash"])
-	assert.Equal(t, "provider1", check1Instance1["config.provider"])
-	assert.Equal(t, 123, check1Instance1["check_provided_key1"])
-	assert.Equal(t, "Hi", check1Instance1["check_provided_key2"])
-	assert.Equal(t, "", check1Instance1["init_config"])
-	assert.Equal(t, "test: 21", check1Instance1["instance_config"])
-
-	check1Instance2 := p.Metadata["check1"][1]
-	assert.Equal(t, "check1_instance2", check1Instance2["config.hash"])
-	assert.Equal(t, "provider1", check1Instance2["config.provider"])
-	assert.Equal(t, "", check1Instance2["init_config"])
-	assert.Equal(t, "test: 22", check1Instance2["instance_config"])
-
-	assert.Len(t, p.Metadata["check2"], 1) // check2 has one instance
-	check2Instance1 := p.Metadata["check2"][0]
-	assert.Equal(t, "check2_instance1", check2Instance1["config.hash"])
-	assert.Equal(t, "provider2", check2Instance1["config.provider"])
-	assert.Equal(t, "{}", check2Instance1["init_config"])
-	assert.Equal(t, "{}", check2Instance1["instance_config"])
-
-	// Check that metadata linked to non-existing check were deleted
-	assert.NotContains(t, "non_running_checkid", ic.data)
-
-	// Check the log sources part of the metadata
-	assert.Len(t, p.LogsMetadata, 1)
-	actualSource, found := p.LogsMetadata["redisdb"]
-	assert.True(t, found)
-	assert.Len(t, actualSource, 1)
-	expectedSourceConfig := `{"type":"file","path":"/var/log/redis/redis.log","service":"awesome_cache","source":"redis","tags":["env:prod"]}`
-	assert.Equal(t, expectedSourceConfig, actualSource[0]["config"])
-	expectedSourceStatus := map[string]string{
-		"status": "error",
-		"error":  "Error: No such file or directory",
-	}
-	assert.Equal(t, expectedSourceStatus, actualSource[0]["state"])
-	assert.Equal(t, "awesome_cache", actualSource[0]["service"])
-	assert.Equal(t, "redis", actualSource[0]["source"])
-	assert.Equal(t, []string{"env:prod"}, actualSource[0]["tags"])
 }
 
 func TestFlareProviderFilename(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR makes it so that the existing `inventories_checks_configuration_enabled` config bool will additionally gate the logic that populates the `logs_metadata` section of the inventories check payload (see-also the original PR introducing this functionality [here](https://github.com/DataDog/datadog-agent/pull/21563)) 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The nature of the `inventories_checks_configuration_enabled` config bool is to determine whether we should build additional metadata for the check payload, including things like the `instance_config` and `init_config`. The `logs_metadata` field is similar in nature and should also be gated by this config, such that if the config is turned off, `logs_metadata` will be empty and the logic to build that field will be skipped.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
This has already been tested:

- Configure a log section in an integration (or configure a log integration in any way you like)
- Start the agent
- Verify that the second inventory checks payload contains the `logs_metadata` section. (One way to do this is to generate a flare and look inside the `metadata/inventory/checks.json file` in the flare)
- Disable the `inventories_checks_configuration_enabled` config field
- Verify that the inventory checks payload does not contain the `logs_metadata` section

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
