### PR TITLE
[CONTINT-3678][Do not merge] Backport "Update SBOM CycloneDx if it is missing RepoDigest"

### DIFF
--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -16,8 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/util"
-	"github.com/mohae/deepcopy"
-
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/content"
@@ -284,7 +282,6 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 	repoDigests := c.knownImages.getRepoDigests(imageID)
 
 	sbom := newSBOM
-	var usingExistingSBOM bool
 
 	// We can get "create" events for images that already exist. That happens
 	// when the same image is referenced with different names. For example,
@@ -305,7 +302,6 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 		}
 
 		if sbom == nil && existingImg.SBOM.Status != workloadmeta.Pending {
-			usingExistingSBOM = true
 			sbom = existingImg.SBOM
 		}
 	}
@@ -330,18 +326,15 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 		variant = platforms[0].Variant
 	}
 
-	// SBOMs are generated only once. However, when they are generated it is possible that
-	// not every RepoDigest and RepoTags are attached to the image. In that case, the SBOM
-	// will also miss metadata and will not be re-generated when new metadata is detected.
+	// SBOMs are generated only once. The scanner needs to attach some metadata to the SBOM
+	// but it might not be available when the SBOM is generated or it might also not inject
+	// this metadata if it uses the file-system scanner.
 	// Because this metadata is essential for processing, it is important to inject new metadata
 	// to the existing SBOM. Generating a new SBOM can be a more robust solution but can also be
 	// costly.
 	// Moreover, it is not safe to modify the original SBOM if it is already stored in workloadmeta,
 	// so we create a copy of it. It is costly but shouldn't be called so often.
