### PR TITLE
Fetch security-agent metadata from the security-agent process

### DIFF
--- a/cmd/security-agent/subcommands/config/config.go
+++ b/cmd/security-agent/subcommands/config/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/fetcher"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -139,19 +140,13 @@ func getSettingsClient(_ *cobra.Command, _ []string) (settings.Client, error) {
 	return settingshttp.NewClient(c, apiConfigURL, "security-agent"), nil
 }
 
-func showRuntimeConfiguration(_ log.Component, _ config.Component, _ secrets.Component, params *cliParams) error {
-	c, err := params.getClient(params.command, params.args)
-	if err != nil {
-		return err
-	}
-
-	runtimeConfig, err := c.FullConfig()
+func showRuntimeConfiguration(_ log.Component, cfg config.Component, _ secrets.Component, _ *cliParams) error {
+	runtimeConfig, err := fetcher.FetchSecurityAgentConfig(cfg)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println(runtimeConfig)
-
 	return nil
 }
 

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/internal/util"
 	iainterface "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
+	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -33,6 +35,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/viper"
 )
 
 // Module defines the fx options for this component.
@@ -43,7 +46,8 @@ func Module() fxutil.Module {
 
 var (
 	// for testing
-	installinfoGet = installinfo.Get
+	installinfoGet      = installinfo.Get
+	fetchSecurityConfig = configFetcher.FetchSecurityAgentConfig
 )
 
 type agentMetadata map[string]interface{}
@@ -173,10 +177,11 @@ func (ia *inventoryagent) initData() {
 		ia.log.Warnf("could not fetch 'hostname_source': %v", err)
 	}
 
+	// core-agent
+
 	ia.data["agent_version"] = version.AgentVersion
 	ia.data["flavor"] = flavor.GetFlavor()
 
-	ia.data["config_apm_dd_url"] = clean(ia.conf.GetString("apm_config.apm_dd_url"))
 	ia.data["config_dd_url"] = clean(ia.conf.GetString("dd_url"))
 	ia.data["config_site"] = clean(ia.conf.GetString("dd_site"))
 	ia.data["config_logs_dd_url"] = clean(ia.conf.GetString("logs_config.logs_dd_url"))
@@ -185,17 +190,26 @@ func (ia *inventoryagent) initData() {
 	ia.data["config_process_dd_url"] = clean(ia.conf.GetString("process_config.process_dd_url"))
 	ia.data["config_proxy_http"] = clean(ia.conf.GetString("proxy.http"))
 	ia.data["config_proxy_https"] = clean(ia.conf.GetString("proxy.https"))
-
 	ia.data["feature_fips_enabled"] = ia.conf.GetBool("fips.enabled")
 	ia.data["feature_logs_enabled"] = ia.conf.GetBool("logs_enabled")
-	ia.data["feature_cspm_enabled"] = ia.conf.GetBool("compliance_config.enabled")
-	ia.data["feature_cspm_host_benchmarks_enabled"] = ia.conf.GetBool("compliance_config.host_benchmarks.enabled")
-	ia.data["feature_apm_enabled"] = ia.conf.GetBool("apm_config.enabled")
 	ia.data["feature_imdsv2_enabled"] = ia.conf.GetBool("ec2_prefer_imdsv2")
-	ia.data["feature_dynamic_instrumentation_enabled"] = getBoolSysProbe("dynamic_instrumentation.enabled")
+
 	ia.data["feature_remote_configuration_enabled"] = ia.conf.GetBool("remote_configuration.enabled")
 
 	ia.data["feature_container_images_enabled"] = ia.conf.GetBool("container_image.enabled")
+
+	// APM / trace-agent
+
+	ia.data["config_apm_dd_url"] = clean(ia.conf.GetString("apm_config.apm_dd_url"))
+	ia.data["feature_apm_enabled"] = ia.conf.GetBool("apm_config.enabled")
+
+	// Process / process-agent
+
+	ia.data["feature_process_enabled"] = ia.conf.GetBool("process_config.process_collection.enabled")
+	ia.data["feature_process_language_detection_enabled"] = ia.conf.GetBool("language_detection.enabled")
+	ia.data["feature_processes_container_enabled"] = ia.conf.GetBool("process_config.container_collection.enabled")
+
+	// Cloud Workload Security / system-probe
 
 	ia.data["feature_cws_enabled"] = getBoolSysProbe("runtime_security_config.enabled")
 	ia.data["feature_cws_network_enabled"] = getBoolSysProbe("event_monitoring_config.network.enabled")
@@ -205,9 +219,7 @@ func (ia *inventoryagent) initData() {
 	ia.data["feature_csm_vm_containers_enabled"] = ia.conf.GetBool("sbom.enabled") && ia.conf.GetBool("container_image.enabled") && ia.conf.GetBool("sbom.container_image.enabled")
 	ia.data["feature_csm_vm_hosts_enabled"] = ia.conf.GetBool("sbom.enabled") && ia.conf.GetBool("sbom.host.enabled")
 
-	ia.data["feature_process_enabled"] = ia.conf.GetBool("process_config.process_collection.enabled")
-	ia.data["feature_process_language_detection_enabled"] = ia.conf.GetBool("language_detection.enabled")
-	ia.data["feature_processes_container_enabled"] = ia.conf.GetBool("process_config.container_collection.enabled")
+	// Service monitoring / system-probe
 
 	ia.data["feature_networks_enabled"] = getBoolSysProbe("network_config.enabled")
 	ia.data["feature_networks_http_enabled"] = getBoolSysProbe("service_monitoring_config.enable_http_monitoring")
@@ -220,6 +232,8 @@ func (ia *inventoryagent) initData() {
 	ia.data["feature_usm_istio_enabled"] = getBoolSysProbe("service_monitoring_config.tls.istio.enabled")
 	ia.data["feature_usm_http_by_status_code_enabled"] = getBoolSysProbe("service_monitoring_config.enable_http_stats_by_status_code")
 	ia.data["feature_usm_go_tls_enabled"] = getBoolSysProbe("service_monitoring_config.tls.go.enabled")
+
+	// miscellaneous / system-probe
 
 	ia.data["feature_tcp_queue_length_enabled"] = getBoolSysProbe("system_probe_config.enable_tcp_queue_length")
 	ia.data["feature_oom_kill_enabled"] = getBoolSysProbe("system_probe_config.enable_oom_kill")
@@ -238,6 +252,37 @@ func (ia *inventoryagent) initData() {
 	ia.data["system_probe_protocol_classification_enabled"] = getBoolSysProbe("network_config.enable_protocol_classification")
 	ia.data["system_probe_gateway_lookup_enabled"] = getBoolSysProbe("network_config.enable_gateway_lookup")
 	ia.data["system_probe_root_namespace_enabled"] = getBoolSysProbe("network_config.enable_root_netns")
+
+	ia.data["feature_dynamic_instrumentation_enabled"] = getBoolSysProbe("dynamic_instrumentation.enabled")
+
+	ia.refreshMetadata()
+}
+
+func (ia *inventoryagent) fetchSecurityAgentMetadata() {
+	type configGetter interface {
+		GetBool(string) bool
+	}
+
+	securityCfg := configGetter(ia.conf)
+	// We query the configuration from the security agent itself to have accurate data. If the security-agent isn't
+	// available we fallback on the current configuration.
+	if securityConfig, err := fetchSecurityConfig(ia.conf); err == nil {
+		cfg := viper.New()
+		cfg.SetConfigType("yaml")
+		if err = cfg.ReadConfig(strings.NewReader(securityConfig)); err != nil {
+			ia.log.Error("Could not pars security-agent configuration: %s", err)
+		} else {
+			securityCfg = cfg
+		}
+	}
+
+	ia.data["feature_cspm_enabled"] = securityCfg.GetBool("compliance_config.enabled")
+	ia.data["feature_cspm_host_benchmarks_enabled"] = securityCfg.GetBool("compliance_config.host_benchmarks.enabled")
+
+}
+func (ia *inventoryagent) refreshMetadata() {
+	// Compliance / security-agent
+	ia.fetchSecurityAgentMetadata()
 }
 
 // Set updates a metadata value in the payload. The given value will be stored in the cache without being copied. It is
@@ -261,6 +306,8 @@ func (ia *inventoryagent) Set(name string, value interface{}) {
 func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
 	ia.m.Lock()
 	defer ia.m.Unlock()
+
+	ia.refreshMetadata()
 
 	// Create a static copy of agentMetadata for the payload
 	data := make(agentMetadata)

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package fetcher is a collection of high level helpers to pull the configuration from other agent processes
+package fetcher
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
+)
+
+// FetchSecurityAgentConfig fetch the configuration from the security-agent process by querying its HTTPS API
+func FetchSecurityAgentConfig(config config.Reader) (string, error) {
+	err := util.SetAuthToken()
+	if err != nil {
+		return "", err
+	}
+
+	c := util.GetClient(false)
+
+	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", config.GetInt("security_agent.cmd_port"))
+	client := settingshttp.NewClient(c, apiConfigURL, "security-agent")
+	return client.FullConfig()
+}


### PR DESCRIPTION
### What does this PR do?

Fetch the `security-agent` metadata from the security agent process itself rather than the local configuration. In a k8s context, the security-agent runs in a different container with potentially a different config (the security-agent API is available from the core-agent container).

### Motivation

This fixes discrepancies in the Fleet Automation product when using the Agent in k8s.

### Describe how to test/QA your changes

Test that `feature_cspm_enabled` and `feature_cspm_host_benchmarks_enabled` correctly reflect the security-agent configuration when using our official helm chart and datadog-operator.

To see the payload: from the core-agent container `agent diagnose show-metadata inventory-agent`

For team agent-security:
- Check that the two metadata  `feature_cspm_enabled` and `feature_cspm_host_benchmarks_enabled` are correctly sent when deploying the security-agent with helm chart. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
