### PR TITLE
[config/setup/apm] Set default for apm_config.instrumentation.lib_version

### DIFF
--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -79,7 +79,7 @@ func setupAPM(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("apm_config.instrumentation.enabled", false, "DD_APM_INSTRUMENTATION_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.instrumentation.enabled_namespaces", []string{}, "DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES")
 	config.BindEnvAndSetDefault("apm_config.instrumentation.disabled_namespaces", []string{}, "DD_APM_INSTRUMENTATION_DISABLED_NAMESPACES")
-	config.BindEnv("apm_config.instrumentation.lib_versions", "DD_APM_INSTRUMENTATION_LIB_VERSIONS")
+	config.BindEnvAndSetDefault("apm_config.instrumentation.lib_versions", map[string]string{}, "DD_APM_INSTRUMENTATION_LIB_VERSIONS")
 
 	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")
 	config.BindEnv("apm_config.receiver_timeout", "DD_APM_RECEIVER_TIMEOUT")


### PR DESCRIPTION
### What does this PR do?

Sets a default value for the `apm_config.instrumentation.lib_version` config option.
This option is only used in the APM instrumentation feature here:
https://github.com/DataDog/datadog-agent/blob/abd337d9a9a1fbc7a5436d93bb756932ff9728de/pkg/clusteragent/admission/mutate/auto_instrumentation.go#L209 and when trying to fetch the value it fails with this error:
```
failed to get configuration value for key "apm_config.instrumentation.lib_versions": unable to cast <nil> of type <nil> to map[string]string
```

### Describe how to test/QA your changes

Enable APM instrumentation `DD_APM_INSTRUMENTATION_ENABLED=true` in the Cluster Agent and verify that it doesn't show the error above when deploying a pod that needs to be instrumented.
Also check that when `apm_config.instrumentation.lib_versions` is set, the version of the library injected is the one specified.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
