### PR TITLE
[CWS] Fix auto-suppression by removing security profile status

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -1202,10 +1202,6 @@ CSM Threats logs have the following JSON schema:
                     "type": "string",
                     "description": "Name of the security profile"
                 },
-                "status": {
-                    "type": "string",
-                    "description": "Status defines in which state the security profile was when the event was triggered"
-                },
                 "version": {
                     "type": "string",
                     "description": "Version of the profile in use"
@@ -1222,7 +1218,6 @@ CSM Threats logs have the following JSON schema:
             "type": "object",
             "required": [
                 "name",
-                "status",
                 "version",
                 "tags"
             ],
@@ -3192,10 +3187,6 @@ CSM Threats logs have the following JSON schema:
             "type": "string",
             "description": "Name of the security profile"
         },
-        "status": {
-            "type": "string",
-            "description": "Status defines in which state the security profile was when the event was triggered"
-        },
         "version": {
             "type": "string",
             "description": "Version of the profile in use"
@@ -3212,7 +3203,6 @@ CSM Threats logs have the following JSON schema:
     "type": "object",
     "required": [
         "name",
-        "status",
         "version",
         "tags"
     ],
@@ -3224,7 +3214,6 @@ CSM Threats logs have the following JSON schema:
 | Field | Description |
 | ----- | ----------- |
 | `name` | Name of the security profile |
-| `status` | Status defines in which state the security profile was when the event was triggered |
 | `version` | Version of the profile in use |
 | `tags` | List of tags associated to this profile |
 

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -1186,10 +1186,6 @@
           "type": "string",
           "description": "Name of the security profile"
         },
