### PR TITLE
[NPM] test if 600+ connections are handled correctly

### DIFF
--- a/test/fakeintake/aggregator/connectionsAggregator.go
+++ b/test/fakeintake/aggregator/connectionsAggregator.go
@@ -69,15 +69,22 @@ type ConnectionsAggregator struct {
 	Aggregator[*Connections]
 }
 
-// ForeachConnection will call the callback for each connection per hostname/netID and CollectorConnections payloads
-func (ca *ConnectionsAggregator) ForeachConnection(callback func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string)) {
+// ForeachHostnameConnections will call the callback for each Connections per hostname/netID payloads
+func (ca *ConnectionsAggregator) ForeachHostnameConnections(callback func(cnx *Connections, hostname string)) {
 	for _, hostname := range ca.GetNames() {
-		for _, cc := range ca.GetPayloadsByName(hostname) {
-			for _, c := range cc.Connections {
-				callback(c, &cc.CollectorConnections, hostname)
-			}
+		for _, cnx := range ca.GetPayloadsByName(hostname) {
+			callback(cnx, hostname)
 		}
 	}
+}
+
+// ForeachConnection will call the callback for each connection per hostname/netID and CollectorConnections payloads
+func (ca *ConnectionsAggregator) ForeachConnection(callback func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string)) {
+	ca.ForeachHostname(func(cnx *Connections, hostname string) {
+		for _, c := range cnx.Connections {
+			callback(c, &cnx.CollectorConnections, hostname)
+		}
+	})
 }
 
 // NewConnectionsAggregator create a new aggregator

--- a/test/fakeintake/aggregator/connectionsAggregator.go
+++ b/test/fakeintake/aggregator/connectionsAggregator.go
@@ -80,7 +80,7 @@ func (ca *ConnectionsAggregator) ForeachHostnameConnections(callback func(cnx *C
 
 // ForeachConnection will call the callback for each connection per hostname/netID and CollectorConnections payloads
 func (ca *ConnectionsAggregator) ForeachConnection(callback func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string)) {
-	ca.ForeachHostname(func(cnx *Connections, hostname string) {
+	ca.ForeachHostnameConnections(func(cnx *Connections, hostname string) {
 		for _, c := range cnx.Connections {
 			callback(c, &cnx.CollectorConnections, hostname)
 		}

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -506,6 +506,7 @@ func (c *Client) FlushServerAndResetAggregators() error {
 		return err
 	}
 	c.checkRunAggregator.Reset()
+	c.connectionAggregator.Reset()
 	c.metricAggregator.Reset()
 	c.logAggregator.Reset()
 	return nil

--- a/test/new-e2e/pkg/environments/aws/host/host.go
+++ b/test/new-e2e/pkg/environments/aws/host/host.go
@@ -49,6 +49,15 @@ func newProvisionerParams() *ProvisionerParams {
 	}
 }
 
+func GetProvisionerParams(opts ...ProvisionerOption) *ProvisionerParams {
+	params := newProvisionerParams()
+	err := optional.ApplyOptions(params, opts)
+	if err != nil {
+		panic(fmt.Errorf("unable to apply ProvisionerOption, err: %w", err))
+	}
+	return params
+}
+
 // ProvisionerOption is a provisioner option.
 type ProvisionerOption func(*ProvisionerParams) error
 
@@ -126,75 +135,79 @@ func ProvisionerNoFakeIntake(opts ...ProvisionerOption) e2e.TypedProvisioner[env
 	return Provisioner(mergedOpts...)
 }
 
+func HostRunFunction(ctx *pulumi.Context, env *environments.Host, params *ProvisionerParams) error {
+	var awsEnv aws.Environment
+	var err error
+	if env.AwsEnvironment != nil {
+		awsEnv = *env.AwsEnvironment
+	} else {
+		awsEnv, err = aws.NewEnvironment(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	host, err := ec2.NewVM(awsEnv, params.name, params.instanceOptions...)
+	if err != nil {
+		return err
+	}
+	err = host.Export(ctx, &env.RemoteHost.HostOutput)
+	if err != nil {
+		return err
+	}
+
+	// Create FakeIntake if required
+	if params.fakeintakeOptions != nil {
+		fakeIntake, err := fakeintake.NewECSFargateInstance(awsEnv, params.name, params.fakeintakeOptions...)
+		if err != nil {
+			return err
+		}
+		err = fakeIntake.Export(ctx, &env.FakeIntake.FakeintakeOutput)
+		if err != nil {
+			return err
+		}
+
+		// Normally if FakeIntake is enabled, Agent is enabled, but just in case
+		if params.agentOptions != nil {
+			// Prepend in case it's overridden by the user
+			newOpts := []agentparams.Option{agentparams.WithFakeintake(fakeIntake)}
+			params.agentOptions = append(newOpts, params.agentOptions...)
+		}
+	} else {
+		// Suite inits all fields by default, so we need to explicitly set it to nil
+		env.FakeIntake = nil
+	}
+
+	// Create Agent if required
+	if params.agentOptions != nil {
+		agent, err := agent.NewHostAgent(awsEnv.CommonEnvironment, host, params.agentOptions...)
+		if err != nil {
+			return err
+		}
+
+		err = agent.Export(ctx, &env.Agent.HostAgentOutput)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Suite inits all fields by default, so we need to explicitly set it to nil
+		env.Agent = nil
+	}
+
+	return nil
+}
+
 // Provisioner creates a VM environment with an EC2 VM, an ECS Fargate FakeIntake and a Host Agent configured to talk to each other.
 // FakeIntake and Agent creation can be deactivated by using [WithoutFakeIntake] and [WithoutAgent] options.
 func Provisioner(opts ...ProvisionerOption) e2e.TypedProvisioner[environments.Host] {
 	// We need to build params here to be able to use params.name in the provisioner name
-	params := newProvisionerParams()
-	err := optional.ApplyOptions(params, opts)
-	if err != nil {
-		panic(fmt.Errorf("unable to apply ProvisionerOption, err: %w", err))
-	}
+	params := GetProvisionerParams(opts...)
 
 	provisioner := e2e.NewTypedPulumiProvisioner(provisionerBaseID+params.name, func(ctx *pulumi.Context, env *environments.Host) error {
 		// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.
 		// and it's easy to forget about it, leading to hard to debug issues.
-		params := newProvisionerParams()
-		_ = optional.ApplyOptions(params, opts)
-
-		awsEnv, err := aws.NewEnvironment(ctx)
-		if err != nil {
-			return err
-		}
-
-		host, err := ec2.NewVM(awsEnv, params.name, params.instanceOptions...)
-		if err != nil {
-			return err
-		}
-		err = host.Export(ctx, &env.RemoteHost.HostOutput)
-		if err != nil {
-			return err
-		}
-
-		// Create FakeIntake if required
-		if params.fakeintakeOptions != nil {
-			fakeIntake, err := fakeintake.NewECSFargateInstance(awsEnv, params.name, params.fakeintakeOptions...)
-			if err != nil {
-				return err
-			}
-			err = fakeIntake.Export(ctx, &env.FakeIntake.FakeintakeOutput)
-			if err != nil {
-				return err
-			}
-
-			// Normally if FakeIntake is enabled, Agent is enabled, but just in case
-			if params.agentOptions != nil {
-				// Prepend in case it's overridden by the user
-				newOpts := []agentparams.Option{agentparams.WithFakeintake(fakeIntake)}
-				params.agentOptions = append(newOpts, params.agentOptions...)
-			}
-		} else {
-			// Suite inits all fields by default, so we need to explicitly set it to nil
-			env.FakeIntake = nil
-		}
-
-		// Create Agent if required
-		if params.agentOptions != nil {
-			agent, err := agent.NewHostAgent(awsEnv.CommonEnvironment, host, params.agentOptions...)
-			if err != nil {
-				return err
-			}
-
-			err = agent.Export(ctx, &env.Agent.HostAgentOutput)
-			if err != nil {
-				return err
-			}
-		} else {
-			// Suite inits all fields by default, so we need to explicitly set it to nil
-			env.Agent = nil
-		}
-
-		return nil
+		params := GetProvisionerParams(opts...)
+		return HostRunFunction(ctx, env, params)
 	}, params.extraConfigParams)
 
 	return provisioner

--- a/test/new-e2e/pkg/environments/aws/host/host.go
+++ b/test/new-e2e/pkg/environments/aws/host/host.go
@@ -49,6 +49,7 @@ func newProvisionerParams() *ProvisionerParams {
 	}
 }
 
+// GetProvisionerParams return ProvisionerParams from options opts setup
 func GetProvisionerParams(opts ...ProvisionerOption) *ProvisionerParams {
 	params := newProvisionerParams()
 	err := optional.ApplyOptions(params, opts)
@@ -135,6 +136,7 @@ func ProvisionerNoFakeIntake(opts ...ProvisionerOption) e2e.TypedProvisioner[env
 	return Provisioner(mergedOpts...)
 }
 
+// HostRunFunction main provisioner work running here
 func HostRunFunction(ctx *pulumi.Context, env *environments.Host, params *ProvisionerParams) error {
 	var awsEnv aws.Environment
 	var err error

--- a/test/new-e2e/pkg/environments/host.go
+++ b/test/new-e2e/pkg/environments/host.go
@@ -9,10 +9,12 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
 )
 
 // Host is an environment that contains a Host, FakeIntake and Agent configured to talk to each other.
 type Host struct {
+	AwsEnvironment *aws.Environment
 	// Components
 	RemoteHost *components.RemoteHost
 	FakeIntake *components.FakeIntake

--- a/test/new-e2e/tests/npm/config/dockercompose_httpbin.yaml
+++ b/test/new-e2e/tests/npm/config/dockercompose_httpbin.yaml
@@ -1,0 +1,11 @@
+version: '3.9'
+services:
+  httpbin:
+    pid: host
+    privileged: true
+    ports:
+    - 80:8080/tcp
+    image: mccutchen/go-httpbin
+    container_name: httpbin
+    volumes: []
+    environment: {}

--- a/test/new-e2e/tests/npm/dockercompose_httpbin.go
+++ b/test/new-e2e/tests/npm/dockercompose_httpbin.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package npm
 
 import (

--- a/test/new-e2e/tests/npm/dockercompose_httpbin.go
+++ b/test/new-e2e/tests/npm/dockercompose_httpbin.go
@@ -1,31 +1,18 @@
 package npm
 
 import (
+	_ "embed"
+
 	"github.com/DataDog/test-infra-definitions/components/docker"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"gopkg.in/yaml.v2"
 )
 
-func dockerHTTPBinCompose() docker.ComposeInlineManifest {
-	httpbinManifestContent := pulumi.All().ApplyT(func(args []interface{}) (string, error) {
-		agentManifest := docker.ComposeManifest{
-			Version: "3.9",
-			Services: map[string]docker.ComposeManifestService{
-				"httpbin": {
-					Privileged:    true,
-					Image:         "mccutchen/go-httpbin",
-					ContainerName: "httpbin",
-					Pid:           "host",
-					Ports:         []string{"80:8080/tcp"},
-				},
-			},
-		}
-		data, err := yaml.Marshal(agentManifest)
-		return string(data), err
-	}).(pulumi.StringOutput)
+//go:embed "config/dockercompose_httpbin.yaml"
+var dockerHTTPBinComposeYaml string
 
+func dockerHTTPBinCompose() docker.ComposeInlineManifest {
 	return docker.ComposeInlineManifest{
 		Name:    "httpbin",
-		Content: httpbinManifestContent,
+		Content: pulumi.String(dockerHTTPBinComposeYaml),
 	}
 }

--- a/test/new-e2e/tests/npm/dockercompose_httpbin.go
+++ b/test/new-e2e/tests/npm/dockercompose_httpbin.go
@@ -1,0 +1,31 @@
+package npm
+
+import (
+	"github.com/DataDog/test-infra-definitions/components/docker"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"gopkg.in/yaml.v2"
+)
+
+func dockerHTTPBinCompose() docker.ComposeInlineManifest {
+	httpbinManifestContent := pulumi.All().ApplyT(func(args []interface{}) (string, error) {
+		agentManifest := docker.ComposeManifest{
+			Version: "3.9",
+			Services: map[string]docker.ComposeManifestService{
+				"httpbin": {
+					Privileged:    true,
+					Image:         "mccutchen/go-httpbin",
+					ContainerName: "httpbin",
+					Pid:           "host",
+					Ports:         []string{"80:8080/tcp"},
+				},
+			},
+		}
+		data, err := yaml.Marshal(agentManifest)
+		return string(data), err
+	}).(pulumi.StringOutput)
+
+	return docker.ComposeInlineManifest{
+		Name:    "httpbin",
+		Content: httpbinManifestContent,
+	}
+}

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -69,7 +69,7 @@ func hostDockerHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[hostHttpbinEnv] {
 		}
 
 		composeContents := []docker.ComposeInlineManifest{dockerHTTPBinCompose()}
-		_, err = manager.ComposeStrUp("agent", composeContents, pulumi.StringMap{})
+		_, err = manager.ComposeStrUp("httpbin", composeContents, pulumi.StringMap{})
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -31,7 +31,7 @@ import (
 type hostHttpbinEnv struct {
 	environments.Host
 	// Extra Components
-	HttpBinHost *components.RemoteHost
+	HTTPBinHost *components.RemoteHost
 }
 type ec2VMSuite struct {
 	e2e.BaseSuite[hostHttpbinEnv]
@@ -57,7 +57,7 @@ func hostDockerHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[hostHttpbinEnv] {
 		if err != nil {
 			return err
 		}
-		err = nginxHost.Export(ctx, &env.HttpBinHost.HostOutput)
+		err = nginxHost.Export(ctx, &env.HTTPBinHost.HostOutput)
 		if err != nil {
 			return err
 		}
@@ -114,7 +114,7 @@ func (v *ec2VMSuite) BeforeTest(suiteName, testName string) {
 //   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
 func (v *ec2VMSuite) TestFakeIntakeNPM() {
 	t := v.T()
-	testURL := "http://" + v.Env().HttpBinHost.Address + "/"
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate a connection
 	v.Env().RemoteHost.MustExecute("curl " + testURL)
@@ -159,7 +159,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM() {
 //   - looking for n payloads and check if the last 2 have a maximum span of 100ms
 func (v *ec2VMSuite) TestFakeIntakeNPM_600cnx_bucket() {
 	t := v.T()
-	testURL := "http://" + v.Env().HttpBinHost.Address + "/"
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
 	v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
@@ -210,7 +210,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM_600cnx_bucket() {
 // with some basic checks, like IPs/Ports present, DNS query has been captured, ...
 func (v *ec2VMSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
 	t := v.T()
-	testURL := "http://" + v.Env().HttpBinHost.Address + "/"
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
 	v.Env().RemoteHost.MustExecute("curl " + testURL)

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -135,17 +135,9 @@ func (v *ec2VMSuite) TestFakeIntakeNPM_600cnx_bucket() {
 			assert.LessOrEqualf(t, len(cnx.Connections), 600, "too many payloads")
 		})
 
-		found600plusConnections := false
 		hostPayloads := cnx.GetPayloadsByName(targetHostnameNetID)
 		lenHostPayloads := len(hostPayloads)
-		for i, cc := range hostPayloads {
-			// check if the 2 last payloads are following 600 connections and n connections
-			if len(cc.Connections) == 600 && (i == (lenHostPayloads - 2)) {
-				found600plusConnections = true
-				break
-			}
-		}
-		if !assert.Truef(c, found600plusConnections, "can't found enough connections 600+") {
+		if !assert.Equalf(c, len(hostPayloads[lenHostPayloads-2].Connections), 600, "can't found enough connections 600+") {
 			return
 		}
 

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -182,7 +182,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM_600cnx_bucket() {
 		cnx, err := v.Env().FakeIntake.Client().GetConnections()
 		assert.NoError(t, err)
 
-		if !assert.Greater(c, len(cnx.GetPayloadsByName(targetHostnameNetID)), 2, "not enough payloads") {
+		if !assert.GreaterOrEqualf(c, len(cnx.GetPayloadsByName(targetHostnameNetID)), 2, "not enough payloads") {
 			return
 		}
 

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -13,6 +13,7 @@ import (
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
 
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
@@ -130,8 +131,8 @@ func (v *ec2VMSuite) TestFakeIntakeNPM_600pluscnx() {
 			return
 		}
 
-		cnx.ForeachConnection(func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
-			assert.LessOrEqualf(t, len(cc.Connections), 600, "too many payloads")
+		cnx.ForeachHostnameConnections(func(cnx *aggregator.Connections, hostname string) {
+			assert.LessOrEqualf(t, len(cnx.Connections), 600, "too many payloads")
 		})
 
 		found600plusConnections := false

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -99,19 +99,19 @@ func (v *ec2VMSuite) TestFakeIntakeNPM() {
 	}, 90*time.Second, time.Second, "not enough connections received")
 }
 
-// TestFakeIntakeNPM_600pluscnx Validate the agent can communicate with the (fake) backend and send connections
+// TestFakeIntakeNPM_600cnx_bucket Validate the agent can communicate with the (fake) backend and send connections
 // every 30 seconds with a maximum of 600 connections per payloads, if more another payload will follow.
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for n payloads and check if the last 2 have a maximum span of 100ms
-func (v *ec2VMSuite) TestFakeIntakeNPM_600pluscnx() {
+func (v *ec2VMSuite) TestFakeIntakeNPM_600cnx_bucket() {
 	t := v.T()
+
+	// generate connections
+	v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 http://www.datadoghq.com/")
 
 	targetHostnameNetID := ""
 	// looking for 1 host to send CollectorConnections payload to the fakeintake
 	v.EventuallyWithT(func(c *assert.CollectT) {
-		// generate a connection
-		v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 http://www.datadoghq.com/")
-
 		hostnameNetID, err := v.Env().FakeIntake.Client().GetConnectionsNames()
 		assert.NoError(c, err, "GetConnectionsNames() errors")
 		if !assert.NotEmpty(c, hostnameNetID, "no connections yet") {


### PR DESCRIPTION
### What does this PR do?


Test if 600+ connections are sent in 2 followed payloads with a maximum of 600 connections per payload

### Motivation

Improve our NPM test E2E

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
