### PR TITLE
USM: make gRPC clasification require prior HTTP2 classification

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -259,13 +259,10 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint_grpc(s
     // The GRPC classification program can be called without a prior
     // classification of HTTP2, which is a precondition.
     protocol_t app_layer_proto = get_protocol_from_stack(protocol_stack, LAYER_APPLICATION);
-    if (app_layer_proto != PROTOCOL_HTTP2) {
-        goto next_program;
+    if (app_layer_proto == PROTOCOL_HTTP2) {
+        classify_grpc(usm_ctx, protocol_stack, skb, &usm_ctx->skb_info);
     }
 
-    classify_grpc(usm_ctx, protocol_stack, skb, &usm_ctx->skb_info);
-
-next_program:
     classification_next_program(skb, usm_ctx);
 }
 

--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -256,9 +256,17 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint_grpc(s
         return;
     }
 
-     classify_grpc(usm_ctx, protocol_stack, skb, &usm_ctx->skb_info);
+    // The GRPC classification program can be called without a prior
+    // classification of HTTP2, which is a precondition.
+    protocol_t app_layer_proto = get_protocol_from_stack(protocol_stack, LAYER_APPLICATION);
+    if (app_layer_proto != PROTOCOL_HTTP2) {
+        goto next_program;
+    }
 
-     classification_next_program(skb, usm_ctx);
+    classify_grpc(usm_ctx, protocol_stack, skb, &usm_ctx->skb_info);
+
+next_program:
+    classification_next_program(skb, usm_ctx);
 }
 
 #endif

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1763,6 +1763,8 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 				extras:        map[string]interface{}{},
 			},
 			preTracerSetup: func(t *testing.T, ctx testContext) {
+				skipIfNotLinux(t, ctx)
+
 				server := NewTCPServerOnAddress(ctx.serverAddress, func(c net.Conn) {})
 				ctx.extras["server"] = server
 				require.NoError(t, server.Run())

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1753,8 +1753,8 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 			validation: validateProtocolConnection(&protocols.Stack{Application: protocols.HTTP}),
 		},
 		{
-			// This test checks than we are not classification a connection as
-			// carrying gRPC traffic without a prior classification as HTTP2.
+			// This test checks that we are not classifying a connection as
+			// gRPC traffic without a prior classification as HTTP2.
 			name: "GRPC without prior HTTP2 classification",
 			context: testContext{
 				serverPort:    http2Port,
@@ -1774,7 +1774,7 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 				// The gRPC classification is based on having only POST requests,
 				// and having "application/grpc" as a content-type.
 				var testHeaderFields = []hpack.HeaderField{
-					{Name: ":authority", Value: "http://127.0.0.0.1:" + http2Port},
+					{Name: ":authority", Value: "127.0.0.0.1:" + http2Port},
 					{Name: ":method", Value: "POST"},
 					{Name: ":path", Value: "/aaa"},
 					{Name: ":scheme", Value: "http"},
@@ -1799,6 +1799,7 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 
 				c, err := net.Dial("tcp", ctx.targetAddress)
 				require.NoError(t, err)
+				defer c.Close()
 				require.NoError(t, writeInput(c, buf.Bytes(), time.Second))
 			},
 			teardown:   nil,

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1797,9 +1797,6 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 					EndHeaders:    true,
 				}))
 
-				// Writing the data frame to the buffer using the Framer.
-				require.NoError(t, framer.WriteData(uint32(1), true, []byte{}), "could not write data frame")
-
 				c, err := net.Dial("tcp", ctx.targetAddress)
 				require.NoError(t, err)
 				require.NoError(t, writeInput(c, buf.Bytes(), time.Second))

--- a/pkg/network/tracer/tracer_classification_windows_test.go
+++ b/pkg/network/tracer/tracer_classification_windows_test.go
@@ -39,3 +39,7 @@ func testProtocolClassificationInner(t *testing.T, params protocolClassification
 	params.postTracerSetup(t, params.context)
 	params.validation(t, params.context, tr)
 }
+
+func writeInput(_ net.Conn, _ []byte, _ time.Duration) error {
+	return nil
+}

--- a/pkg/network/tracer/tracer_classification_windows_test.go
+++ b/pkg/network/tracer/tracer_classification_windows_test.go
@@ -8,7 +8,9 @@
 package tracer
 
 import (
+	"net"
 	"testing"
+	"time"
 )
 
 func TestProtocolClassification(t *testing.T) {

--- a/pkg/network/tracer/tracer_classification_windows_test.go
+++ b/pkg/network/tracer/tracer_classification_windows_test.go
@@ -40,8 +40,8 @@ func testProtocolClassificationInner(t *testing.T, params protocolClassification
 	params.validation(t, params.context, tr)
 }
 
-// This dummy implementation of writeInput is needed for the gRPC classification
-// raw payload test to build on Windows. We don't need an actual implementation
+// writeInput is a dummy implementation needed for the gRPC classification raw
+// payload test to build on Windows. We don't need an actual implementation
 // as the test will be skipped on Windows.
 func writeInput(net.Conn, []byte, time.Duration) error {
 	return nil

--- a/pkg/network/tracer/tracer_classification_windows_test.go
+++ b/pkg/network/tracer/tracer_classification_windows_test.go
@@ -40,6 +40,9 @@ func testProtocolClassificationInner(t *testing.T, params protocolClassification
 	params.validation(t, params.context, tr)
 }
 
-func writeInput(_ net.Conn, _ []byte, _ time.Duration) error {
+// This dummy implementation of writeInput is needed for the gRPC classification
+// raw payload test to build on Windows. We don't need an actual implementation
+// as the test will be skipped on Windows.
+func writeInput(net.Conn, []byte, time.Duration) error {
 	return nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds a check in the gRPC classification program for a prior HTTP2 classification. Currently, the mechanism for getting the next classification program, will try to run the gRPC classification even if the HTTP2 classification fail.

While it makes sense to try to classify the API layer in the general case, gRPC is built on top of HTTP2, so it must not try to classify a connection that is not known to be HTTP2, as it can yield to false positives.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix connections being classified as gRPC without HTTP2.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
