### PR TITLE
[gitlab] skip known flakes by default

### DIFF
--- a/pkg/util/testutil/flake/flake.go
+++ b/pkg/util/testutil/flake/flake.go
@@ -37,8 +37,8 @@ func shouldSkipFlake() bool {
 		return true
 	}
 	shouldSkipFlakeVar, err := strconv.ParseBool(os.Getenv("GO_TEST_SKIP_FLAKE"))
-	if err == nil {
-		return shouldSkipFlakeVar
+	if err != nil {
+		return false
 	}
-	return false
+	return shouldSkipFlakeVar
 }

--- a/pkg/util/testutil/flake/flake.go
+++ b/pkg/util/testutil/flake/flake.go
@@ -37,7 +37,7 @@ func shouldSkipFlake() bool {
 		return true
 	}
 	shouldSkipFlakeVar, err := strconv.ParseBool(os.Getenv("GO_TEST_SKIP_FLAKE"))
-	if err != nil {
+	if err == nil {
 		return shouldSkipFlakeVar
 	}
 	return false

--- a/pkg/util/testutil/flake/flake_test.go
+++ b/pkg/util/testutil/flake/flake_test.go
@@ -7,6 +7,7 @@ package flake
 
 import (
 	"math/rand"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -34,7 +35,9 @@ func (mt *mockTesting) Skip(_ ...any) {
 		defer mt.mutex.Unlock()
 		mt.skipCallCount++
 	}()
-	mt.SkipNow()
+	// implement testing.T.Skip() call to runtime.Goexit()
+	// to mock the behavior of testing.T.Skip()
+	runtime.Goexit()
 }
 
 func (mt *mockTesting) Errorf(_ string, _ ...any) {
@@ -71,8 +74,6 @@ func TestFlake(t *testing.T) {
 		mt := newMockTesting(t)
 		skipFlake = &trueValue
 		wrapAndRunFlakyTest(mt)
-		assert.True(t, mt.Skipped())
-		assert.False(t, mt.Failed())
 		assert.Equal(t, mt.SkipCount(), 1)
 		assert.Equal(t, 0, mt.ErrorCount())
 	})

--- a/pkg/util/testutil/flake/flake_test.go
+++ b/pkg/util/testutil/flake/flake_test.go
@@ -68,7 +68,7 @@ func TestFlake(t *testing.T) {
 		mt := newMockTesting(t)
 		skipFlake = &falseValue
 		wrapAndRunFlakyTest(mt)
-		assert.Equal(t, mt.logs, []any{[]any{flakyTestMessage}})
+		assert.Equal(t, []any{[]any{flakyTestMessage}}, mt.logs)
 		assert.Greater(t, mt.ErrorCount(), 1)
 		assert.Equal(t, 0, mt.SkipCount())
 	})

--- a/pkg/util/testutil/flake/flake_test.go
+++ b/pkg/util/testutil/flake/flake_test.go
@@ -57,6 +57,10 @@ var (
 )
 
 func TestFlake(t *testing.T) {
+	if shouldSkipFlake() {
+		t.Skip("skip flake test metatest when skip-flake flag or GO_TEST_SKIP_FLAKE environment variable is set")
+		return
+	}
 	t.Run("skip flake test", func(t *testing.T) {
 		mt := newMockTesting(t)
 		skipFlake = &trueValue


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Some follow ups improving meta test readability and fixing a bug in env var parsing logic 🤦‍♀️ 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix a bug caught by @clarkb7 🙇‍♀️ 
Follow up on suggestions on [previous PR](https://github.com/DataDog/datadog-agent/pull/22028)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
