### PR TITLE
Add GH workflow for Agent RC creation

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -13,7 +13,7 @@ jobs:
             - name: Install python
               uses: actions/setup-python@v4
               with:
-                python-version: "3.9.12"
+                python-version: 3.11
                 cache: "pip"
 
             - name: Install Python dependencies

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -1,9 +1,7 @@
 name: Create RC PR
 
 on:
-    pull_request:
-        branches:
-            - kacper-murzyn/auto-rc-creation
+  workflow_dispatch:
 jobs:
     create_rc_pr:
         runs-on: ubuntu-latest
@@ -12,21 +10,19 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
 
-            - name: Set up Python 3
-              uses: actions/setup-python@v2
+            - name: Install python
+              uses: actions/setup-python@v4
               with:
-                python-version: 3.x
+                python-version: "3.9.12"
+                cache: "pip"
 
             - name: Install Python dependencies
-              run: pip install -r tasks/requirements_all_tasks.txt
+              run: |
+                python -m pip install --upgrade pip
+                pip install -r requirements.txt
+                pip install -r tasks/libs/requirements-github.txt
 
             - name: Create RC PR
-              run: inv -e release.create-rc
-
-            - name: Notify Slack
-              uses: rtCamp/action-slack-notify@v2
-              with:
-                status: 'success'
-                text: 'New RC PR created!'
-                channel: '#trello-test-channel'
-                icon_emoji: ':rocket:'
+              run: |
+                export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+                inv -e release.create-rc

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -1,0 +1,31 @@
+name: Create RC PR
+
+on:
+    workflow_dispatch:
+
+jobs:
+    create_rc_pr:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Set up Python 3
+              uses: actions/setup-python@v2
+              with:
+                python-version: 3.x
+
+            - name: Install Python dependencies
+              run: pip install -r tasks/requirements_all_tasks.txt
+
+            - name: Create RC PR
+              run: inv -e release.create-rc
+
+            - name: Notify Slack
+              uses: rtCamp/action-slack-notify@v2
+              with:
+                status: 'success'
+                text: 'New RC PR created!'
+                channel: '#trello-test-channel'
+                icon_emoji: ':rocket:'

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -1,8 +1,9 @@
 name: Create RC PR
 
 on:
-    workflow_dispatch:
-
+    pull_request:
+        branches:
+            - kacper-murzyn/auto-rc-creation
 jobs:
     create_rc_pr:
         runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?

This PR introduces a GH action that is responsible for creating new Agent Release Candidate PR.
Two main reasons:
1. This allows anyone to create the RC PR without having to clone/setup repo,
2. This will be part of the RC creation automation (testing this approach).

It definitely requires changes so it can properly work on release branches (in the current version this will work only on `main`). Testing GH workflows is difficult so I want to have an option to check it first and then iterate.

As this is set to be manually triggered, then there is no risk.

### Motivation

Making Agent release process easier and more automated.

### Describe how to test/QA your changes

This workflow was tested locally as much as possible. It should be now tested after merge to the main branch.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
