### PR TITLE
[NPM-3154] Add better assert messages to debug failure

### DIFF
--- a/pkg/network/netlink/consumer_test.go
+++ b/pkg/network/netlink/consumer_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -78,12 +79,13 @@ func TestConsumerKeepsRunningAfterCircuitBreakerTrip(t *testing.T) {
 	// will simply bail since bpf random sampling
 	// is not available
 	if pre315Kernel {
-		require.Eventually(t, func() bool {
-			return !isRecvLoopRunning() && c.breaker.IsOpen()
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.False(collect, isRecvLoopRunning(), "receive loop should not be running")
+			assert.True(collect, c.breaker.IsOpen(), "breaker should be open")
 		}, cfg.ConntrackRateLimitInterval, 100*time.Millisecond)
 	} else {
-		require.Eventually(t, func() bool {
-			return c.samplingRate < 1.0
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.Lessf(collect, c.samplingRate, 1.0, "sampling rate should be less than 1.0")
 		}, cfg.ConntrackRateLimitInterval, 100*time.Millisecond)
 		require.True(t, isRecvLoopRunning())
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds better assert messages to debug failures like this: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/411895639

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
