### PR TITLE
[backport][CWS] fix ptracer size (#22027)

### DIFF
--- a/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
+++ b/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
@@ -14,12 +14,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/selftestscmd"
-	"github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 	"github.com/DataDog/datadog-agent/pkg/security/ptracer"
 )
 
-// EnvDisableStats defines the environ variable to set to disable aviodable stats
-const EnvDisableStats = "DD_CWS_INSTRUMENTATION_DISABLE_STATS"
+const (
+	// envDisableStats defines the environ variable to set to disable aviodable stats
+	envDisableStats = "DD_CWS_INSTRUMENTATION_DISABLE_STATS"
+)
 
 const (
 	// gRPCAddr defines the system-probe addr
@@ -66,12 +68,12 @@ func Command() []*cobra.Command {
 		},
 	}
 
-	traceCmd.Flags().StringVar(&params.ProbeAddr, probeAddr, setup.DefaultEBPFLessProbeAddr, "system-probe eBPF less GRPC address")
+	traceCmd.Flags().StringVar(&params.ProbeAddr, probeAddr, constants.DefaultEBPFLessProbeAddr, "system-probe eBPF less GRPC address")
 	traceCmd.Flags().BoolVar(&params.Verbose, verbose, false, "enable verbose output")
 	traceCmd.Flags().Int32Var(&params.UID, uid, -1, "uid used to start the tracee")
 	traceCmd.Flags().Int32Var(&params.GID, gid, -1, "gid used to start the tracee")
 	traceCmd.Flags().BoolVar(&params.Async, async, false, "enable async GRPC connection")
-	if os.Getenv(EnvDisableStats) != "" {
+	if os.Getenv(envDisableStats) != "" {
 		params.DisableStats = true
 	} else {
 		traceCmd.Flags().BoolVar(&params.DisableStats, disableStats, false, "disable use of stats")

--- a/pkg/config/setup/constants/constants.go
+++ b/pkg/config/setup/constants/constants.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package constants holds constants
+package constants
+
+const (
+	// DefaultEBPFLessProbeAddr defines the default ebpfless probe address
+	DefaultEBPFLessProbeAddr = "localhost:5678"
+)

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -7,11 +7,7 @@ package setup
 
 import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-)
-
-const (
-	// DefaultEBPFLessProbeAddr defines the default ebpfless probe address
-	DefaultEBPFLessProbeAddr = "localhost:5678"
+	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 )
 
 func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
@@ -110,5 +106,5 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	// CWS -eBPF Less
 	cfg.BindEnvAndSetDefault("runtime_security_config.ebpfless.enabled", false)
-	cfg.BindEnvAndSetDefault("runtime_security_config.ebpfless.socket", DefaultEBPFLessProbeAddr)
+	cfg.BindEnvAndSetDefault("runtime_security_config.ebpfless.socket", constants.DefaultEBPFLessProbeAddr)
 }

--- a/pkg/security/tests/main_test.go
+++ b/pkg/security/tests/main_test.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 	"github.com/DataDog/datadog-agent/pkg/security/ptracer"
 	"golang.org/x/exp/slices"
 )
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 		envs := os.Environ()
 		envs = append(envs, "EBPFLESS=true")
 
-		err := ptracer.StartCWSPtracer(args, envs, setup.DefaultEBPFLessProbeAddr, ptracer.Creds{}, false /* verbose */, true /* async */, false /* disableStats */)
+		err := ptracer.StartCWSPtracer(args, envs, constants.DefaultEBPFLessProbeAddr, ptracer.Creds{}, false /* verbose */, true /* async */, false /* disableStats */)
 		if err != nil {
 			fmt.Printf("unable to trace [%v]: %s", args, err)
 			os.Exit(-1)


### PR DESCRIPTION
[CWS] fix ptracer size

(cherry picked from commit c7ffd04ac7a856f0114b1741eb686894c7df0ce6)

backport of https://github.com/DataDog/datadog-agent/pull/22027
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
