### PR TITLE
[oracle] Adjust tests to new sql mock

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/custom_queries_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/custom_queries_test.go
@@ -51,7 +51,7 @@ tns_admin: %s
 }
 
 func TestCustomQueries(t *testing.T) {
-	db, dbMock, err := sqlmock.newCheck()
+	db, dbMock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}


### PR DESCRIPTION
### What does this PR do?

Adjust tests to [new SQL mock](https://github.com/DATA-DOG/go-sqlmock/commit/742d0bc5c892b46187a88ec25910bcffd868c937):

### Motivation

Tests started failing after the most recent SQL Mock change.

### Describe how to test/QA your changes

```
go clean -testcache                                            
gotestsum --jsonfile module_test_output.json --format pkgname --packages=./pkg/collector/corechecks/oracle-dbm/... -- -mod=mod -vet=off --tags=oracle_test,oracle,test
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
