### PR TITLE
Use UUIDs version 4 instead of version 2 to eliminate collisions

### DIFF
--- a/comp/trace/config/install_signature.go
+++ b/comp/trace/config/install_signature.go
@@ -71,7 +71,7 @@ func readInstallSignatureFromDisk(path string, s *config.InstallSignatureConfig)
 }
 
 func generateNewInstallSignature(s *config.InstallSignatureConfig) (err error) {
-	installID, err := uuid.NewDCEGroup()
+	installID, err := uuid.NewRandom()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This one-liner makes us generate version 4 UUIDs instead of version 2 for our install signature, to minimize the likelihood of UUID collisions. We have been seeing collisions between UUIDs from different orgs in production and this change should eliminate them going forward.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

[Use version 4 UUIDs instead of version 2](https://datadoghq.atlassian.net/browse/AIT-9526)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Delete your local `/opt/datadog-agent/etc/install.json` on your MacBook if you have one already, then build and run the trace agent. Verify that the new install.json generated by the new code has an `install_id` that does not begin with a bunch of zeroes:
```
rm /opt/datadog-agent/etc/install.json
cd ~/dd/datadog-agent/
go build ./cmd/trace-agent
./trace-agent -c /opt/datadog-agent/etc/datadog.yaml

[13:46:15] datadog-agent: cat /opt/datadog-agent/etc/install.json
{"install_id":"ecba222b-7f87-426b-ac72-18f1824fd909","install_type":"manual","install_time":1705689975}%
[13:46:19] datadog-agent:
```

The new UUID, which does not start with zeroes, is a version 4 UUID. Previously you'd get something like this:

```
[13:40:44] datadog-agent: cat /opt/datadog-agent/etc/install.json
{"install_id":"00000014-b6fa-21ee-8301-4e8b84448779","install_type":"manual","install_time":1705689627}%
[13:40:49] datadog-agent:
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
