### PR TITLE
Raise error if `ddagentuser` is the same as the user running the installer

### DIFF
--- a/releasenotes/notes/prevent-agent-user-is-current-user-44a342b49717af50.yaml
+++ b/releasenotes/notes/prevent-agent-user-is-current-user-44a342b49717af50.yaml
@@ -4,5 +4,4 @@ upgrade:
     To prevent misconfigurations, the Windows Datadog Agent installer now raises an error if
     the user account running the installer MSI is provided as the ``ddagentuser`` (``DDAGENTUSER_NAME``) account.
     If the account is a service account, such as LocalSystem or a gMSA account, no action is needed.
-    If the account is a regular account, provide the ``ALLOW_CURRENT_USER=true`` option to allow
-    the installer to continue.
+    If the account is a regular account, configure a different Datadog Agent service account.

--- a/releasenotes/notes/prevent-agent-user-is-current-user-44a342b49717af50.yaml
+++ b/releasenotes/notes/prevent-agent-user-is-current-user-44a342b49717af50.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    To prevent misconfigurations the Windows Datadog Agent installer now raises an error if
+    the user account running the installer MSI is provided as the ``ddagentuser`` (``DDAGENTUSER_NAME``) account.
+    If the account is a service account, such as LocalSystem or a gMSA account, then no action is needed.
+    If the account is a regular account, provide the ``ALLOW_CURRENT_USER=true`` option to allow
+    the installer to continue.

--- a/releasenotes/notes/prevent-agent-user-is-current-user-44a342b49717af50.yaml
+++ b/releasenotes/notes/prevent-agent-user-is-current-user-44a342b49717af50.yaml
@@ -1,8 +1,8 @@
 ---
 upgrade:
   - |
-    To prevent misconfigurations the Windows Datadog Agent installer now raises an error if
+    To prevent misconfigurations, the Windows Datadog Agent installer now raises an error if
     the user account running the installer MSI is provided as the ``ddagentuser`` (``DDAGENTUSER_NAME``) account.
-    If the account is a service account, such as LocalSystem or a gMSA account, then no action is needed.
+    If the account is a service account, such as LocalSystem or a gMSA account, no action is needed.
     If the account is a regular account, provide the ``ALLOW_CURRENT_USER=true`` option to allow
     the installer to continue.

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -180,7 +180,7 @@ def _build(
 
     # Construct build command line
     cmd = _get_vs_build_command(
-        f'cd {BUILD_SOURCE_DIR} && msbuild {project} /restore /p:Configuration={configuration} /p:Platform="{arch}"',
+        f'cd {BUILD_SOURCE_DIR} && msbuild {project} /restore /p:Configuration={configuration} /p:Platform="{arch}" /verbosity:minimal',
         vstudio_root,
     )
     print(f"Build Command: {cmd}")

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -210,6 +210,8 @@ def _build_wxs(ctx, env, outdir):
     # Run the builder to produce the WXS
     # Set an env var to tell WixSetup.exe where to put the output
     env['AGENT_MSI_OUTDIR'] = outdir
+    # Create a MSI build cmd, not the full MSI
+    env["BUILD_MSI_CMD"] = "true"
     succeeded = ctx.run(
         f'cd {BUILD_SOURCE_DIR}\\WixSetup && {wixsetup}',
         warn=True,

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/CustomActions.Tests.csproj
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/CustomActions.Tests.csproj
@@ -76,7 +76,7 @@
     <Compile Include="Flare\FlareUnitTests.cs" />
     <Compile Include="IntegrationTests\TestConfig.cs" />
     <Compile Include="Logs\ProcessConfigTests.cs" />
-    <Compile Include="ProcessUserCustomActions\LookupAccountNameDelegate.cs" />
+    <Compile Include="ProcessUserCustomActions\TestDelegate.cs" />
     <Compile Include="Process\ProcessConfigTests.cs" />
     <Compile Include="Proxy\ProcessConfigTests.cs" />
     <Compile Include="Telemetry\TelemetryUnitTests.cs" />

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsTestSetup.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsTestSetup.cs
@@ -1,3 +1,4 @@
+using System;
 using System.DirectoryServices.ActiveDirectory;
 using System.Security.Principal;
 using AutoFixture;
@@ -24,6 +25,7 @@ namespace CustomActions.Tests.ProcessUserCustomActions
             NativeMethods.Setup(n => n.IsDomainController()).Returns(false);
             NativeMethods.Setup(n => n.IsReadOnlyDomainController()).Returns(false);
             NativeMethods.Setup(n => n.GetComputerDomain()).Throws<ActiveDirectoryObjectNotFoundException>();
+            NativeMethods.Setup(n => n.GetCurrentUser(out It.Ref<string>.IsAny, out It.Ref<SecurityIdentifier>.IsAny)).Throws<Exception>();
             ServiceController.SetupGet(s => s.Services).Returns(new WindowsService[] { });
         }
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/TestDelegate.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/TestDelegate.cs
@@ -10,4 +10,8 @@ namespace CustomActions.Tests.ProcessUserCustomActions
         out string domain,
         out SecurityIdentifier securityIdentifier,
         out SID_NAME_USE sidNameUse);
