### PR TITLE
[SLES-1503] Feat: Remove compute stats tag

### DIFF
--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -152,7 +152,7 @@ func MergeWithOverwrite(tags map[string]string, overwritingTags map[string]strin
 
 // BuildTagsFromMap builds an array of tag based on map of tags
 func BuildTagsFromMap(tags map[string]string) []string {
-	tagsMap := buildTags(tags, []string{traceOriginMetadataKey, computeStatsKey})
+	tagsMap := buildTags(tags, []string{traceOriginMetadataKey})
 	return MapToArray(tagsMap)
 }
 

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -56,9 +56,6 @@ const (
 	traceOriginMetadataKey   = "_dd.origin"
 	traceOriginMetadataValue = "lambda"
 
-	computeStatsKey   = "_dd.compute_stats"
-	computeStatsValue = "1"
-
 	extensionVersionKey = "dd_extension_version"
 
 	regionKey     = "region"
@@ -97,7 +94,6 @@ func BuildTagMap(arn string, configTags []string) map[string]string {
 	tags = MergeWithOverwrite(tags, ArrayToMap(configTags))
 
 	tags = setIfNotEmpty(tags, traceOriginMetadataKey, traceOriginMetadataValue)
-	tags = setIfNotEmpty(tags, computeStatsKey, computeStatsValue)
 	tags = setIfNotEmpty(tags, FunctionARNKey, arn)
 	tags = setIfNotEmpty(tags, extensionVersionKey, GetExtensionVersion())
 

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -179,7 +179,7 @@ func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
 	t.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "888")
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
-	assert.Equal(t, 14, len(tagMap))
+	assert.Equal(t, 13, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "us-east-1", tagMap["region"])

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -52,7 +52,6 @@ func TestBuildTagsFromMap(t *testing.T) {
 		"key2":              "value2",
 		"key3":              "value3",
 		"_dd.origin":        "xxx",
-		"_dd.compute_stats": "xxx",
 	}
 	resultTagsArray := BuildTagsFromMap(tagsMap)
 	sort.Strings(resultTagsArray)
@@ -69,7 +68,6 @@ func TestBuildTagMapFromArnIncomplete(t *testing.T) {
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
 	assert.Equal(t, 8, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
-	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "xxx", tagMap["dd_extension_version"])
 	assert.Equal(t, "value0", tagMap["tag0"])
@@ -84,7 +82,6 @@ func TestBuildTagMapFromArnIncompleteWithCommaAndSpaceTags(t *testing.T) {
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "tag1:value1,tag2:VALUE2", "TAG3:VALUE3"})
 	assert.Equal(t, 10, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
-	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "xxx", tagMap["dd_extension_version"])
 	assert.Equal(t, "value0", tagMap["tag0"])
@@ -101,7 +98,6 @@ func TestBuildTagMapFromArnComplete(t *testing.T) {
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
 	assert.Equal(t, 13, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
-	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "us-east-1", tagMap["region"])
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
@@ -128,7 +124,6 @@ func TestBuildTagMapFromArnCompleteWithEnvAndVersionAndService(t *testing.T) {
 	assert.Equal(t, "mytestversion", tagMap["version"])
 	assert.Equal(t, "mytestservice", tagMap["service"])
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
-	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "us-east-1", tagMap["region"])
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
@@ -148,7 +143,6 @@ func TestBuildTagMapFromArnCompleteWithUpperCase(t *testing.T) {
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
 	assert.Equal(t, 13, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
-	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "us-east-1", tagMap["region"])
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
@@ -168,7 +162,6 @@ func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
 	assert.Equal(t, 13, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
-	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "us-east-1", tagMap["region"])
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
@@ -188,7 +181,6 @@ func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
 	assert.Equal(t, 14, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
-	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "us-east-1", tagMap["region"])
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
@@ -321,7 +313,6 @@ func TestBuildTagMapWithRuntimeAndMemoryTag(t *testing.T) {
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
 	assert.Equal(t, 15, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
-	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "us-east-1", tagMap["region"])
 	assert.Equal(t, "123456789012", tagMap["aws_account"])

--- a/test/integration/serverless/snapshots/otlp-python
+++ b/test/integration/serverless/snapshots/otlp-python
@@ -11,7 +11,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "_dd.p.dm": "-9",
               "account_id": "############",
@@ -58,7 +57,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -134,7 +132,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "_dd.p.dm": "-9",
               "account_id": "############",
@@ -181,7 +178,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",

--- a/test/integration/serverless/snapshots/trace-csharp
+++ b/test/integration/serverless/snapshots/trace-csharp
@@ -11,7 +11,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -75,7 +74,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -139,7 +137,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -196,7 +193,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "_dd.p.dm": "-0",
               "account_id": "############",
@@ -265,7 +261,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "_dd.p.dm": "-0",
               "account_id": "############",

--- a/test/integration/serverless/snapshots/trace-go
+++ b/test/integration/serverless/snapshots/trace-go
@@ -11,7 +11,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "_dd.p.dm": "-1",
               "_dd.tracer_hostname": "<redacted>",
@@ -64,7 +63,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -110,7 +108,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -171,7 +168,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "_dd.p.dm": "-1",
               "_dd.tracer_hostname": "<redacted>",
@@ -224,7 +220,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -270,7 +265,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -331,7 +325,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",

--- a/test/integration/serverless/snapshots/trace-java
+++ b/test/integration/serverless/snapshots/trace-java
@@ -11,7 +11,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -72,7 +71,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -133,7 +131,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",

--- a/test/integration/serverless/snapshots/trace-node
+++ b/test/integration/serverless/snapshots/trace-node
@@ -12,7 +12,6 @@
             "error": 0,
             "meta": {
               "_dd.base_service": "integration-tests-service",
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "_dd.p.dm": "-0",
               "account_id": "############",
@@ -63,7 +62,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -125,7 +123,6 @@
             "error": 0,
             "meta": {
               "_dd.base_service": "integration-tests-service",
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "_dd.p.dm": "-0",
               "account_id": "############",
@@ -177,7 +174,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -238,7 +234,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",

--- a/test/integration/serverless/snapshots/trace-python
+++ b/test/integration/serverless/snapshots/trace-python
@@ -11,7 +11,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "_dd.p.dm": "-0",
               "account_id": "############",
@@ -66,7 +65,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -122,7 +120,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "_dd.p.dm": "-0",
               "account_id": "############",
@@ -176,7 +173,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",
@@ -232,7 +228,6 @@
             "duration": null,
             "error": 0,
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "############",
               "architecture": "XXX",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

setting this tag forces the backend to compute trace stats. The trace agent already computes stats, so this isn't needed and presumably was a holdover from the forwarder implementation.

### Motivation
Fixes SLES-1503

### Additional Notes

This fixes an issue where duplicate points are submitted for apm trace stats.
Before, note the `region` tag is `n/a` and `us-east-1, and that the points submitted for `trace.aws.lambda.hits` are roughly 2x what `aws.lambda.enhanced.invocations` is:
![image](https://github.com/DataDog/datadog-agent/assets/1598537/1769fb93-5f59-4b98-96db-9b287d8825bd)

After, we see there is no region tag (maybe something to address?) but the number of points line up:
![image](https://github.com/DataDog/datadog-agent/assets/1598537/b2cef24a-a7ad-4811-86f2-c964c4851a16)

We may also need to add region or other tags to apm trace stats from the agent (this project)

The theory is that this code was inadvertently copied (before my time) from the lambda log forwarder, which does *not* compute trace stats, and requires backend stats computation.

Open question is - does this result with inaccurate stats aggregated across many concurrent function executions? (I'll test).

### Possible Drawbacks / Trade-offs
Is this a breaking change? I'm not sure how we'd classify it because it seemingly was not correct data anyway.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
