### PR TITLE
[ASCII-1020] SNMP Traps status provider

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -83,7 +83,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/comp/snmptraps"
 	snmptrapsServer "github.com/DataDog/datadog-agent/comp/snmptraps/server"
-	snmptrapsStatusImpl "github.com/DataDog/datadog-agent/comp/snmptraps/status/statusimpl"
 	traceagentStatusImpl "github.com/DataDog/datadog-agent/comp/trace/status/statusimpl"
 	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
@@ -310,9 +309,6 @@ func getSharedFxOption() fx.Option {
 			status.NewInformationProvider(endpointsStatus.Provider{}),
 		),
 		fx.Provide(func(config config.Component) status.InformationProvider {
-			return status.NewInformationProvider(snmptrapsStatusImpl.GetProvider(config))
-		}),
-		fx.Provide(func(config config.Component) status.InformationProvider {
 			return status.NewInformationProvider(clusteragentStatus.GetProvider(config))
 		}),
 		fx.Provide(func(config config.Component) status.InformationProvider {
@@ -372,7 +368,7 @@ func getSharedFxOption() fx.Option {
 		}),
 		ndmtmp.Bundle(),
 		netflow.Bundle(),
-		snmptraps.Bundle,
+		snmptraps.Bundle(),
 		fx.Provide(func(demultiplexer demultiplexer.Component) optional.Option[collector.Collector] {
 			return optional.NewOption(common.LoadCollector(demultiplexer))
 		}),

--- a/comp/snmptraps/bundle.go
+++ b/comp/snmptraps/bundle.go
@@ -15,6 +15,8 @@ import (
 // team: network-device-monitoring
 
 // Bundle defines the fx options for this bundle.
-var Bundle = fxutil.Bundle(
-	serverimpl.Module,
-)
+func Bundle() fxutil.BundleOptions {
+	return fxutil.Bundle(
+		serverimpl.Module(),
+	)
+}

--- a/comp/snmptraps/bundle_test.go
+++ b/comp/snmptraps/bundle_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestBundleDependencies(t *testing.T) {
-	fxutil.TestBundle(t, Bundle,
+	fxutil.TestBundle(t, Bundle(),
 		config.MockModule(),
 		hostnameimpl.MockModule(),
 		logimpl.MockModule(),

--- a/comp/snmptraps/config/configimpl/service.go
+++ b/comp/snmptraps/config/configimpl/service.go
@@ -9,11 +9,12 @@ package configimpl
 import (
 	"context"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	trapsconf "github.com/DataDog/datadog-agent/comp/snmptraps/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 type configService struct {
@@ -38,6 +39,8 @@ func newService(conf config.Component, hnService hostname.Component) (trapsconf.
 }
 
 // Module defines the fx options for this component.
-var Module = fxutil.Component(
-	fx.Provide(newService),
-)
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newService),
+	)
+}

--- a/comp/snmptraps/config/configimpl/service_mock.go
+++ b/comp/snmptraps/config/configimpl/service_mock.go
@@ -8,10 +8,11 @@ package configimpl
 import (
 	"context"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	trapsconf "github.com/DataDog/datadog-agent/comp/snmptraps/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 type dependencies struct {
@@ -35,7 +36,9 @@ func newMockConfig(dep dependencies) (trapsconf.Component, error) {
 // MockModule provides the default config, and allows tests to override it by
 // providing `fx.Replace(&TrapsConfig{...})`; a value replaced this way will
 // have default values set sensibly if they aren't provided.
-var MockModule = fxutil.Component(
-	fx.Provide(newMockConfig),
-	fx.Supply(&trapsconf.TrapsConfig{Enabled: true}),
-)
+func MockModule() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newMockConfig),
+		fx.Supply(&trapsconf.TrapsConfig{Enabled: true}),
+	)
+}

--- a/comp/snmptraps/formatter/formatterimpl/formatter.go
+++ b/comp/snmptraps/formatter/formatterimpl/formatter.go
@@ -11,6 +11,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gosnmp/gosnmp"
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/formatter"
@@ -18,14 +21,14 @@ import (
 	"github.com/DataDog/datadog-agent/comp/snmptraps/packet"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/gosnmp/gosnmp"
-	"go.uber.org/fx"
 )
 
 // Module implements the formatter component.
-var Module = fxutil.Component(
-	fx.Provide(newJSONFormatter),
-)
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newJSONFormatter),
+	)
+}
 
 const (
 	ddsource       = "snmp-traps"

--- a/comp/snmptraps/formatter/formatterimpl/formatter_test.go
+++ b/comp/snmptraps/formatter/formatterimpl/formatter_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/formatter"
@@ -20,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/snmptraps/senderhelper"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gosnmp/gosnmp"
@@ -218,8 +219,8 @@ var (
 var testOptions = fx.Options(
 	logimpl.MockModule(),
 	senderhelper.Opts,
-	oidresolverimpl.MockModule,
-	Module,
+	oidresolverimpl.MockModule(),
+	Module(),
 )
 
 func TestFormatPacketV1Generic(t *testing.T) {

--- a/comp/snmptraps/formatter/formatterimpl/mock.go
+++ b/comp/snmptraps/formatter/formatterimpl/mock.go
@@ -11,16 +11,19 @@ import (
 	"encoding/gob"
 	"encoding/hex"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/snmptraps/formatter"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/packet"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 // MockModule provides a dummy formatter that just hashes packets.
-var MockModule = fxutil.Component(
-	fx.Provide(newDummy),
-)
+func MockModule() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newDummy),
+	)
+}
 
 // newDummy creates a new dummy formatter.
 func newDummy() formatter.Component {

--- a/comp/snmptraps/formatter/formatterimpl/mock_test.go
+++ b/comp/snmptraps/formatter/formatterimpl/mock_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMockFormatter(t *testing.T) {
-	formatter := fxutil.Test[formatter.Component](t, MockModule)
+	formatter := fxutil.Test[formatter.Component](t, MockModule())
 	packet := packet.CreateTestV1GenericPacket()
 	// we don't check the value itself because it uses "encoding/gob", which
 	// produces different values depending on the platform.

--- a/comp/snmptraps/forwarder/forwarderimpl/forwarder.go
+++ b/comp/snmptraps/forwarder/forwarderimpl/forwarder.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/config"
@@ -20,13 +22,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 // Module defines the fx options for this component.
-var Module = fxutil.Component(
-	fx.Provide(newTrapForwarder),
-)
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newTrapForwarder),
+	)
+}
 
 // trapForwarder consumes SNMP packets, formats traps and send them as EventPlatformEvents
 // The trapForwarder is an intermediate step between the listener and the epforwarder in order to limit the processing of the listener

