### PR TITLE
[clusteragent/admission/auto_instrumentation] Delete unused code

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -808,44 +808,8 @@ func TestInjectAll(t *testing.T) {
 		"dotnet": {lang: dotnet, image: "gcr.io/datadoghq/dd-lib-dotnet-init:latest"},
 		"ruby":   {lang: ruby, image: "gcr.io/datadoghq/dd-lib-ruby-init:latest"},
 	}
-	tests := []struct {
-		name             string
-		ns               string
-		targetNamespaces []string
-		want             map[string]libInfo
-	}{
-		{
-			name:             "nominal",
-			ns:               "targeted",
-			targetNamespaces: []string{"targeted"},
-			want:             wantAll,
-		},
-		{
-			name:             "many",
-			ns:               "targeted",
-			targetNamespaces: []string{"targeted", "foo", "bar"},
-			want:             wantAll,
-		},
-		{
-			name:             "no match",
-			ns:               "not-targeted",
-			targetNamespaces: []string{"foo", "bar"},
-			want:             map[string]libInfo{},
-		},
-		{
-			name:             "empty target",
-			ns:               "targeted",
-			targetNamespaces: []string{},
-			want:             map[string]libInfo{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			targetNamespaces = tt.targetNamespaces
-			got := getAllLibsToInject(tt.ns, "gcr.io/datadoghq")
-			require.EqualValues(t, tt.want, got)
-		})
-	}
+
+	require.EqualValues(t, wantAll, getAllLibsToInject("gcr.io/datadoghq"))
 }
 
 func injectAllEnvs() []corev1.EnvVar {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1056,7 +1056,6 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("admission_controller.inject_auto_detected_libraries", true)                                                         // allows injecting libraries for languages detected by automatic language detection feature
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu")
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")
-	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_all.namespaces", []string{})
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.pod_endpoint", "/inject-pod-cws")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.command_endpoint", "/inject-command-cws")


### PR DESCRIPTION
### What does this PR do?

Deletes some unused code from `pkg/clusteragent/admission/mutate/auto_instrumentation.go`

`getAllLibsToInject` is only called when `isApmInstrumentationEnabled` is true. This makes a couple of ifs redundant in the `getAllLibsToInject` function. The call to `isNsTargeted` is also redundant. It doesn't have any other callers, so we can remove it. The same goes for the config option that it uses: `admission_controller.auto_instrumentation.inject_all.namespaces`



### Describe how to test/QA your changes

It's a refactor. Skip this one if there are other PRs that change the auto instrumentation feature in the admission controller.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
