### PR TITLE
[NPM] test E2E containerized agent tests

### DIFF
--- a/test/new-e2e/pkg/components/remotehost.go
+++ b/test/new-e2e/pkg/components/remotehost.go
@@ -46,7 +46,7 @@ var _ e2e.Initializable = &RemoteHost{}
 // Init is called by e2e test Suite after the component is provisioned.
 func (h *RemoteHost) Init(ctx e2e.Context) error {
 	h.context = ctx
-	return h.reconnectSSH()
+	return h.ReconnectSSH()
 }
 
 // Execute executes a command and returns an error if any.
@@ -63,7 +63,7 @@ func (h *RemoteHost) Execute(command string, options ...ExecuteOption) (string, 
 	output, err = clients.ExecuteCommand(h.client, cmd)
 
 	if err != nil && strings.Contains(err.Error(), "failed to create session:") {
-		err = h.reconnectSSH()
+		err = h.ReconnectSSH()
 		if err != nil {
 			return "", err
 		}
@@ -156,9 +156,9 @@ func (h *RemoteHost) DialRemotePort(port uint16) (net.Conn, error) {
 	return h.client.DialContext(context.Background(), "tcp", fmt.Sprintf("127.0.0.1:%d", port))
 }
 
-// reconnectSSH recreate the SSH connection to the VM. Should be used only after VM reboot to restore the SSH connection.
+// ReconnectSSH recreate the SSH connection to the VM. Should be used only after VM reboot to restore the SSH connection.
 // Returns an error if the VM is not reachable after retries.
-func (h *RemoteHost) reconnectSSH() error {
+func (h *RemoteHost) ReconnectSSH() error {
 	h.context.T().Logf("connecting to remote VM at %s@%s", h.Username, h.Address)
 
 	if h.client != nil {

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -242,10 +242,6 @@ func (bs *BaseSuite[Env]) init(options []SuiteOption, self Suite[Env]) {
 	}
 
 	bs.originalProvisioners = bs.params.provisioners
-
-	for k := range bs.originalProvisioners {
-		fmt.Printf("=========== %v", k)
-	}
 }
 
 func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners ProvisionerMap) error {

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -242,6 +242,10 @@ func (bs *BaseSuite[Env]) init(options []SuiteOption, self Suite[Env]) {
 	}
 
 	bs.originalProvisioners = bs.params.provisioners
+
+	for k := range bs.originalProvisioners {
+		fmt.Printf("=========== %v", k)
+	}
 }
 
 func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners ProvisionerMap) error {

--- a/test/new-e2e/pkg/environments/aws/docker/host.go
+++ b/test/new-e2e/pkg/environments/aws/docker/host.go
@@ -135,7 +135,7 @@ func Provisioner(opts ...ProvisionerOption) e2e.TypedProvisioner[environments.Do
 		if err != nil {
 			return err
 		}
-		err = host.Export(ctx, &env.Host.HostOutput)
+		err = host.Export(ctx, &env.RemoteHost.HostOutput)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/pkg/environments/aws/docker/host.go
+++ b/test/new-e2e/pkg/environments/aws/docker/host.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
 	"github.com/DataDog/test-infra-definitions/components/docker"
+	"github.com/DataDog/test-infra-definitions/components/remote"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/fakeintake"
@@ -30,14 +31,17 @@ const (
 	defaultVMName     = "dockervm"
 )
 
+type CustomPulumiCallback func(ctx *pulumi.Context, pulumiEnv *ProvisionerPulumiEnv, env any) error
+
 // ProvisionerParams contains all the parameters needed to create the environment
 type ProvisionerParams struct {
 	name string
 
-	vmOptions         []ec2.VMOption
-	agentOptions      []dockeragentparams.Option
-	fakeintakeOptions []fakeintake.Option
-	extraConfigParams runner.ConfigMap
+	vmOptions            []ec2.VMOption
+	agentOptions         []dockeragentparams.Option
+	fakeintakeOptions    []fakeintake.Option
+	extraConfigParams    runner.ConfigMap
+	customPulumiCallback CustomPulumiCallback
 }
 
 func newProvisionerParams() *ProvisionerParams {
@@ -108,6 +112,20 @@ func WithoutAgent() ProvisionerOption {
 		params.agentOptions = nil
 		return nil
 	}
+}
+
+// WithCustomPulumiCallback sets a custom callback to be called by the provisioner
+func WithCustomPulumiCallback(callback CustomPulumiCallback, extraEnv any) ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.customPulumiCallback = callback
+		return nil
+	}
+}
+
+type ProvisionerPulumiEnv struct {
+	AwsEnvironment *aws.Environment
+	Host           *remote.Host
+	DockerManager  *docker.Manager
 }
 
 // Provisioner creates a VM environment with an EC2 VM with Docker, an ECS Fargate FakeIntake and a Docker Agent configured to talk to each other.
@@ -186,6 +204,16 @@ func Provisioner(opts ...ProvisionerOption) e2e.TypedProvisioner[environments.Do
 		} else {
 			// Suite inits all fields by default, so we need to explicitly set it to nil
 			env.Agent = nil
+		}
+
+		provisionerCtx := &ProvisionerPulumiEnv{
+			AwsEnvironment: &awsEnv,
+			Host:           host,
+			DockerManager:  manager,
+		}
+
+		if params.customPulumiCallback != nil {
+			params.customPulumiCallback(ctx, provisionerCtx, env)
 		}
 
 		return nil

--- a/test/new-e2e/pkg/environments/aws/docker/host.go
+++ b/test/new-e2e/pkg/environments/aws/docker/host.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
 	"github.com/DataDog/test-infra-definitions/components/docker"
-	"github.com/DataDog/test-infra-definitions/components/remote"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/fakeintake"
@@ -118,12 +117,6 @@ func WithoutAgent() ProvisionerOption {
 		params.agentOptions = nil
 		return nil
 	}
-}
-
-type ProvisionerPulumiEnv struct {
-	AwsEnvironment *aws.Environment
-	Host           *remote.Host
-	DockerManager  *docker.Manager
 }
 
 func Run(ctx *pulumi.Context, env *environments.DockerHost, params *ProvisionerParams) error {

--- a/test/new-e2e/pkg/environments/aws/docker/host.go
+++ b/test/new-e2e/pkg/environments/aws/docker/host.go
@@ -51,6 +51,7 @@ func newProvisionerParams() *ProvisionerParams {
 	}
 }
 
+// GetProvisionerParams return ProvisionerParams from options opts setup
 func GetProvisionerParams(opts ...ProvisionerOption) *ProvisionerParams {
 	params := newProvisionerParams()
 	err := optional.ApplyOptions(params, opts)

--- a/test/new-e2e/pkg/environments/aws/docker/host.go
+++ b/test/new-e2e/pkg/environments/aws/docker/host.go
@@ -41,7 +41,7 @@ type ProvisionerParams struct {
 	extraConfigParams runner.ConfigMap
 }
 
-func NewProvisionerParams() *ProvisionerParams {
+func newProvisionerParams() *ProvisionerParams {
 	// We use nil arrays to decide if we should create or not
 	return &ProvisionerParams{
 		name:              defaultVMName,
@@ -50,6 +50,15 @@ func NewProvisionerParams() *ProvisionerParams {
 		fakeintakeOptions: []fakeintake.Option{},
 		extraConfigParams: runner.ConfigMap{},
 	}
+}
+
+func GetProvisionerParams(opts ...ProvisionerOption) *ProvisionerParams {
+	params := newProvisionerParams()
+	err := optional.ApplyOptions(params, opts)
+	if err != nil {
+		panic(fmt.Errorf("unable to apply ProvisionerOption, err: %w", err))
+	}
+	return params
 }
 
 // ProvisionerOption is a function that modifies the ProvisionerParams
@@ -188,12 +197,7 @@ func DockerRunFunction(ctx *pulumi.Context, env *environments.DockerHost, params
 // FakeIntake and Agent creation can be deactivated by using [WithoutFakeIntake] and [WithoutAgent] options.
 func Provisioner(opts ...ProvisionerOption) e2e.TypedProvisioner[environments.DockerHost] {
 	// We need to build params here to be able to use params.name in the provisioner name
-	params := NewProvisionerParams()
-	err := optional.ApplyOptions(params, opts)
-	if err != nil {
-		panic(fmt.Errorf("unable to apply ProvisionerOption, err: %w", err))
-	}
-
+	params := GetProvisionerParams(opts...)
 	provisioner := e2e.NewTypedPulumiProvisioner(provisionerBaseID+params.name, func(ctx *pulumi.Context, env *environments.DockerHost) error {
 <<<<<<< HEAD
 		// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.

--- a/test/new-e2e/pkg/environments/aws/docker/host.go
+++ b/test/new-e2e/pkg/environments/aws/docker/host.go
@@ -119,6 +119,7 @@ func WithoutAgent() ProvisionerOption {
 	}
 }
 
+// Run deploys a docker environment given a pulumi.Context
 func Run(ctx *pulumi.Context, env *environments.DockerHost, params *ProvisionerParams) error {
 	var awsEnv aws.Environment
 	var err error

--- a/test/new-e2e/pkg/environments/aws/host/host.go
+++ b/test/new-e2e/pkg/environments/aws/host/host.go
@@ -147,8 +147,8 @@ func ProvisionerNoFakeIntake(opts ...ProvisionerOption) e2e.TypedProvisioner[env
 	return Provisioner(mergedOpts...)
 }
 
-// HostRunFunction main provisioner work running here
-func HostRunFunction(ctx *pulumi.Context, env *environments.Host, params *ProvisionerParams) error {
+// Run main provisioner work running here
+func Run(ctx *pulumi.Context, env *environments.Host, params *ProvisionerParams) error {
 	var awsEnv aws.Environment
 	var err error
 	if env.AwsEnvironment != nil {
@@ -236,7 +236,7 @@ func Provisioner(opts ...ProvisionerOption) e2e.TypedProvisioner[environments.Ho
 		// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.
 		// and it's easy to forget about it, leading to hard to debug issues.
 		params := GetProvisionerParams(opts...)
-		return HostRunFunction(ctx, env, params)
+		return Run(ctx, env, params)
 	}, params.extraConfigParams)
 
 	return provisioner

--- a/test/new-e2e/pkg/environments/aws/host/host.go
+++ b/test/new-e2e/pkg/environments/aws/host/host.go
@@ -147,7 +147,7 @@ func ProvisionerNoFakeIntake(opts ...ProvisionerOption) e2e.TypedProvisioner[env
 	return Provisioner(mergedOpts...)
 }
 
-// Run main provisioner work running here
+// Run deploys a environment given a pulumi.Context
 func Run(ctx *pulumi.Context, env *environments.Host, params *ProvisionerParams) error {
 	var awsEnv aws.Environment
 	var err error

--- a/test/new-e2e/pkg/environments/dockerhost.go
+++ b/test/new-e2e/pkg/environments/dockerhost.go
@@ -16,7 +16,7 @@ import (
 // DockerHost is an environment that contains a Docker VM, FakeIntake and Agent configured to talk to each other.
 type DockerHost struct {
 	// Components
-	Host       *components.RemoteHost
+	RemoteHost *components.RemoteHost
 	FakeIntake *components.FakeIntake
 	Agent      *components.DockerAgent
 
@@ -33,7 +33,7 @@ func (e *DockerHost) Init(ctx e2e.Context) error {
 		return err
 	}
 
-	e.Docker, err = client.NewDocker(ctx.T(), e.Host.HostOutput, privateKeyPath)
+	e.Docker, err = client.NewDocker(ctx.T(), e.RemoteHost.HostOutput, privateKeyPath)
 	if err != nil {
 		return err
 	}

--- a/test/new-e2e/pkg/environments/dockerhost.go
+++ b/test/new-e2e/pkg/environments/dockerhost.go
@@ -50,7 +50,3 @@ func (e *DockerHost) Init(ctx e2e.Context) error {
 
 	return nil
 }
-
-func (e *DockerHost) GetFakeIntake() *components.FakeIntake {
-	return e.FakeIntake
-}

--- a/test/new-e2e/pkg/environments/dockerhost.go
+++ b/test/new-e2e/pkg/environments/dockerhost.go
@@ -11,10 +11,12 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
 )
 
 // DockerHost is an environment that contains a Docker VM, FakeIntake and Agent configured to talk to each other.
 type DockerHost struct {
+	AwsEnvironment *aws.Environment
 	// Components
 	RemoteHost *components.RemoteHost
 	FakeIntake *components.FakeIntake

--- a/test/new-e2e/pkg/environments/dockerhost.go
+++ b/test/new-e2e/pkg/environments/dockerhost.go
@@ -50,3 +50,7 @@ func (e *DockerHost) Init(ctx e2e.Context) error {
 
 	return nil
 }
+
+func (e *DockerHost) GetFakeIntake() *components.FakeIntake {
+	return e.FakeIntake
+}

--- a/test/new-e2e/tests/apm/docker_test.go
+++ b/test/new-e2e/tests/apm/docker_test.go
@@ -70,7 +70,7 @@ func (s *DockerFakeintakeSuite) TestTracesHaveContainerTag() {
 	s.Require().NoError(err)
 
 	service := fmt.Sprintf("tracegen-container-tag-%s", s.transport)
-	defer runTracegenDocker(s.Env().Host, service, tracegenCfg{transport: s.transport})()
+	defer runTracegenDocker(s.Env().RemoteHost, service, tracegenCfg{transport: s.transport})()
 	s.EventuallyWithTf(func(c *assert.CollectT) {
 		testTracesHaveContainerTag(s.T(), c, service, s.Env().FakeIntake)
 	}, 2*time.Minute, 10*time.Second, "Failed finding traces with container tags")
@@ -81,7 +81,7 @@ func (s *DockerFakeintakeSuite) TestStatsForService() {
 	s.Require().NoError(err)
 
 	service := fmt.Sprintf("tracegen-stats-%s", s.transport)
-	defer runTracegenDocker(s.Env().Host, service, tracegenCfg{transport: s.transport})()
+	defer runTracegenDocker(s.Env().RemoteHost, service, tracegenCfg{transport: s.transport})()
 	s.EventuallyWithTf(func(c *assert.CollectT) {
 		testStatsForService(s.T(), c, service, s.Env().FakeIntake)
 	}, 2*time.Minute, 10*time.Second, "Failed finding stats")
@@ -95,7 +95,7 @@ func (s *DockerFakeintakeSuite) TestBasicTrace() {
 
 	// Run Trace Generator
 	s.T().Log("Starting Trace Generator.")
-	shutdown := runTracegenDocker(s.Env().Host, service, tracegenCfg{transport: s.transport})
+	shutdown := runTracegenDocker(s.Env().RemoteHost, service, tracegenCfg{transport: s.transport})
 	defer shutdown()
 
 	s.T().Log("Waiting for traces.")

--- a/test/new-e2e/tests/ndm/snmp/snmp_test.go
+++ b/test/new-e2e/tests/ndm/snmp/snmp_test.go
@@ -51,7 +51,7 @@ func snmpDockerProvisioner() e2e.Provisioner {
 		if err != nil {
 			return err
 		}
-		host.Export(ctx, &env.Host.HostOutput)
+		host.Export(ctx, &env.RemoteHost.HostOutput)
 
 		fakeIntake, err := fakeintake.NewECSFargateInstance(awsEnv, name)
 		if err != nil {

--- a/test/new-e2e/tests/npm/common_1host.go
+++ b/test/new-e2e/tests/npm/common_1host.go
@@ -1,0 +1,165 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package npm
+
+import (
+	"math"
+	"time"
+
+	agentmodel "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// testFakeIntakeNPM
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
+func test1HostFakeIntakeNPM[Env any](v *e2e.BaseSuite[Env], FakeIntake *components.FakeIntake) {
+	t := v.T()
+
+	targetHostnameNetID := ""
+	// looking for 1 host to send CollectorConnections payload to the fakeintake
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		hostnameNetID, err := FakeIntake.Client().GetConnectionsNames()
+		assert.NoError(c, err, "GetConnectionsNames() errors")
+		if !assert.NotEmpty(c, hostnameNetID, "no connections yet") {
+			return
+		}
+		targetHostnameNetID = hostnameNetID[0]
+
+		t.Logf("hostname+networkID %v seen connections", hostnameNetID)
+	}, 60*time.Second, time.Second, "no connections received")
+
+	// looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		cnx, err := FakeIntake.Client().GetConnections()
+		assert.NoError(t, err)
+
+		if !assert.Greater(c, len(cnx.GetPayloadsByName(targetHostnameNetID)), 2, "not enough payloads") {
+			return
+		}
+		var payloadsTimestamps []time.Time
+		for _, cc := range cnx.GetPayloadsByName(targetHostnameNetID) {
+			payloadsTimestamps = append(payloadsTimestamps, cc.GetCollectedTime())
+		}
+		dt := payloadsTimestamps[2].Sub(payloadsTimestamps[1]).Seconds()
+		t.Logf("hostname+networkID %v diff time %f seconds", targetHostnameNetID, dt)
+
+		// we want the test fail now, not retrying on the next payloads
+		assert.Greater(t, 0.5, math.Abs(dt-30), "delta between collection is higher than 500ms")
+	}, 90*time.Second, time.Second, "not enough connections received")
+}
+
+// test1HostFakeIntakeNPM600cnxBucket Validate the agent can communicate with the (fake) backend and send connections
+// every 30 seconds with a maximum of 600 connections per payloads, if more another payload will follow.
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for n payloads and check if the last 2 have a maximum span of 100ms
+func test1HostFakeIntakeNPM600cnxBucket[Env any](v *e2e.BaseSuite[Env], FakeIntake *components.FakeIntake) {
+	t := v.T()
+
+	targetHostnameNetID := ""
+	// looking for 1 host to send CollectorConnections payload to the fakeintake
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		hostnameNetID, err := FakeIntake.Client().GetConnectionsNames()
+		assert.NoError(c, err, "GetConnectionsNames() errors")
+		if !assert.NotEmpty(c, hostnameNetID, "no connections yet") {
+			return
+		}
+		targetHostnameNetID = hostnameNetID[0]
+
+		t.Logf("hostname+networkID %v seen connections", hostnameNetID)
+	}, 60*time.Second, time.Second, "no connections received")
+
+	// looking for x payloads (with max 600 connections) and check if the last 2 have a max span of 100ms
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		cnx, err := FakeIntake.Client().GetConnections()
+		assert.NoError(t, err)
+
+		if !assert.GreaterOrEqualf(c, len(cnx.GetPayloadsByName(targetHostnameNetID)), 2, "not enough payloads") {
+			return
+		}
+
+		cnx.ForeachHostnameConnections(func(cnx *aggregator.Connections, hostname string) {
+			assert.LessOrEqualf(t, len(cnx.Connections), 600, "too many payloads")
+		})
+
+		hostPayloads := cnx.GetPayloadsByName(targetHostnameNetID)
+		lenHostPayloads := len(hostPayloads)
+		if !assert.Equalf(c, len(hostPayloads[lenHostPayloads-2].Connections), 600, "can't found enough connections 600+") {
+			return
+		}
+
+		cnx600PayloadTime := hostPayloads[lenHostPayloads-2].GetCollectedTime()
+		latestPayloadTime := hostPayloads[lenHostPayloads-1].GetCollectedTime()
+
+		dt := latestPayloadTime.Sub(cnx600PayloadTime).Seconds()
+		t.Logf("hostname+networkID %v diff time %f seconds", targetHostnameNetID, dt)
+
+		assert.Greater(t, 0.1, dt, "delta between collection is higher than 100ms")
+	}, 90*time.Second, time.Second, "not enough connections received")
+}
+
+// test1HostFakeIntakeNPMTCPUDPDNS validate we received tcp, udp, and DNS connections
+// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
+func test1HostFakeIntakeNPMTCPUDPDNS[Env any](v *e2e.BaseSuite[Env], FakeIntake *components.FakeIntake) {
+	t := v.T()
+
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		cnx, err := FakeIntake.Client().GetConnections()
+		assert.NoError(c, err, "GetConnections() errors")
+		if !assert.NotEmpty(c, cnx.GetNames(), "no connections yet") {
+			return
+		}
+
+		foundDNS := false
+		cnx.ForeachConnection(func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
+			if len(c.DnsStatsByDomainOffsetByQueryType) > 0 {
+				foundDNS = true
+			}
+		})
+		if !assert.True(c, foundDNS, "DNS not found") {
+			return
+		}
+
+		type countCnx struct {
+			hit int
+			TCP int
+			UDP int
+		}
+		countConnections := make(map[string]*countCnx)
+
+		helperCleanup(t)
+		cnx.ForeachConnection(func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
+			var count *countCnx
+			var found bool
+			if count, found = countConnections[hostname]; !found {
+				countConnections[hostname] = &countCnx{}
+				count = countConnections[hostname]
+			}
+			count.hit++
+
+			switch c.Type {
+			case agentmodel.ConnectionType_tcp:
+				count.TCP++
+			case agentmodel.ConnectionType_udp:
+				count.UDP++
+			}
+			validateConnection(t, c, cc, hostname)
+		})
+
+		totalConnections := countCnx{}
+		for host, count := range countConnections {
+			t.Logf("connections %d tcp %d udp %d received by host/netID %s", count.hit, count.TCP, count.UDP, host)
+			totalConnections.hit += count.hit
+			totalConnections.TCP += count.TCP
+			totalConnections.UDP += count.UDP
+		}
+		t.Logf("sum connections %d tcp %d udp %d", totalConnections.hit, totalConnections.TCP, totalConnections.UDP)
+	}, 60*time.Second, time.Second)
+}

--- a/test/new-e2e/tests/npm/common_1host.go
+++ b/test/new-e2e/tests/npm/common_1host.go
@@ -22,6 +22,7 @@ import (
 //   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
 func test1HostFakeIntakeNPM[Env any](v *e2e.BaseSuite[Env], FakeIntake *components.FakeIntake) {
 	t := v.T()
+	t.Helper()
 
 	targetHostnameNetID := ""
 	// looking for 1 host to send CollectorConnections payload to the fakeintake
@@ -62,6 +63,7 @@ func test1HostFakeIntakeNPM[Env any](v *e2e.BaseSuite[Env], FakeIntake *componen
 //   - looking for n payloads and check if the last 2 have a maximum span of 100ms
 func test1HostFakeIntakeNPM600cnxBucket[Env any](v *e2e.BaseSuite[Env], FakeIntake *components.FakeIntake) {
 	t := v.T()
+	t.Helper()
 
 	targetHostnameNetID := ""
 	// looking for 1 host to send CollectorConnections payload to the fakeintake
@@ -109,6 +111,7 @@ func test1HostFakeIntakeNPM600cnxBucket[Env any](v *e2e.BaseSuite[Env], FakeInta
 // with some basic checks, like IPs/Ports present, DNS query has been captured, ...
 func test1HostFakeIntakeNPMTCPUDPDNS[Env any](v *e2e.BaseSuite[Env], FakeIntake *components.FakeIntake) {
 	t := v.T()
+	t.Helper()
 
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		cnx, err := FakeIntake.Client().GetConnections()

--- a/test/new-e2e/tests/npm/config.go
+++ b/test/new-e2e/tests/npm/config.go
@@ -8,9 +8,19 @@ package npm
 
 import (
 	_ "embed"
+
+	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 // systemProbeConfigNPM define the embedded minimal configuration for NPM
 //
 //go:embed config/npm.yaml
 var systemProbeConfigNPM string
+
+// systemProbeConfigNPMEnv equivalent of config/npm.yaml
+func systemProbeConfigNPMEnv() []dockeragentparams.Option {
+	return []dockeragentparams.Option{
+		dockeragentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_NETWORK_ENABLED", pulumi.StringPtr("true")),
+	}
+}

--- a/test/new-e2e/tests/npm/config/dockercompose_httpbin.yaml
+++ b/test/new-e2e/tests/npm/config/dockercompose_httpbin.yaml
@@ -4,8 +4,8 @@ services:
     pid: host
     privileged: true
     ports:
-    - 80:8080/tcp
-    image: mccutchen/go-httpbin
+    - 80:80/tcp
+    image: public.ecr.aws/r3m4q3r9/pub-mirror-httpbin
     container_name: httpbin
     volumes: []
     environment: {}

--- a/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
@@ -1,0 +1,220 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package npm
+
+import (
+	"math"
+	"os"
+	"testing"
+	"time"
+
+	agentmodel "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awsdocker "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/docker"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ec2VMContainerizedSuite struct {
+	e2e.BaseSuite[environments.DockerHost]
+}
+
+// TestEC2VMSuite will validate running the agent on a single EC2 VM
+func TestEC2VMContainerizedSuite(t *testing.T) {
+	s := &ec2VMContainerizedSuite{}
+	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(awsdocker.Provisioner(awsdocker.WithAgentOptions(
+		dockeragentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_NETWORK_ENABLED", pulumi.StringPtr("true")),
+	)))}
+
+	// debug helper
+	if _, devmode := os.LookupEnv("TESTS_E2E_DEVMODE"); devmode {
+		e2eParams = append(e2eParams, e2e.WithDevMode())
+	}
+
+	// Source of our kitchen CI images test/kitchen/platforms.json
+	// Other VM image can be used, our kitchen CI images test/kitchen/platforms.json
+	// ec2params.WithImageName("ami-a4dc46db", os.AMD64Arch, ec2os.AmazonLinuxOS) // ubuntu-16-04-4.4
+	e2e.Run(t, s, e2eParams...)
+}
+
+// SetupSuite
+func (v *ec2VMContainerizedSuite) SetupSuite() {
+	v.BaseSuite.SetupSuite()
+
+	v.Env().RemoteHost.MustExecute("sudo apt install -y apache2-utils")
+}
+
+// BeforeTest will be called before each test
+func (v *ec2VMContainerizedSuite) BeforeTest(suiteName, testName string) {
+	v.BaseSuite.BeforeTest(suiteName, testName)
+	// default is to reset the current state of the fakeintake aggregators
+	if !v.BaseSuite.IsDevMode() {
+		v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	}
+}
+
+// TestFakeIntakeNPM Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
+func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM() {
+	t := v.T()
+
+	targetHostnameNetID := ""
+	// looking for 1 host to send CollectorConnections payload to the fakeintake
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		// generate a connection
+		v.Env().RemoteHost.MustExecute("curl http://www.datadoghq.com")
+
+		hostnameNetID, err := v.Env().FakeIntake.Client().GetConnectionsNames()
+		assert.NoError(c, err, "GetConnectionsNames() errors")
+		if !assert.NotEmpty(c, hostnameNetID, "no connections yet") {
+			return
+		}
+		targetHostnameNetID = hostnameNetID[0]
+
+		t.Logf("hostname+networkID %v seen connections", hostnameNetID)
+	}, 60*time.Second, time.Second, "no connections received")
+
+	// looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		cnx, err := v.Env().FakeIntake.Client().GetConnections()
+		assert.NoError(t, err)
+
+		if !assert.Greater(c, len(cnx.GetPayloadsByName(targetHostnameNetID)), 2, "not enough payloads") {
+			return
+		}
+		var payloadsTimestamps []time.Time
+		for _, cc := range cnx.GetPayloadsByName(targetHostnameNetID) {
+			payloadsTimestamps = append(payloadsTimestamps, cc.GetCollectedTime())
+		}
+		dt := payloadsTimestamps[2].Sub(payloadsTimestamps[1]).Seconds()
+		t.Logf("hostname+networkID %v diff time %f seconds", targetHostnameNetID, dt)
+
+		// we want the test fail now, not retrying on the next payloads
+		assert.Greater(t, 0.5, math.Abs(dt-30), "delta between collection is higher than 500ms")
+	}, 90*time.Second, time.Second, "not enough connections received")
+}
+
+// TestFakeIntakeNPM_600cnx_bucket Validate the agent can communicate with the (fake) backend and send connections
+// every 30 seconds with a maximum of 600 connections per payloads, if more another payload will follow.
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for n payloads and check if the last 2 have a maximum span of 100ms
+func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_600cnx_bucket() {
+	t := v.T()
+
+	// generate connections
+	v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 http://www.datadoghq.com/")
+
+	targetHostnameNetID := ""
+	// looking for 1 host to send CollectorConnections payload to the fakeintake
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		hostnameNetID, err := v.Env().FakeIntake.Client().GetConnectionsNames()
+		assert.NoError(c, err, "GetConnectionsNames() errors")
+		if !assert.NotEmpty(c, hostnameNetID, "no connections yet") {
+			return
+		}
+		targetHostnameNetID = hostnameNetID[0]
+
+		t.Logf("hostname+networkID %v seen connections", hostnameNetID)
+	}, 60*time.Second, time.Second, "no connections received")
+
+	// looking for x payloads (with max 600 connections) and check if the last 2 have a max span of 100ms
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		cnx, err := v.Env().FakeIntake.Client().GetConnections()
+		assert.NoError(t, err)
+
+		if !assert.Greater(c, len(cnx.GetPayloadsByName(targetHostnameNetID)), 2, "not enough payloads") {
+			return
+		}
+
+		/*
+			cnx.ForeachHostnameConnections(func(cnx *aggregator.Connections, hostname string) {
+				assert.LessOrEqualf(t, len(cnx.Connections), 600, "too many payloads")
+			})
+		*/
+
+		hostPayloads := cnx.GetPayloadsByName(targetHostnameNetID)
+		lenHostPayloads := len(hostPayloads)
+		if !assert.Equalf(c, len(hostPayloads[lenHostPayloads-2].Connections), 600, "can't found enough connections 600+") {
+			return
+		}
+
+		cnx600PayloadTime := hostPayloads[lenHostPayloads-2].GetCollectedTime()
+		latestPayloadTime := hostPayloads[lenHostPayloads-1].GetCollectedTime()
+
+		dt := latestPayloadTime.Sub(cnx600PayloadTime).Seconds()
+		t.Logf("hostname+networkID %v diff time %f seconds", targetHostnameNetID, dt)
+
+		assert.Greater(t, 0.1, dt, "delta between collection is higher than 100ms")
+	}, 90*time.Second, time.Second, "not enough connections received")
+}
+
+// TestFakeIntakeNPM_TCP_UDP_DNS validate we received tcp, udp, and DNS connections
+// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
+func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
+	t := v.T()
+
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		// generate connections
+		v.Env().RemoteHost.MustExecute("curl http://www.datadoghq.com")
+		v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
+
+		cnx, err := v.Env().FakeIntake.Client().GetConnections()
+		assert.NoError(c, err, "GetConnections() errors")
+		if !assert.NotEmpty(c, cnx.GetNames(), "no connections yet") {
+			return
+		}
+
+		foundDNS := false
+		cnx.ForeachConnection(func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
+			if len(c.DnsStatsByDomainOffsetByQueryType) > 0 {
+				foundDNS = true
+			}
+		})
+		if !assert.True(c, foundDNS, "DNS not found") {
+			return
+		}
+
+		type countCnx struct {
+			hit int
+			TCP int
+			UDP int
+		}
+		countConnections := make(map[string]*countCnx)
+
+		helperCleanup(t)
+		cnx.ForeachConnection(func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
+			var count *countCnx
+			var found bool
+			if count, found = countConnections[hostname]; !found {
+				countConnections[hostname] = &countCnx{}
+				count = countConnections[hostname]
+			}
+			count.hit++
+
+			switch c.Type {
+			case agentmodel.ConnectionType_tcp:
+				count.TCP++
+			case agentmodel.ConnectionType_udp:
+				count.UDP++
+			}
+			validateConnection(t, c, cc, hostname)
+		})
+
+		totalConnections := countCnx{}
+		for host, count := range countConnections {
+			t.Logf("connections %d tcp %d udp %d received by host/netID %s", count.hit, count.TCP, count.UDP, host)
+			totalConnections.hit += count.hit
+			totalConnections.TCP += count.TCP
+			totalConnections.UDP += count.UDP
+		}
+		t.Logf("sum connections %d tcp %d udp %d", totalConnections.hit, totalConnections.TCP, totalConnections.UDP)
+	}, 60*time.Second, time.Second)
+}

