### PR TITLE
[snmp/traps] Update gosnmp to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b
 	github.com/gorilla/mux v1.8.0
-	github.com/gosnmp/gosnmp v1.34.1-0.20220306115220-ca8397b73095
+	github.com/gosnmp/gosnmp v1.37.1-0.20240115134726-db0c09337869
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/h2non/filetype v1.1.3
@@ -766,6 +766,3 @@ exclude (
 	github.com/knadh/koanf/maps v0.1.1
 	github.com/knadh/koanf/providers/confmap v0.1.0
 )
-
-// Temporarily use a fork of gosnmp for multiple-user traps support
-replace github.com/gosnmp/gosnmp => github.com/zoedt/gosnmp v0.0.0-20231218153121-83a06ce65d5a

--- a/go.sum
+++ b/go.sum
@@ -911,6 +911,9 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gosnmp/gosnmp v1.34.1-0.20220306115220-ca8397b73095/go.mod h1:QWTRprXN9haHFof3P96XTDYc46boCGAh5IXp0DniEx4=
+github.com/gosnmp/gosnmp v1.37.1-0.20240115134726-db0c09337869 h1:MphZl80DUq02iPzdDxVffuUD1V24UH6UtmEY6FX+/M4=
+github.com/gosnmp/gosnmp v1.37.1-0.20240115134726-db0c09337869/go.mod h1:GDH9vNqpsD7f2HvZhKs5dlqSEcAS6s6Qp099oZRCR+M=
 github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=

--- a/go.sum
+++ b/go.sum
@@ -911,7 +911,6 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gosnmp/gosnmp v1.34.1-0.20220306115220-ca8397b73095/go.mod h1:QWTRprXN9haHFof3P96XTDYc46boCGAh5IXp0DniEx4=
 github.com/gosnmp/gosnmp v1.37.1-0.20240115134726-db0c09337869 h1:MphZl80DUq02iPzdDxVffuUD1V24UH6UtmEY6FX+/M4=
 github.com/gosnmp/gosnmp v1.37.1-0.20240115134726-db0c09337869/go.mod h1:GDH9vNqpsD7f2HvZhKs5dlqSEcAS6s6Qp099oZRCR+M=
 github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
@@ -1748,8 +1747,6 @@ github.com/zclconf/go-cty v1.13.0 h1:It5dfKTTZHe9aeppbNOda3mN7Ag7sg6QkBNm6TkyFa0
 github.com/zclconf/go-cty v1.13.0/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zclconf/go-cty-yaml v1.0.2 h1:dNyg4QLTrv2IfJpm7Wtxi55ed5gLGOlPrZ6kMd51hY0=
 github.com/zclconf/go-cty-yaml v1.0.2/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
-github.com/zoedt/gosnmp v0.0.0-20231218153121-83a06ce65d5a h1:6VhH5g5QFIfRqEqFuvtSfkIAKv4cMz7nXxcnjf9sigM=
-github.com/zoedt/gosnmp v0.0.0-20231218153121-83a06ce65d5a/go.mod h1:GDH9vNqpsD7f2HvZhKs5dlqSEcAS6s6Qp099oZRCR+M=
 github.com/zorkian/go-datadog-api v2.30.0+incompatible h1:R4ryGocppDqZZbnNc5EDR8xGWF/z/MxzWnqTUijDQes=
 github.com/zorkian/go-datadog-api v2.30.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/pkg/snmp/traps/config/config.go
+++ b/pkg/snmp/traps/config/config.go
@@ -121,7 +121,7 @@ func (c *TrapsConfig) BuildSNMPParams(logger log.Component) (*gosnmp.GoSNMP, err
 	}
 
 	// Set up user security params table from config
-	usmTable := gosnmp.NewSnmpV3SecurityParametersTable()
+	usmTable := gosnmp.NewSnmpV3SecurityParametersTable(snmpLogger)
 	for _, user := range c.Users {
 		authProtocol, err := gosnmplib.GetAuthProtocol(user.AuthProtocol)
 		if err != nil {

--- a/pkg/snmp/traps/config/config_test.go
+++ b/pkg/snmp/traps/config/config_test.go
@@ -128,9 +128,10 @@ func TestFullConfig(t *testing.T) {
 	assert.Equal(t, gosnmp.UserSecurityModel, params.SecurityModel)
 	assert.Equal(t, &gosnmp.UsmSecurityParameters{AuthoritativeEngineID: expectedEngineID}, params.SecurityParameters)
 
-	table := gosnmp.NewSnmpV3SecurityParametersTable()
+	table := gosnmp.NewSnmpV3SecurityParametersTable(params.Logger)
 	for _, usmUser := range usmUsers {
-		table.Add(usmUser.UserName, usmUser)
+		err := table.Add(usmUser.UserName, usmUser)
+		assert.Nil(t, err)
 	}
 	var usmConfigTests = []struct {
 		name       string


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Update to the latest version of gosnmp supporting multiple users for traps.

### Motivation
[The PR for multiple user support got officially merged into gosnmp!](https://github.com/gosnmp/gosnmp/pull/457)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
This is just bumping the version to the official main branch of gosnmp, but let's verify that the traps v3 multiple users still works, here's a copypaste of how it is QA'd before:

#### Local changes: (thank you ken for the help lol)
datadog.yaml must include (as example):
```
network_devices:
  namespace: 'zoetraps'
  snmp_traps:
    enabled: true
    port: 1620
    bind_host: 0.0.0.0 # if you need to bind on localhost
    community_strings: # SNMP v1, v2
      - public
    users: # SNMP v3
      - user: "user"
        authKey: myAuthKey
        authProtocol: "SHA"
        privKey: myPrivKey
        privProtocol: "AES"
      - user: "user"
        authKey: myAuthKey
        authProtocol: "MD5"
        privKey: myPrivKey
        privProtocol: "DES"
      - user: "user2"
        authKey: myAuthKey2
        authProtocol: "SHA"
        privKey: myPrivKey2
        privProtocol: "AES"
```

example traps
```
snmptrap -v3 -l authPriv -u user -a SHA -A myAuthKey -x AES -X myPrivKey localhost:1620 '' 1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 123456
snmptrap -v3 -l authPriv -u user -a MD5 -A myAuthKey -x DES -X myPrivKey localhost:1620 '' 1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 123456
snmptrap -v3 -l authPriv -u user2 -a SHA -A myAuthKey2 -x AES -X myPrivKey2 localhost:1620 '' 1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 123456

```


1. Modify <agent-repo>/dev/dist/datadog.yaml (you may have to create it) to incl. traps
2. Run `invoke agent.build`
3. Run agent from agent repo `./bin/agent/agent run -c ./bin/agent/dist/datadog.yaml`
4. Create trapz (refer to example traps)
5. `./bin/agent/agent status -c ./bin/agent/dist/datadog.yaml` and see that the traps packet received count has increased

#### QA with ddev
https://datadoghq.atlassian.net/wiki/spaces/II/pages/2372436027/QA-Testing+Agent+SNMP+Traps+feature


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
