### PR TITLE
[ASCII-1019] update e2e test for agent status

### DIFF
--- a/comp/logs/agent/agent.go
+++ b/comp/logs/agent/agent.go
@@ -118,7 +118,7 @@ func newLogsAgent(deps dependencies) provides {
 
 		return provides{
 			Comp:           optional.NewOption[Component](logsAgent),
-			StatusProvider: statusComponent.NewInformationProvider(logsAgent),
+			StatusProvider: statusComponent.NewInformationProvider(statusProvider{}),
 			FlareProvider:  flaretypes.NewProvider(logsAgent.flarecontroller.FillFlare),
 		}
 	}
@@ -126,7 +126,7 @@ func newLogsAgent(deps dependencies) provides {
 	deps.Log.Info("logs-agent disabled")
 	return provides{
 		Comp:           optional.NewNoneOption[Component](),
-		StatusProvider: statusComponent.NoopInformationProvider(),
+		StatusProvider: statusComponent.NewInformationProvider(statusProvider{}),
 	}
 }
 

--- a/comp/logs/agent/agent_test.go
+++ b/comp/logs/agent/agent_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
-	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/inventoryagentimpl"
@@ -218,12 +217,12 @@ func (suite *AgentTestSuite) TestStatusProvider() {
 		{
 			"logs enabled",
 			true,
-			&agent{},
+			statusProvider{},
 		},
 		{
 			"logs disabled",
 			false,
-			status.NoopProvider{},
+			statusProvider{},
 		},
 	}
 

