### PR TITLE
Fix missing kube_api_version tag on HPA and VPA

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/horizontalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/horizontalpodautoscaler.go
@@ -76,13 +76,7 @@ func (c *HorizontalPodAutoscalerCollector) Run(rcfg *collectors.CollectorRunConf
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/verticalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/verticalpodautoscaler.go
@@ -76,13 +76,7 @@ func (c *VerticalPodAutoscalerCollector) Run(rcfg *collectors.CollectorRunConfig
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/releasenotes-dca/notes/missing-kube_api_version-tag-092f68f355285868.yaml
+++ b/releasenotes-dca/notes/missing-kube_api_version-tag-092f68f355285868.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix missing `kube_api_version` tag on HPA and VPA resources.


### PR DESCRIPTION
### What does this PR do?

Send `kube_api_version` tag on HorizontalPodAutoscaler and VerticalPodAutoscaler as for other resources. It wasn't the case because the collector context wasn't properly instantiated.