### PR TITLE
[CWS] improvement to ebpf program event unmarshalling

### DIFF
--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -691,10 +691,23 @@ func (p *BPFProgram) UnmarshalBinary(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	for _, b := range data[56:64] {
-		p.Tag += fmt.Sprintf("%x", b)
-	}
+	p.Tag = parseSHA1Tag(data[56:64])
 	return 64, nil
+}
+
+// parseSHA1Tag parses the short sha1 digest from the kernel event
+func parseSHA1Tag(data []byte) string {
+	if len(data) != 8 {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.Grow(16)
+
+	for _, b := range data {
+		builder.WriteString(fmt.Sprintf("%02x", b))
+	}
+	return builder.String()
 }
 
 func parseHelpers(helpers []uint64) []uint32 {

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -9,6 +9,7 @@ package model
 import (
 	"encoding/binary"
 	"fmt"
+	"math/bits"
 	"strings"
 	"time"
 
@@ -711,15 +712,18 @@ func parseSHA1Tag(data []byte) string {
 }
 
 func parseHelpers(helpers []uint64) []uint32 {
-	var rep []uint32
-	var add bool
-
 	if len(helpers) < 3 {
-		return rep
+		return nil
 	}
 
+	var popcnt int
+	for _, h := range helpers {
+		popcnt += bits.OnesCount64(h)
+	}
+	rep := make([]uint32, 0, popcnt)
+
 	for i := 0; i < 192; i++ {
-		add = false
+		add := false
 		if i < 64 {
 			if helpers[0]&(1<<i) == (1 << i) {
 				add = true


### PR DESCRIPTION
### What does this PR do?

During 7.51rc3 deployments on arbok it was shown using profiling that BPF program unmarshaling could allocate a lot of memory (not as a total memory usage, but more as a count of small allocations). This PR tries to reduce this pattern by better pre-allocating the resulting buffers.

It also fixes an issue with the BPF tag that was not correctly parsed (no 0 padding on < 16 bytes).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
