### PR TITLE
fix empty linux kernel platform information

### DIFF
--- a/pkg/util/kernel/platform.go
+++ b/pkg/util/kernel/platform.go
@@ -8,7 +8,7 @@
 package kernel
 
 import (
-	gopsutilhost "github.com/shirou/gopsutil/v3/host"
+	gopsutilhost "github.com/DataDog/gopsutil/host"
 
 	"github.com/DataDog/datadog-agent/pkg/util/funcs"
 )
@@ -31,7 +31,9 @@ var PlatformVersion = funcs.Memoize(func() (string, error) {
 	return pi.version, err
 })
 
-var platformInformation = funcs.Memoize(func() (platformInfo, error) {
+var platformInformation = funcs.Memoize(getPlatformInformation)
+
+func getPlatformInformation() (platformInfo, error) {
 	platform, family, version, err := gopsutilhost.PlatformInformation()
 	return platformInfo{platform, family, version}, err
-})
+}

--- a/pkg/util/kernel/platform_test.go
+++ b/pkg/util/kernel/platform_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package kernel
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlatform(t *testing.T) {
+	osr, err := os.Open("/etc/os-release")
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		t.Skip("/etc/os-release does not exist")
+	}
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = osr.Close() })
+
+	tmp := t.TempDir()
+	t.Setenv("HOST_ETC", tmp)
+	require.NoError(t, os.Mkdir(filepath.Join(tmp, "redhat-release"), 0755))
+
+	// copy /etc/os-release to <tmpdir>/os-release
+	dosr, err := os.Create(filepath.Join(tmp, "os-release"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dosr.Close() })
+	_, err = io.Copy(dosr, osr)
+	require.NoError(t, err)
+	_ = dosr.Close()
+
+	pi, err := getPlatformInformation()
+	require.NoError(t, err)
+	require.NotEmpty(t, pi.platform, "platform")
+	require.NotEmpty(t, pi.family, "family")
+	require.NotEmpty(t, pi.version, "version")
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Uses `github.com/DataDog/gopsutil` instead of `github.com/shirou/gopsutil/v3` for getting kernel platform information.

### Motivation

If github.com/shirou/gopsutil/v3 is used and a [/host]/etc/redhat-release file/dir exists but is empty, then it returns empty platform information.

This affects helm-chart users who have kernel header downloading turned on, because it always mounts this file and k8s will create it even if it doesn't exist.

### Additional Notes

This is because this line https://github.com/shirou/gopsutil/blob/83c941c791e7f294752b0cc98ba3059f63dd4f05/host/host_linux.go#L238 does not use `common.PathExistsWithContents`.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
