### PR TITLE
Fix PID registration for APM ETW component

### DIFF
--- a/comp/apm/etwtracer/impl/apmetwtracerimpl.go
+++ b/comp/apm/etwtracer/impl/apmetwtracerimpl.go
@@ -446,6 +446,7 @@ func (a *apmetwtracerimpl) addPID(pid uint32) error {
 	}
 	err = a.reconfigureProvider()
 	if err != nil {
+		c.Close()
 		delete(a.pids, pid)
 	}
 	return err

--- a/comp/apm/etwtracer/impl/apmetwtracerimpl.go
+++ b/comp/apm/etwtracer/impl/apmetwtracerimpl.go
@@ -434,18 +434,21 @@ func (a *apmetwtracerimpl) stop(_ context.Context) error {
 }
 
 func (a *apmetwtracerimpl) addPID(pid uint32) error {
+	if len(a.pids) >= MAX_EVENT_FILTER_PID_COUNT {
+		return fmt.Errorf("too many processes registered")
+	}
 	c, err := winio.DialPipe(fmt.Sprintf(clientNamedPipePath, pid), nil)
 	if err != nil {
 		return err
 	}
-
-	if len(a.pids) > MAX_EVENT_FILTER_PID_COUNT {
-		return fmt.Errorf("too many processes registered")
-	}
 	a.pids[pid] = pidContext{
 		conn: c,
 	}
-	return a.reconfigureProvider()
+	err = a.reconfigureProvider()
+	if err != nil {
+		delete(a.pids, pid)
+	}
+	return err
 }
 
 func (a *apmetwtracerimpl) removePID(pid uint32) error {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR fixes the PID registration code for the APM ETW component. The issues fixed are:
- Check when the number of registered PID is _greater or equal than_ `MAX_EVENT_FILTER_PID_COUNT` instead of just _greater than_
- When adding a PID and configuration of ETW failed, the PID remains in memory (and a later call to `removePID` then succeeds). It should be instead removed.
- The named pipe for communicating with the tracer was created at the start of the `addPID` function, but it should instead be created just before the `reconfigureProvider`.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Better error handling during `addPID`.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
see https://datadoghq.atlassian.net/browse/WINA-605
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
