### PR TITLE
[oracle] Fix host double tagging (DBMON-3214)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/activity.go
+++ b/pkg/collector/corechecks/oracle-dbm/activity.go
@@ -400,8 +400,8 @@ func (c *Check) SampleSession() error {
 		return err
 	}
 	sender.EventPlatformEvent(payloadBytes, "dbm-activity")
-	sender.Count("dd.oracle.activity.samples_count", float64(len(sessionRows)), "", c.tags)
-	sender.Gauge("dd.oracle.activity.time_ms", float64(time.Since(start).Milliseconds()), "", c.tags)
+	sendMetricWithDefaultTags(c, count, "dd.oracle.activity.samples_count", float64(len(sessionRows)))
+	sendMetricWithDefaultTags(c, gauge, "dd.oracle.activity.time_ms", float64(time.Since(start).Milliseconds()))
 	sender.Commit()
 
 	return nil

--- a/pkg/collector/corechecks/oracle-dbm/asm_diskgroups.go
+++ b/pkg/collector/corechecks/oracle-dbm/asm_diskgroups.go
@@ -36,9 +36,9 @@ func (c *Check) asmDiskgroups() error {
 	for _, r := range rows {
 		tags := append(c.tags, "asm_diskgroup_name:"+r.DiskgroupName)
 		tags = append(tags, "state:"+r.State)
-		sender.Gauge(fmt.Sprintf("%s.asm_diskgroup.free_mb", common.IntegrationName), r.Free, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.asm_diskgroup.total_mb", common.IntegrationName), r.Total, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.asm_diskgroup.offline_disks", common.IntegrationName), float64(r.OfflineDisks), "", tags)
+		sendMetric(c, gauge, fmt.Sprintf("%s.asm_diskgroup.free_mb", common.IntegrationName), r.Free, tags)
+		sendMetric(c, gauge, fmt.Sprintf("%s.asm_diskgroup.total_mb", common.IntegrationName), r.Total, tags)
+		sendMetric(c, gauge, fmt.Sprintf("%s.asm_diskgroup.offline_disks", common.IntegrationName), float64(r.OfflineDisks), tags)
 	}
 	sender.Commit()
 	return nil

--- a/pkg/collector/corechecks/oracle-dbm/custom_queries.go
+++ b/pkg/collector/corechecks/oracle-dbm/custom_queries.go
@@ -17,13 +17,10 @@ import (
 	godror "github.com/godror/godror"
 )
 
-//nolint:revive // TODO(DBM) Fix revive linter
-type Method func(string, float64, string, []string)
-
 type metricRow struct {
 	name   string
 	value  float64
-	method Method
+	method metricType
 	tags   []string
 }
 