--- a/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
@@ -64,7 +64,7 @@ func dockerHTTPBinCompose() docker.ComposeInlineManifest {
 	}
 }
 
-func dockerHostNginxEnvProvisioner() e2e.PulumiEnvRunFunc[dockerHostNginxEnv] {
+func dockerHostHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[dockerHostNginxEnv] {
 	return func(ctx *pulumi.Context, env *dockerHostNginxEnv) error {
 		awsEnv, err := aws.NewEnvironment(ctx)
 		if err != nil {
@@ -82,7 +82,7 @@ func dockerHostNginxEnvProvisioner() e2e.PulumiEnvRunFunc[dockerHostNginxEnv] {
 		}
 		awsdocker.DockerRunFunction(ctx, &env.DockerHost, params)
 
-		vmName := "nginxvm"
+		vmName := "httpbinvm"
 
 		nginxHost, err := ec2.NewVM(awsEnv, vmName)
 		if err != nil {
@@ -113,7 +113,7 @@ func dockerHostNginxEnvProvisioner() e2e.PulumiEnvRunFunc[dockerHostNginxEnv] {
 func TestEC2VMContainerizedSuite(t *testing.T) {
 	s := &ec2VMContainerizedSuite{}
 
-	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(e2e.NewTypedPulumiProvisioner("dockerHostNginx", dockerHostNginxEnvProvisioner(), nil))}
+	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(e2e.NewTypedPulumiProvisioner("dockerHostHttpbin", dockerHostHttpbinEnvProvisioner(), nil))}
 
 	// debug helper
 	if _, devmode := os.LookupEnv("TESTS_E2E_DEVMODE"); devmode {

--- a/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
@@ -6,60 +6,28 @@
 package npm
 
 import (
-	"math"
-	"os"
 	"testing"
-	"time"
 
-	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awsdocker "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/docker"
 
-	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
 	"github.com/DataDog/test-infra-definitions/components/docker"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
-
-	"github.com/stretchr/testify/assert"
 )
 
 type dockerHostNginxEnv struct {
 	environments.DockerHost
 	// Extra Components
-	HttpBinHost *components.RemoteHost
+	HTTPBinHost *components.RemoteHost
 }
 
 type ec2VMContainerizedSuite struct {
 	e2e.BaseSuite[dockerHostNginxEnv]
-}
-
-func dockerHTTPBinCompose() docker.ComposeInlineManifest {
-	httpbinManifestContent := pulumi.All().ApplyT(func(args []interface{}) (string, error) {
-		agentManifest := docker.ComposeManifest{
-			Version: "3.9",
-			Services: map[string]docker.ComposeManifestService{
-				"httpbin": {
-					Privileged:    true,
-					Image:         "mccutchen/go-httpbin",
-					ContainerName: "httpbin",
-					Pid:           "host",
-					Ports:         []string{"80:8080/tcp"},
-				},
-			},
-		}
-		data, err := yaml.Marshal(agentManifest)
-		return string(data), err
-	}).(pulumi.StringOutput)
-
-	return docker.ComposeInlineManifest{
-		Name:    "httpbin",
-		Content: httpbinManifestContent,
-	}
 }
 
 func dockerHostHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[dockerHostNginxEnv] {
@@ -71,10 +39,10 @@ func dockerHostHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[dockerHostNginxEnv] 
 		env.DockerHost.AwsEnvironment = &awsEnv
 
 		opts := []awsdocker.ProvisionerOption{
-			awsdocker.WithAgentOptions(dockeragentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_NETWORK_ENABLED", pulumi.StringPtr("true"))),
+			awsdocker.WithAgentOptions(systemProbeConfigNPMEnv()...),
 		}
 		params := awsdocker.GetProvisionerParams(opts...)
-		awsdocker.DockerRunFunction(ctx, &env.DockerHost, params)
+		awsdocker.Run(ctx, &env.DockerHost, params)
 
 		vmName := "httpbinvm"
 
@@ -82,7 +50,7 @@ func dockerHostHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[dockerHostNginxEnv] 
 		if err != nil {
 			return err
 		}
-		err = nginxHost.Export(ctx, &env.HttpBinHost.HostOutput)
+		err = nginxHost.Export(ctx, &env.HTTPBinHost.HostOutput)
 		if err != nil {
 			return err
 		}
@@ -94,7 +62,7 @@ func dockerHostHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[dockerHostNginxEnv] 
 		}
 
 		composeContents := []docker.ComposeInlineManifest{dockerHTTPBinCompose()}
-		_, err = manager.ComposeStrUp("agent", composeContents, pulumi.StringMap{})
+		_, err = manager.ComposeStrUp("httpbin", composeContents, pulumi.StringMap{})
 		if err != nil {
 			return err
 		}
@@ -108,11 +76,6 @@ func TestEC2VMContainerizedSuite(t *testing.T) {
 	s := &ec2VMContainerizedSuite{}
 
 	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(e2e.NewTypedPulumiProvisioner("dockerHostHttpbin", dockerHostHttpbinEnvProvisioner(), nil))}
-
-	// debug helper
-	if _, devmode := os.LookupEnv("TESTS_E2E_DEVMODE"); devmode {
-		e2eParams = append(e2eParams, e2e.WithDevMode())
-	}
 
 	// Source of our kitchen CI images test/kitchen/platforms.json
 	// Other VM image can be used, our kitchen CI images test/kitchen/platforms.json
@@ -145,121 +108,31 @@ func (v *ec2VMContainerizedSuite) beforeTest(suiteName, testName string) {
 	}
 }
 
-// testFakeIntakeNPM
-//   - looking for 1 host to send CollectorConnections payload to the fakeintake
-//   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
-func (v *ec2VMContainerizedSuite) testFakeIntakeNPM() {
-	t := v.T()
-
-	targetHostnameNetID := ""
-	// looking for 1 host to send CollectorConnections payload to the fakeintake
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		hostnameNetID, err := v.Env().FakeIntake.Client().GetConnectionsNames()
-		assert.NoError(c, err, "GetConnectionsNames() errors")
-		if !assert.NotEmpty(c, hostnameNetID, "no connections yet") {
-			return
-		}
-		targetHostnameNetID = hostnameNetID[0]
-
-		t.Logf("hostname+networkID %v seen connections", hostnameNetID)
-	}, 60*time.Second, time.Second, "no connections received")
-
-	// looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		cnx, err := v.Env().FakeIntake.Client().GetConnections()
-		assert.NoError(t, err)
-
-		if !assert.Greater(c, len(cnx.GetPayloadsByName(targetHostnameNetID)), 2, "not enough payloads") {
-			return
-		}
-		var payloadsTimestamps []time.Time
-		for _, cc := range cnx.GetPayloadsByName(targetHostnameNetID) {
-			payloadsTimestamps = append(payloadsTimestamps, cc.GetCollectedTime())
-		}
-		dt := payloadsTimestamps[2].Sub(payloadsTimestamps[1]).Seconds()
-		t.Logf("hostname+networkID %v diff time %f seconds", targetHostnameNetID, dt)
-
-		// we want the test fail now, not retrying on the next payloads
-		assert.Greater(t, 0.5, math.Abs(dt-30), "delta between collection is higher than 500ms")
-	}, 90*time.Second, time.Second, "not enough connections received")
-}
-
 // TestFakeIntakeNPM Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
 // 2 tests generate the request on the host and on docker
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
 func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM() {
 	vt := v.T()
-	testURL := "http://" + v.Env().HttpBinHost.Address + "/"
-	vt.Run("host", func(t *testing.T) {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+	vt.Run("host_requests", func(t *testing.T) {
 		v.BaseSuite.SetT(t)
 		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
 		// generate a connection
 		v.Env().RemoteHost.MustExecute("curl " + testURL)
 
-		v.testFakeIntakeNPM()
+		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
 	})
-	vt.Run("docker", func(t *testing.T) {
+	vt.Run("docker_requests", func(t *testing.T) {
 		v.BaseSuite.SetT(t)
 		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
 		// generate a connection
 		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
 
-		v.testFakeIntakeNPM()
+		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
 	})
-}
-
-// TestFakeIntakeNPM_600cnx_bucket Validate the agent can communicate with the (fake) backend and send connections
-// every 30 seconds with a maximum of 600 connections per payloads, if more another payload will follow.
-//   - looking for 1 host to send CollectorConnections payload to the fakeintake
-//   - looking for n payloads and check if the last 2 have a maximum span of 100ms
-func (v *ec2VMContainerizedSuite) testFakeIntakeNPM_600cnx_bucket() {
-	t := v.T()
-
-	targetHostnameNetID := ""
-	// looking for 1 host to send CollectorConnections payload to the fakeintake
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		hostnameNetID, err := v.Env().FakeIntake.Client().GetConnectionsNames()
-		assert.NoError(c, err, "GetConnectionsNames() errors")
-		if !assert.NotEmpty(c, hostnameNetID, "no connections yet") {
-			return
-		}
-		targetHostnameNetID = hostnameNetID[0]
-
-		t.Logf("hostname+networkID %v seen connections", hostnameNetID)
-	}, 60*time.Second, time.Second, "no connections received")
-
-	// looking for x payloads (with max 600 connections) and check if the last 2 have a max span of 100ms
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		cnx, err := v.Env().FakeIntake.Client().GetConnections()
-		assert.NoError(t, err)
-
-		if !assert.Greater(c, len(cnx.GetPayloadsByName(targetHostnameNetID)), 2, "not enough payloads") {
-			return
-		}
-
-		/*
-			cnx.ForeachHostnameConnections(func(cnx *aggregator.Connections, hostname string) {
-				assert.LessOrEqualf(t, len(cnx.Connections), 600, "too many payloads")
-			})
-		*/
-
-		hostPayloads := cnx.GetPayloadsByName(targetHostnameNetID)
-		lenHostPayloads := len(hostPayloads)
-		if !assert.Equalf(c, len(hostPayloads[lenHostPayloads-2].Connections), 600, "can't found enough connections 600+") {
-			return
-		}
-
-		cnx600PayloadTime := hostPayloads[lenHostPayloads-2].GetCollectedTime()
-		latestPayloadTime := hostPayloads[lenHostPayloads-1].GetCollectedTime()
-
-		dt := latestPayloadTime.Sub(cnx600PayloadTime).Seconds()
-		t.Logf("hostname+networkID %v diff time %f seconds", targetHostnameNetID, dt)
-
-		assert.Greater(t, 0.1, dt, "delta between collection is higher than 100ms")
-	}, 90*time.Second, time.Second, "not enough connections received")
 }
 
 // TestFakeIntakeNPM_600cnx_bucket Validate the agent can communicate with the (fake) backend and send connections
@@ -268,93 +141,33 @@ func (v *ec2VMContainerizedSuite) testFakeIntakeNPM_600cnx_bucket() {
 //   - looking for n payloads and check if the last 2 have a maximum span of 100ms
 func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_600cnx_bucket() {
 	vt := v.T()
-	testURL := "http://" + v.Env().HttpBinHost.Address + "/"
-	vt.Run("host", func(t *testing.T) {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+	vt.Run("host_requests", func(t *testing.T) {
 		v.BaseSuite.SetT(t)
 		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
 		// generate connections
 		v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
 
-		v.testFakeIntakeNPM_600cnx_bucket()
+		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 	})
-	vt.Run("docker", func(t *testing.T) {
+	vt.Run("docker_requests", func(t *testing.T) {
 		v.BaseSuite.SetT(t)
 		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
 		// generate connections
 		v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -n 600 -c 600 " + testURL)
 
-		v.testFakeIntakeNPM_600cnx_bucket()
+		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 	})
-}
-
-// TestFakeIntakeNPM_TCP_UDP_DNS validate we received tcp, udp, and DNS connections
-// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
-func (v *ec2VMContainerizedSuite) testFakeIntakeNPM_TCP_UDP_DNS() {
-	t := v.T()
-
-	v.EventuallyWithT(func(c *assert.CollectT) {
-
-		cnx, err := v.Env().FakeIntake.Client().GetConnections()
-		assert.NoError(c, err, "GetConnections() errors")
-		if !assert.NotEmpty(c, cnx.GetNames(), "no connections yet") {
-			return
-		}
-
-		foundDNS := false
-		cnx.ForeachConnection(func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
-			if len(c.DnsStatsByDomainOffsetByQueryType) > 0 {
-				foundDNS = true
-			}
-		})
-		if !assert.True(c, foundDNS, "DNS not found") {
-			return
-		}
-
-		type countCnx struct {
-			hit int
-			TCP int
-			UDP int
-		}
-		countConnections := make(map[string]*countCnx)
-
-		helperCleanup(t)
-		cnx.ForeachConnection(func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
-			var count *countCnx
-			var found bool
-			if count, found = countConnections[hostname]; !found {
-				countConnections[hostname] = &countCnx{}
-				count = countConnections[hostname]
-			}
-			count.hit++
-
-			switch c.Type {
-			case agentmodel.ConnectionType_tcp:
-				count.TCP++
-			case agentmodel.ConnectionType_udp:
-				count.UDP++
-			}
-			validateConnection(t, c, cc, hostname)
-		})
-
-		totalConnections := countCnx{}
-		for host, count := range countConnections {
-			t.Logf("connections %d tcp %d udp %d received by host/netID %s", count.hit, count.TCP, count.UDP, host)
-			totalConnections.hit += count.hit
-			totalConnections.TCP += count.TCP
-			totalConnections.UDP += count.UDP
-		}
-		t.Logf("sum connections %d tcp %d udp %d", totalConnections.hit, totalConnections.TCP, totalConnections.UDP)
-	}, 60*time.Second, time.Second)
 }
 
 // TestFakeIntakeNPM_TCP_UDP_DNS validate we received tcp, udp, and DNS connections
 // with some basic checks, like IPs/Ports present, DNS query has been captured, ...
 func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
 	vt := v.T()
-	testURL := "http://" + v.Env().HttpBinHost.Address + "/"
-	vt.Run("host", func(t *testing.T) {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+	vt.Run("host_requests", func(t *testing.T) {
 		v.BaseSuite.SetT(t)
 		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
@@ -362,9 +175,9 @@ func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
 		v.Env().RemoteHost.MustExecute("curl " + testURL)
 		v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
 
-		v.testFakeIntakeNPM_TCP_UDP_DNS()
+		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
 	})
-	vt.Run("docker", func(t *testing.T) {
+	vt.Run("docker_requests", func(t *testing.T) {
 		v.BaseSuite.SetT(t)
 		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
@@ -372,6 +185,6 @@ func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
 		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
 		v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig @8.8.8.8 www.google.ch")
 
-		v.testFakeIntakeNPM_TCP_UDP_DNS()
+		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
 	})
 }

--- a/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
@@ -6,7 +6,6 @@
 package npm
 
 import (
-	"fmt"
 	"math"
 	"os"
 	"testing"
@@ -20,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awsdocker "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/docker"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/optional"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
 	"github.com/DataDog/test-infra-definitions/components/docker"
@@ -75,11 +73,7 @@ func dockerHostHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[dockerHostNginxEnv] 
 		opts := []awsdocker.ProvisionerOption{
 			awsdocker.WithAgentOptions(dockeragentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_NETWORK_ENABLED", pulumi.StringPtr("true"))),
 		}
-		params := awsdocker.NewProvisionerParams()
-		err = optional.ApplyOptions(params, opts)
-		if err != nil {
-			panic(fmt.Errorf("unable to apply ProvisionerOption, err: %w", err))
-		}
+		params := awsdocker.GetProvisionerParams(opts...)
 		awsdocker.DockerRunFunction(ctx, &env.DockerHost, params)
 
 		vmName := "httpbinvm"

--- a/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
@@ -101,7 +101,7 @@ func (v *ec2VMContainerizedSuite) BeforeTest(suiteName, testName string) {
 	v.beforeTest(suiteName, testName)
 }
 
-func (v *ec2VMContainerizedSuite) beforeTest(suiteName, testName string) {
+func (v *ec2VMContainerizedSuite) beforeTest(_, _ string) {
 	// default is to reset the current state of the fakeintake aggregators
 	if !v.BaseSuite.IsDevMode() {
 		v.Env().FakeIntake.Client().FlushServerAndResetAggregators()

--- a/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
@@ -98,93 +98,85 @@ func (v *ec2VMContainerizedSuite) SetupSuite() {
 // BeforeTest will be called before each test
 func (v *ec2VMContainerizedSuite) BeforeTest(suiteName, testName string) {
 	v.BaseSuite.BeforeTest(suiteName, testName)
-	v.beforeTest(suiteName, testName)
-}
 
-func (v *ec2VMContainerizedSuite) beforeTest(_, _ string) {
 	// default is to reset the current state of the fakeintake aggregators
 	if !v.BaseSuite.IsDevMode() {
 		v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 	}
 }
 
-// TestFakeIntakeNPM Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
+// TestFakeIntakeNPMHostRequests Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
 // 2 tests generate the request on the host and on docker
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
-func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM() {
-	vt := v.T()
+func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
-	vt.Run("host_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		// generate a connection
-		v.Env().RemoteHost.MustExecute("curl " + testURL)
+	// generate a connection
+	v.Env().RemoteHost.MustExecute("curl " + testURL)
 
-		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
-	})
-	vt.Run("docker_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
-
-		// generate a connection
-		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
-
-		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
-	})
+	test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
 }
 
-// TestFakeIntakeNPM_600cnx_bucket Validate the agent can communicate with the (fake) backend and send connections
+// TestFakeIntakeNPMDockerRequests Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
+// 2 tests generate the request on the host and on docker
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
+func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_DockerRequests() {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+
+	// generate a connection
+	v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
+
+	test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
+}
+
+// TestFakeIntakeNPM600cnxBucket_HostRequests Validate the agent can communicate with the (fake) backend and send connections
 // every 30 seconds with a maximum of 600 connections per payloads, if more another payload will follow.
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for n payloads and check if the last 2 have a maximum span of 100ms
-func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_600cnx_bucket() {
-	vt := v.T()
+func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM600cnxBucket_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
-	vt.Run("host_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		// generate connections
-		v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
+	// generate connections
+	v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
 
-		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
-	})
-	vt.Run("docker_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
-
-		// generate connections
-		v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -n 600 -c 600 " + testURL)
-
-		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
-	})
+	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 }
 
-// TestFakeIntakeNPM_TCP_UDP_DNS validate we received tcp, udp, and DNS connections
-// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
-func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
-	vt := v.T()
+// TestFakeIntakeNPM600cnxBucket_DockerRequests Validate the agent can communicate with the (fake) backend and send connections
+// every 30 seconds with a maximum of 600 connections per payloads, if more another payload will follow.
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for n payloads and check if the last 2 have a maximum span of 100ms
+func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM600cnxBucket_DockerRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
-	vt.Run("host_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		// generate connections
-		v.Env().RemoteHost.MustExecute("curl " + testURL)
-		v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
+	// generate connections
+	v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -n 600 -c 600 " + testURL)
 
-		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
-	})
-	vt.Run("docker_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMContainerizedSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
+	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
+}
 
-		// generate connections
-		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
-		v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig @8.8.8.8 www.google.ch")
+// TestFakeIntakeNPM_TCP_UDP_DNS_HostRequests validate we received tcp, udp, and DNS connections
+// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
+func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_TCP_UDP_DNS_HostRequests() {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
-		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
-	})
+	// generate connections
+	v.Env().RemoteHost.MustExecute("curl " + testURL)
+	v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
+
+	test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
+}
+
+// TestFakeIntakeNPM_TCP_UDP_DNS_DockerRequests validate we received tcp, udp, and DNS connections
+// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
+func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_TCP_UDP_DNS_DockerRequests() {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+
+	// generate connections
+	v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
+	v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig @8.8.8.8 www.google.ch")
+
+	test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
 }

--- a/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
@@ -90,9 +90,9 @@ func (v *ec2VMContainerizedSuite) SetupSuite() {
 	v.Env().RemoteHost.MustExecute("sudo apt install -y apache2-utils")
 
 	// prefetch docker image locally
-	v.Env().RemoteHost.MustExecute("docker run curlimages/curl --version")
-	v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -V")
-	v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig")
+	v.Env().RemoteHost.MustExecute("docker pull public.ecr.aws/k8m1l3p1/alpine/curler:latest")
+	v.Env().RemoteHost.MustExecute("docker pull public.ecr.aws/docker/library/httpd:latest")
+	v.Env().RemoteHost.MustExecute("docker pull public.ecr.aws/patrickc/troubleshoot-util:latest")
 }
 
 // BeforeTest will be called before each test
@@ -126,7 +126,7 @@ func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_DockerRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate a connection
-	v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/k8m1l3p1/alpine/curler curl " + testURL)
 
 	test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
 }
@@ -152,7 +152,7 @@ func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM600cnxBucket_DockerRequests()
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
-	v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -n 600 -c 600 " + testURL)
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/docker/library/httpd ab -n 600 -c 600 " + testURL)
 
 	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 }
@@ -175,8 +175,8 @@ func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_TCP_UDP_DNS_DockerRequests()
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
-	v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
-	v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig @8.8.8.8 www.google.ch")
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/k8m1l3p1/alpine/curler curl " + testURL)
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/patrickc/troubleshoot-util dig @8.8.8.8 www.google.ch")
 
 	test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
 }

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -95,7 +95,7 @@ func (v *ec2VMSuite) BeforeTest(suiteName, testName string) {
 	v.beforeTest(suiteName, testName)
 }
 
-func (v *ec2VMSuite) beforeTest(suiteName, testName string) {
+func (v *ec2VMSuite) beforeTest(_, _ string) {
 	// default is to reset the current state of the fakeintake aggregators
 	if !v.BaseSuite.IsDevMode() {
 		v.Env().FakeIntake.Client().FlushServerAndResetAggregators()

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -6,15 +6,10 @@
 package npm
 
 import (
-	"math"
-	"os"
 	"testing"
-	"time"
 
-	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
-	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
@@ -24,8 +19,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/docker"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
-
-	"github.com/stretchr/testify/assert"
 )
 
 type hostHttpbinEnv struct {
@@ -49,7 +42,7 @@ func hostDockerHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[hostHttpbinEnv] {
 			awshost.WithAgentOptions(agentparams.WithSystemProbeConfig(systemProbeConfigNPM)),
 		}
 		params := awshost.GetProvisionerParams(opts...)
-		awshost.HostRunFunction(ctx, &env.Host, params)
+		awshost.Run(ctx, &env.Host, params)
 
 		vmName := "httpbinvm"
 
@@ -83,10 +76,6 @@ func TestEC2VMSuite(t *testing.T) {
 	s := &ec2VMSuite{}
 
 	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(e2e.NewTypedPulumiProvisioner("hostHttpbin", hostDockerHttpbinEnvProvisioner(), nil))}
-	// debug helper
-	if _, devmode := os.LookupEnv("TESTS_E2E_DEVMODE"); devmode {
-		e2eParams = append(e2eParams, e2e.WithDevMode())
-	}
 
 	// Source of our kitchen CI images test/kitchen/platforms.json
 	// Other VM image can be used, our kitchen CI images test/kitchen/platforms.json
@@ -98,11 +87,16 @@ func (v *ec2VMSuite) SetupSuite() {
 	v.BaseSuite.SetupSuite()
 
 	v.Env().RemoteHost.MustExecute("sudo apt install -y apache2-utils")
+	v.Env().RemoteHost.MustExecute("sudo snap install docker")
 }
 
 // BeforeTest will be called before each test
 func (v *ec2VMSuite) BeforeTest(suiteName, testName string) {
 	v.BaseSuite.BeforeTest(suiteName, testName)
+	v.beforeTest(suiteName, testName)
+}
+
+func (v *ec2VMSuite) beforeTest(suiteName, testName string) {
 	// default is to reset the current state of the fakeintake aggregators
 	if !v.BaseSuite.IsDevMode() {
 		v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
@@ -110,47 +104,30 @@ func (v *ec2VMSuite) BeforeTest(suiteName, testName string) {
 }
 
 // TestFakeIntakeNPM Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
+// 2 tests generate the request on the host and on docker
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
 func (v *ec2VMSuite) TestFakeIntakeNPM() {
-	t := v.T()
+	vt := v.T()
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+	vt.Run("host_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-	// generate a connection
-	v.Env().RemoteHost.MustExecute("curl " + testURL)
+		// generate a connection
+		v.Env().RemoteHost.MustExecute("curl " + testURL)
 
-	targetHostnameNetID := ""
-	// looking for 1 host to send CollectorConnections payload to the fakeintake
-	v.EventuallyWithT(func(c *assert.CollectT) {
+		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
+	})
+	vt.Run("docker_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		hostnameNetID, err := v.Env().FakeIntake.Client().GetConnectionsNames()
-		assert.NoError(c, err, "GetConnectionsNames() errors")
-		if !assert.NotEmpty(c, hostnameNetID, "no connections yet") {
-			return
-		}
-		targetHostnameNetID = hostnameNetID[0]
+		// generate a connection
+		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
 
-		t.Logf("hostname+networkID %v seen connections", hostnameNetID)
-	}, 60*time.Second, time.Second, "no connections received")
-
-	// looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		cnx, err := v.Env().FakeIntake.Client().GetConnections()
-		assert.NoError(t, err)
-
-		if !assert.Greater(c, len(cnx.GetPayloadsByName(targetHostnameNetID)), 2, "not enough payloads") {
-			return
-		}
-		var payloadsTimestamps []time.Time
-		for _, cc := range cnx.GetPayloadsByName(targetHostnameNetID) {
-			payloadsTimestamps = append(payloadsTimestamps, cc.GetCollectedTime())
-		}
-		dt := payloadsTimestamps[2].Sub(payloadsTimestamps[1]).Seconds()
-		t.Logf("hostname+networkID %v diff time %f seconds", targetHostnameNetID, dt)
-
-		// we want the test fail now, not retrying on the next payloads
-		assert.Greater(t, 0.5, math.Abs(dt-30), "delta between collection is higher than 500ms")
-	}, 90*time.Second, time.Second, "not enough connections received")
+		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
+	})
 }
 
 // TestFakeIntakeNPM_600cnx_bucket Validate the agent can communicate with the (fake) backend and send connections
@@ -158,115 +135,51 @@ func (v *ec2VMSuite) TestFakeIntakeNPM() {
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for n payloads and check if the last 2 have a maximum span of 100ms
 func (v *ec2VMSuite) TestFakeIntakeNPM_600cnx_bucket() {
-	t := v.T()
+	vt := v.T()
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+	vt.Run("host_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-	// generate connections
-	v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
+		// generate connections
+		v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
 
-	targetHostnameNetID := ""
-	// looking for 1 host to send CollectorConnections payload to the fakeintake
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		hostnameNetID, err := v.Env().FakeIntake.Client().GetConnectionsNames()
-		assert.NoError(c, err, "GetConnectionsNames() errors")
-		if !assert.NotEmpty(c, hostnameNetID, "no connections yet") {
-			return
-		}
-		targetHostnameNetID = hostnameNetID[0]
+		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
+	})
+	vt.Run("docker_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		t.Logf("hostname+networkID %v seen connections", hostnameNetID)
-	}, 60*time.Second, time.Second, "no connections received")
+		// generate connections
+		v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -n 600 -c 600 " + testURL)
 
-	// looking for x payloads (with max 600 connections) and check if the last 2 have a max span of 100ms
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		cnx, err := v.Env().FakeIntake.Client().GetConnections()
-		assert.NoError(t, err)
-
-		if !assert.GreaterOrEqualf(c, len(cnx.GetPayloadsByName(targetHostnameNetID)), 2, "not enough payloads") {
-			return
-		}
-
-		cnx.ForeachHostnameConnections(func(cnx *aggregator.Connections, hostname string) {
-			assert.LessOrEqualf(t, len(cnx.Connections), 600, "too many payloads")
-		})
-
-		hostPayloads := cnx.GetPayloadsByName(targetHostnameNetID)
-		lenHostPayloads := len(hostPayloads)
-		if !assert.Equalf(c, len(hostPayloads[lenHostPayloads-2].Connections), 600, "can't found enough connections 600+") {
-			return
-		}
-
-		cnx600PayloadTime := hostPayloads[lenHostPayloads-2].GetCollectedTime()
-		latestPayloadTime := hostPayloads[lenHostPayloads-1].GetCollectedTime()
-
-		dt := latestPayloadTime.Sub(cnx600PayloadTime).Seconds()
-		t.Logf("hostname+networkID %v diff time %f seconds", targetHostnameNetID, dt)
-
-		assert.Greater(t, 0.1, dt, "delta between collection is higher than 100ms")
-	}, 90*time.Second, time.Second, "not enough connections received")
+		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
+	})
 }
 
 // TestFakeIntakeNPM_TCP_UDP_DNS validate we received tcp, udp, and DNS connections
 // with some basic checks, like IPs/Ports present, DNS query has been captured, ...
 func (v *ec2VMSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
-	t := v.T()
+	vt := v.T()
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+	vt.Run("host_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-	// generate connections
-	v.Env().RemoteHost.MustExecute("curl " + testURL)
-	v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
+		// generate connections
+		v.Env().RemoteHost.MustExecute("curl " + testURL)
+		v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
 
-	v.EventuallyWithT(func(c *assert.CollectT) {
+		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
+	})
+	vt.Run("docker_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		cnx, err := v.Env().FakeIntake.Client().GetConnections()
-		assert.NoError(c, err, "GetConnections() errors")
-		if !assert.NotEmpty(c, cnx.GetNames(), "no connections yet") {
-			return
-		}
+		// generate connections
+		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
+		v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig @8.8.8.8 www.google.ch")
 
-		foundDNS := false
-		cnx.ForeachConnection(func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
-			if len(c.DnsStatsByDomainOffsetByQueryType) > 0 {
-				foundDNS = true
-			}
-		})
-		if !assert.True(c, foundDNS, "DNS not found") {
-			return
-		}
-
-		type countCnx struct {
-			hit int
-			TCP int
-			UDP int
-		}
-		countConnections := make(map[string]*countCnx)
-
-		helperCleanup(t)
-		cnx.ForeachConnection(func(c *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
-			var count *countCnx
-			var found bool
-			if count, found = countConnections[hostname]; !found {
-				countConnections[hostname] = &countCnx{}
-				count = countConnections[hostname]
-			}
-			count.hit++
-
-			switch c.Type {
-			case agentmodel.ConnectionType_tcp:
-				count.TCP++
-			case agentmodel.ConnectionType_udp:
-				count.UDP++
-			}
-			validateConnection(t, c, cc, hostname)
-		})
-
-		totalConnections := countCnx{}
-		for host, count := range countConnections {
-			t.Logf("connections %d tcp %d udp %d received by host/netID %s", count.hit, count.TCP, count.UDP, host)
-			totalConnections.hit += count.hit
-			totalConnections.TCP += count.TCP
-			totalConnections.UDP += count.UDP
-		}
-		t.Logf("sum connections %d tcp %d udp %d", totalConnections.hit, totalConnections.TCP, totalConnections.UDP)
-	}, 60*time.Second, time.Second)
+		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
+	})
 }

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -86,7 +86,9 @@ func TestEC2VMSuite(t *testing.T) {
 func (v *ec2VMSuite) SetupSuite() {
 	v.BaseSuite.SetupSuite()
 
-	v.Env().RemoteHost.MustExecute("sudo apt install -y apache2-utils")
+	v.Env().RemoteHost.MustExecute("sudo apt install -y apache2-utils docker.io")
+	v.Env().RemoteHost.MustExecute("sudo usermod -a -G docker ubuntu")
+	v.Env().RemoteHost.ReconnectSSH()
 }
 
 // BeforeTest will be called before each test

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -99,93 +99,85 @@ func (v *ec2VMSuite) SetupSuite() {
 // BeforeTest will be called before each test
 func (v *ec2VMSuite) BeforeTest(suiteName, testName string) {
 	v.BaseSuite.BeforeTest(suiteName, testName)
-	v.beforeTest(suiteName, testName)
-}
 
-func (v *ec2VMSuite) beforeTest(_, _ string) {
 	// default is to reset the current state of the fakeintake aggregators
 	if !v.BaseSuite.IsDevMode() {
 		v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 	}
 }
 
-// TestFakeIntakeNPM Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
+// TestFakeIntakeNPM_HostRequests Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
 // 2 tests generate the request on the host and on docker
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
-func (v *ec2VMSuite) TestFakeIntakeNPM() {
-	vt := v.T()
+func (v *ec2VMSuite) TestFakeIntakeNPM_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
-	vt.Run("host_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		// generate a connection
-		v.Env().RemoteHost.MustExecute("curl " + testURL)
+	// generate a connection
+	v.Env().RemoteHost.MustExecute("curl " + testURL)
 
-		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
-	})
-	vt.Run("docker_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
-
-		// generate a connection
-		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
-
-		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
-	})
+	test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
 }
 
