### PR TITLE
[Agent APIs] Do not log query parameters, fix to also log non-existing endpoints

### DIFF
--- a/comp/api/api/apiimpl/utils/observability.go
+++ b/comp/api/api/apiimpl/utils/observability.go
@@ -19,7 +19,7 @@ import (
 
 type logFunc func(format string, args ...interface{})
 
-const logFormat = "%s: %s %s from %s took %s and returned http code %d"
+const logFormat = "%s: %s %s from %s to %s took %s and returned http code %d"
 
 func getLogFunc(code int) logFunc {
 	if code >= 100 && code < 400 {
@@ -56,7 +56,7 @@ func logResponseHandler(serverName string, getLogFunc func(int) logFunc) mux.Mid
 			} else {
 				path = "<invalid url>" // redacted in case it contained sensitive information
 			}
-			logFunc(logFormat, serverName, r.Method, path, r.RemoteAddr, duration, code)
+			logFunc(logFormat, serverName, r.Method, path, r.RemoteAddr, r.Host, duration, code)
 		})
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix logging added by https://github.com/DataDog/datadog-agent/pull/22072 to only print the query path, in particular not the parameters.
Also move the handler to run on every request to the API instead of in each `mux` separately.
Also print the host part of the query following suggestion.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The query parameters could contain secrets.
It didn't log when hitting an endpoint which didn't exist, moving the handler higher in the handler chain allows to also have logs for non-existing endpoints (which were otherwise filtered by the `mux` itself).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Also improved testing, eg. tested that even when using `http.StringPrefix` the full path is printed.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Done with unit tests.

Can be tested manually with
```
curl -k -H "authorization: Bearer $(cat dev/dist/auth_token)" "https://localhost:5001/agent/ver?mysecret=qwertyuiop"
```

It will print
```
2024-01-22 12:34:54 CET | CORE | WARN | (comp/api/api/apiimpl/utils/observability.go:29 in func1) | CMD API Server: GET /agent/ver from 127.0.0.1:64515 to localhost:5001 took 9.875µs and returned http code 404
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
