### PR TITLE
Add a `go mod tidy` git hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
 default_language_version:
   python: python3
+default_install_hook_types:
+  - pre-commit
+  - pre-push
+default_stages:
+  - pre-commit
 
 repos:
 - repo: https://github.com/pycqa/flake8
@@ -75,3 +80,14 @@ repos:
       require_serial: true
       files: '^pkg/(ebpf|network|security)/.*\.(c|h)$'
       exclude: '^pkg/ebpf/(c/bpf_endian|c/bpf_helpers|compiler/clang-stdarg).h$'
+    - id: go-mod-tidy
+      name: go-mod-tidy
+      description: check that all go.mod files are tidy
+      entry: 'python3 -m tasks.git-hooks.go-mod-tidy'
+      language: system
+      require_serial: true
+      files: (\.go|^go\.mod|^go\.sum)$
+      # no need to pass filenames, all go.mod have to be tidied anyway
+      pass_filenames: false
+      # inv tidy-all takes several seconds so only run it on pre-push
+      stages: [pre-push]

--- a/tasks/git-hooks/go-mod-tidy.py
+++ b/tasks/git-hooks/go-mod-tidy.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+from invoke.context import Context
+from invoke.exceptions import UnexpectedExit
+
+from ..go import tidy_all
+
+if __name__ == "__main__":
+    # need to tidy all modules due to the replace directives
+    # disable module lookup so that it fails as early as possible
+    # might be possible to do something smarter once https://github.com/golang/go/issues/27005 is fixed
+    os.environ["GOPROXY"] = "off"
+    ctx = Context()
+    try:
+        tidy_all(ctx)
+    except UnexpectedExit:
+        sys.exit(1)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add a `go mod tidy` git hook which checks that all `go.mod` and `go.sum` files are clean.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This is a common error which is often caught in CI.
Having a hook to catch it before pushing is way better, gain a lot of time.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Due to the replace directives in this repo, a change in any `go` file can cause a change in any `go.mod` file.
For this reason, the hook is somewhat stupid and just calls `inv tidy-all`.
It's possible to do something smarter, but this is better than nothing.

The hook is a `pre-push` hook, because it takes several seconds to run (4s when clean, 10s if there was a go file changed), and I don't want to delay every commit.

If you already installed `pre-commit`, you need to install it again so that `pre-push` hooks run too (not just `pre-commit` hooks).

The hook could call `inv tidy-all` and commit in case of changes but it's much safer to let the user fix any issue.
For this reason I set `GOPROXY=off` so that any modules needing to be downloaded makes the hook fail.

Example failure (when importing a new dependency in `pkg/gohai` without tidy):
```
❯ git push
go-mod-tidy..............................................................Failed
- hook id: go-mod-tidy
- exit code: 1

go: finding module for package k8s.io/client-go/tools/clientcmd
go: github.com/DataDog/datadog-agent/pkg/gohai imports
	k8s.io/client-go/tools/clientcmd: cannot find module providing package k8s.io/client-go/tools/clientcmd: module lookup disabled by GOPROXY=off
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
