### PR TITLE
[clusteragent/admission/controllers/webhook] Fix flaky tests

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -15,24 +15,27 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate"
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
-
+	"github.com/stretchr/testify/require"
 	admiv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 )
 
 var v1beta1Cfg = NewConfig(false, false)
 
 func TestSecretNotFoundV1beta1(t *testing.T) {
 	f := newFixtureV1beta1(t)
-	c := f.run(t)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c := f.run(stopCh)
 
 	_, err := c.webhooksLister.Get(v1beta1Cfg.getWebhookName())
 	if !errors.IsNotFound(err) {
@@ -42,7 +45,7 @@ func TestSecretNotFoundV1beta1(t *testing.T) {
 	// The queue might not be closed yet because it's done asynchronously
 	assert.Eventually(t, func() bool {
 		return c.queue.Len() == 0
-	}, 1*time.Second, 5*time.Millisecond, "Work queue isn't empty")
+	}, waitFor, tick, "Work queue isn't empty")
 }
 
 func TestCreateWebhookV1beta1(t *testing.T) {
@@ -56,12 +59,15 @@ func TestCreateWebhookV1beta1(t *testing.T) {
 	secret := buildSecret(data, v1beta1Cfg)
 	f.populateSecretsCache(secret)
 
-	c := f.run(t)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c := f.run(stopCh)
 
-	webhook, err := c.webhooksLister.Get(v1beta1Cfg.getWebhookName())
-	if err != nil {
-		t.Fatalf("Failed to get the Webhook: %v", err)
-	}
+	var webhook *admiv1beta1.MutatingWebhookConfiguration
+	require.Eventually(t, func() bool {
+		webhook, err = c.webhooksLister.Get(v1beta1Cfg.getWebhookName())
+		return err == nil
+	}, waitFor, tick)
 
 	if err := validateV1beta1(webhook, secret); err != nil {
 		t.Fatalf("Invalid Webhook: %v", err)
@@ -99,16 +105,15 @@ func TestUpdateOutdatedWebhookV1beta1(t *testing.T) {
 
 	f.populateWebhooksCache(webhook)
 
-	c := f.run(t)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c := f.run(stopCh)
 
-	newWebhook, err := c.webhooksLister.Get(v1beta1Cfg.getWebhookName())
-	if err != nil {
-		t.Fatalf("Failed to get the Webhook: %v", err)
-	}
-
-	if reflect.DeepEqual(webhook, newWebhook) {
-		t.Fatal("The Webhook hasn't been modified")
-	}
+	var newWebhook *admiv1beta1.MutatingWebhookConfiguration
+	require.Eventually(t, func() bool {
+		newWebhook, err = c.webhooksLister.Get(v1beta1Cfg.getWebhookName())
+		return err == nil && !reflect.DeepEqual(webhook, newWebhook)
+	}, waitFor, tick)
 
 	if err := validateV1beta1(newWebhook, secret); err != nil {
 		t.Fatalf("Invalid Webhook: %v", err)
@@ -815,15 +820,11 @@ func (f *fixtureV1beta1) createController() (*ControllerV1beta1, informers.Share
 	), factory
 }
 
-func (f *fixtureV1beta1) run(t *testing.T) *ControllerV1beta1 { //nolint:revive // TODO fix revive unused-parameter
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
+func (f *fixtureV1beta1) run(stopCh chan struct{}) *ControllerV1beta1 {
 	c, factory := f.createController()
+
 	factory.Start(stopCh)
 	go c.Run(stopCh)
-
-	f.waitOnActions()
 
 	return c
 }

--- a/pkg/clusteragent/admission/controllers/webhook/utils_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/utils_test.go
@@ -10,7 +10,6 @@ package webhook
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 
@@ -22,24 +21,6 @@ import (
 type fixture struct {
 	t      *testing.T //nolint:structcheck
 	client *fake.Clientset
-}
-
-// waitOnActions can be used to wait for controller to start watching
-// resources effectively and handling objects before returning it.
-// Otherwise tests will start making assertions before the reconciliation is done.
-func (f *fixture) waitOnActions() {
-	lastChange := time.Now()
-	lastCount := 0
-	for {
-		time.Sleep(1 * time.Second)
-		count := len(f.client.Actions())
-		if count > lastCount {
-			lastChange = time.Now()
-			lastCount = count
-		} else if time.Since(lastChange) > 2*time.Second {
-			return
-		}
-	}
 }
 
 func (f *fixture) populateSecretsCache(secrets ...*corev1.Secret) {


### PR DESCRIPTION
### What does this PR do?

Attempt to fix flaky tests in the admission controller webhook: `TestCreateWebhookV1` and `TestCreateWebhookV1beta1`.

These tests fail very rarely and it seems that it's because they didn't wait long enough. These tests were using the `waitOnActions` function which waiting a minimum of 3 seconds to make sure that everything was ready. I've refactored the code so that the tests use `require.Eventually` instead of that function so that they don't wait 3 seconds if everything has been setup. I've also increased the timeout from 3s to 5s.

### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
