### PR TITLE
Run the containers e2e tests only when containers related code has changed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1001,6 +1001,38 @@ workflow:
   - when: manual
     allow_failure: true
 
+.on_container_changes_or_manual:
+  - <<: *if_disable_e2e
+    when: never
+  - <<: *if_main_branch
+    when: on_success
+  - <<: *if_mergequeue
+    when: never
+  - changes:
+      paths:
+        - comp/core/tagger/**/*
+        - comp/core/workloadmeta/**/*
+        - pkg/autodiscovery/listeners/**/*
+        - pkg/autodiscovery/providers/**/*
+        - pkg/collector/corechecks/cluster/**/*
+        - pkg/collector/corechecks/containers/**/*
+        - pkg/collector/corechecks/containerimage/**/*
+        - pkg/collector/corechecks/containerlifecycle/**/*
+        - pkg/collector/corechecks/kubernetes/**/*
+        - pkg/collector/corechecks/sbom/**/*
+        - pkg/util/clusteragent/**/*
+        - pkg/util/containerd/**/*
+        - pkg/util/containers/**/*
+        - pkg/util/docker/**/*
+        - pkg/util/ecs/**/*
+        - pkg/util/kubernetes/**/*
+        - pkg/util/cgroups/**/*
+        - test/new-e2e/tests/containers/**/*
+        - test/new-e2e/go.mod
+      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+    when: on_success
+  - when: manual
+
 .on_install_script_release_manual:
   - <<: *if_not_version_7
     when: never

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -244,9 +244,11 @@ dev_nightly-dogstatsd:
     IMG_DESTINATIONS: dogstatsd-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA},dogstatsd-dev:nightly-${CI_COMMIT_REF_SLUG}
 
 # push images to `datadog-agent-qa` ECR for the end-to-end tests defined in `e2e.yml`
-.qa_agent:
+qa_agent:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
+  rules:
+    !reference [.on_container_changes_or_manual]
   needs:
     - docker_build_agent7
     - docker_build_agent7_arm64
@@ -257,9 +259,11 @@ dev_nightly-dogstatsd:
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-winltsc2022-amd64
     IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
-.qa_dca:
+qa_dca:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
+  rules:
+    !reference [.on_container_changes_or_manual]
   needs:
     - docker_build_cluster_agent_amd64
     - docker_build_cluster_agent_arm64
@@ -268,9 +272,11 @@ dev_nightly-dogstatsd:
     IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: cluster-agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
-.qa_dogstatsd:
+qa_dogstatsd:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
+  rules:
+    !reference [.on_container_changes_or_manual]
   needs:
     - docker_build_dogstatsd_amd64
     - docker_build_dogstatsd_arm64
@@ -289,36 +295,6 @@ dev_nightly-dogstatsd:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_CWS_INSTRUMENTATION}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_CWS_INSTRUMENTATION}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: cws-instrumentation:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-
-qa_main_agent:
-  extends: .qa_agent
-  rules: !reference [.on_main_and_no_skip_e2e]
-
-qa_branch_agent:
-  extends: .qa_agent
-  rules:
-    - !reference [.if_run_e2e_tests]
-    - !reference [.on_dev_branch_manual]
-
-qa_main_dca:
-  extends: .qa_dca
-  rules: !reference [.on_main_and_no_skip_e2e]
-
-qa_branch_dca:
-  extends: .qa_dca
-  rules:
-    - !reference [.if_run_e2e_tests]
-    - !reference [.on_dev_branch_manual]
-
-qa_main_dogstatsd:
-  extends: .qa_dogstatsd
-  rules: !reference [.on_main_and_no_skip_e2e]
-
-qa_branch_dogstatsd:
-  extends: .qa_dogstatsd
-  rules:
-    - !reference [.if_run_e2e_tests]
-    - !reference [.on_dev_branch_manual]
 
 qa_main_cws_instrumentation:
   extends: .qa_cws_instrumentation

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -111,35 +111,17 @@ k8s-e2e-otlp-main:
     reports:
       junit: test/new-e2e/junit-*.xml
 
-new-e2e-containers-dev:
+new-e2e-containers:
   extends: .new_e2e_template
   # TODO once images are deployed to ECR for dev branches, update
   # on_main_and_no_skip_e2e adding on_dev_branch_manual rules
   # and move rules to template
   rules:
-    - !reference [.if_run_e2e_tests]
-    - !reference [.on_dev_branch_manual]
+    !reference [.on_container_changes_or_manual]
   needs:
-    - qa_branch_agent
-    - qa_branch_dca
-    - qa_branch_dogstatsd
-  variables:
-    TARGETS: ./tests/containers
-    TEAM: container-integrations
-  parallel:
-    matrix:
-      - EXTRA_PARAMS: --run TestKindSuite
-      - EXTRA_PARAMS: --run TestEKSSuite
-      - EXTRA_PARAMS: --run TestECSSuite
-      - EXTRA_PARAMS: --skip "Test(Kind|EKS|ECS)Suite"
-
-new-e2e-containers-main:
-  extends: .new_e2e_template
-  rules: !reference [.on_main_and_no_skip_e2e]
-  needs:
-    - qa_main_agent
-    - qa_main_dca
-    - qa_main_dogstatsd
+    - qa_agent
+    - qa_dca
+    - qa_dogstatsd
   variables:
     TARGETS: ./tests/containers
     TEAM: container-integrations
@@ -304,9 +286,9 @@ new-e2e-orchestrator-dev:
     - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
   needs:
-    - qa_branch_agent
-    - qa_branch_dca
-    - qa_branch_dogstatsd
+    - qa_agent
+    - qa_dca
+    - qa_dogstatsd
   variables:
     TARGETS: ./tests/orchestrator
     TEAM: container-app
@@ -315,9 +297,9 @@ new-e2e-orchestrator-main:
   extends: .new_e2e_template
   rules: !reference [.on_main_and_no_skip_e2e]
   needs:
-    - qa_main_agent
-    - qa_main_dca
-    - qa_main_dogstatsd
+    - qa_agent
+    - qa_dca
+    - qa_dogstatsd
   variables:
     TARGETS: ./tests/orchestrator
     TEAM: container-app
@@ -330,9 +312,9 @@ new-e2e-apm-dev:
     - !reference [.if_run_e2e_tests]
     - !reference [.on_dev_branch_manual]
   needs:
-    - qa_branch_agent
-    - qa_branch_dca
-    - qa_branch_dogstatsd
+    - qa_agent
+    - qa_dca
+    - qa_dogstatsd
   variables:
     TARGETS: ./tests/apm
     TEAM: apm-agent

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -10,7 +10,7 @@ e2e_test_junit_upload:
   dependencies:
     # We need to exhaustively list all the `new-e2e-…` jobs that produce junit reports here
     # to avoid downloading all the artifacts of all the jobs of all the previous stages.
-    - new-e2e-containers-main
+    - new-e2e-containers
     - new-e2e-agent-shared-components-main
     - new-e2e-agent-subcommands-main
     - new-e2e-language-detection-main


### PR DESCRIPTION
### What does this PR do?

The current policy regarding e2e tests is:
* On PR, e2e tests are optional: their execution is manual.
* On merge queue, e2e tests are not run.
* On `main` branch, e2e tests are run.

In order to reduce the risk of breaking `main` and in order to avoid the prohibitive cost of running e2e tests on all PR, this proposition consists in launching the containers e2e tests only on the subset of PRs that are touching containers-related pieces of code.

### Motivation

Avoid breaking `main` too easily.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
