### PR TITLE
Fix several E2E tests errors following refactor merge

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -179,7 +179,7 @@ variables:
   # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: e67bb289c3d1
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: a9f0b41a7576
   DATADOG_AGENT_BUILDERS: v22276738-b36b132
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -22,7 +22,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240112104706-e67bb289c3d1
+	github.com/DataDog/test-infra-definitions v0.0.0-20240112184113-4b6449f1208f
 	github.com/aws/aws-sdk-go-v2 v1.24.0
 	github.com/aws/aws-sdk-go-v2/config v1.25.10
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -22,7 +22,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240112184113-4b6449f1208f
+	github.com/DataDog/test-infra-definitions v0.0.0-20240115091817-a9f0b41a7576
 	github.com/aws/aws-sdk-go-v2 v1.24.0
 	github.com/aws/aws-sdk-go-v2/config v1.25.10
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20240112184113-4b6449f1208f h1:pkIgpyfYHK6i/GTmPZgzoHM5WdHJZ+xHwDHmgQTTib8=
-github.com/DataDog/test-infra-definitions v0.0.0-20240112184113-4b6449f1208f/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
+github.com/DataDog/test-infra-definitions v0.0.0-20240115091817-a9f0b41a7576 h1:L+kWa/WPg3mCilbcMZk5AFlNBI7uLJcswOjgm8i4gE4=
+github.com/DataDog/test-infra-definitions v0.0.0-20240115091817-a9f0b41a7576/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20240112104706-e67bb289c3d1 h1:Q/JXtfbXa88yT0nLTACKun7MZn+tm3L//DAljjFEeFw=
-github.com/DataDog/test-infra-definitions v0.0.0-20240112104706-e67bb289c3d1/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
+github.com/DataDog/test-infra-definitions v0.0.0-20240112184113-4b6449f1208f h1:pkIgpyfYHK6i/GTmPZgzoHM5WdHJZ+xHwDHmgQTTib8=
+github.com/DataDog/test-infra-definitions v0.0.0-20240112184113-4b6449f1208f/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -283,7 +283,7 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners ProvisionerMap) {
 		}
 
 		if err != nil {
-			panic(fmt.Errorf("unable to provision stack: %s, provisioner %s, err: %v", bs.params.stackName, id, err))
+			panic(fmt.Errorf("your stack '%s' provisioning failed, check logs above. Provisioner was %s, failed with err: %v", bs.params.stackName, id, err))
 		}
 
 		resources.Merge(provisionerResources)

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -204,15 +204,16 @@ func (bs *BaseSuite[Env]) UpdateEnv(newProvisioners ...Provisioner) {
 	targetProvisioners := make(ProvisionerMap, len(newProvisioners))
 	for _, provisioner := range newProvisioners {
 		if _, found := uniqueIDs[provisioner.ID()]; found {
-			bs.T().Errorf("Multiple providers with same id found, provisioner with id %s already exists", provisioner.ID())
-			bs.T().FailNow()
+			panic(fmt.Errorf("Multiple providers with same id found, provisioner with id %s already exists", provisioner.ID()))
 		}
 
 		uniqueIDs[provisioner.ID()] = struct{}{}
 		targetProvisioners[provisioner.ID()] = provisioner
 	}
 
-	bs.reconcileEnv(targetProvisioners)
+	if err := bs.reconcileEnv(targetProvisioners); err != nil {
+		panic(err)
+	}
 }
 
 // IsDevMode returns true if the test suite is running in dev mode.
@@ -243,10 +244,10 @@ func (bs *BaseSuite[Env]) init(options []SuiteOption, self Suite[Env]) {
 	bs.originalProvisioners = bs.params.provisioners
 }
 
