### PR TITLE
Add external_metrics_updated in DCA telemetry to check when we last received data from backend for it

### DIFF
--- a/pkg/clusteragent/externalmetrics/metrics_retriever.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever.go
@@ -72,7 +72,6 @@ func (mr *MetricsRetriever) Run(stopCh <-chan struct{}) {
 }
 
 func (mr *MetricsRetriever) retrieveMetricsValues() {
-
 	if mr.splitBatchBackoffOnErrors {
 		// We only update active DatadogMetrics
 		// We split metrics in two slices, those with errors and those without.
@@ -107,7 +106,6 @@ func (mr *MetricsRetriever) retrieveMetricsValues() {
 }
 
 func (mr *MetricsRetriever) retrieveMetricsValuesSlice(datadogMetrics []model.DatadogMetricInternal) {
-
 	if len(datadogMetrics) == 0 {
 		log.Debugf("No active DatadogMetric, nothing to refresh")
 		return

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -32,6 +32,9 @@ var (
 	metricsEval = telemetry.NewGaugeWithOpts("", "external_metrics_processed_value",
 		[]string{"metric", le.JoinLeaderLabel}, "value processed from querying Datadog",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
+	metricsUpdated = telemetry.NewCounterWithOpts("", "external_metrics_updated",
+		[]string{"metric", le.JoinLeaderLabel}, "increased by 1 everytime a metric value is updated",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 	metricsDelay = telemetry.NewGaugeWithOpts("", "external_metrics_delay_seconds",
 		[]string{"metric", le.JoinLeaderLabel}, "freshness of the metric evaluated from querying Datadog",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
@@ -103,10 +106,10 @@ func (p *Processor) queryDatadogExternal(ddQueries []string, timeWindow time.Dur
 	currentTimeUnix := time.Now().Unix()
 	seriesSlice, err := p.datadogClient.QueryMetrics(currentTime.Add(-timeWindow).Unix(), currentTimeUnix, query)
 	if err != nil {
-		ddRequests.Inc("error", le.JoinLeaderValue)
-
 		if isRateLimitError(err) {
 			ddRequests.Inc("rate_limit_error", le.JoinLeaderValue)
+		} else {
+			ddRequests.Inc("error", le.JoinLeaderValue)
 		}
 
 		return nil, fmt.Errorf("error while executing metric query %s: %w", query, err)
@@ -177,6 +180,7 @@ func (p *Processor) queryDatadogExternal(ddQueries []string, timeWindow time.Dur
 		// Prometheus submissions on the processed external metrics
 		metricTag := fmt.Sprintf("%s{%s}", *serie.Metric, *serie.Scope)
 		metricsEval.Set(processedPoint.Value, metricTag, le.JoinLeaderValue)
+		metricsUpdated.Inc(metricTag, le.JoinLeaderValue)
 		delay := currentTimeUnix - processedPoint.Timestamp
 		metricsDelay.Set(float64(delay), metricTag, le.JoinLeaderValue)
 	}


### PR DESCRIPTION
### What does this PR do?

Add a telemetry `external_metrics_updated` counting the number of updates to be able to know when the lag metric is updated.

### Motivation

Improved debugging

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy Agent and Cluster Agent with Cluster Agent integration. Verify that the `datadog.cluster_agent.external_metrics.updated` metric is emitted and increasing with each external metrics refresh (every 30s)

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
