### PR TITLE
[ASCII-1009] Add CLI command `agent secret refresh` to refresh secrets

### DIFF
--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -9,7 +9,6 @@ package secret
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -25,12 +24,6 @@ import (
 // cliParams are the command-line arguments for this subcommand
 type cliParams struct {
 	*command.GlobalParams
-
-	// args are the positional command-line arguments
-	args []string
-
-	// cmd is the cobra Command, used to show help
-	cmd *cobra.Command
 }
 
 // Commands returns a slice of subcommands for the 'agent' command.
@@ -39,78 +32,62 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		GlobalParams: globalParams,
 	}
 
-	cmd := &cobra.Command{
-		Use:   "secret [refresh]",
-		Short: "Display information about or refresh secrets in configuration.",
+	secretInfoCommand := &cobra.Command{
+		Use:   "secret",
+		Short: "Display information secrets in configuration.",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliParams.cmd = cmd
-			cliParams.args = args
-			return fxutil.OneShot(secretCommand,
-				fx.Supply(cliParams),
+			return fxutil.OneShot(showSecretInfo,
 				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle(),
 			)
 		},
 	}
-
-	return []*cobra.Command{cmd}
-}
-
-func secretCommand(config config.Component, cliParams *cliParams) error {
-	if err := util.SetAuthToken(); err != nil {
-		fmt.Println(err)
-		return nil
+	secretRefreshCommand := &cobra.Command{
+		Use:   "refresh",
+		Short: "Refresh secrets in configuration.",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fxutil.OneShot(secretRefresh,
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
+				core.Bundle(),
+			)
+		},
 	}
+	secretInfoCommand.AddCommand(secretRefreshCommand)
 
-	if len(cliParams.args) == 0 {
-		if err := showSecretInfo(config); err != nil {
-			fmt.Println(err)
-		}
-	} else if len(cliParams.args) == 1 && cliParams.args[0] == "refresh" {
-		if err := secretRefresh(config); err != nil {
-			fmt.Println(err)
-		}
-	} else {
-		fmt.Printf("The command arguments must be empty or 'refresh'\n")
-		cliParams.cmd.Help() //nolint:errcheck
-		os.Exit(1)
-	}
-
-	return nil
+	return []*cobra.Command{secretInfoCommand}
 }
 
 func showSecretInfo(config config.Component) error {
-	c := util.GetClient(false)
-	ipcAddress, err := pkgconfig.GetIPCAddress()
+	r, err := callAPIEndpoint("/agent/secrets", config)
 	if err != nil {
 		return err
 	}
-	apiConfigURL := fmt.Sprintf("https://%v:%v/agent/secrets", ipcAddress, config.GetInt("cmd_port"))
-
-	r, err := util.DoGet(c, apiConfigURL, util.LeaveConnectionOpen)
-	if err != nil {
-		var errMap = make(map[string]string)
-		json.Unmarshal(r, &errMap) //nolint:errcheck
-		// If the error has been marshalled into a json object, check it and return it properly
-		if e, found := errMap["error"]; found {
-			return fmt.Errorf("%s", e)
-		}
-
-		return fmt.Errorf("Could not reach agent: %v\nMake sure the agent is running before requesting the runtime configuration and contact support if you continue having issues", err)
-	}
-
 	fmt.Println(string(r))
 	return nil
 }
 
 func secretRefresh(config config.Component) error {
-	c := util.GetClient(false)
-	ipcAddress, err := pkgconfig.GetIPCAddress()
+	r, err := callAPIEndpoint("/agent/secret/refresh", config)
 	if err != nil {
 		return err
 	}
-	apiConfigURL := fmt.Sprintf("https://%v:%v/agent/secret/refresh", ipcAddress, config.GetInt("cmd_port"))
+	fmt.Printf("Secrets refresh: %s\n", r)
+	return nil
+}
+
+func callAPIEndpoint(apiEndpointPath string, config config.Component) ([]byte, error) {
+	if err := util.SetAuthToken(); err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+	c := util.GetClient(false)
+	ipcAddress, err := pkgconfig.GetIPCAddress()
+	if err != nil {
+		return nil, err
+	}
+	apiConfigURL := fmt.Sprintf("https://%v:%v%v", ipcAddress, config.GetInt("cmd_port"), apiEndpointPath)
 
 	r, err := util.DoGet(c, apiConfigURL, util.LeaveConnectionOpen)
 	if err != nil {
@@ -118,12 +95,10 @@ func secretRefresh(config config.Component) error {
 		json.Unmarshal(r, &errMap) //nolint:errcheck
 		// If the error has been marshalled into a json object, check it and return it properly
 		if e, found := errMap["error"]; found {
-			return fmt.Errorf("%s", e)
+			return nil, fmt.Errorf("%s", e)
 		}
 
-		return fmt.Errorf("Could not reach agent: %v\nMake sure the agent is running before requesting the runtime configuration and contact support if you continue having issues", err)
+		return nil, fmt.Errorf("Could not reach agent: %v\nMake sure the agent is running before requesting the runtime configuration and contact support if you continue having issues", err)
 	}
-
-	fmt.Printf("Secrets refresh: %s\n", r)
-	return nil
+	return r, nil
 }

--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -35,7 +35,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 	secretInfoCommand := &cobra.Command{
 		Use:   "secret",
-		Short: "Display information secrets in configuration.",
+		Short: "Display information about secrets in configuration.",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(showSecretInfo,

--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -9,6 +9,7 @@ package secret
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -16,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -25,6 +25,12 @@ import (
 // cliParams are the command-line arguments for this subcommand
 type cliParams struct {
 	*command.GlobalParams
+
+	// args are the positional command-line arguments
+	args []string
+
+	// cmd is the cobra Command, used to show help
+	cmd *cobra.Command
 }
 
 // Commands returns a slice of subcommands for the 'agent' command.
@@ -32,12 +38,15 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cliParams := &cliParams{
 		GlobalParams: globalParams,
 	}
-	secretInfoCommand := &cobra.Command{
-		Use:   "secret",
-		Short: "Print information about decrypted secrets in configuration.",
+
+	cmd := &cobra.Command{
+		Use:   "secret [refresh]",
+		Short: "Display information about or refresh secrets in configuration.",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fxutil.OneShot(secret,
+			cliParams.cmd = cmd
+			cliParams.args = args
+			return fxutil.OneShot(secretCommand,
 				fx.Supply(cliParams),
 				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle(),
@@ -45,19 +54,29 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		},
 	}
 
-	return []*cobra.Command{secretInfoCommand}
+	return []*cobra.Command{cmd}
 }
 
-func secret(_ log.Component, config config.Component, _ *cliParams) error {
+func secretCommand(config config.Component, cliParams *cliParams) error {
 	if err := util.SetAuthToken(); err != nil {
 		fmt.Println(err)
 		return nil
 	}
 
-	if err := showSecretInfo(config); err != nil {
-		fmt.Println(err)
-		return nil
+	if len(cliParams.args) == 0 {
+		if err := showSecretInfo(config); err != nil {
+			fmt.Println(err)
+		}
+	} else if len(cliParams.args) == 1 && cliParams.args[0] == "refresh" {
+		if err := secretRefresh(config); err != nil {
+			fmt.Println(err)
+		}
+	} else {
+		fmt.Printf("The command arguments must be empty or 'refresh'\n")
+		cliParams.cmd.Help() //nolint:errcheck
+		os.Exit(1)
 	}
+
 	return nil
 }
 
@@ -82,5 +101,29 @@ func showSecretInfo(config config.Component) error {
 	}
 
 	fmt.Println(string(r))
+	return nil
+}
+
+func secretRefresh(config config.Component) error {
+	c := util.GetClient(false)
+	ipcAddress, err := pkgconfig.GetIPCAddress()
+	if err != nil {
+		return err
+	}
+	apiConfigURL := fmt.Sprintf("https://%v:%v/agent/secret/refresh", ipcAddress, config.GetInt("cmd_port"))
+
+	r, err := util.DoGet(c, apiConfigURL, util.LeaveConnectionOpen)
+	if err != nil {
+		var errMap = make(map[string]string)
+		json.Unmarshal(r, &errMap) //nolint:errcheck
+		// If the error has been marshalled into a json object, check it and return it properly
+		if e, found := errMap["error"]; found {
+			return fmt.Errorf("%s", e)
+		}
+
+		return fmt.Errorf("Could not reach agent: %v\nMake sure the agent is running before requesting the runtime configuration and contact support if you continue having issues", err)
+	}
+
+	fmt.Printf("Secrets refresh: %s\n", r)
 	return nil
 }

--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -9,6 +9,7 @@ package secret
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -73,7 +74,7 @@ func secretRefresh(config config.Component) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Secrets refresh: %s\n", r)
+	fmt.Println(string(r))
 	return nil
 }
 
@@ -87,9 +88,13 @@ func callAPIEndpoint(apiEndpointPath string, config config.Component) ([]byte, e
 	if err != nil {
 		return nil, err
 	}
-	apiConfigURL := fmt.Sprintf("https://%v:%v%v", ipcAddress, config.GetInt("cmd_port"), apiEndpointPath)
+	apiConfigURL := url.URL{
+		Scheme: "https",
+		Host:   fmt.Sprintf("%s:%d", ipcAddress, config.GetInt("cmd_port")),
+		Path:   apiEndpointPath,
+	}
 
-	r, err := util.DoGet(c, apiConfigURL, util.LeaveConnectionOpen)
+	r, err := util.DoGet(c, apiConfigURL.String(), util.LeaveConnectionOpen)
 	if err != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck

--- a/cmd/agent/subcommands/secret/command_test.go
+++ b/cmd/agent/subcommands/secret/command_test.go
@@ -20,7 +20,17 @@ func TestCommand(t *testing.T) {
 	fxutil.TestOneShotSubcommand(t,
 		Commands(&command.GlobalParams{}),
 		[]string{"secret"},
-		secret,
+		secretCommand,
+		func(cliParams *cliParams, coreParams core.BundleParams, secretParams secrets.Params) {
+			require.Equal(t, false, secretParams.Enabled)
+		})
+}
+
+func TestRefreshCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"secret", "refresh"},
+		secretCommand,
 		func(cliParams *cliParams, coreParams core.BundleParams, secretParams secrets.Params) {
 			require.Equal(t, false, secretParams.Enabled)
 		})

--- a/cmd/agent/subcommands/secret/command_test.go
+++ b/cmd/agent/subcommands/secret/command_test.go
@@ -20,8 +20,8 @@ func TestCommand(t *testing.T) {
 	fxutil.TestOneShotSubcommand(t,
 		Commands(&command.GlobalParams{}),
 		[]string{"secret"},
-		secretCommand,
-		func(cliParams *cliParams, coreParams core.BundleParams, secretParams secrets.Params) {
+		showSecretInfo,
+		func(coreParams core.BundleParams, secretParams secrets.Params) {
 			require.Equal(t, false, secretParams.Enabled)
 		})
 }
@@ -30,8 +30,8 @@ func TestRefreshCommand(t *testing.T) {
 	fxutil.TestOneShotSubcommand(t,
 		Commands(&command.GlobalParams{}),
 		[]string{"secret", "refresh"},
-		secretCommand,
-		func(cliParams *cliParams, coreParams core.BundleParams, secretParams secrets.Params) {
+		secretRefresh,
+		func(coreParams core.BundleParams, secretParams secrets.Params) {
 			require.Equal(t, false, secretParams.Enabled)
 		})
 }

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -454,11 +454,12 @@ func secretInfo(w http.ResponseWriter, _ *http.Request, secretResolver secrets.C
 }
 
 func secretRefresh(w http.ResponseWriter, _ *http.Request, secretResolver secrets.Component) {
-	if err := secretResolver.Refresh(); err != nil {
+	result, err := secretResolver.Refresh()
+	if err != nil {
 		setJSONError(w, err, 500)
 		return
 	}
-	w.Write([]byte("OK"))
+	w.Write([]byte(result))
 }
 
 func metadataPayloadV5(w http.ResponseWriter, _ *http.Request, hostMetadataComp host.Component) {

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -105,6 +105,7 @@ func SetupHandlers(
 		getWorkloadList(w, r, wmeta)
 	}).Methods("GET")
 	r.HandleFunc("/secrets", func(w http.ResponseWriter, r *http.Request) { secretInfo(w, r, secretResolver) }).Methods("GET")
+	r.HandleFunc("/secret/refresh", func(w http.ResponseWriter, r *http.Request) { secretRefresh(w, r, secretResolver) }).Methods("GET")
 	r.HandleFunc("/metadata/gohai", metadataPayloadGohai).Methods("GET")
 	r.HandleFunc("/metadata/v5", func(w http.ResponseWriter, r *http.Request) { metadataPayloadV5(w, r, hostMetadata) }).Methods("GET")
 	r.HandleFunc("/metadata/inventory-checks", func(w http.ResponseWriter, r *http.Request) { metadataPayloadInvChecks(w, r, invChecks) }).Methods("GET")
@@ -450,6 +451,14 @@ func getWorkloadList(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.
 
 func secretInfo(w http.ResponseWriter, _ *http.Request, secretResolver secrets.Component) {
 	secretResolver.GetDebugInfo(w)
+}
+
+func secretRefresh(w http.ResponseWriter, _ *http.Request, secretResolver secrets.Component) {
+	if err := secretResolver.Refresh(); err != nil {
+		setJSONError(w, err, 500)
+		return
+	}
+	w.Write([]byte("OK"))
 }
 
 func metadataPayloadV5(w http.ResponseWriter, _ *http.Request, hostMetadataComp host.Component) {

--- a/comp/core/secrets/component.go
+++ b/comp/core/secrets/component.go
@@ -23,5 +23,5 @@ type Component interface {
 	// SubscribeToChanges registers a callback to be invoked whenever secrets are resolved or refreshed
 	SubscribeToChanges(callback SecretChangeCallback)
 	// Refresh will resolve secret handles again, notifying any subscribers of changed values
-	Refresh() error
+	Refresh() (string, error)
 }

--- a/comp/core/secrets/secretsimpl/refresh.tmpl
+++ b/comp/core/secrets/secretsimpl/refresh.tmpl
@@ -1,0 +1,9 @@
+=== Secret refresh stats ===
+Number of secrets refreshed: {{ len .Handles }}
+Secrets handle refreshed:
+{{ range $handleInfo := .Handles }}
+- '{{ $handleInfo.Name }}':
+	{{- range $place := $handleInfo.Places }}
+	used in '{{$place.Context }}' configuration in entry '{{$place.Path }}'
+	{{- end}}
+{{- end }}

--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -392,7 +392,7 @@ func (r *secretResolver) Refresh() error {
 		return nil
 	}
 
-	log.Info("Refreshing secrets for %d handles", len(newHandles))
+	log.Infof("Refreshing secrets for %d handles", len(newHandles))
 
 	var secretResponse map[string]string
 	var err error

--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -222,7 +222,7 @@ func (r *secretResolver) startRefreshRoutine() {
 	go func() {
 		for {
 			<-r.ticker.C
-			if err := r.Refresh(); err != nil {
+			if _, err := r.Refresh(); err != nil {
 				log.Info(err)
 			}
 		}
@@ -346,34 +346,46 @@ func (r *secretResolver) Resolve(data []byte, origin string) ([]byte, error) {
 // allowlistHandles restricts what config settings may be updated
 // tests can override this to exercise functionality: by setting this to nil, allow all handles
 // NOTE: Related feature to `authorizedConfigPathsCore` in `comp/api/api/apiimpl/internal/config/endpoint.go`
-var allowlistHandles = []string{"api_key"}
+var allowlistHandles = map[string]struct{}{"api_key": {}}
 
-func (r *secretResolver) processSecretResponse(secretResponse map[string]string, useAllowlist bool) {
+func (r *secretResolver) processSecretResponse(secretResponse map[string]string, useAllowlist bool) secretRefreshInfo {
+	var handleInfoList []handleInfo
+
 	// notify subscriptions about the changes to secrets
 	for handle, secretValue := range secretResponse {
 		// if allowlist is enabled and the handle is not contained in it, skip it
-		if useAllowlist && allowlistHandles != nil && !slices.Contains(allowlistHandles, handle) {
-			continue
+		if useAllowlist && allowlistHandles != nil {
+			if _, ok := allowlistHandles[handle]; !ok {
+				continue
+			}
 		}
 		oldValue := r.cache[handle]
 		// if value hasn't changed, don't send notifications
 		if oldValue == secretValue {
 			continue
 		}
+		places := make([]handlePlace, 0, len(r.origin[handle]))
 		for _, secretCtx := range r.origin[handle] {
 			for _, sub := range r.subscriptions {
 				sub(handle, secretCtx.origin, secretCtx.path, oldValue, secretValue)
+				places = append(places, handlePlace{Context: secretCtx.origin, Path: strings.Join(secretCtx.path, "/")})
 			}
 		}
+		handleInfoList = append(handleInfoList, handleInfo{Name: handle, Places: places})
 	}
 	// add results to the cache
 	for handle, secretValue := range secretResponse {
 		r.cache[handle] = secretValue
 	}
+	// return info about the handles sorted by their name
+	sort.Slice(handleInfoList, func(i, j int) bool {
+		return handleInfoList[i].Name < handleInfoList[j].Name
+	})
+	return secretRefreshInfo{Handles: handleInfoList}
 }
 
 // Refresh the secrets after they have been Resolved by fetching them from the backend again
-func (r *secretResolver) Refresh() error {
+func (r *secretResolver) Refresh() (string, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
@@ -382,14 +394,14 @@ func (r *secretResolver) Refresh() error {
 	if allowlistHandles != nil {
 		filteredHandles := make([]string, 0, len(newHandles))
 		for _, handle := range newHandles {
-			if slices.Contains(allowlistHandles, handle) {
+			if _, ok := allowlistHandles[handle]; ok {
 				filteredHandles = append(filteredHandles, handle)
 			}
 		}
 		newHandles = filteredHandles
 	}
 	if len(newHandles) == 0 {
-		return nil
+		return "", nil
 	}
 
 	log.Infof("Refreshing secrets for %d handles", len(newHandles))
@@ -403,12 +415,24 @@ func (r *secretResolver) Refresh() error {
 		secretResponse, err = r.fetchSecret(newHandles)
 	}
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	// when Refreshing secrets, only update what the allowlist allows
-	r.processSecretResponse(secretResponse, true)
-	return nil
+	// when Refreshing secrets, only update what the allowlist allows by passing `true`
+	refreshResult := r.processSecretResponse(secretResponse, true)
+
+	// render a report
+	t := template.New("secret_refresh")
+	t, err = t.Parse(secretRefreshTmpl)
+	if err != nil {
+		return "", err
+	}
+	b := new(strings.Builder)
+	err = t.Execute(b, refreshResult)
+	if err != nil {
+		return "", err
+	}
+	return b.String(), nil
 }
 
 type secretInfo struct {
@@ -419,8 +443,25 @@ type secretInfo struct {
 	Handles                      map[string][][]string
 }
 
+type secretRefreshInfo struct {
+	Handles []handleInfo
+}
+
+type handleInfo struct {
+	Name   string
+	Places []handlePlace
+}
+
+type handlePlace struct {
+	Context string
+	Path    string
+}
+
 //go:embed info.tmpl
 var secretInfoTmpl string
+
+//go:embed refresh.tmpl
+var secretRefreshTmpl string
 
 // GetDebugInfo exposes debug informations about secrets to be included in a flare
 func (r *secretResolver) GetDebugInfo(w io.Writer) {

--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -392,6 +392,8 @@ func (r *secretResolver) Refresh() error {
 		return nil
 	}
 
+	log.Info("Refreshing secrets for %d handles", len(newHandles))
+
 	var secretResponse map[string]string
 	var err error
 	if r.fetchHookFunc != nil {

--- a/pkg/autodiscovery/secrets_test.go
+++ b/pkg/autodiscovery/secrets_test.go
@@ -55,8 +55,8 @@ func (m *MockSecretResolver) Resolve(data []byte, origin string) ([]byte, error)
 func (m *MockSecretResolver) SubscribeToChanges(_ secrets.SecretChangeCallback) {
 }
 
-func (m *MockSecretResolver) Refresh() error {
-	return nil
+func (m *MockSecretResolver) Refresh() (string, error) {
+	return "", nil
 }
 
 func (m *MockSecretResolver) haveAllScenariosBeenCalled() bool {


### PR DESCRIPTION
### What does this PR do?

Adds a CLI command `agent secret refresh` that will immediately refresh secrets from the secret backend. This is an alternative to using the `secret_refresh_interval` config setting.

### Motivation

Part of the initiative to refresh secrets at runtime.

### Additional Notes



### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

# QA instructions

Have two valid API Keys ready for usage

Create this script for resolving secrets, name it 'secret-script.py':
```
#!/usr/bin/env python
import datetime
import json
import os
import sys

FIRST_API_KEY  = <YOUR API KEY #0>
SECOND_API_KEY = <YOUR API KEY #1>

def log(fout, msg):
  dt = datetime.datetime.now()
  if not msg.endswith('\n'):
    msg += '\n'
  fout.write('[%s] %s' % (dt, msg))

def main():
  fout = open('secret-script.log', 'a')
  content = sys.stdin.read()
  obj = json.loads(content)
  log(fout, 'request: %s' % content)
  handles = obj['secrets']
  log(fout, 'num handles = %d' % len(handles))
  result = {}
  resolved = []
  for h in handles:
    resolved.append(h)
    if h == 'api_key':
      if not os.path.isfile('alt.cfg'):
        result[h] = {'value': FIRST_API_KEY}
      else:
        result[h] = {'value': SECOND_API_KEY}
      continue
    result[h] = {
      'value': 'decoded_%s' % h,
    }
  print(json.dumps(result))
  log(fout, '%s => %s\n' % (','.join(resolved), result))
  fout.close()

if __name__ == '__main__':
  main()
```

Add your two API Keys into this script (lines 7 and 8)

Set the required permissions on the script:
```
chmod 500 secret-script.py
```

Set your api_key in datadog.yaml, and configure the secret backend:

```
api_key: ENC[api_key]
secret_backend_command: ./secret-script.py
```

Start up the agent and then check that your first API Key is being used:

```
agent run
```

```
agent status
```

Look for "API Key ending with" in the "Endpoints" section

Tell our script to use the new API Key by creating this file:

```
touch alt.cfg
```

Refresh the API Key using this new CLI command:

```
agent secret refresh
```

You should get the message "Secrets refresh: OK".

Finally, run status again and make sure that the second API Key is now being used

```
agent status
```

Look for "API Key ending with" in the "Endpoints" section, verify that it is the second API Key instead of the first.


### Reviewer's Checklist


- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