-func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners ProvisionerMap) {
+func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners ProvisionerMap) error {
 	if reflect.DeepEqual(bs.currentProvisioners, targetProvisioners) {
 		bs.T().Logf("No change in provisioners, skipping environment update")
-		return
+		return nil
 	}
 
 	logger := newTestLogger(bs.T())
@@ -255,14 +256,14 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners ProvisionerMap) {
 
 	newEnv, newEnvFields, newEnvValues, err := bs.createEnv()
 	if err != nil {
-		panic(fmt.Errorf("unable to create new env: %T for stack: %s, err: %v", newEnv, bs.params.stackName, err))
+		return fmt.Errorf("unable to create new env: %T for stack: %s, err: %v", newEnv, bs.params.stackName, err)
 	}
 
 	// Check for removed provisioners, we need to call delete on them first
 	for id, provisioner := range bs.currentProvisioners {
 		if _, found := targetProvisioners[id]; !found {
 			if err := provisioner.Destroy(ctx, bs.params.stackName, logger); err != nil {
-				panic(fmt.Errorf("unable to delete stack: %s, provisioner %s, err: %v", bs.params.stackName, id, err))
+				return fmt.Errorf("unable to delete stack: %s, provisioner %s, err: %v", bs.params.stackName, id, err)
 			}
 		}
 	}
@@ -279,11 +280,11 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners ProvisionerMap) {
 		case UntypedProvisioner:
 			provisionerResources, err = pType.Provision(ctx, bs.params.stackName, logger)
 		default:
-			panic(fmt.Errorf("provisioner of type %T does not implement UntypedProvisioner nor TypedProvisioner", provisioner))
+			return fmt.Errorf("provisioner of type %T does not implement UntypedProvisioner nor TypedProvisioner", provisioner)
 		}
 
 		if err != nil {
-			panic(fmt.Errorf("your stack '%s' provisioning failed, check logs above. Provisioner was %s, failed with err: %v", bs.params.stackName, id, err))
+			return fmt.Errorf("your stack '%s' provisioning failed, check logs above. Provisioner was %s, failed with err: %v", bs.params.stackName, id, err)
 		}
 
 		resources.Merge(provisionerResources)
@@ -292,13 +293,13 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners ProvisionerMap) {
 	// Env is taken as parameter as some fields may have keys set by Env pulumi program.
 	err = bs.buildEnvFromResources(resources, newEnvFields, newEnvValues)
 	if err != nil {
-		panic(fmt.Errorf("unable to build env: %T from resources for stack: %s, err: %v", newEnv, bs.params.stackName, err))
+		return fmt.Errorf("unable to build env: %T from resources for stack: %s, err: %v", newEnv, bs.params.stackName, err)
 	}
 
 	// If env implements Initializable, we call Init
 	if initializable, ok := any(newEnv).(Initializable); ok {
 		if err := initializable.Init(bs); err != nil {
-			panic(fmt.Errorf("failed to init environment, err: %v", err))
+			return fmt.Errorf("failed to init environment, err: %v", err)
 		}
 	}
 
@@ -306,6 +307,7 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners ProvisionerMap) {
 	// We need top copy provisioners to protect against external modifications
 	bs.currentProvisioners = copyProvisioners(targetProvisioners)
 	bs.env = newEnv
+	return nil
 }
 
 func (bs *BaseSuite[Env]) createEnv() (*Env, []reflect.StructField, []reflect.Value, error) {
@@ -428,7 +430,10 @@ func (bs *BaseSuite[Env]) providerContext(opTimeout time.Duration) (context.Cont
 // [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (bs *BaseSuite[Env]) SetupSuite() {
 	// Do the initial provisioning
-	bs.reconcileEnv(bs.originalProvisioners)
+	// In `SetupSuite` we cannot fail as `TearDownSuite` will not be called otherwise.
+	// Meaning that stack clean up may not be called.
+	// We should `reconcileEnv` here, but currently removed for this reason.
+	// Provisioning is done in `BeforeTest` instead, the first test will support the provisioning time and failures.
 }
 
 // BeforeTest is executed right before the test starts and receives the suite and test names as input.
@@ -439,7 +444,11 @@ func (bs *BaseSuite[Env]) SetupSuite() {
 // [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (bs *BaseSuite[Env]) BeforeTest(string, string) {
 	// Reset provisioners to original provisioners
-	bs.reconcileEnv(bs.originalProvisioners)
+	// In `Test` scope we can `panic`, it will be recovered and `AfterTest` will be called.
+	// Next tests will be called as well
+	if err := bs.reconcileEnv(bs.originalProvisioners); err != nil {
+		panic(err)
+	}
 }
 
 // AfterTest is executed right after the test finishes and receives the suite and test names as input.

--- a/test/new-e2e/pkg/utils/infra/stack_manager.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager.go
@@ -366,7 +366,6 @@ func sendEventToDatadog(title string, message string, tags []string, logger io.W
 		Text:  message,
 		Tags:  append([]string{"repository:datadog/datadog-agent", "test:new-e2e", "source:pulumi"}, tags...),
 	})
