### PR TITLE
Fix crash when event has missing publisher and no event data

### DIFF
--- a/pkg/util/winutil/eventlog/api/windows/render.go
+++ b/pkg/util/winutil/eventlog/api/windows/render.go
@@ -128,7 +128,9 @@ func (v *evtVariantValues) Buffer() unsafe.Pointer {
 }
 
 func (v *evtVariantValues) Close() {
-	C.free(v.buf)
+	if v.buf != nil {
+		C.free(v.buf)
+	}
 }
 
 // EvtRenderEventValues renders EvtRenderEventValues
@@ -145,6 +147,8 @@ func (api *API) EvtRenderEventValues(Context evtapi.EventRenderContextHandle, Fr
 // evtRenderEventValues renders EvtRenderEventValues
 // https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender
 func evtRenderEventValues(Context evtapi.EventRenderContextHandle, Fragment evtapi.EventRecordHandle) (*evtVariantValues, error) {
+
+	var rv evtVariantValues
 
 	Flags := evtapi.EvtRenderEventValues
 	// Get required buffer size
@@ -164,7 +168,7 @@ func evtRenderEventValues(Context evtapi.EventRenderContextHandle, Fragment evta
 			return nil, lastErr
 		}
 	} else {
-		return nil, nil
+		return &rv, nil
 	}
 
 	if BufferUsed == 0 {
@@ -195,7 +199,6 @@ func evtRenderEventValues(Context evtapi.EventRenderContextHandle, Fragment evta
 		return nil, lastErr
 	}
 
-	var rv evtVariantValues
 	rv.buf = Buffer
 	rv.count = (uint)(PropertyCount)
 

--- a/releasenotes/notes/fix-crash-eventlog-missing-publisher-no-data-40181f55b9c931ee.yaml
+++ b/releasenotes/notes/fix-crash-eventlog-missing-publisher-no-data-40181f55b9c931ee.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a crash in the ``win32_event_log`` check when processing an event that has
+    a missing publisher and no ``EventData``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix a crash/panic that would occur in the `win32_event_log` check when processing an event that has a missing publisher and no `EventData`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-641

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
If affected by this bug but unable to upgrade, set `interpret_messages: false` in the instance configuration to skip the code path that has the bug.
Code/bug introduced in Agent 7.50.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
covered by new integration test.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
