### PR TITLE
[CONTINT-3678] Update SBOM CycloneDx if it is missing RepoDigest

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -23,7 +23,6 @@ import (
 	containerdevents "github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/mohae/deepcopy"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"google.golang.org/protobuf/proto"
 )
@@ -303,19 +302,6 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 		if strings.Contains(wlmImage.Name, "sha256:") && !strings.Contains(existingImg.Name, "sha256:") {
 			wlmImage.Name = existingImg.Name
 		}
-
-		// SBOMs are generated only once. However, when they are generated it is possible that
-		// not every RepoDigest and RepoTags are attached to the image. In that case, the SBOM
-		// will also miss metadata and will not be re-generated when new metadata is detected.
-		// Because this metadata is essential for processing, it is important to inject new metadata
-		// to the existing SBOM. Generating a new SBOM can be a more robust solution but can also be
-		// costly.
-		// Moreover, it is not safe to modify the original SBOM if it is already stored in workloadmeta,
-		// so we create a copy of it. It is costly but shouldn't be called so often.
-		if wlmImage.SBOM == nil && existingImg.SBOM != nil && existingImg.SBOM.Status != workloadmeta.Pending {
-			wlmImage.SBOM = deepcopy.Copy(existingImg.SBOM).(*workloadmeta.SBOM)
-			wlmImage.SBOM = util.UpdateSBOMRepoMetadata(wlmImage.SBOM, wlmImage.RepoTags, wlmImage.RepoDigests)
-		}
 	}
 
 	if wlmImage.SBOM == nil {
@@ -323,6 +309,12 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 			Status: workloadmeta.Pending,
 		}
 	}
+
+	// The CycloneDX should contain the RepoTags and RepoDigests but the scanner might not be able to do it.
+	// For example, if we use the scanner from filesystem or if the `imgMeta` object does not contain all the
+	// metadata when it is sent.
+	// We add them here to make sure they are present.
+	wlmImage.SBOM = util.UpdateSBOMRepoMetadata(wlmImage.SBOM, wlmImage.RepoTags, wlmImage.RepoDigests)
 
 	c.store.Notify([]workloadmeta.CollectorEvent{
 		{

--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -310,9 +310,9 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 		}
 	}
 
-	// The CycloneDX should contain the RepoTags and RepoDigests but the scanner might not be able to do it.
-	// For example, if we use the scanner from filesystem or if the `imgMeta` object does not contain all the
-	// metadata when it is sent.
+	// The CycloneDX should contain the RepoTags and RepoDigests but the scanner might
+	// not be able to inject them. For example, if we use the scanner from filesystem or
+	// if the `imgMeta` object does not contain all the metadata when it is sent.
 	// We add them here to make sure they are present.
 	wlmImage.SBOM = util.UpdateSBOMRepoMetadata(wlmImage.SBOM, wlmImage.RepoTags, wlmImage.RepoDigests)
 

--- a/comp/core/workloadmeta/collectors/internal/docker/docker.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker.go
@@ -610,9 +610,10 @@ func (c *collector) getImageMetadata(ctx context.Context, imageID string, newSBO
 		}
 	}
 
