### PR TITLE
Add framework of CI testing for windows CWS

### DIFF
--- a/.gitlab/functional_test/system_probe_windows.yml
+++ b/.gitlab/functional_test/system_probe_windows.yml
@@ -27,3 +27,25 @@ kitchen_test_system_probe_windows_x64:
     - tasks/kitchen_setup.sh
   script:
     - tasks/run-test-kitchen.sh windows-sysprobe-test $AGENT_MAJOR_VERSION
+
+kitchen_test_security_agent_windows_x64:
+  extends:
+    - .kitchen_agent_a7
+    - .kitchen_os_windows
+    - .kitchen_test_system_probe
+    - .kitchen_azure_x64
+    - .kitchen_azure_location_north_central_us
+  stage: functional_test
+  needs: [ "tests_windows_secagent_x64" ]
+  variables:
+    KITCHEN_ARCH: x86_64
+    KITCHEN_OSVERS: "win2016"
+    CHEF_VERSION: 14.12.9 # newer versions error out during kitchen setup of azure VM
+  before_script:
+    - export WINDOWS_DDPROCMON_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDPROCMON_DRIVER")
+    - export WINDOWS_DDPROCMON_VERSION=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDPROCMON_VERSION")
+    - export WINDOWS_DDPROCMON_SHASUM=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDPROCMON_SHASUM")
+    - pushd $DD_AGENT_TESTING_DIR
+    - tasks/kitchen_setup.sh
+  script:
+    - tasks/run-test-kitchen.sh windows-secagent-test $AGENT_MAJOR_VERSION

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -26,60 +26,6 @@
     - invoke -e security-agent.run-ebpf-unit-tests --verbose
     - invoke -e lint-go --targets=./pkg/security/tests --cpus 4 --build-tags="functionaltests stresstests trivy containerd linux_bpf ebpf_bindata" --arch=$TASK_ARCH
 
-.tests_windows_sysprobe:
-  stage: source_test
-  needs: ["go_deps"]
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
-  script:
-    - $ErrorActionPreference = "Stop"
-    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
-    - !reference [.setup_python_mirror_win]
-    - >
-      docker run --rm
-      -m 16384M
-      -v "$(Get-Location):c:\mnt"
-      -e AWS_NETWORKING=true
-      -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
-      -e CI_PROJECT_NAME=${CI_PROJECT_NAME}
-      -e SIGN_WINDOWS_DD_WCS=true
-      -e PY_RUNTIMES="$PYTHON_RUNTIMES"
-      -e GOMODCACHE="c:\modcache"
-      -e PIP_INDEX_URL=${PIP_INDEX_URL}
-      486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
-      c:\mnt\tasks\winbuildscripts\sysprobe.bat
-    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-  artifacts:
-    when: always
-    paths:
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
-
-.tests_windows_secagent:
-  stage: source_test
-  needs: ["go_deps"]
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
-  script:
-    - $ErrorActionPreference = "Stop"
-    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
-    - !reference [.setup_python_mirror_win]
-    - >
-      docker run --rm
-      -m 16384M
-      -v "$(Get-Location):c:\mnt"
-      -e AWS_NETWORKING=true
-      -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
-      -e CI_PROJECT_NAME=${CI_PROJECT_NAME}
-      -e SIGN_WINDOWS_DD_WCS=true
-      -e PY_RUNTIMES="$PYTHON_RUNTIMES"
-      -e GOMODCACHE="c:\modcache"
-      -e PIP_INDEX_URL=${PIP_INDEX_URL}
-      486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
-      c:\mnt\tasks\winbuildscripts\secagent.bat
-    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-  artifacts:
-    when: always
-    paths:
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files
-
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
@@ -130,21 +76,3 @@ prepare_ebpf_functional_tests_x64:
   tags: ["arch:amd64"]
   variables:
     ARCH: amd64
