### PR TITLE
[usmon 680] usm: http2: Support split frame header from frame payload

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -528,6 +528,22 @@ int socket__http2_handle_first_frame(struct __sk_buff *skb) {
         return 0;
     }
 
+    // A case where we read an interesting valid frame header in the previous call, and now we're trying to read the
+    // rest of the frame payload. But, since we already read a valid frame, we just fill it as an interesting frame,
+    // and continue to the next tail call.
+    if (frame_state != NULL && frame_state->header_length == HTTP2_FRAME_HEADER_SIZE) {
+        // Copy the cached frame header to the current frame.
+        bpf_memcpy((char *)&current_frame, frame_state->buf, HTTP2_FRAME_HEADER_SIZE);
+        // Delete the cached frame header.
+        bpf_map_delete_elem(&http2_remainder, &dispatcher_args_copy.tup);
+        // Save the frame as an interesting frame (a.k.a, restoring the state we had in the previous call).
+        // We need to do so, as we're zeroing the iteration_value at the beginning of this function.
+        iteration_value->frames_array[0].frame = current_frame;
+        iteration_value->frames_array[0].offset = 0;
+        iteration_value->frames_count = 1;
+        // Continuing to the next tail call.
+        bpf_tail_call_compat(skb, &protocols_progs, PROG_HTTP2_FRAME_FILTER);
+    }
     if (!get_first_frame(skb, &dispatcher_args_copy.skb_info, frame_state, &current_frame, http2_tel)) {
         return 0;
     }
@@ -545,6 +561,23 @@ int socket__http2_handle_first_frame(struct __sk_buff *skb) {
         iteration_value->frames_count = 1;
     }
     dispatcher_args_copy.skb_info.data_off += current_frame.length;