-	// The CycloneDX should contain the RepoTags and RepoDigests but the scanner might not be able to do it.
-	// For example, if we use the scanner from filesystem or if the `imgMeta` object does not contain all the
-	// metadata when it is sent
+	// The CycloneDX should contain the RepoTags and RepoDigests but the scanner might
+	// not be able to inject them. For example, if we use the scanner from filesystem or
+	// if the `imgMeta` object does not contain all the metadata when it is sent.
+	// We add them here to make sure they are present.
 	sbom = util.UpdateSBOMRepoMetadata(sbom, imgInspect.RepoTags, imgInspect.RepoDigests)
 
 	return &workloadmeta.ContainerImageMetadata{

--- a/comp/core/workloadmeta/collectors/internal/docker/docker.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker.go
@@ -18,8 +18,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/scanner"
-	"github.com/mohae/deepcopy"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
@@ -583,7 +581,6 @@ func (c *collector) getImageMetadata(ctx context.Context, imageID string, newSBO
 	)
 
 	sbom := newSBOM
-	var usingExistingSBOM bool
 	// We can get "create" events for images that already exist. That happens
 	// when the same image is referenced with different names. For example,
 	// datadog/agent:latest and datadog/agent:7 might refer to the same image.
@@ -604,7 +601,6 @@ func (c *collector) getImageMetadata(ctx context.Context, imageID string, newSBO
 
 		if sbom == nil && existingImg.SBOM.Status != workloadmeta.Pending {
 			sbom = existingImg.SBOM
-			usingExistingSBOM = true
 		}
 	}
 
@@ -614,18 +610,10 @@ func (c *collector) getImageMetadata(ctx context.Context, imageID string, newSBO
 		}
 	}
 