--- a/comp/logs/agent/status.go
+++ b/comp/logs/agent/status.go
@@ -16,36 +16,38 @@ import (
 //go:embed status_templates
 var templatesFS embed.FS
 
-func (a *agent) Name() string {
+type statusProvider struct{}
+
+func (p statusProvider) Name() string {
 	return "Logs Agent"
 }
 
-func (a *agent) Section() string {
+func (p statusProvider) Section() string {
 	return "Logs Agent"
 }
 
-func (a *agent) getStatusInfo(verbose bool) map[string]interface{} {
+func (p statusProvider) getStatusInfo(verbose bool) map[string]interface{} {
 	stats := make(map[string]interface{})
 
-	a.populateStatus(verbose, stats)
+	p.populateStatus(verbose, stats)
 
 	return stats
 }
 
-func (a *agent) populateStatus(verbose bool, stats map[string]interface{}) {
+func (p statusProvider) populateStatus(verbose bool, stats map[string]interface{}) {
 	stats["logsStats"] = logsStatus.Get(verbose)
 }
 
-func (a *agent) JSON(verbose bool, stats map[string]interface{}) error {
-	a.populateStatus(verbose, stats)
+func (p statusProvider) JSON(verbose bool, stats map[string]interface{}) error {
+	p.populateStatus(verbose, stats)
 
 	return nil
 }
 
-func (a *agent) Text(verbose bool, buffer io.Writer) error {
-	return status.RenderText(templatesFS, "logsagent.tmpl", buffer, a.getStatusInfo(verbose))
+func (p statusProvider) Text(verbose bool, buffer io.Writer) error {
+	return status.RenderText(templatesFS, "logsagent.tmpl", buffer, p.getStatusInfo(verbose))
 }
 
-func (a *agent) HTML(verbose bool, buffer io.Writer) error {
-	return status.RenderHTML(templatesFS, "logsagentHTML.tmpl", buffer, a.getStatusInfo(verbose))
+func (p statusProvider) HTML(verbose bool, buffer io.Writer) error {
+	return status.RenderHTML(templatesFS, "logsagentHTML.tmpl", buffer, p.getStatusInfo(verbose))
 }

--- a/comp/metadata/host/hostimpl/status.go
+++ b/comp/metadata/host/hostimpl/status.go
@@ -22,7 +22,7 @@ import (
 var templatesFS embed.FS
 
 func (h *host) Name() string {
-	return "Hostanme"
+	return "Hostname"
 }
 
 func (h *host) Index() int {

--- a/comp/trace/status/statusimpl/status.go
+++ b/comp/trace/status/statusimpl/status.go
@@ -73,12 +73,12 @@ var templatesFS embed.FS
 
 // Name returns the name
 func (s statusProvider) Name() string {
-	return "APM Status"
+	return "APM Agent"
 }
 
 // Section return the section
 func (s statusProvider) Section() string {
-	return "APM Status"
+	return "APM Agent"
 }
 
 func (s statusProvider) getStatusInfo() map[string]interface{} {

--- a/pkg/status/jmx/status.go
+++ b/pkg/status/jmx/status.go
@@ -25,7 +25,7 @@ func (Provider) Name() string {
 
 // Section return the section
 func (Provider) Section() string {
-	return "jmx fetch"
+	return "JMX Fetch"
 }
 
 func (p Provider) getStatusInfo(verbose bool) map[string]interface{} {

--- a/test/new-e2e/tests/agent-subcommands/subcommands_test.go
+++ b/test/new-e2e/tests/agent-subcommands/subcommands_test.go
@@ -102,8 +102,12 @@ func (v *subcommandSuite) TestDefaultInstallStatus() {
 		{
 			name:             `Agent \(.*\)`, // TODO: verify that the right version is output
 			shouldBePresent:  true,
-			shouldContain:    []string{fmt.Sprintf("hostname: %v", resourceID), "hostname provider: aws"},
 			shouldNotContain: []string{"FIPS proxy"},
+		},
+		{
+			name:            `Hostname`,
+			shouldBePresent: true,
+			shouldContain:   []string{fmt.Sprintf("hostname: %v", resourceID), "hostname provider: aws"},
 		},
 		{
 			name:            "Aggregator",

--- a/test/new-e2e/tests/agent-subcommands/subcommands_test.go
+++ b/test/new-e2e/tests/agent-subcommands/subcommands_test.go
@@ -157,7 +157,8 @@ func (v *subcommandSuite) TestDefaultInstallStatus() {
 		},
 		{
 			name:            "Logs Agent",
-			shouldBePresent: false,
+			shouldBePresent: true,
+			shouldContain:   []string{"Logs Agent is not running"},
 		},
 		{
 			name:            "Metadata Mapper",

--- a/test/new-e2e/tests/agent-subcommands/subcommands_test.go
+++ b/test/new-e2e/tests/agent-subcommands/subcommands_test.go
@@ -80,7 +80,7 @@ func verifySectionContent(t *testing.T, statusOutput string, section expectedSec
 	sectionContent, err := getStatusComponentContent(statusOutput, section.name)
 
 	if section.shouldBePresent {
-		if assert.NoError(t, err, "Section %v was expected in the status output, but was not found", section.name) {
+		if assert.NoError(t, err, "Section %v was expected in the status output, but was not found. \n Here is the status output %s", section.name, statusOutput) {
 			for _, expectedContent := range section.shouldContain {
 				assert.Contains(t, sectionContent.content, expectedContent)
 			}
@@ -151,14 +151,13 @@ func (v *subcommandSuite) TestDefaultInstallStatus() {
 			shouldBePresent: true,
 		},
 		{
-			name:            "JMXFetch",
+			name:            "JMX Fetch",
 			shouldBePresent: true,
 			shouldContain:   []string{"no checks"},
 		},
 		{
 			name:            "Logs Agent",
-			shouldBePresent: true,
-			shouldContain:   []string{"Logs Agent is not running"},
+			shouldBePresent: false,
 		},
 		{
 			name:            "Metadata Mapper",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixing e2e test. The test broke after merging https://github.com/DataDog/datadog-agent/pull/22115

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

I wasn't able to use the `skip-qa` label. So there is no need to do any QA as the PR fixes the e2e test. The test serve as QA

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