-
-tests_windows_sysprobe_x64:
-  extends: .tests_windows_sysprobe
-  rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
-  variables:
-    PYTHON_RUNTIMES: 3
-    ARCH: "x64"
-
-tests_windows_secagent_x64:
-  extends: .tests_windows_secagent
-  rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
-  variables:
-    PYTHON_RUNTIMES: 3
-    ARCH: "x64"

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -53,6 +53,33 @@
     paths:
       - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
 
+.tests_windows_secagent:
+  stage: source_test
+  needs: ["go_deps"]
+  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  script:
+    - $ErrorActionPreference = "Stop"
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
+    - !reference [.setup_python_mirror_win]
+    - >
+      docker run --rm
+      -m 16384M
+      -v "$(Get-Location):c:\mnt"
+      -e AWS_NETWORKING=true
+      -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
+      -e CI_PROJECT_NAME=${CI_PROJECT_NAME}
+      -e SIGN_WINDOWS_DD_WCS=true
+      -e PY_RUNTIMES="$PYTHON_RUNTIMES"
+      -e GOMODCACHE="c:\modcache"
+      -e PIP_INDEX_URL=${PIP_INDEX_URL}
+      486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      c:\mnt\tasks\winbuildscripts\secagent.bat
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+  artifacts:
+    when: always
+    paths:
+      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files
+
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
@@ -106,6 +133,15 @@ prepare_ebpf_functional_tests_x64:
 
 tests_windows_sysprobe_x64:
   extends: .tests_windows_sysprobe
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
+  variables:
+    PYTHON_RUNTIMES: 3
+    ARCH: "x64"
+
+tests_windows_secagent_x64:
+  extends: .tests_windows_secagent
   rules:
     - !reference [.except_mergequeue]
     - when: on_success

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -88,3 +88,76 @@ lint_windows-x64:
   variables:
     PYTHON_RUNTIMES: 3
     ARCH: "x64"
+
+
+.tests_windows_sysprobe:
+  stage: source_test
+  needs: ["go_deps"]
+  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  script:
+    - $ErrorActionPreference = "Stop"
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
+    - !reference [.setup_python_mirror_win]
+    - >
+      docker run --rm
+      -m 16384M
+      -v "$(Get-Location):c:\mnt"
+      -e AWS_NETWORKING=true
+      -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
+      -e CI_PROJECT_NAME=${CI_PROJECT_NAME}
+      -e SIGN_WINDOWS_DD_WCS=true
+      -e PY_RUNTIMES="$PYTHON_RUNTIMES"
+      -e GOMODCACHE="c:\modcache"
+      -e PIP_INDEX_URL=${PIP_INDEX_URL}
+      486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      c:\mnt\tasks\winbuildscripts\sysprobe.bat
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+  artifacts:
+    when: always
+    paths:
+      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
+
+.tests_windows_secagent:
+  stage: source_test
+  needs: ["go_deps"]
+  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  script:
+    - $ErrorActionPreference = "Stop"
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
+    - !reference [.setup_python_mirror_win]
+    - >
+      docker run --rm
+      -m 16384M
+      -v "$(Get-Location):c:\mnt"
+      -e AWS_NETWORKING=true
+      -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
+      -e CI_PROJECT_NAME=${CI_PROJECT_NAME}
+      -e SIGN_WINDOWS_DD_WCS=true
+      -e PY_RUNTIMES="$PYTHON_RUNTIMES"
+      -e GOMODCACHE="c:\modcache"
+      -e PIP_INDEX_URL=${PIP_INDEX_URL}
+      486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      c:\mnt\tasks\winbuildscripts\secagent.bat
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+  artifacts:
+    when: always
+    paths:
+      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files
+
+tests_windows_sysprobe_x64:
+  extends: .tests_windows_sysprobe
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
+  variables:
+    PYTHON_RUNTIMES: 3
+    ARCH: "x64"
+
+tests_windows_secagent_x64:
+  extends: .tests_windows_secagent
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
+  variables:
+    PYTHON_RUNTIMES: 3
+    ARCH: "x64"