-	if usingExistingSBOM {
-		sbom = deepcopy.Copy(sbom).(*workloadmeta.SBOM)
-		sbom = util.UpdateSBOMRepoMetadata(sbom, repoTags, repoDigests)
-	}
+	sbom = util.UpdateSBOMRepoMetadata(sbom, repoTags, repoDigests)
 
 	workloadmetaImg := workloadmeta.ContainerImageMetadata{
 		EntityID: workloadmeta.EntityID{

--- a/pkg/workloadmeta/collectors/util/image_util.go
+++ b/pkg/workloadmeta/collectors/util/image_util.go
@@ -9,11 +9,13 @@
 package util
 
 import (
+	"sort"
+
 	"github.com/CycloneDX/cyclonedx-go"
-	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	trivydx "github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
 	"github.com/mohae/deepcopy"
-	"sort"
+
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 const (

--- a/pkg/workloadmeta/collectors/util/image_util.go
+++ b/pkg/workloadmeta/collectors/util/image_util.go
@@ -12,6 +12,8 @@ import (
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	trivydx "github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
+	"github.com/mohae/deepcopy"
+	"sort"
 )
 
 const (
@@ -19,8 +21,8 @@ const (
 	repoDigestPropertyKey = trivydx.Namespace + trivydx.PropertyRepoDigest
 )
 
-// UpdateSBOMRepoMetadata updates entered SBOM with new metadata properties if the initial SBOM status was successful
-// and there are new repoTags and repoDigests missing in the SBOM. It returns the updated SBOM.
+// UpdateSBOMRepoMetadata finds if the repo tags and repo digests are present in the SBOM and updates them if not.
+// It returns a copy of the SBOM with the updated properties if they were not already present.
 func UpdateSBOMRepoMetadata(sbom *workloadmeta.SBOM, repoTags, repoDigests []string) *workloadmeta.SBOM {
 	if sbom == nil ||
 		sbom.Status != workloadmeta.Success ||
@@ -32,18 +34,62 @@ func UpdateSBOMRepoMetadata(sbom *workloadmeta.SBOM, repoTags, repoDigests []str
 	}
 
 	properties := *sbom.CycloneDXBOM.Metadata.Component.Properties
-	properties = removeOldRepoProperties(properties)
+	mismatched := !propertiesEqualsValues(properties, repoTags, repoTagPropertyKey) || !propertiesEqualsValues(properties, repoDigests, repoDigestPropertyKey)
 
-	properties = appendRepoProperties(properties, repoTags, repoTagPropertyKey)
-	properties = appendRepoProperties(properties, repoDigests, repoDigestPropertyKey)
+	if mismatched {
+		sbom = deepcopy.Copy(sbom).(*workloadmeta.SBOM)
+		newProperties := *sbom.CycloneDXBOM.Metadata.Component.Properties
+		newProperties = cleanProperties(newProperties)
 
-	sbom.CycloneDXBOM.Metadata.Component.Properties = &properties
+		newProperties = appendProperties(newProperties, repoTags, repoTagPropertyKey)
+		newProperties = appendProperties(newProperties, repoDigests, repoDigestPropertyKey)
+
+		// Sort properties to ensure consistent ordering for tests
+		sort.Slice(newProperties, func(i, j int) bool {
+			return newProperties[i].Name < newProperties[j].Name || newProperties[i].Value < newProperties[j].Value
+		})
+		sbom.CycloneDXBOM.Metadata.Component.Properties = &newProperties
+	}
 
 	return sbom
 }
 
-// removeOldRepoProperties returns an array without repodigests and repoTags
-func removeOldRepoProperties(properties []cyclonedx.Property) []cyclonedx.Property {
+// propertiesEqualsValues function compares the existing properties with the new values
+func propertiesEqualsValues(properties []cyclonedx.Property, newValues []string, propertyKeyType string) bool {
+	existingValuesMap := make(map[string]bool)
+	for _, prop := range properties {
+		if prop.Name == propertyKeyType {
+			existingValuesMap[prop.Value] = true
+		}
+	}
+
+	for _, newValue := range newValues {
+		if !existingValuesMap[newValue] {
+			return false
+		}
+	}
+
+	for existingValue := range existingValuesMap {
+		if !contains(newValues, existingValue) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// contains is a helper function to check if the slice contains the string value
+func contains(slice []string, value string) bool {
+	for _, item := range slice {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
+// Remove properties from the list that are present in the mismatched map
+func cleanProperties(properties []cyclonedx.Property) []cyclonedx.Property {
 	res := make([]cyclonedx.Property, 0, len(properties))
 
 	for _, prop := range properties {
@@ -56,11 +102,20 @@ func removeOldRepoProperties(properties []cyclonedx.Property) []cyclonedx.Proper
 	return res
 }
 
-// appendRepoProperties function updates the slice of properties
-func appendRepoProperties(properties []cyclonedx.Property, repoValues []string, propertyKeyType string) []cyclonedx.Property {
-	for _, repoValue := range repoValues {
-		prop := cdxProperty(propertyKeyType, repoValue)
-		properties = append(properties, prop)
+// Append new values to the properties that were not already present
+func appendProperties(properties []cyclonedx.Property, newValues []string, propertyKeyType string) []cyclonedx.Property {
+	existingValues := make(map[string]bool)
+	for _, prop := range properties {
+		if prop.Name == propertyKeyType {
+			existingValues[prop.Value] = true
+		}
+	}
+
+	for _, newValue := range newValues {
+		if !existingValues[newValue] {
+			prop := cdxProperty(propertyKeyType, newValue)
+			properties = append(properties, prop)
+		}
 	}
 	return properties
 }

--- a/pkg/workloadmeta/collectors/util/image_util_test.go
+++ b/pkg/workloadmeta/collectors/util/image_util_test.go
@@ -73,8 +73,8 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 						Metadata: &cyclonedx.Metadata{
 							Component: &cyclonedx.Component{
 								Properties: &[]cyclonedx.Property{
-									{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 									{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest2"},
+									{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 								},
 							},
 						},
@@ -89,10 +89,10 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 					Metadata: &cyclonedx.Metadata{
 						Component: &cyclonedx.Component{
 							Properties: &[]cyclonedx.Property{
-								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
-								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 								{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest1"},
 								{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest2"},
+								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
+								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 							},
 						},
 					},
@@ -164,7 +164,7 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "other properties are not touched",
+			name: "other properties are still there",
 			args: args{
 				sbom: &workloadmeta.SBOM{
 					Status: workloadmeta.Success,
@@ -188,8 +188,8 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 					Metadata: &cyclonedx.Metadata{
 						Component: &cyclonedx.Component{
 							Properties: &[]cyclonedx.Property{
-								{Name: "prop1", Value: "tag1"},
 								{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest1"},
+								{Name: "prop1", Value: "tag1"},
 							},
 						},
 					},
@@ -200,7 +200,7 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := UpdateSBOMRepoMetadata(tt.args.sbom, tt.args.repoTags, tt.args.repoDigests); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("UpdateSBOMRepoMetadata) = %v, want %v", got, tt.want)
+				t.Errorf("UpdateSBOMRepoMetadata) = %v, want %v", got.CycloneDXBOM.Metadata.Component.Properties, tt.want.CycloneDXBOM.Metadata.Component.Properties)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR injects repotags and repodigests in the SBOM if the metadata is missing. Previously, it was done only when new metadata is discovered. Now it is always done because the scanner might miss some metadata.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This metadata is required.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Same as [here](https://github.com/DataDog/datadog-agent/pull/20437), but you will need to install the agent with helm using
```
  sbom:
    containerImage:
      enabled: enabled
      uncompressedLayersSupport: true
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
