### PR TITLE
usm: Add unix socket transparent proxy

### DIFF
--- a/pkg/network/testutil/cmd.go
+++ b/pkg/network/testutil/cmd.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -65,8 +64,6 @@ func StartCommandCtx(ctx context.Context, cmd string) (*exec.Cmd, io.WriteCloser
 	args := strings.Split(cmd, " ")
 	c := exec.CommandContext(ctx, args[0], args[1:]...)
 	clientInput, err := c.StdinPipe()
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stdout
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get command %s standard input: %w", c, err)
 	}

--- a/pkg/network/testutil/cmd.go
+++ b/pkg/network/testutil/cmd.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -64,6 +65,8 @@ func StartCommandCtx(ctx context.Context, cmd string) (*exec.Cmd, io.WriteCloser
 	args := strings.Split(cmd, " ")
 	c := exec.CommandContext(ctx, args[0], args[1:]...)
 	clientInput, err := c.StdinPipe()
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stdout
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get command %s standard input: %w", c, err)
 	}

--- a/pkg/network/tracer/testutil/proxy/external_unix_proxy_server/.gitignore
+++ b/pkg/network/tracer/testutil/proxy/external_unix_proxy_server/.gitignore
@@ -1,1 +1,1 @@
-external_unix_transparent_proxy_server
+external_unix_proxy_server

--- a/pkg/network/tracer/testutil/proxy/external_unix_proxy_server/.gitignore
+++ b/pkg/network/tracer/testutil/proxy/external_unix_proxy_server/.gitignore
@@ -1,0 +1,1 @@
+external_unix_transparent_proxy_server

--- a/pkg/network/tracer/testutil/proxy/external_unix_proxy_server/external_unix_proxy_server.go
+++ b/pkg/network/tracer/testutil/proxy/external_unix_proxy_server/external_unix_proxy_server.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package main provides a unix transparent proxy server that can be used for testing.
+package main
+
+import (
+	"flag"
+	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/proxy"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	// Define command-line flags
+	var remoteAddr string
+	var unixPath string
+	var useTLS bool
+
+	flag.StringVar(&remoteAddr, "remote", "", "Remote server address to forward connections to")
+	flag.StringVar(&unixPath, "unix", "/tmp/transparent.sock", "A local unix socket to listen on")
+	flag.BoolVar(&useTLS, "tls", false, "Use TLS to connect to the remote server")
+
+	// Parse command-line flags
+	flag.Parse()
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, syscall.SIGINT)
+
+	srv := proxy.NewUnixTransparentProxyServer(unixPath, remoteAddr, useTLS)
+	defer srv.Stop()
+
+	if err := srv.Run(); err != nil {
+		log.Fatal(err)
+	}
+
+	<-done
+}