--- a/pkg/security/tests/activity_dumps_common.go
+++ b/pkg/security/tests/activity_dumps_common.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests || stresstests
+//go:build linux && (functionaltests || stresstests)
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/activity_dumps_encoding_test.go
+++ b/pkg/security/tests/activity_dumps_encoding_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/activity_dumps_loadcontroller_test.go
+++ b/pkg/security/tests/activity_dumps_loadcontroller_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/bind_test.go
+++ b/pkg/security/tests/bind_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/blank_windows_test.go
+++ b/pkg/security/tests/blank_windows_test.go
@@ -3,16 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && functionaltests
+//go:build windows && functionaltests
 
 // Package tests holds tests related files
 package tests
 
-import "testing"
+import (
+	"testing"
 
-func TestEnv(t *testing.T) {
-	if testEnvironment != "" && testEnvironment != HostEnvironment && testEnvironment != DockerEnvironment {
-		t.Error("invalid environment")
-		return
-	}
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThatWindowsCanRunATest(t *testing.T) {
+	assert.Equal(t, 2, 2)
 }

--- a/pkg/security/tests/bpf_test.go
+++ b/pkg/security/tests/bpf_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests && amd64
+//go:build linux && functionaltests && amd64
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests && !386
+//go:build linux && functionaltests && !386
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests || stresstests
+//go:build linux && (functionaltests || stresstests)
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests && linux_bpf
+//go:build linux && functionaltests && linux_bpf
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/dentry_test.go
+++ b/pkg/security/tests/dentry_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/dns_test.go
+++ b/pkg/security/tests/dns_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/eventmonitor_test.go
+++ b/pkg/security/tests/eventmonitor_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/fields_test.go
+++ b/pkg/security/tests/fields_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/files_generator.go
+++ b/pkg/security/tests/files_generator.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests || stresstests
+//go:build linux && (functionaltests || stresstests)
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/hardlink_test.go
+++ b/pkg/security/tests/hardlink_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/macros_test.go
+++ b/pkg/security/tests/macros_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/main_test.go
+++ b/pkg/security/tests/main_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests || stresstests
+//go:build linux && (functionaltests || stresstests)
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests || stresstests
+//go:build linux && (functionaltests || stresstests)
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/mprotect_test.go
+++ b/pkg/security/tests/mprotect_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/ptrace_test.go
+++ b/pkg/security/tests/ptrace_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/rule_filters_test.go
+++ b/pkg/security/tests/rule_filters_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests && trivy
+//go:build linux && functionaltests && trivy
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests || stresstests
+//go:build linux && (functionaltests || stresstests)
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/serializers_test.go
+++ b/pkg/security/tests/serializers_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/signal_test.go
+++ b/pkg/security/tests/signal_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/snapshot_replay_test.go
+++ b/pkg/security/tests/snapshot_replay_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 package tests
 

--- a/pkg/security/tests/span_test.go
+++ b/pkg/security/tests/span_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/splice_test.go
+++ b/pkg/security/tests/splice_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/syscall_tester.go
+++ b/pkg/security/tests/syscall_tester.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/syscalls_amd64.go
+++ b/pkg/security/tests/syscalls_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (functionaltests && amd64) || (stresstests && amd64)
+//go:build linux && ((functionaltests && amd64) || (stresstests && amd64))
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/testdrive.go
+++ b/pkg/security/tests/testdrive.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/testmount.go
+++ b/pkg/security/tests/testmount.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/threat_score_test.go
+++ b/pkg/security/tests/threat_score_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/user_session_test.go
+++ b/pkg/security/tests/user_session_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 package tests
 

--- a/pkg/security/tests/usergroup_test.go
+++ b/pkg/security/tests/usergroup_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
+//go:build linux && functionaltests
 
 // Package tests holds tests related files
 package tests

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -37,13 +37,18 @@ from tasks.system_probe import (
 )
 from tasks.windows_resources import build_messagetable, build_rc, versioninfo_vars
 
+is_windows = sys.platform == "win32"
+
 BIN_DIR = os.path.join(".", "bin")
 BIN_PATH = os.path.join(BIN_DIR, "security-agent", bin_name("security-agent"))
 CI_PROJECT_DIR = os.environ.get("CI_PROJECT_DIR", ".")
 KITCHEN_DIR = os.getenv('DD_AGENT_TESTING_DIR') or os.path.normpath(os.path.join(os.getcwd(), "test", "kitchen"))
+#if is_windows:
+#  KITCHEN_ARTIFACT_DIR = os.path.join(KITCHEN_DIR, "site-cookbooks", "dd-security-agent-check", "files", "default")
+#else:
 KITCHEN_ARTIFACT_DIR = os.path.join(KITCHEN_DIR, "site-cookbooks", "dd-security-agent-check", "files")
 STRESS_TEST_SUITE = "stresssuite"
-is_windows = sys.platform == "win32"
+
 
 @task(iterable=["build_tags"])
 def build(
@@ -380,7 +385,6 @@ def build_functional_tests(
             kernel_release=kernel_release,
             debug=debug,
         )
-
     
         build_embed_syscall_tester(ctx)
 
@@ -842,7 +846,7 @@ def kitchen_prepare(ctx, windows=is_windows, skip_linters=False):
     out_binary = "testsuite"
     if windows:
         out_binary = "testsuite.exe"
-        
+
     testsuite_out_path = os.path.join(KITCHEN_ARTIFACT_DIR, "tests", out_binary)
     build_functional_tests(
         ctx,

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -43,9 +43,6 @@ BIN_DIR = os.path.join(".", "bin")
 BIN_PATH = os.path.join(BIN_DIR, "security-agent", bin_name("security-agent"))
 CI_PROJECT_DIR = os.environ.get("CI_PROJECT_DIR", ".")
 KITCHEN_DIR = os.getenv('DD_AGENT_TESTING_DIR') or os.path.normpath(os.path.join(os.getcwd(), "test", "kitchen"))
-#if is_windows:
-#  KITCHEN_ARTIFACT_DIR = os.path.join(KITCHEN_DIR, "site-cookbooks", "dd-security-agent-check", "files", "default")
-#else:
 KITCHEN_ARTIFACT_DIR = os.path.join(KITCHEN_DIR, "site-cookbooks", "dd-security-agent-check", "files")
 STRESS_TEST_SUITE = "stresssuite"
 
@@ -385,7 +382,7 @@ def build_functional_tests(
             kernel_release=kernel_release,
             debug=debug,
         )
-    
+
         build_embed_syscall_tester(ctx)
 
     ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version, static=static)

--- a/tasks/winbuildscripts/secagent.bat
+++ b/tasks/winbuildscripts/secagent.bat
@@ -1,0 +1,25 @@
+if not exist c:\mnt\ goto nomntdir
+
+@echo c:\mnt found, continuing
+
+@echo PARAMS %*
+@echo PY_RUNTIMES %PY_RUNTIMES%
+
+if NOT DEFINED PY_RUNTIMES set PY_RUNTIMES=%~1
+
+
+set BUILD_ROOT=c:\buildroot
+mkdir %BUILD_ROOT%\datadog-agent
+if not exist %BUILD_ROOT%\datadog-agent exit /b 2
+cd %BUILD_ROOT%\datadog-agent || exit /b 3
+xcopy /e/s/h/q c:\mnt\*.* || exit /b 4
+
+call %BUILD_ROOT%\datadog-agent\tasks\winbuildscripts\extract-modcache.bat %BUILD_ROOT%\datadog-agent modcache
+call %BUILD_ROOT%\datadog-agent\tasks\winbuildscripts\extract-modcache.bat %BUILD_ROOT%\datadog-agent modcache_tools
+
+
+Powershell -C "%BUILD_ROOT%\datadog-agent\tasks\winbuildscripts\secagent.ps1" || exit /b 5
+
+REM copy resulting packages to expected location for collection by gitlab.
+if not exist c:\mnt\test\kitchen\site-cookbooks\dd-security-agent-check\files\tests\ mkdir c:\mnt\test\kitchen\site-cookbooks\dd-security-agent-check\files\tests\ || exit /b 6
+xcopy /e/s/q %BUILD_ROOT%\datadog-agent\test\kitchen\site-cookbooks\dd-security-agent-check\files\tests\*.* c:\mnt\test\kitchen\site-cookbooks\dd-security-agent-check\files\tests\ || exit /b 7

--- a/tasks/winbuildscripts/secagent.ps1
+++ b/tasks/winbuildscripts/secagent.ps1
@@ -1,0 +1,42 @@
+$Password = ConvertTo-SecureString "dummyPW_:-gch6Rejae9" -AsPlainText -Force
+New-LocalUser -Name "ddagentuser" -Description "Test user for the secrets feature on windows." -Password $Password
+
+$Env:Python2_ROOT_DIR=$Env:TEST_EMBEDDED_PY2
+$Env:Python3_ROOT_DIR=$Env:TEST_EMBEDDED_PY3
+
+if ($Env:TARGET_ARCH -eq "x64") {
+    & ridk enable
+}
+& $Env:Python3_ROOT_DIR\python.exe -m  pip install -r requirements.txt
+
+$PROBE_BUILD_ROOT=(Get-Location).Path
+$Env:PATH="$PROBE_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python2_ROOT_DIR;$Env:Python2_ROOT_DIR\Scripts;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:PATH"
+
+& $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
+& pip install awscli==1.19.112 --upgrade
+
+& inv -e deps
+& inv -e install-tools
+
+# Must build the rtloader libs cgo depends on before running golangci-lint, which requires code to be compilable
+$archflag = "x64"
+if ($Env:TARGET_ARCH -eq "x86") {
+    $archflag = "x86"
+}
+& .\tasks\winbuildscripts\pre-go-build.ps1 -Architecture "$archflag" -PythonRuntimes "$Env:PY_RUNTIMES"
+
+#& inv -e lint-go --build system-probe-unit-tests --targets .\pkg
+#$err = $LASTEXITCODE
+#if ($err -ne 0) {
+#    Write-Host -ForegroundColor Red "lint-go failed $err"
+#    [Environment]::Exit($err)
+#}
+
+& inv -e security-agent.kitchen-prepare --skip-linters
+
+$err = $LASTEXITCODE
+Write-Host Test result is $err
+if($err -ne 0){
+    Write-Host -ForegroundColor Red "kitchen prepare failed $err"
+    [Environment]::Exit($err)
+}

--- a/tasks/winbuildscripts/secagent.ps1
+++ b/tasks/winbuildscripts/secagent.ps1
@@ -25,12 +25,6 @@ if ($Env:TARGET_ARCH -eq "x86") {
 }
 & .\tasks\winbuildscripts\pre-go-build.ps1 -Architecture "$archflag" -PythonRuntimes "$Env:PY_RUNTIMES"
 
-#& inv -e lint-go --build system-probe-unit-tests --targets .\pkg
-#$err = $LASTEXITCODE
-#if ($err -ne 0) {
-#    Write-Host -ForegroundColor Red "lint-go failed $err"
-#    [Environment]::Exit($err)
-#}
 
 & inv -e security-agent.kitchen-prepare --skip-linters
 

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/chefignore
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/chefignore
@@ -39,7 +39,7 @@ a.out
 *.com
 *.class
 *.dll
-*.exe
+## *.exe need exe files to be copied (testsuite.exe)
 */rdoc/
 
 # Testing #

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/files/windows/decompress_merge_module.ps1
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/files/windows/decompress_merge_module.ps1
@@ -1,0 +1,61 @@
+param(
+        [Parameter(Mandatory = $true)][string] $file,
+        [Parameter(Mandatory = $true)][string] $targetDir
+    )
+
+
+[Reflection.Assembly]::LoadFrom("$($Env:WIX)\Microsoft.Deployment.WindowsInstaller.dll")
+
+write-host "Extracting files from merge module: "$file
+
+if(![IO.Directory]::Exists($targetDir)) { new-item -type directory -path $targetDir }
+
+$cabFile = join-path $targetDir "temp.cab"
+if([IO.File]::Exists($cabFile)) { remove-item $cabFile }
+
+$db = new-object Microsoft.Deployment.WindowsInstaller.DataBase($file, [Microsoft.Deployment.WindowsInstaller.DataBaseOpenMode]::ReadOnly)
+$view = $db.OpenView("SELECT `Name`,`Data` FROM _Streams WHERE `Name`= 'MergeModule.CABinet'")
+$view.Execute()
+$record = $view.Fetch()
+$record.GetStream(2, $cabFile)
+$view.Dispose()
+
+& "$($Env:WINDIR)\system32\expand" -F:* $cabFile $targetDir
+
+remove-item $cabFile
+
+$extractedFiles = get-childitem $targetDir
+$hashFiles = @{}
+foreach($extracted in $extractedFiles)
+{
+    try
+    {
+        $longName = $db.ExecuteScalar("SELECT `FileName` FROM `File` WHERE `File`='{0}'", $extracted.Name) 
+    }
+    catch 
+    {
+        write-host "$($extracted.Name) is not in the MSM file"
+    }
+
+    if($longName)
+    {
+        $longName = $LongName.SubString($LongName.IndexOf("|") + 1)
+        Write-host $longName
+
+        #There are duplicates in the 
+        if($hashFiles.Contains($longName))
+        {
+            write-host "Removing duplicate of $longName"
+            remove-item $extracted.FullName
+        }
+        else
+        {
+            write-host "Rename $($extracted.Name) to $longName"
+            $hashFiles[$longName] = $extracted
+            $targetFilePath = join-path $targetDir $longName
+            if([IO.File]::Exists($targetFilePath)) {remove-item $targetFilePath}
+            rename-item $extracted.FullName -NewName $longName    
+        }
+    }
+}
+$db.Dispose()

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/linux.rb
@@ -4,10 +4,7 @@
 #
 # Copyright (C) 2020-present Datadog
 #
-
-
-if platform?('windows')
-  include_recipe "::windows"
-else
-  include_recipe "::linux"
+directory "#{node['common']['work_dir']}/tests" do
+  recursive true
 end
+  

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/windows.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/windows.rb
@@ -1,0 +1,76 @@
+require 'json'
+
+rootdir = value_for_platform(
+  'windows' => { 'default' => ::File.join(Chef::Config[:file_cache_path], 'security-agent') },
+  'default' => '/tmp/ci/system-probe'
+)
+
+directory "#{rootdir}/tests" do
+  recursive true
+end
+  
+
+cookbook_file "#{rootdir}/tests/testsuite.exe" do
+  source "tests/testsuite.exe"
+  mode '755'
+end
+
+# manually install and start the procmon driver
+tmp_dir = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp"
+dna_json_path = "#{tmp_dir}\\kitchen\\dna.json"
+agentvars = JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec')
+driver_path = agentvars.fetch('driver_path')
+driver_ver = agentvars.fetch('driver_ver')
+driver_msmsha = agentvars.fetch('driver_msmsha')
+
+remote_path = "https://s3.amazonaws.com/dd-windowsfilter/builds/#{driver_path}/ddprocmoninstall-#{driver_ver}.msm"
+remote_file "#{tmp_dir}\\ddprocmon.msm" do
+  source remote_path
+  checksum driver_msmsha
+end
+
+remote_file "#{tmp_dir}\\wix311-binaries.zip" do
+  source "https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip"
+end
+
+
+execute 'wix-extract' do
+  cwd tmp_dir
+  command "powershell -C \"Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('wix311-binaries.zip', 'wix');\""
+  not_if { ::File.directory?(::File.join(tmp_dir, 'wix')) }
+end
+
+cookbook_file "#{tmp_dir}\\decompress_merge_module.ps1" do
+  source 'decompress_merge_module.ps1'
+end
+
+execute 'extract driver merge module' do
+  cwd tmp_dir
+  live_stream true
+  environment 'WIX' => "#{tmp_dir}\\wix"
+  command "powershell -C \".\\decompress_merge_module.ps1 -file ddprocmon.msm -targetDir .\\expanded\""
+  not_if { ::File.exist?(::File.join(tmp_dir, 'expanded', 'ddprocmon.msm')) }
+end
+
+if driver_path == "testsigned"
+  reboot 'now' do
+    action :nothing
+    reason 'Cannot continue Chef run without a reboot.'
+  end
+
+  execute 'enable unsigned drivers' do
+    command "bcdedit.exe /set testsigning on"
+    notifies :reboot_now, 'reboot[now]', :immediately
+    not_if 'bcdedit.exe | findstr "testsigning" | findstr "Yes"'
+  end
+end
+
+execute 'procmon-driver-install' do
+  command "powershell -C \"sc.exe create ddprocmon type= kernel binpath= #{tmp_dir}\\expanded\\ddprocmon.sys start= demand\""
+  not_if 'sc.exe query ddprocmon'
+end
+
+windows_service 'procmon-driver' do
+  service_name 'ddprocmon'
+  action :start
+end

--- a/test/kitchen/test-definitions/windows-secagent-test.yml
+++ b/test/kitchen/test-definitions/windows-secagent-test.yml
@@ -1,0 +1,10 @@
+suites:
+
+- name: win-secagent-test
+  run_list:
+    - "recipe[dd-security-agent-check]"
+  attributes:
+    dd-agent-rspec:
+      driver_path: <%= ENV['WINDOWS_DDPROCMON_DRIVER'] %>
+      driver_ver: <%= ENV['WINDOWS_DDPROCMON_VERSION'] %>
+      driver_msmsha: <%= ENV['WINDOWS_DDPROCMON_SHASUM'] %>

--- a/test/kitchen/test/integration/win-secagent-test/rspec_datadog/Gemfile
+++ b/test/kitchen/test/integration/win-secagent-test/rspec_datadog/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem "rspec"
+gem "rspec_junit_formatter"

--- a/test/kitchen/test/integration/win-secagent-test/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/win-secagent-test/rspec_datadog/spec_helper.rb
@@ -1,0 +1,1 @@
+../../common/rspec_datadog/spec_helper.rb

--- a/test/kitchen/test/integration/win-secagent-test/rspec_datadog/win-secagent-test_spec.rb
+++ b/test/kitchen/test/integration/win-secagent-test/rspec_datadog/win-secagent-test_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+#require 'sysprobe_spec_helper'
+#require 'windows_npm_spec_helper'
 require 'open3'
 
 GOLANG_TEST_FAILURE = /FAIL:/
@@ -20,13 +22,15 @@ end
 
 print `Powershell -C "Get-WmiObject Win32_OperatingSystem | Select Caption, OSArchitecture, Version, BuildNumber | FL"`
 
-root_dir = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\cache\\system-probe\\tests".gsub("\\", File::SEPARATOR)
-print root_dir
-print Dir.entries(root_dir)
+wait_until_service_stopped('datadog-agent-sysprobe')
+
+root_dir = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\cache\\security-agent\\tests".gsub("\\", File::SEPARATOR)
+print "#{root_dir}\n"
+print "#{Dir.entries(root_dir)}\n"
 
 Dir.glob("#{root_dir}/**/testsuite.exe").each do |f|
-  pkg = f.delete_prefix(root_dir).delete_suffix('/testsuite')
-  describe "security agent tests for #{pkg}" do
+  #pkg = f.delete_prefix(root_dir).delete_suffix('/testsuite.exe')
+  describe "security-agent tests for #{f}" do
     it 'successfully runs' do
       Dir.chdir(File.dirname(f)) do
         Open3.popen2e(f, "-test.v", "-test.count=1") do |_, output, wait_thr|


### PR DESCRIPTION
### What does this PR do?

Does NOT actually add any meaningful tests yet.

This PR is intended simply to get the framework in place for adding meaningful tests, so that multiple groups can work in parallel.
### Motivation

Write more tests.
### Additional Notes



### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run a pipeline.  Does the new test job run

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
