### PR TITLE
fix flaky eventlog integration tests

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -62,6 +62,9 @@ internal_kubernetes_deploy*            @DataDog/container-integrations
 # Deploy
 deploy_containers*                     @DataDog/container-integrations
 
+# Integration test
+integration_tests_windows*    @DataDog/windows-agent
+
 # Functional test
 kitchen_*_system_probe*                        @DataDog/ebpf-platform
 kitchen_*_security_agent*                      @DataDog/agent-security

--- a/pkg/collector/corechecks/windows_event_log/check_test.go
+++ b/pkg/collector/corechecks/windows_event_log/check_test.go
@@ -18,6 +18,7 @@ import (
 	agentCheck "github.com/DataDog/datadog-agent/pkg/collector/check"
 	agentConfig "github.com/DataDog/datadog-agent/pkg/config"
 	agentEvent "github.com/DataDog/datadog-agent/pkg/metrics/event"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/reporter"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/test"
@@ -231,6 +232,9 @@ start: oldest
 
 // Test that the check can detect and recover from a broken subscription
 func (s *GetEventsTestSuite) TestRecoverFromBrokenSubscription() {
+	// TODO: https://datadoghq.atlassian.net/browse/WINA-480
+	flake.Mark(s.T())
+
 	// Put events in the log
 	err := s.ti.GenerateEvents(s.eventSource, s.numEvents)
 	require.NoError(s.T(), err)

--- a/pkg/logs/tailers/windowsevent/tailer_test.go
+++ b/pkg/logs/tailers/windowsevent/tailer_test.go
@@ -23,6 +23,7 @@ import (
 	logconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/test"
 )
@@ -154,6 +155,9 @@ func (s *ReadEventsSuite) TestCustomQuery() {
 }
 
 func (s *ReadEventsSuite) TestRecoverFromBrokenSubscription() {
+	// TODO: https://datadoghq.atlassian.net/browse/WINA-480
+	flake.Mark(s.T())
+
 	// create tailer and ensure events can be read
 	config := Config{
 		ChannelPath: s.channelPath,

--- a/pkg/util/winutil/eventlog/api/fake/fake.go
+++ b/pkg/util/winutil/eventlog/api/fake/fake.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
+
 //go:build windows
 
 package fakeevtapi

--- a/pkg/util/winutil/eventlog/api/fake/test.go
+++ b/pkg/util/winutil/eventlog/api/fake/test.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
+
 //go:build windows
 
 package fakeevtapi

--- a/pkg/util/winutil/eventlog/api/fake/wevtapi.go
+++ b/pkg/util/winutil/eventlog/api/fake/wevtapi.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
+
 //go:build windows
 
 // Package fakeevtapi is a fake implementation of the Windows Event Log API intended to be used in tests.

--- a/pkg/util/winutil/eventlog/api/types.go
+++ b/pkg/util/winutil/eventlog/api/types.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
+
 //go:build windows
 
 // Package evtapi defines the interface and common types for interacting with the Windows Event Log API from Golang

--- a/pkg/util/winutil/eventlog/api/windows/types.go
+++ b/pkg/util/winutil/eventlog/api/windows/types.go
@@ -5,7 +5,6 @@
 
 //go:build windows
 
-//nolint:revive // TODO(WINA) Fix revive linter
 package winevtapi
 
 //revive:disable:var-naming These names are intended to match the Windows API names

--- a/pkg/util/winutil/eventlog/api/windows/wevtapi.go
+++ b/pkg/util/winutil/eventlog/api/windows/wevtapi.go
@@ -5,7 +5,8 @@
 
 //go:build windows
 
-package winevtapi //nolint:revive // TODO fix revive package-comments
+// Package winevtapi implements the evtapi.API interface with the Windows Event Log API
+package winevtapi
 
 import (
 	"fmt"

--- a/pkg/util/winutil/eventlog/example_test.go
+++ b/pkg/util/winutil/eventlog/example_test.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
+
 //go:build windows
 
 package eventlog

--- a/pkg/util/winutil/eventlog/test/fake.go
+++ b/pkg/util/winutil/eventlog/test/fake.go
@@ -9,6 +9,8 @@ package eventlog_test
 import (
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api/fake"
+
+	"testing"
 )
 
 const (
@@ -63,4 +65,14 @@ func (ti *FakeAPITester) RemoveSource(channel string, source string) error {
 // GenerateEvents creates numEvents new event records
 func (ti *FakeAPITester) GenerateEvents(channelName string, numEvents uint) error {
 	return ti.eventlogapi.GenerateEvents(channelName, numEvents)
+}
+
+// StartEventLogService is TODO for the fake API
+func (ti *FakeAPITester) StartEventLogService(t *testing.T) {
+	panic("not implemented")
+}
+
+// KillEventLogService is TODO for the fake API
+func (ti *FakeAPITester) KillEventLogService(t *testing.T) {
+	panic("not implemented")
 }

--- a/pkg/util/winutil/eventlog/test/fake.go
+++ b/pkg/util/winutil/eventlog/test/fake.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
+
 //go:build windows
 
 package eventlog_test
@@ -68,11 +69,15 @@ func (ti *FakeAPITester) GenerateEvents(channelName string, numEvents uint) erro
 }
 
 // StartEventLogService is TODO for the fake API
-func (ti *FakeAPITester) StartEventLogService(t *testing.T) {
+func (ti *FakeAPITester) StartEventLogService(
+	t *testing.T, //nolint:revive // TODO(WINA) fix revive unused-parameter
+) {
 	panic("not implemented")
 }
 
 // KillEventLogService is TODO for the fake API
-func (ti *FakeAPITester) KillEventLogService(t *testing.T) {
+func (ti *FakeAPITester) KillEventLogService(
+	t *testing.T, //nolint:revive // TODO(WINA) fix revive unused-parameter
+) {
 	panic("not implemented")
 }

--- a/pkg/util/winutil/eventlog/test/test.go
+++ b/pkg/util/winutil/eventlog/test/test.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
+
 //go:build windows
 
 // Package eventlog_test provides helpers for testing code that uses the eventlog package

--- a/pkg/util/winutil/eventlog/test/test.go
+++ b/pkg/util/winutil/eventlog/test/test.go
@@ -34,6 +34,8 @@ type APITester interface {
 	InstallSource(channel string, source string) error
 	RemoveSource(channel string, name string) error
 	GenerateEvents(channelName string, numEvents uint) error
+	StartEventLogService(t *testing.T)
+	KillEventLogService(t *testing.T)
 }
 
 // GetEnabledAPITesters returns the APIs that are available to test as specified by enabledAPIsFlag

--- a/pkg/util/winutil/eventlog/test/windows.go
+++ b/pkg/util/winutil/eventlog/test/windows.go
@@ -8,12 +8,16 @@ package eventlog_test
 
 import (
 	"fmt"
+	"os/exec"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api/windows"
+
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 const (
@@ -164,4 +168,35 @@ func channelRootKey() string {
 
 func channelRegistryKey(channel string) string {
 	return fmt.Sprintf(`%v\%v`, channelRootKey(), channel)
+}
+
+// StartEventLogService starts the Windows Event Log service
+func (ti *WindowsAPITester) StartEventLogService(t *testing.T) {
+	t.Helper()
+
+	cmd := exec.Command("powershell.exe", "-Command", "Start-Service", "EventLog")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "Failed to start EventLog service %s", out)
+}
+
+// KillEventLogService stops the Windows Event Log service and adds a Cleanup task to the test
+// to restart it at the end of the test.
+func (ti *WindowsAPITester) KillEventLogService(t *testing.T) {
+	t.Helper()
+
+	// kill the process rather than use `Stop-Service` because even with `-Force` it can fail to stop the service.
+	cmd := `Stop-Process -Force -Id (Get-WmiObject -Class Win32_Service -Filter "Name LIKE 'EventLog'" | Select-Object -ExpandProperty ProcessId)`
+	p := exec.Command("powershell.exe", "-Command", cmd)
+	out, err := p.CombinedOutput()
+
+	t.Cleanup(func() {
+		// ensure service is started at end of this test
+		p := exec.Command("powershell.exe", "-Command", "Start-Service", "EventLog")
+		out, err = p.CombinedOutput()
+		if err != nil {
+			t.Logf("Failed to start EventLog service %s", err)
+		}
+	})
+
+	require.NoError(t, err, "Failed to stop EventLog service %s", out)
 }

--- a/pkg/util/winutil/eventlog/test/windows.go
+++ b/pkg/util/winutil/eventlog/test/windows.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
+
 //go:build windows
 
 package eventlog_test


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix race condition in event log check tests. `MockSender` is now prepared prior to generating events for the test.

Fix flaky event log service stop by using hard kill instead of SCM commands which sometimes fail to due `EventLog`s dependent services.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-588

https://datadoghq.atlassian.net/browse/WINA-480

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
