### PR TITLE
Rename failures to error in API config expvars

### DIFF
--- a/comp/api/api/apiimpl/internal/config/endpoint.go
+++ b/comp/api/api/apiimpl/internal/config/endpoint.go
@@ -33,7 +33,7 @@ type configEndpoint struct {
 	successExpvar      expvar.Map
 	unauthorizedExpvar expvar.Map
 	unsetExpvar        expvar.Map
-	failedExpvar       expvar.Map
+	errorsExpvar       expvar.Map
 }
 
 func (c *configEndpoint) serveHTTP(w http.ResponseWriter, r *http.Request) {
@@ -75,7 +75,7 @@ func getConfigEndpoint(cfg config.Reader, authorizedConfigPaths authorizedSet, e
 		"success":      &configEndpoint.successExpvar,
 		"unauthorized": &configEndpoint.unauthorizedExpvar,
 		"unset":        &configEndpoint.unsetExpvar,
-		"failed":       &configEndpoint.failedExpvar,
+		"errors":       &configEndpoint.errorsExpvar,
 	} {
 		configEndpoint.expvars.Set(name, expv)
 	}
@@ -109,7 +109,7 @@ func (c *configEndpoint) getConfigValueAsJSON(r *http.Request) ([]byte, int, err
 
 	body, err := json.Marshal(value)
 	if err != nil {
-		c.failedExpvar.Add(path, 1)
+		c.errorsExpvar.Add(path, 1)
 		return nil, http.StatusInternalServerError, fmt.Errorf("could not marshal config value of '%s': %v", path, err)
 	}
 

--- a/comp/api/api/apiimpl/internal/config/endpoint_test.go
+++ b/comp/api/api/apiimpl/internal/config/endpoint_test.go
@@ -27,7 +27,7 @@ type testCase struct {
 
 type expvals struct {
 	Success      map[string]int `json:"success"`
-	Failed       map[string]int `json:"failed"`
+	Errors       map[string]int `json:"errors"`
 	Unauthorized map[string]int `json:"unauthorized"`
 	Unset        map[string]int `json:"unset"`
 }
@@ -112,7 +112,7 @@ func checkExpvars(t *testing.T, beforeVars, afterVars expvals, configName string
 	case http.StatusForbidden:
 		beforeVars.Unauthorized[configName]++
 	case http.StatusInternalServerError:
-		beforeVars.Failed[configName]++
+		beforeVars.Errors[configName]++
 	default:
 		t.Fatalf("unexpected status: %d", expectedStatus)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Rename failures to error in API config expvars.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Better reflect what it represents.
Eg. it's not access failure but actual server side errors.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The config API is not enabled by default nor publicly documented so we don't consider it a breaking change.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Tested manually and by unit tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
