### PR TITLE
CI: prepare pipelines for conductor

### DIFF
--- a/.gitlab/deploy_containers.yml
+++ b/.gitlab/deploy_containers.yml
@@ -27,7 +27,7 @@ deploy_containers-a6-on-failure:
   trigger:
     include: .gitlab/deploy_containers/deploy_containers_a6.yml
 
-  
+
 deploy_containers-a7:
   stage: deploy_containers
   rules:

--- a/.gitlab/docker_common/publish_job_templates.yml
+++ b/.gitlab/docker_common/publish_job_templates.yml
@@ -18,4 +18,6 @@
     - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
     - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_VARIABLES,IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS,IMG_SIGNING"
+    - >
+      inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main"
+      --variables "IMG_VARIABLES,IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS,IMG_SIGNING,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"

--- a/.gitlab/docker_common/publish_job_templates.yml
+++ b/.gitlab/docker_common/publish_job_templates.yml
@@ -18,6 +18,16 @@
     - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
     - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
-    - >
-      inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main"
-      --variables "IMG_VARIABLES,IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS,IMG_SIGNING,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/public-images --git-ref main
+      --variables
+        IMG_VARIABLES,\
+        IMG_REGISTRIES,\
+        IMG_SOURCES,\
+        IMG_DESTINATIONS,\
+        IMG_SIGNING,\
+        APPS,\
+        BAZEL_TARGET,\
+        DDR,\
+        DDR_WORKFLOW_ID,\
+        TARGET_ENV,\
+        DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"

--- a/.gitlab/install_script_testing.yml
+++ b/.gitlab/install_script_testing.yml
@@ -10,7 +10,9 @@ test_install_script:
     - export TESTING_APT_URL=$DEB_TESTING_S3_BUCKET
     - export TESTING_YUM_URL=$RPM_TESTING_S3_BUCKET
     - export TEST_PIPELINE_ID=$CI_PIPELINE_ID
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-linux-install-script" --git-ref "main" --variables "TESTING_APT_URL,TESTING_YUM_URL,TEST_PIPELINE_ID"
+    - >
+      inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-linux-install-script" --git-ref "main"
+      --variables "TESTING_APT_URL,TESTING_YUM_URL,TEST_PIPELINE_ID,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
   needs: ["deploy_deb_testing-a6_x64", "deploy_rpm_testing-a6_x64", "deploy_deb_testing-a7_x64", "deploy_rpm_testing-a7_x64"]
   rules:
     !reference [.on_deploy]

--- a/.gitlab/install_script_testing.yml
+++ b/.gitlab/install_script_testing.yml
@@ -10,9 +10,14 @@ test_install_script:
     - export TESTING_APT_URL=$DEB_TESTING_S3_BUCKET
     - export TESTING_YUM_URL=$RPM_TESTING_S3_BUCKET
     - export TEST_PIPELINE_ID=$CI_PIPELINE_ID
-    - >
-      inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-linux-install-script" --git-ref "main"
-      --variables "TESTING_APT_URL,TESTING_YUM_URL,TEST_PIPELINE_ID,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/agent-linux-install-script --git-ref main
+      --variables
+        TESTING_APT_URL,\
+        TESTING_YUM_URL,\
+        TEST_PIPELINE_ID,\
+        APPS,BAZEL_TARGET,\
+        DDR,DDR_WORKFLOW_ID,\
+        TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
   needs: ["deploy_deb_testing-a6_x64", "deploy_rpm_testing-a6_x64", "deploy_deb_testing-a7_x64", "deploy_rpm_testing-a7_x64"]
   rules:
     !reference [.on_deploy]

--- a/.gitlab/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy.yml
@@ -28,7 +28,9 @@ docker_trigger_internal:
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master" --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_SRC_IMAGE,TMPL_SRC_REPO,RELEASE_STAGING,RELEASE_PROD,DYNAMIC_BUILD_RENDER_RULES"
+    - >
+      inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master"
+      --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_SRC_IMAGE,TMPL_SRC_REPO,RELEASE_STAGING,RELEASE_PROD,DYNAMIC_BUILD_RENDER_RULES,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
 
 
 docker_trigger_cluster_agent_internal:
