### PR TITLE
[omnibus] Pin oracledb cryptography dependency

### DIFF
--- a/omnibus/config/software/oracledb-py3.rb
+++ b/omnibus/config/software/oracledb-py3.rb
@@ -16,7 +16,5 @@ build do
   license_file "./LICENSE.txt"
 
   command "sed -i 's/cython/cython<3.0.0/g' pyproject.toml"
-  command "sed -i 's/cryptography>=3.2.1/cryptography>=3.2.1,<42.0.0/g' setup.cfg"
-
-  command "#{install_dir}/embedded/bin/pip3 install ."
+  command "#{install_dir}/embedded/bin/pip3 install cryptography<42.0.0 ."
 end

--- a/omnibus/config/software/oracledb-py3.rb
+++ b/omnibus/config/software/oracledb-py3.rb
@@ -16,6 +16,7 @@ build do
   license_file "./LICENSE.txt"
 
   command "sed -i 's/cython/cython<3.0.0/g' pyproject.toml"
+  command "sed -i 's/cryptography>=3.2.1/cryptography>=3.2.1,<42.0.0/g' setup.cfg"
 
   command "#{install_dir}/embedded/bin/pip3 install ."
 end

--- a/omnibus/config/software/oracledb-py3.rb
+++ b/omnibus/config/software/oracledb-py3.rb
@@ -16,5 +16,5 @@ build do
   license_file "./LICENSE.txt"
 
   command "sed -i 's/cython/cython<3.0.0/g' pyproject.toml"
-  command "#{install_dir}/embedded/bin/pip3 install cryptography<42.0.0 ."
+  command "#{install_dir}/embedded/bin/pip3 install 'cryptography<42.0.0' ."
 end


### PR DESCRIPTION
### What does this PR do?

Ensures that we pin cryptography dependency to < 42.0.0, which fails on our RPM x86_64 builders, as it requires Rust >= 1.63.0. (FWIW, similar pin already exists in integrations-core)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
