### PR TITLE
[testutil] add flake testing marker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -367,6 +367,7 @@
 /pkg/util/crashreport/                  @DataDog/windows-kernel-integrations
 /pkg/util/pdhutil/                      @DataDog/windows-agent
 /pkg/util/winutil/                      @DataDog/windows-agent
+/pkg/util/testutil/flake                @DataDog/agent-platform
 /pkg/languagedetection                  @DataDog/processes @DataDog/universal-service-monitoring
 /pkg/logs/                              @DataDog/agent-metrics-logs
 /pkg/logs/launchers/windowsevent        @DataDog/agent-metrics-logs @DataDog/windows-agent

--- a/pkg/util/testutil/flake/flake.go
+++ b/pkg/util/testutil/flake/flake.go
@@ -3,13 +3,10 @@
 // This product includes software developed at Datadog (https://www.Datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package flake provides a [testing.TB](https://pkg.go.dev/testing#TB) implementation that support flaky tests.
-// Flaky tests are tests that are not reliable and may fail for various reasons.
-// Wrap your *testing.T with [flake.FlakyTesting] to allow flaky tests to fail or skip them.
-// Use flags `allow-flake-failure` and `skip-flake` to control the behavior, or set the environment variables `ALLOW_FLAKE_FAILURE` and `SKIP_FLAKE`.
-// If both `allow-flake-failure` and `skip-flake` are set, `skip-flake` takes precedence.
+// Package flake marks an instance of [testing.TB](https://pkg.go.dev/testing#TB) as flake.
+// Use [flake.Mark] to mark a known flake test.
+// Use `skip-flake` to control the behavior, or set the environment variable `SKIP_FLAKE`.
 // Flags take precedence over environment variables.