-// TestFakeIntakeNPM_600cnx_bucket Validate the agent can communicate with the (fake) backend and send connections
+// TestFakeIntakeNPM_DockerRequests Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
+// 2 tests generate the request on the host and on docker
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
+func (v *ec2VMSuite) TestFakeIntakeNPM_DockerRequests() {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+
+	// generate a connection
+	v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
+
+	test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
+}
+
+// TestFakeIntakeNPM600cnxBucket_HostRequests Validate the agent can communicate with the (fake) backend and send connections
 // every 30 seconds with a maximum of 600 connections per payloads, if more another payload will follow.
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for n payloads and check if the last 2 have a maximum span of 100ms
-func (v *ec2VMSuite) TestFakeIntakeNPM_600cnx_bucket() {
-	vt := v.T()
+func (v *ec2VMSuite) TestFakeIntakeNPM600cnxBucket_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
-	vt.Run("host_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		// generate connections
-		v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
+	// generate connections
+	v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
 
-		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
-	})
-	vt.Run("docker_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
-
-		// generate connections
-		v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -n 600 -c 600 " + testURL)
-
-		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
-	})
+	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 }
 
-// TestFakeIntakeNPM_TCP_UDP_DNS validate we received tcp, udp, and DNS connections
-// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
-func (v *ec2VMSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
-	vt := v.T()
+// TestFakeIntakeNPM600cnxBucket_DockerRequests Validate the agent can communicate with the (fake) backend and send connections
+// every 30 seconds with a maximum of 600 connections per payloads, if more another payload will follow.
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for n payloads and check if the last 2 have a maximum span of 100ms
+func (v *ec2VMSuite) TestFakeIntakeNPM600cnxBucket_DockerRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
-	vt.Run("host_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		// generate connections
-		v.Env().RemoteHost.MustExecute("curl " + testURL)
-		v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
+	// generate connections
+	v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -n 600 -c 600 " + testURL)
 
-		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
-	})
-	vt.Run("docker_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
+	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
+}
 
