### PR TITLE
Consolidate multiple image references in initial containerd image collection

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
@@ -279,7 +279,7 @@ func (c *collector) notifyInitialImageEvents(ctx context.Context, namespace stri
 		return err
 	}
 
-	filteredImages := make(map[workloadmeta.EntityID]*workloadmeta.ContainerImageMetadata)
+	mergedImages := make(map[workloadmeta.EntityID]*workloadmeta.ContainerImageMetadata)
 	for _, image := range existingImages {
 		wlmImage, err := c.createOrUpdateImageMetadata(ctx, namespace, image, nil)
 		if err != nil {
@@ -287,12 +287,12 @@ func (c *collector) notifyInitialImageEvents(ctx context.Context, namespace stri
 			continue
 		}
 		//Image is referenced by several different names but has only one entity id (= manifest.Config.Digest).
-		//filteredImages will be refreshed by updated workloadmeta.ContainerImageMetadata
+		//mergedImages will be refreshed by updated workloadmeta.ContainerImageMetadata
 		if wlmImage != nil {
-			filteredImages[wlmImage.EntityID] = wlmImage
+			mergedImages[wlmImage.EntityID] = wlmImage
 		}
 	}
-	for _, wlmImage := range filteredImages {
+	for _, wlmImage := range mergedImages {
 		c.store.Notify([]workloadmeta.CollectorEvent{
 			{
 				Type:   workloadmeta.EventTypeSet,

--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -244,6 +244,9 @@ func (c *collector) handleImageCreateOrUpdate(ctx context.Context, namespace str
 	return c.notifyEventForImage(ctx, namespace, img, bom)
 }
 
+// Create image metadata from containerd image and manifest if not already present
+// Update image metadata by adding references when existing entity is found
+// return nil when it fails to get image manifest
 func (c *collector) createOrUpdateImageMetadata(ctx context.Context,
 	namespace string,
 	img containerd.Image,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
[CONTINT-3682](https://datadoghq.atlassian.net/browse/CONTINT-3682)
### Motivation
When agent starts, as a part of initialization, container images with multiple [references](https://github.com/containerd/containerd/blob/2b661b890f689716b2928408e386e656d8dd7118/pkg/cri/server/image_pull.go#L176) could be pulled from containerd runtime. Since the link between imageId, repo-digest and repo-tags are not created in the beginning,  some fields such as repo-digest can be missing in the first image reference. In addition, notifyInitialImageEvents will trigger workloadmetastore notify for each image reference which causes stale image in image check process. 

The proposed solution is to send notify after all images reference are collected and linked. This will remove any duplicate image metadata or incomplete image metadata.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Stale images can also be collected from live container check which comes from a race condition during container restart. It will be addressed in another fix. 
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
<img width="1682" alt="Screenshot 2024-02-10 at 10 00 57 AM" src="https://github.com/DataDog/datadog-agent/assets/3947770/d1259784-efaf-4fb7-8f08-c2af8a5387b9">

Image check should no longer create a dangling image. 

For example, we can launch a customized alpine image:
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: alpine-daemonset
  namespace: default
spec:
  selector:
    matchLabels:
      name: alpine-daemonset
  template:
    metadata:
      labels:
        name: alpine-daemonset
    spec:
      containers:
        - name: alpine
          image: us-east4-docker.pkg.dev/datadog-sandbox/mztest/alpine:test_image_with_fix
          command: ["sh", "-c", "while true; do sleep 1000; done"]
```
In UI, you should only see one row of running containers
<img width="1684" alt="Screenshot 2024-02-10 at 10 21 16 AM" src="https://github.com/DataDog/datadog-agent/assets/3947770/6ce8eb1a-8670-4bf6-8cf5-9926c0877dc1">


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[CONTINT-3682]: https://datadoghq.atlassian.net/browse/CONTINT-3682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