### PR TITLE
[Windows] Replace cinst with choco install

### DIFF
--- a/devenv/scripts/Install-DevEnv.ps1
+++ b/devenv/scripts/Install-DevEnv.ps1
@@ -22,13 +22,13 @@ Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://cho
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1" -Force;
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Getting git'
-cinst -y git
+choco install -y git
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Getting 7zip'
-cinst -y 7zip
+choco install -y 7zip
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing CMake'
-cinst -y cmake
+choco install -y cmake
 [Environment]::SetEnvironmentVariable(
     "Path",
     [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";${env:ProgramFiles}\CMake\bin",
@@ -37,7 +37,7 @@ cinst -y cmake
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Golang'
 
 # TODO: Enable this when we can use Chocolatey again
-#cinst -y golang --version 1.15.13
+#choco install -y golang --version 1.15.13
 
 # Workaround for go 1.15.13 since it does not exist in Chocolatey
 # taken from https://github.com/DataDog/datadog-agent-buildimages/blob/master/windows/install_go.ps1
@@ -72,13 +72,13 @@ setx /m GOROOT c:\go
 Write-Host -ForegroundColor Green "Installed go $ENV:GO_VERSION"
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Python 3'
-cinst -y python3
+choco install -y python3
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing MINGW'
-cinst -y mingw
+choco install -y mingw
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Make'
-cinst -y make
+choco install -y make
 
 $GoPath="C:\gopath"
 $AgentPath="$GoPath\src\github.com\datadog\datadog-agent"

--- a/devenv/scripts/Install-DevEnv.ps1
+++ b/devenv/scripts/Install-DevEnv.ps1
@@ -92,3 +92,6 @@ mkdir -Force $AgentPath
 setx /m GOPATH "$GoPath"
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen ' * DONE *'
+Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '*** Please restart your computer at the end of this script execution on Windows. ***'
+Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '*** This is necessary for the Go, Python, etc paths to be recognized and updated correctly. ***'
+Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen 'For this you can run Restart-Computer'


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Replace `cinst` with `choco install`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

`cinst` [got deprecated](https://github.com/chocolatey/choco/issues/2642).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
