### PR TITLE
[oracle] Replace instant_client with oracle_client in config

### DIFF
--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -43,7 +43,7 @@ instances:
   ## @param tns_alias - string - optional
   ## The alias for the database connect string (stored in tnsnames.ora or in LDAP) to a CDB.
   ## It's an alternative to specifying 'server' and 'service_name'. 'tns_alias' requires
-  ## instant client installation.
+  ## an Oracle software installation.
   # 
   # tns_alias: <TNS_ALIAS>
 
@@ -65,13 +65,15 @@ instances:
   #
   # wallet: <WALLET_DIR>>
 
-  ## @param instant_client - boolean - optional
-  ## Force using instant_client even when 'tns_alias' isn't used. This might be necessary
+  ## @param oracle_client - boolean - optional
+  ## Force using an external Oracle client even when `tns_alias` isn't set. This might be necessary
   ## for using some advanced Oracle SQLNet features which aren't supported by the 
-  ## Oracle driver for Go. If you specify 'tns_admin' the agent will automatically try
-  ## to use instant client.
+  ## Oracle driver for Go. If you specify 'tns_admin', the agent will automatically try
+  ## to use an external client. For Linux, if you are using instant client, set
+  ## the environment variable `LD_LIBRARY_PATH` for the Agent process. If you are using
+  ## an Oracle home, additionally set `ORACLE_HOME`.
   #
-  # instant_client: false
+  # oracle_client: false
 
   ## @param username - string - required
   ## Username for the Datadog-Oracle server check user. The user has to exist in CDB.

--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -65,13 +65,22 @@ instances:
   #
   # wallet: <WALLET_DIR>>
 
+  ## @param instant_client - boolean - optional
+  ## DEPRECATED, use oracle_client instead
+  ## Force using instant_client even when 'tns_alias' isn't used. This might be necessary
+  ## for using some advanced Oracle SQLNet features which aren't supported by the 
+  ## Oracle driver for Go. If you specify 'tns_admin' the agent will automatically try
+  ## to use instant client.
+  #
+  # instant_client: false
+
   ## @param oracle_client - boolean - optional
   ## Force using an external Oracle client even when `tns_alias` isn't set. This might be necessary
   ## for using some advanced Oracle SQLNet features which aren't supported by the 
   ## Oracle driver for Go. If you specify 'tns_admin', the agent will automatically try
   ## to use an external client. For Linux, if you are using instant client, set
   ## the environment variable `LD_LIBRARY_PATH` for the Agent process. If you are using
-  ## an Oracle home, additionally set `ORACLE_HOME`.
+  ## a client or server Oracle home, additionally set `ORACLE_HOME`.
   #
   # oracle_client: false
 

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -128,6 +128,7 @@ type InstanceConfig struct {
 	LogUnobfuscatedQueries             bool                   `yaml:"log_unobfuscated_queries"`
 	ObfuscatorOptions                  obfuscate.SQLConfig    `yaml:"obfuscator_options"`
 	InstantClient                      bool                   `yaml:"instant_client"`
+	OracleClient                       bool                   `yaml:"oracle_client"`
 	ReportedHostname                   string                 `yaml:"reported_hostname"`
 	QuerySamples                       QuerySamplesConfig     `yaml:"query_samples"`
 	QueryMetrics                       QueryMetricsConfig     `yaml:"query_metrics"`
@@ -232,6 +233,15 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		} else {
 			instance.Port = 1521
 		}
+	}
+
+	/*
+	 * `instant_client` is deprecated but still supported to avoid a breaking change
+	 * `oracle_client` is a more appropriate naming because besides Instant Client
+	 * the Agent can be used with an Oracle software home.
+	 */
+	if instance.InstantClient {
+		instance.OracleClient = true
 	}
 
 	c := &CheckConfig{

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -242,6 +242,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	 */
 	if instance.InstantClient {
 		instance.OracleClient = true
+		log.Warn("The config parameter instance_client is deprecated and will be removed in future versions. Please use oracle_client instead.")
 	}
 
 	c := &CheckConfig{

--- a/pkg/collector/corechecks/oracle-dbm/connection_handling.go
+++ b/pkg/collector/corechecks/oracle-dbm/connection_handling.go
@@ -36,7 +36,7 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 		oracleDriver = "godror"
 	} else {
 		//godror ezconnect string
-		if c.config.InstanceConfig.InstantClient {
+		if c.config.InstanceConfig.OracleClient {
 			oracleDriver = "godror"
 			protocolString := ""
 			walletString := ""

--- a/pkg/collector/corechecks/oracle-dbm/oracle_dictionary_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_dictionary_test.go
@@ -26,7 +26,7 @@ func TestGetFullSqlText(t *testing.T) {
 		var driver string
 		if tnsAlias == "" {
 			driver = common.GoOra
-			chk.config.InstanceConfig.InstantClient = false
+			chk.config.InstanceConfig.OracleClient = false
 		} else {
 			driver = common.Godror
 		}

--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -105,7 +105,7 @@ func getTemporaryLobs(db *sqlx.DB) (int, error) {
 
 func TestChkRun(t *testing.T) {
 	chk.dbmEnabled = true
-	chk.config.InstanceConfig.InstantClient = false
+	chk.config.InstanceConfig.OracleClient = false
 
 	// This is to ensure that query samples return rows
 	chk.config.QuerySamples.IncludeAllSessions = true
@@ -121,7 +121,7 @@ func TestChkRun(t *testing.T) {
 		var driver string
 		if tnsAlias == "" {
 			driver = common.GoOra
-			chk.config.InstanceConfig.InstantClient = false
+			chk.config.InstanceConfig.OracleClient = false
 		} else {
 			driver = common.Godror
 		}

--- a/pkg/collector/corechecks/oracle-dbm/statements_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements_test.go
@@ -98,7 +98,7 @@ func TestUInt64Binding(t *testing.T) {
 	chk.dbmEnabled = true
 	chk.config.QueryMetrics.Enabled = true
 
-	chk.config.InstanceConfig.InstantClient = false
+	chk.config.InstanceConfig.OracleClient = false
 
 	type RowsStruct struct {
 		N                      int    `db:"N"`
@@ -114,7 +114,7 @@ func TestUInt64Binding(t *testing.T) {
 		var driver string
 		if tnsAlias == "" {
 			driver = common.GoOra
-			chk.config.InstanceConfig.InstantClient = false
+			chk.config.InstanceConfig.OracleClient = false
 		} else {
 			driver = common.Godror
 		}

--- a/releasenotes/notes/oracle-client-7645e2dac281fec0.yaml
+++ b/releasenotes/notes/oracle-client-7645e2dac281fec0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    [oracle] Deprecate the configuration parameter ``instant_client``. Replacing it with ``oracle_client``.


### PR DESCRIPTION
### What does this PR do?

Deprecating the parameter `instant_client` and replacing it with `oracle_client`. The parameter `instant_client` is still supported in the code to avoid a breaking change.

### Motivation

`oracle_client` is a more appropriate naming because besides Instant Client the Agent can be used with an Oracle software home.

### Describe how to test/QA your changes

Check if both `instant_client` and `oracle_client` cause the `godror` driver usage.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
