### PR TITLE
usm: Add Stringer implementation to ConnectionKey and Key

### DIFF
--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -80,6 +80,11 @@ type Key struct {
 	Method Method
 }
 
+// String returns a string representation of the Key
+func (k Key) String() string {
+	return "{IP: " + k.ConnectionKey.String() + ", Method: " + k.Method.String() + ", Path: " + k.Path.Content.Get() + "}"
+}
+
 // NewKey generates a new Key
 func NewKey(saddr, daddr util.Address, sport, dport uint16, path []byte, fullPath bool, method Method) Key {
 	return NewKeyWithConnection(types.NewConnectionKey(saddr, daddr, sport, dport), path, fullPath, method)

--- a/pkg/network/types/connection_key.go
+++ b/pkg/network/types/connection_key.go
@@ -6,7 +6,11 @@
 //nolint:revive // TODO(NET) Fix revive linter
 package types
 
-import "github.com/DataDog/datadog-agent/pkg/process/util"
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
 
 // ConnectionKey represents a network four-tuple (source IP, destination IP, source port, destination port)
 type ConnectionKey struct {
@@ -19,6 +23,17 @@ type ConnectionKey struct {
 	// ports separated for alignment/size optimization
 	SrcPort uint16
 	DstPort uint16
+}
+
+// String returns a string representation of the ConnectionKey
+func (c *ConnectionKey) String() string {
+	return fmt.Sprintf(
+		"[%v:%d ⇄ %v:%d]",
+		util.FromLowHigh(c.SrcIPLow, c.SrcIPHigh),
+		c.SrcPort,
+		util.FromLowHigh(c.DstIPLow, c.DstIPHigh),
+		c.DstPort,
+	)
 }
 
 // NewConnectionKey generates a new ConnectionKey


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Implements stringer interface on 2 structs that are widely used in tests.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Improve test output.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Old representation
```
{{0xc000715b18 false} {0 0 0 0 0 0} GET}
```

new format
```
{IP: [0.0.0.0:0 ⇄ 0.0.0.0:0], Method: GET, Path: /status/200}
```
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
