### PR TITLE
EVP Proxy: Include allowed headers in /info

### DIFF
--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -28,8 +28,8 @@ const (
 	validPathQueryStringSymbols = "/_-+@?&=.:\""
 )
 
-// allowedHeaders contains the headers that the proxy will forward. All others will be cleared.
-var allowedHeaders = [...]string{"Content-Type", "Accept-Encoding", "Content-Encoding", "User-Agent", "DD-CI-PROVIDER-NAME"}
+// EvpProxyAllowedHeaders contains the headers that the proxy will forward. All others will be cleared.
+var EvpProxyAllowedHeaders = []string{"Content-Type", "Accept-Encoding", "Content-Encoding", "User-Agent", "DD-CI-PROVIDER-NAME"}
 
 // evpProxyEndpointsFromConfig returns the configured list of endpoints to forward payloads to.
 func evpProxyEndpointsFromConfig(conf *config.AgentConfig) []config.Endpoint {
@@ -150,7 +150,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	req.Header.Set("Via", fmt.Sprintf("trace-agent %s", t.conf.AgentVersion))
 
 	// Copy allowed headers from the input request
-	for _, header := range allowedHeaders {
+	for _, header := range EvpProxyAllowedHeaders {
 		val := inputHeaders.Get(header)
 		if val != "" {
 			req.Header.Set(header, val)

--- a/pkg/trace/api/info.go
+++ b/pkg/trace/api/info.go
@@ -62,22 +62,24 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		oconf.Memcached = o.Memcached
 	}
 	txt, err := json.MarshalIndent(struct {
-		Version          string        `json:"version"`
-		GitCommit        string        `json:"git_commit"`
-		Endpoints        []string      `json:"endpoints"`
-		FeatureFlags     []string      `json:"feature_flags,omitempty"`
-		ClientDropP0s    bool          `json:"client_drop_p0s"`
-		SpanMetaStructs  bool          `json:"span_meta_structs"`
-		LongRunningSpans bool          `json:"long_running_spans"`
-		Config           reducedConfig `json:"config"`
+		Version                string        `json:"version"`
+		GitCommit              string        `json:"git_commit"`
+		Endpoints              []string      `json:"endpoints"`
+		FeatureFlags           []string      `json:"feature_flags,omitempty"`
+		ClientDropP0s          bool          `json:"client_drop_p0s"`
+		SpanMetaStructs        bool          `json:"span_meta_structs"`
+		LongRunningSpans       bool          `json:"long_running_spans"`
+		EvpProxyAllowedHeaders []string      `json:"evp_proxy_allowed_headers"`
+		Config                 reducedConfig `json:"config"`
 	}{
-		Version:          r.conf.AgentVersion,
-		GitCommit:        r.conf.GitCommit,
-		Endpoints:        all,
-		FeatureFlags:     r.conf.AllFeatures(),
-		ClientDropP0s:    true,
-		SpanMetaStructs:  true,
-		LongRunningSpans: true,
+		Version:                r.conf.AgentVersion,
+		GitCommit:              r.conf.GitCommit,
+		Endpoints:              all,
+		FeatureFlags:           r.conf.AllFeatures(),
+		ClientDropP0s:          true,
+		SpanMetaStructs:        true,
+		LongRunningSpans:       true,
+		EvpProxyAllowedHeaders: EvpProxyAllowedHeaders,
 		Config: reducedConfig{
 			DefaultEnv:             r.conf.DefaultEnv,
 			TargetTPS:              r.conf.TargetTPS,

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -298,13 +298,14 @@ func TestInfoHandler(t *testing.T) {
 	}
 
 	expectedKeys := map[string]interface{}{
-		"version":            nil,
-		"git_commit":         nil,
-		"endpoints":          nil,
-		"feature_flags":      nil,
-		"client_drop_p0s":    nil,
-		"span_meta_structs":  nil,
-		"long_running_spans": nil,
+		"version":                   nil,
+		"git_commit":                nil,
+		"endpoints":                 nil,
+		"feature_flags":             nil,
+		"client_drop_p0s":           nil,
+		"span_meta_structs":         nil,
+		"long_running_spans":        nil,
+		"evp_proxy_allowed_headers": nil,
 		"config": map[string]interface{}{
 			"default_env":               nil,
 			"target_tps":                nil,


### PR DESCRIPTION
### Motivation

Instead of adding a new API version every time we add a new allowed header like we did in https://github.com/DataDog/datadog-agent/pull/22090, this way clients can just query the available headers.

### QA plan

Running the trace agent and getting http://localhost:8126/info should return a new entry in the json with the headers "Content-Type", "Accept-Encoding", "Content-Encoding", "User-Agent" and "DD-CI-PROVIDER-NAME".


