### PR TITLE
Simplify configuration layer logic

### DIFF
--- a/comp/metadata/inventoryagent/inventoryagentimpl/configuration.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/configuration.go
@@ -31,7 +31,7 @@ func marshalAndScrub(conf map[string]interface{}) (string, error) {
 	return string(scrubbed), nil
 }
 
-func (ia *inventoryagent) getProvidedAgentConfiguration() (string, error) {
+func (ia *inventoryagent) getProvidedConfiguration() (string, error) {
 	if !ia.conf.GetBool("inventories_configuration_enabled") {
 		return "", fmt.Errorf("inventories_configuration_enabled is disabled")
 	}
@@ -39,7 +39,7 @@ func (ia *inventoryagent) getProvidedAgentConfiguration() (string, error) {
 	return marshalAndScrub(ia.conf.AllSettingsWithoutDefault())
 }
 
-func (ia *inventoryagent) getFullAgentConfiguration() (string, error) {
+func (ia *inventoryagent) getFullConfiguration() (string, error) {
 	if !ia.conf.GetBool("inventories_configuration_enabled") {
 		return "", fmt.Errorf("inventories_configuration_enabled is disabled")
 	}
@@ -47,7 +47,7 @@ func (ia *inventoryagent) getFullAgentConfiguration() (string, error) {
 	return marshalAndScrub(ia.conf.AllSettings())
 }
 
-func (ia *inventoryagent) getAgentFileConfiguration() (string, error) {
+func (ia *inventoryagent) getFileConfiguration() (string, error) {
 	if !ia.conf.GetBool("inventories_configuration_enabled") {
 		return "", fmt.Errorf("inventories_configuration_enabled is disabled")
 	}
@@ -55,7 +55,7 @@ func (ia *inventoryagent) getAgentFileConfiguration() (string, error) {
 	return marshalAndScrub(ia.conf.AllSourceSettingsWithoutDefault(model.SourceFile))
 }
 
-func (ia *inventoryagent) getAgentEnvVarConfiguration() (string, error) {
+func (ia *inventoryagent) getEnvVarConfiguration() (string, error) {
 	if !ia.conf.GetBool("inventories_configuration_enabled") {
 		return "", fmt.Errorf("inventories_configuration_enabled is disabled")
 	}
@@ -63,7 +63,7 @@ func (ia *inventoryagent) getAgentEnvVarConfiguration() (string, error) {
 	return marshalAndScrub(ia.conf.AllSourceSettingsWithoutDefault(model.SourceEnvVar))
 }
 
-func (ia *inventoryagent) getAgentRuntimeConfiguration() (string, error) {
+func (ia *inventoryagent) getRuntimeConfiguration() (string, error) {
 	if !ia.conf.GetBool("inventories_configuration_enabled") {
 		return "", fmt.Errorf("inventories_configuration_enabled is disabled")
 	}
@@ -71,7 +71,7 @@ func (ia *inventoryagent) getAgentRuntimeConfiguration() (string, error) {
 	return marshalAndScrub(ia.conf.AllSourceSettingsWithoutDefault(model.SourceAgentRuntime))
 }
 
-func (ia *inventoryagent) getAgentRemoteConfiguration() (string, error) {
+func (ia *inventoryagent) getRemoteConfiguration() (string, error) {
 	if !ia.conf.GetBool("inventories_configuration_enabled") {
 		return "", fmt.Errorf("inventories_configuration_enabled is disabled")
 	}
@@ -79,7 +79,7 @@ func (ia *inventoryagent) getAgentRemoteConfiguration() (string, error) {
 	return marshalAndScrub(ia.conf.AllSourceSettingsWithoutDefault(model.SourceRC))
 }
 
-func (ia *inventoryagent) getAgentCliConfiguration() (string, error) {
+func (ia *inventoryagent) getCliConfiguration() (string, error) {
 	if !ia.conf.GetBool("inventories_configuration_enabled") {
 		return "", fmt.Errorf("inventories_configuration_enabled is disabled")
 	}

--- a/comp/metadata/inventoryagent/inventoryagentimpl/configuration_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/configuration_test.go
@@ -11,135 +11,135 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetProvidedAgentConfigurationDisable(t *testing.T) {
+func TestGetProvidedConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
 	}, nil)
 
-	_, err := ia.getProvidedAgentConfiguration()
+	_, err := ia.getProvidedConfiguration()
 	assert.Error(t, err)
 }
 
-func TestGetProvidedAgentConfiguration(t *testing.T) {
+func TestGetProvidedConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
 	}, nil)
 
-	data, err := ia.getProvidedAgentConfiguration()
+	data, err := ia.getProvidedConfiguration()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, data)
 }
 
-func TestGetFullAgentConfigurationDisable(t *testing.T) {
+func TestGetFullConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
 	}, nil)
 
-	_, err := ia.getFullAgentConfiguration()
+	_, err := ia.getFullConfiguration()
 	assert.Error(t, err)
 }
 
-func TestGetFullAgentConfiguration(t *testing.T) {
+func TestGetFullConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
 	}, nil)
 
-	data, err := ia.getFullAgentConfiguration()
+	data, err := ia.getFullConfiguration()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, data)
 }
 
-func TestGetAgentFileConfigurationDisable(t *testing.T) {
+func TestGetFileConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
 	}, nil)
 
-	_, err := ia.getFullAgentConfiguration()
+	_, err := ia.getFullConfiguration()
 	assert.Error(t, err)
 }
 
-func TestGetAgentFileConfiguration(t *testing.T) {
+func TestGetFileConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
 	}, nil)
 
-	data, err := ia.getAgentFileConfiguration()
+	data, err := ia.getFileConfiguration()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, data)
 }
 
