### PR TITLE
[system-probe] set ebpf_bindata when bundle_ebpf is set

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -125,6 +125,7 @@ def build(
     windows_sysprobe=False,
     cmake_options='',
     bundle=None,
+    bundle_ebpf=False,
 ):
     """
     Build the agent. If the bits to include in the build are not specified,
@@ -177,7 +178,7 @@ def build(
         build_tags = get_default_build_tags(build="agent", arch=arch, flavor=flavor)
     else:
         all_tags = set()
-        if development and "system-probe" in bundled_agents:
+        if bundle_ebpf and "system-probe" in bundled_agents:
             all_tags.add("ebpf_bindata")
 
         for build in bundled_agents:

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -574,6 +574,7 @@ def build_sysprobe_binary(
             python_runtimes=python_runtimes,
             arch=arch,
             go_mod=go_mod,
+            bundle_ebpf=bundle_ebpf,
             bundle=BUNDLED_AGENTS[AgentFlavor.base] + ["system-probe"],
         )
 


### PR DESCRIPTION

### What does this PR do?

Build system-probe witn ebpf_bindata tag only if bundle_ebpf is set

### Motivation

Fixing CO-RE binaries that can't be loaded properly and fallback
`tracer.go:156 in LoadTracer) | error loading CO-RE network tracer, falling back to runtime compiled: error reading tracer.o: open build/tracer.o: file does not exist
`

### Additional Notes

Bug introduced during the [PR19280](https://github.com/DataDog/datadog-agent/pull/19280)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
