### PR TITLE
[USM] Reduced http2 classification ut's execution time 

### DIFF
--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -49,7 +49,7 @@ import (
 
 const (
 	defaultTimeout      = 30 * time.Second
-	http2DefaultTimeout = 30 * time.Second
+	http2DefaultTimeout = 3 * time.Second
 )
 
 // testContext shares the context of a given test.
@@ -1724,7 +1724,7 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 				_, err = c.Write(usmhttp2.ComposeMessage([]byte(http2.ClientPreface), buf.Bytes()))
 				require.NoError(t, err)
 				buf.Reset()
-				c.SetReadDeadline(time.Now().Add(defaultTimeout))
+				c.SetReadDeadline(time.Now().Add(http2DefaultTimeout))
 				frameReader := http2.NewFramer(nil, c)
 				for {
 					_, err := frameReader.ReadFrame()

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -48,7 +48,8 @@ import (
 )
 
 const (
-	defaultTimeout = 30 * time.Second
+	defaultTimeout      = 30 * time.Second
+	http2DefaultTimeout = 30 * time.Second
 )
 
 // testContext shares the context of a given test.
@@ -1723,7 +1724,7 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 				_, err = c.Write(usmhttp2.ComposeMessage([]byte(http2.ClientPreface), buf.Bytes()))
 				require.NoError(t, err)
 				buf.Reset()
-				c.SetReadDeadline(time.Now().Add(defaultTimeout))
+				c.SetReadDeadline(time.Now().Add(http2DefaultTimeout))
 				frameReader := http2.NewFramer(nil, c)
 				for {
 					_, err := frameReader.ReadFrame()

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1724,7 +1724,7 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 				_, err = c.Write(usmhttp2.ComposeMessage([]byte(http2.ClientPreface), buf.Bytes()))
 				require.NoError(t, err)
 				buf.Reset()
-				c.SetReadDeadline(time.Now().Add(http2DefaultTimeout))
+				c.SetReadDeadline(time.Now().Add(defaultTimeout))
 				frameReader := http2.NewFramer(nil, c)
 				for {
 					_, err := frameReader.ReadFrame()
@@ -1746,7 +1746,7 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 
 				_, err = c.Write(buf.Bytes())
 				require.NoError(t, err)
-				c.SetReadDeadline(time.Now().Add(defaultTimeout))
+				c.SetReadDeadline(time.Now().Add(http2DefaultTimeout))
 				frameReader = http2.NewFramer(nil, c)
 				for {
 					_, err := frameReader.ReadFrame()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Reduce the execution time of the http2 classifications unit tests.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Reduces the execution time of the http2 classification in around 88%.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
