### PR TITLE
Distribute microvm VCPUs across host CPUs on launch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,7 +181,7 @@ variables:
   # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: db7cdb8d8c3a
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 7a7f90428438
   DATADOG_AGENT_BUILDERS: v22276738-b36b132
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -300,7 +300,7 @@ upload_minimized_btfs_arm64:
   script:
     - echo "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE" > $STACK_DIR
     - pulumi login $(cat $STACK_DIR | tr -d '\n')
-    - inv -e kmt.gen-config --ci --arch=$ARCH --output-file=$VMCONFIG_FILE --sets=$TEST_SETS
+    - inv -e kmt.gen-config --ci --arch=$ARCH --output-file=$VMCONFIG_FILE --sets=$TEST_SETS --host-cpus=$AVAILABLE_CPUS
     - inv -e system-probe.start-microvms --provision --vmconfig=$VMCONFIG_FILE $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$ARCH-$CI_PIPELINE_ID --run-agent
     - jq -r '.' $CI_PROJECT_DIR/stack.output
     - pulumi logout
@@ -328,6 +328,7 @@ kernel_matrix_testing_setup_env_arm64:
     ARCH: arm64
     AMI_ID_ARG: "--arm-ami-id=$KERNEL_MATRIX_TESTING_ARM_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-arm
+    AVAILABLE_CPUS: "64"
 
 kernel_matrix_testing_setup_env_x64:
   extends:
@@ -338,6 +339,7 @@ kernel_matrix_testing_setup_env_x64:
     ARCH: x86_64
     AMI_ID_ARG: "--x86-ami-id=$KERNEL_MATRIX_TESTING_X86_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-x86
+    AVAILABLE_CPUS: "96"
 
 .kernel_matrix_testing_run_tests:
   stage: kernel_matrix_testing

--- a/tasks/kernel_matrix_testing/vmconfig.py
+++ b/tasks/kernel_matrix_testing/vmconfig.py
@@ -2,6 +2,7 @@ import copy
 import itertools
 import json
 import math
+import multiprocessing
 import os
 import platform
 from urllib.parse import urlparse
@@ -369,6 +370,10 @@ def add_console(vmset):
     vmset["console_type"] = "file"
 
 
+def add_available_cpus(vmset, cpus):
+    vmset["host"] = {"available_cpus": cpus}
+
+
 def url_to_fspath(url):
     source = urlparse(url)
     filename = os.path.basename(source.path)
@@ -460,7 +465,7 @@ def build_vmsets(normalized_vm_defs, sets):
     return vmsets
 
 
-def generate_vmconfig(vm_config, normalized_vm_defs, vcpu, memory, sets, ci):
+def generate_vmconfig(vm_config, normalized_vm_defs, vcpu, memory, sets, ci, host_cpus):
     with open(platforms_file) as f:
         platforms = json.load(f)
 
@@ -497,6 +502,8 @@ def generate_vmconfig(vm_config, normalized_vm_defs, vcpu, memory, sets, ci):
         if ci:
             add_console(vmset)
 
+        add_available_cpus(host_cpus)
+
     return vm_config
 
 
@@ -521,9 +528,7 @@ def build_normalized_vm_def_set(vms):
     return normalized_vms
 
 
-def gen_config_for_stack(
-    ctx, stack=None, vms="", sets="", init_stack=False, vcpu="4", memory="8192", new=False, ci=False
-):
+def gen_config_for_stack(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, host_cpus):
     stack = check_and_get_stack(stack)
     if not stack_exists(stack) and not init_stack:
         raise Exit(
@@ -544,7 +549,7 @@ def gen_config_for_stack(
         orig_vm_config = f.read()
     vm_config = json.loads(orig_vm_config)
 
-    vm_config = generate_vmconfig(vm_config, build_normalized_vm_def_set(vms), vcpu, memory, sets, ci)
+    vm_config = generate_vmconfig(vm_config, build_normalized_vm_def_set(vms), vcpu, memory, sets, ci, host_cpus)
     vm_config_str = json.dumps(vm_config, indent=4)
 
     tmpfile = "/tmp/vm.json"
@@ -579,7 +584,7 @@ def list_all_distro_normalized_vms(archs):
     return vms
 
 
-def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file):
+def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file, host_cpus):
     vcpu_ls = vcpu.split(',')
     memory_ls = memory.split(',')
 
@@ -590,8 +595,19 @@ def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, o
         set_ls = sets.split(",")
 
     if not ci:
+        if host_cpus is None:
+            host_cpus = multiprocessing.cpu_count()
         return gen_config_for_stack(
-            ctx, stack, vms, set_ls, init_stack, ls_to_int(vcpu_ls), ls_to_int(memory_ls), new, ci
+            ctx,
+            stack,
+            vms,
+            set_ls,
+            init_stack,
+            ls_to_int(vcpu_ls),
+            ls_to_int(memory_ls),
+            new,
+            ci,
+            int(host_cpus),
         )
 
     arch_ls = ["x86_64", "arm64"]
