### PR TITLE
[CONTINT-3437] Extend WLM deployment entity to allow storing languages detected by node agents

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments.go
@@ -35,8 +35,8 @@ func (f *deploymentFilter) filteredOut(entity workloadmeta.Entity) bool {
 		(deployment.Env == "" &&
 			deployment.Version == "" &&
 			deployment.Service == "" &&
-			len(deployment.InitContainerLanguages) == 0 &&
-			len(deployment.ContainerLanguages) == 0)
+			len(deployment.InjectableLanguages.InitContainerLanguages) == 0 &&
+			len(deployment.InjectableLanguages.ContainerLanguages) == 0)
 }
 
 func newDeploymentStore(ctx context.Context, wlm workloadmeta.Component, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
@@ -107,10 +107,12 @@ func (p deploymentParser) Parse(obj interface{}) workloadmeta.Entity {
 			Kind: workloadmeta.KindKubernetesDeployment,
 			ID:   deployment.Namespace + "/" + deployment.Name, // we use the namespace/name as id to make it easier for the admission controller to retrieve the corresponding deployment
 		},
-		Env:                    deployment.Labels[ddkube.EnvTagLabelKey],
-		Service:                deployment.Labels[ddkube.ServiceTagLabelKey],
-		Version:                deployment.Labels[ddkube.VersionTagLabelKey],
-		ContainerLanguages:     containerLanguages,
-		InitContainerLanguages: initContainerLanguages,
+		Env:     deployment.Labels[ddkube.EnvTagLabelKey],
+		Service: deployment.Labels[ddkube.ServiceTagLabelKey],
+		Version: deployment.Labels[ddkube.VersionTagLabelKey],
+		InjectableLanguages: workloadmeta.Languages{
+			ContainerLanguages:     containerLanguages,
+			InitContainerLanguages: initContainerLanguages,
+		},
 	}
 }

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
@@ -37,18 +37,20 @@ func TestDeploymentParser_Parse(t *testing.T) {
 				Env:     "env",
 				Service: "service",
 				Version: "version",
-				InitContainerLanguages: map[string][]languagemodels.Language{
-					"nginx-cont": {
-						{Name: languagemodels.Go},
-						{Name: languagemodels.Java},
-						{Name: languagemodels.Python},
+				InjectableLanguages: workloadmeta.Languages{
+					InitContainerLanguages: map[string][]languagemodels.Language{
+						"nginx-cont": {
+							{Name: languagemodels.Go},
+							{Name: languagemodels.Java},
+							{Name: languagemodels.Python},
+						},
 					},
-				},
-				ContainerLanguages: map[string][]languagemodels.Language{
-					"nginx-cont": {
-						{Name: languagemodels.Go},
-						{Name: languagemodels.Java},
-						{Name: languagemodels.Python},
+					ContainerLanguages: map[string][]languagemodels.Language{
+						"nginx-cont": {
+							{Name: languagemodels.Go},
+							{Name: languagemodels.Java},
+							{Name: languagemodels.Python},
+						},
 					},
 				},
 			},
@@ -76,11 +78,13 @@ func TestDeploymentParser_Parse(t *testing.T) {
 					Kind: workloadmeta.KindKubernetesDeployment,
 					ID:   "test-namespace/test-deployment",
 				},
-				Env:                    "env",
-				Service:                "service",
-				Version:                "version",
-				InitContainerLanguages: map[string][]languagemodels.Language{},
-				ContainerLanguages:     map[string][]languagemodels.Language{},
+				Env:     "env",
+				Service: "service",
+				Version: "version",
+				InjectableLanguages: workloadmeta.Languages{
+					InitContainerLanguages: map[string][]languagemodels.Language{},
+					ContainerLanguages:     map[string][]languagemodels.Language{},
+				},
 			},
 			deployment: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -102,18 +106,20 @@ func TestDeploymentParser_Parse(t *testing.T) {
 					Kind: workloadmeta.KindKubernetesDeployment,
 					ID:   "test-namespace/test-deployment",
 				},
-				InitContainerLanguages: map[string][]languagemodels.Language{
-					"nginx-cont": {
-						{Name: languagemodels.Go},
-						{Name: languagemodels.Java},
-						{Name: languagemodels.Python},
+				InjectableLanguages: workloadmeta.Languages{
+					InitContainerLanguages: map[string][]languagemodels.Language{
+						"nginx-cont": {
+							{Name: languagemodels.Go},
+							{Name: languagemodels.Java},
+							{Name: languagemodels.Python},
+						},
 					},
-				},
-				ContainerLanguages: map[string][]languagemodels.Language{
-					"nginx-cont": {
-						{Name: languagemodels.Go},
-						{Name: languagemodels.Java},
-						{Name: languagemodels.Python},
+					ContainerLanguages: map[string][]languagemodels.Language{
+						"nginx-cont": {
+							{Name: languagemodels.Go},
+							{Name: languagemodels.Java},
+							{Name: languagemodels.Python},
+						},
 					},
 				},
 			},
@@ -132,6 +138,7 @@ func TestDeploymentParser_Parse(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := newdeploymentParser()
@@ -173,9 +180,11 @@ func Test_DeploymentsFakeKubernetesClient(t *testing.T) {
 								ID:   "test-namespace/test-deployment",
 								Kind: workloadmeta.KindKubernetesDeployment,
 							},
-							Env:                    "env",
-							ContainerLanguages:     map[string][]languagemodels.Language{},
-							InitContainerLanguages: map[string][]languagemodels.Language{},
+							Env: "env",
+							InjectableLanguages: workloadmeta.Languages{
+								ContainerLanguages:     map[string][]languagemodels.Language{},
+								InitContainerLanguages: map[string][]languagemodels.Language{},
+							},
 						},
 					},
 				},
@@ -207,11 +216,13 @@ func Test_DeploymentsFakeKubernetesClient(t *testing.T) {
 								ID:   "test-namespace/test-deployment",
 								Kind: workloadmeta.KindKubernetesDeployment,
 							},
-							ContainerLanguages: map[string][]languagemodels.Language{
-								"nginx": {{Name: languagemodels.Go}, {Name: languagemodels.Java}},
-							},
-							InitContainerLanguages: map[string][]languagemodels.Language{
-								"redis": {{Name: languagemodels.Go}, {Name: languagemodels.Python}},
+							InjectableLanguages: workloadmeta.Languages{
+								ContainerLanguages: map[string][]languagemodels.Language{
+									"nginx": {{Name: languagemodels.Go}, {Name: languagemodels.Java}},
+								},
+								InitContainerLanguages: map[string][]languagemodels.Language{
+									"redis": {{Name: languagemodels.Go}, {Name: languagemodels.Python}},
+								},
 							},
 						},
 					},
@@ -239,9 +250,11 @@ func Test_Deployment_FilteredOut(t *testing.T) {
 					ID:   "object-id",
 					Kind: workloadmeta.KindKubernetesDeployment,
 				},
-				Env:                    "env",
-				ContainerLanguages:     map[string][]languagemodels.Language{},
-				InitContainerLanguages: map[string][]languagemodels.Language{},
+				Env: "env",
+				InjectableLanguages: workloadmeta.Languages{
+					ContainerLanguages:     map[string][]languagemodels.Language{},
+					InitContainerLanguages: map[string][]languagemodels.Language{},
+				},
 			},
 			expected: false,
 		},
