### PR TITLE
[APR-23] comp: Add option to dual ship logs to Observability Pipelines Worker

### DIFF
--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -280,14 +280,24 @@ func (l *LogsConfigKeys) obsPipelineWorkerEnabled() bool {
 	return l.getConfig().GetBool(l.getObsPipelineConfigKey("vector", "enabled"))
 }
 
-func (l *LogsConfigKeys) obsPipelineWorkerDualShip() bool {
+func (l *LogsConfigKeys) obsPipelineWorkerDualShipEnabled() bool {
 	if l.vectorPrefix == "" {
 		return false
 	}
-	if l.getConfig().GetBool(l.getObsPipelineConfigKey("observability_pipelines_worker", "dualship")) {
+	if l.getConfig().GetBool(l.getObsPipelineConfigKey("observability_pipelines_worker", "dualship.enabled")) {
 		return true
 	}
-	return l.getConfig().GetBool(l.getObsPipelineConfigKey("vector", "dualship"))
+	return l.getConfig().GetBool(l.getObsPipelineConfigKey("vector", "dualship.enabled"))
+}
+
+func (l *LogsConfigKeys) obsPipelineWorkerDualShipReliable() bool {
+	if l.vectorPrefix == "" {
+		return false
+	}
+	if l.getConfig().GetBool(l.getObsPipelineConfigKey("observability_pipelines_worker", "dualship.reliable")) {
+		return true
+	}
+	return l.getConfig().GetBool(l.getObsPipelineConfigKey("vector", "dualship.reliable"))
 }
 
 func (l *LogsConfigKeys) getObsPipelineURL() (string, bool) {

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -280,6 +280,16 @@ func (l *LogsConfigKeys) obsPipelineWorkerEnabled() bool {
 	return l.getConfig().GetBool(l.getObsPipelineConfigKey("vector", "enabled"))
 }
 
+func (l *LogsConfigKeys) obsPipelineWorkerDualShip() bool {
+	if l.vectorPrefix == "" {
+		return false
+	}
+	if l.getConfig().GetBool(l.getObsPipelineConfigKey("observability_pipelines_worker", "dualship")) {
+		return true
+	}
+	return l.getConfig().GetBool(l.getObsPipelineConfigKey("vector", "dualship"))
+}
+
 func (l *LogsConfigKeys) getObsPipelineURL() (string, bool) {
 	if l.vectorPrefix != "" {
 		configKey := l.getObsPipelineConfigKey("observability_pipelines_worker", "url")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -619,6 +619,12 @@ api_key:
     #
     # enabled: false
 
+    ## @param dualship - boolean - optional - default: false
+    ## @env DD_OBSERVABILITY_PIPELINES_WORKER_LOGS_DUALSHIP - boolean - optional - default: false
+    ## Enables dual shipping of logs to the main endpoint as well as the Observability Pipelines Worker
+    #
+    # dualship: false
+
     ## @param url - string - optional - default: ""
     ## @env DD_OBSERVABILITY_PIPELINES_WORKER_LOGS_URL - string - optional - default: ""
     ## URL endpoint for the Observability Pipelines Worker to send logs to

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -623,7 +623,17 @@ api_key:
     ## @env DD_OBSERVABILITY_PIPELINES_WORKER_LOGS_DUALSHIP - boolean - optional - default: false
     ## Enables dual shipping of logs to the main endpoint as well as the Observability Pipelines Worker
     #
-    # dualship: false
+    # dualship:
+
+      ## @param enabled - boolean - optional - default: false
+      ## @env DD_OBSERVABILITY_PIPELINES_WORKER_LOGS_DUALSHIP_ENABLED - boolean - optional - default: false
+      ## Enables dual shipping of logs to the main endpoint as well as the Observability Pipelines Worker
+      # enabled: false
+
+      ## @param is_reliable - boolean - optional - default: false
+      ## @env DD_OBSERVABILITY_PIPELINES_WORKER_LOGS_DUALSHIP_IS_RELIABLE - boolean - optional - default: false
+      ## Is the  Observability Pipelines Worker endpoint treated as a reliable endpoint?
+      # is_reliable: false
 
     ## @param url - string - optional - default: ""
     ## @env DD_OBSERVABILITY_PIPELINES_WORKER_LOGS_URL - string - optional - default: ""

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2107,9 +2107,11 @@ func getValidHostAliasesWithConfig(config pkgconfigmodel.Reader) []string {
 
 func bindVectorOptions(config pkgconfigmodel.Config, datatype DataType) {
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.enabled", datatype), false)
+	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.dualship", datatype), false)
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.url", datatype), "")
 
 	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.enabled", datatype), false)
+	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.dualship", datatype), false)
 	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.url", datatype), "")
 }
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2107,11 +2107,21 @@ func getValidHostAliasesWithConfig(config pkgconfigmodel.Reader) []string {
 
 func bindVectorOptions(config pkgconfigmodel.Config, datatype DataType) {
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.enabled", datatype), false)
-	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.dualship", datatype), false)
+
+	if datatype == Logs {
+		// Dual shipping is currently only supported for logs
+		config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.dualship.enabled", datatype), false)
+		config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.dualship.is_reliable", datatype), false)
+	}
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.url", datatype), "")
 
 	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.enabled", datatype), false)
-	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.dualship", datatype), false)
+
+	if datatype == Logs {
+		// Dual shipping is currently only supported for logs
+		config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.dualship.enabled", datatype), false)
+		config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.dualship.is_reliable", datatype), false)
+	}
 	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.url", datatype), "")
 }
 

--- a/releasenotes/notes/dualship-opw-logs-ee951ca2b29cd66e.yaml
+++ b/releasenotes/notes/dualship-opw-logs-ee951ca2b29cd66e.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    A new configuration option has been added to `observability_pipelines_worker.logs`
+    called `dualship`. When this is set to `true`, the agent will ship 
+    logs both to the Observability Pipelines Worker and to the main
+    endpoint.


### PR DESCRIPTION
Had some feedback from @jszwedko which I need to address, so putting this into draft for now.

-------------------------

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This adds a new option - `dualship` - to `observability_pipelines_worker.logs`. When true the agent will ship logs both to the Observability Pipelines Worker and to the main endpoint specified.

### Describe how to test/QA your changes

There are unit tests to ensure the endpoints are setup correctly. 

To manually test, run the OPW with the given configuration 

```yaml
sources:
  in:
    type: datadog_agent
    address: 127.0.0.1:8900

sinks:
  out:
    type: console
    inputs:
      - in
    target: stdout
    encoding:
      codec: json
```

Configure the agent with and configure to collect logs and ship to datadog.

```yaml
vector:
  logs:
    enabled: true
    dualship: true
    url: http://localhost:8900
```

Then check logs are received both by OPW (it will print to the console) and Datadog.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