+
+    delegate void GetCurrentUserDelegate(
+        out string accountName,
+        out SecurityIdentifier securityIdentifier);
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
@@ -120,5 +120,76 @@ namespace CustomActions.Tests.ProcessUserCustomActions
             Test.Properties.Should()
                 .Contain("DDAGENTUSER_FOUND", "true");
         }
+
+        [Theory]
+        [AutoData]
+        public void ProcessDdAgentUserCredentials_With_Agent_User_Equal_Current_User(string userDomain, string userName)
+        {
+            var userSID = new SecurityIdentifier("S-1-0-5");
+            Test.WithLocalUser(userDomain, userName, SID_NAME_USE.SidTypeUser, userSID)
+                .WithCurrentUser(userName, userSID);
+
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_NAME"]).Returns($"{userDomain}\\{userName}");
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Failure);
+
+            Test.Properties.Should()
+                .Contain("DDAGENTUSER_FOUND", "true").And
+                .Contain("DDAGENTUSER_SID", userSID.ToString());
+        }
+
+        [Theory]
+        [AutoData]
+        public void ProcessDdAgentUserCredentials_With_Agent_User_Equal_Current_User_With_Allow_Flag(string userDomain, string userName)
+        {
+            Test.Session
+                .Setup(session => session["ALLOW_CURRENT_USER"]).Returns("true");
+
+            var userSID = new SecurityIdentifier("S-1-0-5");
+            Test.WithLocalUser(userDomain, userName, SID_NAME_USE.SidTypeUser, userSID)
+                .WithCurrentUser(userName, userSID);
+
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_NAME"]).Returns($"{userDomain}\\{userName}");
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain("DDAGENTUSER_FOUND", "true").And
+                .Contain("DDAGENTUSER_SID", userSID.ToString()).And
+                .Contain("DDAGENTUSER_PROCESSED_NAME", userName).And
+                .Contain("DDAGENTUSER_PROCESSED_DOMAIN", userDomain);
+        }
+
+        [Theory]
+        [AutoData]
+        public void ProcessDdAgentUserCredentials_With_Local_System_And_Current_User_Local_System()
+        {
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_NAME"]).Returns("LocalSystem");
+
+            Test.WithCurrentUser("SYSTEM", new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null));
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain("DDAGENTUSER_FOUND", "true").And
+                .Contain("DDAGENTUSER_SID", new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null).Value).And
+                .Contain("DDAGENTUSER_PROCESSED_NAME", "SYSTEM").And
+                .Contain("DDAGENTUSER_PROCESSED_DOMAIN", "NT AUTHORITY").And
+                .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", "NT AUTHORITY\\SYSTEM").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_RESET_PASSWORD" && string.IsNullOrEmpty(kvp.Value)).And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && string.IsNullOrEmpty(kvp.Value));
+        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
@@ -144,33 +144,6 @@ namespace CustomActions.Tests.ProcessUserCustomActions
 
         [Theory]
         [AutoData]
