### PR TITLE
[oracle] Fix tablespaces (DBMON-3428)

### DIFF
--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -34,6 +34,14 @@ func (m *MockSender) AssertMetric(t *testing.T, method string, metric string, va
 	return m.Mock.AssertCalled(t, method, metric, value, hostname, MatchTagsContains(tags))
 }
 
+// AssertMetric that the metric is emitted only once
+// Additional tags over the ones specified don't make it fail
+func (m *MockSender) AssertMetricOnce(t *testing.T, method string, metric string, value float64, hostname string, tags []string) bool {
+	okCall := m.Mock.AssertCalled(t, method, metric, value, hostname, MatchTagsContains(tags))
+	notOkCalls := m.Mock.AssertNotCalled(t, method, metric, AnythingBut(value), hostname, MatchTagsContains(tags))
+	return okCall && notOkCalls
+}
+
 // AssertMonotonicCount allows to assert a monotonic count was emitted with given parameters.
 // Additional tags over the ones specified don't make it fail
 func (m *MockSender) AssertMonotonicCount(t *testing.T, method string, metric string, value float64, hostname string, tags []string, flushFirstValue bool) bool {

--- a/pkg/collector/corechecks/oracle-dbm/tablespaces.go
+++ b/pkg/collector/corechecks/oracle-dbm/tablespaces.go
@@ -24,7 +24,7 @@ const tablespaceQuery12 = `SELECT
 FROM
   cdb_tablespace_usage_metrics m, cdb_tablespaces t, v$containers c
 WHERE
-  m.tablespace_name(+) = t.tablespace_name and c.con_id(+) = t.con_id`
+  m.con_id = t.con_id and m.tablespace_name(+) = t.tablespace_name and c.con_id(+) = t.con_id`
 
 const tablespaceQuery11 = `SELECT
   t.tablespace_name tablespace_name,

--- a/pkg/collector/corechecks/oracle-dbm/tablespaces_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/tablespaces_test.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle_test
+
+package oracle
+
+import (
+	"testing"
+
+	//"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+/*
+ * Prerequisites:
+ * create tablespace tbs_test datafile '/opt/oracle/oradata/XE/tbs_test01.dbf' size 100M ;
+ * alter session set container=xepdb1 ;
+ * create tablespace tbs_test datafile '/opt/oracle/oradata/XE/XEPDB1/tbs_test01.dbf' size 200M;
+ */
+
+func TestTablespaces(t *testing.T) {
+	tags := []string{"pdb:cdb$root", "tablespace:TBS_TEST"}
+	c, s := newRealCheck(t, "")
+	err := c.Run()
+	require.NoError(t, err)
+	s.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.size", 104857600, "", tags)
+}

--- a/releasenotes/notes/add-bc805b87b54515ef.yaml
+++ b/releasenotes/notes/add-bc805b87b54515ef.yaml
@@ -1,3 +1,3 @@
 ---
 fixes:
-  - [oracle]: Fix wrong tablespace metrics.
+  - oracle: Fix wrong tablespace metrics.

--- a/releasenotes/notes/add-bc805b87b54515ef.yaml
+++ b/releasenotes/notes/add-bc805b87b54515ef.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - [oracle]: Fix wrong tablespace metrics.


### PR DESCRIPTION
### What does this PR do?

Fix wrong tablespace metrics.

### Additional Notes

Metrics were emitted multiple times with wrong values because a missing join condition generated Cartesian product. A test case, and also a new `AssertMetricOnce` were added.

### Describe how to test/QA your changes

Test that tablespace metrics are emitted only once.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
