### PR TITLE
[NPM] tests end to end

### DIFF
--- a/test/new-e2e/tests/npm/agentenv_npm_test.go
+++ b/test/new-e2e/tests/npm/agentenv_npm_test.go
@@ -23,7 +23,6 @@ type vmSuiteEx6 struct {
 }
 
 func TestVMSuiteEx6(t *testing.T) {
-	t.Skip("Skipping TestVMSuiteEx6 as it's flaky")
 	e2e.Run(t, &vmSuiteEx6{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithSystemProbeConfig(systemProbeConfigNPM)))))
 }
 

--- a/test/new-e2e/tests/npm/agentenv_npm_test.go
+++ b/test/new-e2e/tests/npm/agentenv_npm_test.go
@@ -30,13 +30,13 @@ func (v *vmSuiteEx6) Test1_FakeIntakeNPM() {
 	t := v.T()
 
 	// force pulumi to deploy before running the test
-	v.Env().RemoteHost.MustExecute("curl http://httpbin.org/anything")
+	v.Env().RemoteHost.MustExecute("curl http://www.datadoghq.com")
 	v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 
 	// This loop waits for agent and system-probe to be ready, stated by
 	// checking we eventually receive a payload
 	v.EventuallyWithT(func(c *assert.CollectT) {
-		v.Env().RemoteHost.MustExecute("curl http://httpbin.org/anything")
+		v.Env().RemoteHost.MustExecute("curl http://www.datadoghq.com")
 
 		hostnameNetID, err := v.Env().FakeIntake.Client().GetConnectionsNames()
 		if !assert.NoError(c, err, "fakeintake GetConnectionsNames() error") {

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -64,7 +64,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM() {
 
 		hostnameNetID, err := v.Env().FakeIntake.Client().GetConnectionsNames()
 		assert.NoError(c, err, "GetConnectionsNames() errors")
-		if !assert.NotZero(c, len(hostnameNetID), "no connections yet") {
+		if !assert.NotEmpty(c, hostnameNetID, "no connections yet") {
 			return
 		}
 		targetHostnameNetID = hostnameNetID[0]
@@ -104,7 +104,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
 
 		cnx, err := v.Env().FakeIntake.Client().GetConnections()
 		assert.NoError(c, err, "GetConnections() errors")
-		if !assert.NotZero(c, len(cnx.GetNames()), "no connections yet") {
+		if !assert.NotEmpty(c, cnx.GetNames(), "no connections yet") {
 			return
 		}
 

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -30,7 +30,6 @@ type ec2VMSuite struct {
 
 // TestEC2VMSuite will validate running the agent on a single EC2 VM
 func TestEC2VMSuite(t *testing.T) {
-	t.Skip("Skipping TestEC2VMSuite as it's flaky")
 	s := &ec2VMSuite{}
 	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithSystemProbeConfig(systemProbeConfigNPM))))}
 	// debug helper

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -34,7 +34,7 @@ func TestEC2VMSuite(t *testing.T) {
 	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithSystemProbeConfig(systemProbeConfigNPM))))}
 	// debug helper
 	if _, devmode := os.LookupEnv("TESTS_E2E_DEVMODE"); devmode {
-		e2eParams = []e2e.SuiteOption{e2e.WithDevMode()}
+		e2eParams = append(e2eParams, e2e.WithDevMode())
 	}
 
 	// Source of our kitchen CI images test/kitchen/platforms.json

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -106,7 +106,10 @@ func (v *ec2VMSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
 		v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
 
 		cnx, err := v.Env().FakeIntake.Client().GetConnections()
-		require.NoError(c, err)
+		assert.NoError(c, err, "GetConnections() errors")
+		if !assert.NotZero(c, len(cnx.GetNames()), "no connections yet") {
+			return
+		}
 
 		foundDNS := false
 		cnx.ForeachConnection(func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -42,6 +42,11 @@ func TestEC2VMSuite(t *testing.T) {
 	e2e.Run(t, s, e2eParams...)
 }
 
+// SetupSuite run before all the tests in the suite have been run.
+func (v *ec2VMSuite) SetupSuite() {
+	v.BaseSuite.SetupSuite()
+}
+
 // TestFakeIntakeNPM Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type ec2VMSuite struct {
@@ -86,7 +85,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM() {
 		t.Logf("hostname+networkID %v diff time %f seconds", targetHostnameNetID, dt)
 
 		// we want the test fail now, not retrying on the next payloads
-		require.Greater(t, 0.5, math.Abs(dt-30), "delta between collection is higher than 500ms")
+		assert.Greater(t, 0.5, math.Abs(dt-30), "delta between collection is higher than 500ms")
 	}, 90*time.Second, time.Second, "not enough connections received")
 }
 

--- a/test/new-e2e/tests/npm/helper_test.go
+++ b/test/new-e2e/tests/npm/helper_test.go
@@ -11,8 +11,7 @@ import (
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	krpretty "github.com/kr/pretty"
-
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 var helperCurrentHostname string
@@ -27,27 +26,27 @@ func helperCleanup(t *testing.T) {
 }
 
 func validateAddr(t *testing.T, addr *agentmodel.Addr) {
-	require.NotEmpty(t, addr.Ip, "addr.Ip = 0")
-	require.GreaterOrEqualf(t, addr.Port, int32(1), "addr.Port < 1 %d", addr.Port)
-	require.Lessf(t, addr.Port, int32(65536), "addr.Port > 16bits %d", addr.Port)
+	assert.NotEmpty(t, addr.Ip, "addr.Ip = 0")
+	assert.GreaterOrEqualf(t, addr.Port, int32(1), "addr.Port < 1 %d", addr.Port)
+	assert.Lessf(t, addr.Port, int32(65536), "addr.Port > 16bits %d", addr.Port)
 
-	require.NotNilf(t, net.ParseIP(addr.Ip), "IP address not valid %s", addr.Ip)
+	assert.NotNilf(t, net.ParseIP(addr.Ip), "IP address not valid %s", addr.Ip)
 }
 
 func validateConnection(t *testing.T, c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
 	helperCurrentHostname = hostname
 	helperCurrentConnection = c
 
-	require.NotZero(t, c.Pid, "Pid = 0")
-	require.NotZero(t, c.NetNS, "network namespace = 0")
-	require.NotNil(t, c.Laddr, "Laddr is nil")
-	require.NotNil(t, c.Raddr, "Raddr is nil")
+	assert.NotZero(t, c.Pid, "Pid = 0")
+	assert.NotZero(t, c.NetNS, "network namespace = 0")
+	assert.NotNil(t, c.Laddr, "Laddr is nil")
+	assert.NotNil(t, c.Raddr, "Raddr is nil")
 
 	validateAddr(t, c.Laddr)
 	validateAddr(t, c.Raddr)
 
 	// un-comment the line below when https://datadoghq.atlassian.net/browse/NPM-2958 will be fixed
-	// require.False(t, c.LastPacketsSent == 0 && c.LastPacketsReceived == 0, "connection with no packets")
+	// assert.False(t, c.LastPacketsSent == 0 && c.LastPacketsReceived == 0, "connection with no packets")
 
 	switch c.Type {
 	case agentmodel.ConnectionType_tcp:
@@ -66,8 +65,8 @@ func validateDNSConnection(t *testing.T, c *agentmodel.Connection, cc *agentmode
 	for domain, stats := range c.DnsStatsByDomainOffsetByQueryType {
 		for queryType, dnsstat := range stats.DnsStatsByQueryType {
 			domainName, err := cc.GetDNSNameByOffset(domain)
-			require.NoErrorf(t, err, "can't resolve domain tags on %s connection %s", hostname, krpretty.Sprint(c))
-			require.Greaterf(t, len(domainName), 0, "len(domainName) = 0 %s connection %s", hostname, krpretty.Sprint(c))
+			assert.NoErrorf(t, err, "can't resolve domain tags on %s connection %s", hostname, krpretty.Sprint(c))
+			assert.Greaterf(t, len(domainName), 0, "len(domainName) = 0 %s connection %s", hostname, krpretty.Sprint(c))
 			t.Logf("DNS %s query type %v %s", domainName, queryType, krpretty.Sprint(dnsstat))
 			t.Logf("connection to %s:%d", c.Raddr.Ip, c.Raddr.Port)
 		}
@@ -75,27 +74,27 @@ func validateDNSConnection(t *testing.T, c *agentmodel.Connection, cc *agentmode
 }
 
 func validateTCPConnection(t *testing.T, c *agentmodel.Connection) {
-	require.Equal(t, c.Type, agentmodel.ConnectionType_tcp, "connection is not TCP")
+	assert.Equal(t, c.Type, agentmodel.ConnectionType_tcp, "connection is not TCP")
 
 	// un-comment the lines below when https://datadoghq.atlassian.net/browse/NPM-2958 will be fixed
-	// require.NotZero(t, c.Rtt, "Rtt = 0")
-	// require.NotZero(t, c.RttVar, "RttVar = 0")
+	// assert.NotZero(t, c.Rtt, "Rtt = 0")
+	// assert.NotZero(t, c.RttVar, "RttVar = 0")
 	//
-	// require.NotZero(t, c.LastRetransmits, "LastRetransmits = 0")
-	// require.NotZero(t, c.LastTcpClosed, "LastTcpClosed = 0")
-	// require.NotZero(t, c.LastTcpEstablished, "LastTcpEstablished = 0")
+	// assert.NotZero(t, c.LastRetransmits, "LastRetransmits = 0")
+	// assert.NotZero(t, c.LastTcpClosed, "LastTcpClosed = 0")
+	// assert.NotZero(t, c.LastTcpEstablished, "LastTcpEstablished = 0")
 }
 
 func validateUDPConnection(t *testing.T, c *agentmodel.Connection) {
-	require.Equal(t, c.Type, agentmodel.ConnectionType_udp, "connection is not UDP")
+	assert.Equal(t, c.Type, agentmodel.ConnectionType_udp, "connection is not UDP")
 
-	require.Zero(t, c.Rtt, "Rtt != 0")
-	require.Zero(t, c.RttVar, "RttVar != 0")
-	require.Zero(t, c.LastRetransmits, "LastRetransmits != 0")
-	require.Zero(t, c.LastTcpEstablished, "LastTcpEstablished != 0")
-	require.Zero(t, c.LastTcpClosed, "LastTcpClosed != 0")
+	assert.Zero(t, c.Rtt, "Rtt != 0")
+	assert.Zero(t, c.RttVar, "RttVar != 0")
+	assert.Zero(t, c.LastRetransmits, "LastRetransmits != 0")
+	assert.Zero(t, c.LastTcpEstablished, "LastTcpEstablished != 0")
+	assert.Zero(t, c.LastTcpClosed, "LastTcpClosed != 0")
 
 	// we can this only for UDP connection as there are no empty payload packets
 	// technically possible but in reality no UDP protocol implement that
-	// require.False(t, c.LastBytesSent == 0 && c.LastBytesReceived == 0, "connection with no packet bytes")
+	// assert.False(t, c.LastBytesSent == 0 && c.LastBytesReceived == 0, "connection with no packet bytes")
 }


### PR DESCRIPTION
### What does this PR do?

Fix and re-enabled E2E tests for NPM

### Motivation

Simple tests to validate our agent in different environments.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
