### PR TITLE
guess conntrack netns ino independently of tracer netns ino v2

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/offset-guess.h
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.h
@@ -120,6 +120,8 @@ typedef struct {
     __u64 offset_netns;
     __u64 offset_ino;
 
+    __u64 err;
+
     __u32 saddr;
     __u32 netns;
 } conntrack_status_t;
@@ -152,5 +154,6 @@ static const __u8 SIZEOF_SK_BUFF_HEAD = sizeof((void*)0); // char*
 static const __u8 SIZEOF_CT_TUPLE_ORIGIN = sizeof_member(conntrack_status_t, saddr);
 static const __u8 SIZEOF_CT_TUPLE_REPLY = sizeof_member(conntrack_status_t, saddr);
 static const __u8 SIZEOF_CT_NET = sizeof((void*)0); // possible_net_t*
+static const __u8 SIZEOF_CT_NETNS_INO = sizeof_member(conntrack_status_t, netns);
 
 #endif //__OFFSET_GUESS_H

--- a/pkg/network/tracer/offsetguess/conntrack.go
+++ b/pkg/network/tracer/offsetguess/conntrack.go
@@ -48,28 +48,8 @@ type conntrackOffsetGuesser struct {
 
 //nolint:revive // TODO(NET) Fix revive linter
 func NewConntrackOffsetGuesser(cfg *config.Config) (OffsetGuesser, error) {
-	consts, err := TracerOffsets.Offsets(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	var offsetIno uint64
-	var tcpv6Enabled, udpv6Enabled uint64
-	for _, c := range consts {
-		switch c.Name {
-		case "offset_ino":
-			offsetIno = c.Value.(uint64)
-		case "tcpv6_enabled":
-			tcpv6Enabled = c.Value.(uint64)
-		case "udpv6_enabled":
-			udpv6Enabled = c.Value.(uint64)
-		}
-	}
-
-	if offsetIno == 0 {
-		return nil, fmt.Errorf("ino offset is 0")
-	}
-
+	tcpv6Enabled, udpv6Enabled := getIpv6Configuration(cfg)
+	tcpv6EnabledConst, udpv6EnabledConst := boolToUint64(tcpv6Enabled), boolToUint64(udpv6Enabled)
 	return &conntrackOffsetGuesser{
 		m: &manager.Manager{
 			Maps: []*manager.Map{
@@ -84,9 +64,9 @@ func NewConntrackOffsetGuesser(cfg *config.Config) (OffsetGuesser, error) {
 				// so explicitly disabled, and the manager won't load it
 				{ProbeIdentificationPair: idPair(probes.NetDevQueue)}},
 		},
-		status:       &ConntrackStatus{Offset_ino: offsetIno},
-		tcpv6Enabled: tcpv6Enabled,
-		udpv6Enabled: udpv6Enabled,
+		status:       &ConntrackStatus{},
+		tcpv6Enabled: tcpv6EnabledConst,
+		udpv6Enabled: udpv6EnabledConst,
 	}, nil
 }
 
@@ -102,7 +82,7 @@ func (c *conntrackOffsetGuesser) Close() {
 }
 
 //nolint:revive // TODO(NET) Fix revive linter
-func (c *conntrackOffsetGuesser) Probes(cfg *config.Config) (map[probes.ProbeFuncName]struct{}, error) {
+func (c *conntrackOffsetGuesser) Probes(*config.Config) (map[probes.ProbeFuncName]struct{}, error) {
 	p := map[probes.ProbeFuncName]struct{}{}
 	enableProbe(p, probes.ConntrackHashInsert)
 	return p, nil
@@ -186,12 +166,17 @@ func (c *conntrackOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expec
 
 		if c.status.Netns == expected.netns {
 			c.logAndAdvance(c.status.Offset_netns, GuessNotApplicable)
+			log.Debugf("Successfully guessed %v with offset of %d bytes", "ino", c.status.Offset_ino)
 			return c.setReadyState(mp)
 		}
+		c.status.Offset_ino++
 		log.Tracef("%v %d does not match expected %d, incrementing offset %d",
 			whatString[GuessWhat(c.status.What)], c.status.Netns, expected.netns, c.status.Offset_netns)
-		c.status.Offset_netns++
-		c.status.Offset_netns, _ = skipOverlaps(c.status.Offset_netns, c.nfConnRanges())
+		if c.status.Err != 0 || c.status.Offset_ino >= threshold {
+			c.status.Offset_ino = 0
+			c.status.Offset_netns++
+			c.status.Offset_netns, _ = skipOverlaps(c.status.Offset_netns, c.nfConnRanges())
+		}
 	default:
 		return fmt.Errorf("unexpected field to guess: %v", whatString[GuessWhat(c.status.What)])
 	}
@@ -282,6 +267,7 @@ func (c *conntrackOffsetGuesser) Guess(cfg *config.Config) ([]manager.ConstantEd
 
 	for _, ns := range nss {
 		var consts []manager.ConstantEditor
+
 		if consts, err = c.runOffsetGuessing(cfg, ns, mp); err == nil {
 			return consts, nil
 		}

--- a/pkg/network/tracer/offsetguess/offsetguess.go
+++ b/pkg/network/tracer/offsetguess/offsetguess.go
@@ -10,6 +10,7 @@ package offsetguess
 import (
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -20,10 +21,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var zero uint64
+var tcpv6Enabled, udpv6Enabled bool
 
 // These constants should be in sync with the equivalent definitions in the ebpf program.
 const (
@@ -37,6 +40,8 @@ const (
 
 	notApplicable = 99999 // An arbitrary large number to indicate that the value should be ignored
 )
+
+var ipv6Config sync.Once
 
 var stateString = map[State]string{
 	StateUninitialized: "uninitialized",
@@ -121,6 +126,30 @@ func idPair(name probes.ProbeFuncName) manager.ProbeIdentificationPair {
 
 func enableProbe(enabled map[probes.ProbeFuncName]struct{}, name probes.ProbeFuncName) {
 	enabled[name] = struct{}{}
+}
+
+func boolToUint64(in bool) uint64 {
+	if in {
+		return 1
+	}
+	return 0
+}
+
+func getIpv6Configuration(c *config.Config) (bool, bool) {
+	ipv6Config.Do(func() {
+		tcpv6Enabled = c.CollectTCPv6Conns
+		udpv6Enabled = c.CollectUDPv6Conns
+		if c.CollectUDPv6Conns {
+			kv, err := kernel.HostVersion()
+			if err != nil {
+				return
+			}
+			if kv >= kernel.VersionCode(5, 18, 0) {
+				udpv6Enabled = false
+			}
+		}
+	})
+	return tcpv6Enabled, udpv6Enabled
 }
 
 func setupOffsetGuesser(guesser OffsetGuesser, config *config.Config, buf bytecode.AssetReader) error {

--- a/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
+++ b/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
@@ -85,6 +85,7 @@ type ConntrackStatus struct {
 	Offset_status uint64
 	Offset_netns  uint64
 	Offset_ino    uint64
+	Err           uint64
 	Saddr         uint32
 	Netns         uint32
 }

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -734,8 +734,7 @@ func (t *tracerOffsetGuesser) Guess(cfg *config.Config) ([]manager.ConstantEdito
 		cProcName[i] = int8(ch)
 	}
 
-	t.guessUDPv6 = cfg.CollectUDPv6Conns
-	t.guessTCPv6 = cfg.CollectTCPv6Conns
+	t.guessTCPv6, t.guessUDPv6 = getIpv6Configuration(cfg)
 	t.status = &TracerStatus{
 		State:        uint64(StateChecking),
 		Proc:         Proc{Comm: cProcName},
@@ -828,6 +827,8 @@ func (t *tracerOffsetGuesser) getConstantEditors() []manager.ConstantEditor {
 		{Name: "offset_sk_buff_sock", Value: t.status.Offset_sk_buff_sock},
 		{Name: "offset_sk_buff_transport_header", Value: t.status.Offset_sk_buff_transport_header},
 		{Name: "offset_sk_buff_head", Value: t.status.Offset_sk_buff_head},
+		{Name: "tcpv6_enabled", Value: boolToUint64(t.guessTCPv6)},
+		{Name: "udpv6_enabled", Value: boolToUint64(t.guessUDPv6)},
 	}
 }
 
@@ -1100,65 +1101,9 @@ type tracerOffsets struct {
 	err     error
 }
 
-func boolConst(name string, value bool) manager.ConstantEditor {
-	c := manager.ConstantEditor{
-		Name:  name,
-		Value: uint64(1),
-	}
-	if !value {
-		c.Value = uint64(0)
-	}
-
-	return c
-}
-
 func (o *tracerOffsets) Offsets(cfg *config.Config) ([]manager.ConstantEditor, error) {
-	fromConfig := func(c *config.Config, offsets []manager.ConstantEditor) []manager.ConstantEditor {
-		//nolint:revive // TODO(NET) Fix revive linter
-		var foundTcp, foundUdp bool
-		for o := range offsets {
-			switch offsets[o].Name {
-			case "tcpv6_enabled":
-				offsets[o] = boolConst("tcpv6_enabled", c.CollectTCPv6Conns)
-				foundTcp = true
-			case "udpv6_enabled":
-				offsets[o] = boolConst("udpv6_enabled", c.CollectUDPv6Conns)
-				foundUdp = true
-			}
-			if foundTcp && foundUdp {
-				break
-			}
-		}
-		if !foundTcp {
-			offsets = append(offsets, boolConst("tcpv6_enabled", c.CollectTCPv6Conns))
-		}
-		if !foundUdp {
-			offsets = append(offsets, boolConst("udpv6_enabled", c.CollectUDPv6Conns))
-		}
-
-		return offsets
-	}
-
 	if o.err != nil {
 		return nil, o.err
-	}
-
-	if cfg.CollectUDPv6Conns {
-		kv, err := kernel.HostVersion()
-		if err != nil {
-			return nil, err
-		}
-
-		if kv >= kernel.VersionCode(5, 18, 0) {
-			_cfg := *cfg
-			_cfg.CollectUDPv6Conns = false
-			cfg = &_cfg
-		}
-	}
-
-	if len(o.offsets) > 0 {
-		// already run
-		return fromConfig(cfg, o.offsets), o.err
 	}
 
 	offsetBuf, err := netebpf.ReadOffsetBPFModule(cfg.BPFDir, cfg.BPFDebug)
@@ -1167,9 +1112,8 @@ func (o *tracerOffsets) Offsets(cfg *config.Config) ([]manager.ConstantEditor, e
 		return nil, o.err
 	}
 	defer offsetBuf.Close()
-
 	o.offsets, o.err = RunOffsetGuessing(cfg, offsetBuf, NewTracerOffsetGuesser)
-	return fromConfig(cfg, o.offsets), o.err
+	return o.offsets, o.err
 }
 
 func (o *tracerOffsets) Reset() {

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -1106,6 +1106,15 @@ func (o *tracerOffsets) Offsets(cfg *config.Config) ([]manager.ConstantEditor, e
 		return nil, o.err
 	}
 
+	_, udpv6Enabled := getIpv6Configuration(cfg)
+	_cfg := *cfg
+	_cfg.CollectUDPv6Conns = udpv6Enabled
+	cfg = &_cfg
+
+	if len(o.offsets) > 0 {
+		return o.offsets, o.err
+	}
+
 	offsetBuf, err := netebpf.ReadOffsetBPFModule(cfg.BPFDir, cfg.BPFDebug)
 	if err != nil {
 		o.err = fmt.Errorf("could not read offset bpf module: %s", err)


### PR DESCRIPTION
Reverts DataDog/datadog-agent#22097

fixes a small bug where the UDPv6 config for USM were not being set properly on newer kernels

https://datadoghq.atlassian.net/browse/NPM-3143