### PR TITLE
[CWS] Enforce containerID parsing

### DIFF
--- a/pkg/security/common/containerutils/utils.go
+++ b/pkg/security/common/containerutils/utils.go
@@ -12,9 +12,9 @@ import (
 )
 
 // ContainerIDPatternStr defines the regexp used to match container IDs
-// ([0-9a-fA-F]{64}) is standard container id used pretty much everywhere, lenght: 64
-// ([0-9a-fA-F]{32}-[0-9]{10}) is container id used by AWS ECS, lenght: 43
-// ([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4}) is container id used by Garden, lenght: 28
+// ([0-9a-fA-F]{64}) is standard container id used pretty much everywhere, length: 64
+// ([0-9a-fA-F]{32}-[0-9]{10}) is container id used by AWS ECS, length: 43
+// ([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4}) is container id used by Garden, length: 28
 var ContainerIDPatternStr = "([0-9a-fA-F]{64})|([0-9a-fA-F]{32}-[0-9]{10})|([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4})"
 var containerIDPattern = regexp.MustCompile(ContainerIDPatternStr)
 

--- a/pkg/security/common/containerutils/utils_test.go
+++ b/pkg/security/common/containerutils/utils_test.go
@@ -57,11 +57,10 @@ func TestFindContainerID(t *testing.T) {
 			input:  "/docker/01234567-0123-4567-890a-bcde",
 			output: "01234567-0123-4567-890a-bcde",
 		},
-		// TODO: put back this test once we get better at parsing proc from various container runtimes
-		// { // Some random path which could match garden format
-		// 	input:  "/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-f9176c6a-2a34-4ce2-86af-60d16888ed8e.scope",
-		// 	output: "",
-		// },
+		{ // Some random path which could match garden format
+			input:  "/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-f9176c6a-2a34-4ce2-86af-60d16888ed8e.scope",
+			output: "",
+		},
 		{ // GARDEN with prefix / suffix
 			input:  "prefix01234567-0123-4567-890a-bcdesuffix",
 			output: "01234567-0123-4567-890a-bcde",


### PR DESCRIPTION
### What does this PR do?

This PR enforces the containerID parsing, making sure the found result is well delimited.
It fixes an issue that was observed (see the new un-commented test).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