+    // We're exceeding the packet boundaries, so we have a remainder.
+    if (dispatcher_args_copy.skb_info.data_off > dispatcher_args_copy.skb_info.data_end) {
+        frame_header_remainder_t new_frame_state = { 0 };
+
+        // Saving the remainder.
+        new_frame_state.remainder = dispatcher_args_copy.skb_info.data_off - dispatcher_args_copy.skb_info.data_end;
+        // We did find an interesting frame (as frames_count == 1), so we cache the current frame and waiting for the
+        // next call.
+        if (iteration_value->frames_count == 1) {
+            new_frame_state.header_length = HTTP2_FRAME_HEADER_SIZE;
+            bpf_memcpy(new_frame_state.buf, (char *)&current_frame, HTTP2_FRAME_HEADER_SIZE);
+        }
+
+        bpf_map_update_elem(&http2_remainder, &dispatcher_args_copy.tup, &new_frame_state, BPF_ANY);
+        // Not calling the next tail call as we have nothing to process.
+        return 0;
+    }
     // Overriding the data_off field of the cached skb_info. The next prog will start from the offset of the next valid
     // frame.
     args->skb_info.data_off = dispatcher_args_copy.skb_info.data_off;

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -492,21 +492,23 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 	tests := []struct {
 		name              string
 		skip              bool
-		messageBuilder    func() []byte
+		messageBuilder    func() [][]byte
 		expectedEndpoints map[usmhttp.Key]int
 	}{
 		{
 			name: "parse_frames tail call using 1 program",
 			// The objective of this test is to verify that we accurately perform the parsing of frames within
 			// a single program.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				const settingsFramesCount = 100
 				framer := newFramer()
-				return framer.
-					writeMultiMessage(t, settingsFramesCount, framer.writeSettings).
-					writeHeaders(t, 1, testHeaders()).
-					writeData(t, 1, true, emptyBody).
-					bytes()
+				return [][]byte{
+					framer.
+						writeMultiMessage(t, settingsFramesCount, framer.writeSettings).
+						writeHeaders(t, 1, testHeaders()).
+						writeData(t, 1, true, emptyBody).
+						bytes(),
+				}
 			},
 			expectedEndpoints: map[usmhttp.Key]int{
 				{
@@ -519,14 +521,16 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			name: "parse_frames tail call using 2 programs",
 			// The purpose of this test is to validate that when we surpass the limit of HTTP2_MAX_FRAMES_ITERATIONS,
 			// the filtering of subsequent frames will continue using tail calls.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				const settingsFramesCount = 130
 				framer := newFramer()
-				return framer.
-					writeMultiMessage(t, settingsFramesCount, framer.writeSettings).
-					writeHeaders(t, 1, testHeaders()).
-					writeData(t, 1, true, emptyBody).
-					bytes()
+				return [][]byte{
+					framer.
+						writeMultiMessage(t, settingsFramesCount, framer.writeSettings).
+						writeHeaders(t, 1, testHeaders()).
+						writeData(t, 1, true, emptyBody).
+						bytes(),
+				}
 			},
 			expectedEndpoints: map[usmhttp.Key]int{
 				{
@@ -542,14 +546,16 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			name: "validate frames_filter tail calls limit",
 			// The purpose of this test is to validate that when we surpass the limit of HTTP2_MAX_TAIL_CALLS_FOR_FRAMES_FILTER,
 			// for 2 filter_frames we do not use more than two tail calls.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				settingsFramesCount := getTLSNumber(241, 121, s.isTLS)
 				framer := newFramer()
-				return framer.
-					writeMultiMessage(t, settingsFramesCount, framer.writeSettings).
-					writeHeaders(t, 1, testHeaders()).
-					writeData(t, 1, true, emptyBody).
-					bytes()
+				return [][]byte{
+					framer.
+						writeMultiMessage(t, settingsFramesCount, framer.writeSettings).
+						writeHeaders(t, 1, testHeaders()).
+						writeData(t, 1, true, emptyBody).
+						bytes(),
+				}
 			},
 			expectedEndpoints: nil,
 		},
@@ -557,7 +563,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			name: "validate max interesting frames limit",
 			// The purpose of this test is to verify our ability to reach the limit set by HTTP2_MAX_FRAMES_ITERATIONS, which
 			// determines the maximum number of "interesting frames" we can process.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				iterations := getTLSNumber(120, 60, s.isTLS)
 				framer := newFramer()
 				for i := 0; i < iterations; i++ {
@@ -566,7 +572,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 						writeHeaders(t, streamID, testHeaders()).
 						writeData(t, streamID, true, emptyBody)
 				}
-				return framer.bytes()
+				return [][]byte{framer.bytes()}
 			},
 			expectedEndpoints: map[usmhttp.Key]int{
 				{
@@ -580,7 +586,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			// The purpose of this test is to verify our ability the case:
 			// Literal Header Field without Indexing (0b0000xxxx: top four bits are 0000)
 			// https://httpwg.org/specs/rfc7541.html#rfc.section.C.2.2
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				const iterations = 5
 				const setDynamicTableSize = true
 				framer := newFramer()
@@ -590,7 +596,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 						writeHeaders(t, streamID, generateTestHeaderFields(headersGenerationOptions{pathTypeValue: pathLiteralWithoutIndexing}), setDynamicTableSize).
 						writeData(t, streamID, true, emptyBody)
 				}
-				return framer.bytes()
+				return [][]byte{framer.bytes()}
 			},
 			expectedEndpoints: map[usmhttp.Key]int{
 				{
@@ -604,7 +610,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			// The purpose of this test is to verify our ability the case:
 			// Literal Header Field never Indexed (0b0001xxxx: top four bits are 0001)
 			// https://httpwg.org/specs/rfc7541.html#rfc.section.6.2.3
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				const iterations = 5
 				framer := newFramer()
 				for i := 0; i < iterations; i++ {
@@ -613,8 +619,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 						writeHeaders(t, streamID, generateTestHeaderFields(headersGenerationOptions{pathTypeValue: pathLiteralNeverIndexed})).
 						writeData(t, streamID, true, emptyBody)
 				}
-				return framer.bytes()
-
+				return [][]byte{framer.bytes()}
 			},
 			expectedEndpoints: map[usmhttp.Key]int{
 				{
@@ -626,7 +631,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		{
 			name: "validate path with index 4",
 			// The purpose of this test is to verify our ability to identify paths with index 4.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				const iterations = 5
 				// pathHeaderField is the hex representation of the path /aaa with index 4.
 				pathHeaderField := []byte{0x44, 0x83, 0x60, 0x63, 0x1f}
@@ -644,7 +649,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 						writeRawHeaders(t, streamID, headersFrame).
 						writeData(t, streamID, true, emptyBody)
 				}
-				return framer.bytes()
+				return [][]byte{framer.bytes()}
 			},
 			expectedEndpoints: map[usmhttp.Key]int{
 				{
@@ -656,7 +661,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		{
 			name: "validate PING and WINDOWS_UPDATE frames between HEADERS and DATA",
 			// The purpose of this test is to verify our ability to process PING and WINDOWS_UPDATE frames between HEADERS and DATA.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				const iterations = 5
 				framer := newFramer()
 
@@ -669,7 +674,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 						writeData(t, streamID, true, emptyBody)
 				}
 
-				return framer.bytes()
+				return [][]byte{framer.bytes()}
 			},
 			expectedEndpoints: map[usmhttp.Key]int{
 				{
@@ -683,7 +688,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			// The purpose of this test is to validate that when a cancel error code is sent, we will not count the request.
 			// We are sending 10 requests, and 5 of them will contain RST_STREAM with a cancel error code.Therefore, we expect to
 			// capture five valid requests.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				const iterations = 10
 				rstFramesCount := 5
 				framer := newFramer()
@@ -697,7 +702,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 						rstFramesCount--
 					}
 				}
-				return framer.bytes()
+				return [][]byte{framer.bytes()}
 			},
 			expectedEndpoints: map[usmhttp.Key]int{
 				{
@@ -710,7 +715,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			name: "validate RST_STREAM before server status ok",
 			// The purpose of this test is to validate that when we see RST before DATA frame with status ok,
 			// we will not count the requests.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				const iterations = 10
 				framer := newFramer()
 				for i := 0; i < iterations; i++ {
@@ -720,7 +725,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 						writeData(t, streamID, true, emptyBody).
 						writeRSTStream(t, streamID, http2.ErrCodeNo)
 				}
-				return framer.bytes()
+				return [][]byte{framer.bytes()}
 			},
 			expectedEndpoints: nil,
 		},
@@ -731,40 +736,51 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			// When we exceed the limit, we expect to lose our internal counter (because we can filter up to 25 requests),
 			// and therefore, the next time we write the request "/aaa",
 			// its internal index will not be correct, and we will not be able to find it.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				const multiHeadersCount = 25
 				framer := newFramer()
-				return framer.writeHeaders(t, 1, multipleTestHeaders(multiHeadersCount)).
-					writeData(t, 1, true, emptyBody).
-					writeHeaders(t, 1, testHeaders()).
-					writeData(t, 1, true, emptyBody).bytes()
+				return [][]byte{
+					framer.writeHeaders(t, 1, multipleTestHeaders(multiHeadersCount)).
+						writeData(t, 1, true, emptyBody).
+						writeHeaders(t, 1, testHeaders()).
+						writeData(t, 1, true, emptyBody).
+						bytes(),
+				}
 			},
 			expectedEndpoints: nil,
 		},
 		{
 			name: "validate 300 status code",
 			// The purpose of this test is to verify that currently we do not support status code 300.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				framer := newFramer()
-				return framer.writeHeaders(t, 1, headersWithGivenEndpoint("/status/300")).
-					writeData(t, 1, true, emptyBody).bytes()
+				return [][]byte{
+					framer.
+						writeHeaders(t, 1, headersWithGivenEndpoint("/status/300")).
+						writeData(t, 1, true, emptyBody).
+						bytes(),
+				}
 			},
 			expectedEndpoints: nil,
 		},
 		{
 			name: "validate 401 status code",
 			// The purpose of this test is to verify that currently we do not support status code 401.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				framer := newFramer()
-				return framer.writeHeaders(t, 1, headersWithGivenEndpoint("/status/401")).
-					writeData(t, 1, true, emptyBody).bytes()
+				return [][]byte{
+					framer.
+						writeHeaders(t, 1, headersWithGivenEndpoint("/status/401")).
+						writeData(t, 1, true, emptyBody).
+						bytes(),
+				}
 			},
 			expectedEndpoints: nil,
 		},
 		{
 			name: "validate http methods",
 			// The purpose of this test is to validate that we are not supporting http2 methods different from POST and GET.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				httpMethods = []string{http.MethodHead, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions}
 				framer := newFramer()
 				for i, method := range httpMethods {
@@ -773,18 +789,21 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 						writeHeaders(t, streamID, generateTestHeaderFields(headersGenerationOptions{overrideMethod: method})).
 						writeData(t, streamID, true, emptyBody)
 				}
-				return framer.bytes()
+				return [][]byte{framer.bytes()}
 			},
 			expectedEndpoints: nil,
 		},
 		{
 			name: "validate max path length",
 			// The purpose of this test is to validate that we are not able to process a path longer than HTTP2_MAX_PATH_LEN.
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				framer := newFramer()
-				return framer.
-					writeHeaders(t, 1, generateTestHeaderFields(headersGenerationOptions{pathTypeValue: pathTooLarge})).
-					writeData(t, 1, true, emptyBody).bytes()
+				return [][]byte{
+					framer.
+						writeHeaders(t, 1, generateTestHeaderFields(headersGenerationOptions{pathTypeValue: pathTooLarge})).
+						writeData(t, 1, true, emptyBody).
+						bytes(),
+				}
 			},
 			expectedEndpoints: nil,
 		},
