### PR TITLE
[Backport] Add checksum to Chocolatey install (#21959)

### DIFF
--- a/.gitlab/choco_build.yml
+++ b/.gitlab/choco_build.yml
@@ -27,7 +27,7 @@ windows_choco_offline_7_x64:
 # it is run only once the msi package is pushed
 windows_choco_online_7_x64:
   rules:
-    !reference [.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7]
+    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
   stage: choco_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["deploy_staging_windows_tags-7"]

--- a/.gitlab/choco_deploy.yml
+++ b/.gitlab/choco_deploy.yml
@@ -4,7 +4,7 @@
 
 publish_choco_7_x64:
   rules:
-    !reference [.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7_manual_on_stable]
+    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
   stage: choco_deploy
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["windows_choco_online_7_x64"]

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -7,6 +7,8 @@ $packageArgs = @{
   fileType      = 'msi'
   # Note: Url is replaced at build time with the full URL to the MSI
   url64bit      = $__url_from_ci__
+  checksum64    = $__checksum_from_ci__
+  checksumType  = 'sha256'
   softwareName  = 'Datadog Agent'
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
   validExitCodes= @(0, 3010, 1641)

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -64,19 +64,15 @@ Write-Host "Generating Chocolatey $installMethod package version $agentVersion i
 Write-Host ("Downloading {0}" -f $url)
 $statusCode = -1
 try {
-    $req = [System.Net.WebRequest]::Create($url)
-    $rep = $req.GetResponse()
-    $statusCode = $rep.StatusCode
+    $tempMsi = "$(Get-Location)\ddagent.msi"
+    Remove-Item $tempMsi -ErrorAction Ignore
+    (New-Object net.webclient).Downloadfile($url, $tempMsi)
+    $checksum = (Get-FileHash $tempMsi -Algorithm SHA256).Hash
+    Remove-Item $tempMsi
 }
-catch [System.Net.WebException] {
-    if ($_.Exception.Status -eq "ProtocolError") {
-        $statusCode = [int]$_.Exception.Response.StatusCode
-    }
-}
-Write-Host $statusCode
-
-if ($statusCode -ne 200) {
-    Write-Warning "Package $($url) doesn't exists yet, make sure it exists before publishing the Chocolatey package !"
+catch {
+    Write-Host "Could not generate checksum for package $($url): $($_)"
+    exit 4
 }
 
 if (!(Test-Path $outputDirectory)) {
@@ -85,7 +81,7 @@ if (!(Test-Path $outputDirectory)) {
 
 if ($installMethod -eq "online") {
     # Set the $url in the install script
-    (Get-Content $installScript).replace('$__url_from_ci__', '"' +  $url  + '"') | Set-Content $installScript
+    (Get-Content $installScript).replace('$__url_from_ci__', '"' +  $url  + '"').replace('$__checksum_from_ci__', '"' +  $checksum  + '"') | Set-Content $installScript
 }
 
 Write-Host "Generated nupsec file:"


### PR DESCRIPTION
Add checksum to Chocolatey install

(cherry picked from commit 273390950e6965f11a1379e1865a34402359fa39)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
