### PR TITLE
usm: tests: Reuse testutil building

### DIFF
--- a/pkg/network/usm/sharedlibraries/testutil/fmapper/.gitignore
+++ b/pkg/network/usm/sharedlibraries/testutil/fmapper/.gitignore
@@ -1,0 +1,1 @@
+fmapper

--- a/pkg/network/usm/testutil/generic_testutil_builder.go
+++ b/pkg/network/usm/testutil/generic_testutil_builder.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package testutil provides utilities for testing USM.
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+)
+
+// BuildUnixTransparentProxyServer builds the unix transparent proxy server binary and returns the path to the binary.
+// If the binary is already built (meanly in the CI), it returns the path to the binary.
+func BuildUnixTransparentProxyServer(curDir, binaryDir string) (string, error) {
+	serverSrcDir := path.Join(curDir, binaryDir)
+	cachedServerBinaryPath := path.Join(serverSrcDir, binaryDir)
+
+	// If there is a compiled binary already, skip the compilation.
+	// Meant for the CI.
+	if _, err := os.Stat(cachedServerBinaryPath); err == nil {
+		return cachedServerBinaryPath, nil
+	}
+
+	c := exec.Command("go", "build", "-buildvcs=false", "-a", "-tags=test", "-ldflags=-extldflags '-static'", "-o", cachedServerBinaryPath, serverSrcDir)
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("could not build unix transparent proxy server test binary: %s\noutput: %s", err, string(out))
+	}
+
+	return cachedServerBinaryPath, nil
+}

--- a/pkg/network/usm/testutil/grpc/grpc_external_server/.gitignore
+++ b/pkg/network/usm/testutil/grpc/grpc_external_server/.gitignore
@@ -1,0 +1,1 @@
+grpc_external_server


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Consolidates the building mechanism for a testutils in USM tests.
It only affects local runs, as CI runs have a task to build the images before the test runs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Remove duplication
Improve local runs, as we build the intermediate binaries to the same location, allowing local runs to reuse them 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