@@ -792,7 +811,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			name: "validate path sent by value (:path)",
 			// The purpose of this test is to verify our ability to identify paths which were sent with a key that
 			// sent by value (:path).
-			messageBuilder: func() []byte {
+			messageBuilder: func() [][]byte {
 				headerFields := removeHeaderFieldByKey(testHeaders(), ":path")
 				headersFrame, err := usmhttp2.NewHeadersFrameMessage(headerFields)
 				require.NoError(t, err, "could not create headers frame")
@@ -801,8 +820,12 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 				pathHeaderField := []byte{0x40, 0x84, 0xb9, 0x58, 0xd3, 0x3f, 0x83, 0x60, 0x63, 0x1f}
 				headersFrame = append(pathHeaderField, headersFrame...)
 				framer := newFramer()
-				return framer.writeRawHeaders(t, 1, headersFrame).
-					writeData(t, 1, true, emptyBody).bytes()
+				return [][]byte{
+					framer.
+						writeRawHeaders(t, 1, headersFrame).
+						writeData(t, 1, true, emptyBody).
+						bytes(),
+				}
 			},
 			expectedEndpoints: nil,
 		},
@@ -821,7 +844,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			c := dialHTTP2Server(t)
 
 			// Composing a message with the number of setting frames we want to send.