-	// SBOMs are generated only once. However, when they are generated it is possible that
-	// not every RepoDigest and RepoTags are attached to the image. In that case, the SBOM
-	// will also miss metadata and will not be re-generated when new metadata is detected.
-	// Because this metadata is essential for processing, it is important to inject new metadata
-	// to the existing SBOM. Generating a new SBOM can be a more robust solution but can also be
-	// costly.
-	// Moreover, it is not safe to modify the original SBOM if it is already stored in workloadmeta,
-	// so we create a copy of it. It is costly but shouldn't be called so often.
-	if usingExistingSBOM {
-		sbom = deepcopy.Copy(sbom).(*workloadmeta.SBOM)
-		sbom = util.UpdateSBOMRepoMetadata(sbom, imgInspect.RepoTags, imgInspect.RepoDigests)
-	}
+	// The CycloneDX should contain the RepoTags and RepoDigests but the scanner might not be able to do it.
+	// For example, if we use the scanner from filesystem or if the `imgMeta` object does not contain all the
+	// metadata when it is sent
+	sbom = util.UpdateSBOMRepoMetadata(sbom, imgInspect.RepoTags, imgInspect.RepoDigests)
 
 	return &workloadmeta.ContainerImageMetadata{
 		EntityID: workloadmeta.EntityID{

--- a/comp/core/workloadmeta/collectors/util/image_util.go
+++ b/comp/core/workloadmeta/collectors/util/image_util.go
@@ -9,9 +9,13 @@
 package util
 
 import (
+	"sort"
+
 	"github.com/CycloneDX/cyclonedx-go"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	trivydx "github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
+	"github.com/mohae/deepcopy"
+
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 )
 
 const (
@@ -19,8 +23,8 @@ const (
 	repoDigestPropertyKey = trivydx.Namespace + trivydx.PropertyRepoDigest
 )
 
-// UpdateSBOMRepoMetadata updates entered SBOM with new metadata properties if the initial SBOM status was successful
-// and there are new repoTags and repoDigests missing in the SBOM. It returns the updated SBOM.
+// UpdateSBOMRepoMetadata finds if the repo tags and repo digests are present in the SBOM and updates them if not.
+// It returns a copy of the SBOM with the updated properties if they were not already present.
 func UpdateSBOMRepoMetadata(sbom *workloadmeta.SBOM, repoTags, repoDigests []string) *workloadmeta.SBOM {
 	if sbom == nil ||
 		sbom.Status != workloadmeta.Success ||
@@ -32,18 +36,62 @@ func UpdateSBOMRepoMetadata(sbom *workloadmeta.SBOM, repoTags, repoDigests []str
 	}
 
 	properties := *sbom.CycloneDXBOM.Metadata.Component.Properties
-	properties = removeOldRepoProperties(properties)
+	mismatched := !propertiesEqualsValues(properties, repoTags, repoTagPropertyKey) || !propertiesEqualsValues(properties, repoDigests, repoDigestPropertyKey)
 
-	properties = appendRepoProperties(properties, repoTags, repoTagPropertyKey)
-	properties = appendRepoProperties(properties, repoDigests, repoDigestPropertyKey)
+	if mismatched {
+		sbom = deepcopy.Copy(sbom).(*workloadmeta.SBOM)
+		newProperties := *sbom.CycloneDXBOM.Metadata.Component.Properties
+		newProperties = cleanProperties(newProperties)
 
-	sbom.CycloneDXBOM.Metadata.Component.Properties = &properties
+		newProperties = appendProperties(newProperties, repoTags, repoTagPropertyKey)
+		newProperties = appendProperties(newProperties, repoDigests, repoDigestPropertyKey)
+
+		// Sort properties to ensure consistent ordering for tests
+		sort.Slice(newProperties, func(i, j int) bool {
+			return newProperties[i].Name < newProperties[j].Name || newProperties[i].Value < newProperties[j].Value
+		})
+		sbom.CycloneDXBOM.Metadata.Component.Properties = &newProperties
+	}
 
 	return sbom
 }
 
-// removeOldRepoProperties returns an array without repodigests and repoTags
-func removeOldRepoProperties(properties []cyclonedx.Property) []cyclonedx.Property {
+// propertiesEqualsValues function compares the existing properties with the new values
+func propertiesEqualsValues(properties []cyclonedx.Property, newValues []string, propertyKeyType string) bool {
+	existingValuesMap := make(map[string]bool)
+	for _, prop := range properties {
+		if prop.Name == propertyKeyType {
+			existingValuesMap[prop.Value] = true
+		}
+	}
+
+	for _, newValue := range newValues {
+		if !existingValuesMap[newValue] {
+			return false
+		}
+	}
+
+	for existingValue := range existingValuesMap {
+		if !contains(newValues, existingValue) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// contains is a helper function to check if the slice contains the string value
+func contains(slice []string, value string) bool {
+	for _, item := range slice {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
+// Remove properties from the list that are present in the mismatched map
+func cleanProperties(properties []cyclonedx.Property) []cyclonedx.Property {
 	res := make([]cyclonedx.Property, 0, len(properties))
 
 	for _, prop := range properties {
@@ -56,11 +104,20 @@ func removeOldRepoProperties(properties []cyclonedx.Property) []cyclonedx.Proper
 	return res
 }
 
-// appendRepoProperties function updates the slice of properties
-func appendRepoProperties(properties []cyclonedx.Property, repoValues []string, propertyKeyType string) []cyclonedx.Property {
-	for _, repoValue := range repoValues {
-		prop := cdxProperty(propertyKeyType, repoValue)
-		properties = append(properties, prop)
+// Append new values to the properties that were not already present
+func appendProperties(properties []cyclonedx.Property, newValues []string, propertyKeyType string) []cyclonedx.Property {
+	existingValues := make(map[string]bool)
+	for _, prop := range properties {
+		if prop.Name == propertyKeyType {
+			existingValues[prop.Value] = true
+		}
+	}
+
+	for _, newValue := range newValues {
+		if !existingValues[newValue] {
+			prop := cdxProperty(propertyKeyType, newValue)
+			properties = append(properties, prop)
+		}
 	}
 	return properties
 }

--- a/comp/core/workloadmeta/collectors/util/image_util.go
+++ b/comp/core/workloadmeta/collectors/util/image_util.go
@@ -58,15 +58,15 @@ func UpdateSBOMRepoMetadata(sbom *workloadmeta.SBOM, repoTags, repoDigests []str
 
 // propertiesEqualsValues function compares the existing properties with the new values
 func propertiesEqualsValues(properties []cyclonedx.Property, newValues []string, propertyKeyType string) bool {
-	existingValuesMap := make(map[string]bool)
+	existingValuesMap := make(map[string]struct{})
 	for _, prop := range properties {
 		if prop.Name == propertyKeyType {
-			existingValuesMap[prop.Value] = true
+			existingValuesMap[prop.Value] = struct{}{}
 		}
 	}
 
 	for _, newValue := range newValues {
-		if !existingValuesMap[newValue] {
+		if _, found := existingValuesMap[newValue]; !found {
 			return false
 		}
 	}

--- a/comp/core/workloadmeta/collectors/util/image_util.go
+++ b/comp/core/workloadmeta/collectors/util/image_util.go
@@ -9,6 +9,7 @@
 package util
 
 import (
+	"golang.org/x/exp/slices"
 	"sort"
 
 	"github.com/CycloneDX/cyclonedx-go"
@@ -72,22 +73,12 @@ func propertiesEqualsValues(properties []cyclonedx.Property, newValues []string,
 	}
 
 	for existingValue := range existingValuesMap {
-		if !contains(newValues, existingValue) {
+		if !slices.Contains(newValues, existingValue) {
 			return false
 		}
 	}
 
 	return true
-}
-
-// contains is a helper function to check if the slice contains the string value
-func contains(slice []string, value string) bool {
-	for _, item := range slice {
-		if item == value {
-			return true
-		}
-	}
-	return false
 }
 
 // Remove properties from the list that are present in the mismatched map

--- a/comp/core/workloadmeta/collectors/util/image_util.go
+++ b/comp/core/workloadmeta/collectors/util/image_util.go
@@ -106,15 +106,15 @@ func cleanProperties(properties []cyclonedx.Property) []cyclonedx.Property {
 
 // Append new values to the properties that were not already present
 func appendProperties(properties []cyclonedx.Property, newValues []string, propertyKeyType string) []cyclonedx.Property {
-	existingValues := make(map[string]bool)
+	existingValues := make(map[string]struct{})
 	for _, prop := range properties {
 		if prop.Name == propertyKeyType {
-			existingValues[prop.Value] = true
+			existingValues[prop.Value] = struct{}{}
 		}
 	}
 
 	for _, newValue := range newValues {
-		if !existingValues[newValue] {
+		if _, found := existingValues[newValue]; !found {
 			prop := cdxProperty(propertyKeyType, newValue)
 			properties = append(properties, prop)
 		}

--- a/comp/core/workloadmeta/collectors/util/image_util.go
+++ b/comp/core/workloadmeta/collectors/util/image_util.go
@@ -9,12 +9,10 @@
 package util
 
 import (
-	"golang.org/x/exp/slices"
-	"sort"
-
 	"github.com/CycloneDX/cyclonedx-go"
 	trivydx "github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
 	"github.com/mohae/deepcopy"
+	"golang.org/x/exp/slices"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 )
@@ -47,10 +45,6 @@ func UpdateSBOMRepoMetadata(sbom *workloadmeta.SBOM, repoTags, repoDigests []str
 		newProperties = appendProperties(newProperties, repoTags, repoTagPropertyKey)
 		newProperties = appendProperties(newProperties, repoDigests, repoDigestPropertyKey)
 
-		// Sort properties to ensure consistent ordering for tests
-		sort.Slice(newProperties, func(i, j int) bool {
-			return newProperties[i].Name < newProperties[j].Name || newProperties[i].Value < newProperties[j].Value
-		})
 		sbom.CycloneDXBOM.Metadata.Component.Properties = &newProperties
 	}
 

--- a/comp/core/workloadmeta/collectors/util/image_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/image_util_test.go
@@ -3,13 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-//go:build trivy && test
+//go:build trivy
 
 // Package util contains utility functions for image metadata collection
 package util
 
 import (
-	"reflect"
+	"gotest.tools/assert"
+	"sort"
 	"testing"
 
 	"github.com/CycloneDX/cyclonedx-go"
@@ -124,8 +125,8 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 					Metadata: &cyclonedx.Metadata{
 						Component: &cyclonedx.Component{
 							Properties: &[]cyclonedx.Property{
-								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
 								{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest1"},
+								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
 							},
 						},
 					},
@@ -172,8 +173,8 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 						Metadata: &cyclonedx.Metadata{
 							Component: &cyclonedx.Component{
 								Properties: &[]cyclonedx.Property{
-									{Name: "prop1", Value: "tag1"},
 									{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
+									{Name: "prop1", Value: "tag1"},
 									{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest1"},
 								},
 							},
@@ -199,9 +200,23 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := UpdateSBOMRepoMetadata(tt.args.sbom, tt.args.repoTags, tt.args.repoDigests); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("UpdateSBOMRepoMetadata) = %v, want %v", got.CycloneDXBOM.Metadata.Component.Properties, tt.want.CycloneDXBOM.Metadata.Component.Properties)
+
+			got := UpdateSBOMRepoMetadata(tt.args.sbom, tt.args.repoTags, tt.args.repoDigests)
+			if got != nil &&
+				got.CycloneDXBOM != nil &&
+				got.CycloneDXBOM.Metadata != nil &&
+				got.CycloneDXBOM.Metadata.Component != nil &&
+				got.CycloneDXBOM.Metadata.Component.Properties != nil {
+				// Sort properties to ensure consistent ordering for tests
+				props := *got.CycloneDXBOM.Metadata.Component.Properties
+				sort.Slice(props, func(i, j int) bool {
+					if props[i].Name == props[j].Name {
+						return props[i].Value < props[j].Value
+					}
+					return props[i].Name < props[j].Name
+				})
 			}
+			assert.DeepEqual(t, got, tt.want)
 		})
 	}
 }

--- a/comp/core/workloadmeta/collectors/util/image_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/image_util_test.go
@@ -73,8 +73,8 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 						Metadata: &cyclonedx.Metadata{
 							Component: &cyclonedx.Component{
 								Properties: &[]cyclonedx.Property{
-									{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 									{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest2"},
+									{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 								},
 							},
 						},
@@ -89,10 +89,10 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 					Metadata: &cyclonedx.Metadata{
 						Component: &cyclonedx.Component{
 							Properties: &[]cyclonedx.Property{
-								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
-								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 								{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest1"},
 								{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest2"},
+								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
+								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 							},
 						},
 					},
@@ -164,7 +164,7 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "other properties are not touched",
+			name: "other properties are still there",
 			args: args{
 				sbom: &workloadmeta.SBOM{
 					Status: workloadmeta.Success,
@@ -188,8 +188,8 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 					Metadata: &cyclonedx.Metadata{
 						Component: &cyclonedx.Component{
 							Properties: &[]cyclonedx.Property{
-								{Name: "prop1", Value: "tag1"},
 								{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest1"},
+								{Name: "prop1", Value: "tag1"},
 							},
 						},
 					},
@@ -200,7 +200,7 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := UpdateSBOMRepoMetadata(tt.args.sbom, tt.args.repoTags, tt.args.repoDigests); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("UpdateSBOMRepoMetadata) = %v, want %v", got, tt.want)
+				t.Errorf("UpdateSBOMRepoMetadata) = %v, want %v", got.CycloneDXBOM.Metadata.Component.Properties, tt.want.CycloneDXBOM.Metadata.Component.Properties)
 			}
 		})
 	}

--- a/comp/core/workloadmeta/collectors/util/image_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/image_util_test.go
@@ -9,7 +9,7 @@
 package util
 
 import (
-	"gotest.tools/assert"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -216,7 +216,9 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 					return props[i].Name < props[j].Name
 				})
 			}
-			assert.DeepEqual(t, got, tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateSBOMRepoMetadata) = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR injects repotags and repodigests in the SBOM if the metadata is missing. Previously, it was done only when new metadata is discovered. Now it is always done because the scanner might miss some metadata.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This metadata is required.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Same as [here](https://github.com/DataDog/datadog-agent/pull/20437), but you will need to install the agent with helm using
```
  sbom:
    containerImage:
      enabled: true
      uncompressedLayersSupport: true
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
