### PR TITLE
[ASCII-1078] Remove redundant scrubbing in log package

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -46,6 +46,9 @@ var (
 	logsBuffer        = []func(){}
 	bufferMutex       sync.Mutex
 	defaultStackDepth = 3
+
+	// for testing purposes
+	scrubBytesFunc = scrubber.ScrubBytes
 )
 
 // DatadogLogger wrapper structure for seelog
@@ -164,7 +167,7 @@ func (sw *DatadogLogger) unregisterAdditionalLogger(n string) error {
 }
 
 func (sw *DatadogLogger) scrub(s string) string {
-	if scrubbed, err := scrubber.ScrubBytes([]byte(s)); err == nil {
+	if scrubbed, err := scrubBytesFunc([]byte(s)); err == nil {
 		return string(scrubbed)
 	}
 
@@ -420,7 +423,7 @@ func BuildLogEntry(v ...interface{}) string {
 }
 
 func scrubMessage(message string) string {
-	msgScrubbed, err := scrubber.ScrubBytes([]byte(message))
+	msgScrubbed, err := scrubBytesFunc([]byte(message))
 	if err == nil {
 		return string(msgScrubbed)
 	}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -465,7 +465,7 @@ func log(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string), v ..
 		s := BuildLogEntry(v...)
 		l.l.Lock()
 		defer l.l.Unlock()
-		logFunc(l.scrub(s))
+		logFunc(s)
 	} else if l == nil || l.inner == nil {
 		addLogToBuffer(bufferFunc)
 	}
@@ -477,7 +477,7 @@ func logWithError(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(stri
 		s := BuildLogEntry(v...)
 		l.l.Lock()
 		defer l.l.Unlock()
-		return logFunc(l.scrub(s))
+		return logFunc(s)
 	} else if l == nil || l.inner == nil {
 		addLogToBuffer(bufferFunc)
 	}
@@ -528,12 +528,11 @@ func logFormatWithError(logLevel seelog.LogLevel, bufferFunc func(), logFunc fun
 func logContext(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string), message string, depth int, context ...interface{}) {
 	l := logger.Load()
 	if l != nil && l.inner != nil && l.shouldLog(logLevel) {
-		msg := l.scrub(message)
 		l.l.Lock()
 		defer l.l.Unlock()
 		l.inner.SetContext(context)
 		l.inner.SetAdditionalStackDepth(defaultStackDepth + depth) //nolint:errcheck
-		logFunc(msg)
+		logFunc(message)
 		l.inner.SetContext(nil)
 		l.inner.SetAdditionalStackDepth(defaultStackDepth) //nolint:errcheck
 	} else if l == nil || l.inner == nil {
@@ -544,12 +543,11 @@ func logContext(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string
 func logContextWithError(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string) error, message string, fallbackStderr bool, depth int, context ...interface{}) error {
 	l := logger.Load()
 	if l != nil && l.inner != nil && l.shouldLog(logLevel) {
-		msg := l.scrub(message)
 		l.l.Lock()
 		defer l.l.Unlock()
 		l.inner.SetContext(context)
 		l.inner.SetAdditionalStackDepth(defaultStackDepth + depth) //nolint:errcheck
-		err := logFunc(msg)
+		err := logFunc(message)
 		l.inner.SetContext(nil)
 		l.inner.SetAdditionalStackDepth(defaultStackDepth) //nolint:errcheck
 		return err

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -457,9 +457,9 @@ func formatErrorc(message string, context ...interface{}) error {
 	return errors.New(scrubMessage(msg))
 }
 
-// Log logs a message at the given level, using either bufferFunc (if logging is not yet set up) or
+// log logs a message at the given level, using either bufferFunc (if logging is not yet set up) or
 // logFunc, and treating the variadic args as the message.
-func Log(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string), v ...interface{}) {
+func log(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string), v ...interface{}) {
 	l := logger.Load()
 	if l != nil && l.inner != nil && l.shouldLog(logLevel) {
 		s := BuildLogEntry(v...)
@@ -565,7 +565,7 @@ func logContextWithError(logLevel seelog.LogLevel, bufferFunc func(), logFunc fu
 
 // Trace logs at the trace level
 func Trace(v ...interface{}) {
-	Log(seelog.TraceLvl, func() { Trace(v...) }, logger.trace, v...)
+	log(seelog.TraceLvl, func() { Trace(v...) }, logger.trace, v...)
 }
 
 // Tracef logs with format at the trace level
@@ -580,7 +580,7 @@ func TracefStackDepth(depth int, format string, params ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, params...)
-	Log(seelog.TraceLvl, func() { TraceStackDepth(depth, msg) }, func(s string) {
+	log(seelog.TraceLvl, func() { TraceStackDepth(depth, msg) }, func(s string) {
 		logger.traceStackDepth(s, depth)
 	}, msg)
 }
@@ -605,7 +605,7 @@ func TraceFunc(logFunc func() string) {
 
 // Debug logs at the debug level
 func Debug(v ...interface{}) {
-	Log(seelog.DebugLvl, func() { Debug(v...) }, logger.debug, v...)
+	log(seelog.DebugLvl, func() { Debug(v...) }, logger.debug, v...)
 }
 
 // Debugf logs with format at the debug level
@@ -620,7 +620,7 @@ func DebugfStackDepth(depth int, format string, params ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, params...)
-	Log(seelog.DebugLvl, func() { DebugStackDepth(depth, msg) }, func(s string) {
+	log(seelog.DebugLvl, func() { DebugStackDepth(depth, msg) }, func(s string) {
 		logger.debugStackDepth(s, depth)
 	}, msg)
 }
@@ -645,7 +645,7 @@ func DebugFunc(logFunc func() string) {
 
 // Info logs at the info level
 func Info(v ...interface{}) {
-	Log(seelog.InfoLvl, func() { Info(v...) }, logger.info, v...)
+	log(seelog.InfoLvl, func() { Info(v...) }, logger.info, v...)
 }
 
 // Infof logs with format at the info level
@@ -660,7 +660,7 @@ func InfofStackDepth(depth int, format string, params ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, params...)
-	Log(seelog.InfoLvl, func() { InfoStackDepth(depth, msg) }, func(s string) {
+	log(seelog.InfoLvl, func() { InfoStackDepth(depth, msg) }, func(s string) {
 		logger.infoStackDepth(s, depth)
 	}, msg)
 }
@@ -793,7 +793,7 @@ func CriticalFunc(logFunc func() string) {
 
 // InfoStackDepth logs at the info level and the current stack depth plus the additional given one
 func InfoStackDepth(depth int, v ...interface{}) {
-	Log(seelog.InfoLvl, func() { InfoStackDepth(depth, v...) }, func(s string) {
+	log(seelog.InfoLvl, func() { InfoStackDepth(depth, v...) }, func(s string) {
 		logger.infoStackDepth(s, depth)
 	}, v...)
 }
@@ -807,14 +807,14 @@ func WarnStackDepth(depth int, v ...interface{}) error {
 
 // DebugStackDepth logs at the debug level and the current stack depth plus the additional given one and returns an error containing the formated log message
 func DebugStackDepth(depth int, v ...interface{}) {
-	Log(seelog.DebugLvl, func() { DebugStackDepth(depth, v...) }, func(s string) {
+	log(seelog.DebugLvl, func() { DebugStackDepth(depth, v...) }, func(s string) {
 		logger.debugStackDepth(s, depth)
 	}, v...)
 }
 
 // TraceStackDepth logs at the trace level and the current stack depth plus the additional given one and returns an error containing the formated log message
 func TraceStackDepth(depth int, v ...interface{}) {
-	Log(seelog.TraceLvl, func() { TraceStackDepth(depth, v...) }, func(s string) {
+	log(seelog.TraceLvl, func() { TraceStackDepth(depth, v...) }, func(s string) {
 		logger.traceStackDepth(s, depth)
 	}, v...)
 }
@@ -840,7 +840,7 @@ func JMXError(v ...interface{}) error {
 
 // JMXInfo Logs
 func JMXInfo(v ...interface{}) {
-	Log(seelog.InfoLvl, func() { JMXInfo(v...) }, jmxLogger.info, v...)
+	log(seelog.InfoLvl, func() { JMXInfo(v...) }, jmxLogger.info, v...)
 }
 
 // Flush flushes the underlying inner log

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -461,26 +461,26 @@ func formatErrorc(message string, context ...interface{}) error {
 }
 
 // log logs a message at the given level, using either bufferFunc (if logging is not yet set up) or
-// logFunc, and treating the variadic args as the message.
-func log(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string), v ...interface{}) {
+// scrubAndLogFunc, and treating the variadic args as the message.
+func log(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLogFunc func(string), v ...interface{}) {
 	l := logger.Load()
 	if l != nil && l.inner != nil && l.shouldLog(logLevel) {
 		s := BuildLogEntry(v...)
 		l.l.Lock()
 		defer l.l.Unlock()
-		logFunc(s)
+		scrubAndLogFunc(s)
 	} else if l == nil || l.inner == nil {
 		addLogToBuffer(bufferFunc)
 	}
 }
 
-func logWithError(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string) error, fallbackStderr bool, v ...interface{}) error {
+func logWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLogFunc func(string) error, fallbackStderr bool, v ...interface{}) error {
 	l := logger.Load()
 	if l != nil && l.inner != nil && l.shouldLog(logLevel) {
 		s := BuildLogEntry(v...)
 		l.l.Lock()
 		defer l.l.Unlock()
-		return logFunc(s)
+		return scrubAndLogFunc(s)
 	} else if l == nil || l.inner == nil {
 		addLogToBuffer(bufferFunc)
 	}
@@ -496,23 +496,23 @@ func logWithError(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(stri
 	return err
 }
 
-func logFormat(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string, ...interface{}), format string, params ...interface{}) {
+func logFormat(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLogFunc func(string, ...interface{}), format string, params ...interface{}) {
 	l := logger.Load()
 	if l != nil && l.inner != nil && l.shouldLog(logLevel) {
 		l.l.Lock()
 		defer l.l.Unlock()
-		logFunc(format, params...)
+		scrubAndLogFunc(format, params...)
 	} else if l == nil || l.inner == nil {
 		addLogToBuffer(bufferFunc)
 	}
 }
 
-func logFormatWithError(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string, ...interface{}) error, format string, fallbackStderr bool, params ...interface{}) error {
+func logFormatWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLogFunc func(string, ...interface{}) error, format string, fallbackStderr bool, params ...interface{}) error {
 	l := logger.Load()
 	if l != nil && l.inner != nil && l.shouldLog(logLevel) {
 		l.l.Lock()
 		defer l.l.Unlock()
-		return logFunc(format, params...)
+		return scrubAndLogFunc(format, params...)
 	} else if l == nil || l.inner == nil {
 		addLogToBuffer(bufferFunc)
 	}
@@ -528,14 +528,14 @@ func logFormatWithError(logLevel seelog.LogLevel, bufferFunc func(), logFunc fun
 	return err
 }
 
-func logContext(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string), message string, depth int, context ...interface{}) {
+func logContext(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLogFunc func(string), message string, depth int, context ...interface{}) {
 	l := logger.Load()
 	if l != nil && l.inner != nil && l.shouldLog(logLevel) {
 		l.l.Lock()
 		defer l.l.Unlock()
 		l.inner.SetContext(context)
 		l.inner.SetAdditionalStackDepth(defaultStackDepth + depth) //nolint:errcheck
-		logFunc(message)
+		scrubAndLogFunc(message)
 		l.inner.SetContext(nil)
 		l.inner.SetAdditionalStackDepth(defaultStackDepth) //nolint:errcheck
 	} else if l == nil || l.inner == nil {
@@ -543,14 +543,14 @@ func logContext(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string
 	}
 }
 
-func logContextWithError(logLevel seelog.LogLevel, bufferFunc func(), logFunc func(string) error, message string, fallbackStderr bool, depth int, context ...interface{}) error {
+func logContextWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLogFunc func(string) error, message string, fallbackStderr bool, depth int, context ...interface{}) error {
 	l := logger.Load()
 	if l != nil && l.inner != nil && l.shouldLog(logLevel) {
 		l.l.Lock()
 		defer l.l.Unlock()
 		l.inner.SetContext(context)
 		l.inner.SetAdditionalStackDepth(defaultStackDepth + depth) //nolint:errcheck
-		err := logFunc(message)
+		err := scrubAndLogFunc(message)
 		l.inner.SetContext(nil)
 		l.inner.SetAdditionalStackDepth(defaultStackDepth) //nolint:errcheck
 		return err

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -518,34 +518,18 @@ func mockScrubBytesWithCount(t *testing.T) *atomic.Int32 {
 	return counterPtr
 }
 
-func testFunctionsScrubbingCount(t *testing.T, funcs []any, args []any) {
-	for _, fun := range funcs {
-		valTy := reflect.TypeOf(fun)
-		require.Equal(t, valTy.Kind(), reflect.Func)
-
-		// get the function name to use as test name
-		val := reflect.ValueOf(fun)
-		fun := runtime.FuncForPC(val.Pointer())
-		require.NotNil(t, fun)
-
-		funcName := fun.Name()
-		if parts := strings.Split(funcName, "/"); len(parts) > 0 {
-			funcName = parts[len(parts)-1]
-		}
-
-		testName := fmt.Sprintf("Scrub Count %s", funcName)
-		t.Run(testName, func(t *testing.T) {
-			// create a slice of reflect.Value from the args
-			reflArgs := make([]reflect.Value, 0, len(args))
-			for _, arg := range args {
-				reflArgs = append(reflArgs, reflect.ValueOf(arg))
-			}
-
-			counter := mockScrubBytesWithCount(t)
-			val.Call(reflArgs)
-			require.Equal(t, 1, int(counter.Load()))
-		})
+func getFuncName(val reflect.Value) (string, error) {
+	fun := runtime.FuncForPC(val.Pointer())
+	if fun == nil {
+		return "", fmt.Errorf("cannot get function name for %v", val)
 	}
+
+	funcName := fun.Name()
+	if parts := strings.Split(funcName, "."); len(parts) > 0 {
+		funcName = parts[len(parts)-1]
+	}
+
+	return funcName, nil
 }
 
 func TestLoggerScrubbingCount(t *testing.T) {
@@ -555,52 +539,84 @@ func TestLoggerScrubbingCount(t *testing.T) {
 	require.NoError(t, err)
 	SetupLogger(l, "trace")
 
-	// package public methods
-	testFunctionsScrubbingCount(
-		t,
-		[]any{Trace, Debug, Info, Warn, Error, Critical},
-		[]any{"a", "b"},
-	)
-	testFunctionsScrubbingCount(
-		t,
-		[]any{Tracef, Debugf, Infof, Warnf, Errorf, Criticalf},
-		[]any{"a %s c", "b"},
-	)
-	testFunctionsScrubbingCount(
-		t,
-		[]any{TracefStackDepth, DebugfStackDepth, InfofStackDepth, WarnfStackDepth, ErrorfStackDepth, CriticalfStackDepth},
-		[]any{1, "a %s c", "b"},
-	)
-	testFunctionsScrubbingCount(
-		t,
-		[]any{Tracec, Debugc, Infoc, Warnc, Errorc, Criticalc},
-		[]any{"a b", "1 %s 3", "2"},
-	)
-	testFunctionsScrubbingCount(
-		t,
-		[]any{TracecStackDepth, DebugcStackDepth, InfocStackDepth, WarncStackDepth, ErrorcStackDepth, CriticalcStackDepth},
-		[]any{"a b", 1, "1 %s 3", "2"},
-	)
-	testFunctionsScrubbingCount(
-		t,
-		[]any{TraceFunc, DebugFunc, InfoFunc, WarnFunc, ErrorFunc, CriticalFunc},
-		[]any{func() string { return "a b" }},
-	)
+	testCases := []struct {
+		name  string
+		funcs []any
+		args  []any
+	}{
+		// package public methods
+		{
+			"public functions basic",
+			[]any{Trace, Debug, Info, Warn, Error, Critical},
+			[]any{"a", "b"},
+		},
+		{
+			"public functions with format",
+			[]any{Tracef, Debugf, Infof, Warnf, Errorf, Criticalf},
+			[]any{"a %s c", "b"},
+		},
+		{
+			"public functions with format and stack depth",
+			[]any{TracefStackDepth, DebugfStackDepth, InfofStackDepth, WarnfStackDepth, ErrorfStackDepth, CriticalfStackDepth},
+			[]any{1, "a %s c", "b"},
+		},
+		{
+			"public functions with context",
+			[]any{Tracec, Debugc, Infoc, Warnc, Errorc, Criticalc},
+			[]any{"a b", "1 %s 3", "2"},
+		},
+		{
+			"public functions with context and stack depth",
+			[]any{TracecStackDepth, DebugcStackDepth, InfocStackDepth, WarncStackDepth, ErrorcStackDepth, CriticalcStackDepth},
+			[]any{"a b", 1, "1 %s 3", "2"},
+		},
+		{
+			"public functions with anonymous function",
+			[]any{TraceFunc, DebugFunc, InfoFunc, WarnFunc, ErrorFunc, CriticalFunc},
+			[]any{func() string { return "a b" }},
+		},
+		// loggerPointer methods
+		{
+			"loggerPointer methods basic",
+			[]any{logger.trace, logger.debug, logger.info, logger.warn, logger.error, logger.critical},
+			[]any{"a b"},
+		},
+		{
+			"loggerPointer methods with format",
+			[]any{logger.tracef, logger.debugf, logger.infof, logger.warnf, logger.errorf, logger.criticalf},
+			[]any{"a %s c", "b"},
+		},
+		{
+			"loggerPointer methods with stack depth",
+			[]any{logger.traceStackDepth, logger.debugStackDepth, logger.infoStackDepth, logger.warnStackDepth, logger.errorStackDepth, logger.criticalStackDepth},
+			[]any{"a b", 1},
+		},
+	}
 
-	// loggerPointer methods
-	testFunctionsScrubbingCount(
-		t,
-		[]any{logger.trace, logger.debug, logger.info, logger.warn, logger.error, logger.critical},
-		[]any{"a b"},
-	)
-	testFunctionsScrubbingCount(
-		t,
-		[]any{logger.tracef, logger.debugf, logger.infof, logger.warnf, logger.errorf, logger.criticalf},
-		[]any{"a %s c", "b"},
-	)
-	testFunctionsScrubbingCount(
-		t,
-		[]any{logger.traceStackDepth, logger.debugStackDepth, logger.infoStackDepth, logger.warnStackDepth, logger.errorStackDepth, logger.criticalStackDepth},
-		[]any{"a b", 1},
-	)
+	for _, tc := range testCases {
+		t.Run("scrub count "+tc.name, func(t *testing.T) {
+			for _, fun := range tc.funcs {
+				val := reflect.ValueOf(fun)
+				funcName, err := getFuncName(val)
+				if !assert.NoError(t, err) {
+					continue
+				}
+
+				valTy := reflect.TypeOf(fun)
+				if !assert.Equalf(t, valTy.Kind(), reflect.Func, "expected %s to be a function", funcName) {
+					continue
+				}
+
+				// create a slice of reflect.Value from the args
+				reflArgs := make([]reflect.Value, 0, len(tc.args))
+				for _, arg := range tc.args {
+					reflArgs = append(reflArgs, reflect.ValueOf(arg))
+				}
+
+				counter := mockScrubBytesWithCount(t)
+				val.Call(reflArgs)
+				assert.Equalf(t, 1, int(counter.Load()), "expected %s to call scrubBytesFunc once", funcName)
+			}
+		})
+	}
 }

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -530,8 +530,8 @@ func testFunctionsScrubbingCount(t *testing.T, funcs []any, args []any) {
 		require.NotNil(t, fun)
 
 		funcName := fun.Name()
-		if _, fname, ok := strings.Cut(funcName, "."); ok {
-			funcName = fname
+		if parts := strings.Split(funcName, "/"); len(parts) > 0 {
+			funcName = parts[len(parts)-1]
 		}
 
 		testName := fmt.Sprintf("Scrub Count %s", funcName)
@@ -556,6 +556,7 @@ func TestLoggerScrubbingCount(t *testing.T) {
 	require.NoError(t, err)
 	SetupLogger(l, "trace")
 
+	// package public methods
 	testFunctionsScrubbingCount(
 		t,
 		[]any{Trace, Debug, Info, Warn, Error, Critical},
@@ -585,5 +586,22 @@ func TestLoggerScrubbingCount(t *testing.T) {
 		t,
 		[]any{TraceFunc, DebugFunc, InfoFunc, WarnFunc, ErrorFunc, CriticalFunc},
 		[]any{func() string { return "a b" }},
+	)
+
+	// loggerPointer methods
+	testFunctionsScrubbingCount(
+		t,
+		[]any{logger.trace, logger.debug, logger.info, logger.warn, logger.error, logger.critical},
+		[]any{"a b"},
+	)
+	testFunctionsScrubbingCount(
+		t,
+		[]any{logger.tracef, logger.debugf, logger.infof, logger.warnf, logger.errorf, logger.criticalf},
+		[]any{"a %s c", "b"},
+	)
+	testFunctionsScrubbingCount(
+		t,
+		[]any{logger.traceStackDepth, logger.debugStackDepth, logger.infoStackDepth, logger.warnStackDepth, logger.errorStackDepth, logger.criticalStackDepth},
+		[]any{"a b", 1},
 	)
 }

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -508,8 +508,7 @@ func mockScrubBytesWithCount(t *testing.T) *atomic.Int32 {
 	oldScrubber := scrubBytesFunc
 	t.Cleanup(func() { scrubBytesFunc = oldScrubber })
 
-	var counter atomic.Int32
-	counterPtr := &counter
+	counterPtr := atomic.NewInt32(0)
 
 	scrubBytesFunc = func(msg []byte) ([]byte, error) {
 		counterPtr.Add(1)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Remove superfluous scrubbing in log package.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Reduce memory allocations and CPU use when logging. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Remove scrubbing in `Log`, `logWithError`, `logContext`, and `logContextWithError`, as these function each call a method of `loggerPointer`, which all scrub already.

Also took the chance to unexport the `Log` function (which is not used outside of the package) to align with other similar functions (`logWithError`, `logContext`, etc).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Only functional change is removing scrubbing, and the unit tests added check that we still scrub (exactly) once both in exported functions of the package, and methods of `loggerPointer`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