--- a/comp/snmptraps/forwarder/forwarderimpl/forwarder_test.go
+++ b/comp/snmptraps/forwarder/forwarderimpl/forwarder_test.go
@@ -43,12 +43,12 @@ func setUp(t *testing.T) *services {
 	t.Helper()
 	s := fxutil.Test[services](t,
 		hostnameimpl.MockModule(),
-		configimpl.MockModule,
+		configimpl.MockModule(),
 		logimpl.MockModule(),
 		senderhelper.Opts,
-		formatterimpl.MockModule,
-		listenerimpl.MockModule,
-		Module,
+		formatterimpl.MockModule(),
+		listenerimpl.MockModule(),
+		Module(),
 	)
 	return &s
 }

--- a/comp/snmptraps/listener/listenerimpl/listener.go
+++ b/comp/snmptraps/listener/listenerimpl/listener.go
@@ -13,10 +13,11 @@ import (
 	"net"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/gosnmp/gosnmp"
 	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/core/log"
@@ -27,9 +28,11 @@ import (
 )
 
 // Module defines the fx options for this component.
-var Module = fxutil.Component(
-	fx.Provide(newTrapListener),
-)
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newTrapListener),
+	)
+}
 
 // trapListener opens an UDP socket and put all received traps in a channel
 type trapListener struct {

--- a/comp/snmptraps/listener/listenerimpl/listener_test.go
+++ b/comp/snmptraps/listener/listenerimpl/listener_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
@@ -22,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/snmptraps/status/statusimpl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
@@ -47,10 +48,10 @@ func listenerTestSetup(t *testing.T, conf *config.TrapsConfig) *services {
 	s := fxutil.Test[services](t,
 		hostnameimpl.MockModule(),
 		logimpl.MockModule(),
-		configimpl.MockModule,
-		statusimpl.MockModule,
+		configimpl.MockModule(),
+		statusimpl.MockModule(),
 		senderhelper.Opts,
-		Module,
+		Module(),
 		fx.Replace(conf),
 	)
 	return &s

--- a/comp/snmptraps/listener/listenerimpl/mock_listener.go
+++ b/comp/snmptraps/listener/listenerimpl/mock_listener.go
@@ -6,16 +6,19 @@
 package listenerimpl
 
 import (
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/snmptraps/listener"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/packet"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 // MockModule provides a MockComponent as the Component.
-var MockModule = fxutil.Component(
-	fx.Provide(newMock),
-)
+func MockModule() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newMock),
+	)
+}
 
 type mockListener struct {
 	packets packet.PacketsChannel

--- a/comp/snmptraps/oidresolver/oidresolverimpl/mock.go
+++ b/comp/snmptraps/oidresolver/oidresolverimpl/mock.go
@@ -8,17 +8,20 @@ package oidresolverimpl
 import (
 	"fmt"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/snmptraps/oidresolver"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 // MockModule provides a dummy resolver with canned data.
 // Set your own data with fx.Replace(&oidresolver.TrapDBFileContent{...})
-var MockModule = fxutil.Component(
-	fx.Provide(NewMockResolver),
-	fx.Supply(&dummyTrapDB),
-)
+func MockModule() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(NewMockResolver),
+		fx.Supply(&dummyTrapDB),
+	)
+}
 
 // MockResolver implements OIDResolver with a mock database.
 type MockResolver struct {
@@ -36,7 +39,7 @@ func (r MockResolver) GetTrapMetadata(trapOid string) (oidresolver.TrapMetadata,
 }
 
 // GetVariableMetadata implements OIDResolver#GetVariableMetadata.
-func (r MockResolver) GetVariableMetadata(string, varOid string) (oidresolver.VariableMetadata, error) { //nolint:revive // TODO fix revive unusued-parameter
+func (r MockResolver) GetVariableMetadata(_ string, varOid string) (oidresolver.VariableMetadata, error) { //nolint:revive // TODO fix revive unusued-parameter
 	varOid = oidresolver.NormalizeOID(varOid)
 	varData, ok := r.content.Variables[varOid]
 	if !ok {

--- a/comp/snmptraps/oidresolver/oidresolverimpl/oid_resolver.go
+++ b/comp/snmptraps/oidresolver/oidresolverimpl/oid_resolver.go
@@ -27,9 +27,11 @@ import (
 )
 
 // Module defines the fx options for this component.
-var Module = fxutil.Component(
-	fx.Provide(newResolver),
-)
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newResolver),
+	)
+}
 
 const ddTrapDBFileNamePrefix string = "dd_traps_db"
 

--- a/comp/snmptraps/server/serverimpl/server.go
+++ b/comp/snmptraps/server/serverimpl/server.go
@@ -32,9 +32,10 @@ import (
 )
 
 // Module defines the fx options for this component.
-var Module = fxutil.Component(
-	fx.Provide(newServer),
-)
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newServer))
+}
 
 type dependencies struct {
 	fx.In
@@ -102,11 +103,11 @@ func newServer(lc fx.Lifecycle, deps dependencies) provides {
 			Logger:    deps.Logger,
 			Status:    stat,
 		}),
