### PR TITLE
[backport][CWS] Fix container ID parsing (which was too loose) (#22025)

### DIFF
--- a/pkg/security/common/containerutils/utils.go
+++ b/pkg/security/common/containerutils/utils.go
@@ -8,18 +8,24 @@ package containerutils
 
 import (
 	"regexp"
+	"strings"
 )
 
-// ContainerIDPatternStr defines the regexp used to match container IDs
+// StrictContainerIDPatternStr defines the regexp used to match container IDs
 // ([0-9a-fA-F]{64}) is standard container id used pretty much everywhere
 // ([0-9a-fA-F]{32}-[0-9]{10}) is container id used by AWS ECS
 // ([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4}) is container id used by Garden
-var ContainerIDPatternStr = "([0-9a-fA-F]{64})|([0-9a-fA-F]{32}-[0-9]{10})|([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4})"
+var StrictContainerIDPatternStr = "^(([0-9a-fA-F]{64})|([0-9a-fA-F]{32}-[0-9]{10})|([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4}))$"
+var strictContainerIDPattern = regexp.MustCompilePOSIX(StrictContainerIDPatternStr)
 
-// containerIDPattern is the pattern of a container ID
-var containerIDPattern = regexp.MustCompile(ContainerIDPatternStr)
+// WildContainerIDPatternStr is a bit more loose and match within a path string like "/docker/<containerID>"
+var WildContainerIDPatternStr = "(([0-9a-fA-F]{64})|([0-9a-fA-F]{32}-[0-9]{10})|([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4}))"
+var wildContainerIDPattern = regexp.MustCompilePOSIX(WildContainerIDPatternStr)
 
 // FindContainerID extracts the first sub string that matches the pattern of a container ID
 func FindContainerID(s string) string {
-	return containerIDPattern.FindString(s)
+	if strings.Contains(s, "docker") {
+		return wildContainerIDPattern.FindString(s)
+	}
+	return strictContainerIDPattern.FindString(s)
 }

--- a/pkg/security/common/containerutils/utils_test.go
+++ b/pkg/security/common/containerutils/utils_test.go
@@ -35,11 +35,15 @@ func TestFindContainerID(t *testing.T) {
 		},
 		{ // with prefix/suffix
 			input:  "prefixaAbBcCdDeEfF2345678901234567890123456789012345678901234567890123suffix",
-			output: "aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
+			output: "",
 		},
 		{ // multiple
 			input:  "prefixaAbBcCdDeEfF2345678901234567890123456789012345678901234567890123-0123456789012345678901234567890123456789012345678901234567890123-9999999999999999999999999999999999999999999999999999999999999999suffix",
-			output: "aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
+			output: "",
+		},
+		{ // path reducer test
+			input:  "/var/run/docker/overlay2/47c1f1930c1831f2359c6d276912c583be1cda5924233cf273022b91763a20f7/merged/etc/passwd",
+			output: "47c1f1930c1831f2359c6d276912c583be1cda5924233cf273022b91763a20f7",
 		},
 		{ // GARDEN
 			input:  "01234567-0123-4567-890a-bcde",
@@ -51,23 +55,23 @@ func TestFindContainerID(t *testing.T) {
 		},
 		{ // GARDEN with prefix / suffix
 			input:  "prefix01234567-0123-4567-890a-bcdesuffix",
-			output: "01234567-0123-4567-890a-bcde",
+			output: "",
+		},
+		{ // Some random path which could match garden format
+			input:  "/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-f9176c6a-2a34-4ce2-86af-60d16888ed8e.scope",
+			output: "",
 		},
 		{ // ECS
 			input:  "0123456789aAbBcCdDeEfF0123456789-0123456789",
 			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
 		},
-		{ // ECS double with first having a bad format
-			input:  "0123456789aAbBcCdDeEfF0123456789-abcdef6789/0123456789aAbBcCdDeEfF0123456789-0123456789",
-			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
-		},
 		{ // ECS as present in proc
-			input:  "/proc/0123456789aAbBcCdDeEfF0123456789-0123456789",
+			input:  "/docker/0123456789aAbBcCdDeEfF0123456789-0123456789",
 			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
 		},
 		{ // ECS with prefix / suffix
 			input:  "prefix0123456789aAbBcCdDeEfF0123456789-0123456789suffix",
-			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
+			output: "",
 		},
 	}
 

--- a/pkg/security/security_profile/activity_tree/paths_reducer.go
+++ b/pkg/security/security_profile/activity_tree/paths_reducer.go
@@ -143,7 +143,7 @@ func getPathsReducerPatterns() []PatternReducer {
 			},
 		},
 		{
-			Pattern: regexp.MustCompile(containerutils.ContainerIDPatternStr), // container ID
+			Pattern: regexp.MustCompile(containerutils.WildContainerIDPatternStr), // container ID
 			Callback: func(ctx *callbackContext) {
 				start, end := ctx.getGroup(0)
 				ctx.replaceBy(start, end, "*")


### PR DESCRIPTION
### What does this PR do?

Backport of [this PR](https://github.com/DataDog/datadog-agent/pull/22025), fixing containerID parsing.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
