### PR TITLE
[ASCII-1079] Return all queryable config values when fetching bare config endpoint path

### DIFF
--- a/comp/api/api/apiimpl/internal/config/endpoint.go
+++ b/comp/api/api/apiimpl/internal/config/endpoint.go
@@ -36,18 +36,41 @@ type configEndpoint struct {
 	errorsExpvar       expvar.Map
 }
 
-func (c *configEndpoint) serveHTTP(w http.ResponseWriter, r *http.Request) {
-	body, statusCode, err := c.getConfigValueAsJSON(r)
-	if err != nil {
-		http.Error(w, err.Error(), statusCode)
+func (c *configEndpoint) getConfigValueHandler(w http.ResponseWriter, r *http.Request) {
+	vars := gorilla.Vars(r)
+	path := vars["path"]
+
+	if _, ok := c.authorizedConfigPaths[path]; !ok {
+		c.unauthorizedExpvar.Add(path, 1)
+		log.Warnf("config endpoint received a request from '%s' for config '%s' which is not allowed", r.RemoteAddr, path)
+		http.Error(w, fmt.Sprintf("querying config value '%s' is not allowed", path), http.StatusForbidden)
 		return
 	}
 
-	w.WriteHeader(statusCode)
-	_, err = w.Write(body)
-	if err != nil {
-		log.Warnf("config endpoint: could not write response body: %v", err)
+	log.Debug("config endpoint received a request from '%s' for config '%s'", r.RemoteAddr, path)
+	value := c.cfg.Get(path)
+	if value == nil {
+		c.unsetExpvar.Add(path, 1)
+		http.Error(w, fmt.Sprintf("no runtime setting found for %s", path), http.StatusNotFound)
+		return
 	}
+
+	c.marshalAndSendResponse(w, path, value)
+}
+
+func (c *configEndpoint) getAllConfigValuesHandler(w http.ResponseWriter, r *http.Request) {
+	log.Debug("config endpoint received a request from '%s' for all authorized config values", r.RemoteAddr)
+	allValues := make(map[string]interface{}, len(c.authorizedConfigPaths))
+	for key := range c.authorizedConfigPaths {
+		value := c.cfg.Get(key)
+		if value == nil {
+			c.unsetExpvar.Add(key, 1)
+			continue
+		}
+		allValues[key] = value
+	}
+
+	c.marshalAndSendResponse(w, "/", allValues)
 }
 
 // GetConfigEndpointMuxCore builds and returns the mux for the config endpoint with default values
@@ -80,39 +103,27 @@ func getConfigEndpoint(cfg config.Reader, authorizedConfigPaths authorizedSet, e
 		configEndpoint.expvars.Set(name, expv)
 	}
 
-	configEndpointHandler := http.HandlerFunc(configEndpoint.serveHTTP)
 	configEndpointMux := gorilla.NewRouter()
-	configEndpointMux.HandleFunc("/", configEndpointHandler).Methods("GET")
-	configEndpointMux.HandleFunc("/{path}", configEndpointHandler).Methods("GET")
+	configEndpointMux.HandleFunc("/", http.HandlerFunc(configEndpoint.getAllConfigValuesHandler)).Methods("GET")
+	configEndpointMux.HandleFunc("/{path}", http.HandlerFunc(configEndpoint.getConfigValueHandler)).Methods("GET")
 
 	return configEndpointMux, configEndpoint
 }
 
-// returns the marshalled JSON value of the config path requested
-// or an error and http status code in case of failure
-func (c *configEndpoint) getConfigValueAsJSON(r *http.Request) ([]byte, int, error) {
-	vars := gorilla.Vars(r)
-	path := vars["path"]
-
-	if _, ok := c.authorizedConfigPaths[path]; !ok {
-		c.unauthorizedExpvar.Add(path, 1)
-		log.Warnf("config endpoint received a request from '%s' for config '%s' which is not allowed", r.RemoteAddr, path)
-		return nil, http.StatusForbidden, fmt.Errorf("querying config value '%s' is not allowed", path)
-	}
-
-	log.Debug("config endpoint received a request from '%s' for config '%s'", r.RemoteAddr, path)
-	value := c.cfg.Get(path)
-	if value == nil {
-		c.unsetExpvar.Add(path, 1)
-		return nil, http.StatusNotFound, fmt.Errorf("no runtime setting found for %s", path)
-	}
-
+func (c *configEndpoint) marshalAndSendResponse(w http.ResponseWriter, path string, value interface{}) {
 	body, err := json.Marshal(value)
 	if err != nil {
 		c.errorsExpvar.Add(path, 1)
-		return nil, http.StatusInternalServerError, fmt.Errorf("could not marshal config value of '%s': %v", path, err)
+		http.Error(w, fmt.Sprintf("could not marshal config value of '%s': %v", path, err), http.StatusInternalServerError)
+		return
 	}
 
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(body)
+	if err != nil {
+		c.errorsExpvar.Add(path, 1)
+		log.Warnf("config endpoint: could not write response body: %v", err)
+		return
+	}
 	c.successExpvar.Add(path, 1)
-	return body, http.StatusOK, nil
 }

--- a/comp/api/api/apiimpl/internal/config/endpoint.go
+++ b/comp/api/api/apiimpl/internal/config/endpoint.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"expvar"
 	"fmt"
+	"html"
 	"net/http"
 
 	gorilla "github.com/gorilla/mux"
@@ -39,6 +40,9 @@ type configEndpoint struct {
 func (c *configEndpoint) getConfigValueHandler(w http.ResponseWriter, r *http.Request) {
 	vars := gorilla.Vars(r)
 	path := vars["path"]
+	// escape in case it contains html special characters that would be unsafe to include as is in a response
+	// all valid config paths won't contain such characters so for a valid request this is a no-op
+	path = html.EscapeString(path)
 
 	if _, ok := c.authorizedConfigPaths[path]; !ok {
 		c.unauthorizedExpvar.Add(path, 1)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Return the map of all authorized config keys to their values in the config API when querying the bare endpoint (ie. without specifying any config key).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The endpoint only accepts a limited set of config as parameters, and returns a 403 otherwise.
Most of the time we'll just query all values anyway, doing so in a single request is easier and more efficient.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Unit tests ensure that the list is properly returned by the endpoint.

For manual testing, enable the config api:
```
agent_ipc_port: 5004
```

and run:
```
curl -L -k -H "authorization: Bearer $(cat <path_to_auth_token>)" https://localhost:5004/config/v1
```

It should all authorized keys along with their values as a JSON map, ie. `{"api_key": "qwertyuiop"}`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
