### PR TITLE
[ASCII-1099] Remove workloadmeta start

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -46,7 +46,6 @@ func testCollectEvent(t *testing.T, createResource func(*fake.Clientset) error, 
 		workloadmeta.MockModuleV2(),
 	))
 	ctx := context.TODO()
-	wlm.Start(ctx)
 
 	store, _ := newStore(ctx, wlm, client)
 	stopStore := make(chan struct{})

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
@@ -149,7 +149,6 @@ func TestCollection(t *testing.T) {
 		fx.Supply(workloadmeta.NewParams()),
 		workloadmeta.MockModuleV2(),
 	))
-	mockServerStore.Start(context.TODO())
 	server := &serverSecure{workloadmetaServer: server.NewServer(mockServerStore)}
 
 	// gRPC server

--- a/comp/core/workloadmeta/component.go
+++ b/comp/core/workloadmeta/component.go
@@ -7,8 +7,6 @@
 package workloadmeta
 
 import (
-	"context"
-
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -18,16 +16,6 @@ import (
 
 // Component is the component type.
 type Component interface {
-	// TODO(components): Start method is currently unused in components and is
-	//                   a legacy method from pre-componentization and will probably
-	//                   not need to ever be part of the component interface. Clean-up
-	//                   the workloademeta.Component interface.
-
-	// Start starts the store, asynchronously initializing collectors and
-	// beginning to gather workload data.  This is typically called during
-	// agent startup.
-	Start(ctx context.Context)
-
 	// Subscribe subscribes the caller to events representing changes to the
 	// store, limited to events matching the filter.  The name is used for
 	// telemetry and debugging.

--- a/comp/core/workloadmeta/store.go
+++ b/comp/core/workloadmeta/store.go
@@ -37,8 +37,8 @@ type subscriber struct {
 	filter   *Filter
 }
 
-// Start starts the workload metadata store.
-func (w *workloadmeta) Start(ctx context.Context) {
+// start starts the workload metadata store.
+func (w *workloadmeta) start(ctx context.Context) {
 	go func() {
 		health := health.RegisterLiveness("workloadmeta-store")
 		for {

--- a/comp/core/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/workloadmeta.go
@@ -95,7 +95,7 @@ func newWorkloadMeta(deps dependencies) Component {
 				return err
 			}
 		}
-		wm.Start(mainCtx)
+		wm.start(mainCtx)
 		return nil
 	}})
 	deps.Lc.Append(fx.Hook{OnStop: func(context.Context) error {

--- a/pkg/util/trivy/cache_test.go
+++ b/pkg/util/trivy/cache_test.go
@@ -231,7 +231,6 @@ func TestCustomBoltCache_GarbageCollector(t *testing.T) {
 	))
 
 	// setup workloadmeta for test
-	workloadmetaStore.Start(context.TODO())
 	workloadmeta.SetGlobalStore(workloadmetaStore)
 	defer workloadmeta.SetGlobalStore(nil)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR removes `Start` from workloadmeta component.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
