### PR TITLE
[clusteragent/admission/auto_instrumentation] Remove support for container-level annotations

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -81,10 +81,8 @@ const (
 	dotnet language = "dotnet"
 	ruby   language = "ruby"
 
-	libVersionAnnotationKeyFormat    = "admission.datadoghq.com/%s-lib.version"
-	customLibAnnotationKeyFormat     = "admission.datadoghq.com/%s-lib.custom-image"
-	libVersionAnnotationKeyCtrFormat = "admission.datadoghq.com/%s.%s-lib.version"
-	customLibAnnotationKeyCtrFormat  = "admission.datadoghq.com/%s.%s-lib.custom-image"
+	libVersionAnnotationKeyFormat = "admission.datadoghq.com/%s-lib.version"
+	customLibAnnotationKeyFormat  = "admission.datadoghq.com/%s-lib.custom-image"
 
 	// Env vars
 	instrumentationInstallTypeEnvVarName = "DD_INSTRUMENTATION_INSTALL_TYPE"
@@ -330,27 +328,6 @@ func extractLibrariesFromAnnotations(
 			libInfoMap[string(lang)] = libInfo{
 				lang:  lang,
 				image: image,
-			}
-		}
-
-		for _, ctr := range pod.Spec.Containers {
-			customLibAnnotation := strings.ToLower(fmt.Sprintf(customLibAnnotationKeyCtrFormat, ctr.Name, lang))
-			if image, found := annotations[customLibAnnotation]; found {
-				log.Debugf(
-					"Found custom library annotation for %s, will inject %s to container %s",
-					string(lang), image, ctr.Name,
-				)
-				libList = append(libList, libInfo{ctrName: ctr.Name, lang: lang, image: image})
-			}
-
-			libVersionAnnotation := strings.ToLower(fmt.Sprintf(libVersionAnnotationKeyCtrFormat, ctr.Name, lang))
-			if version, found := annotations[libVersionAnnotation]; found {
-				image := libImageName(registry, lang, version)
-				log.Debugf(
-					"Found version library annotation for %s, will inject %s to container %s",
-					string(lang), image, ctr.Name,
-				)
-				libList = append(libList, libInfo{ctrName: ctr.Name, lang: lang, image: image})
 			}
 		}
 	}

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -363,40 +363,6 @@ func TestExtractLibInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "java and js on specific containers",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"admission.datadoghq.com/java-app.java-lib.version": "v1",
-						"admission.datadoghq.com/node-app.js-lib.version":   "v1",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "java-app",
-						},
-						{
-							Name: "node-app",
-						},
-					},
-				},
-			},
-			containerRegistry: "registry",
-			expectedLibsToInject: []libInfo{
-				{
-					ctrName: "java-app",
-					lang:    "java",
-					image:   "registry/dd-lib-java-init:v1",
-				},
-				{
-					ctrName: "node-app",
-					lang:    "js",
-					image:   "registry/dd-lib-js-init:v1",
-				},
-			},
-		},
-		{
 			name:              "ruby",
 			pod:               fakePodWithAnnotation("admission.datadoghq.com/ruby-lib.version", "v1"),
 			containerRegistry: "registry",


### PR DESCRIPTION
### What does this PR do?

Removes support for container-level annotations in the auto instrumentation webhook.
It doesn't really work as it is implemented now. It was decided not to support this for now.


### Describe how to test/QA your changes

Should be safe to skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
