### PR TITLE
Add Goland Datadog Agent Dev Container configurations.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,6 +50,9 @@
 /.github/workflows/go-update-commenter.yml          @DataDog/agent-shared-components
 /.github/workflows/buildimages-update.yml           @DataDog/agent-platform @DataDog/agent-shared-components
 
+/.run                                               @DataDog/agent-platform
+/.run/docker/                                       @DataDog/container-integrations
+
 # Gitlab files
 # Files containing job contents are owned by teams in charge of the jobs + agent-platform
 # Files that only describe structure (eg. includes, rules) are owned by agent-platform

--- a/.run/docker/Run development container.run.xml
+++ b/.run/docker/Run development container.run.xml
@@ -1,0 +1,22 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run development container" type="docker-deploy" factoryName="docker-image" server-name="Docker">
+    <deployment type="docker-image">
+      <settings>
+        <option name="imageTag" value="486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-devenv:1-arm64" />
+        <option name="command" value="sleep infinity" />
+        <option name="containerName" value="datadog-agent-devenv" />
+        <option name="commandLineOptions" value="-w /home/datadog/go/src/github.com/DataDog/datadog-agent" />
+        <option name="showCommandPreview" value="true" />
+        <option name="volumeBindings">
+          <list>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/home/datadog/go/src/github.com/DataDog/datadog-agent" />
+              <option name="hostPath" value="$PROJECT_DIR$" />
+            </DockerVolumeBindingImpl>
+          </list>
+        </option>
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/docker/Run linter.run.xml
+++ b/.run/docker/Run linter.run.xml
@@ -1,0 +1,22 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run linter" type="docker-deploy" factoryName="docker-image" server-name="Docker">
+    <deployment type="docker-image">
+      <settings>
+        <option name="imageTag" value="486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-devenv:1-arm64" />
+        <option name="command" value="invoke lint-go" />
+        <option name="containerName" value="datadog-agent-lint-go" />
+        <option name="commandLineOptions" value="-w /home/datadog/go/src/github.com/DataDog/datadog-agent" />
+        <option name="showCommandPreview" value="true" />
+        <option name="volumeBindings">
+          <list>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/home/datadog/go/src/github.com/DataDog/datadog-agent" />
+              <option name="hostPath" value="$PROJECT_DIR$" />
+            </DockerVolumeBindingImpl>
+          </list>
+        </option>
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/docker/Run unit tests.run.xml
+++ b/.run/docker/Run unit tests.run.xml
@@ -1,0 +1,22 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run unit tests" type="docker-deploy" factoryName="docker-image" server-name="Docker">
+    <deployment type="docker-image">
+      <settings>
+        <option name="imageTag" value="486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-devenv:1-arm64" />
+        <option name="command" value="invoke test" />
+        <option name="containerName" value="datadog-agent-test" />
+        <option name="commandLineOptions" value="-w /home/datadog/go/src/github.com/DataDog/datadog-agent" />
+        <option name="showCommandPreview" value="true" />
+        <option name="volumeBindings">
+          <list>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/home/datadog/go/src/github.com/DataDog/datadog-agent" />
+              <option name="hostPath" value="$PROJECT_DIR$" />
+            </DockerVolumeBindingImpl>
+          </list>
+        </option>
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add Goland run configurations for the Datadog Agent Dev Container.

- Run linter: Runs `invoke lint-go` on the whole codebase.
- Run unit tests: Runs `invoke test` on the whole codebase.
- Run development container: Runs a Dev Container that will `sleep` indefinitely. You can then exec into it and run any command you might need.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The current Jetbrains implementation of Dev Containers is still pretty rough with degraded performance and running in an EAP version of Goland.

Those configurations improves development process if you do not want to rely on Jetbrains' default mechanism of Dev Containers.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

You will need the latest version of the Datadog Agent Dev Container.
Note that Jetbrains also allow you to run Dev Containers the same way VS Code does ([https://www.jetbrains.com/help/idea/connect-to-devcontainer.html](https://www.jetbrains.com/help/idea/connect-to-devcontainer.html)). Although it does come with a few limitations.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

No drawbacks.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

No QA.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