@@ -58,7 +60,9 @@ docker_trigger_cluster_agent_internal:
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master" --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_SRC_IMAGE,TMPL_SRC_REPO,RELEASE_STAGING,RELEASE_PROD,DYNAMIC_BUILD_RENDER_RULES"
+    - >
+      inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master"
+      --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_SRC_IMAGE,TMPL_SRC_REPO,RELEASE_STAGING,RELEASE_PROD,DYNAMIC_BUILD_RENDER_RULES,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
 
 docker_trigger_cws_instrumentation_internal:
   stage: internal_image_deploy
@@ -86,4 +90,6 @@ docker_trigger_cws_instrumentation_internal:
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master" --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_SRC_IMAGE,TMPL_SRC_REPO,RELEASE_STAGING,RELEASE_PROD,DYNAMIC_BUILD_RENDER_RULES"
+    - >
+      inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master"
+      --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_SRC_IMAGE,TMPL_SRC_REPO,RELEASE_STAGING,RELEASE_PROD,DYNAMIC_BUILD_RENDER_RULES,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"

--- a/.gitlab/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy.yml
@@ -28,9 +28,23 @@ docker_trigger_internal:
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
-    - >
-      inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master"
-      --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_SRC_IMAGE,TMPL_SRC_REPO,RELEASE_STAGING,RELEASE_PROD,DYNAMIC_BUILD_RENDER_RULES,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master
+      --variables
+        IMAGE_VERSION,\
+        IMAGE_NAME,\
+        RELEASE_TAG,\
+        BUILD_TAG,\
+        TMPL_SRC_IMAGE,\
+        TMPL_SRC_REPO,\
+        RELEASE_STAGING,\
+        RELEASE_PROD,\
+        DYNAMIC_BUILD_RENDER_RULES,\
+        APPS,\
+        BAZEL_TARGET,\
+        DDR,\
+        DDR_WORKFLOW_ID,\
+        TARGET_ENV,\
+        DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
 
 
 docker_trigger_cluster_agent_internal:
@@ -60,9 +74,23 @@ docker_trigger_cluster_agent_internal:
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
-    - >
-      inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master"
-      --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_SRC_IMAGE,TMPL_SRC_REPO,RELEASE_STAGING,RELEASE_PROD,DYNAMIC_BUILD_RENDER_RULES,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master
+      --variables
+        IMAGE_VERSION,\
+        IMAGE_NAME,\
+        RELEASE_TAG,\
+        BUILD_TAG,\
+        TMPL_SRC_IMAGE,\
+        TMPL_SRC_REPO,\
+        RELEASE_STAGING,\
+        RELEASE_PROD,\
+        DYNAMIC_BUILD_RENDER_RULES,\
+        APPS,\
+        BAZEL_TARGET,\
+        DDR,\
+        DDR_WORKFLOW_ID,\
+        TARGET_ENV,\
+        DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
 
 docker_trigger_cws_instrumentation_internal:
   stage: internal_image_deploy
@@ -90,6 +118,20 @@ docker_trigger_cws_instrumentation_internal:
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
-    - >
-      inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master"
-      --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_SRC_IMAGE,TMPL_SRC_REPO,RELEASE_STAGING,RELEASE_PROD,DYNAMIC_BUILD_RENDER_RULES,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master
+      --variables
+        IMAGE_VERSION,\
+        IMAGE_NAME,\
+        RELEASE_TAG,\
+        BUILD_TAG,\
+        TMPL_SRC_IMAGE,\
+        TMPL_SRC_REPO,\
+        RELEASE_STAGING,\
+        RELEASE_PROD,\
+        DYNAMIC_BUILD_RENDER_RULES,\
+        APPS,\
+        BAZEL_TARGET,\
+        DDR,\
+        DDR_WORKFLOW_ID,\
+        TARGET_ENV,\
+        DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"

--- a/.gitlab/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy.yml
@@ -30,7 +30,9 @@ internal_kubernetes_deploy_experimental:
   script:
     - source /root/.bashrc
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "main" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+    - >
+      inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "main"
+      --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
 
 notify-slack:
   stage: internal_kubernetes_deploy

--- a/.gitlab/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy.yml
@@ -30,9 +30,17 @@ internal_kubernetes_deploy_experimental:
   script:
     - source /root/.bashrc
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
-    - >
-      inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "main"
-      --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/k8s-datadog-agent-ops --git-ref main
+      --variables
+        OPTION_AUTOMATIC_ROLLOUT,\
+        EXPLICIT_WORKFLOWS,\
+        OPTION_PRE_SCRIPT,\
+        SKIP_PLAN_CHECK,\
+        APPS,BAZEL_TARGET,\
+        DDR,\
+        DDR_WORKFLOW_ID,\
+        TARGET_ENV,\
+        DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
 
 notify-slack:
   stage: internal_kubernetes_deploy

--- a/.gitlab/rc_jobs/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_jobs/rc_kubernetes_deploy.yml
@@ -26,7 +26,16 @@ rc_kubernetes_deploy:
     - source /root/.bashrc
     - set +x
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
-    - >
-      inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "main"
-      --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/k8s-datadog-agent-ops --git-ref main
       --no-follow
+      --variables
+        OPTION_AUTOMATIC_ROLLOUT,\
+        EXPLICIT_WORKFLOWS,\
+        OPTION_PRE_SCRIPT,\
+        SKIP_PLAN_CHECK,\
+        APPS,\
+        BAZEL_TARGET,\
+        DDR,\
+        DDR_WORKFLOW_ID,\
+        TARGET_ENV,\
+        DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"

--- a/.gitlab/rc_jobs/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_jobs/rc_kubernetes_deploy.yml
@@ -26,4 +26,7 @@ rc_kubernetes_deploy:
     - source /root/.bashrc
     - set +x
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "main" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow
+    - >
+      inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "main"
+      --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+      --no-follow

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -21,7 +21,9 @@
     - source /root/.bashrc
     - export RELEASE_VERSION=$(inv agent.version --major-version 7 --url-safe --omnibus-format)-1
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "main" --variables "ACTION,AUTO_RELEASE,BUILD_PIPELINE_ID,RELEASE_PRODUCT,RELEASE_VERSION,TARGET_REPO,TARGET_REPO_BRANCH"
+    - >
+      inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "main"
+      --variables "ACTION,AUTO_RELEASE,BUILD_PIPELINE_ID,RELEASE_PRODUCT,RELEASE_VERSION,TARGET_REPO,TARGET_REPO_BRANCH,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
   dependencies: []
 
 trigger_auto_staging_release:

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -21,9 +21,21 @@
     - source /root/.bashrc
     - export RELEASE_VERSION=$(inv agent.version --major-version 7 --url-safe --omnibus-format)-1
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
-    - >
-      inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "main"
-      --variables "ACTION,AUTO_RELEASE,BUILD_PIPELINE_ID,RELEASE_PRODUCT,RELEASE_VERSION,TARGET_REPO,TARGET_REPO_BRANCH,APPS,BAZEL_TARGET,DDR,DDR_WORKFLOW_ID,TARGET_ENV,DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+    - 'inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "main"
+      --variables
+        ACTION,
+        AUTO_RELEASE,
+        BUILD_PIPELINE_ID,
+        RELEASE_PRODUCT,
+        RELEASE_VERSION,
+        TARGET_REPO,
+        TARGET_REPO_BRANCH,
+        APPS,
+        BAZEL_TARGET,
+        DDR,
+        DDR_WORKFLOW_ID,
+        TARGET_ENV,
+        DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS'
   dependencies: []
 
 trigger_auto_staging_release:

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -477,6 +477,17 @@ def trigger_child_pipeline(_, git_ref, project_name, variables="", follow=True):
 
     # Fill the environment variables to pass to the child pipeline.
     for v in variables.split(','):
+        # An empty string or a terminal ',' will yield an empty string which
+        # we don't need to bother with
+        if not v:
+            continue
+        if v not in os.environ:
+            print(
+                color_message(
+                    f"WARNING: attempting to pass undefined variable \"{v}\" to downstream pipeline", "orange"
+                )
+            )
+            continue
         data['variables'][v] = os.environ[v]
 
     print(


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR prepares our pipelines for the introduction of conductor

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We need to forward some of the environment variables to the downstream pipelines in order for conductor to be able to track the build & deployments across those
See https://datadoghq.atlassian.net/browse/APL-2694

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