-func TestGetAgentEnvVarConfigurationDisable(t *testing.T) {
+func TestGetEnvVarConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
 	}, nil)
 
-	_, err := ia.getAgentEnvVarConfiguration()
+	_, err := ia.getEnvVarConfiguration()
 	assert.Error(t, err)
 }
 
-func TestGetAgentEnvVarConfiguration(t *testing.T) {
+func TestGetEnvVarConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
 	}, nil)
 
-	data, err := ia.getAgentEnvVarConfiguration()
+	data, err := ia.getEnvVarConfiguration()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, data)
 }
 
-func TestGetAgentRuntimeConfigurationDisable(t *testing.T) {
+func TestGetRuntimeConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
 	}, nil)
 
-	_, err := ia.getAgentRuntimeConfiguration()
+	_, err := ia.getRuntimeConfiguration()
 	assert.Error(t, err)
 }
 
-func TestGetAgentRuntimeConfiguration(t *testing.T) {
+func TestGetRuntimeConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
 	}, nil)
 
-	data, err := ia.getAgentRuntimeConfiguration()
+	data, err := ia.getRuntimeConfiguration()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, data)
 }
 
-func TestGetAgentRemoteConfigurationDisable(t *testing.T) {
+func TestGetRemoteConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
 	}, nil)
 
-	_, err := ia.getAgentRemoteConfiguration()
+	_, err := ia.getRemoteConfiguration()
 	assert.Error(t, err)
 }
 
-func TestGetAgentRemoteConfiguration(t *testing.T) {
+func TestGetRemoteConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
 	}, nil)
 
-	data, err := ia.getAgentRemoteConfiguration()
+	data, err := ia.getRemoteConfiguration()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, data)
 }
 
-func TestGetAgentCliConfigurationDisable(t *testing.T) {
+func TestGetCliConfigurationDisable(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": false,
 	}, nil)
 
-	_, err := ia.getAgentCliConfiguration()
+	_, err := ia.getCliConfiguration()
 	assert.Error(t, err)
 }
 
-func TestGetAgentCliConfiguration(t *testing.T) {
+func TestGetCliConfiguration(t *testing.T) {
 	ia := getTestInventoryPayload(t, map[string]any{
 		"inventories_configuration_enabled": true,
 	}, nil)
 
-	data, err := ia.getAgentCliConfiguration()
+	data, err := ia.getCliConfiguration()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, data)
 }

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -265,26 +265,19 @@ func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
 		data[k] = v
 	}
 
-	if fullConf, err := ia.getFullAgentConfiguration(); err == nil {
-		data["full_configuration"] = fullConf
+	configLayer := map[string]func() (string, error){
+		"full_configuration":                 ia.getFullConfiguration,
+		"provided_configuration":             ia.getProvidedConfiguration,
+		"file_configuration":                 ia.getFileConfiguration,
+		"environment_variable_configuration": ia.getEnvVarConfiguration,
+		"agent_runtime_configuration":        ia.getRuntimeConfiguration,
+		"remote_configuration":               ia.getRemoteConfiguration,
+		"cli_configuration":                  ia.getCliConfiguration,
 	}
-	if providedConf, err := ia.getProvidedAgentConfiguration(); err == nil {
-		data["provided_configuration"] = providedConf
-	}
-	if fileConf, err := ia.getAgentFileConfiguration(); err == nil {
-		data["file_configuration"] = fileConf
-	}
-	if envVarConf, err := ia.getAgentEnvVarConfiguration(); err == nil {
-		data["environment_variable_configuration"] = envVarConf
-	}
-	if agentRuntimeConf, err := ia.getAgentRuntimeConfiguration(); err == nil {
-		data["agent_runtime_configuration"] = agentRuntimeConf
-	}
-	if remoteConf, err := ia.getAgentRemoteConfiguration(); err == nil {
-		data["remote_configuration"] = remoteConf
-	}
-	if cliConf, err := ia.getAgentCliConfiguration(); err == nil {
-		data["cli_configuration"] = cliConf
+	for layer, getter := range configLayer {
+		if conf, err := getter(); err == nil {
+			data[layer] = conf
+		}
 	}
 
 	return &Payload{


### PR DESCRIPTION

### What does this PR do?

Simplify configuration layer logic. This change nothing but simplify the code for future configuration layers.

### Describe how to test/QA your changes

Test that the configuration layer are still correctly sent with (`datadog-agent diagnose show-metadata inventory-agent`).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this changes.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
