### PR TITLE
Fix missing lock in metadata

### DIFF
--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -256,6 +256,9 @@ func (ia *inventoryagent) Set(name string, value interface{}) {
 }
 
 func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
+	ia.m.Lock()
+	defer ia.m.Unlock()
+
 	// Create a static copy of agentMetadata for the payload
 	data := make(agentMetadata)
 	for k, v := range ia.data {
@@ -293,6 +296,9 @@ func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
 
 // Get returns a copy of the agent metadata. Useful to be incorporated in the status page.
 func (ia *inventoryagent) Get() map[string]interface{} {
+	ia.m.Lock()
+	defer ia.m.Unlock()
+
 	data := map[string]interface{}{}
 	for k, v := range ia.data {
 		data[k] = v

--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
@@ -175,6 +175,9 @@ func (ic *inventorychecksImpl) GetInstanceMetadata(instanceID string) map[string
 }
 
 func (ic *inventorychecksImpl) getPayload() marshaler.JSONMarshaler {
+	ic.m.Lock()
+	defer ic.m.Unlock()
+
 	payloadData := make(checksMetadata)
 	invChecksEnabled := ic.conf.GetBool("inventories_checks_configuration_enabled")
 


### PR DESCRIPTION
### What does this PR do?

We were missing a lock when generating metadata payload. Until now all metadata were set at startup before generating the first payload, so we didn't encounter any race condition. But since the migration we could set information at any time.

### Describe how to test/QA your changes

Test that the metadata payload are still sent to the backend and shipped in the flare.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