-        "status": {
-          "type": "string",
-          "description": "Status defines in which state the security profile was when the event was triggered"
-        },
         "version": {
           "type": "string",
           "description": "Version of the profile in use"
@@ -1206,7 +1202,6 @@
       "type": "object",
       "required": [
         "name",
-        "status",
         "version",
         "tags"
       ],

--- a/pkg/security/ebpf/c/include/constants/enums.h
+++ b/pkg/security/ebpf/c/include/constants/enums.h
@@ -186,10 +186,4 @@ enum selinux_event_kind_t {
     SELINUX_BOOL_COMMIT_EVENT_KIND,
 };
 
-enum security_profile_state {
-    SECURITY_PROFILE_UNKNOWN,
-    SECURITY_PROFILE_ALERT,
-    SECURITY_PROFILE_KILL,
-};
-
 #endif

--- a/pkg/security/ebpf/c/include/helpers/security_profile.h
+++ b/pkg/security/ebpf/c/include/helpers/security_profile.h
@@ -37,12 +37,6 @@ __attribute__((always_inline)) void evaluate_security_profile_syscalls(void *arg
 
     // reset syscall id in case we're also dumping this workload
     event->syscall_data.syscall_id = 0;
-
-    if (profile->state == SECURITY_PROFILE_KILL) {
-        if (is_send_signal_available()) {
-            bpf_send_signal(9); // SIGKILL
-        }
-    }
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/structs/security_profile.h
+++ b/pkg/security/ebpf/c/include/structs/security_profile.h
@@ -5,7 +5,6 @@
 
 struct security_profile_t {
     u64 cookie;
-    u32 state;
 };
 
 struct security_profile_syscalls_t {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -410,9 +410,7 @@ func (p *EBPFProbe) DispatchEvent(event *model.Event) {
 
 	// handle anomaly detections
 	if event.IsAnomalyDetectionEvent() {
-		if event.IsKernelSpaceAnomalyDetectionEvent() {
-			p.profileManagers.securityProfileManager.FillProfileContextFromContainerID(event.FieldHandlers.ResolveContainerID(event, event.ContainerContext), &event.SecurityProfileContext)
-		}
+		p.profileManagers.securityProfileManager.FillProfileContextFromContainerID(event.FieldHandlers.ResolveContainerID(event, event.ContainerContext), &event.SecurityProfileContext)
 		if p.config.RuntimeSecurity.AnomalyDetectionEnabled {
 			p.sendAnomalyDetection(event)
 		}

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -389,7 +389,6 @@ func (e *RuleEngine) RuleMatch(rule *rules.Rule, event eval.Event) bool {
 
 	ev.Suppressed = false
 	if e.config.SecurityProfileAutoSuppressionEnabled &&
-		ev.SecurityProfileContext.Status.IsEnabled(model.AutoSuppression) &&
 		ev.IsInProfile() {
 		if val, ok := rule.Definition.GetTag("allow_autosuppression"); ok {
 			if b, err := strconv.ParseBool(val); err == nil && b {

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -85,49 +85,9 @@ type ContainerContext struct {
 	Resolved  bool     `field:"-"`
 }
 
-// Status defines the possible status of a profile as a bitmask
-type Status uint32
-
-const (
-	// AnomalyDetection will trigger alerts each time an event is not part of the profile
-	AnomalyDetection Status = 1 << iota
-	// AutoSuppression will suppress any signal to events present on the profile
-	AutoSuppression
-	// WorkloadHardening will kill the process that triggered anomaly detection
-	WorkloadHardening
-)
-
-// IsEnabled returns true if enabled
-func (s Status) IsEnabled(option Status) bool {
-	return (s & option) != 0
-}
-
-func (s Status) String() string {
-	var options []string
-	if s.IsEnabled(AnomalyDetection) {
-		options = append(options, "anomaly_detection")
-	}
-	if s.IsEnabled(AutoSuppression) {
-		options = append(options, "auto_suppression")
-	}
-	if s.IsEnabled(WorkloadHardening) {
-		options = append(options, "workload_hardening")
-	}
-
-	var res string
-	for _, option := range options {
-		if len(res) > 0 {
-			res += ","
-		}
-		res += option
-	}
-	return res
-}
-
 // SecurityProfileContext holds the security context of the profile
 type SecurityProfileContext struct {
 	Name                       string      `field:"name"`                          // SECLDoc[name] Definition:`Name of the security profile`
-	Status                     Status      `field:"status"`                        // SECLDoc[status] Definition:`Status of the security profile`
 	Version                    string      `field:"version"`                       // SECLDoc[version] Definition:`Version of the security profile`
 	Tags                       []string    `field:"tags"`                          // SECLDoc[tags] Definition:`Tags of the security profile`
 	AnomalyDetectionEventTypes []EventType `field:"anomaly_detection_event_types"` // SECLDoc[anomaly_detection_event_types] Definition:`Event types enabled for anomaly detection`
@@ -262,10 +222,6 @@ func (e *Event) IsKernelSpaceAnomalyDetectionEvent() bool {
 
 // IsAnomalyDetectionEvent returns true if the current event is an anomaly detection event (kernel or user space)
 func (e *Event) IsAnomalyDetectionEvent() bool {
-	if !e.SecurityProfileContext.Status.IsEnabled(AnomalyDetection) {
-		return false
-	}
-
 	// first, check if the current event is a kernel generated anomaly detection event
 	if e.IsKernelSpaceAnomalyDetectionEvent() {
 		return true

--- a/pkg/security/security_profile/dump/activity_dump_profile_proto_enc_v1.go
+++ b/pkg/security/security_profile/dump/activity_dump_profile_proto_enc_v1.go
@@ -11,7 +11,6 @@ package dump
 import (
 	proto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
 
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	security_profile "github.com/DataDog/datadog-agent/pkg/security/security_profile"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
 	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
@@ -24,7 +23,6 @@ func ActivityDumpToSecurityProfileProto(input *ActivityDump) *proto.SecurityProf
 	}
 
 	output := proto.SecurityProfile{
-		Status:   uint32(model.AnomalyDetection),
 		Version:  security_profile.LocalProfileVersion,
 		Metadata: mtdt.ToProto(&input.Metadata),
 		Syscalls: input.ActivityTree.ComputeSyscallsList(),

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -176,13 +176,7 @@ func NewSecurityProfileManager(config *config.Config, statsdClient statsd.Client
 
 	// instantiate directory provider
 	if len(config.RuntimeSecurity.SecurityProfileDir) != 0 {
-		// override the status if autosuppression is enabled
-		var status model.Status
-		if config.RuntimeSecurity.SecurityProfileAutoSuppressionEnabled {
-			status = model.AnomalyDetection | model.AutoSuppression
-		}
-
-		dirProvider, err := NewDirectoryProvider(config.RuntimeSecurity.SecurityProfileDir, config.RuntimeSecurity.SecurityProfileWatchDir, status)
+		dirProvider, err := NewDirectoryProvider(config.RuntimeSecurity.SecurityProfileDir, config.RuntimeSecurity.SecurityProfileWatchDir)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't instantiate a new security profile directory provider: %w", err)
 		}
@@ -381,7 +375,6 @@ func (m *SecurityProfileManager) FillProfileContextFromContainerID(id string, ct
 				ctx.Name = profile.Metadata.Name
 				ctx.Version = profile.Version
 				ctx.Tags = profile.Tags
-				ctx.Status = profile.Status
 			}
 			instance.Unlock()
 		}
@@ -401,7 +394,6 @@ func FillProfileContextFromProfile(ctx *model.SecurityProfileContext, profile *S
 
 	ctx.Version = profile.Version
 	ctx.Tags = profile.Tags
-	ctx.Status = profile.Status
 	ctx.AnomalyDetectionEventTypes = profile.anomalyDetectionEvents
 }
 
@@ -539,31 +531,21 @@ func (m *SecurityProfileManager) SendStats() error {
 	m.pendingCacheLock.Lock()
 	defer m.pendingCacheLock.Unlock()
 
-	profileStats := make(map[model.Status]map[bool]float64)
+	profilesLoadedInKernel := 0
 	for _, profile := range m.profiles {
 		if profile.loadedInKernel { // make sure the profile is loaded
 			if err := profile.SendStats(m.statsdClient); err != nil {
 				return fmt.Errorf("couldn't send metrics for [%s]: %w", profile.selector.String(), err)
 			}
+			profilesLoadedInKernel++
 		}
-		if profileStats[profile.Status] == nil {
-			profileStats[profile.Status] = make(map[bool]float64)
-		}
-		profileStats[profile.Status][profile.loadedInKernel]++
 	}
 
-	for status, counts := range profileStats {
-		for inKernel, count := range counts {
-			tags := []string{
-				fmt.Sprintf("in_kernel:%v", inKernel),
-				fmt.Sprintf("anomaly_detection:%v", status.IsEnabled(model.AnomalyDetection)),
-				fmt.Sprintf("auto_suppression:%v", status.IsEnabled(model.AutoSuppression)),
-				fmt.Sprintf("workload_hardening:%v", status.IsEnabled(model.WorkloadHardening)),
-			}
-			if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileProfiles, count, tags, 1.0); err != nil {
-				return fmt.Errorf("couldn't send MetricSecurityProfileProfiles: %w", err)
-			}
-		}
+	tags := []string{
+		fmt.Sprintf("in_kernel:%v", profilesLoadedInKernel),
+	}
+	if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileProfiles, float64(len(m.profiles)), tags, 1.0); err != nil {
+		return fmt.Errorf("couldn't send MetricSecurityProfileProfiles: %w", err)
 	}
 
 	if val := float64(m.pendingCache.Len()); val > 0 {
@@ -615,7 +597,7 @@ func (m *SecurityProfileManager) loadProfile(profile *SecurityProfile) error {
 	}
 
 	// TODO: load generated programs
-	seclog.Debugf("security profile %s (version:%s status:%s) loaded in kernel space", profile.Metadata.Name, profile.Version, profile.Status.String())
+	seclog.Debugf("security profile %s (version:%s) loaded in kernel space", profile.Metadata.Name, profile.Version)
 	return nil
 }
 
@@ -629,12 +611,12 @@ func (m *SecurityProfileManager) unloadProfile(profile *SecurityProfile) {
 	}
 
 	// TODO: delete all kernel space programs
-	seclog.Debugf("security profile %s (version:%s status:%s) unloaded from kernel space", profile.Metadata.Name, profile.Version, profile.Status.String())
+	seclog.Debugf("security profile %s (version:%s) unloaded from kernel space", profile.Metadata.Name, profile.Version)
 }
 
 // linkProfile (thread unsafe) updates the kernel space mapping between a workload and its profile
 func (m *SecurityProfileManager) linkProfile(profile *SecurityProfile, workload *cgroupModel.CacheEntry) {
-	if err := m.securityProfileMap.Put([]byte(workload.ID), profile.generateKernelSecurityProfileDefinition()); err != nil {
+	if err := m.securityProfileMap.Put([]byte(workload.ID), profile.profileCookie); err != nil {
 		seclog.Errorf("couldn't link workload %s (selector: %s) with profile %s (check map size limit ?): %v", workload.ID, workload.WorkloadSelector.String(), profile.Metadata.Name, err)
 		return
 	}
@@ -679,7 +661,7 @@ func (m *SecurityProfileManager) LookupEventInProfiles(event *model.Event) {
 
 	// lookup profile
 	profile := m.GetProfile(selector)
-	if profile == nil || profile.Status == 0 {
+	if profile == nil || profile.ActivityTree == nil {
 		m.incrementEventFilteringStat(event.GetEventType(), NoProfile, NA)
 		return
 	}
@@ -802,7 +784,7 @@ func (m *SecurityProfileManager) SaveSecurityProfile(params *api.SecurityProfile
 	}
 
 	p := m.GetProfile(selector)
-	if p == nil || p.Status == 0 || p.ActivityTree == nil {
+	if p == nil || p.ActivityTree == nil {
 		return &api.SecurityProfileSaveMessage{
 			Error: "security profile not found",
 		}, nil

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -50,9 +50,6 @@ type SecurityProfile struct {
 	// Instances is the list of workload instances to witch the profile should apply
 	Instances []*cgroupModel.CacheEntry
 
-	// Status is the status of the profile
-	Status model.Status
-
 	// Version is the version of a Security Profile
 	Version string
 
@@ -106,13 +103,6 @@ func (p *SecurityProfile) generateSyscallsFilters() [64]byte {
 			output[syscall/8] |= 1 << (syscall % 8)
 		}
 	}
-	return output
-}
-
-func (p *SecurityProfile) generateKernelSecurityProfileDefinition() [16]byte {
-	var output [16]byte
-	model.ByteOrder.PutUint64(output[0:8], p.profileCookie)
-	model.ByteOrder.PutUint32(output[8:12], uint32(p.Status))
 	return output
 }
 
@@ -177,7 +167,6 @@ func (p *SecurityProfile) ToSecurityProfileMessage(timeResolver *timeResolver.Re
 			Tag:  p.selector.Tag,
 		},
 		ProfileCookie: p.profileCookie,
-		Status:        p.Status.String(),
 		Version:       p.Version,
 		Metadata: &api.MetadataMessage{
 			Name: p.Metadata.Name,

--- a/pkg/security/security_profile/profile/profile_proto_dec_v1.go
+++ b/pkg/security/security_profile/profile/profile_proto_dec_v1.go
@@ -11,7 +11,6 @@ package profile
 import (
 	proto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
 
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
 	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 )
@@ -22,7 +21,6 @@ func ProtoToSecurityProfile(output *SecurityProfile, pathsReducer *activity_tree
 		return
 	}
 
-	output.Status = model.Status(input.Status)
 	output.Version = input.Version
 	output.Metadata = mtdt.ProtoMetadataToMetadata(input.Metadata)
 

--- a/pkg/security/security_profile/profile/profile_proto_enc_v1.go
+++ b/pkg/security/security_profile/profile/profile_proto_enc_v1.go
@@ -22,7 +22,6 @@ func SecurityProfileToProto(input *SecurityProfile) *proto.SecurityProfile {
 	}
 
 	output := proto.SecurityProfile{
-		Status:   uint32(input.Status),
 		Version:  input.Version,
 		Metadata: mtdt.ToProto(&input.Metadata),
 		Syscalls: input.Syscalls,

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -447,8 +447,6 @@ type MountEventSerializer struct {
 type SecurityProfileContextSerializer struct {
 	// Name of the security profile
 	Name string `json:"name"`
-	// Status defines in which state the security profile was when the event was triggered
-	Status string `json:"status"`
 	// Version of the profile in use
 	Version string `json:"version"`
 	// List of tags associated to this profile
@@ -921,7 +919,6 @@ func newSecurityProfileContextSerializer(e *model.SecurityProfileContext) *Secur
 	return &SecurityProfileContextSerializer{
 		Name:    e.Name,
 		Version: e.Version,
-		Status:  e.Status.String(),
 		Tags:    tags,
 	}
 }

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -3381,8 +3381,6 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(
 		switch key {
 		case "name":
 			out.Name = string(in.String())
-		case "status":
-			out.Status = string(in.String())
 		case "version":
 			out.Version = string(in.String())
 		case "tags":
@@ -3426,11 +3424,6 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(
 		const prefix string = ",\"name\":"
 		out.RawString(prefix[1:])
 		out.String(string(in.Name))
-	}
-	{
-		const prefix string = ",\"status\":"
-		out.RawString(prefix)
-		out.String(string(in.Status))
 	}
 	{
 		const prefix string = ",\"version\":"

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -157,6 +157,7 @@ runtime_security_config:
     dir: {{ .SecurityProfileDir }}
     watch_dir: {{ .SecurityProfileWatchDir }}
     anomaly_detection:
+      enabled: true
       default_minimum_stable_period: {{.AnomalyDetectionDefaultMinimumStablePeriod}}
       minimum_stable_period:
         exec: {{.AnomalyDetectionMinimumStablePeriodExec}}
@@ -2518,31 +2519,4 @@ func (tm *testModule) GetADSelector(dumpID *activityDumpIdentifier) (*cgroupMode
 
 	selector, err := cgroupModel.NewWorkloadSelector(utils.GetTagValue("image_name", ad.Tags), utils.GetTagValue("image_tag", ad.Tags))
 	return &selector, err
-}
-
-func (tm *testModule) SetProfileStatus(selector *cgroupModel.WorkloadSelector, newStatus model.Status) error {
-	p, ok := tm.probe.PlatformProbe.(*sprobe.EBPFProbe)
-	if !ok {
-		return errors.New("not supported")
-	}
-
-	managers := p.GetProfileManagers()
-	if managers == nil {
-		return errors.New("no manager")
-	}
-
-	spm := managers.GetSecurityProfileManager()
-	if spm == nil {
-		return errors.New("No security profile manager")
-	}
-
-	profile := spm.GetProfile(*selector)
-	if profile == nil || profile.Status == 0 {
-		return errors.New("No profile found for given selector")
-	}
-
-	profile.Lock()
-	profile.Status = newStatus
-	profile.Unlock()
-	return nil
 }


### PR DESCRIPTION
### What does this PR do?

This is a backport of [the PR](https://github.com/DataDog/datadog-agent/pull/22021) fixing security profile auto-suppression feature, by removing the profile side configuration.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
