### PR TITLE
pkg/trace/api: limit simultaneous otlp requests, do not drop payloads

### DIFF
--- a/comp/otelcol/otlp/map_provider_config_not_serverless.go
+++ b/comp/otelcol/otlp/map_provider_config_not_serverless.go
@@ -14,17 +14,12 @@ package otlp
 const defaultTracesConfig string = `
 receivers:
   otlp:
-    protocols:
-      grpc:
-        max_concurrent_streams: 1
 
 exporters:
   otlp:
     tls:
       insecure: true
     compression: none
-    sending_queue:
-      enabled: false
 
 service:
   telemetry:

--- a/comp/otelcol/otlp/map_provider_config_not_serverless.go
+++ b/comp/otelcol/otlp/map_provider_config_not_serverless.go
@@ -14,12 +14,17 @@ package otlp
 const defaultTracesConfig string = `
 receivers:
   otlp:
+    protocols:
+      grpc:
+        max_concurrent_streams: 1
 
 exporters:
   otlp:
     tls:
       insecure: true
     compression: none
+    sending_queue:
+      enabled: false
 
 service:
   telemetry:

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -76,7 +76,10 @@ func (o *OTLPReceiver) Start() {
 		if err != nil {
 			log.Criticalf("Error starting OpenTelemetry gRPC server: %v", err)
 		} else {
-			o.grpcsrv = grpc.NewServer(grpc.MaxRecvMsgSize(10 * 1024 * 1024))
+			o.grpcsrv = grpc.NewServer(
+				grpc.MaxRecvMsgSize(10*1024*1024),
+				grpc.MaxConcurrentStreams(1), // Each payload must be sent to processing stage before we decode the next.
+			)
 			ptraceotlp.RegisterGRPCServer(o.grpcsrv, o)
 			o.wg.Add(1)
 			go func() {
@@ -307,12 +310,8 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 			tagContainersTags: payloadTags.String(),
 		}
 	}
-	select {
-	case o.out <- &p:
-		// success
-	default:
-		log.Warn("Payload in channel full. Dropped 1 payload.")
-	}
+
+	o.out <- &p
 	return src
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This causes the OTLP Receiver to not drop traces when the payload channel is full.

This commit also limits the number of simultaneous RPC requests, forwarding
the backpressure from the pipeline to the client, and limiting our memory
to O(MaxConnections * MaxStreams * MaxPayloadSize) in the receiver, with
MaxStreams being 1.

### Motivation

This should improve the trace dropping situation without exploding memory as badly as having a large channel.

By default, a gRPC server will allow practically unlimited concurrent RPC
requests, spawning a goroutine for each. The routine will read and
deserialize the payload before calling the handler.

This means that our memory usage is not reasonably bounded, since we
could be holding hundreds of payloads in memory waiting to be processed.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Adding this means that traces will not be dropped when the payload buffer to the processor is full, meaning GRPC will not send a response to the sender right away.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

We will use the new OTel load testing environment to exercise this change.

We should compare:
* throughput (are traces being dropped)
* memory usage (is memory usage better or worse)

See @knusbaum for details about more specifics regarding infrastructure.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
