### PR TITLE
fix(new-e2e): Adapt the regexp to the new datadog-agent status display

### DIFF
--- a/test/new-e2e/tests/agent-platform/common/agent_install.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_install.go
@@ -45,13 +45,13 @@ func CheckSigningKeys(t *testing.T, client *TestClient) {
 // CheckInstallationMajorAgentVersion run tests to check the installation of an agent has the correct major version
 func CheckInstallationMajorAgentVersion(t *testing.T, client *TestClient, expectedVersion string) bool {
 	return t.Run("Check datadog-agent status version", func(tt *testing.T) {
-		versionRegexPattern := regexp.MustCompile(`(?m:^Agent \(v([0-9]).*\)$)`)
+		versionRegexPattern := regexp.MustCompile(`(?m:^(IoT )?Agent \(v([0-9]).*\)$)`)
 		tmpCmd := fmt.Sprintf("sudo %s status", client.Helper.GetBinaryPath())
 		output, err := client.ExecuteWithRetry(tmpCmd)
 		require.NoError(tt, err, "datadog-agent status failed")
 		matchList := versionRegexPattern.FindStringSubmatch(output)
-		require.NotEmpty(tt, matchList, "wasn't able to retrieve datadog-agent version on the following output : %s", output)
-		require.True(tt, matchList[1] == expectedVersion, "Expected datadog-agent version %s got %s", expectedVersion, matchList[0])
+		require.NotEmpty(tt, matchList, "wasn't able to retrieve datadog-agent major version on the following output : %s", output)
+		require.True(tt, matchList[2] == expectedVersion, "Expected datadog-agent major version %s got %s", expectedVersion, matchList[2])
 	})
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Change the matching regex as the `datadog-agent status` header can start with `IoT Agent` instead of `Agent` since PR#22115 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fix new-e2e which are [failing](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/418823251)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Triggered a [full pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/27240428)

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
