### PR TITLE
Add oracle.tablespace.maxsize metric (DBMON-3217)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/tablespaces.go
+++ b/pkg/collector/corechecks/oracle-dbm/tablespaces.go
@@ -37,6 +37,22 @@ FROM
 WHERE
   m.tablespace_name(+) = t.tablespace_name`
 
+const (
+	maxSizeQuery12 = `SELECT
+  c.name pdb_name,
+  f.tablespace_name tablespace_name,
+  SUM(CASE WHEN autoextensible = 'YES' THEN maxbytes ELSE bytes END) maxsize
+FROM cdb_data_files f, v$containers c
+WHERE c.con_id(+) = f.con_id
+GROUP BY c.name, f.tablespace_name`
+
+	maxSizeQuery11 = `SELECT
+	f.tablespace_name tablespace_name,
+	SUM(CASE WHEN autoextensible = 'YES' THEN maxbytes ELSE bytes END) maxsize
+	FROM dba_data_files f
+	GROUP BY f.tablespace_name`
+)
+
 //nolint:revive // TODO(DBM) Fix revive linter
 type RowDB struct {
 	PdbName        sql.NullString `db:"PDB_NAME"`
@@ -47,23 +63,33 @@ type RowDB struct {
 	Offline        float64        `db:"OFFLINE_"`
 }
 
+type rowMaxSizeDB struct {
+	PdbName        sql.NullString `db:"PDB_NAME"`
+	TablespaceName string         `db:"TABLESPACE_NAME"`
+	MaxSize        float64        `db:"MAXSIZE"`
+}
+
 //nolint:revive // TODO(DBM) Fix revive linter
 func (c *Check) Tablespaces() error {
 	rows := []RowDB{}
-	var tablespaceQuery string
+	var tablespaceQuery, maxSizeQuery string
 	if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
 		tablespaceQuery = tablespaceQuery12
+		maxSizeQuery = maxSizeQuery12
 	} else {
 		tablespaceQuery = tablespaceQuery11
+		maxSizeQuery = maxSizeQuery11
 	}
 	err := selectWrapper(c, &rows, tablespaceQuery)
 	if err != nil {
 		return fmt.Errorf("failed to collect tablespace info: %w", err)
 	}
+
 	sender, err := c.GetSender()
 	if err != nil {
 		return fmt.Errorf("failed to initialize sender: %w", err)
 	}
+
 	for _, r := range rows {
 		tags := appendPDBTag(c.tags, r.PdbName)
 		tags = append(tags, "tablespace:"+r.TablespaceName)
@@ -72,6 +98,19 @@ func (c *Check) Tablespaces() error {
 		sender.Gauge(fmt.Sprintf("%s.tablespace.in_use", common.IntegrationName), r.InUse, "", tags)
 		sender.Gauge(fmt.Sprintf("%s.tablespace.offline", common.IntegrationName), r.Offline, "", tags)
 	}
+
+	rowsMaxSize := []rowMaxSizeDB{}
+	err = selectWrapper(c, &rowsMaxSize, maxSizeQuery)
+	if err != nil {
+		return fmt.Errorf("failed to collect max size tablespace info: %w", err)
+	}
+
+	for _, r := range rowsMaxSize {
+		tags := appendPDBTag(c.tags, r.PdbName)
+		tags = append(tags, "tablespace:"+r.TablespaceName)
+		sender.Gauge(fmt.Sprintf("%s.tablespace.maxsize", common.IntegrationName), r.MaxSize, "", tags)
+	}
+
 	sender.Commit()
 	return nil
 }

--- a/releasenotes/notes/oracle-tablespace-maxsize-b5b28a3e60aeeeef.yaml
+++ b/releasenotes/notes/oracle-tablespace-maxsize-b5b28a3e60aeeeef.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    [oracle]: Add `oracle.tablespace.maxsize` metric.
+    [oracle]: Add ``oracle.tablespace.maxsize`` metric.

--- a/releasenotes/notes/oracle-tablespace-maxsize-b5b28a3e60aeeeef.yaml
+++ b/releasenotes/notes/oracle-tablespace-maxsize-b5b28a3e60aeeeef.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [oracle]: Add `oracle.tablespace.maxsize` metric.


### PR DESCRIPTION
### What does this PR do?

Adding `oracle.tablespace.maxsize` metric.

### Motivation

Accounting for autoextensible tablespaces. Request by Castle Crown and Cognizant.

### Describe how to test/QA your changes

Check if the metric `oracle.tablespace.maxsize` is being emitted.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
