### PR TITLE
test/new-e2e/tests/apm: add first apm tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -514,6 +514,7 @@
 /test/new-e2e/tests/agent-platform            @DataDog/agent-platform
 /test/new-e2e/tests/agent-metric-logs   @DataDog/agent-metrics-logs
 /test/new-e2e/tests/windows                   @DataDog/windows-agent @DataDog/windows-kernel-integrations
+/test/new-e2e/tests/apm                       @DataDog/agent-apm
 /test/system/                                 @DataDog/agent-shared-components
 /test/system/dogstatsd/                       @DataDog/agent-metrics-logs
 /test/benchmarks/apm_scripts/                 @DataDog/agent-apm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,7 +181,7 @@ variables:
   # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: dc24e7da422c
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: db7cdb8d8c3a
   DATADOG_AGENT_BUILDERS: v22276738-b36b132
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -336,7 +336,6 @@ new-e2e-apm-dev:
   variables:
     TARGETS: ./tests/apm
     TEAM: apm-agent
-  allow_failure: true # blocked by APL-2786
 
 new-e2e-apm-main:
   extends: .new_e2e_template
@@ -344,7 +343,6 @@ new-e2e-apm-main:
   variables:
     TARGETS: ./tests/apm
     TEAM: apm-agent
-  allow_failure: true # blocked by APL-2786
 
 #   ^    If you create a new job here that extends `.new_e2e_template`,
 #  /!\   do not forget to add it in the `dependencies` statement of the

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -324,6 +324,26 @@ new-e2e-orchestrator-main:
 
   allow_failure: true #TODO: Remove when https://github.com/DataDog/datadog-agent/pull/22113 is merged
 
+new-e2e-apm-dev:
+  extends: .new_e2e_template
+  rules:
+    - !reference [.if_run_e2e_tests]
+    - !reference [.on_dev_branch_manual]
+  needs:
+    - qa_branch_agent
+    - qa_branch_dca
+    - qa_branch_dogstatsd
+  variables:
+    TARGETS: ./tests/apm
+    TEAM: apm-agent
+
+new-e2e-apm-main:
+  extends: .new_e2e_template
+  rules: !reference [.on_main_and_no_skip_e2e]
+  variables:
+    TARGETS: ./tests/apm
+    TEAM: apm-agent
+
 #   ^    If you create a new job here that extends `.new_e2e_template`,
 #  /!\   do not forget to add it in the `dependencies` statement of the
 # /___\  `e2e_test_junit_upload` job in the `.gitlab/e2e_test_junit_upload.yml` file

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -336,6 +336,7 @@ new-e2e-apm-dev:
   variables:
     TARGETS: ./tests/apm
     TEAM: apm-agent
+  allow_failure: true # blocked by APL-2786
 
 new-e2e-apm-main:
   extends: .new_e2e_template
@@ -343,6 +344,7 @@ new-e2e-apm-main:
   variables:
     TARGETS: ./tests/apm
     TEAM: apm-agent
+  allow_failure: true # blocked by APL-2786
 
 #   ^    If you create a new job here that extends `.new_e2e_template`,
 #  /!\   do not forget to add it in the `dependencies` statement of the

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -81,6 +81,7 @@ e2e_test_junit_upload:
     - new-e2e-windows-agent-msi-windows-server-a6-x86_64
     - new-e2e-windows-agent-msi-windows-server-a7-x86_64
     - new-e2e-orchestrator-main
+    - new-e2e-apm-main
 
   script:
     - set +x

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -27,7 +27,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240123083226-dc24e7da422c
+	github.com/DataDog/test-infra-definitions v0.0.0-20240124125737-db7cdb8d8c3a
 	github.com/aws/aws-sdk-go-v2 v1.24.0
 	github.com/aws/aws-sdk-go-v2/config v1.25.10
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.19.0 h1:Wvz/63/q39EpVwSH1T8jVyRvP
 github.com/DataDog/datadog-api-client-go/v2 v2.19.0/go.mod h1:oD5Lx8Li3oPRa/BSBenkn4i48z+91gwYORF/+6ph71g=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20240123083226-dc24e7da422c h1:rWBvaRvcprxzOaiDGTTjeA2V3KbnUOUdxVbj15zBduU=
-github.com/DataDog/test-infra-definitions v0.0.0-20240123083226-dc24e7da422c/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
+github.com/DataDog/test-infra-definitions v0.0.0-20240124125737-db7cdb8d8c3a h1:GEvzcF4I6oEjtq2C5Y/mCA2mT491yz+OfK8VUstrCmY=
+github.com/DataDog/test-infra-definitions v0.0.0-20240124125737-db7cdb8d8c3a/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/tests/apm/apm.go
+++ b/test/new-e2e/tests/apm/apm.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package apm for all apm new E2E tests
+package apm