-		configimpl.Module,
-		formatterimpl.Module,
-		forwarderimpl.Module,
-		listenerimpl.Module,
-		oidresolverimpl.Module,
+		configimpl.Module(),
+		formatterimpl.Module(),
+		forwarderimpl.Module(),
+		listenerimpl.Module(),
+		oidresolverimpl.Module(),
 		fx.Invoke(func(_ forwarder.Component, _ listener.Component) {}),
 	)
 	server := &TrapsServer{app: app, stat: stat}

--- a/comp/snmptraps/server/serverimpl/server.go
+++ b/comp/snmptraps/server/serverimpl/server.go
@@ -13,6 +13,9 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	coreStatus "github.com/DataDog/datadog-agent/comp/core/status"
+
+	"go.uber.org/fx"
 
 	trapsconfig "github.com/DataDog/datadog-agent/comp/snmptraps/config"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/config/configimpl"
@@ -26,7 +29,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/snmptraps/status"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/status/statusimpl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 // Module defines the fx options for this component.
@@ -52,6 +54,13 @@ type injections struct {
 	Status    status.Component
 }
 
+type provides struct {
+	fx.Out
+
+	Comp           server.Component
+	StatusProvider coreStatus.InformationProvider
+}
+
 // TrapsServer implements the SNMP traps service.
 type TrapsServer struct {
 	app     *fx.App
@@ -74,9 +83,12 @@ func (w *TrapsServer) Error() error {
 
 // newServer creates a new traps server, registering it with the fx lifecycle
 // system if traps are enabled.
-func newServer(lc fx.Lifecycle, deps dependencies) server.Component {
+func newServer(lc fx.Lifecycle, deps dependencies) provides {
 	if !trapsconfig.IsEnabled(deps.Conf) {
-		return &TrapsServer{running: false}
+		return provides{
+			Comp:           &TrapsServer{running: false},
+			StatusProvider: coreStatus.NoopInformationProvider(),
+		}
 	}
 	stat := statusimpl.New()
 	// TODO: (components) Having apps within apps is not ideal - you have to be
@@ -98,11 +110,16 @@ func newServer(lc fx.Lifecycle, deps dependencies) server.Component {
 		fx.Invoke(func(_ forwarder.Component, _ listener.Component) {}),
 	)
 	server := &TrapsServer{app: app, stat: stat}
+
 	if err := app.Err(); err != nil {
 		deps.Logger.Errorf("Failed to initialize snmp-traps server: %s", err)
 		server.stat.SetStartError(err)
-		return server
+		return provides{
+			Comp:           server,
+			StatusProvider: coreStatus.NoopInformationProvider(),
+		}
 	}
+
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
 			err := app.Start(ctx)
@@ -119,5 +136,9 @@ func newServer(lc fx.Lifecycle, deps dependencies) server.Component {
 			return app.Stop(ctx)
 		},
 	})
-	return server
+
+	return provides{
+		Comp:           server,
+		StatusProvider: coreStatus.NewInformationProvider(statusimpl.Provider{}),
+	}
 }

--- a/comp/snmptraps/server/serverimpl/server_test.go
+++ b/comp/snmptraps/server/serverimpl/server_test.go
@@ -48,7 +48,7 @@ func TestServer(t *testing.T) {
 			},
 		}),
 		hostnameimpl.MockModule(),
