### PR TITLE
add some logging to potential olreader failure cases

### DIFF
--- a/pkg/windowsdriver/olreader/olreader.go
+++ b/pkg/windowsdriver/olreader/olreader.go
@@ -18,11 +18,12 @@ package olreader
 import "C"
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"golang.org/x/sys/windows"
 	"sync"
 	"syscall"
 	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"golang.org/x/sys/windows"
 )
 
 const (

--- a/pkg/windowsdriver/olreader/olreader.go
+++ b/pkg/windowsdriver/olreader/olreader.go
@@ -18,11 +18,11 @@ package olreader
 import "C"
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"golang.org/x/sys/windows"
 	"sync"
 	"syscall"
 	"unsafe"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"golang.org/x/sys/windows"
 )
 
 const (


### PR DESCRIPTION

### What does this PR do?

Add s some additional debug logging

### Motivation

Some additional troubleshooting help in dev

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Turn on debug logging.  look for new logs

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ x At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
