### PR TITLE
[CONTINT-3437] allow external event push on workloadmeta

### DIFF
--- a/comp/core/workloadmeta/component.go
+++ b/comp/core/workloadmeta/component.go
@@ -129,6 +129,10 @@ type Component interface {
 	// - EventTypeUnset: one for each entity that exists in the store but is not
 	// present in newEntities.
 	Reset(newEntities []Entity, source Source)
+
+	// Push allows external sources to push events to the metadata store.
+	// Only EventTypeSet and EventTypeUnset event types are allowed.
+	Push(source Source, events ...Event) error
 }
 
 // Module defines the fx options for this component.

--- a/comp/core/workloadmeta/store.go
+++ b/comp/core/workloadmeta/store.go
@@ -450,6 +450,35 @@ func (w *workloadmeta) Reset(newEntities []Entity, source Source) {
 	w.Notify(events)
 }
 
+func (w *workloadmeta) validatePushEvents(events []Event) error {
+	for _, event := range events {
+		if event.Type != EventTypeSet && event.Type != EventTypeUnset {
+			return fmt.Errorf("unsupported Event type: only EventTypeSet and EventTypeUnset types are allowed for push events")
+		}
+	}
+	return nil
+}
+
+// Push implements Store#Push
+func (w *workloadmeta) Push(source Source, events ...Event) error {
+	err := w.validatePushEvents(events)
+	if err != nil {
+		return err
+	}
+
+	collectorEvents := make([]CollectorEvent, len(events))
+	for index, event := range events {
+		collectorEvents[index] = CollectorEvent{
+			Type:   event.Type,
+			Source: source,
+			Entity: event.Entity,
+		}
+	}
+
+	w.Notify(collectorEvents)
+	return nil
+}
+
 func (w *workloadmeta) startCandidatesWithRetry(ctx context.Context) error {
 	expBackoff := backoff.NewExponentialBackOff()
 	expBackoff.InitialInterval = retryCollectorInitialInterval

--- a/comp/core/workloadmeta/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/workloadmeta_mock.go
@@ -280,6 +280,22 @@ func (w *workloadMetaMock) Notify(events []CollectorEvent) {
 	w.notifiedEvents = append(w.notifiedEvents, events...)
 }
 
+// Push pushes events from an external source into workloadmeta store
+// This mock implementation does not check the event types
+func (w *workloadMetaMock) Push(source Source, events ...Event) error {
+	collectorEvents := make([]CollectorEvent, len(events))
+	for index, event := range events {
+		collectorEvents[index] = CollectorEvent{
+			Type:   event.Type,
+			Source: source,
+			Entity: event.Entity,
+		}
+	}
+
+	w.Notify(collectorEvents)
+	return nil
+}
+
 // GetNotifiedEvents returns all registered notification events.
 func (w *workloadMetaMock) GetNotifiedEvents() []CollectorEvent {
 	w.mu.RLock()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds a new method `Push` to the workload metadata store component that allows external sources (components other than collectors) to inject events into the metadata store.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The `Notify` method of workloadmeta is supposed to be invoked only by collectors. In certain cases, an external component might need to update/set/unset an entity in workloadmeta, which is not possible with the existing implementation (because, by design, workloadmeta is populated strictly via collectors, which are static and internal to workloadmeta).

Existing use cases within the context of language detection feature:
- Allowing the language detection API handler to store in deployment entities languages that were detected by node agents, so that the language detection patcher can receive these languages by subscribing to workloadmeta store and perform the patching process.
- Being able to set/update TTL detected languages stored in deployment entities.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->


### Possible Drawbacks / Trade-offs
- Following the existing pattern in the implementation of workloadmeta, the `Push` method doesn't validate the entity `Kind` and the `Source` of the event. The caller of the method is expected to supply a valid `Kind` and create a new `Source` in workloadmeta to be used when calling the method.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Unit tests were implemented to verify the required functionaliyu.

- Manual tests: made a call to the `Push` method from the language detection component as follows:
```
c.store.Push("LanguageDetectionComponent", workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: &workloadmeta.KubernetesDeployment{
		EntityID: workloadmeta.EntityID{
			Kind: workloadmeta.KindKubernetesDeployment,
			ID:   "some-deployment",
		},
		Env:                    "some-env",
		Service:                "some-service",
		Version:                "some-version",
		ContainerLanguages:     map[string][]languagemodels.Language{"some-container": {languagemodels.Language{Name: "java"}}},
		InitContainerLanguages: map[string][]languagemodels.Language{"some-init-container": {languagemodels.Language{Name: "python"}}},
	}})
```

After that, the content of workload metadata store was checked by executing `agent workload-list -v`. 
The entity set by the `PushEvent` can be found in the output:

```
=== Entity kubernetes_deployment sources(merged):[LanguageDetectionComponent] id: some-deployment ===
----------- Entity ID -----------
Kind: kubernetes_deployment ID: some-deployment

----------- Unified Service Tagging -----------
Env : some-env
Service : some-service
Version : some-version
----------- Languages -----------
InitContainer some-init-container=>[python]
Container some-container=>[java]
===
```

- To QA this change, we need to test another change that leverages this new method of workloadmeta store. A link to an example PR will be added here in the future.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