@@ -252,13 +265,14 @@ func Test_Deployment_FilteredOut(t *testing.T) {
 					ID:   "object-id",
 					Kind: workloadmeta.KindKubernetesDeployment,
 				},
-				ContainerLanguages: map[string][]languagemodels.Language{
-					"nginx": {{Name: languagemodels.Go}},
+				InjectableLanguages: workloadmeta.Languages{
+					ContainerLanguages:     map[string][]languagemodels.Language{"nginx": {{Name: languagemodels.Go}}},
+					InitContainerLanguages: map[string][]languagemodels.Language{},
 				},
-				InitContainerLanguages: map[string][]languagemodels.Language{},
 			},
 			expected: false,
 		},
+
 		{
 			name: "nothing",
 			deployment: &workloadmeta.KubernetesDeployment{
@@ -266,9 +280,7 @@ func Test_Deployment_FilteredOut(t *testing.T) {
 					ID:   "object-id",
 					Kind: workloadmeta.KindKubernetesDeployment,
 				},
-				Env:                    "",
-				ContainerLanguages:     map[string][]languagemodels.Language{},
-				InitContainerLanguages: map[string][]languagemodels.Language{},
+				Env: "",
 			},
 			expected: true,
 		},

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_util.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_util.go
@@ -49,7 +49,7 @@ func getLibListFromDeploymentAnnotations(store workloadmeta.Component, deploymen
 		return libList
 	}
 