-			require.NoError(t, writeInput(c, tt.messageBuilder(), 500*time.Millisecond))
+			require.NoError(t, writeInput(c, 500*time.Millisecond, tt.messageBuilder()...))
 
 			res := make(map[usmhttp.Key]int)
 			assert.Eventually(t, func() bool {
@@ -894,7 +917,7 @@ func (s *usmHTTP2Suite) TestDynamicTable() {
 			c := dialHTTP2Server(t)
 
 			// Composing a message with the number of setting frames we want to send.
-			require.NoError(t, writeInput(c, tt.messageBuilder(), 500*time.Millisecond))
+			require.NoError(t, writeInput(c, 500*time.Millisecond, tt.messageBuilder()))
 
 			res := make(map[usmhttp.Key]int)
 			assert.Eventually(t, func() bool {
@@ -973,7 +996,7 @@ func (s *usmHTTP2Suite) TestRawHuffmanEncoding() {
 			c := dialHTTP2Server(t)
 
 			// Composing a message with the number of setting frames we want to send.
-			require.NoError(t, writeInput(c, tt.messageBuilder(), 500*time.Millisecond))
+			require.NoError(t, writeInput(c, 500*time.Millisecond, tt.messageBuilder()))
 
 			res := make(map[usmhttp.Key]int)
 			assert.Eventually(t, func() bool {
@@ -1049,9 +1072,11 @@ func getHTTP2UnixClientArray(size int, unixPath string) []*http.Client {
 // writeInput writes the given input to the socket and reads the response.
 // Presently, the timeout is configured to one second for all readings.
 // In case of encountered issues, increasing this duration might be necessary.
-func writeInput(c net.Conn, input []byte, timeout time.Duration) error {
-	if _, err := c.Write(input); err != nil {
-		return err
+func writeInput(c net.Conn, timeout time.Duration, inputs ...[]byte) error {
+	for _, input := range inputs {
+		if _, err := c.Write(input); err != nil {
+			return err
+		}
 	}
 	// Since we don't know when to stop reading from the socket, we set a timeout.
 	if err := c.SetReadDeadline(time.Now().Add(timeout)); err != nil {
@@ -1323,6 +1348,6 @@ func dialHTTP2Server(t *testing.T) net.Conn {
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Writing a magic and the settings in the same packet to socket.
-	require.NoError(t, writeInput(c, usmhttp2.ComposeMessage([]byte(http2.ClientPreface), newFramer().writeSettings(t).bytes()), time.Millisecond*200))
+	require.NoError(t, writeInput(c, time.Millisecond*200, usmhttp2.ComposeMessage([]byte(http2.ClientPreface), newFramer().writeSettings(t).bytes())))
 	return c
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The PR backports behavior that exists in the TLS version.
We now support the case where the frame header is being sent separately from the frame payload. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Support more edge cases

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

TLS matching commit - https://github.com/DataDog/datadog-agent/commit/a72bd8660c43f256a1c53431ce3f213cf6ffb93a

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
