### PR TITLE
[e2e] Increase the tolerance margin for `kubernetes.cpu.usage.total`

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -543,8 +543,8 @@ func (suite *k8sSuite) TestCPU() {
 				`^short_image:stress-ng$`,
 			},
 			Value: &testMetricExpectValueArgs{
-				Max: 200000000,
-				Min: 100000000,
+				Max: 250000000,
+				Min: 75000000,
 			},
 		},
 	})


### PR DESCRIPTION
### What does this PR do?

A containers e2e test is asserting the `kubernetes.cpu.usage.total` metric value.
This PR increases the tolerance margin around the expected value.

### Motivation

This [test is currently slightly flaky](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.name%3A%22TestEKSSuite%2FTestCPU%2Fmetric___kubernetes.cpu.usage.total%7Bkube_deployment%3Astress-ng%2Ckube_namespace%3Aworkload-cpustress%7D%22&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=AgAAAY1CEfakwtGv4AAAAAAAAAAYAAAAAEFZMUNFZmFrQUFEaUJUWkpxRmZkUGJ2awAAACQAAAAAMDE4ZDQyMTktYmVhYy00MzRhLTg1N2MtM2JkOTgwZmE5OGYz&index=citest&mode=sliding&saved-view-id=2236559&testId=AgAAAY1CEfakwtGv4AAAAAAAAAAYAAAAAEFZMUNFZmFrQUFEaUJUWkpxRmZkUGJ2awAAACQAAAAAMDE4ZDQyMTktYmVhYy00MzRhLTg1N2MtM2JkOTgwZmE5OGYz&trace=AgAAAY1CEfakwtGv4AAAAAAAAAAYAAAAAEFZMUNFZmFrQUFEaUJUWkpxRmZkUGJ2awAAACQAAAAAMDE4ZDQyMTktYmVhYy00MzRhLTg1N2MtM2JkOTgwZmE5OGYz&start=1703583495157&end=1706261895157&paused=false) because the value reported by the agent is outside the window expected by the test.

### Additional Notes

`kubernetes.cpu.usage.total` metric is so broken that a ±35% error margin around the expected value (150 millicores) isn’t enough.

This is well visible on [the dasboard](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?fullscreen_end_ts=1706212492447&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=overview&fullscreen_start_ts=1706211745121&fullscreen_widget=5717020205158046&refresh_mode=paused&tpl_var_fake_intake_task_family%5B0%5D=ci-27199321-4670-eks-cluster-fakeintake-ecs&tpl_var_kube_cluster_name%5B0%5D=ci-27199321-4670-eks-cluster&view=spans&from_ts=1706211745121&to_ts=1706212492447&live=false) where we can compare exactly the same data (CPU usage) of exactly the same workload (a pod specially crafted to have stable CPU consumption of 150 millicores) at exactly the same time but reported by the `container` check:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/3c420079-48a9-481c-98a8-c461ac6799c3)
and by the `kubelet` check:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/c4795c55-4aee-4769-89e3-868f28626215)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