@@ -599,7 +615,9 @@ def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, o
         arch_ls = [arch_mapping[arch]]
 
     vms_to_generate = list_all_distro_normalized_vms(arch_ls)
-    vm_config = generate_vmconfig({"vmsets": []}, vms_to_generate, ls_to_int(vcpu_ls), ls_to_int(memory_ls), set_ls, ci)
+    if host_cpus is None:
+        raise Exit("no value for available cpus provided")
+    vm_config = generate_vmconfig({"vmsets": []}, vms_to_generate, ls_to_int(vcpu_ls), ls_to_int(memory_ls), set_ls, ci, int(host_cpus))
 
     with open(output_file, "w") as f:
         f.write(json.dumps(vm_config, indent=4))

--- a/tasks/kernel_matrix_testing/vmconfig.py
+++ b/tasks/kernel_matrix_testing/vmconfig.py
@@ -617,7 +617,15 @@ def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, o
     vms_to_generate = list_all_distro_normalized_vms(arch_ls)
     if host_cpus is None:
         raise Exit("no value for available cpus provided")
-    vm_config = generate_vmconfig({"vmsets": []}, vms_to_generate, ls_to_int(vcpu_ls), ls_to_int(memory_ls), set_ls, ci, int(host_cpus))
+    vm_config = generate_vmconfig(
+        {"vmsets": []},
+        vms_to_generate,
+        ls_to_int(vcpu_ls),
+        ls_to_int(memory_ls),
+        set_ls,
+        ci,
+        int(host_cpus),
+    )
 
     with open(output_file, "w") as f:
         f.write(json.dumps(vm_config, indent=4))

--- a/tasks/kernel_matrix_testing/vmconfig.py
+++ b/tasks/kernel_matrix_testing/vmconfig.py
@@ -502,7 +502,7 @@ def generate_vmconfig(vm_config, normalized_vm_defs, vcpu, memory, sets, ci, hos
         if ci:
             add_console(vmset)
 
-        add_available_cpus(host_cpus)
+        add_available_cpus(vmset, host_cpus)
 
     return vm_config
 

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -62,6 +62,7 @@ def gen_config(
     output_file="vmconfig.json",
     from_ci_pipeline=None,
     use_local_if_possible=False,
+    host_cpus=None,
 ):
     """
     Generate a vmconfig.json file with the given VMs.
@@ -83,7 +84,7 @@ def gen_config(
     else:
         vcpu = DEFAULT_VCPU if vcpu is None else vcpu
         memory = DEFAULT_MEMORY if memory is None else memory
-        vmconfig.gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file)
+        vmconfig.gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file, host_cpus)
 
 
 def gen_config_from_ci_pipeline(
@@ -141,6 +142,7 @@ def gen_config_from_ci_pipeline(
                 if vcpu is None and len(vcpu_list) > 0:
                     vcpu = str(vcpu_list[0])
                     info(f"[+] setting vcpu to {vcpu}")
+
         elif name.startswith("kernel_matrix_testing_run") and job["status"] == "failed":
             arch = "x86" if "x64" in name else "arm64"
             match = re.search(r"\[(.*)\]", name)

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -27,7 +27,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240124125737-db7cdb8d8c3a
+	github.com/DataDog/test-infra-definitions v0.0.0-20240126084003-7a7f90428438
 	github.com/aws/aws-sdk-go-v2 v1.24.0
 	github.com/aws/aws-sdk-go-v2/config v1.25.10
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.19.0 h1:Wvz/63/q39EpVwSH1T8jVyRvP
 github.com/DataDog/datadog-api-client-go/v2 v2.19.0/go.mod h1:oD5Lx8Li3oPRa/BSBenkn4i48z+91gwYORF/+6ph71g=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20240124125737-db7cdb8d8c3a h1:GEvzcF4I6oEjtq2C5Y/mCA2mT491yz+OfK8VUstrCmY=
-github.com/DataDog/test-infra-definitions v0.0.0-20240124125737-db7cdb8d8c3a/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
+github.com/DataDog/test-infra-definitions v0.0.0-20240126084003-7a7f90428438 h1:6ksJFkTKBgQGXIy1VvWEto4J0Uqp6qwBppXUuHYtexQ=
+github.com/DataDog/test-infra-definitions v0.0.0-20240126084003-7a7f90428438/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR pulls in [changes](https://github.com/DataDog/test-infra-definitions/pull/526) from test-infra-definitions to allow pinning microvm vcpus to host cpus.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Improve schedueler latency on VM startup.
It was observed that various timeouts in tests were being triggered because the VM process would sleep for unexpectedly long times. This was concluded from observing the elapsed wall clock time to be orders of magnitude larger than the time spent executing VM code in some cases.
By pinning VM vcpus to specific CPUs, we aim to reduce latency due to the scheduler migrating processes to different CPUs.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
https://datadoghq.atlassian.net/browse/EBPF-385

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
