### PR TITLE
Fix panic in Kind dump_cluster_state

### DIFF
--- a/test/new-e2e/tests/containers/dump_cluster_state.go
+++ b/test/new-e2e/tests/containers/dump_cluster_state.go
@@ -118,7 +118,7 @@ func dumpKindClusterState(ctx context.Context, name string) (ret string) {
 			},
 			{
 				Name:   pointer.Ptr("tag:Name"),
-				Values: []string{name + "-aws-vm"},
+				Values: []string{name + "-aws-kind"},
 			},
 		},
 	})
@@ -127,7 +127,7 @@ func dumpKindClusterState(ctx context.Context, name string) (ret string) {
 		return
 	}
 
-	if len(instancesDescription.Reservations) != 1 && len(instancesDescription.Reservations[0].Instances) != 1 {
+	if instancesDescription == nil || (len(instancesDescription.Reservations) != 1 && len(instancesDescription.Reservations[0].Instances) != 1) {
 		fmt.Fprintf(&out, "Didn’t find exactly one instance for cluster %s\n", name)
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

Fix a panic in E2E Kind `dump_cluster_state`

### Motivation

Fix `containers/Kind` E2E Tests.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