-
 	if err != nil {
 		fmt.Fprintf(logger, "error when calling `EventsApi.CreateEvent`: %v", err)
 		fmt.Fprintf(logger, "Full HTTP response: %v\n", r)

--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -80,8 +80,7 @@ func TestInstallScript(t *testing.T) {
 
 			e2e.Run(tt,
 				&installScriptSuite{cwsSupported: cwsSupported},
-				e2e.WithProvisioner(awshost.Provisioner(
-					awshost.WithoutAgent(),
+				e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(
 					awshost.WithEC2InstanceOptions(vmOpts...),
 				)),
 				e2e.WithStackName(fmt.Sprintf("install-script-test-%v-%v-%s-%s-%v", os.Getenv("CI_PIPELINE_ID"), osVers, *architecture, *flavor, *majorVersion)),
@@ -158,7 +157,7 @@ func (is *installScriptSuite) DogstatsdAgentTest() {
 	agentClient, err := client.NewHostAgentClient(is.T(), host, false)
 	require.NoError(is.T(), err)
 
-	unixHelper := helpers.NewUnixHelper()
+	unixHelper := helpers.NewUnixDogstatsdHelper()
 	client := common.NewTestClient(is.Env().RemoteHost, agentClient, fileManager, unixHelper)
 
 	install.Unix(is.T(), client, installparams.WithArch(*architecture), installparams.WithFlavor(*flavor))

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -8,19 +8,15 @@ package containers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"os"
-	"path"
 	"testing"
 
-	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/eks"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/stretchr/testify/suite"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -53,22 +49,25 @@ func (suite *eksSuite) SetupSuite() {
 		suite.T().FailNow()
 	}
 
-	fakeintakeHost := stackOutput.Outputs["fakeintake-host"].Value.(string)
-	suite.Fakeintake = fakeintake.NewClient(fmt.Sprintf("http://%s", fakeintakeHost))
-	suite.KubeClusterName = stackOutput.Outputs["kube-cluster-name"].Value.(string)
+	fakeintake := &components.FakeIntake{}
+	fiSerialized, err := json.Marshal(stackOutput.Outputs["dd-Fakeintake-aws-ecs"].Value)
+	suite.Require().NoError(err)
+	suite.Require().NoError(fakeintake.Import(fiSerialized, &fakeintake))
+	suite.Require().NoError(fakeintake.Init(suite))
+	suite.Fakeintake = fakeintake.Client()
+
+	kubeCluster := &components.KubernetesCluster{}
+	kubeSerialized, err := json.Marshal(stackOutput.Outputs["dd-Cluster-aws-eks"].Value)
+	suite.Require().NoError(err)
+	suite.Require().NoError(kubeCluster.Import(kubeSerialized, &kubeCluster))
+	suite.Require().NoError(kubeCluster.Init(suite))
+	suite.KubeClusterName = kubeCluster.ClusterName
+	suite.K8sClient = kubeCluster.Client()
+	suite.K8sConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(kubeCluster.KubeConfig))
+	suite.Require().NoError(err)
+
 	suite.AgentLinuxHelmInstallName = stackOutput.Outputs["agent-linux-helm-install-name"].Value.(string)
 	suite.AgentWindowsHelmInstallName = stackOutput.Outputs["agent-windows-helm-install-name"].Value.(string)
-
-	kubeconfig, err := json.Marshal(stackOutput.Outputs["kubeconfig"].Value.(map[string]interface{}))
-	suite.Require().NoError(err)
-
-	kubeconfigFile := path.Join(suite.T().TempDir(), "kubeconfig")
-	suite.Require().NoError(os.WriteFile(kubeconfigFile, kubeconfig, 0600))
-
-	suite.K8sConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigFile)
-	suite.Require().NoError(err)
-
-	suite.K8sClient = kubernetes.NewForConfigOrDie(suite.K8sConfig)
 
 	suite.k8sSuite.SetupSuite()
 }

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -44,7 +44,7 @@ type k8sSuite struct {
 	AgentWindowsHelmInstallName string
 
 	K8sConfig *restclient.Config
-	K8sClient *kubernetes.Clientset
+	K8sClient kubernetes.Interface
 }
 
 func (suite *k8sSuite) SetupSuite() {
@@ -104,7 +104,6 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 
 	suite.Run("agent pods are ready and not restarting", func() {
 		suite.EventuallyWithTf(func(c *assert.CollectT) {
-
 			linuxNodes, err := suite.K8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
 				LabelSelector: fields.OneTermEqualSelector("kubernetes.io/os", "linux").String(),
 			})

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -7,19 +7,16 @@ package containers
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"path"
+	"encoding/json"
 	"testing"
 
-	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/kindvm"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/stretchr/testify/suite"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -52,21 +49,25 @@ func (suite *kindSuite) SetupSuite() {
 		suite.T().FailNow()
 	}
 
-	fakeintakeHost := stackOutput.Outputs["fakeintake-host"].Value.(string)
-	suite.Fakeintake = fakeintake.NewClient(fmt.Sprintf("http://%s", fakeintakeHost))
-	suite.KubeClusterName = stackOutput.Outputs["kube-cluster-name"].Value.(string)
-	suite.AgentLinuxHelmInstallName = stackOutput.Outputs["agent-linux-helm-install-name"].Value.(string)
-	suite.AgentWindowsHelmInstallName = "none"
+	var fakeintake components.FakeIntake
+	fiSerialized, err := json.Marshal(stackOutput.Outputs["dd-Fakeintake-aws-kind"].Value)
+	suite.Require().NoError(err)
+	suite.Require().NoError(fakeintake.Import(fiSerialized, &fakeintake))
+	suite.Require().NoError(fakeintake.Init(suite))
+	suite.Fakeintake = fakeintake.Client()
 
-	kubeconfig := stackOutput.Outputs["kubeconfig"].Value.(string)
-
-	kubeconfigFile := path.Join(suite.T().TempDir(), "kubeconfig")
-	suite.Require().NoError(os.WriteFile(kubeconfigFile, []byte(kubeconfig), 0o600))
-
-	suite.K8sConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigFile)
+	var kubeCluster components.KubernetesCluster
+	kubeSerialized, err := json.Marshal(stackOutput.Outputs["dd-Cluster-kind"].Value)
+	suite.Require().NoError(err)
+	suite.Require().NoError(kubeCluster.Import(kubeSerialized, &kubeCluster))
+	suite.Require().NoError(kubeCluster.Init(suite))
+	suite.KubeClusterName = kubeCluster.ClusterName
+	suite.K8sClient = kubeCluster.Client()
+	suite.K8sConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(kubeCluster.KubeConfig))
 	suite.Require().NoError(err)
 
-	suite.K8sClient = kubernetes.NewForConfigOrDie(suite.K8sConfig)
+	suite.AgentLinuxHelmInstallName = stackOutput.Outputs["agent-linux-helm-install-name"].Value.(string)
+	suite.AgentWindowsHelmInstallName = "none"
 
 	suite.k8sSuite.SetupSuite()
 }


### PR DESCRIPTION
### What does this PR do?

Requires https://github.com/DataDog/test-infra-definitions/pull/555
Gitlab Runner image id will be changed when merged.

Fix missing changes for export in `containers` test.
Fix bad copy/paste in Dogstatsd install script test

### Motivation

Fix failing E2E

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
