### PR TITLE
[NPM-3068] Don't use hardcoded ports for some tests

### DIFF
--- a/pkg/network/testutil/server.go
+++ b/pkg/network/testutil/server.go
@@ -113,7 +113,7 @@ func StartServerUDP(t *testing.T, ip net.IP, port int) io.Closer {
 	}
 
 	udpConn, err := net.ListenUDP(network, addr)
-	assert.Nil(t, err)
+	require.NoError(t, err, "could not listen udp on address %s", addr)
 
 	addrStr := udpConn.LocalAddr().String()
 	_, portStr, err := net.SplitHostPort(addrStr)

--- a/pkg/network/tracer/conntracker_test.go
+++ b/pkg/network/tracer/conntracker_test.go
@@ -9,7 +9,9 @@ package tracer
 
 import (
 	"net"
+	"net/url"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -26,11 +28,6 @@ import (
 	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-)
-
-const (
-	natPort    = 5432
-	nonNatPort = 9876
 )
 
 func TestConntrackers(t *testing.T) {
@@ -107,6 +104,18 @@ func setupNetlinkConntracker(t *testing.T, cfg *config.Config) (netlink.Conntrac
 	return ct, err
 }
 
+func getPort(t *testing.T, listener net.Listener) uint16 {
+	addr := listener.Addr()
+	listenerURL := url.URL{Scheme: addr.Network(), Host: addr.String()}
+	port, err := strconv.Atoi(listenerURL.Port())
+	require.NoError(t, err)
+	return uint16(port)
+}
+
+func getPortUDP(_ *testing.T, udpConn *net.UDPConn) uint16 {
+	return uint16(udpConn.LocalAddr().(*net.UDPAddr).Port)
+}
+
 func testConntracker(t *testing.T, serverIP, clientIP net.IP, ct netlink.Conntracker, cfg *config.Config) {
 	isIPv6 := false
 	if cip, _ := netipx.FromStdIP(clientIP); cip.Is6() {
@@ -123,10 +132,13 @@ func testConntracker(t *testing.T, serverIP, clientIP net.IP, ct netlink.Conntra
 	t.Logf("ns: %d", curNs)
 
 	t.Run("TCP", func(t *testing.T) {
+		var natPort, nonNatPort int
 		srv1 := nettestutil.StartServerTCP(t, serverIP, natPort)
 		defer srv1.Close()
+		natPort = int(getPort(t, srv1.(net.Listener)))
 		srv2 := nettestutil.StartServerTCP(t, serverIP, nonNatPort)
 		defer srv2.Close()
+		nonNatPort = int(getPort(t, srv2.(net.Listener)))
 
 		localAddr := nettestutil.MustPingTCP(t, clientIP, natPort).LocalAddr().(*net.TCPAddr)
 		var trans *network.IPTranslation
@@ -159,13 +171,16 @@ func testConntracker(t *testing.T, serverIP, clientIP net.IP, ct netlink.Conntra
 		trans = ct.GetTranslationForConn(cs)
 		assert.Nil(t, trans)
 	})
+
 	t.Run("UDP", func(t *testing.T) {
 		if isIPv6 && !cfg.CollectUDPv6Conns {
 			t.Skip("UDPv6 disabled")
 		}
 
+		var natPort int
 		srv3 := nettestutil.StartServerUDP(t, serverIP, natPort)
 		defer srv3.Close()
+		natPort = int(getPortUDP(t, srv3.(*net.UDPConn)))
 
 		localAddrUDP := nettestutil.MustPingUDP(t, clientIP, natPort).LocalAddr().(*net.UDPAddr)
 		var trans *network.IPTranslation


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes failures like https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/414351549

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