-        public void ProcessDdAgentUserCredentials_With_Agent_User_Equal_Current_User_With_Allow_Flag(string userDomain,
-            string userName)
-        {
-            Test.Session
-                .Setup(session => session["ALLOW_CURRENT_USER"]).Returns("true");
-
-            var userSID = new SecurityIdentifier("S-1-0-5");
-            Test.WithLocalUser(userDomain, userName, SID_NAME_USE.SidTypeUser, userSID)
-                .WithCurrentUser(userName, userSID);
-
-            Test.Session
-                .Setup(session => session["DDAGENTUSER_NAME"]).Returns($"{userDomain}\\{userName}");
-
-            Test.Create()
-                .ProcessDdAgentUserCredentials()
-                .Should()
-                .Be(ActionResult.Success);
-
-            Test.Properties.Should()
-                .Contain("DDAGENTUSER_FOUND", "true").And
-                .Contain("DDAGENTUSER_SID", userSID.ToString()).And
-                .Contain("DDAGENTUSER_PROCESSED_NAME", userName).And
-                .Contain("DDAGENTUSER_PROCESSED_DOMAIN", userDomain);
-        }
-
-        [Theory]
-        [AutoData]
         public void ProcessDdAgentUserCredentials_With_Local_System_And_Current_User_Local_System()
         {
             Test.Session
@@ -191,59 +164,6 @@ namespace CustomActions.Tests.ProcessUserCustomActions
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", "NT AUTHORITY\\SYSTEM").And
                 .Contain(kvp => kvp.Key == "DDAGENTUSER_RESET_PASSWORD" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && string.IsNullOrEmpty(kvp.Value));
-        }
-
-        [Theory]
-        [AutoData]
-        public void ProcessDdAgentUserCredentials_With_Agent_User_Equal_Current_User_On_Upgrade_Same_User(
-            string userDomain, string userName)
-        {
-            var userSID = new SecurityIdentifier("S-1-0-5");
-            Test.WithLocalUser(userDomain, userName, SID_NAME_USE.SidTypeUser, userSID)
-                .WithCurrentUser(userName, userSID)
-                .WithPreviousAgentUser(userDomain, userName);
-
-            Test.Session
-                .Setup(session => session["DDAGENTUSER_NAME"]).Returns($"{userDomain}\\{userName}");
-
-            Test.Create()
-                .ProcessDdAgentUserCredentials()
-                .Should()
-                .Be(ActionResult.Success);
-
-            Test.Properties.Should()
-                .Contain("DDAGENTUSER_FOUND", "true").And
-                .Contain("DDAGENTUSER_SID", userSID.ToString()).And
-                .Contain("DDAGENTUSER_PROCESSED_NAME", userName).And
-                .Contain("DDAGENTUSER_PROCESSED_DOMAIN", userDomain);
-        }
-
-        [Theory]
-        [AutoData]
-        public void ProcessDdAgentUserCredentials_With_Agent_User_Equal_Current_User_On_Upgrade_Change_User(
-            string userDomain, string userName)
-        {
-            var previousAgentUserName = "previousAgentUser";
-            var previousAgentUserDomain = Environment.MachineName;
-            var previousAgentUserSID = new SecurityIdentifier("S-1-0-6");
-            var userSID = new SecurityIdentifier("S-1-0-5");
-            Test.WithLocalUser(userDomain, userName, SID_NAME_USE.SidTypeUser, userSID)
-                .WithLocalUser(previousAgentUserDomain, previousAgentUserName, SID_NAME_USE.SidTypeUser,
-                    previousAgentUserSID)
-                .WithCurrentUser(userName, userSID)
-                .WithPreviousAgentUser(previousAgentUserDomain, previousAgentUserName);
-
-            Test.Session
-                .Setup(session => session["DDAGENTUSER_NAME"]).Returns($"{userDomain}\\{userName}");
-
-            Test.Create()
-                .ProcessDdAgentUserCredentials()
-                .Should()
-                .Be(ActionResult.Failure);
-
-            Test.Properties.Should()
-                .Contain("DDAGENTUSER_FOUND", "true").And
-                .Contain("DDAGENTUSER_SID", userSID.ToString());
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/INativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/INativeMethods.cs
@@ -44,5 +44,7 @@ namespace Datadog.CustomActions.Interfaces
         int AddUser(string userName, string userPassword);
 
         void EnablePrivilege(string privilegeName);
+
+        void GetCurrentUser(out string name, out SecurityIdentifier sid);
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -898,6 +898,18 @@ namespace Datadog.CustomActions.Native
             }
         }
 
+        public void GetCurrentUser(out string name, out SecurityIdentifier sid)
+        {
+            var identity = WindowsIdentity.GetCurrent();
+            if (identity == null)
+            {
+                throw new Exception("Unable to get current user");
+            }
+
+            name = identity.Name;
+            sid = identity.User;
+        }
+
         #endregion
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -908,6 +908,10 @@ namespace Datadog.CustomActions.Native
 
             name = identity.Name;
             sid = identity.User;
