### PR TITLE
fix(remote): Return unexpected errors with code 500 in the trace-agent RC proxy

### DIFF
--- a/cmd/trace-agent/config/remote/config.go
+++ b/cmd/trace-agent/config/remote/config.go
@@ -78,13 +78,12 @@ func ConfigHandler(r *api.HTTPReceiver, client rcclient.ConfigUpdater, cfg *conf
 		}
 		cfg, err := client.ClientGetConfigs(req.Context(), &configsRequest)
 		if err != nil {
+			statusCode = http.StatusInternalServerError
 			if e, ok := status.FromError(err); ok {
 				switch e.Code() {
 				case codes.Unimplemented, codes.NotFound:
 					statusCode = http.StatusNotFound
 				}
-			} else {
-				statusCode = http.StatusInternalServerError
 			}
 			http.Error(w, err.Error(), statusCode)
 			return


### PR DESCRIPTION
### What does this PR do?
Fixes a small issue where the trace agent RC proxy would return a 200 with an error.
Adds tests around it as well.

This was detected because of https://github.com/golang/go/issues/63830 causing core-agent restarts, which in turned resulted in `Unavailable` error codes in the trace-agent, causing this 200 + error case.

### Motivation
Less error logs in the tracers when unmarshalling JSON. The usual path is "if 200 then unmarshal", but in this case code 200 + error that's not JSON would return an error when unmarshalling.

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
N/A. If tests pass we're good.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
