### PR TITLE
remove BTF directory on install

### DIFF
--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -14,6 +14,8 @@ build do
   mkdir "#{install_dir}/embedded/share/system-probe/ebpf"
   mkdir "#{install_dir}/embedded/share/system-probe/ebpf/runtime"
   mkdir "#{install_dir}/embedded/share/system-probe/ebpf/co-re"
+  # ensure previous agent version extracted BTFs are removed
+  delete "#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf"
   mkdir "#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf"
   mkdir "#{install_dir}/embedded/share/system-probe/java"
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Removes the `#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf` directory on install.

### Motivation

To avoid system-probe using minimized BTFs from a previous version that were already extracted.

### Additional Notes

Minimized BTFs are shipped with each agent version, and are specific to the eBPF programs in that version. The BTFs are shipped as a tarball of tarballs. Both the kernel version specific tarball and BTF file itself are extracted into the `#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf` directory.

If either of those files exist upon BTF search, it will use them, rather than re-extracting the BTFs. The files themselves contain no version information (BTF does not allow for this). If the BTF files were extracted for a previous agent version, then upon upgrade they will still be used. They *may* still work, but that largely depends on the eBPF code changes between agent versions.

This does not affect containerized deploys because those extract within the container filesystem.

https://datadoghq.atlassian.net/browse/EBPF-368

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
