### PR TITLE
[USMON-711] USM: Ignore TLS traffic from decoding in socket-filter

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
+++ b/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
@@ -124,10 +124,9 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
     stack->flags |= FLAG_USM_ENABLED;
 
     protocol_t cur_fragment_protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
-    protocol_t encryption_layer = get_protocol_from_stack(stack, LAYER_ENCRYPTION);
     if (tcp_termination) {
         dispatcher_delete_protocol_stack(&skb_tup, stack);
-    } else if (encryption_layer == PROTOCOL_TLS) {
+    } else if (is_protocol_layer_known(stack, LAYER_ENCRYPTION)) {
         // If we have a TLS connection and we're not in the middle of a TCP termination, we can skip the packet.
         return;
     }

--- a/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
+++ b/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
@@ -123,11 +123,13 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
     // For more context refer to the comments in `delete_protocol_stack`
     stack->flags |= FLAG_USM_ENABLED;
 
-    // TODO: consider adding early return if `is_layer_known(stack, LAYER_ENCRYPTION)`
-
     protocol_t cur_fragment_protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
+    protocol_t encryption_layer = get_protocol_from_stack(stack, LAYER_ENCRYPTION);
     if (tcp_termination) {
         dispatcher_delete_protocol_stack(&skb_tup, stack);
+    } else if (encryption_layer == PROTOCOL_TLS) {
+        // If we have a TLS connection and we're not in the middle of a TCP termination, we can skip the packet.
+        return;
     }
 
     if (cur_fragment_protocol == PROTOCOL_UNKNOWN) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

If a connection was classified as TLS, then we're not processing it in our socket-filter callbacks.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

In the context of a socket filter we're not able to decode encrypted traffic.
Thus, we should abort early.
The only exception for this new rule is TCP termination, meaning, if we're identifying
a TCP termination, we should still process it in our probes. This is a fallback for missing
TLS termination and ensure we're cleaning resources.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