-		Module,
+		Module(),
 	)
 	assert.NotEmpty(t, server)
 	assert.NoError(t, server.Error())
@@ -73,7 +73,7 @@ func TestNonBlockingFailure(t *testing.T) {
 			},
 		}),
 		hostnameimpl.MockModule(),
-		Module,
+		Module(),
 	)
 	assert.NotEmpty(t, server)
 	assert.ErrorIs(t, server.Error(), os.ErrNotExist)
@@ -90,7 +90,7 @@ func TestDisabled(t *testing.T) {
 			},
 		}),
 		hostnameimpl.MockModule(),
-		Module,
+		Module(),
 	)
 	assert.NotNil(t, server)
 	assert.NoError(t, server.Error())

--- a/comp/snmptraps/status/statusimpl/mock.go
+++ b/comp/snmptraps/status/statusimpl/mock.go
@@ -8,15 +8,18 @@ package statusimpl
 import (
 	"sync"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/snmptraps/status"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 // MockModule defines a fake Component
-var MockModule = fxutil.Component(
-	fx.Provide(newMock),
-)
+func MockModule() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newMock),
+	)
+}
 
 // newMock returns a Component that uses plain internal values instead of expvars
 func newMock() status.Component {

--- a/comp/snmptraps/status/statusimpl/status.go
+++ b/comp/snmptraps/status/statusimpl/status.go
@@ -12,12 +12,12 @@ import (
 	"expvar"
 	"io"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	trapsStatus "github.com/DataDog/datadog-agent/comp/snmptraps/status"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 // Module defines the fx options for this component.
@@ -75,15 +75,6 @@ var templatesFS embed.FS
 
 // Provider provides the functionality to populate the status output
 type Provider struct{}
-
-// GetProvider if snamp traps is enabled returns status.Provider otherwise returns NoopProvider
-func GetProvider(conf config.Component) status.Provider {
-	if conf.GetBool("network_devices.snmp_traps.enabled") {
-		return Provider{}
-	}
-
-	return status.NoopProvider{}
-}
 
 // Name returns the name
 func (Provider) Name() string {
@@ -143,7 +134,7 @@ func GetStatus() map[string]interface{} {
 
 	status := make(map[string]interface{})
 
-	metricsJSON := []byte(expvar.Get("snmp_traps").String())
+	metricsJSON := []byte(trapsExpvars.String())
 	metrics := make(map[string]interface{})
 	json.Unmarshal(metricsJSON, &metrics) //nolint:errcheck
 	if dropped := getDroppedPackets(); dropped > 0 {

--- a/comp/snmptraps/status/statusimpl/status.go
+++ b/comp/snmptraps/status/statusimpl/status.go
@@ -21,9 +21,11 @@ import (
 )
 
 // Module defines the fx options for this component.
-var Module = fxutil.Component(
-	fx.Provide(New),
-)
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(New),
+	)
+}
 
 var (
 	trapsExpvars                       = expvar.NewMap("snmp_traps")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Rather than passing the SNMP status provider directly, we must rely on FX value groups to do that 😄 https://github.com/DataDog/datadog-agent/pull/22396/commits/e90c78bf426c7bb55d2844042ab960f0ad4a6bf1

I also, updated the SNMP components to use `Module()` and `Bundle()`. For more information refer to https://github.com/DataDog/datadog-agent/pull/21249 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Running `agent status` or `agent launch-gui` with SNMP enabled should display the information.

Here is an example configuration for enabling SNMP:

```
network_devices:
  namespace: test
  snmp_traps:
    enabled: true
    port: 9162
    community_strings:
      - public
    bind_host: 0.0.0.0
```



### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