+            if (sid == null)
+            {
+                throw new Exception($"Unable to lookup SID for current user: {name}");
+            }
         }
 
         #endregion

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -307,6 +307,9 @@ namespace Datadog.CustomActions
             _session.Log($"Error processing ddAgentUser credentials: {e}");
             if (calledFromUIControl)
             {
+                // When called from a UI control we must store the error information in the session
+                // because logging is not available.
+                _session["ErrorModal_ExceptionInformation"] = e.ToString();
                 // When called from InstallUISequence we must return success for the modal dialog to show,
                 // otherwise the installer exits. The control that called this action should check the
                 // DDAgentUser_Valid property to determine if this function succeeded or failed.

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -234,10 +234,15 @@ namespace Datadog.CustomActions
         private void TestAgentUserIsNotCurrentUser(SecurityIdentifier agentUser, bool isServiceAccount)
         {
             var allowInstallCurrentUser = _session.Property("ALLOW_CURRENT_USER")?.ToLower() == "true";
-            _nativeMethods.GetCurrentUser(out var currentUserName, out var currentUserSID);
-            if (currentUserSID == null)
+            string currentUserName;
+            SecurityIdentifier currentUserSID;
+            try
             {
-                _session.Log("Unable to get current user SID");
+                _nativeMethods.GetCurrentUser(out currentUserName, out currentUserSID);
+            }
+            catch (Exception e)
+            {
+                _session.Log($"Unable to get current user SID: {e}");
                 return;
             }
             _session.Log($"Currently logged in user: {currentUserName} ({currentUserSID})");

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -255,7 +255,7 @@ namespace Datadog.CustomActions
                 return;
             }
 
-            throw new ExceptionWithDialogMessage("The account provided is the same as the current user. Please supply a different account for the Datadog Agent.");
+            throw new ExceptionWithDialogMessage("The account provided is the same as the currently logged in user. Please supply a different account for the Datadog Agent.");
         }
 
         /// <summary>

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -499,8 +499,7 @@ namespace Datadog.CustomActions
             }
             catch (Exception e)
             {
-                var errorDialogMessage = $"An unexpected error occurred while parsing the account name: {e.Message}";
-                return HandleProcessDdAgentUserCredentialsException(e, errorDialogMessage, calledFromUIControl);
+                return HandleProcessDdAgentUserCredentialsException(e, "An unexpected error occurred while parsing the account name. Refer to the installation log for more information or contact support for assistance.", calledFromUIControl);
             }
 
             if (calledFromUIControl)

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -255,7 +255,7 @@ namespace Datadog.CustomActions
                 return;
             }
 
