### PR TITLE
[CWS] optimization to DNS event unmarshalling path

### DIFF
--- a/pkg/security/secl/model/dns_helpers_linux.go
+++ b/pkg/security/secl/model/dns_helpers_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build unix
+//go:build linux
 
 // Package model holds model related files
 package model

--- a/pkg/security/secl/model/dns_helpers_linux.go
+++ b/pkg/security/secl/model/dns_helpers_linux.go
@@ -9,7 +9,6 @@
 package model
 
 import (
-	"bytes"
 	"errors"
 	"strings"
 )
@@ -33,7 +32,7 @@ func decodeDNSName(raw []byte) (string, error) {
 		i       = 0
 		rawLen  = len(raw)
 		atStart = true
-		rep     bytes.Buffer
+		rep     strings.Builder
 		err     error
 	)
 

--- a/pkg/security/secl/model/dns_helpers_linux.go
+++ b/pkg/security/secl/model/dns_helpers_linux.go
@@ -83,6 +83,10 @@ LOOP:
 }
 
 func validateDNSName(dns string) error {
+	if dns == "" {
+		return nil
+	}
+
 	// Maximum length of the DNS name field in the DNS protocol is 255 bytes:
 	//
 	//                  <------------- 255 --------------->
@@ -94,11 +98,25 @@ func validateDNSName(dns string) error {
 		return ErrDNSNameMalformatted
 	}
 
+	// Check that the DNS doesn't start or end with a dot.
+	if dns[0] == '.' || dns[len(dns)-1] == '.' {
+		return ErrDNSNameMalformatted
+	}
+
 	// Check that each label isn't empty and at most 63 characters.
-	for _, sub := range strings.Split(dns, ".") {
-		if n := len(sub); n < 1 || n > 63 {
+	previousIndex := -1
+	for previousIndex < len(dns) {
+		delta := strings.IndexByte(dns[previousIndex+1:], '.')
+		if delta < 0 {
+			break
+		}
+
+		if delta < 1 || delta > 63 {
 			return ErrDNSNameMalformatted
 		}
+
+		previousIndex += delta + 1
 	}
+
 	return nil
 }

--- a/pkg/security/secl/model/dns_helpers_linux_test.go
+++ b/pkg/security/secl/model/dns_helpers_linux_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build unix
+//go:build linux
 
 // Package model holds model related files
 package model


### PR DESCRIPTION
### What does this PR do?

This PR improves the DNS event unmarshalling code path by:
- switching the buffer to a string builder (skipping the bytes to string copy)
- re-implement the validation function to be alloc-free

This PR also removes the sync the build tags with the file names
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
