### PR TITLE
iot-agent: fix armhf detection

### DIFF
--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -55,9 +55,10 @@ end
 
 if ENV.has_key?("OMNIBUS_WORKERS_OVERRIDE")
   COMPRESSION_THREADS = ENV["OMNIBUS_WORKERS_OVERRIDE"].to_i
-  if ohai["kernel"]["machine"] == 'armv7l'
-    # On armv7, we can only address 32 bits of memory, which is likely to OOM
-    # if we use to many compression threads
+  # On armv7, dpkg is built as a 32bits application, which means
+  # we can only address 32 bits of memory, which is likely to OOM
+  # if we use to many compression threads
+  if ENV.has_key?("PACKAGE_ARCH") && ENV["PACKAGE_ARCH"] == "armhf"
     COMPRESSION_THREADS = [COMPRESSION_THREADS, 4].min
   end
 else

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -618,6 +618,8 @@ def get_omnibus_env(
     # Forward the DEPLOY_AGENT variable so that we can use a higher compression level for deployed artifacts
     if os.environ.get('DEPLOY_AGENT'):
         env['DEPLOY_AGENT'] = os.environ.get('DEPLOY_AGENT')
+    if 'PACKAGE_ARCH' in os.environ:
+        env['PACKAGE_ARCH'] = os.environ.get('PACKAGE_ARCH')
 
     return env
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR fixes the armhf specific logic handling

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We build dpkg-deb as an armv7 program, meaning it won't be able to address more than 32bits of memory. This in turn causes issues when trying to compress the package using (many) multiple threads, which sometimes triggers an allocation failure.
By reducing the number of threads for armhf, we should work around the issue at a small performance cost (which we don't really care for iot-agent since the package is rather small. It take ≃20s to compress the package instead of less than 10 with more threads, but that's quick enough for our purposes)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
