### PR TITLE
[clusterchecks/dispatcher] Make rebalance period configurable and constant

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -22,12 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const (
-	firstRunnerStatsMinutes  = 2  // collect runner stats after the first 2 minutes
-	secondRunnerStatsMinutes = 5  // collect runner stats after the first 7 minutes
-	finalRunnerStatsMinutes  = 10 // collect runner stats endlessly every 10 minutes
-)
-
 // dispatcher holds the management logic for cluster-checks
 type dispatcher struct {
 	store                         *clusterStore
@@ -37,6 +31,7 @@ type dispatcher struct {
 	advancedDispatching           bool
 	excludedChecks                map[string]struct{}
 	excludedChecksFromDispatching map[string]struct{}
+	rebalancingPeriod             time.Duration
 }
 
 func newDispatcher() *dispatcher {
@@ -63,6 +58,8 @@ func newDispatcher() *dispatcher {
 			d.excludedChecksFromDispatching[checkName] = struct{}{}
 		}
 	}
+
+	d.rebalancingPeriod = config.Datadog.GetDuration("cluster_checks.rebalance_period")
 
 	hname, _ := hostname.Get(context.TODO())
 	clusterTagValue := clustername.GetClusterName(context.TODO(), hname)
@@ -201,9 +198,8 @@ func (d *dispatcher) run(ctx context.Context) {
 	cleanupTicker := time.NewTicker(time.Duration(d.nodeExpirationSeconds/2) * time.Second)
 	defer cleanupTicker.Stop()
 
-	runnerStatsMinutes := firstRunnerStatsMinutes
-	runnerStatsTicker := time.NewTicker(time.Duration(runnerStatsMinutes) * time.Minute)
-	defer runnerStatsTicker.Stop()
+	rebalanceTicker := time.NewTicker(d.rebalancingPeriod)
+	defer rebalanceTicker.Stop()
 
 	for {
 		select {
@@ -220,19 +216,8 @@ func (d *dispatcher) run(ctx context.Context) {
 				danglingConfs := d.retrieveAndClearDangling()
 				d.reschedule(danglingConfs)
 			}
-		case <-runnerStatsTicker.C:
-			// Collect stats with an exponential backoff 2 - 5 - 10 minutes
-			if runnerStatsMinutes == firstRunnerStatsMinutes {
-				runnerStatsMinutes = secondRunnerStatsMinutes
-				runnerStatsTicker = time.NewTicker(time.Duration(runnerStatsMinutes) * time.Minute)
-			} else if runnerStatsMinutes == secondRunnerStatsMinutes {
-				runnerStatsMinutes = finalRunnerStatsMinutes
-				runnerStatsTicker = time.NewTicker(time.Duration(runnerStatsMinutes) * time.Minute)
-			}
-
-			// Rebalance if needed
+		case <-rebalanceTicker.C:
 			if d.advancedDispatching {
-				// Rebalance checks distribution
 				d.rebalance(false)
 			}
 		}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1010,6 +1010,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks_from_dispatching", []string{})
+	config.BindEnvAndSetDefault("cluster_checks.rebalance_period", 10*time.Minute)
 
 	// Cluster check runner
 	config.BindEnvAndSetDefault("clc_runner_enabled", false)

--- a/releasenotes-dca/notes/rebalance-period-config-862b4a174ec9e5d6.yaml
+++ b/releasenotes-dca/notes/rebalance-period-config-862b4a174ec9e5d6.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Introduces a new config option in the Cluster Agent to set the rebalance
+    period when advanced dispatching is enabled:
+    ``cluster_checks.rebalance_period``. The default value is 10 min.


### PR DESCRIPTION
### What does this PR do?

When advanced dispatching is enabled, cluster checks are rebalanced first 2 min after the DCA starts, then after 5 min, and then every 10 min. I believe the first 2 rebalances are unnecessary because it's better to wait a bit until check runtimes stabilize (some checks might take a bit to start). This PR changes the rebalance frequency to every 10 mins and also makes it configurable.


### Describe how to test/QA your changes

Run then agent on Kubernetes with the DCA and runners enabled. Enable advanced dispatching and set the log level to "debug" so you can see when it tries to rebalance checks.

You can use a config like this when deploying using Helm:
```yaml
datadog:
  kubelet:
    tlsVerify: false
  helmCheck:
    enabled: true
    collectEvents: true
  kubeStateMetricsCore:
    useClusterCheckRunners: true
clusterAgent:
  env:
    - name: "DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED"
      value: "true"
    - name: "DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION"
      value: "true"
    - name: "DD_LOG_LEVEL"
      value: "debug"
    - name: "DD_CLUSTER_CHECKS_REBALANCE_PERIOD"
      value: "2m"
clusterChecksRunner:
  enabled: true
```
You should see in the logs one of this 2 messages in the period specified:
- "Didn't find a distribution better enough so that rescheduling checks is worth it ..."
- "Found a better distribution for the cluster checks..."

`DD_CLUSTER_CHECKS_REBALANCE_PERIOD` defaults to 10 min.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
