### PR TITLE
Disable GOWORK by default when running invoke tasks

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -55,6 +55,7 @@ from tasks.go import (
 from tasks.go_test import codecov, e2e_tests, get_modified_packages, integration_tests, send_unit_tests_stats, test
 from tasks.install_tasks import download_tools, install_shellcheck, install_tools
 from tasks.junit_tasks import junit_macos_repack, junit_upload
+from tasks.libs.go_workspaces import handle_go_work
 from tasks.linter_tasks import lint_copyrights, lint_filenames, lint_go, lint_python
 from tasks.pr_checks import lint_releasenote
 from tasks.show_linters_issues import show_linters_issues
@@ -145,3 +146,6 @@ ns.configure(
         }
     }
 )
+
+# disable go workspaces by default
+handle_go_work()

--- a/tasks/libs/go_workspaces.py
+++ b/tasks/libs/go_workspaces.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import sys
+
+from tasks.libs.common.color import color_message
+
+
+def handle_go_work():
+    """
+    If go workspaces aren't explicitly enabled from the environment but there is a go.work file,
+    this function will print a warning and export GOWORK=off so that subprocesses don't use workspaces.
+
+    At least the following go commands behave differently with workspaces:
+    - go build
+    - go list
+    - go run
+    - go test
+    - go vet
+    - go work
+    """
+    if "GOWORK" in os.environ:
+        # go work is explicitly set
+        return
+
+    try:
+        # find the go.work file
+        # according to the blog https://go.dev/blog/get-familiar-with-workspaces :
+        # "The output is empty if the go command is not in workspace mode."
+        # meaning it didn't find a go.work file in the ancestor directories and GOWORK is not set
+        res = subprocess.run(["go", "env", "GOWORK"], capture_output=True)
+        if res.returncode != 0 or not res.stdout:
+            return
+    except Exception:
+        # go command not found, no need to care about workspaces
+        return
+
+    print(
+        color_message(
+            "Disabling GOWORK to avoid failures or weird behavior.\n"
+            "It can be enabled by setting the GOWORK environment variable to the empty string, "
+            "or to the absolute path of a go.work file.",
+            "orange",
+        ),
+        file=sys.stderr,
+    )
+    os.environ["GOWORK"] = "off"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Disable GOWORK by default when running invoke tasks.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Go workspaces are great for IDEs, but we don't actually use them in the CI, so building / testing / linting is not supported with workspaces enabled.
Workspaces are enabled by default in Go if you have a go.work file, they can be disabled by setting `GOWORK=off`.
It means every time one runs an invoke task they need to export `GOWORK=off`, or the command will fail weirdly.

To avoid that by default, this PR adds a piece of code which exports `GOWORK=off`, if `go` can find a `go.work` file and the `GOWORK` environment variable is not already defined.

In case of doubt (eg. the `go` command is not found or fails), it doesn't do anything.

One can still explicitly enable go workspaces by setting `GOWORK=""` (`go` will find the `go.work` file by itself) or directly the path of the `go.work` file.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

When go workspaces are implicitly disabled, a warning is printed to make it visible. 

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
