### PR TITLE
AMLII-1446: Adds python check_id pprof labels

### DIFF
--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -8,10 +8,12 @@
 package python
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"runtime"
+	"runtime/pprof"
 	"strings"
 	"time"
 	"unsafe"
@@ -86,7 +88,7 @@ func NewPythonCheck(senderManager sender.SenderManager, name string, class *C.rt
 	return pyCheck, nil
 }
 
-func (c *PythonCheck) runCheck(commitMetrics bool) error {
+func (c *PythonCheck) runCheckImpl(commitMetrics bool) error {
 	// Lock the GIL and release it at the end of the run
 	gstate, err := newStickyLock()
 	if err != nil {
@@ -121,6 +123,16 @@ func (c *PythonCheck) runCheck(commitMetrics bool) error {
 		return nil
 	}
 	return errors.New(checkErrStr)
+}
+
+func (c *PythonCheck) runCheck(commitMetrics bool) error {
+	ctx := context.Background()
+	var err error
+	idStr := string(c.id)
+	pprof.Do(ctx, pprof.Labels("check_id", idStr), func(ctx context.Context) {
+		err = c.runCheckImpl(commitMetrics)
+	})
+	return err
 }
 
 // Run a Python check

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -844,6 +844,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("internal_profiling.enable_goroutine_stacktraces", false)
 	config.BindEnvAndSetDefault("internal_profiling.delta_profiles", true)
 	config.BindEnvAndSetDefault("internal_profiling.extra_tags", []string{})
+	config.BindEnvAndSetDefault("internal_profiling.custom_attributes", []string{"check_id"})
 
 	config.BindEnvAndSetDefault("internal_profiling.capture_all_allocations", false)
 


### PR DESCRIPTION
### What does this PR do?
This change implements a pprof label `check_id` that is set while executing a python check.

### Motivation
In the in-app profiler, we'll now be able to break down execution by the individual check.

### Additional Notes

<img width="1329" alt="image" src="https://github.com/DataDog/datadog-agent/assets/996472/b5412b5e-c3d9-458a-9d95-a19770817e50">

This only implements this for python checks, corechecks will be handled in a separate PR.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