--- a/test/new-e2e/tests/apm/docker_test.go
+++ b/test/new-e2e/tests/apm/docker_test.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package apm
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awsdocker "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/docker"
+	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+)
+
+type DockerFakeintakeSuite struct {
+	e2e.BaseSuite[environments.DockerHost]
+}
+
+func TestDockerFakeintakeSuite(t *testing.T) {
+	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
+	envs := pulumi.StringMap{"STATSD_URL": pulumi.String("unix:///var/run/datadog/dsd.socket")} // UDP appears to be flaky, use UDS instead.
+	options := []e2e.SuiteOption{
+		e2e.WithProvisioner(awsdocker.Provisioner(awsdocker.WithAgentOptions(dockeragentparams.WithEnvironmentVariables(envs)))),
+	}
+	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
+		options = append(options, e2e.WithDevMode())
+	}
+	e2e.Run(t, &DockerFakeintakeSuite{}, options...)
+}
+
+func (s *DockerFakeintakeSuite) TestAPMDocker() {
+	s.Run("TraceAgentMetrics", s.TraceAgentMetrics)
+}
+
+func (s *DockerFakeintakeSuite) TraceAgentMetrics() {
+	s.EventuallyWithTf(func(c *assert.CollectT) {
+		expected := map[string]struct{}{
+			"datadog.trace_agent.heartbeat":                       {},
+			"datadog.trace_agent.started":                         {},
+			"datadog.trace_agent.heap_alloc":                      {},
+			"datadog.trace_agent.cpu_percent":                     {},
+			"datadog.trace_agent.events.max_eps.current_rate":     {},
+			"datadog.trace_agent.events.max_eps.max_rate":         {},
+			"datadog.trace_agent.events.max_eps.reached_max":      {},
+			"datadog.trace_agent.events.max_eps.sample_rate":      {},
+			"datadog.trace_agent.sampler.kept":                    {},
+			"datadog.trace_agent.sampler.rare.hits":               {},
+			"datadog.trace_agent.sampler.rare.misses":             {},
+			"datadog.trace_agent.sampler.rare.shrinks":            {},
+			"datadog.trace_agent.sampler.seen":                    {},
+			"datadog.trace_agent.sampler.size":                    {},
+			"datadog.trace_agent.stats_writer.bytes":              {},
+			"datadog.trace_agent.stats_writer.client_payloads":    {},
+			"datadog.trace_agent.stats_writer.encode_ms.avg":      {},
+			"datadog.trace_agent.stats_writer.encode_ms.count":    {},
+			"datadog.trace_agent.stats_writer.encode_ms.max":      {},
+			"datadog.trace_agent.stats_writer.errors":             {},
+			"datadog.trace_agent.stats_writer.payloads":           {},
+			"datadog.trace_agent.stats_writer.retries":            {},
+			"datadog.trace_agent.stats_writer.splits":             {},
+			"datadog.trace_agent.stats_writer.stats_buckets":      {},
+			"datadog.trace_agent.stats_writer.stats_entries":      {},
+			"datadog.trace_agent.trace_writer.bytes":              {},
+			"datadog.trace_agent.trace_writer.bytes_uncompressed": {},
+			"datadog.trace_agent.trace_writer.errors":             {},
+			"datadog.trace_agent.trace_writer.events":             {},
+			"datadog.trace_agent.trace_writer.payloads":           {},
+			"datadog.trace_agent.trace_writer.retries":            {},
+			"datadog.trace_agent.trace_writer.spans":              {},
+			"datadog.trace_agent.trace_writer.traces":             {},
+		}
+		metrics, err := s.Env().FakeIntake.Client().GetMetricNames()
+		assert.NoError(c, err)
+		s.T().Log("Got metric names", metrics)
+		assert.GreaterOrEqual(c, len(metrics), len(expected))
+		for _, m := range metrics {
+			delete(expected, m)
+			if len(expected) == 0 {
+				s.T().Log("All expected metrics are found")
+				return
+			}
+		}
+		s.T().Log("Remaining metrics", expected)
+		assert.Empty(c, expected)
+	}, 5*time.Minute, 10*time.Second, "Failed finding datadog.trace_agent.* metrics")
+}

--- a/test/new-e2e/tests/apm/docker_test.go
+++ b/test/new-e2e/tests/apm/docker_test.go
@@ -26,6 +26,10 @@ type DockerFakeintakeSuite struct {
 }
 
 func TestDockerFakeintakeSuite(t *testing.T) {
+	isCI, _ := strconv.ParseBool(os.Getenv("CI"))
+	if isCI {
+		t.Skipf("blocked by APL-2786")
+	}
 	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awsdocker.Provisioner(awsdocker.WithAgentOptions(

--- a/test/new-e2e/tests/apm/docker_test.go
+++ b/test/new-e2e/tests/apm/docker_test.go
@@ -152,7 +152,7 @@ func hasContainerTag(payloads []*aggregator.TracePayload, tag string) bool {
 }
 
 func dockerRunUDS(service string) (string, string) {
-	// TODO: use a proper docker-compose defintion for tracegen
+	// TODO: use a proper docker-compose definition for tracegen
 	run := "docker run -d --network host --rm --name " + service + " -v /var/run/datadog/:/var/run/datadog/ -e DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket -e DD_SERVICE=" + service + " ghcr.io/datadog/apps-tracegen:main"
 	rm := "docker rm -f " + service
 	return run, rm


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

AIT-9391

Implement `TraceAgentMetrics` in `new-e2e`. The tests ensure the trace-agent submits its `datadog.trace_agent.*` metrics correctly through dogstatsd. The tests relies on the metrics fake intake.

Implement `TracesOnUDS` and `StatsOnUDS`, the tests ensure the agent produces the expected traces and stats payloads for traffic coming on UDS.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Tests are good.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
