### PR TITLE
Fix duplicated stack name between containers and orch tests

### DIFF
--- a/test/new-e2e/tests/orchestrator/suite_test.go
+++ b/test/new-e2e/tests/orchestrator/suite_test.go
@@ -30,8 +30,10 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
 )
 
-var replaceStacks = flag.Bool("replace-stacks", false, "Attempt to destroy the Pulumi stacks at the beginning of the tests")
-var keepStacks = flag.Bool("keep-stacks", false, "Do not destroy the Pulumi stacks at the end of the tests")
+var (
+	replaceStacks = flag.Bool("replace-stacks", false, "Attempt to destroy the Pulumi stacks at the beginning of the tests")
+	keepStacks    = flag.Bool("keep-stacks", false, "Do not destroy the Pulumi stacks at the end of the tests")
+)
 
 func TestMain(m *testing.M) {
 	code := m.Run()
@@ -76,7 +78,7 @@ func (suite *k8sSuite) SetupSuite() {
 			fmt.Fprint(os.Stderr, err.Error())
 		}
 	}
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(ctx, "kind-cluster", stackConfig, Apply, false, nil)
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(ctx, "orch-kind-cluster", stackConfig, Apply, false, nil)
 
 	suite.printKubeConfig(stackOutput)
 
@@ -99,7 +101,7 @@ func (suite *k8sSuite) SetupSuite() {
 	suite.Fakeintake = fakeintake.Client()
 
 	kubeconfigFile := path.Join(suite.T().TempDir(), "kubeconfig")
-	suite.Require().NoError(os.WriteFile(kubeconfigFile, []byte(kubeconfig), 0600))
+	suite.Require().NoError(os.WriteFile(kubeconfigFile, []byte(kubeconfig), 0o600))
 
 	suite.K8sConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigFile)
 	suite.Require().NoError(err)
@@ -116,8 +118,8 @@ func (suite *k8sSuite) TearDownSuite() {
 // printKubeConfig prints the command to update the local kubeconfig to point to the kind cluster
 func (suite *k8sSuite) printKubeConfig(stackOutput auto.UpResult) {
 	if out, ok := stackOutput.Outputs["kubeconfig"]; ok {
-		//fmt.Println("LOCAL KUBECONFIG")
-		//fmt.Println(out.Value.(string))
+		// fmt.Println("LOCAL KUBECONFIG")
+		// fmt.Println(out.Value.(string))
 		var cfg struct {
 			Clusters []struct {
 				Cluster struct {


### PR DESCRIPTION
### What does this PR do?

Fix conflicting stack names between orchestrator and containers tests.

### Motivation

Fix test failures due to lock.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
