### PR TITLE
add counters to monitor tls handshake errors in cluster-agent

### DIFF
--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -88,7 +88,7 @@ func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error
 		tlsMinVersion = tls.VersionTLS10
 	}
 
-	logWriter, _ := config.NewTLSHandshakeErrorWriter(4, seelog.WarnLvl)
+	logWriter, _ := config.NewTLSHandshakeErrorWriter(4, seelog.WarnLvl, &(metrics.TLSHandshakeErrors))
 	server := &http.Server{
 		Addr:     fmt.Sprintf(":%d", config.Datadog.GetInt("admission_controller.port")),
 		Handler:  s.mux,

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
@@ -106,7 +107,7 @@ func StartServer(w workloadmeta.Component, senderManager sender.DiagnoseSenderMa
 	}
 
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
-	logWriter, _ := config.NewTLSHandshakeErrorWriter(4, seelog.WarnLvl)
+	logWriter, _ := config.NewTLSHandshakeErrorWriter(4, seelog.WarnLvl, &(api.TLSHandshakeErrors))
 
 	authInterceptor := grpcutil.AuthInterceptor(func(token string) (interface{}, error) {
 		if token != util.GetDCAAuthToken() {

--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -80,4 +80,7 @@ var (
 	PatchErrors = telemetry.NewCounterWithOpts("admission_webhooks", "patcher_errors",
 		[]string{}, "Number of patch errors.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
+	TLSHandshakeErrors = telemetry.NewCounterWithOpts("admission_webhooks", "tls_handshake_errors",
+		[]string{}, "Number of tls handshake errors.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 )

--- a/pkg/clusteragent/api/handler_telemetry.go
+++ b/pkg/clusteragent/api/handler_telemetry.go
@@ -24,6 +24,11 @@ var (
 		[]string{"handler", "status", "forwarded"}, "Poll duration distribution by config provider (in seconds).",
 		prometheus.DefBuckets,
 		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	// TLSHandshakeErrors counts the number of requests dropped due to TLS handshake errors
+	TLSHandshakeErrors = telemetry.NewCounterWithOpts("", "api_server_tls_handshake_errors",
+		[]string{}, "Number of tls handshake errors from cluster-agent http api server.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 )
 
 // TelemetryHandler provides a http handler and emits requests telemetry for it.

--- a/releasenotes/notes/add-cluster-agent-http-handshake-error-count-707a7f10b3f9dd33.yaml
+++ b/releasenotes/notes/add-cluster-agent-http-handshake-error-count-707a7f10b3f9dd33.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    add two new metrics to the cluster agent to count the number of 
+    requests dropped with 'TLS handshake error from' in api http 
+    server and admission controller http server


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
CONS-6014

After log level of handshake error is downgraded in cluster-agent, two counters are added to monitor the number of requests dropped in admission.controller and api http server. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Most handshake errors are harmless so we make it debug level log in [pr1](https://github.com/DataDog/datadog-agent/pull/21876) and [pr2](https://github.com/DataDog/datadog-agent/pull/22093). However, that will make it impossible to debug how many connections are interrupted, for example, too many connections can cause high CPU usage. In order to monitor the overall tls error number, two counters are added when this error log is reported in logwriter. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
`$ kubectl exec -it datadog-agent-linux-cluster-agent-<cluster agent container name> -- /bin/bash`
`$ curl localhost:5000/metrics | grep tls
`
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