-// Subtests from [testing.T.Run](https://pkg.go.dev/testing#T.Run) should be wrapped with [flake.Wrap](https://pkg.go.dev/github.com/DataDog/datadog-agent/pkg/util/testutil/flake#Wrap) to inherit the behavior.
 package flake
 
 import (
@@ -25,7 +22,7 @@ var skipFlake = flag.Bool("skip-flake", false, "skip tests labeled as flakes")
 
 // Mark test as a known flaky.
 // If any of skip-flake flag or GO_TEST_SKIP_FLAKE environment variable is set, the test will be skipped.
-// Otherwise test will be retried on failure.
+// Otherwise test will be marked as known flake through a special message on tests output.
 func Mark(t testing.TB) {
 	t.Helper()
 	if shouldSkipFlake() {

--- a/pkg/util/testutil/flake/flake.go
+++ b/pkg/util/testutil/flake/flake.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.Datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package flake provides a [testing.TB](https://pkg.go.dev/testing#TB) implementation that support flaky tests.
+// Flaky tests are tests that are not reliable and may fail for various reasons.
+// Wrap your *testing.T with [flake.FlakyTesting] to allow flaky tests to fail or skip them.
+// Use flags `allow-flake-failure` and `skip-flake` to control the behavior, or set the environment variables `ALLOW_FLAKE_FAILURE` and `SKIP_FLAKE`.
+// If both `allow-flake-failure` and `skip-flake` are set, `skip-flake` takes precedence.
+// Flags take precedence over environment variables.
+// Subtests from [testing.T.Run](https://pkg.go.dev/testing#T.Run) should be wrapped with [flake.Wrap](https://pkg.go.dev/github.com/DataDog/datadog-agent/pkg/util/testutil/flake#Wrap) to inherit the behavior.
+package flake
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+var allowFlakeFailure = flag.Bool("allow-flake-failure", false, "allow flake tests failures")
+var skipFlake = flag.Bool("skip-flake", false, "skip tests labeled as flakes")
+
+type allowflakeTesting struct {
+	testing.TB
+}
+
+// Wrap wraps a testing.TB to allow flaky tests to fail or skip them.
+func Wrap(t testing.TB) testing.TB {
+	// skip flake takes precedence over allow flake failure
+	if shouldAllowFlake() && shouldSkipFlake() {
+		t.Log("skip flake and allow flake failure are both set, skip flake takes precedence")
+	}
+	if shouldSkipFlake() {
+		t.Skip("skip test marked as flake")
+		return t
+	}
+	if shouldAllowFlake() {
+		t.Log("🟡 allow flake failure")
+		return &allowflakeTesting{t}
+	}
+	return t
+}
+
+func shouldAllowFlake() bool {
+	if *allowFlakeFailure {
+		return true
+	}
+	if os.Getenv("ALLOW_FLAKE_FAILURE") == "true" {
+		return true
+	}
+	return false
+}
+
+func shouldSkipFlake() bool {
+	if *skipFlake {
+		return true
+	}
+	if os.Getenv("SKIP_FLAKE") == "true" {
+		return true
+	}
+	return false
+}
+
+func (t *allowflakeTesting) Error(args ...any) {
+	t.Log(args...)
+	t.Skip("allowing error - test marked as flake")
+}
+
+func (t *allowflakeTesting) Errorf(format string, args ...any) {
+	t.Logf(format, args...)
+	t.Skip("allowing error - test marked as flake")
+}
+
+func (t *allowflakeTesting) Fail() {
+	t.Skip("allowing failure - test marked as flake")
+}
+
+func (t *allowflakeTesting) FailNow() {
+	t.Skip("allowing failure - test marked as flake")
+}
+
+func (t *allowflakeTesting) Fatal(args ...any) {
+	t.Log(args...)
+	t.Skip("allowing fatal - test marked as flake")
+}
+
+func (t *allowflakeTesting) Fatalf(format string, args ...any) {
+	t.Logf(format, args...)
+	t.Skip("allowing fatal - test marked as flake")
+}

--- a/pkg/util/testutil/flake/flake.go
+++ b/pkg/util/testutil/flake/flake.go
@@ -15,6 +15,7 @@ package flake
 import (
 	"flag"
 	"os"
+	"strconv"
 	"testing"
 )
 
@@ -38,8 +39,9 @@ func shouldSkipFlake() bool {
 	if *skipFlake {
 		return true
 	}
-	if os.Getenv("GO_TEST_SKIP_FLAKE") == "true" {
-		return true
+	shouldSkipFlakeVar, err := strconv.ParseBool(os.Getenv("GO_TEST_SKIP_FLAKE"))
+	if err != nil {
+		return shouldSkipFlakeVar
 	}
 	return false
 }

--- a/pkg/util/testutil/flake/flake_test.go
+++ b/pkg/util/testutil/flake/flake_test.go
@@ -1,0 +1,140 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.Datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package flake
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockTesting struct {
+	*testing.T
+
+	mutex         sync.RWMutex
+	skipCallCount int
+	failCallCount int
+}
+
+func newMockTesting(t *testing.T) *mockTesting {
+	return &mockTesting{
+		T: t,
+	}
+}
+
+func (mt *mockTesting) Skip(_ ...any) {
+	func() {
+		mt.mutex.Lock()
+		defer mt.mutex.Unlock()
+		mt.skipCallCount++
+	}()
+	mt.SkipNow()
+}
+
+func (mt *mockTesting) Fail() {
+	mt.mutex.Lock()
+	defer mt.mutex.Unlock()
+	mt.failCallCount++
+}
+
+func (mt *mockTesting) SkipCount() int {
+	mt.mutex.RLock()
+	defer mt.mutex.RUnlock()
+	return mt.skipCallCount
+}
+
+func (mt *mockTesting) FailCount() int {
+	mt.mutex.RLock()
+	defer mt.mutex.RUnlock()
+	return mt.failCallCount
+}
+
+var trueValue = true
+var falseValue = false
+
+func TestFlake(t *testing.T) {
+	t.Run("allow flake test", func(t *testing.T) {
+		mt := newMockTesting(t)
+		// set allow-flake-failure flag to true
+		allowFlakeFailure = &trueValue
+		skipFlake = &falseValue
+		wrapAndRunFlakyTest(mt)
+		assert.True(t, mt.Skipped())
+		assert.False(t, mt.Failed())
+		assert.Greater(t, mt.SkipCount(), 1)
+		assert.Equal(t, 0, mt.FailCount())
+	})
+	t.Run("skip flake test", func(t *testing.T) {
+		mt := newMockTesting(t)
+		// set skip-flake flag to true
+		allowFlakeFailure = &falseValue
+		skipFlake = &trueValue
+		wrapAndRunFlakyTest(mt)
+		assert.Equal(t, 1, mt.SkipCount())
+		assert.Equal(t, 0, mt.FailCount())
+		assert.True(t, mt.Skipped())
+		assert.False(t, mt.Failed())
+	})
+	t.Run("skip flake test when both allow and skip are set", func(t *testing.T) {
+		mt := newMockTesting(t)
+		// set allow-flake-failure and skip-flake flag to true
+		allowFlakeFailure = &trueValue
+		skipFlake = &trueValue
+		wrapAndRunFlakyTest(mt)
+		assert.Equal(t, 1, mt.SkipCount())
+		assert.Equal(t, 0, mt.FailCount())
+		assert.True(t, mt.Skipped())
+		assert.False(t, mt.Failed())
+	})
+
+	t.Run("allow flaky sub tests", func(t *testing.T) {
+		mt := newMockTesting(t)
+		allowFlakeFailure = &trueValue
+		skipFlake = &falseValue
+		wrapAndRunSubFlakyTest(mt)
+		assert.False(t, mt.Failed())
+	})
+}
+
+func wrapAndRunFlakyTest(t *mockTesting) {
+	t.Helper()
+	wg := sync.WaitGroup{}
+	// testing.T.Skip() calls runtime.Goexit() which terminates the goroutine
+	// run the test in a separate goroutine to avoid terminating `TestFlake` test
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ft := Wrap(t)
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				coin := flipCoin()
+				assert.Equal(ft, "heads", coin)
+			}()
+		}
+	}()
+	wg.Wait()
+}
+
+func wrapAndRunSubFlakyTest(t *mockTesting) {
+	t.Helper()
+	for i := 0; i < 100; i++ {
+		t.Run("sub flake test", func(t *testing.T) {
+			ft := Wrap(t)
+			assert.Equal(ft, "heads", flipCoin())
+		})
+	}
+}
+
+func flipCoin() string {
+	if rand.Intn(2) == 1 {
+		return "heads"
+	}
+	return "tails"
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Implements support to mark and optionally skip flaky tests

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Flaky tests are tests that fail, sometimes. They pass, eventually, on retry. Most of the time, they are an unwanted barrier for dev branches, preventing merge and requiring a manual triggered retry. 

We currently handle flaky tests allowing failure on the job that runs them. This has the downside of allowing failures on all tests running in the same job of a flaky test, hiding actual issues.

We want to improve the current quarantine experience by allowing flagging single go tests as flaky. This is why we are introducing the `flake.Mark` test utils. 

When a test is known as flaky, we will skip it by default on the CI, preventing unwanted CI cost. To keep track of its flake state, we will keep running it on `main` branch, retrying it on failure. If it passes, it will prevent breaking the job it is executed on. If it does not pass after retries, it is not a flaky, rather a broken tests and will be disabled. This is similar to what we have today, improving the granularity of tests that are allowed to fail.

#### ℹ Note

In a follow up PR we will skip flakes in dev pipelines and retry flake failures on main pipelines.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Do you have a flaky test ? Mark it with `flake.Mark`. 

By default the marker sends a log with a special message that marks it as known flake.

Optionally with **skip flake**, the CI skips the test as soon as the marker is called. Use `--skip-flake` or set `GO_TEST_SKIP_FLAKE` environment variable to true.

See examples in [flake_test.go](https://github.com/DataDog/datadog-agent/blob/pducolin/APL-2357-allow-tagging-flaky-tests/pkg/util/testutil/flake/flake_test.go)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
