### PR TITLE
[CONTINT-3685] Add container images sboms to the flare

### DIFF
--- a/comp/core/workloadmeta/dump_test.go
+++ b/comp/core/workloadmeta/dump_test.go
@@ -25,7 +25,7 @@ func TestDump(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+	s := newWorkloadmetaObject(deps)
 
 	container := &Container{
 		EntityID: EntityID{

--- a/comp/core/workloadmeta/dump_test.go
+++ b/comp/core/workloadmeta/dump_test.go
@@ -25,7 +25,7 @@ func TestDump(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).(*workloadmeta)
+	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 	container := &Container{
 		EntityID: EntityID{

--- a/comp/core/workloadmeta/flare_provider.go
+++ b/comp/core/workloadmeta/flare_provider.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workloadmeta
+
+import (
+	"encoding/json"
+	"fmt"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
+	"github.com/samber/lo"
+)
+
+/*
+This file contains the implementation of the flare providers for the workloadmeta component.
+The flare providers are used to add additional data to the flare archive. They should be provided
+with workloadmeta to dump its state.
+*/
+
+// sbomFlareProvider will add the SBOMs of all the images in the flare archive.
+// Note that the generated file uncompressed can be very large
+func (w *workloadmeta) sbomFlareProvider(fb flaretypes.FlareBuilder) error {
+	images := w.ListImages()
+
+	fields := lo.SliceToMap(images, func(image *ContainerImageMetadata) (string, *SBOM) {
+		return image.ID, image.SBOM
+	})
+
+	// Using indent or splitting the file is necessary. Otherwise the scrubber will understand
+	// the file as a single very large token and it will exceed the max buffer size.
+	content, err := json.MarshalIndent(fields, "", "    ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal results to JSON: %v", err)
+	}
+
+	_ = fb.AddFile("sbom.json", content)
+
+	return nil
+}

--- a/comp/core/workloadmeta/store_example_test.go
+++ b/comp/core/workloadmeta/store_example_test.go
@@ -23,7 +23,7 @@ func TestExampleStoreSubscribe(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).(*workloadmeta)
+	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 	SetGlobalStore(s)
 
 	filterParams := FilterParams{

--- a/comp/core/workloadmeta/store_example_test.go
+++ b/comp/core/workloadmeta/store_example_test.go
@@ -23,7 +23,7 @@ func TestExampleStoreSubscribe(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+	s := newWorkloadmetaObject(deps)
 	SetGlobalStore(s)
 
 	filterParams := FilterParams{

--- a/comp/core/workloadmeta/store_test.go
+++ b/comp/core/workloadmeta/store_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package workloadmeta
 
 import (
@@ -26,6 +28,10 @@ const (
 	barSource       = "bar"
 )
 
+func newWorkloadmetaObject(deps dependencies) *workloadmeta {
+	return newWorkloadMeta(deps).Comp.(*workloadmeta)
+}
+
 func TestHandleEvents(t *testing.T) {
 
 	deps := fxutil.Test[dependencies](t, fx.Options(
@@ -34,7 +40,7 @@ func TestHandleEvents(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+	s := newWorkloadmetaObject(deps)
 
 	container := &Container{
 		EntityID: EntityID{
@@ -595,7 +601,7 @@ func TestSubscribe(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+			s := newWorkloadmetaObject(deps)
 
 			s.handleEvents(tt.preEvents)
 
@@ -637,7 +643,7 @@ func TestGetKubernetesDeployment(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+	s := newWorkloadmetaObject(deps)
 
 	deployment := &KubernetesDeployment{
 		EntityID: EntityID{
@@ -680,7 +686,7 @@ func TestGetProcess(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+	s := newWorkloadmetaObject(deps)
 
 	process := &Process{
 		EntityID: EntityID{
@@ -759,7 +765,7 @@ func TestListContainers(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+			s := newWorkloadmetaObject(deps)
 
 			s.handleEvents(test.preEvents)
 
@@ -797,7 +803,7 @@ func TestListContainersWithFilter(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+	s := newWorkloadmetaObject(deps)
 
 	s.handleEvents([]CollectorEvent{
 		{
@@ -856,7 +862,7 @@ func TestListProcesses(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+			s := newWorkloadmetaObject(deps)
 
 			s.handleEvents(test.preEvents)
 
@@ -894,7 +900,7 @@ func TestListProcessesWithFilter(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+	s := newWorkloadmetaObject(deps)
 
 	s.handleEvents([]CollectorEvent{
 		{
@@ -1011,7 +1017,7 @@ func TestGetKubernetesPodByName(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+			s := newWorkloadmetaObject(deps)
 
 			for _, pod := range []*KubernetesPod{pod1, pod2, pod3} {
 				s.handleEvents([]CollectorEvent{
@@ -1072,7 +1078,7 @@ func TestListImages(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+			s := newWorkloadmetaObject(deps)
 
 			s.handleEvents(test.preEvents)
 
@@ -1124,7 +1130,7 @@ func TestGetImage(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+			s := newWorkloadmetaObject(deps)
 			s.handleEvents(test.preEvents)
 
 			actualImage, err := s.GetImage(test.imageID)
@@ -1219,7 +1225,7 @@ func TestResetProcesses(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+			s := newWorkloadmetaObject(deps)
 			s.handleEvents(test.preEvents)
 
 			ch := s.Subscribe(dummySubscriber, NormalPriority, nil)
@@ -1417,7 +1423,7 @@ func TestReset(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+			s := newWorkloadmetaObject(deps)
 
 			s.handleEvents(test.preEvents)
 
@@ -1464,7 +1470,7 @@ func TestNoDataRace(t *testing.T) { //nolint:revive // TODO fix revive unused-pa
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
+	s := newWorkloadmetaObject(deps)
 
 	container := &Container{
 		EntityID: EntityID{
@@ -1494,7 +1500,7 @@ func TestPushEvents(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	wlm := newWorkloadMeta(deps).Comp.(*workloadmeta)
+	wlm := newWorkloadmetaObject(deps)
 
 	mockSource := Source("mockSource")
 

--- a/comp/core/workloadmeta/store_test.go
+++ b/comp/core/workloadmeta/store_test.go
@@ -34,7 +34,7 @@ func TestHandleEvents(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).(*workloadmeta)
+	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 	container := &Container{
 		EntityID: EntityID{
@@ -595,7 +595,7 @@ func TestSubscribe(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).(*workloadmeta)
+			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 			s.handleEvents(tt.preEvents)
 
@@ -637,7 +637,7 @@ func TestGetKubernetesDeployment(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).(*workloadmeta)
+	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 	deployment := &KubernetesDeployment{
 		EntityID: EntityID{
@@ -680,7 +680,7 @@ func TestGetProcess(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).(*workloadmeta)
+	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 	process := &Process{
 		EntityID: EntityID{
@@ -759,7 +759,7 @@ func TestListContainers(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).(*workloadmeta)
+			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 			s.handleEvents(test.preEvents)
 
@@ -797,7 +797,7 @@ func TestListContainersWithFilter(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).(*workloadmeta)
+	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 	s.handleEvents([]CollectorEvent{
 		{
@@ -856,7 +856,7 @@ func TestListProcesses(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).(*workloadmeta)
+			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 			s.handleEvents(test.preEvents)
 
@@ -894,7 +894,7 @@ func TestListProcessesWithFilter(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).(*workloadmeta)
+	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 	s.handleEvents([]CollectorEvent{
 		{
@@ -1011,7 +1011,7 @@ func TestGetKubernetesPodByName(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).(*workloadmeta)
+			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 			for _, pod := range []*KubernetesPod{pod1, pod2, pod3} {
 				s.handleEvents([]CollectorEvent{
@@ -1072,7 +1072,7 @@ func TestListImages(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).(*workloadmeta)
+			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 			s.handleEvents(test.preEvents)
 
@@ -1124,7 +1124,7 @@ func TestGetImage(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).(*workloadmeta)
+			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 			s.handleEvents(test.preEvents)
 
 			actualImage, err := s.GetImage(test.imageID)
@@ -1219,7 +1219,7 @@ func TestResetProcesses(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).(*workloadmeta)
+			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 			s.handleEvents(test.preEvents)
 
 			ch := s.Subscribe(dummySubscriber, NormalPriority, nil)
@@ -1417,7 +1417,7 @@ func TestReset(t *testing.T) {
 				fx.Supply(NewParams()),
 			))
 
-			s := newWorkloadMeta(deps).(*workloadmeta)
+			s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 			s.handleEvents(test.preEvents)
 
@@ -1464,7 +1464,7 @@ func TestNoDataRace(t *testing.T) { //nolint:revive // TODO fix revive unused-pa
 		fx.Supply(NewParams()),
 	))
 
-	s := newWorkloadMeta(deps).(*workloadmeta)
+	s := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 	container := &Container{
 		EntityID: EntityID{
@@ -1494,7 +1494,7 @@ func TestPushEvents(t *testing.T) {
 		fx.Supply(NewParams()),
 	))
 
-	wlm := newWorkloadMeta(deps).(*workloadmeta)
+	wlm := newWorkloadMeta(deps).Comp.(*workloadmeta)
 
 	mockSource := Source("mockSource")
 

--- a/comp/core/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/workloadmeta.go
@@ -7,6 +7,7 @@ package workloadmeta
 
 import (
 	"context"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"sync"
 	"time"
 
@@ -57,7 +58,21 @@ type dependencies struct {
 	Params Params
 }
 
-func newWorkloadMeta(deps dependencies) Component {
+type provider struct {
+	fx.Out
+
+	Comp          Component
+	FlareProvider flaretypes.Provider
+}
+
+type optionalProvider struct {
+	fx.Out
+
+	Comp          optional.Option[Component]
+	FlareProvider flaretypes.Provider
+}
+
+func newWorkloadMeta(deps dependencies) provider {
 	candidates := make(map[string]Collector)
 	for _, c := range deps.Catalog {
 		if (c.GetTargetCatalog() & deps.Params.AgentType) > 0 {
@@ -103,14 +118,22 @@ func newWorkloadMeta(deps dependencies) Component {
 		return nil
 	}})
 
-	return wm
+	return provider{
+		Comp:          wm,
+		FlareProvider: flaretypes.NewProvider(wm.sbomFlareProvider),
+	}
 }
 
-func newWorkloadMetaOptional(deps dependencies) optional.Option[Component] {
+func newWorkloadMetaOptional(deps dependencies) optionalProvider {
 	if deps.Params.NoInstance {
-		return optional.NewNoneOption[Component]()
+		return optionalProvider{
+			Comp: optional.NewNoneOption[Component](),
+		}
 	}
 	c := newWorkloadMeta(deps)
 
-	return optional.NewOption[Component](c)
+	return optionalProvider{
+		Comp:          optional.NewOption(c.Comp),
+		FlareProvider: c.FlareProvider,
+	}
 }

--- a/comp/core/workloadmeta/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/workloadmeta_mock.go
@@ -367,9 +367,8 @@ type workloadMetaMockV2 struct {
 
 // newWorkloadMetaMockV2 returns a Mock
 func newWorkloadMetaMockV2(deps dependencies) Mock {
-	provider := newWorkloadMeta(deps)
 	w := &workloadMetaMockV2{
-		workloadmeta: provider.Comp.(*workloadmeta),
+		workloadmeta: newWorkloadMeta(deps).Comp.(*workloadmeta),
 	}
 	return w
 }

--- a/comp/core/workloadmeta/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/workloadmeta_mock.go
@@ -367,14 +367,11 @@ type workloadMetaMockV2 struct {
 
 // newWorkloadMetaMockV2 returns a Mock
 func newWorkloadMetaMockV2(deps dependencies) Mock {
-	wm := newWorkloadMeta(deps)
-
+	provider := newWorkloadMeta(deps)
 	w := &workloadMetaMockV2{
-		workloadmeta: wm.(*workloadmeta),
+		workloadmeta: provider.Comp.(*workloadmeta),
 	}
-
 	return w
-
 }
 
 // Notify overrides store to allow for synchronous event processing

--- a/releasenotes/notes/add-sbom-to-flare-f4797557cc4b48c6.yaml
+++ b/releasenotes/notes/add-sbom-to-flare-f4797557cc4b48c6.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Add the Software Bill of Materials (SBOM) for container-images to the output of the flare command.

--- a/releasenotes/notes/add-sbom-to-flare-f4797557cc4b48c6.yaml
+++ b/releasenotes/notes/add-sbom-to-flare-f4797557cc4b48c6.yaml
@@ -1,3 +1,3 @@
 enhancements:
   - |
-    Add the Software Bill of Materials (SBOM) for container-images to the output of the flare command.
+    Add the Software Bill of Materials (SBOM) for container images to the output of the flare command.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR adds the SBOMs of container-images to the flare.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Make it easier to investigate issues related to SBOM collection.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
The generated file can be very large. However, a lot of strings are repetitive which makes the compressed file rather small. On testing, a flare of 17MB had 120KB of sboms. The total compressed archive was 500KB.

The size is quite important for the SBOM to be sent to the back-end.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent with sbom collection enabled in a containerized environment. With helm:
```
datadog:
  sbom:
    host:
      enabled: true
    containerImage:
      enabled: true
      uncompressedLayersSupport: true
```

Run the `agent flare` command. Make sure that it contains the `sbom.json` file and its content is correct. The size of the generated archive must be within the limits to be emitted to Zendesk.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