-            throw new ExceptionWithDialogMessage("The account provided is the same as the current user. Please supply a different account name.");
+            throw new ExceptionWithDialogMessage("The account provided is the same as the current user. Please supply a different account for the Datadog Agent.");
         }
 
         /// <summary>

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -228,14 +228,13 @@ namespace Datadog.CustomActions
         private void TestAgentUserIsNotCurrentUser(SecurityIdentifier agentUser, bool isServiceAccount)
         {
             var allowInstallCurrentUser = _session.Property("ALLOW_CURRENT_USER")?.ToLower() == "true";
-            var currentUser = WindowsIdentity.GetCurrent();
-            var currentUserSID = currentUser?.User;
+            _nativeMethods.GetCurrentUser(out var currentUserName, out var currentUserSID);
             if (currentUserSID == null)
             {
                 _session.Log("Unable to get current user SID");
                 return;
             }
-            _session.Log($"Current user: {currentUser.Name} ({currentUserSID})");
+            _session.Log($"Current user: {currentUserName} ({currentUserSID})");
 
             // If the user is a service account (e.g. LocalSystem) then it's ok to use the same account
             if (isServiceAccount)

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -258,7 +258,7 @@ namespace Datadog.CustomActions
             if (_previousDdAgentUserSID != null)
             {
                 _session.Log($"Previous agent user: {_previousDdAgentUserSID}");
-                // If the previous agent user is the same as the new agentUser, then we are upgrading and the user has already
+                // If the previous agent user is the same as the new agentUser, then we are upgrading/changing/repairing and the user has already
                 // opted in to allow it to be the same as the current user.
                 if (_previousDdAgentUserSID.Equals(agentUser))
                 {

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -25,22 +25,26 @@ namespace Datadog.CustomActions
         private readonly ISession _session;
         private readonly INativeMethods _nativeMethods;
         private readonly IServiceController _serviceController;
+        private readonly IRegistryServices _registryServices;
 
         public ProcessUserCustomActions(
             ISession session,
             INativeMethods nativeMethods,
-            IServiceController serviceController)
+            IServiceController serviceController,
+            IRegistryServices registryServices)
         {
             _session = session;
             _nativeMethods = nativeMethods;
             _serviceController = serviceController;
+            _registryServices = registryServices;
         }
 
         public ProcessUserCustomActions(ISession session)
             : this(
                 session,
                 new Win32NativeMethods(),
-                new ServiceController()
+                new ServiceController(),
+                new RegistryServices()
             )
         {
         }
@@ -222,7 +226,9 @@ namespace Datadog.CustomActions
         /// <remarks>
         /// Since the installer modifies the user account, if the current user is provided for the ddagentuser the account will be locked out.
         /// If a customer does this by mistake, they will have to use a different account to log in to the machine and fix the account.
-        /// To avoid this, we disallow using the current user as the ddagentuser.
+        /// To avoid this, we disallow using the current user as the ddagentuser unless
+        ///   - The user is a service account (e.g. LocalSystem)
+        ///   - The agent is already installed and the agent user is not being changed
         /// If a customer must use the current user, they can pass ALLOW_CURRENT_USER=true to the installer on the command line.
         /// </remarks>
         private void TestAgentUserIsNotCurrentUser(SecurityIdentifier agentUser, bool isServiceAccount)
@@ -234,7 +240,7 @@ namespace Datadog.CustomActions
                 _session.Log("Unable to get current user SID");
                 return;
             }
-            _session.Log($"Current user: {currentUserName} ({currentUserSID})");
+            _session.Log($"Currently logged in user: {currentUserName} ({currentUserSID})");
 
             // If the user is a service account (e.g. LocalSystem) then it's ok to use the same account
             if (isServiceAccount)
@@ -246,6 +252,19 @@ namespace Datadog.CustomActions
             if (!currentUserSID.Equals(agentUser))
             {
                 return;
+            }
+
+            var _previousDdAgentUserSID = InstallStateCustomActions.GetPreviousAgentUser(_session, _registryServices, _nativeMethods);
+            if (_previousDdAgentUserSID != null)
+            {
+                _session.Log($"Previous agent user: {_previousDdAgentUserSID}");
+                // If the previous agent user is the same as the new agentUser, then we are upgrading and the user has already
+                // opted in to allow it to be the same as the current user.
+                if (_previousDdAgentUserSID.Equals(agentUser))
+                {
+                    _session.Log("The account provided is the same as the currently logged in user and the previous agent user, allowing install to continue.");
+                    return;
+                }
             }
 
             if (allowInstallCurrentUser)

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -96,6 +96,11 @@ namespace WixSetup.Datadog
                 {
                     AttributesDefinition = "Secure=yes"
                 },
+                // Set to "true" to allow the currently logged in user to be used as the Agent user.
+                new Property("ALLOW_CURRENT_USER")
+                {
+                    AttributesDefinition = "Secure=yes"
+                },
                 // Add a checkbox at the end of the setup to launch the Datadog Agent Manager
                 new LaunchCustomApplicationFromExitDialog(
                     _agentBinaries.TrayId,

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -96,11 +96,6 @@ namespace WixSetup.Datadog
                 {
                     AttributesDefinition = "Secure=yes"
                 },
-                // Set to "true" to allow the currently logged in user to be used as the Agent user.
-                new Property("ALLOW_CURRENT_USER")
-                {
-                    AttributesDefinition = "Secure=yes"
-                },
                 // Add a checkbox at the end of the setup to launch the Datadog Agent Manager
                 new LaunchCustomApplicationFromExitDialog(
                     _agentBinaries.TrayId,

--- a/tools/windows/DatadogAgentInstaller/WixSetup/dialogs/ddagentuserdlg.wxi
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/dialogs/ddagentuserdlg.wxi
@@ -1,16 +1,14 @@
 <Include>
   <Dialog Id="DDAgentUserDlg" Width="370" Height="270" Title="!(loc.DDAgentUserDialog_Title)">
 
-    <Control Id="InfoLabel" Type="Hyperlink" X="20" Y="52" Width="330" Height="40" >
-	  <Text>!(loc.DDAgentUserDialogInfoLabel)</Text>
-    </Control>
-
     <!-- Username and Password fields
-           Sets the same property as the command line options
-             - DDAGENTUSER_NAME
-             - DDAGENTUSER_PASSWORD
-           If the properties are set on the command line, the controls will be pre-filled
-      -->
+         Sets the same property as the command line options
+           - DDAGENTUSER_NAME
+           - DDAGENTUSER_PASSWORD
+         If the properties are set on the command line, the controls will be pre-filled.
+         Even though the InfoLabel comes first on the dialog, we list the controls here
+         first so that they receive focus first when the dialog is opened.
+    -->
     <Control Id="EnterUserName" Type="Text" Height="15" Width="320" X="20" Y="95"
              Text="!(loc.DDAgentUserDialogUserNameLabel)" />
     <Control Id="UserNameFromDefault" Type="Edit" Height="15" Width="320" X="20" Y="111"
@@ -20,6 +18,7 @@
     <Control Id="PasswordFromDefault" Type="Edit" Height="15" Width="320" X="20" Y="159"
              Password="yes"
              Property="DDAGENTUSER_PASSWORD" />
+
 
     <!-- back button -->
     <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
@@ -35,6 +34,11 @@
     <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
                Text="Cancel">
       <Publish Event="EndDialog" Value="Exit">1</Publish>
+    </Control>
+
+    <!-- The InfoLabel is listed last so that its tab order is after the buttons and before the edit controls. -->
+    <Control Id="InfoLabel" Type="Hyperlink" X="20" Y="52" Width="330" Height="40" >
+	  <Text>!(loc.DDAgentUserDialogInfoLabel)</Text>
     </Control>
 
     <!-- Title + Banner -->

--- a/tools/windows/DatadogAgentInstaller/WixSetup/dialogs/ddagentuserdlg.wxi
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/dialogs/ddagentuserdlg.wxi
@@ -1,19 +1,23 @@
 <Include>
   <Dialog Id="DDAgentUserDlg" Width="370" Height="270" Title="!(loc.DDAgentUserDialog_Title)">
 
+    <Control Id="InfoLabel" Type="Hyperlink" X="20" Y="52" Width="330" Height="40" >
+	  <Text>!(loc.DDAgentUserDialogInfoLabel)</Text>
+    </Control>
+
     <!-- Username and Password fields
            Sets the same property as the command line options
              - DDAGENTUSER_NAME
              - DDAGENTUSER_PASSWORD
            If the properties are set on the command line, the controls will be pre-filled
       -->
-    <Control Id="EnterUserName" Type="Text" Height="15" Width="320" X="25" Y="70"
+    <Control Id="EnterUserName" Type="Text" Height="15" Width="320" X="20" Y="95"
              Text="!(loc.DDAgentUserDialogUserNameLabel)" />
-    <Control Id="UserNameFromDefault" Type="Edit" Height="15" Width="320" X="25" Y="86"
+    <Control Id="UserNameFromDefault" Type="Edit" Height="15" Width="320" X="20" Y="111"
              Property="DDAGENTUSER_NAME" />
-    <Control Id="EnterPassword" Type="Text" Height="30" Width="320" X="25" Y="118"
+    <Control Id="EnterPassword" Type="Text" Height="15" Width="320" X="20" Y="143"
              Text="!(loc.DDAgentUserDialogPasswordLabel)" />
-    <Control Id="PasswordFromDefault" Type="Edit" Height="15" Width="320" X="25" Y="149"
+    <Control Id="PasswordFromDefault" Type="Edit" Height="15" Width="320" X="20" Y="159"
              Password="yes"
              Property="DDAGENTUSER_PASSWORD" />
 

--- a/tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl
@@ -45,8 +45,8 @@
 	<String Id ="DDAgentUserDialog_Title" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
 	<String Id ="DDAgentUserDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Enter the agent user account</String>
 	<String Id ="DDAgentUserDialogTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Title_White}Datadog Agent User Account</String>
-	<String Id ="DDAgentUserDialogUserNameLabel" Overridable="yes" Localizable="yes">Please enter the username (leave blank to use ddagentuser):</String>
-	<String Id ="DDAgentUserDialogPasswordLabel" Overridable="yes" Localizable="yes">Please enter the password (leave blank to let the installer decide):</String>
+	<String Id ="DDAgentUserDialogUserNameLabel" Overridable="yes" Localizable="yes">Username (leave blank to use ddagentuser):</String>
+	<String Id ="DDAgentUserDialogPasswordLabel" Overridable="yes" Localizable="yes">Password (leave blank to let the installer decide):</String>
 	<String Id ="DDAgentUserDialogInfoLabel">Please provide the user account to use as the Datadog Agent service account. Refer to the <![CDATA[<a href="https://docs.datadoghq.com/agent/guide/windows-agent-ddagent-user/">Datadog Windows Agent User</a>]]> documentation for more information on choosing and configuring a service account for the Datadog Agent.</String>
 
 	<!-- these strings for the FatalError dialog -->

--- a/tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl
@@ -47,6 +47,7 @@
 	<String Id ="DDAgentUserDialogTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Title_White}Datadog Agent User Account</String>
 	<String Id ="DDAgentUserDialogUserNameLabel" Overridable="yes" Localizable="yes">Please enter the username (leave blank to use ddagentuser):</String>
 	<String Id ="DDAgentUserDialogPasswordLabel" Overridable="yes" Localizable="yes">Please enter the password (leave blank to let the installer decide):</String>
+	<String Id ="DDAgentUserDialogInfoLabel">Please provide the user account to use as the Datadog Agent service account. Refer to the <![CDATA[<a href="https://docs.datadoghq.com/agent/guide/windows-agent-ddagent-user/">Datadog Windows Agent User</a>]]> documentation for more information on choosing and configuring a service account for the Datadog Agent.</String>
 
 	<!-- these strings for the FatalError dialog -->
 	<String Id ="FatalErrorDialog_ViewLog" Overridable="yes" Localizable="yes">View Log</String>


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Prevent a user from entering their own account in the `ddagentuser` field.
  - GUI installs show an error dialog, silent installs will fail the installation.

It is not an error to provide `LocalSystem` (or another service account) while running the installer as `LocalSystem` (or another service account).

Assuming that if it was okay previously, it should be okay now, upgrade/change/repair are allowed to continue if the provided account is the same as the currently installed `ddagentuser` account. However it will raise an error if trying to change the user account to the currently logged in user.

Add link to documentation on the agent user selection dialog.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The installer modifies the account provided as the `ddagentuser` account (user rights, groups, password, etc). If a user mistakenly provides their own account as the `ddagentuser` account it can cause the user to become locked out of their account.

https://datadoghq.atlassian.net/browse/WINA-591

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Link to documentation on the dialog
![image](https://github.com/DataDog/datadog-agent/assets/2266830/8eb230e5-d5af-4e09-a169-ccc3719d2a80)

error message when current user is provided
![image](https://github.com/DataDog/datadog-agent/assets/2266830/6b256261-9aef-4b28-b0d8-2b3a09ee47e2)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Considering this a breaking change since It might be possible currently to use the `ddagentuser` account to deploy the agent, but it seems unlikely because:
- One of the user rights set by the installer at install time is `Deny access to this computer from the network`, so in normal circumstances the `ddagentuser` account can't be used to remotely configure a host.
- Administrator rights are required to install the Datadog Agent, but the `ddagentuser` is intended to be a low privilege account and should not normally be an Administrator.

For these reasons, and since we infrequently but regularly get support requests for users locking out their own accounts we are choosing to disallow this configuration by default in the installer.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Ensure the hyperlink on the `ddagentuser` dialog opens the documentation page.

The installer must be tested in both GUI and silent (`/qn`) mode.
- In GUI mode, ensure the error dialog is shown
- In silent mode, ensure the installer fails and the log contains the error message `The account provided is the same as the currently logged in user. Please supply a different account for the Datadog Agent.`

Use the following commands to try to install, it should raise an error
```PowerShell
.\ddagent.msi /l install.log DDAGENTUSER_NAME=$(whoami)
.\ddagent.msi /l install.log DDAGENTUSER_NAME=$(whoami) /qn
```

Install as a service account, like `LocalSystem`, install should succeed
```PowerShell
.\PsExec.exe -s cmd /c "$(Get-Location)\ddagent.msi" /l "$(Get-Location)\install.log" DDAGENTUSER_NAME=LocalSystem
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
