### PR TITLE
[flake] skip known flakes out of main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,9 @@ jobs:
       - run:
           name: run unit tests
           no_output_timeout: 20m
-          command: inv -e test --rerun-fails=2 --python-runtimes 3 --coverage --race --profile --cpus 8 --skip-flakes
+          command: inv -e test --rerun-fails=2 --python-runtimes 3 --coverage --race --profile --cpus 8
+          environment:
+            GO_TEST_SKIP_FLAKE: "true"
       - run:
           name: upload code coverage results
           # Never fail on coverage upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
       - run:
           name: run unit tests
           no_output_timeout: 20m
-          command: inv -e test --rerun-fails=2 --python-runtimes 3 --coverage --race --profile --cpus 8
+          command: inv -e test --rerun-fails=2 --python-runtimes 3 --coverage --race --profile --cpus 8 --skip-flakes
       - run:
           name: upload code coverage results
           # Never fail on coverage upload

--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -55,7 +55,7 @@ jobs:
           powershell.exe -Command ./tasks/winbuildscripts/pre-go-build.ps1
           # FIXME: skipping rtloader tests because they fail with a DLL-not-found error
           # inv -e rtloader.test
-          inv -e test --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation --timeout=600
+          inv -e test --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation --timeout=600 --skip-flakes
 
       - name: Upload Codecov results
         uses: codecov/codecov-action@v3

--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -49,13 +49,15 @@ jobs:
 
       - name: Run tests
         shell: bash # using bash so we don't have to check $lastExitCode all the time
+        env:
+          GO_TEST_SKIP_FLAKE: "true"
         run: |
           export PATH="/c/msys64/mingw64/bin:/c/msys64/usr/bin/:$PATH" # prepend msys, otherwise make from mingw gets used
           echo $PATH
           powershell.exe -Command ./tasks/winbuildscripts/pre-go-build.ps1
           # FIXME: skipping rtloader tests because they fail with a DLL-not-found error
           # inv -e rtloader.test
-          inv -e test --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation --timeout=600 --skip-flakes
+          inv -e test --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation --timeout=600
 
       - name: Upload Codecov results
         uses: codecov/codecov-action@v3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -207,6 +207,8 @@ variables:
   CLANG_LLVM_VER: 12.0.1
   KERNEL_MATRIX_TESTING_X86_AMI_ID: "ami-00e807c0351f270b7"
   KERNEL_MATRIX_TESTING_ARM_AMI_ID: "ami-0be4fd85ce146ab3b"
+  # skip known flaky tests by default
+  GO_TEST_SKIP_FLAKE: "true"
 
 #
 # Condition mixins for simplification of rules
@@ -393,6 +395,8 @@ workflow:
 
 .on_main:
   - <<: *if_main_branch
+    variables:
+      GO_TEST_SKIP_FLAKE: false
 
 .on_main_manual:
   - <<: *if_main_branch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -396,7 +396,7 @@ workflow:
 .on_main:
   - <<: *if_main_branch
     variables:
-      GO_TEST_SKIP_FLAKE: false
+      GO_TEST_SKIP_FLAKE: "false"
 
 .on_main_manual:
   - <<: *if_main_branch

--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -256,6 +256,7 @@ def test(
     go_mod="mod",
     junit_tar="",
     only_modified_packages=False,
+    skip_flakes=False,
 ):
     """
     Run go tests on the given module and targets.
@@ -271,7 +272,6 @@ def test(
         inv test --targets=./pkg/collector/check,./pkg/aggregator --race
         inv test --module=. --race
     """
-
     modules_results_per_phase = defaultdict(dict)
 
     sanitize_env_vars()
@@ -319,7 +319,7 @@ def test(
     stdlib_build_cmd = 'go build {verbose} -mod={go_mod} -tags "{go_build_tags}" -gcflags="{gcflags}" '
     stdlib_build_cmd += '-ldflags="{ldflags}" {build_cpus} {race_opt} std cmd'
     cmd = 'gotestsum {junit_file_flag} {json_flag} --format pkgname {rerun_fails} --packages="{packages}" -- {verbose} -mod={go_mod} -vet=off -timeout {timeout}s -tags "{go_build_tags}" -gcflags="{gcflags}" '
-    cmd += '-ldflags="{ldflags}" {build_cpus} {race_opt} -short {covermode_opt} {coverprofile} {nocache} {test_run_arg}'
+    cmd += '-ldflags="{ldflags}" {build_cpus} {race_opt} -short {covermode_opt} {coverprofile} {nocache} {test_run_arg} {skip_flakes}'
     args = {
         "go_mod": go_mod,
         "gcflags": gcflags,
@@ -335,6 +335,7 @@ def test(
         # Used to print failed tests at the end of the go test command
         "json_flag": f'--jsonfile "{GO_TEST_RESULT_TMP_JSON}" ',
         "rerun_fails": f"--rerun-fails={rerun_fails}" if rerun_fails else "",
+        "skip_flakes": "--skip-flake" if skip_flakes else "",
     }
 
     # Test


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Skip go tests marked as flake by default, allow running them only on Gitlab pipelines based on `main` branch

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Flake tests are a barrier with low value on PR branches, they often prevent merging PRs and are overall consuming CI time while not bringing much value, on branches. We start skipping them by default, keeping them alive on `main` Gitlab pipelines. Note they are not allowed to fail: this is because a flake tests is expected to pass on retry. If it does not pass on retry, then we consider it broken and should not run at all.

We might increase retry limit on `gotestsum` for unit tests, while e2e tests should handle retries within test implementation - we should retry flaky by nature operations rather than retrying the full e2e test.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