--- a/pkg/network/tracer/testutil/proxy/external_unix_proxy_server/external_unix_proxy_server.go
+++ b/pkg/network/tracer/testutil/proxy/external_unix_proxy_server/external_unix_proxy_server.go
@@ -8,11 +8,12 @@ package main
 
 import (
 	"flag"
-	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/proxy"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/proxy"
 )
 
 func main() {

--- a/pkg/network/tracer/testutil/proxy/unix_transparent_proxy.go
+++ b/pkg/network/tracer/testutil/proxy/unix_transparent_proxy.go
@@ -1,0 +1,168 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+// Package proxy provides a unix transparent proxy server that can be used for testing.
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	defaultDialTimeout = 15 * time.Second
+)
+
+// UnixTransparentProxyServer is a proxy server that listens on a unix socket, and forwards all incoming and outgoing traffic
+// to a remote address.
+type UnixTransparentProxyServer struct {
+	// unixPath is the path to the unix socket to listen on.
+	unixPath string
+	// remoteAddr is the address to forward all traffic to.
+	remoteAddr string
+	// useTLS indicates whether the proxy should use TLS to connect to the remote address.
+	useTLS bool
+	// isReady is a flag indicating whether the server is ready to accept connections.
+	isReady atomic.Bool
+	// wg is a wait group used to wait for the server to stop.
+	wg sync.WaitGroup
+	// ln is the listener used by the server.
+	ln net.Listener
+}
+
+// NewUnixTransparentProxyServer returns a new instance of a UnixTransparentProxyServer.
+func NewUnixTransparentProxyServer(unixPath, remoteAddr string, useTLS bool) *UnixTransparentProxyServer {
+	return &UnixTransparentProxyServer{
+		unixPath:   unixPath,
+		remoteAddr: remoteAddr,
+		useTLS:     useTLS,
+	}
+}
+
+// Run starts the proxy server.
+func (p *UnixTransparentProxyServer) Run() error {
+	// Clear the old socket if it exists.
+	if err := p.clearOldSocket(); err != nil {
+		return err
+	}
+
+	ln, err := net.Listen("unix", p.unixPath)
+	if err != nil {
+		return err
+	}
+	p.ln = ln
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		p.isReady.Store(true)
+
+		for {
+			unixSocketConn, err := ln.Accept()
+			if err != nil {
+				// We can get this error when the listener is closed, during shutdown.
+				if !errors.Is(err, net.ErrClosed) {
+					log.Errorf("failed accepting connection: %s", err)
+				}
+				return
+			}
+			go p.handleConnection(unixSocketConn)
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the proxy server.
+func (p *UnixTransparentProxyServer) Stop() {
+	defer p.clearOldSocket()
+
+	_ = p.ln.Close()
+	p.wg.Wait()
+}
+
+// WaitUntilServerIsReady blocks until the server is ready to accept connections.
+func (p *UnixTransparentProxyServer) WaitUntilServerIsReady() {
+	for !p.isReady.Load() {
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// WaitForConnectionReady blocks until the server is ready to accept connections.
+// meant for external servers.
+func WaitForConnectionReady(unixSocket string) error {
+	for i := 0; i < 30; i++ {
+		_, err := net.DialTimeout("unix", unixSocket, time.Second)
+		if err == nil {
+			return nil
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	return fmt.Errorf("could not connect %q after 30 retries", unixSocket)
+}
+
+// handleConnection handles a new connection, by forwarding all traffic to the remote address.
+func (p *UnixTransparentProxyServer) handleConnection(unixSocketConn net.Conn) {
+	defer unixSocketConn.Close()
+
+	var remoteConn net.Conn
+	var err error
+	if p.useTLS {
+		timedContext, cancel := context.WithTimeout(context.Background(), defaultDialTimeout)
+		dialer := &tls.Dialer{Config: &tls.Config{InsecureSkipVerify: true}}
+		remoteConn, err = dialer.DialContext(timedContext, "tcp", p.remoteAddr)
+		cancel()
+	} else {
+		remoteConn, err = net.DialTimeout("tcp", p.remoteAddr, defaultDialTimeout)
+	}
+	if err != nil {
+		log.Errorf("failed to dial remote: %s", err)
+		return
+	}
+	defer remoteConn.Close()
+
+	var streamWait sync.WaitGroup
+	streamWait.Add(2)
+
+	streamConn := func(dst io.Writer, src io.Reader) {
+		defer streamWait.Done()
+		io.Copy(dst, src)
+	}
+
+	go streamConn(remoteConn, unixSocketConn)
+	go streamConn(unixSocketConn, remoteConn)
+
+	streamWait.Wait()
+}
+
+// clearOldSocket clears the old socket if it exists.
+func (p *UnixTransparentProxyServer) clearOldSocket() error {
+	pipe, err := os.Stat(p.unixPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+
+	mode := pipe.Mode()
+	if os.ModeSocket&mode != 0 { // is a socket
+		return os.Remove(p.unixPath)
+	}
+	return fmt.Errorf("%q exists but it is not a socket", p.unixPath)
+}

--- a/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_builder.go
+++ b/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_builder.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package proxy
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
+)
+
+// NewExternalUnixTransparentProxyServer triggers an external unix transparent proxy (plaintext or TLS) server.
+func NewExternalUnixTransparentProxyServer(t *testing.T, unixPath, remoteAddr string, useTLS bool) (*exec.Cmd, context.CancelFunc) {
+	serverBin := buildUnixTransparentProxyServer(t)
+	args := []string{serverBin, "-unix", unixPath, "-remote", remoteAddr}
+	if useTLS {
+		args = append(args, "-tls")
+	}
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	commandLine := strings.Join(args, " ")
+	c, _, err := nettestutil.StartCommandCtx(cancelCtx, commandLine)
+
+	require.NoError(t, err)
+	return c, func() {
+		cancel()
+		if c.Process != nil {
+			_, _ = c.Process.Wait()
+		}
+	}
+}
+
+const (
+	serverSrcPath = "external_unix_proxy_server"
+)
+
+// buildUnixTransparentProxyServer builds the unix transparent proxy server binary and returns the path to the binary.
+// If the binary is already built (meanly in the CI), it returns the path to the binary.
+func buildUnixTransparentProxyServer(t *testing.T) string {
+	t.Helper()
+
+	cur, err := testutil.CurDir()
+	require.NoError(t, err)
+
+	serverSrcDir := path.Join(cur, serverSrcPath)
+	cachedServerBinaryPath := path.Join(serverSrcDir, serverSrcPath)
+
+	// If there is a compiled binary already, skip the compilation.
+	// Meant for the CI.
+	if _, err = os.Stat(cachedServerBinaryPath); err == nil {
+		return cachedServerBinaryPath
+	}
+
+	c := exec.Command("go", "build", "-buildvcs=false", "-a", "-tags=test", "-ldflags=-extldflags '-static'", "-o", cachedServerBinaryPath, serverSrcDir)
+	out, err := c.CombinedOutput()
+	require.NoError(t, err, "could not build grpc server test binary: %s\noutput: %s", err, string(out))
+
+	return cachedServerBinaryPath
+}

--- a/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_test.go
+++ b/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux_bpf
+
 package proxy
 
 import (

--- a/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_test.go
+++ b/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_test.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package proxy
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+)
+
+func TestUnixTransparentParentProxy(t *testing.T) {
+	const remoteServerAddr = "127.0.0.1:5555"
+	const unixPath = "/tmp/transparent.sock"
+
+	// Start the proxy server.
+	_, cancel := NewExternalUnixTransparentProxyServer(t, unixPath, remoteServerAddr, false)
+	t.Cleanup(cancel)
+
+	// Start the remote server.
+	tcpEchoServer := testutil.NewTCPServer(remoteServerAddr, func(c net.Conn) {
+		defer c.Close()
+		// Copy data from the connection's reader to its writer (echo)
+		_, _ = io.Copy(c, c)
+	})
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+	require.NoError(t, tcpEchoServer.Run(done))
+
+	require.NoError(t, WaitForConnectionReady(unixPath))
+
+	// Start the proxy client.
+	conn, err := net.DialTimeout("unix", unixPath, defaultDialTimeout)
+	require.NoError(t, err)
+
+	_, err = conn.Write([]byte("test"))
+	require.NoError(t, err)
+	output := make([]byte, 4)
+	_, err = conn.Read(output)
+	require.NoError(t, err)
+	require.Equal(t, "test", string(output))
+}
+
+func TestTLSUnixTransparentParentProxy(t *testing.T) {
+	const remoteServerAddr = "127.0.0.1:5555"
+	const unixPath = "/tmp/transparent2.sock"
+
+	// Start the proxy server.
+	_, cancel := NewExternalUnixTransparentProxyServer(t, unixPath, remoteServerAddr, true)
+	t.Cleanup(cancel)
+
+	// Start the remote server.
+	tlsServerCancel := testutil.HTTPServer(t, remoteServerAddr, testutil.Options{EnableTLS: true})
+	t.Cleanup(tlsServerCancel)
+
+	client := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", unixPath)
+			},
+		},
+	}
+
+	require.NoError(t, WaitForConnectionReady(unixPath))
+	response, err := client.Get("http://unix/status/201")
+	require.NoError(t, err)
+	require.Equal(t, 201, response.StatusCode)
+}

--- a/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_test.go
+++ b/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_test.go
@@ -50,8 +50,8 @@ func TestUnixTransparentParentProxy(t *testing.T) {
 }
 
 func TestTLSUnixTransparentParentProxy(t *testing.T) {
-	const remoteServerAddr = "127.0.0.1:5555"
-	const unixPath = "/tmp/transparent2.sock"
+	const remoteServerAddr = "127.0.0.1:5556"
+	const unixPath = "/tmp/transparent-tls.sock"
 
 	// Start the proxy server.
 	_, cancel := NewExternalUnixTransparentProxyServer(t, unixPath, remoteServerAddr, true)
@@ -72,5 +72,6 @@ func TestTLSUnixTransparentParentProxy(t *testing.T) {
 	require.NoError(t, WaitForConnectionReady(unixPath))
 	response, err := client.Get("http://unix/status/201")
 	require.NoError(t, err)
+	defer response.Body.Close()
 	require.Equal(t, 201, response.StatusCode)
 }

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -797,12 +797,12 @@ def kitchen_prepare(ctx, windows=is_windows, kernel_release=None, ci=False, pack
         if pkg.endswith("java"):
             shutil.copy(os.path.join(pkg, "agent-usm.jar"), os.path.join(target_path, "agent-usm.jar"))
 
-        for gobin in ["gotls_client", "grpc_external_server", "fmapper", "prefetch_file"]:
+        for gobin in ["gotls_client", "grpc_external_server", "external_unix_proxy_server", "fmapper", "prefetch_file"]:
             src_file_path = os.path.join(pkg, f"{gobin}.go")
             if not windows and os.path.isdir(pkg) and os.path.isfile(src_file_path):
                 binary_path = os.path.join(target_path, gobin)
                 with chdir(pkg):
-                    ctx.run(f"go build -o {binary_path} -ldflags=\"-extldflags '-static'\" {gobin}.go")
+                    ctx.run(f"go build -o {binary_path} -tags=\"test\" -ldflags=\"-extldflags '-static'\" {gobin}.go")
 
     gopath = os.getenv("GOPATH")
     copy_files = [


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Creates a testing util of a unix socket transparent proxy, to allow us to spin a remote external client, and control its communication to a remote server.
The utility is meant to be used mainly in our TLS tests, where the traffic can vary between test scenarios, but we don't need to re-implement the setup for external client.
The proxy listens on a unix socket and forwards the input to a remote TCP connection.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Testing utility

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
