### PR TITLE
[e2e] test full python version in installer tests

### DIFF
--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -193,8 +193,10 @@ func CheckDogstatsdAgentRestarts(t *testing.T, client *TestClient) {
 }
 
 const (
+	// ExpectedPythonVersion2 is the expected python 2 version
 	// Bump this version when the version in omnibus/config/software/python2.rb changes
 	ExpectedPythonVersion2 = "2.7.18"
+	// ExpectedPythonVersion3 is the expected python 3 version
 	// Bump this version when the version in omnibus/config/software/python3.rb changes
 	ExpectedPythonVersion3 = "3.11.5"
 )

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/bound-port"
+	boundport "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/bound-port"
 	filemanager "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/file-manager"
 	helpers "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/helper"
 	pkgmanager "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/pkg-manager"

--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -129,9 +129,11 @@ func (is *installScriptSuite) AgentTest(flavor string) {
 	common.CheckAgentRestarts(is.T(), client)
 	common.CheckIntegrationInstall(is.T(), client)
 	if *majorVersion == "6" {
-		common.CheckAgentPython(is.T(), client, "2")
+		common.SetAgentPythonMajorVersion(is.T(), client, "2")
+		common.CheckAgentPython(is.T(), client, common.ExpectedPythonVersion2)
 	}
-	common.CheckAgentPython(is.T(), client, "3")
+	common.SetAgentPythonMajorVersion(is.T(), client, "3")
+	common.CheckAgentPython(is.T(), client, common.ExpectedPythonVersion3)
 	common.CheckApmEnabled(is.T(), client)
 	common.CheckApmDisabled(is.T(), client)
 	if flavor == "datadog-agent" && is.cwsSupported {

--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -152,9 +152,11 @@ func (is *stepByStepSuite) CheckStepByStepAgentInstallation(VMclient *common.Tes
 	common.CheckAgentStops(is.T(), VMclient)
 	common.CheckAgentRestarts(is.T(), VMclient)
 	common.CheckIntegrationInstall(is.T(), VMclient)
-	common.CheckAgentPython(is.T(), VMclient, "3")
+	common.SetAgentPythonMajorVersion(is.T(), VMclient, "3")
+	common.CheckAgentPython(is.T(), VMclient, common.ExpectedPythonVersion3)
 	if *majorVersion == "6" {
-		common.CheckAgentPython(is.T(), VMclient, "2")
+		common.SetAgentPythonMajorVersion(is.T(), VMclient, "2")
+		common.CheckAgentPython(is.T(), VMclient, common.ExpectedPythonVersion2)
 	}
 	common.CheckApmEnabled(is.T(), VMclient)
 	common.CheckApmDisabled(is.T(), VMclient)

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -15,9 +15,10 @@ import (
 	windows "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/agent"
 
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // Tester is a test helper for testing agent installations
@@ -114,10 +115,12 @@ func (t *Tester) TestRuntimeExpectations(tt *testing.T) {
 		t.testDefaultPythonVersion(tt)
 		if t.ExpectPython2Installed() {
 			tt.Run("switch to Python3", func(tt *testing.T) {
-				common.CheckAgentPython(tt, t.InstallTestClient, "3")
+				common.SetAgentPythonMajorVersion(tt, t.InstallTestClient, "3")
+				common.CheckAgentPython(tt, t.InstallTestClient, common.ExpectedPythonVersion3)
 			})
 			tt.Run("switch to Python2", func(tt *testing.T) {
-				common.CheckAgentPython(tt, t.InstallTestClient, "2")
+				common.SetAgentPythonMajorVersion(tt, t.InstallTestClient, "2")
+				common.CheckAgentPython(tt, t.InstallTestClient, common.ExpectedPythonVersion2)
 			})
 		}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Assert we install the expected embed python version at install

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We recently had a bug on macos where the build pipeline was not embedding the expected python version. This improves tests by adding the full python version test at install time.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
