### PR TITLE
 [CONTINT-3678] Backport Update SBOM CycloneDx if it is missing RepoDigest to 7.51.x

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/docker/docker.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker.go
@@ -18,8 +18,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/scanner"
-	"github.com/mohae/deepcopy"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
@@ -583,7 +581,6 @@ func (c *collector) getImageMetadata(ctx context.Context, imageID string, newSBO
 	)
 
 	sbom := newSBOM
-	var usingExistingSBOM bool
 	// We can get "create" events for images that already exist. That happens
 	// when the same image is referenced with different names. For example,
 	// datadog/agent:latest and datadog/agent:7 might refer to the same image.
@@ -604,7 +601,6 @@ func (c *collector) getImageMetadata(ctx context.Context, imageID string, newSBO
 
 		if sbom == nil && existingImg.SBOM.Status != workloadmeta.Pending {
 			sbom = existingImg.SBOM
-			usingExistingSBOM = true
 		}
 	}
 
@@ -614,18 +610,11 @@ func (c *collector) getImageMetadata(ctx context.Context, imageID string, newSBO
 		}
 	}
 
-	// SBOMs are generated only once. However, when they are generated it is possible that
-	// not every RepoDigest and RepoTags are attached to the image. In that case, the SBOM
-	// will also miss metadata and will not be re-generated when new metadata is detected.
-	// Because this metadata is essential for processing, it is important to inject new metadata
-	// to the existing SBOM. Generating a new SBOM can be a more robust solution but can also be
-	// costly.
-	// Moreover, it is not safe to modify the original SBOM if it is already stored in workloadmeta,
-	// so we create a copy of it. It is costly but shouldn't be called so often.
-	if usingExistingSBOM {
-		sbom = deepcopy.Copy(sbom).(*workloadmeta.SBOM)
-		sbom = util.UpdateSBOMRepoMetadata(sbom, imgInspect.RepoTags, imgInspect.RepoDigests)
-	}
+	// The CycloneDX should contain the RepoTags and RepoDigests but the scanner might
+	// not be able to inject them. For example, if we use the scanner from filesystem or
+	// if the `imgMeta` object does not contain all the metadata when it is sent.
+	// We add them here to make sure they are present.
+	sbom = util.UpdateSBOMRepoMetadata(sbom, imgInspect.RepoTags, imgInspect.RepoDigests)
 
 	return &workloadmeta.ContainerImageMetadata{
 		EntityID: workloadmeta.EntityID{

--- a/comp/core/workloadmeta/collectors/util/image_util.go
+++ b/comp/core/workloadmeta/collectors/util/image_util.go
@@ -9,12 +9,10 @@
 package util
 
 import (
-	"golang.org/x/exp/slices"
-	"sort"
-
 	"github.com/CycloneDX/cyclonedx-go"
 	trivydx "github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
 	"github.com/mohae/deepcopy"
+	"golang.org/x/exp/slices"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 )
@@ -47,10 +45,6 @@ func UpdateSBOMRepoMetadata(sbom *workloadmeta.SBOM, repoTags, repoDigests []str
 		newProperties = appendProperties(newProperties, repoTags, repoTagPropertyKey)
 		newProperties = appendProperties(newProperties, repoDigests, repoDigestPropertyKey)
 
-		// Sort properties to ensure consistent ordering for tests
-		sort.Slice(newProperties, func(i, j int) bool {
-			return newProperties[i].Name < newProperties[j].Name || newProperties[i].Value < newProperties[j].Value
-		})
 		sbom.CycloneDXBOM.Metadata.Component.Properties = &newProperties
 	}
 

--- a/comp/core/workloadmeta/collectors/util/image_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/image_util_test.go
@@ -3,13 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-//go:build trivy && test
+//go:build trivy
 
 // Package util contains utility functions for image metadata collection
 package util
 
 import (
-	"reflect"
+	"gotest.tools/assert"
+	"sort"
 	"testing"
 
 	"github.com/CycloneDX/cyclonedx-go"
@@ -124,8 +125,8 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 					Metadata: &cyclonedx.Metadata{
 						Component: &cyclonedx.Component{
 							Properties: &[]cyclonedx.Property{
-								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
 								{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest1"},
+								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
 							},
 						},
 					},
@@ -172,8 +173,8 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 						Metadata: &cyclonedx.Metadata{
 							Component: &cyclonedx.Component{
 								Properties: &[]cyclonedx.Property{
-									{Name: "prop1", Value: "tag1"},
 									{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
+									{Name: "prop1", Value: "tag1"},
 									{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest1"},
 								},
 							},
@@ -199,9 +200,23 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := UpdateSBOMRepoMetadata(tt.args.sbom, tt.args.repoTags, tt.args.repoDigests); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("UpdateSBOMRepoMetadata) = %v, want %v", got.CycloneDXBOM.Metadata.Component.Properties, tt.want.CycloneDXBOM.Metadata.Component.Properties)
+
+			got := UpdateSBOMRepoMetadata(tt.args.sbom, tt.args.repoTags, tt.args.repoDigests)
+			if got != nil &&
+				got.CycloneDXBOM != nil &&
+				got.CycloneDXBOM.Metadata != nil &&
+				got.CycloneDXBOM.Metadata.Component != nil &&
+				got.CycloneDXBOM.Metadata.Component.Properties != nil {
+				// Sort properties to ensure consistent ordering for tests
+				props := *got.CycloneDXBOM.Metadata.Component.Properties
+				sort.Slice(props, func(i, j int) bool {
+					if props[i].Name == props[j].Name {
+						return props[i].Value < props[j].Value
+					}
+					return props[i].Name < props[j].Name
+				})
 			}
+			assert.DeepEqual(t, got, tt.want)
 		})
 	}
 }

--- a/comp/core/workloadmeta/collectors/util/image_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/image_util_test.go
@@ -73,8 +73,8 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 						Metadata: &cyclonedx.Metadata{
 							Component: &cyclonedx.Component{
 								Properties: &[]cyclonedx.Property{
-									{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 									{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest2"},
+									{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 								},
 							},
 						},
@@ -89,10 +89,10 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 					Metadata: &cyclonedx.Metadata{
 						Component: &cyclonedx.Component{
 							Properties: &[]cyclonedx.Property{
-								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
-								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 								{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest1"},
 								{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest2"},
+								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag1"},
+								{Name: trivydx.Namespace + trivydx.PropertyRepoTag, Value: "tag2"},
 							},
 						},
 					},
@@ -164,7 +164,7 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "other properties are not touched",
+			name: "other properties are still there",
 			args: args{
 				sbom: &workloadmeta.SBOM{
 					Status: workloadmeta.Success,
@@ -188,8 +188,8 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 					Metadata: &cyclonedx.Metadata{
 						Component: &cyclonedx.Component{
 							Properties: &[]cyclonedx.Property{
-								{Name: "prop1", Value: "tag1"},
 								{Name: trivydx.Namespace + trivydx.PropertyRepoDigest, Value: "digest1"},
+								{Name: "prop1", Value: "tag1"},
 							},
 						},
 					},
@@ -200,7 +200,7 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := UpdateSBOMRepoMetadata(tt.args.sbom, tt.args.repoTags, tt.args.repoDigests); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("UpdateSBOMRepoMetadata) = %v, want %v", got, tt.want)
+				t.Errorf("UpdateSBOMRepoMetadata) = %v, want %v", got.CycloneDXBOM.Metadata.Component.Properties, tt.want.CycloneDXBOM.Metadata.Component.Properties)
 			}
 		})
 	}

--- a/comp/core/workloadmeta/collectors/util/image_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/image_util_test.go
@@ -9,7 +9,7 @@
 package util
 
 import (
-	"gotest.tools/assert"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -216,7 +216,9 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 					return props[i].Name < props[j].Name
 				})
 			}
-			assert.DeepEqual(t, got, tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateSBOMRepoMetadata) = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
backports this PR https://github.com/DataDog/datadog-agent/pull/22042
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Refer to https://github.com/DataDog/datadog-agent/pull/22042
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
](https://github.com/DataDog/datadog-agent/pull/22042)R