@@ -62,14 +59,6 @@ func (c *Check) CustomQueries() error {
 	sender, err := c.GetSender()
 	if err != nil {
 		return fmt.Errorf("failed to get sender for custom queries %w", err)
-	}
-	methods := map[string]Method{
-		"gauge":           sender.Gauge,
-		"count":           sender.Count,
-		"rate":            sender.Rate,
-		"monotonic_count": sender.MonotonicCount,
-		"histogram":       sender.Histogram,
-		"historate":       sender.Historate,
 	}
 	var allErrors error
 	var customQueries []config.CustomQuery
@@ -143,7 +132,8 @@ func (c *Check) CustomQueries() error {
 					if v != nil {
 						tags = append(tags, fmt.Sprintf("%s:%s", q.Columns[i].Name, v))
 					}
-				} else if methodFunc, ok := methods[q.Columns[i].Type]; ok {
+					//} else if methodFunc, ok := methods[q.Columns[i].Type]; ok {
+				} else if method, err := getMetricFunctionCode(q.Columns[i].Type); err != nil {
 					metricRow.name = fmt.Sprintf("%s.%s", metricPrefix, q.Columns[i].Name)
 					if v_str, ok := v.(string); ok {
 						metricRow.value, err = strconv.ParseFloat(v_str, 64)
@@ -169,7 +159,7 @@ func (c *Check) CustomQueries() error {
 						break
 					}
 
-					metricRow.method = methodFunc
+					metricRow.method = method
 					metricsFromSingleRow = append(metricsFromSingleRow, metricRow)
 				} else {
 					allErrors = concatenateError(allErrors, fmt.Sprintf("Unknown column type %s in custom query %s", q.Columns[i].Type, metricRow.name))
@@ -197,7 +187,7 @@ func (c *Check) CustomQueries() error {
 		}
 		for _, m := range metricRows {
 			log.Debugf("%s send metric %+v", c.logPrompt, m)
-			m.method(m.name, m.value, "", m.tags)
+			sendMetric(c, m.method, m.name, m.value, m.tags)
 		}
 		sender.Commit()
 	}

--- a/pkg/collector/corechecks/oracle-dbm/custom_queries.go
+++ b/pkg/collector/corechecks/oracle-dbm/custom_queries.go
@@ -132,8 +132,7 @@ func (c *Check) CustomQueries() error {
 					if v != nil {
 						tags = append(tags, fmt.Sprintf("%s:%s", q.Columns[i].Name, v))
 					}
-					//} else if methodFunc, ok := methods[q.Columns[i].Type]; ok {
-				} else if method, err := getMetricFunctionCode(q.Columns[i].Type); err != nil {
+				} else if method, err := getMetricFunctionCode(q.Columns[i].Type); err == nil {
 					metricRow.name = fmt.Sprintf("%s.%s", metricPrefix, q.Columns[i].Name)
 					if v_str, ok := v.(string); ok {
 						metricRow.value, err = strconv.ParseFloat(v_str, 64)

--- a/pkg/collector/corechecks/oracle-dbm/custom_queries_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/custom_queries_test.go
@@ -103,5 +103,5 @@ func TestFloat(t *testing.T) {
 	require.NoError(t, err)
 	s.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	s.AssertMetricTaggedWith(t, "Gauge", "oracle.custom_query.test.value", []string{"name:TAG1"})
-	s.AssertMetric(t, "Gauge", "oracle.custom_query.test.value", 1.012345, "", []string{})
+	s.AssertMetric(t, "Gauge", "oracle.custom_query.test.value", 1.012345, c.dbHostname, []string{})
 }

--- a/pkg/collector/corechecks/oracle-dbm/data_guard.go
+++ b/pkg/collector/corechecks/oracle-dbm/data_guard.go
@@ -47,7 +47,7 @@ func (c *Check) dataGuard() error {
 		return fmt.Errorf("failed to initialize sender: %w", err)
 	}
 	var stats []dataguardStats
-	err = selectWrapper(c, &stats, `SELECT name, EXTRACT(DAY from TO_DSINTERVAL(value)*86400) value 
+	err = selectWrapper(c, &stats, `SELECT name, EXTRACT(DAY from TO_DSINTERVAL(value)*86400) value
 	FROM v$dataguard_stats WHERE name IN ('apply lag','transport lag')`)
 	if err != nil {
 		return fmt.Errorf("failed to query data guard statistics %w", err)
@@ -59,7 +59,7 @@ func (c *Check) dataGuard() error {
 		} else {
 			v = invalidLagValue
 		}
-		sender.Gauge(fmt.Sprintf("%s.data_guard.%s", common.IntegrationName, strings.ReplaceAll(string(s.Name), " ", "_")), v, "", c.tags)
+		sendMetricWithDefaultTags(c, gauge, fmt.Sprintf("%s.data_guard.%s", common.IntegrationName, strings.ReplaceAll(string(s.Name), " ", "_")), v)
 	}
 	sender.Commit()
 	return nil

--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -51,9 +51,6 @@ func (c *Check) init() error {
 	if i.HostName.Valid {
 		tags = append(tags, fmt.Sprintf("real_hostname:%s", i.HostName.String))
 	}
-	if c.dbHostname != "" {
-		tags = append(tags, fmt.Sprintf("host:%s", c.dbHostname), fmt.Sprintf("db_server:%s", c.dbHostname))
-	}
 	tags = append(tags, fmt.Sprintf("oracle_version:%s", c.dbVersion))
 
 	var d vDatabase

--- a/pkg/collector/corechecks/oracle-dbm/os_stats.go
+++ b/pkg/collector/corechecks/oracle-dbm/os_stats.go
@@ -53,13 +53,13 @@ func (c *Check) OS_Stats() error {
 		if r.StatName == "NUM_CPUS" {
 			numCPUsFound = true
 		}
-		s.Gauge(fmt.Sprintf("%s.%s", common.IntegrationName, name), value, "", c.tags)
+		sendMetricWithDefaultTags(c, gauge, fmt.Sprintf("%s.%s", common.IntegrationName, name), value)
 	}
 
 	var cpuCount float64
 	if !numCPUsFound {
 		if err := c.db.Get(&cpuCount, "SELECT value FROM v$parameter WHERE name = 'cpu_count'"); err == nil {
-			s.Gauge(fmt.Sprintf("%s.num_cpus", common.IntegrationName), cpuCount, "", c.tags)
+			sendMetricWithDefaultTags(c, gauge, fmt.Sprintf("%s.num_cpus", common.IntegrationName), cpuCount)
 		} else {
 			log.Errorf("%s failed to get cpu_count: %s", c.logPrompt, err)
 		}

--- a/pkg/collector/corechecks/oracle-dbm/processes.go
+++ b/pkg/collector/corechecks/oracle-dbm/processes.go
@@ -15,28 +15,28 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
 )
 
-const pgaQuery12 = `SELECT 
-	c.name as pdb_name, 
+const pgaQuery12 = `SELECT
+	c.name as pdb_name,
 	p.pid as pid, p.program as server_process,
 	s.sid as sid, s.username as username, s.program as program, s.machine as machine, s.osuser as osuser,
 	s.status as status, last_call_et,
 	module, client_info,
-	nvl(pga_used_mem,0) pga_used_mem, 
-	nvl(pga_alloc_mem,0) pga_alloc_mem, 
-	nvl(pga_freeable_mem,0) pga_freeable_mem, 
+	nvl(pga_used_mem,0) pga_used_mem,
+	nvl(pga_alloc_mem,0) pga_alloc_mem,
+	nvl(pga_freeable_mem,0) pga_freeable_mem,
 	nvl(pga_max_mem,0) pga_max_mem
 FROM v$process p, v$containers c, v$session s
 WHERE
   c.con_id(+) = p.con_id
 	AND s.paddr(+) = p.addr`
 
-const pgaQuery11 = `SELECT  
+const pgaQuery11 = `SELECT
 	p.pid as pid, p.program as server_process,
 	s.sid as sid, s.username as username, s.program as program, s.machine as machine, s.osuser as osuser,
 	s.status as status, last_call_et,
-	nvl(pga_used_mem,0) pga_used_mem, 
-	nvl(pga_alloc_mem,0) pga_alloc_mem, 
-	nvl(pga_freeable_mem,0) pga_freeable_mem, 
+	nvl(pga_used_mem,0) pga_used_mem,
+	nvl(pga_alloc_mem,0) pga_alloc_mem,
+	nvl(pga_freeable_mem,0) pga_freeable_mem,
 	nvl(pga_max_mem,0) pga_max_mem
 FROM v$process p, v$session s
 WHERE s.paddr(+) = p.addr`
@@ -105,10 +105,10 @@ func (c *Check) ProcessMemory() error {
 			tags = append(tags, "osuser:"+r.OsUser.String)
 		}
 		if c.config.ProcessMemory.Enabled {
-			sender.Gauge(fmt.Sprintf("%s.process.pga_used_memory", common.IntegrationName), r.PGAUsedMem, "", tags)
-			sender.Gauge(fmt.Sprintf("%s.process.pga_allocated_memory", common.IntegrationName), r.PGAAllocMem, "", tags)
-			sender.Gauge(fmt.Sprintf("%s.process.pga_freeable_memory", common.IntegrationName), r.PGAFreeableMem, "", tags)
-			sender.Gauge(fmt.Sprintf("%s.process.pga_max_memory", common.IntegrationName), r.PGAMaxMem, "", tags)
+			sendMetric(c, gauge, fmt.Sprintf("%s.process.pga_used_memory", common.IntegrationName), r.PGAUsedMem, tags)
+			sendMetric(c, gauge, fmt.Sprintf("%s.process.pga_allocated_memory", common.IntegrationName), r.PGAAllocMem, tags)
+			sendMetric(c, gauge, fmt.Sprintf("%s.process.pga_freeable_memory", common.IntegrationName), r.PGAFreeableMem, tags)
+			sendMetric(c, gauge, fmt.Sprintf("%s.process.pga_max_memory", common.IntegrationName), r.PGAMaxMem, tags)
 		}
 
 		if c.config.InactiveSessions.Enabled && r.Status.Valid && r.Status.String == "INACTIVE" && r.LastCallEt.Valid {
@@ -118,7 +118,7 @@ func (c *Check) ProcessMemory() error {
 			if r.ClientInfo.Valid {
 				tags = append(tags, "client_info:"+r.ClientInfo.String)
 			}
-			sender.Gauge(fmt.Sprintf("%s.session.inactive_seconds", common.IntegrationName), float64(r.LastCallEt.Int64), "", tags)
+			sendMetric(c, gauge, fmt.Sprintf("%s.session.inactive_seconds", common.IntegrationName), float64(r.LastCallEt.Int64), tags)
 		}
 	}
 	sender.Commit()

--- a/pkg/collector/corechecks/oracle-dbm/resource_manager.go
+++ b/pkg/collector/corechecks/oracle-dbm/resource_manager.go
@@ -14,14 +14,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
 )
 
-const resourceManagerQuery = `SELECT c.name name, consumer_group_name, plan_name, cpu_consumed_time, cpu_wait_time 
+const resourceManagerQuery = `SELECT c.name name, consumer_group_name, plan_name, cpu_consumed_time, cpu_wait_time
 FROM v$rsrcmgrmetric r, v$containers c
 WHERE c.con_id(+) = r.con_id`
 
-const resourceManagerQueryNonCdb = `SELECT consumer_group_name, plan_name, cpu_consumed_time, cpu_wait_time 
+const resourceManagerQueryNonCdb = `SELECT consumer_group_name, plan_name, cpu_consumed_time, cpu_wait_time
 FROM v$rsrcmgrmetric r`
 
-const resourceManagerQuery11 = `SELECT consumer_group_name, cpu_consumed_time, cpu_wait_time 
+const resourceManagerQuery11 = `SELECT consumer_group_name, cpu_consumed_time, cpu_wait_time
 FROM v$rsrcmgrmetric r`
 
 type resourceManagerRow struct {
@@ -58,8 +58,8 @@ func (c *Check) resourceManager() error {
 		if r.PlanName.Valid && r.PlanName.String != "" {
 			tags = append(tags, "plan_name:"+r.PlanName.String)
 		}
-		sender.Gauge(fmt.Sprintf("%s.resource_manager.cpu_consumed_time", common.IntegrationName), r.CPUConsumedTime, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.resource_manager.cpu_wait_time", common.IntegrationName), r.CPUWaitTime, "", tags)
+		sendMetric(c, gauge, fmt.Sprintf("%s.resource_manager.cpu_consumed_time", common.IntegrationName), r.CPUConsumedTime, tags)
+		sendMetric(c, gauge, fmt.Sprintf("%s.resource_manager.cpu_wait_time", common.IntegrationName), r.CPUWaitTime, tags)
 	}
 	sender.Commit()
 	return nil

--- a/pkg/collector/corechecks/oracle-dbm/sender_util.go
+++ b/pkg/collector/corechecks/oracle-dbm/sender_util.go
@@ -42,9 +42,8 @@ func getMetricFunction(sender sender.Sender, method metricType) (metricSender, e
 	}
 	if val, ok := methods[method]; ok {
 		return val, nil
-	} else {
-		return nil, fmt.Errorf("Invalid metric function code %d", method)
 	}
+	return nil, fmt.Errorf("Invalid metric function code %d", method)
 }
 
 func getMetricFunctionCode(name string) (metricType, error) {

--- a/pkg/collector/corechecks/oracle-dbm/sender_util.go
+++ b/pkg/collector/corechecks/oracle-dbm/sender_util.go
@@ -29,6 +29,9 @@ const (
 type metricSender func(string, float64, string, []string)
 
 func getMetricFunction(sender sender.Sender, method metricType) (metricSender, error) {
+	if sender == nil {
+		return nil, fmt.Errorf("sender is nil")
+	}
 	methods := map[metricType]metricSender{
 		gauge:          sender.Gauge,
 		count:          sender.Count,
@@ -59,20 +62,6 @@ func getMetricFunctionCode(name string) (metricType, error) {
 		return unknownMetricType, fmt.Errorf("unknown metric type: %s", name)
 	}
 }
-
-/*
-func sendMetric(c *Check, method metricType, metric string, value float64) {
-	sender, err := c.GetSender()
-	if err != nil {
-		log.Errorf("%s failed to get metric sender %s", err)
-	}
-	metricFunction, err := getMetricFunction(sender, method)
-	if err != nil {
-		log.Errorf("failed to get metric function: %s", err)
-	}
-	metricFunction(metric, value, c.dbHostname, c.tags)
-}
-*/
 
 func sendMetric(c *Check, method metricType, metric string, value float64, tags []string) {
 	sender, err := c.GetSender()

--- a/pkg/collector/corechecks/oracle-dbm/sender_util.go
+++ b/pkg/collector/corechecks/oracle-dbm/sender_util.go
@@ -58,9 +58,8 @@ func getMetricFunctionCode(name string) (metricType, error) {
 	}
 	if val, ok := metricTypes[name]; ok {
 		return val, nil
-	} else {
-		return unknownMetricType, fmt.Errorf("unknown metric type: %s", name)
 	}
+	return unknownMetricType, fmt.Errorf("unknown metric type: %s", name)
 }
 
 func sendMetric(c *Check, method metricType, metric string, value float64, tags []string) {

--- a/pkg/collector/corechecks/oracle-dbm/sender_util.go
+++ b/pkg/collector/corechecks/oracle-dbm/sender_util.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
+)
+
+type metricType int
+
+const (
+	unknownMetricType metricType = iota
+	gauge
+	count
+	rate
+	monotonicCount
+	histogram
+	historate
+)
+
+type metricSender func(string, float64, string, []string)
+
+func getMetricFunction(sender sender.Sender, method metricType) (metricSender, error) {
+	methods := map[metricType]metricSender{
+		gauge:          sender.Gauge,
+		count:          sender.Count,
+		rate:           sender.Rate,
+		monotonicCount: sender.MonotonicCount,
+		histogram:      sender.Histogram,
+		historate:      sender.Historate,
+	}
+	if val, ok := methods[method]; ok {
+		return val, nil
+	} else {
+		return nil, fmt.Errorf("Invalid metric function code %d", method)
+	}
+}
+
+func getMetricFunctionCode(name string) (metricType, error) {
+	metricTypes := map[string]metricType{
+		"gauge":           gauge,
+		"count":           count,
+		"rate":            rate,
+		"monotonic_count": monotonicCount,
+		"histogram":       histogram,
+		"historate":       historate,
+	}
+	if val, ok := metricTypes[name]; ok {
+		return val, nil
+	} else {
+		return unknownMetricType, fmt.Errorf("unknown metric type: %s", name)
+	}
+}
+
+/*
+func sendMetric(c *Check, method metricType, metric string, value float64) {
+	sender, err := c.GetSender()
+	if err != nil {
+		log.Errorf("%s failed to get metric sender %s", err)
+	}
+	metricFunction, err := getMetricFunction(sender, method)
+	if err != nil {
+		log.Errorf("failed to get metric function: %s", err)
+	}
+	metricFunction(metric, value, c.dbHostname, c.tags)
+}
+*/
+
+func sendMetric(c *Check, method metricType, metric string, value float64, tags []string) {
+	sender, err := c.GetSender()
+	if err != nil {
+		log.Errorf("%s failed to get metric sender %s", err)
+	}
+	metricFunction, err := getMetricFunction(sender, method)
+	if err != nil {
+		log.Errorf("failed to get metric function: %s", err)
+	}
+	metricFunction(metric, value, c.dbHostname, tags)
+}
+
+func sendMetricWithDefaultTags(c *Check, method metricType, metric string, value float64) {
+	sendMetric(c, method, metric, value, c.tags)
+}

--- a/pkg/collector/corechecks/oracle-dbm/shared_memory.go
+++ b/pkg/collector/corechecks/oracle-dbm/shared_memory.go
@@ -15,17 +15,17 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
 )
 
-const shmQuery12 = `SELECT 
+const shmQuery12 = `SELECT
     c.name pdb_name, s.name, ROUND(bytes/1024/1024,2) size_
   FROM v$sgainfo s, v$containers c
-  WHERE 
+  WHERE
     c.con_id(+) = s.con_id
     AND s.name NOT IN ('Maximum SGA Size','Startup overhead in Shared Pool','Granule Size','Shared IO Pool Size')`
 
-const shmQuery11 = `SELECT 
+const shmQuery11 = `SELECT
 	s.name, ROUND(bytes/1024/1024,2) size_
 FROM v$sgainfo s
-WHERE 
+WHERE
   s.name NOT IN ('Maximum SGA Size','Startup overhead in Shared Pool','Granule Size','Shared IO Pool Size')`
 
 //nolint:revive // TODO(DBM) Fix revive linter
@@ -58,7 +58,7 @@ func (c *Check) SharedMemory() error {
 		memoryTag = strings.ToLower(memoryTag)
 		memoryTag = strings.ReplaceAll(memoryTag, "_size", "")
 		tags = append(tags, fmt.Sprintf("memory:%s", memoryTag))
-		sender.Gauge(fmt.Sprintf("%s.shared_memory.size", common.IntegrationName), r.Size, "", tags)
+		sendMetric(c, gauge, fmt.Sprintf("%s.shared_memory.size", common.IntegrationName), r.Size, tags)
 	}
 	sender.Commit()
 	return nil

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -859,9 +859,9 @@ func (c *Check) StatementMetrics() (int, error) {
 	log.Debugf("%s Query metrics payload %s", c.logPrompt, strings.ReplaceAll(string(payloadBytes), "@", "XX"))
 
 	sender.EventPlatformEvent(payloadBytes, "dbm-metrics")
-	sender.Gauge("dd.oracle.statements_metrics.time_ms", float64(time.Since(start).Milliseconds()), "", c.tags)
+	sendMetricWithDefaultTags(c, gauge, "dd.oracle.statements_metrics.time_ms", float64(time.Since(start).Milliseconds()))
 	if c.config.ExecutionPlans.Enabled {
-		sender.Gauge("dd.oracle.plan_errors.count", float64(planErrors), "", c.tags)
+		sendMetricWithDefaultTags(c, gauge, "dd.oracle.plan_errors.count", float64(planErrors))
 	}
 	sender.Commit()
 

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -16,18 +16,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const sysMetricsQuery11 = `SELECT 
+const sysMetricsQuery11 = `SELECT
 	metric_name,
-	value, 
+	value,
 	metric_unit
   FROM %s s`
 
-const sysMetricsQuery12 = `SELECT 
+const sysMetricsQuery12 = `SELECT
 	metric_name,
-	value, 
-	metric_unit, 
-	name pdb_name 
-  FROM %s s, v$containers c 
+	value,
+	metric_unit,
+	name pdb_name
+  FROM %s s, v$containers c
   WHERE s.con_id = c.con_id(+)`
 
 const (
@@ -126,7 +126,7 @@ func (c *Check) sendMetric(s sender.Sender, r SysmetricsRowDB, seen map[string]b
 		}
 		if !SYSMETRICS_COLS[r.MetricName].DBM || SYSMETRICS_COLS[r.MetricName].DBM && c.dbmEnabled {
 			log.Debugf("%s %s: %f", c.logPrompt, metric.DDmetric, value)
-			s.Gauge(fmt.Sprintf("%s.%s", common.IntegrationName, metric.DDmetric), value, "", appendPDBTag(c.tags, r.PdbName))
+			sendMetric(c, gauge, fmt.Sprintf("%s.%s", common.IntegrationName, metric.DDmetric), value, appendPDBTag(c.tags, r.PdbName))
 			seen[r.MetricName] = true
 			*n++
 		}

--- a/pkg/collector/corechecks/oracle-dbm/tablespaces.go
+++ b/pkg/collector/corechecks/oracle-dbm/tablespaces.go
@@ -93,10 +93,10 @@ func (c *Check) Tablespaces() error {
 	for _, r := range rows {
 		tags := appendPDBTag(c.tags, r.PdbName)
 		tags = append(tags, "tablespace:"+r.TablespaceName)
-		sender.Gauge(fmt.Sprintf("%s.tablespace.used", common.IntegrationName), r.Used, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.tablespace.size", common.IntegrationName), r.Size, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.tablespace.in_use", common.IntegrationName), r.InUse, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.tablespace.offline", common.IntegrationName), r.Offline, "", tags)
+		sendMetric(c, gauge, fmt.Sprintf("%s.tablespace.used", common.IntegrationName), r.Used, tags)
+		sendMetric(c, gauge, fmt.Sprintf("%s.tablespace.size", common.IntegrationName), r.Size, tags)
+		sendMetric(c, gauge, fmt.Sprintf("%s.tablespace.in_use", common.IntegrationName), r.InUse, tags)
+		sendMetric(c, gauge, fmt.Sprintf("%s.tablespace.offline", common.IntegrationName), r.Offline, tags)
 	}
 
 	rowsMaxSize := []rowMaxSizeDB{}
@@ -108,7 +108,7 @@ func (c *Check) Tablespaces() error {
 	for _, r := range rowsMaxSize {
 		tags := appendPDBTag(c.tags, r.PdbName)
 		tags = append(tags, "tablespace:"+r.TablespaceName)
-		sender.Gauge(fmt.Sprintf("%s.tablespace.maxsize", common.IntegrationName), r.MaxSize, "", tags)
+		sendMetric(c, gauge, fmt.Sprintf("%s.tablespace.maxsize", common.IntegrationName), r.MaxSize, tags)
 	}
 
 	sender.Commit()

--- a/pkg/collector/corechecks/oracle-dbm/tablespaces_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/tablespaces_test.go
@@ -29,5 +29,5 @@ func TestTablespaces(t *testing.T) {
 	err := c.Run()
 	require.NoError(t, err)
 	s.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.size", 104857600, "", tags)
+	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.size", 104857600, c.dbHostname, tags)
 }

--- a/releasenotes/notes/oracle-host-multi-tagging-7742a13fcb763436.yaml
+++ b/releasenotes/notes/oracle-host-multi-tagging-7742a13fcb763436.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    [oracle] Fix multi-tagging bug.


### PR DESCRIPTION
### What does this PR do?

Fix host double tagging in generic metrics.

### Additional Notes

The agent metrics were tagged with two hosts in cases where the agent host was different from the database host. In other words, metric was tagged with both database and agent host. The reason for that is that the agent explicitly tagged metrics with the database host, and the `hostname` parameter was left out. The empty `hostname` was  resolved to the agent host. The metric processor added to the `host` tags, so we ended up with two host tags.

Now, we don't emit `host` tag anymore, and initialize `hostname` to the database host.

Besides that, the code that emits the metrics has been refactored to facilitate future changes.

### Describe how to test/QA your changes

Check emitted metrics and tags.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
