### PR TITLE
[RC-1484] allow log scheduling from remote-config provider

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -288,6 +288,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.enabled", false)
 	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.allow_list", defaultAllowedRCIntegrations)
 	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.block_list", []string{})
+	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.allow_log_config_scheduling", false)
 
 	// Auto exit configuration
 	config.BindEnvAndSetDefault("auto_exit.validation_period", 60)

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -8,7 +8,6 @@ package ad
 
 import (
 	"fmt"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"strings"
 
 	yaml "gopkg.in/yaml.v2"
@@ -17,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/adlistener"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/adlistener"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
@@ -144,11 +145,14 @@ func (s *Scheduler) toSources(config integration.Config) ([]*sourcesPkg.LogSourc
 	var configs []*logsConfig.LogsConfig
 	var err error
 
-	switch config.Provider {
-	case names.File:
+	switch {
+	case config.Provider == names.File:
 		// config defined in a file
 		configs, err = logsConfig.ParseYAML(config.LogsConfig)
-	case names.Container, names.Kubernetes, names.KubeContainer:
+	case config.Provider == names.Container,
+		config.Provider == names.Kubernetes,
+		config.Provider == names.KubeContainer,
+		config.Provider == names.RemoteConfig && pkgconfig.Datadog.GetBool("remote_configuration.agent_integrations.allow_log_config_scheduling"):
 		// config attached to a container label or a pod annotation
 		configs, err = logsConfig.ParseJSON(config.LogsConfig)
 	default:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR allows log scheduling for log integrations provided via the AGENT_INTEGRATIONS remote configuration product. This functionality is disabled by default and needs to be enabled via a new agent config feature flag.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This was intended to be working already, but was discovered to be gated by a log scheduling switch case that we missed during 7.51.0 QA testing for [RC-1484](https://datadoghq.atlassian.net/browse/RC-1484)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Already tested locally:

- publish new AGENT_INTEGRATION configs to the RC backend with a redisdb log integration: 
```
{
  "name": "redisdb",
  "init_config": {},
  "instances": [
    {
      "host": "localhost",
      "port": 6378
    }
  ],
  "logs": [
    {
      "type": "file",
      "path": "/var/log/redis_6379",
      "source": "redis",
      "service": "paulredis"
    }
  ]
}
```
- With RC enabled and the AGENT_INTEGRATIONS project configured to allow `redisdb` configs, watch for the following log message (due to the configuration being disabled by default): `parsing logs config from remote-config is not supported yet`

```remote_configuration:
  agent_integrations:
    allow_list: ["redisdb"]
    enabled: true
```
- Now configure the agent to allow log scheduling from RC, and restart the agent. Now you should not see the log message above, and should see the redis integration shown in the `agent status` command output under the `redisdb` section 

```remote_configuration:
  agent_integrations:
    allow_list: ["redisdb"]
    enabled: true
    allow_log_config_scheduling: true
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[RC-1484]: https://datadoghq.atlassian.net/browse/RC-1484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