-		// generate connections
-		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
-		v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig @8.8.8.8 www.google.ch")
+// TestFakeIntakeNPM_TCP_UDP_DNS_HostRequests validate we received tcp, udp, and DNS connections
+// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
+func (v *ec2VMSuite) TestFakeIntakeNPM_TCP_UDP_DNS_HostRequests() {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
-		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
-	})
+	// generate connections
+	v.Env().RemoteHost.MustExecute("curl " + testURL)
+	v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
+
+	test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
+}
+
+// TestFakeIntakeNPM_TCP_UDP_DNS_DockerRequests validate we received tcp, udp, and DNS connections
+// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
+func (v *ec2VMSuite) TestFakeIntakeNPM_TCP_UDP_DNS_DockerRequests() {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+
+	// generate connections
+	v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
+	v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig @8.8.8.8 www.google.ch")
+
+	test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
 }

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -89,6 +89,11 @@ func (v *ec2VMSuite) SetupSuite() {
 	v.Env().RemoteHost.MustExecute("sudo apt install -y apache2-utils docker.io")
 	v.Env().RemoteHost.MustExecute("sudo usermod -a -G docker ubuntu")
 	v.Env().RemoteHost.ReconnectSSH()
+
+	// prefetch docker image locally
+	v.Env().RemoteHost.MustExecute("docker run curlimages/curl --version")
+	v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -V")
+	v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig")
 }
 
 // BeforeTest will be called before each test

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -91,9 +91,9 @@ func (v *ec2VMSuite) SetupSuite() {
 	v.Env().RemoteHost.ReconnectSSH()
 
 	// prefetch docker image locally
-	v.Env().RemoteHost.MustExecute("docker run curlimages/curl --version")
-	v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -V")
-	v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig")
+	v.Env().RemoteHost.MustExecute("docker pull public.ecr.aws/k8m1l3p1/alpine/curler:latest")
+	v.Env().RemoteHost.MustExecute("docker pull public.ecr.aws/docker/library/httpd:latest")
+	v.Env().RemoteHost.MustExecute("docker pull public.ecr.aws/patrickc/troubleshoot-util:latest")
 }
 
 // BeforeTest will be called before each test
@@ -127,7 +127,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM_DockerRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate a connection
-	v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/k8m1l3p1/alpine/curler curl " + testURL)
 
 	test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
 }
@@ -153,7 +153,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM600cnxBucket_DockerRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
-	v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -n 600 -c 600 " + testURL)
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/docker/library/httpd ab -n 600 -c 600 " + testURL)
 
 	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 }
@@ -176,8 +176,8 @@ func (v *ec2VMSuite) TestFakeIntakeNPM_TCP_UDP_DNS_DockerRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
-	v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
-	v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig @8.8.8.8 www.google.ch")
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/k8m1l3p1/alpine/curler curl " + testURL)
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/patrickc/troubleshoot-util dig @8.8.8.8 www.google.ch")
 
 	test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
 }

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -87,7 +87,6 @@ func (v *ec2VMSuite) SetupSuite() {
 	v.BaseSuite.SetupSuite()
 
 	v.Env().RemoteHost.MustExecute("sudo apt install -y apache2-utils")
-	v.Env().RemoteHost.MustExecute("sudo snap install docker")
 }
 
 // BeforeTest will be called before each test


### PR DESCRIPTION
### What does this PR do?

Run NPM basic test when an agent is deploy in a container (docker)

### Motivation


### Additional Notes

Depend on test infra [PR581](https://github.com/DataDog/test-infra-definitions/pull/581)
Docker Images are from public ECR aws rate limited at 10 pull per seconds
https://docs.aws.amazon.com/AmazonECR/latest/public/public-service-quotas.html

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
