### PR TITLE
pkg/trace/api: debug log tags stored in headers by reverse-proxies

### DIFF
--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -113,6 +113,7 @@ func getDirector(hostTags string, cidProvider IDProvider, containerTags func(str
 		}
 		tags = tags[0:maxLen]
 		q.Set("ddtags", tags)
+		log.Debugf("Setting query value ddtags=%s for debugger proxy", tags)
 		req.URL.RawQuery = q.Encode()
 	}
 }

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -162,10 +162,12 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 		req.Header.Set(header.ContainerID, containerID)
 		if ctags := getContainerTags(t.conf.ContainerTags, containerID); ctags != "" {
 			req.Header.Set("X-Datadog-Container-Tags", ctags)
+			log.Debugf("Setting header X-Datadog-Container-Tags=%s for evp proxy", ctags)
 		}
 	}
 	req.Header.Set("X-Datadog-Hostname", t.conf.Hostname)
 	req.Header.Set("X-Datadog-AgentDefaultEnv", t.conf.DefaultEnv)
+	log.Debugf("Setting headers X-Datadog-Hostnames=%s, X-Datadog-AgentDefaultEnv=%s for evp proxy", t.conf.Hostname, t.conf.DefaultEnv)
 	req.Header.Set(header.ContainerID, containerID)
 	if needsAppKey {
 		req.Header.Set("DD-APPLICATION-KEY", t.conf.EVPProxy.ApplicationKey)

--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -83,8 +83,10 @@ func newPipelineStatsProxy(conf *config.AgentConfig, urls []*url.URL, apiKeys []
 		containerID := cidProvider.GetContainerID(req.Context(), req.Header)
 		if ctags := getContainerTags(conf.ContainerTags, containerID); ctags != "" {
 			req.Header.Set("X-Datadog-Container-Tags", ctags)
+			log.Debugf("Setting header X-Datadog-Container-Tags=%s for pipeline stats proxy", ctags)
 		}
 		req.Header.Set("X-Datadog-Additional-Tags", tags)
+		log.Debugf("Setting header X-Datadog-Additional-Tags=%s for pipeline stats proxy", tags)
 		metrics.Count("datadog.trace_agent.pipelines_stats", 1, nil, 1)
 	}
 	logger := log.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -112,8 +112,10 @@ func newProfileProxy(conf *config.AgentConfig, targets []*url.URL, keys []string
 		containerID := cidProvider.GetContainerID(req.Context(), req.Header)
 		if ctags := getContainerTags(conf.ContainerTags, containerID); ctags != "" {
 			req.Header.Set("X-Datadog-Container-Tags", ctags)
+			log.Debugf("Setting header X-Datadog-Container-Tags=%s for profiles proxy", ctags)
 		}
 		req.Header.Set("X-Datadog-Additional-Tags", tags)
+		log.Debugf("Setting header X-Datadog-Additional-Tags=%s for profiles proxy", tags)
 		metrics.Count("datadog.trace_agent.profile", 1, nil, 1)
 		// URL, Host and key are set in the transport for each outbound request
 	}

--- a/pkg/trace/api/symdb.go
+++ b/pkg/trace/api/symdb.go
@@ -88,5 +88,6 @@ func getSymDBDirector(hostTags string, cidProvider IDProvider, containerTags fun
 			tags = fmt.Sprintf("%s,%s", tags, qtags)
 		}
 		req.Header.Set("X-Datadog-Additional-Tags", tags)
+		log.Debugf("Setting header X-Datadog-Additional-Tags=%s for symdb proxy", tags)
 	}
 }

--- a/pkg/trace/api/telemetry.go
+++ b/pkg/trace/api/telemetry.go
@@ -114,11 +114,13 @@ func (r *HTTPReceiver) telemetryProxyHandler() http.Handler {
 
 		req.Header.Set("DD-Agent-Hostname", r.conf.Hostname)
 		req.Header.Set("DD-Agent-Env", r.conf.DefaultEnv)
+		log.Debugf("Setting headers DD-Agent-Hostname=%s, DD-Agent-Env=%s for telemetry proxy", r.conf.Hostname, r.conf.DefaultEnv)
 		if containerID != "" {
 			req.Header.Set(header.ContainerID, containerID)
 		}
 		if containerTags != "" {
 			req.Header.Set("x-datadog-container-tags", containerTags)
+			log.Debugf("Setting header x-datadog-container-tags=%s for telemetry proxy", containerTags)
 		}
 		if installSignature.Found {
 			req.Header.Set("DD-Agent-Install-Id", installSignature.InstallID)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add debug logging in the various reverse-proxies in the trace-agent.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Ease debugging tags-related issues for the reverse-proxies that rely on HTTP headers to report container and host-level tags.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the trace-agent with log level debug, the following logs should be seen (depending on the products sending data)
```
2024-01-19 11:11:02 CET | TRACE | DEBUG | (pkg/trace/api/profiles.go:118 in func1) | Setting header X-Datadog-Additional-Tags=host:dev.host,default_env:dev.env,agent_version:7.52.0-devel+git.122.3c47e77 for profiles proxy
2024-01-19 11:11:03 CET | TRACE | DEBUG | (pkg/trace/api/telemetry.go:117 in func1) | Setting headers DD-Agent-Hostname=dev.host, DD-Agent-Env=dev.env for telemetry proxy
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
