### PR TITLE
[CWS][SEC-12089] add e2e test for CWS activation 

### DIFF
--- a/test/new-e2e/tests/cws/api/api.go
+++ b/test/new-e2e/tests/cws/api/api.go
@@ -66,7 +66,10 @@ func (c *Client) GetAppLog(query string) (*datadog.LogsListResponse, error) {
 		Body: &body,
 	}
 
-	result, _, err := c.api.LogsApi.ListLogs(c.ctx, request)
+	result, r, err := c.api.LogsApi.ListLogs(c.ctx, request)
+	if r != nil {
+		_ = r.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +99,10 @@ func (c *Client) GetAppSignal(query string) (*datadog.SecurityMonitoringSignalsL
 		Body: &body,
 	}
 
-	result, _, err := c.api.SecurityMonitoringApi.SearchSecurityMonitoringSignals(c.ctx, request)
+	result, r, err := c.api.SecurityMonitoringApi.SearchSecurityMonitoringSignals(c.ctx, request)
+	if r != nil {
+		_ = r.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +154,10 @@ func (c *Client) CreateCwsSignalRule(name string, msg string, agentRuleID string
 		Type: &monitoringRuleType,
 	}
 
-	response, _, err := c.api.SecurityMonitoringApi.CreateSecurityMonitoringRule(c.ctx, body)
+	response, r, err := c.api.SecurityMonitoringApi.CreateSecurityMonitoringRule(c.ctx, body)
+	if r != nil {
+		_ = r.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +179,10 @@ func (c *Client) CreateCWSAgentRule(name string, msg string, secl string) (*data
 		},
 	}
 
-	response, _, err := c.api.CloudWorkloadSecurityApi.CreateCloudWorkloadSecurityAgentRule(c.ctx, body)
+	response, r, err := c.api.CloudWorkloadSecurityApi.CreateCloudWorkloadSecurityAgentRule(c.ctx, body)
+	if r != nil {
+		_ = r.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -180,12 +192,18 @@ func (c *Client) CreateCWSAgentRule(name string, msg string, secl string) (*data
 
 // DeleteSignalRule deletes a signal rule
 func (c *Client) DeleteSignalRule(ruleID string) error {
-	_, err := c.api.SecurityMonitoringApi.DeleteSecurityMonitoringRule(c.ctx, ruleID)
+	r, err := c.api.SecurityMonitoringApi.DeleteSecurityMonitoringRule(c.ctx, ruleID)
+	if r != nil {
+		_ = r.Body.Close()
+	}
 	return err
 }
 
 // DeleteAgentRule deletes an agent rule
 func (c *Client) DeleteAgentRule(ruleID string) error {
-	_, err := c.api.CloudWorkloadSecurityApi.DeleteCloudWorkloadSecurityAgentRule(c.ctx, ruleID)
+	r, err := c.api.CloudWorkloadSecurityApi.DeleteCloudWorkloadSecurityAgentRule(c.ctx, ruleID)
+	if r != nil {
+		_ = r.Body.Close()
+	}
 	return err
 }

--- a/test/new-e2e/tests/cws/api/ddsql.go
+++ b/test/new-e2e/tests/cws/api/ddsql.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+// DDSQLTableQueryParams is a struct that represents a DDSQL table query
+type DDSQLTableQueryParams struct {
+	DefaultStart    int    `json:"default_start"`
+	DefaultEnd      int    `json:"default_end"`
+	DefaultInterval int    `json:"default_interval"`
+	Query           string `json:"query"`
+	Source          string `json:"source"`
+}
+
+// DDSQLTableResponse is a struct that represents a DDSQL table response
+type DDSQLTableResponse struct {
+	Data []DataEntry `json:"data"`
+}
+
+// DataEntry is a struct that represents a data entry in a DDSQL table response
+type DataEntry struct {
+	Type       string     `json:"type"`
+	Attributes Attributes `json:"attributes"`
+}
+
+// Attributes is a struct that represents the attributes of a data entry in a DDSQL table response
+type Attributes struct {
+	Columns []Column `json:"columns"`
+}
+
+// Column is a struct that represents a column of a data entry in a DDSQL table response
+type Column struct {
+	Name   string        `json:"name"`
+	Type   string        `json:"type"`
+	Values []interface{} `json:"values"`
+}
+
+// DDSQLClient is a struct that represents a DDSQL client
+type DDSQLClient struct {
+	http   http.Client
+	apiKey string
+	appKey string
+}
+
+// NewDDSQLClient returns a new DDSQL client
+func NewDDSQLClient(apiKey, appKey string) *DDSQLClient {
+	return &DDSQLClient{
+		http:   http.Client{},
+		apiKey: apiKey,
+		appKey: appKey,
+	}
+}
+
+// Do executes a DDSQL query, returning a DDSQL table response
+func (c *DDSQLClient) Do(query string) (*DDSQLTableResponse, error) {
+	now := time.Now()
+	params := DDSQLTableQueryParams{
+		DefaultStart:    int(now.Add(-10 * time.Minute).Unix()),
+		DefaultEnd:      int(now.Unix()),
+		DefaultInterval: 20000,
+		Query:           query,
+		Source:          "inventories",
+	}
+
+	reqData, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", "https://app.datadoghq.com/api/v2/ddql/table", bytes.NewBuffer(reqData))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("accept", "application/json")
+	req.Header.Add("content-type", "application/json")
+	req.Header.Add("DD-API-KEY", c.apiKey)
+	req.Header.Add("DD-APPLICATION-KEY", c.appKey)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var ddSQLResp DDSQLTableResponse
+	err = json.Unmarshal(data, &ddSQLResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ddSQLResp, nil
+}

--- a/test/new-e2e/tests/cws/config/e2e-datadog.yaml
+++ b/test/new-e2e/tests/cws/config/e2e-datadog.yaml
@@ -1,3 +1,0 @@
-hostname: cws-new-e2e-test-host
-log_level: DEBUG
-logs_enabled: true

--- a/test/new-e2e/tests/cws/ec2_test.go
+++ b/test/new-e2e/tests/cws/ec2_test.go
@@ -30,6 +30,9 @@ import (
 )
 
 const (
+	// ec2HostnamePrefix is the prefix of the hostname of the agent
+	ec2HostnamePrefix = "cws-e2e-ec2-host"
+
 	// securityStartLog is the log corresponding to a successful start of the security-agent
 	securityStartLog = "Successfully connected to the runtime security module"
 
@@ -46,18 +49,16 @@ const (
 type agentSuite struct {
 	e2e.BaseSuite[environments.Host]
 	apiClient     *api.Client
+	testID        string
+	ddHostname    string
 	signalRuleID  string
 	agentRuleID   string
 	dirname       string
 	filename      string
-	testID        string
 	desc          string
 	agentRuleName string
 	policies      string
 }
-
-//go:embed config/e2e-datadog.yaml
-var agentConfig string
 
 //go:embed config/e2e-system-probe.yaml
 var systemProbeConfig string
@@ -66,16 +67,19 @@ var systemProbeConfig string
 var securityAgentConfig string
 
 func TestAgentSuite(t *testing.T) {
-	e2e.Run(t, &agentSuite{}, e2e.WithProvisioner(
-		awshost.Provisioner(
-			awshost.WithName("cws-agent-e2e-tests"),
-			awshost.WithAgentOptions(
-				agentparams.WithAgentConfig(agentConfig),
-				agentparams.WithSecurityAgentConfig(securityAgentConfig),
-				agentparams.WithSystemProbeConfig(systemProbeConfig),
+	testID := uuid.NewString()[:4]
+	ddHostname := fmt.Sprintf("%s-%s", ec2HostnamePrefix, testID)
+	e2e.Run(t, &agentSuite{testID: testID, ddHostname: ddHostname},
+		e2e.WithProvisioner(
+			awshost.ProvisionerNoFakeIntake(
+				awshost.WithAgentOptions(
+					agentparams.WithAgentConfig(fmt.Sprintf("hostname: %s", ddHostname)),
+					agentparams.WithSecurityAgentConfig(securityAgentConfig),
+					agentparams.WithSystemProbeConfig(systemProbeConfig),
+				),
 			),
 		),
-	))
+	)
 }
 
 func (a *agentSuite) SetupSuite() {
@@ -99,7 +103,6 @@ func (a *agentSuite) TestOpenSignal() {
 	tempDir := a.Env().RemoteHost.MustExecute("mktemp -d")
 	a.dirname = strings.TrimSuffix(tempDir, "\n")
 	a.filename = fmt.Sprintf("%s/secret", a.dirname)
-	a.testID = uuid.NewString()[:4]
 	a.desc = fmt.Sprintf("e2e test rule %s", a.testID)
 	a.agentRuleName = fmt.Sprintf("new_e2e_agent_rule_%s", a.testID)
 
@@ -152,7 +155,7 @@ func (a *agentSuite) TestOpenSignal() {
 	a.Env().RemoteHost.MustExecute(fmt.Sprintf("sudo %s runtime policy reload", securityAgentPath))
 
 	// Check `downloaded` ruleset_loaded
-	result, err := api.WaitAppLogs(a.apiClient, "host:cws-new-e2e-test-host rule_id:ruleset_loaded")
+	result, err := api.WaitAppLogs(a.apiClient, fmt.Sprintf("host:%s rule_id:ruleset_loaded", a.ddHostname))
 	require.NoError(a.T(), err, "could not get new ruleset")
 
 	agentContext := result.Attributes["agent"].(map[string]interface{})
@@ -166,7 +169,7 @@ func (a *agentSuite) TestOpenSignal() {
 	require.NoError(a.T(), err, "could not send payload")
 
 	// Check app signal
-	signal, err := api.WaitAppSignal(a.apiClient, fmt.Sprintf("host:cws-new-e2e-test-host @workflow.rule.id:%s", a.signalRuleID))
+	signal, err := api.WaitAppSignal(a.apiClient, fmt.Sprintf("host:%s @workflow.rule.id:%s", a.ddHostname, a.signalRuleID))
 	require.NoError(a.T(), err)
 	assert.Contains(a.T(), signal.Tags, fmt.Sprintf("rule_id:%s", strings.ToLower(a.agentRuleName)), "unable to find rule_id tag")
 	agentContext = signal.Attributes["agent"].(map[string]interface{})

--- a/test/new-e2e/tests/cws/fargate_test.go
+++ b/test/new-e2e/tests/cws/fargate_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	ddHostnamePrefix    = "cws-tests-ecs-fg-task"
+	ecsFgHostnamePrefix = "cws-e2e-ecs-fg-task"
 	selfTestsPolicyName = "selftests.policy"
 	execRuleID          = "selftest_exec"
 	openRuleID          = "selftest_open"
@@ -60,7 +60,7 @@ func TestECSFargate(t *testing.T) {
 	policy, err := getPolicyContent(ruleDefs)
 	require.NoErrorf(t, err, "failed generate policy from test rules: %v", err)
 
-	ddHostname := fmt.Sprintf("%s-%s", ddHostnamePrefix, uuid.NewString()[:4])
+	ddHostname := fmt.Sprintf("%s-%s", ecsFgHostnamePrefix, uuid.NewString()[:4])
 
 	e2e.Run(t, &ecsFargateSuite{ddHostname: ddHostname},
 		e2e.WithUntypedPulumiProvisioner(func(ctx *pulumi.Context) error {
@@ -135,7 +135,7 @@ func TestECSFargate(t *testing.T) {
 							Interval:    pulumi.IntPtr(30),
 							Timeout:     pulumi.IntPtr(5),
 						},
-						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String(ddHostnamePrefix), apiKeyParam.Name),
+						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String(ecsFgHostnamePrefix), apiKeyParam.Name),
 					},
 					"ubuntu-with-tracer": {
 						Cpu:       pulumi.IntPtr(0),
@@ -179,7 +179,7 @@ func TestECSFargate(t *testing.T) {
 								ReadOnly:      pulumi.Bool(true),
 							},
 						},
-						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("ubuntu-with-tracer"), pulumi.String(ddHostnamePrefix), apiKeyParam.Name),
+						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("ubuntu-with-tracer"), pulumi.String(ecsFgHostnamePrefix), apiKeyParam.Name),
 					},
 					"cws-instrumentation-init": {
 						Cpu:       pulumi.IntPtr(0),
@@ -199,7 +199,7 @@ func TestECSFargate(t *testing.T) {
 								ReadOnly:      pulumi.Bool(false),
 							},
 						},
-						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("cws-instrumentation-init"), pulumi.String(ddHostnamePrefix), apiKeyParam.Name),
+						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("cws-instrumentation-init"), pulumi.String(ecsFgHostnamePrefix), apiKeyParam.Name),
 					},
 					"log_router": *ecsResources.FargateFirelensContainerDefinition(),
 				},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add an e2e test checking that `feature_cws_enabled` is properly set to true when the agent is properly configured: both `/etc/datadog-agent/security-agent.yaml` and `/etc/datadog-agent/system-probe.yaml` include the `runtime_security_config.enabled: true` config parameter.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Test coverage.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Currently `feature_cws_enabled` is set to true as long as the `/etc/datadog-agent/system-probe.yaml` config file includes the `runtime_security_config.enabled: true` parameter.
This should probably be changed in a followup PR to make sure we also check that the parameter in `/etc/datadog-agent/security-agent.yaml` is also properly set.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
