### PR TITLE
Add test tag to govet hook

### DIFF
--- a/tasks/git-hooks/govet.py
+++ b/tasks/git-hooks/govet.py
@@ -13,6 +13,8 @@ EXCLUDED_PACKAGES = {
     },
 }
 
+GO_TAGS = ["test"]
+
 
 def go_module_for_package(package_path):
     """
@@ -84,11 +86,12 @@ for module, packages in by_mod.items():
         print(f"Skipping {package} in {module}: not a valid package or all files are excluded by build tags")
         packages.remove(package)
 
+go_tags_arg = '-tags ' + ','.join(GO_TAGS) if GO_TAGS else ''
 for module, packages in by_mod.items():
     if not packages:
         continue
     try:
-        subprocess.run(f"go vet {' '.join(packages)}", shell=True, check=True, cwd=module)
+        subprocess.run(f"go vet {go_tags_arg} {' '.join(packages)}", shell=True, check=True, cwd=module)
     except subprocess.CalledProcessError:
         # Signal failure to pre-commit
         sys.exit(-1)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add the `test` build tag to `govet` command in the `govet` git hook.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Test helpers shared between test files are usually defined behind the `test` Go build tag.
When the hook runs on a package which does that, it can't find the helper function and fails with (for example):
```
govet....................................................................Failed
- hook id: govet
- exit code: 255

# github.com/DataDog/datadog-agent/pkg/util/http
vet: ./transport_test.go:21:2: undefined: setupTest
```

Adding the test build tag fixes the error.
There is only a single use of `!test` (versus 269 uses of `test`) in the whole repository so it's also a good default.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
