### PR TITLE
Implement automatic reconnection for SSH session

### DIFF
--- a/test/new-e2e/pkg/components/remotehost.go
+++ b/test/new-e2e/pkg/components/remotehost.go
@@ -44,7 +44,7 @@ var _ e2e.Initializable = &RemoteHost{}
 // Init is called by e2e test Suite after the component is provisioned.
 func (h *RemoteHost) Init(ctx e2e.Context) error {
 	h.context = ctx
-	return h.ReconnectSSH()
+	return h.reconnectSSH()
 }
 
 // Execute executes a command and returns an error if any.
@@ -61,7 +61,7 @@ func (h *RemoteHost) Execute(command string, options ...ExecuteOption) (string, 
 	output, err = clients.ExecuteCommand(h.client, cmd)
 
 	if err != nil && strings.Contains(err.Error(), "failed to create session:") {
-		err = h.ReconnectSSH()
+		err = h.reconnectSSH()
 		if err != nil {
 			return "", err
 		}
@@ -143,9 +143,9 @@ func (h *RemoteHost) RemoveAll(path string) error {
 	return clients.RemoveAll(h.client, path)
 }
 
-// ReconnectSSH recreate the SSH connection to the VM. Should be used only after VM reboot to restore the SSH connection.
+// reconnectSSH recreate the SSH connection to the VM. Should be used only after VM reboot to restore the SSH connection.
 // Returns an error if the VM is not reachable after retries.
-func (h *RemoteHost) ReconnectSSH() error {
+func (h *RemoteHost) reconnectSSH() error {
 	h.context.T().Logf("connecting to remote VM at %s@%s", h.Username, h.Address)
 
 	if h.client != nil {

--- a/test/new-e2e/pkg/utils/clients/ssh.go
+++ b/test/new-e2e/pkg/utils/clients/ssh.go
@@ -89,7 +89,7 @@ func getSSHClient(user, host string, privateKey, privateKeyPassphrase []byte) (*
 func ExecuteCommand(client *ssh.Client, command string) (string, error) {
 	session, err := client.NewSession()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to create session: %v", err)
 	}
 
 	stdout, err := session.CombinedOutput(command)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Automatically try to reconnect when the execute command encounters an error on the ssh session creation. The max number of retries for SSH connection has been increased to handle longer reboot time (note that the default one was enough for most of the tries I did)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
