### PR TITLE
EVP Proxy: Support forwarding encoding headers

### DIFF
--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -118,7 +118,11 @@ var endpoints = []Endpoint{
 	},
 	{
 		Pattern: "/evp_proxy/v3/",
-		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(2) },
+		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(3) },
+	},
+	{
+		Pattern: "/evp_proxy/v4/",
+		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(4) },
 	},
 	{
 		Pattern: "/debugger/v1/input",

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -29,7 +29,7 @@ const (
 )
 
 // allowedHeaders contains the headers that the proxy will forward. All others will be cleared.
-var allowedHeaders = [...]string{"Content-Type", "User-Agent", "DD-CI-PROVIDER-NAME"}
+var allowedHeaders = [...]string{"Content-Type", "Accept-Encoding", "Content-Encoding", "User-Agent", "DD-CI-PROVIDER-NAME"}
 
 // evpProxyEndpointsFromConfig returns the configured list of endpoints to forward payloads to.
 func evpProxyEndpointsFromConfig(conf *config.AgentConfig) []config.Endpoint {

--- a/pkg/trace/api/evp_proxy_test.go
+++ b/pkg/trace/api/evp_proxy_test.go
@@ -372,6 +372,8 @@ func TestEVPProxyForwarder(t *testing.T) {
 		req := httptest.NewRequest("POST", "/mypath/mysubpath?arg=test", bytes.NewReader(randBodyBuf))
 		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
 		req.Header.Set("Content-Type", "text/json")
+		req.Header.Set("Accept-Encoding", "gzip")
+		req.Header.Set("Content-Encoding", "gzip")
 		req.Header.Set("Unexpected-Header", "To-Be-Discarded")
 		req.Header.Set("DD-CI-PROVIDER-NAME", "Allowed-Header")
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
@@ -382,6 +384,8 @@ func TestEVPProxyForwarder(t *testing.T) {
 		proxyreq := proxyreqs[0]
 		assert.Equal(t, "", proxyreq.Header.Get("User-Agent")) // User Agent is always set, even if empty
 		assert.Equal(t, "text/json", proxyreq.Header.Get("Content-Type"))
+		assert.Equal(t, "gzip", proxyreq.Header.Get("Accept-Encoding"))
+		assert.Equal(t, "gzip", proxyreq.Header.Get("Content-Encoding"))
 		assert.Equal(t, "Allowed-Header", proxyreq.Header.Get("DD-CI-PROVIDER-NAME"))
 		assert.NotContains(t, proxyreq.Header, "Unexpected-Header")
 		assert.NotContains(t, proxyreq.Header, "X-Datadog-EVP-Subdomain")


### PR DESCRIPTION
### What does this PR do?

Makes the EVP Proxy not drop the `Content-Encoding` and `Accept-Encoding` from the requests. It also adds a new version to the API, so clients know they can start specifying these headers. 

### Motivation

To support sending and receiving gziped data, we must allow the `Content-Encoding` and `Accept-Encoding` respectively.
