### PR TITLE
[EBPF-377] Change metric of ebpf maps and helpers errors to Counters instead of Gauge

### DIFF
--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -53,7 +53,7 @@ func NewEBPFErrorsCollector() prometheus.Collector {
 
 // Describe returns all descriptions of the collector
 func (e *EBPFErrorsCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- e.ebpfHelperErrors
+	ch <- e.ebpfMapOpsErrors
 	ch <- e.ebpfHelperErrors
 }
 

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -32,7 +32,7 @@ type EBPFErrorsCollector struct {
 	ebpfMapOpsErrorsGauge *prometheus.Desc
 	ebpfHelperErrorsGauge *prometheus.Desc
 	//we can use one map for both map errors and ebpf helpers errors, as the keys are different
-	lastValues map[string]uint64 // used to calculate the delta of the error counters
+	lastValues map[string]uint64
 }
 
 // NewEBPFErrorsCollector initializes a new Collector object for ebpf helper and map operations errors

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -9,10 +9,10 @@ package telemetry
 
 import (
 	"fmt"
-	"golang.org/x/sys/unix"
 	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -10,7 +10,6 @@ package telemetry
 import (
 	"errors"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"hash"
 	"hash/fnv"
 	"sync"
@@ -18,6 +17,7 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"golang.org/x/exp/slices"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/maps"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -10,28 +10,18 @@ package telemetry
 import (
 	"errors"
 	"fmt"
+	"golang.org/x/exp/slices"
 	"hash"
 	"hash/fnv"
 	"sync"
-	"syscall"
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
-	"golang.org/x/exp/slices"
-	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/maps"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-)
-
-const (
-	maxErrno    = 64
-	maxErrnoStr = "other"
-
-	ebpfMapTelemetryNS    = "ebpf_maps"
-	ebpfHelperTelemetryNS = "ebpf_helpers"
 )
 
 const (
@@ -92,24 +82,6 @@ func (b *EBPFTelemetry) populateMapsWithKeys(m *manager.Manager) error {
 		return err
 	}
 	return nil
-}
-
-func getErrCount(v []uint64) map[string]uint64 {
-	errCount := make(map[string]uint64)
-	for i, count := range v {
-		if count == 0 {
-			continue
-		}
-
-		if (i + 1) == maxErrno {
-			errCount[maxErrnoStr] = count
-		} else if name := unix.ErrnoName(syscall.Errno(i)); name != "" {
-			errCount[name] = count
-		} else {
-			errCount[syscall.Errno(i).Error()] = count
-		}
-	}
-	return errCount
 }
 
 func buildMapErrTelemetryConstants(mgr *manager.Manager) []manager.ConstantEditor {


### PR DESCRIPTION
### What does this PR do?

Replacing prometheus metrics for errors on ebpf operations (ebpf maps operations and ebpf helpers) from Gauge type to Counter type.

also fixed a typo in `Describe` method, introduced in this [PR](https://github.com/DataDog/datadog-agent/pull/22308)

### Motivation

Errors are monotonic and always increasing values, therefore reporting them as gauge is incorrect

### Additional Notes

Added an additional map of a **fixed** size to store the previous state of all counters and calculate the delta for each invocation of Collect method

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
