### PR TITLE
[oracle] Fix execution plan payload (DBMON-3422)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/plan_queries.go
+++ b/pkg/collector/corechecks/oracle-dbm/plan_queries.go
@@ -9,6 +9,7 @@ package oracle
 
 // including sql_id for indexed access
 const planQuery12 = `SELECT /* DD */
+  child_number,
 	timestamp,
 	operation,
 	options,
@@ -46,9 +47,10 @@ const planQuery12 = `SELECT /* DD */
 FROM v$sql_plan_statistics_all s
 WHERE 
   sql_id = :1 AND plan_hash_value = :2 AND con_id = :3
-ORDER BY id, position`
+ORDER BY timestamp desc, child_number, id, position`
 
 const planQuery11 = `SELECT /* DD */
+  child_number,
 	timestamp,
 	operation,
 	options,
@@ -86,4 +88,4 @@ const planQuery11 = `SELECT /* DD */
 FROM v$sql_plan_statistics_all s
 WHERE 
   sql_id = :1 AND plan_hash_value = :2
-ORDER BY id, position`
+ORDER BY timestamp desc, child_number, id, position`

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -228,7 +228,7 @@ type PlanDefinition struct {
 	Depth            int64   `json:"depth"`
 	Position         int64   `json:"position"`
 	SearchColumns    int64   `json:"search_columns,omitempty"`
-	Cost             float64 `json:"cost,omitempty"`
+	Cost             float64 `json:"cost"`
 	Cardinality      float64 `json:"cardinality,omitempty"`
 	Bytes            float64 `json:"bytes,omitempty"`
 	PartitionStart   string  `json:"partition_start,omitempty"`

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -223,10 +223,10 @@ type PlanDefinition struct {
 	ObjectAlias string `json:"object_alias,omitempty"`
 	ObjectType  string `json:"object_type,omitempty"`
 	//nolint:revive // TODO(DBM) Fix revive linter
-	PlanStepId       int64   `json:"id,omitempty"`
-	ParentId         int64   `json:"parent_id,omitempty"`
-	Depth            int64   `json:"depth,omitempty"`
-	Position         int64   `json:"position,omitempty"`
+	PlanStepId       int64   `json:"id"`
+	ParentId         int64   `json:"parent_id"`
+	Depth            int64   `json:"depth"`
+	Position         int64   `json:"position"`
 	SearchColumns    int64   `json:"search_columns,omitempty"`
 	Cost             float64 `json:"cost,omitempty"`
 	Cardinality      float64 `json:"cardinality,omitempty"`
@@ -653,7 +653,19 @@ func (c *Check) StatementMetrics() (int, error) {
 
 					if err == nil {
 						if len(planStepsDB) > 0 {
-							for _, stepRow := range planStepsDB {
+							var firstChildNumber int64
+							for i, stepRow := range planStepsDB {
+								if !stepRow.ChildNumber.Valid {
+									log.Errorf("%s invalid child numner in execution plan", c.logPrompt)
+									break
+								}
+								if i == 0 {
+									firstChildNumber = stepRow.ChildNumber.Int64
+								} else {
+									if firstChildNumber != stepRow.ChildNumber.Int64 {
+										break
+									}
+								}
 								var stepPayload PlanDefinition
 								if stepRow.Operation.Valid {
 									stepPayload.Operation = stepRow.Operation.String


### PR DESCRIPTION
### What does this PR do?

1. Avoid duplicate entries if the execution plan has several child cursor.
2. Previously, zero values in `id`, `parent_id` and `cost` were omitted in the payload. Now we are emitting them.

### Motivation

1. We should send only the execution plan for the child cursors, that was last executed.
2. Since these are critical fields, it's better to distinguish between "zero" and "not sent" cases. 

### Additional Notes

Front end has been adjusted to handle both cases transparently, 

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Check the root node in the execution plan payload.

```
  {
    "cost": 1,
    "depth": 0,
    "parent_id": 0,
    "id": 0,
    "position": 1,
    "operation": "SELECT STATEMENT"
  },
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
