### PR TITLE
[EBPF-424] Add calls to remove memlock to fix flaky tests

### DIFF
--- a/pkg/ebpf/maps/generic_map_test.go
+++ b/pkg/ebpf/maps/generic_map_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -36,6 +37,9 @@ func TestBatchAPISupported(t *testing.T) {
 }
 
 func TestSingleItemIter(t *testing.T) {
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
+
 	m, err := NewGenericMap[uint32, uint32](&ebpf.MapSpec{
 		Type:       ebpf.Hash,
 		MaxEntries: 10,
@@ -71,6 +75,8 @@ func TestBatchIter(t *testing.T) {
 	if !BatchAPISupported() {
 		t.Skip("Batch API not supported")
 	}
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
 
 	m, err := NewGenericMap[uint32, uint32](&ebpf.MapSpec{
 		Type:       ebpf.Hash,
@@ -104,6 +110,8 @@ func TestBatchIterArray(t *testing.T) {
 	if !BatchAPISupported() {
 		t.Skip("Batch API not supported")
 	}
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
 
 	m, err := NewGenericMap[uint32, uint32](&ebpf.MapSpec{
 		Type:       ebpf.Array,
@@ -142,6 +150,8 @@ func TestBatchIterLessItemsThanBatchSize(t *testing.T) {
 	if !BatchAPISupported() {
 		t.Skip("Batch API not supported")
 	}
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
 
 	m, err := NewGenericMap[uint32, uint32](&ebpf.MapSpec{
 		Type:       ebpf.Hash,
@@ -175,6 +185,8 @@ func TestBatchIterWhileUpdated(t *testing.T) {
 	if !BatchAPISupported() {
 		t.Skip("Batch API not supported")
 	}
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
 
 	maxEntries := 50
 	m, err := NewGenericMap[uint32, uint32](&ebpf.MapSpec{
@@ -232,6 +244,9 @@ func TestIteratePerCPUMaps(t *testing.T) {
 	if kernelVersion < kernel.VersionCode(4, 6, 0) {
 		t.Skip("Per CPU maps not supported on this kernel version")
 	}
+
+	err = rlimit.RemoveMemlock()
+	require.NoError(t, err)
 
 	m, err := NewGenericMap[uint32, []uint32](&ebpf.MapSpec{
 		Type:       ebpf.PerCPUHash,
@@ -348,6 +363,8 @@ func TestBatchIterAllocsPerRun(t *testing.T) {
 	if !BatchAPISupported() {
 		t.Skip("Batch API not supported")
 	}
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
 
 	m, err := NewGenericMap[uint32, uint32](&ebpf.MapSpec{
 		Type:       ebpf.Hash,
@@ -438,6 +455,8 @@ func TestBatchDelete(t *testing.T) {
 	if !BatchAPISupported() {
 		t.Skip("Batch API not supported")
 	}
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
 
 	m, err := NewGenericMap[uint32, uint32](&ebpf.MapSpec{
 		Type:       ebpf.Hash,
@@ -482,6 +501,8 @@ func TestBatchUpdate(t *testing.T) {
 	if !BatchAPISupported() {
 		t.Skip("Batch API not supported")
 	}
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
 
 	m, err := NewGenericMap[uint32, uint32](&ebpf.MapSpec{
 		Type:       ebpf.Hash,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes flaky tests in GenericMap tests by calling RemoveMemlock before each.

https://datadoghq.atlassian.net/browse/EBPF-422
https://datadoghq.atlassian.net/browse/EBPF-423
https://datadoghq.atlassian.net/browse/EBPF-424

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
