### PR TITLE
[CSPM] dbconfig: Define a type for Cassandra configuration data

### DIFF
--- a/pkg/compliance/dbconfig/loader.go
+++ b/pkg/compliance/dbconfig/loader.go
@@ -191,7 +191,7 @@ func LoadCassandraConfig(ctx context.Context, hostroot string, proc *process.Pro
 		result.ProcessName, _ = proc.NameWithContext(ctx)
 	}
 
-	var configData map[string]interface{}
+	var configData *cassandraDBConfig
 	matches, _ := filepath.Glob(filepath.Join(hostroot, cassandraConfigGlob))
 	for _, configPath := range matches {
 		fi, err := os.Stat(configPath)
@@ -217,8 +217,8 @@ func LoadCassandraConfig(ctx context.Context, hostroot string, proc *process.Pro
 
 	logback, err := readFileLimit(filepath.Join(hostroot, cassandraLogbackPath))
 	if err == nil {
-		configData["logback_file_path"] = cassandraLogbackPath
-		configData["logback_file_content"] = string(logback)
+		configData.LogbackFilePath = cassandraLogbackPath
+		configData.LogbackFileContent = string(logback)
 	}
 	result.ConfigData = configData
 	return &result, true

--- a/pkg/compliance/dbconfig/loader_test.go
+++ b/pkg/compliance/dbconfig/loader_test.go
@@ -264,13 +264,13 @@ func TestCassandraConfParsing(t *testing.T) {
 	}
 	c, ok := LoadCassandraConfig(context.Background(), hostroot, nil)
 	assert.True(t, ok)
-	configData := c.ConfigData.(map[string]interface{})
+	configData := c.ConfigData.(*cassandraDBConfig)
 	assert.Equal(t, uint32(0600), c.ConfigFileMode)
 	assert.Equal(t, "/etc/cassandra/cassandra.yaml", c.ConfigFilePath)
 	assert.NotEmpty(t, c.ConfigFileUser)
 	assert.NotNil(t, configData)
-	assert.Equal(t, "/etc/cassandra/logback.xml", configData["logback_file_path"])
-	assert.Equal(t, cassandraLogbackSample, configData["logback_file_content"])
+	assert.Equal(t, "/etc/cassandra/logback.xml", configData.LogbackFilePath)
+	assert.Equal(t, cassandraLogbackSample, configData.LogbackFileContent)
 }
 
 func TestMongoDBConfParsing(t *testing.T) {

--- a/pkg/compliance/dbconfig/types.go
+++ b/pkg/compliance/dbconfig/types.go
@@ -215,3 +215,18 @@ type mongoDBConfig struct {
 		AuthenticationMechanisms  *string `yaml:"authenticationMechanisms,omitempty" json:"authenticationMechanisms,omitempty"`
 	} `yaml:"setParameter,omitempty" json:"setParameter,omitempty"`
 }
+
+type cassandraDBConfig struct {
+	Authenticator           string `yaml:"authenticator" json:"authenticator"`
+	LogbackFilePath         string `yaml:"logback_file_path" json:"logback_file_path"`
+	LogbackFileContent      string `yaml:"logback_file_content" json:"logback_file_content"`
+	Authorizer              string `yaml:"authorizer" json:"authorizer"`
+	ListenAddress           string `yaml:"listen_address" json:"listen_address"`
+	ClientEncryptionOptions struct {
+		Enabled  bool `yaml:"enabled" json:"enabled"`
+		Optional bool `yaml:"optional" json:"optional"`
+	} `yaml:"client_encryption_options" json:"client_encryption_options"`
+	ServerEncryptionOptions struct {
+		InternodeEncryption string `yaml:"internode_encryption" json:"internode_encryption"`
+	} `yaml:"server_encryption_options" json:"server_encryption_options"`
+}


### PR DESCRIPTION
### What does this PR do?

Defines a dedicated type for loading and exporting cassandra configuration data.

### Motivation

- helps to define a dedicated schema
- limits the data to only what we are required to

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
