### PR TITLE
pkg/trace: make pkg/trace/agent control the lifecycle of pkg timing

### DIFF
--- a/comp/trace/agent/run.go
+++ b/comp/trace/agent/run.go
@@ -26,7 +26,6 @@ import (
 	tracecfg "github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
-	"github.com/DataDog/datadog-agent/pkg/trace/metrics/timing"
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -142,7 +141,6 @@ func stopAgentSidekicks(cfg config.Component) {
 	log.Flush()
 	metrics.Flush()
 
-	timing.Stop()
 	tracecfg := cfg.Object()
 	if pcfg := profilingConfig(tracecfg); pcfg != nil {
 		profiling.Stop()

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -131,7 +131,8 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig, telemetryCollector 
 
 // Run starts routers routines and individual pieces then stop them when the exit order is received.
 func (a *Agent) Run() {
-	timing.Start()
+	timing.Start(metrics.Client)
+	defer timing.Stop()
 	for _, starter := range []interface{ Start() }{
 		a.Receiver,
 		a.Concentrator,
@@ -219,7 +220,6 @@ func (a *Agent) loop() {
 	} {
 		stopper.Stop()
 	}
-	timing.Stop()
 }
 
 // setRootSpanTags sets up any necessary tags on the root span.

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -131,6 +131,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig, telemetryCollector 
 
 // Run starts routers routines and individual pieces then stop them when the exit order is received.
 func (a *Agent) Run() {
+	timing.Start()
 	for _, starter := range []interface{ Start() }{
 		a.Receiver,
 		a.Concentrator,
@@ -218,6 +219,7 @@ func (a *Agent) loop() {
 	} {
 		stopper.Stop()
 	}
+	timing.Stop()
 }
 
 // setRootSpanTags sets up any necessary tags on the root span.

--- a/pkg/trace/metrics/client.go
+++ b/pkg/trace/metrics/client.go
@@ -6,7 +6,6 @@
 package metrics
 
 import (
-	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -21,23 +20,12 @@ type StatsClient interface {
 	Flush() error
 }
 
-var m sync.Mutex
-
-// SetClient sets the global Statsd client.
-func SetClient(client StatsClient) {
-	m.Lock()
-	defer m.Unlock()
-	Client = client
-}
-
 // Client is a global Statsd client. When a client is configured via Configure,
 // that becomes the new global Statsd client in the package.
 var Client StatsClient = (*statsd.Client)(nil)
 
 // Gauge calls Gauge on the global Client, if set.
 func Gauge(name string, value float64, tags []string, rate float64) error {
-	m.Lock()
-	defer m.Unlock()
 	if Client == nil {
 		return nil // no-op
 	}
@@ -46,8 +34,6 @@ func Gauge(name string, value float64, tags []string, rate float64) error {
 
 // Count calls Count on the global Client, if set.
 func Count(name string, value int64, tags []string, rate float64) error {
-	m.Lock()
-	defer m.Unlock()
 	if Client == nil {
 		return nil // no-op
 	}
@@ -56,8 +42,6 @@ func Count(name string, value int64, tags []string, rate float64) error {
 
 // Histogram calls Histogram on the global Client, if set.
 func Histogram(name string, value float64, tags []string, rate float64) error {
-	m.Lock()
-	defer m.Unlock()
 	if Client == nil {
 		return nil // no-op
 	}
@@ -66,8 +50,6 @@ func Histogram(name string, value float64, tags []string, rate float64) error {
 
 // Timing calls Timing on the global Client, if set.
 func Timing(name string, value time.Duration, tags []string, rate float64) error {
-	m.Lock()
-	defer m.Unlock()
 	if Client == nil {
 		return nil // no-op
 	}
@@ -76,8 +58,6 @@ func Timing(name string, value time.Duration, tags []string, rate float64) error
 
 // Flush flushes any pending metrics to the agent.
 func Flush() error {
-	m.Lock()
-	defer m.Unlock()
 	if Client == nil {
 		return nil // no-op
 	}

--- a/pkg/trace/metrics/client.go
+++ b/pkg/trace/metrics/client.go
@@ -6,6 +6,7 @@
 package metrics
 
 import (
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -20,12 +21,23 @@ type StatsClient interface {
 	Flush() error
 }
 
+var m sync.Mutex
+
+// SetClient sets the global Statsd client.
+func SetClient(client StatsClient) {
+	m.Lock()
+	defer m.Unlock()
+	Client = client
+}
+
 // Client is a global Statsd client. When a client is configured via Configure,
 // that becomes the new global Statsd client in the package.
 var Client StatsClient = (*statsd.Client)(nil)
 
 // Gauge calls Gauge on the global Client, if set.
 func Gauge(name string, value float64, tags []string, rate float64) error {
+	m.Lock()
+	defer m.Unlock()
 	if Client == nil {
 		return nil // no-op
 	}
@@ -34,6 +46,8 @@ func Gauge(name string, value float64, tags []string, rate float64) error {
 
 // Count calls Count on the global Client, if set.
 func Count(name string, value int64, tags []string, rate float64) error {
+	m.Lock()
+	defer m.Unlock()
 	if Client == nil {
 		return nil // no-op
 	}
@@ -42,6 +56,8 @@ func Count(name string, value int64, tags []string, rate float64) error {
 
 // Histogram calls Histogram on the global Client, if set.
 func Histogram(name string, value float64, tags []string, rate float64) error {
+	m.Lock()
+	defer m.Unlock()
 	if Client == nil {
 		return nil // no-op
 	}
@@ -50,6 +66,8 @@ func Histogram(name string, value float64, tags []string, rate float64) error {
 
 // Timing calls Timing on the global Client, if set.
 func Timing(name string, value time.Duration, tags []string, rate float64) error {
+	m.Lock()
+	defer m.Unlock()
 	if Client == nil {
 		return nil // no-op
 	}
@@ -58,6 +76,8 @@ func Timing(name string, value time.Duration, tags []string, rate float64) error
 
 // Flush flushes any pending metrics to the agent.
 func Flush() error {
+	m.Lock()
+	defer m.Unlock()
 	if Client == nil {
 		return nil // no-op
 	}

--- a/pkg/trace/metrics/timing/timing.go
+++ b/pkg/trace/metrics/timing/timing.go
@@ -15,75 +15,94 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 )
 
-// AutoreportInterval specifies the interval at which the default set reports.
-const AutoreportInterval = 10 * time.Second
+// autoreportInterval specifies the interval at which the default set reports.
+const autoreportInterval = 10 * time.Second
 
 var (
-	defaultSet = NewSet()
-	stopReport = defaultSet.Autoreport(AutoreportInterval)
+	defaultSet *set
 )
 
 // Since records the duration for the given metric name as time passed since start.
 // It uses the default set which is reported at 10 second intervals.
-func Since(name string, start time.Time) { defaultSet.Since(name, start) }
+func Since(name string, start time.Time) {
+	if defaultSet == nil {
+		log.Error("Timing hasn't been initialized, trace-agent metrics will be missing")
+		return
+	}
+	defaultSet.Since(name, start)
+}
+
+// Start initializes autoreporting of timing metrics.
+func Start() {
+	defaultSet = newSet()
+	defaultSet.autoreport(autoreportInterval)
+}
 
 // Stop permanently stops the default set from auto-reporting and flushes any remaining
 // metrics. It can be useful to call when the program exits to ensure everything is
 // submitted.
-func Stop() { stopReport() }
+func Stop() {
+	if defaultSet == nil {
+		return
+	}
+	defaultSet.stop()
+}
 
-// NewSet returns a new, ready to use Set.
-func NewSet() *Set {
-	return &Set{c: make(map[string]*counter)}
+// newSet returns a new, ready to use Set.
+func newSet() *set {
+	return &set{c: make(map[string]*counter), close: make(chan struct{})}
 }
 
 // Set represents a set of metrics that can be used for timing. Use NewSet to initialize
 // a new Set. Use Report (or Autoreport) to submit metrics. Set is safe for concurrent use.
-type Set struct {
-	mu sync.RWMutex        // guards c
-	c  map[string]*counter // maps names to their aggregates
+type set struct {
+	mu        sync.RWMutex        // guards c
+	c         map[string]*counter // maps names to their aggregates
+	close     chan struct{}
+	startOnce sync.Once
+	stopOnce  sync.Once
 }
 
-// Autoreport enables autoreporting of the Set at the given interval. It returns a
+// autoreport enables autoreporting of the Set at the given interval. It returns a
 // cancellation function.
-func (s *Set) Autoreport(interval time.Duration) (cancelFunc func()) {
-	stop := make(chan struct{})
-	go func() {
-		defer close(stop)
-		tick := time.NewTicker(interval)
-		defer tick.Stop()
-		for {
-			select {
-			case <-tick.C:
-				s.Report()
-			case <-stop:
-				s.Report()
-				return
+func (s *set) autoreport(interval time.Duration) {
+	s.startOnce.Do(func() {
+		go func() {
+			tick := time.NewTicker(interval)
+			defer tick.Stop()
+			for {
+				select {
+				case <-tick.C:
+					s.report()
+				case <-s.close:
+					s.report()
+					return
+				}
 			}
-		}
-	}()
-	var once sync.Once // avoid panics
-	return func() {
-		once.Do(func() {
-			stop <- struct{}{}
-			<-stop
-		})
-	}
+		}()
+	})
+}
+
+func (s *set) stop() {
+	s.stopOnce.Do(func() {
+		close(s.close)
+	})
 }
 
 // Since records the duration for the given metric name as *time passed since start*.
 // If name does not exist, as defined by NewSet, it creates it.
-func (s *Set) Since(name string, start time.Time) {
+func (s *set) Since(name string, start time.Time) {
 	ms := time.Since(start) / time.Millisecond
 	s.getCounter(name).add(float64(ms))
 }
 
 // getCounter returns the counter with the given name, initializing any uninitialized
 // fields of s.
-func (s *Set) getCounter(name string) *counter {
+func (s *set) getCounter(name string) *counter {
 	s.mu.RLock()
 	c, ok := s.c[name]
 	s.mu.RUnlock()
@@ -102,7 +121,7 @@ func (s *Set) getCounter(name string) *counter {
 }
 
 // Report reports all of the Set's metrics to the statsd client.
-func (s *Set) Report() {
+func (s *set) report() {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, c := range s.c {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Revamp the timing package and make pkg/trace/agent control its lifecycle. Inject the dogstatsd client as a dependency of `timing` instead of importing the `metrics` package directly, this simplifies the refactor and eases testing.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

fixes https://github.com/DataDog/datadog-agent/issues/22030

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Checked the metrics submitted using the `timing` package haven't regressed.

![image](https://github.com/DataDog/datadog-agent/assets/38987709/4ecbad5e-cda4-45b8-b2f6-e3a0dd7d8703)


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