-	for containerName, languages := range deployment.ContainerLanguages {
+	for containerName, languages := range deployment.InjectableLanguages.ContainerLanguages {
 		for _, lang := range languages {
 			imageToInject := libImageName(registry, language(lang.Name), "latest")
 			libList = append(libList, libInfo{ctrName: containerName, lang: language(lang.Name), image: imageToInject})

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_util_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_util_test.go
@@ -96,18 +96,20 @@ func TestGetLibListFromDeploymentAnnotations(t *testing.T) {
 			Kind: workloadmeta.KindKubernetesDeployment,
 			ID:   "default/dummy",
 		},
-		ContainerLanguages: map[string][]languagemodels.Language{
-			"container-1": {
-				{
-					Name: "java",
+		InjectableLanguages: workloadmeta.Languages{
+			ContainerLanguages: map[string][]languagemodels.Language{
+				"container-1": {
+					{
+						Name: "java",
+					},
+					{
+						Name: "js",
+					},
 				},
-				{
-					Name: "js",
-				},
-			},
-			"container-2": {
-				{
-					Name: "python",
+				"container-2": {
+					{
+						Name: "python",
+					},
 				},
 			},
 		},
@@ -118,18 +120,20 @@ func TestGetLibListFromDeploymentAnnotations(t *testing.T) {
 			Kind: workloadmeta.KindKubernetesDeployment,
 			ID:   "custom/dummy",
 		},
-		ContainerLanguages: map[string][]languagemodels.Language{
-			"container-1": {
-				{
-					Name: "ruby",
+		InjectableLanguages: workloadmeta.Languages{
+			ContainerLanguages: map[string][]languagemodels.Language{
+				"container-1": {
+					{
+						Name: "ruby",
+					},
+					{
+						Name: "python",
+					},
 				},
-				{
-					Name: "python",
-				},
-			},
-			"container-2": {
-				{
-					Name: "java",
+				"container-2": {
+					{
+						Name: "java",
+					},
 				},
 			},
 		},

--- a/pkg/clusteragent/languagedetection/patcher.go
+++ b/pkg/clusteragent/languagedetection/patcher.go
@@ -104,13 +104,13 @@ func (lp *LanguagePatcher) detectedNewLanguages(namespacedOwnerRef *NamespacedOw
 
 	existingContainersLanguages := langUtil.NewContainersLanguages()
 
-	for container, languages := range owner.ContainerLanguages {
+	for container, languages := range owner.InjectableLanguages.ContainerLanguages {
 		for _, language := range languages {
 			existingContainersLanguages.GetOrInitializeLanguageset(container).Add(string(language.Name))
 		}
 	}
 
-	for container, languages := range owner.InitContainerLanguages {
+	for container, languages := range owner.InjectableLanguages.InitContainerLanguages {
 		for _, language := range languages {
 			existingContainersLanguages.GetOrInitializeLanguageset(fmt.Sprintf("init.%s", container)).Add(string(language.Name))
 		}

--- a/pkg/clusteragent/languagedetection/patcher_test.go
+++ b/pkg/clusteragent/languagedetection/patcher_test.go
@@ -221,19 +221,21 @@ func TestDetectedNewLanguages(t *testing.T) {
 			Kind: workloadmeta.KindKubernetesDeployment,
 			ID:   "default/dummy",
 		},
-		ContainerLanguages: map[string][]languagemodels.Language{
-			"container-1": {
-				{
-					Name:    "go",
-					Version: "1.2",
+		InjectableLanguages: workloadmeta.Languages{
+			ContainerLanguages: map[string][]languagemodels.Language{
+				"container-1": {
+					{
+						Name:    "go",
+						Version: "1.2",
+					},
 				},
 			},
-		},
-		InitContainerLanguages: map[string][]languagemodels.Language{
-			"container-2": {
-				{
-					Name:    "java",
-					Version: "18",
+			InitContainerLanguages: map[string][]languagemodels.Language{
+				"container-2": {
+					{
+						Name:    "java",
+						Version: "18",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Modifies workloadmeta deployment entity to allow storing languages detected by node agent, in addition to languages read from annotations.

Within the context of language detection:
- Language detection process takes place in the node agents
- When a language is detected, it is sent to the cluster agent, which patches the language annotation on the pod owner (i.e. parent deployment)
- The kubernetes informer notifies the store that the deployment annotation was updated, and the deployment resource is parsed, where languages of each container are extracted from annotations and stored in workloadmeta deployment entity.

We want to allow the cluster agent to store in deployment entities the languages detected and reported by node agents. We need to make a distinction between what is reported by Node Agents and what results from parsing language annotations. In theory, language annotations should converge to languages reported by agents, but in practice, they might be different temporarily until the patching process finishes successfully.

### Motivation

Two main motivations:
- Being able to decouple language detection handler and language detection patcher. The language detection handler receives languages reported by node agent, and pushes them into workloadmeta. On the other side, the language detection patcher subscribes to workloadmeta and processes reported languages. 
- Storing and updating TTL for languages reported by node agent (without needing to re-patch deployments). This can be beneficial for implementing a cleanup process.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

In this PR, the Cluster Agent still doesn't populate the languages reported by node agent into the deployment entity in workloadmeta store. It only modifies the structure of the deployment entity to support populating these information when needed. This will be leveraged in other tasks.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
- Now we have two fields in the deployment entity including information about containers languages: `InjectableLanguages` and `DetectedLanguages`. The `kubeapiserver` shouldn't be modifying `DetectedLanguages` at all, and this is already handled in the unit tests of the deployment store (specifically in `Test_DeploymentsFakeKubernetesClient`. On the other side, `SourceLanguageDetectionServer` should not be setting `InjectableLanguages`, and this should be handled in the unit tests when implementing the language detection server push events. This should guarantee that the default `merge` implementation will not cause any problems when merging events emitted by these two sources.

### Describe how to test/QA your changes

ATTENTION: `qa/done` label is added because it this task will be tested during QA of other tasks that will leverage it.

To QA this change, ensure that workloadmeta can still parse deployments with language annotations correctly. Deploy the cluster agent with language detection enabled. Deploy a sample deployment have language annotations. Ensure that the language annotations are parsed and stored in workloadmeta. 

Steps:

Sample helm:
```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret

clusterAgent:
  enabled: true
  env:
    - name: DD_LANGUAGE_DETECTION_ENABLED
      value: true
```

Sample mock user app deployment:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: mock-user-app
  annotations:
    internal.dd.datadoghq.com/mock-app-container-1.detected_langs: python,java
    internal.dd.datadoghq.com/mock-app-container-2.detected_langs: golang,ruby
  labels:
    app: mock-user-app
spec:
  replicas: 3
  selector:
    matchLabels:
      app: mock-user-app
  template:
    metadata:
      labels:
        app: mock-user-app
    spec:
      containers:
        - name: mock-app-container-1
          image: ubuntu:latest
          command: ["/bin/bash", "-c", "--"]
          args: ["while true; do sleep 30; done;"]
        - name: mock-app-container-2
          image: ubuntu:latest
          command: ["/bin/bash", "-c", "--"]
          args: ["while true; do sleep 30; done;"]
```

After you deploy the mock application, you should be able to find the detected language (which can be found in language annotations) stored in workloadmeta output by executing `kubectl exec datadog-agent-cluster-agent-xxxxx   -- agent workload-list -v`. The output should be similar to the following:

```
=== Entity kubernetes_deployment sources(merged):[kubeapiserver] id: default/mock-user-app ===
----------- Entity ID -----------
Kind: kubernetes_deployment ID: default/mock-user-app

----------- Unified Service Tagging -----------
Env : 
Service : 
Version : 
----------- Injectable Languages -----------
Container mock-app-container-1=>[python,java]
Container mock-app-container-2=>[golang,ruby]
----------- Detected Languages -----------
===
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
