### PR TITLE
Use upstream shirou/gopsutil where possible

### DIFF
--- a/cmd/manager/auto_exit_noprocess.go
+++ b/cmd/manager/auto_exit_noprocess.go
@@ -34,7 +34,8 @@ func fetchProcesses() (processes, error) {
 	for _, p := range ps {
 		name, err := p.Name()
 		if err != nil {
-			return nil, err
+			log.Debugf("unable to get process name for PID %d: %s", p.Pid, err)
+			continue
 		}
 		procs[p.Pid] = name
 	}

--- a/cmd/manager/auto_exit_noprocess_test.go
+++ b/cmd/manager/auto_exit_noprocess_test.go
@@ -24,9 +24,6 @@ func (f *processFixture) run(t *testing.T) {
 	t.Helper()
 
 	processFetcher = func() (processes, error) {
-		for pid, p := range f.processes {
-			p.Pid = pid
-		}
 		return f.processes, nil
 	}
 
@@ -39,18 +36,10 @@ func TestExitDetection(t *testing.T) {
 		{
 			name: "existing process",
 			processes: processes{
-				42: {
-					Name: "agent",
-				},
-				100: {
-					Name: "foo",
-				},
-				101: {
-					Name: "pause",
-				},
-				102: {
-					Name: "security-agent",
-				},
+				42:  "agent",
+				100: "foo",
+				101: "pause",
+				102: "security-agent",
 			},
 			regexps:    defaultRegexps,
 			shouldExit: false,
@@ -58,15 +47,9 @@ func TestExitDetection(t *testing.T) {
 		{
 			name: "no other case",
 			processes: processes{
-				42: {
-					Name: "agent",
-				},
-				101: {
-					Name: "pause",
-				},
-				102: {
-					Name: "security-agent",
-				},
+				42:  "agent",
+				101: "pause",
+				102: "security-agent",
 			},
 			regexps:    defaultRegexps,
 			shouldExit: true,

--- a/comp/dogstatsd/listeners/ratelimit/host_memory_usage.go
+++ b/comp/dogstatsd/listeners/ratelimit/host_memory_usage.go
@@ -6,7 +6,7 @@
 package ratelimit
 
 import (
-	"github.com/DataDog/gopsutil/mem"
+	"github.com/shirou/gopsutil/v3/mem"
 )
 
 var _ memoryUsage = (*hostMemoryUsage)(nil)
@@ -23,5 +23,7 @@ func (m *hostMemoryUsage) getMemoryStats() (float64, float64, error) {
 		return 0, 0, err
 	}
 
+	// using shirou/gopsutil results in a different Used value, see
+	// https://github.com/shirou/gopsutil/commit/4510db20dbab6fdd64061e5d6c7e93015c115fd5
 	return float64(memoryStats.Used), float64(memoryStats.Total), nil
 }

--- a/pkg/ebpf/bytecode/runtime/helpers_test.go
+++ b/pkg/ebpf/bytecode/runtime/helpers_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/gopsutil/host"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -23,7 +22,7 @@ import (
 func TestGetAvailableHelpers(t *testing.T) {
 	kv, err := kernel.HostVersion()
 	require.NoError(t, err)
-	_, family, _, err := host.PlatformInformation()
+	family, err := kernel.Family()
 	require.NoError(t, err)
 	if kv < kernel.VersionCode(4, 10, 0) && family != "rhel" {
 		t.Skip("__BPF_FUNC_MAPPER macro not available on vanilla kernels < 4.10.0")

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -16,8 +16,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/DataDog/gopsutil/host"
-
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/compiler"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -72,7 +70,7 @@ func compileToObjectFile(inFile, outputDir, filename, inHash string, additionalF
 		if err != nil {
 			return nil, kernelVersionErr, fmt.Errorf("unable to get kernel version: %w", err)
 		}
-		_, family, _, err := host.PlatformInformation()
+		family, err := kernel.Family()
 		if err != nil {
 			return nil, kernelVersionErr, fmt.Errorf("unable to get kernel family: %w", err)
 		}

--- a/pkg/ebpf/ebpftest/buildmode_linux.go
+++ b/pkg/ebpf/ebpftest/buildmode_linux.go
@@ -10,22 +10,21 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/DataDog/gopsutil/host"
-
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
-var hostinfo *host.InfoStat
+var hostPlatform string
 var kv = kernel.MustHostVersion()
 
 func init() {
-	hostinfo, _ = host.Info()
+	hostPlatform, _ = kernel.Platform()
 }
 
 // SupportedBuildModes returns the build modes supported on the current host
 func SupportedBuildModes() []BuildMode {
 	modes := []BuildMode{Prebuilt, RuntimeCompiled, CORE}
-	if os.Getenv("TEST_FENTRY_OVERRIDE") == "true" || (runtime.GOARCH == "amd64" && (hostinfo.Platform == "amazon" || hostinfo.Platform == "amzn") && kv.Major() == 5 && kv.Minor() == 10) {
+	if os.Getenv("TEST_FENTRY_OVERRIDE") == "true" ||
+		(runtime.GOARCH == "amd64" && (hostPlatform == "amazon" || hostPlatform == "amzn") && kv.Major() == 5 && kv.Minor() == 10) {
 		modes = append(modes, Fentry)
 	}
 	return modes

--- a/pkg/network/protocols/tls/java/jattach.go
+++ b/pkg/network/protocols/tls/java/jattach.go
@@ -10,8 +10,10 @@ package java
 import (
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	// needs NsPid from fork
 	"github.com/DataDog/gopsutil/process"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // minJavaAgeToAttachMS is the minimum age of a java process to be able to attach it

--- a/pkg/network/protocols/tls/java/testutil/inject.go
+++ b/pkg/network/protocols/tls/java/testutil/inject.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/gopsutil/process"
+	"github.com/shirou/gopsutil/v3/process"
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/usm/testutil/grpc"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	grpc2 "github.com/DataDog/datadog-agent/pkg/util/grpc"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func httpSupported() bool {

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/usm/testutil/grpc"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	grpc2 "github.com/DataDog/datadog-agent/pkg/util/grpc"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func httpSupported() bool {

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 	"go.uber.org/atomic"
 
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -12,11 +12,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 

--- a/pkg/process/checks/process_nix.go
+++ b/pkg/process/checks/process_nix.go
@@ -56,6 +56,7 @@ func formatUser(fp *procutil.Process, uidProbe *LookupIdProbe) *model.ProcessUse
 
 func formatCPUTimes(fp *procutil.Stats, t2, t1 *procutil.CPUTimesStat, syst2, syst1 cpu.TimesStat) *model.CPUStat {
 	numCPU := float64(hostCPUCount())
+	// nolint: staticcheck
 	deltaSys := syst2.Total() - syst1.Total()
 	return &model.CPUStat{
 		LastCpu:    "cpu",

--- a/pkg/process/checks/process_nix.go
+++ b/pkg/process/checks/process_nix.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/util/system"

--- a/pkg/process/checks/process_nix_test.go
+++ b/pkg/process/checks/process_nix_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"

--- a/pkg/process/checks/process_test.go
+++ b/pkg/process/checks/process_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -11,7 +11,7 @@ import (
 	"math"
 	"runtime"
 
-	"github.com/DataDog/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 

--- a/pkg/process/checks/process_windows_test.go
+++ b/pkg/process/checks/process_windows_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/config"

--- a/pkg/process/checks/system_info.go
+++ b/pkg/process/checks/system_info.go
@@ -8,9 +8,10 @@
 package checks
 
 import (
-	"github.com/DataDog/gopsutil/cpu"
+	// waiting for upstream fix to platform collection in containerized environments
 	"github.com/DataDog/gopsutil/host"
-	"github.com/DataDog/gopsutil/mem"
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/mem"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 )

--- a/pkg/process/checks/system_info_darwin.go
+++ b/pkg/process/checks/system_info_darwin.go
@@ -11,9 +11,11 @@ import (
 	"fmt"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/gopsutil/cpu"
+	// difference between methods for collecting macOS platform, kernel version
+	// between shirou and Datadog psutil
 	"github.com/DataDog/gopsutil/host"
-	"github.com/DataDog/gopsutil/mem"
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/mem"
 	"golang.org/x/sys/unix"
 )
 

--- a/pkg/process/checks/system_info_darwin_test.go
+++ b/pkg/process/checks/system_info_darwin_test.go
@@ -8,9 +8,10 @@
 package checks
 
 import (
-	"github.com/DataDog/gopsutil/cpu"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/stretchr/testify/assert"
 )
 
 var _ statsProvider = &mockStatsProvider{}

--- a/pkg/process/procutil/process_fallback.go
+++ b/pkg/process/procutil/process_fallback.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	// using process.AllProcesses()
 	"github.com/DataDog/gopsutil/process"
 )
 

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -20,7 +20,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	// relying upon fork BootTime behavior
 	"github.com/DataDog/gopsutil/host"
+	// using process.AllProcesses()
 	"github.com/DataDog/gopsutil/process"
 )
 

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -7,6 +7,7 @@ package procutil
 
 import (
 	"github.com/DataDog/gopsutil/cpu"
+	// using process.FilledProcess
 	"github.com/DataDog/gopsutil/process"
 )
 

--- a/pkg/process/procutil/process_windows_toolhelp.go
+++ b/pkg/process/procutil/process_windows_toolhelp.go
@@ -16,7 +16,7 @@ import (
 	"github.com/shirou/w32"
 	"golang.org/x/sys/windows"
 
-	process "github.com/DataDog/gopsutil/process"
+	process "github.com/shirou/gopsutil/v3/process"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -20,6 +20,9 @@ import (
 	"syscall"
 	"time"
 
+	// shirou/gopsutil uses different logic for getting the memory maps Path
+	// it assumes space-separation and the path is last
+	// DD: combines 6th+ fields into the path
 	legacyprocess "github.com/DataDog/gopsutil/process"
 	"github.com/prometheus/procfs"
 	"github.com/shirou/gopsutil/v3/process"

--- a/pkg/util/kernel/platform.go
+++ b/pkg/util/kernel/platform.go
@@ -31,6 +31,12 @@ var PlatformVersion = funcs.Memoize(func() (string, error) {
 	return pi.version, err
 })
 
+// Family is the string describing the Linux distribution family (rhel, debian, etc.)
+var Family = funcs.Memoize(func() (string, error) {
+	pi, err := platformInformation()
+	return pi.family, err
+})
+
 var platformInformation = funcs.Memoize(getPlatformInformation)
 
 func getPlatformInformation() (platformInfo, error) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Uses the upstream `shirou/gopsutil` where possible

### Motivation

Our fork `DataDog/gopsutil` has diverged significantly and isn't actively maintained.

### Additional Notes

I added comments about why I wasn't able to change certain usages. The most common reason is the usage of `process.AllProcesses()` which is something added to our fork.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
