### PR TITLE
Fetch process-agent metadata from the process-agent process

### DIFF
--- a/cmd/process-agent/subcommands/config/config.go
+++ b/cmd/process-agent/subcommands/config/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/fetcher"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -31,8 +32,15 @@ type dependencies struct {
 	Config config.Component
 }
 
+// cliParams are the command-line arguments for this subcommand
+type cliParams struct {
+	showEntireConfig bool
+}
+
 // Commands returns a slice of subcommands for the `config` command in the Process Agent
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	params := &cliParams{}
+
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Print the runtime configuration of a running agent",
@@ -42,9 +50,11 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(globalParams, command.GetCoreBundleParamsForOneShot(globalParams)),
 				core.Bundle(),
 				process.Bundle(),
+				fx.Supply(params),
 			)
 		},
 	}
+	cmd.Flags().BoolVarP(&params.showEntireConfig, "all", "a", false, "Show the entire configuration for the process-agent, not just the 'process_config' section")
 
 	cmd.AddCommand(
 		&cobra.Command{
@@ -93,19 +103,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{cmd}
 }
 
-func showRuntimeConfiguration(deps dependencies) error {
-	c, err := getClient(deps.Config)
-	if err != nil {
-		return err
-	}
-
-	runtimeConfig, err := c.FullConfig()
+func showRuntimeConfiguration(deps dependencies, params *cliParams) error {
+	runtimeConfig, err := fetcher.ProcessAgentConfig(deps.Config, params.showEntireConfig)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println(runtimeConfig)
-
 	return nil
 }
 

--- a/cmd/security-agent/subcommands/config/config.go
+++ b/cmd/security-agent/subcommands/config/config.go
@@ -141,7 +141,7 @@ func getSettingsClient(_ *cobra.Command, _ []string) (settings.Client, error) {
 }
 
 func showRuntimeConfiguration(_ log.Component, cfg config.Component, _ secrets.Component, _ *cliParams) error {
-	runtimeConfig, err := fetcher.FetchSecurityAgentConfig(cfg)
+	runtimeConfig, err := fetcher.SecurityAgentConfig(cfg)
 	if err != nil {
 		return err
 	}

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -26,6 +26,7 @@ import (
 	iainterface "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -47,7 +48,8 @@ func Module() fxutil.Module {
 var (
 	// for testing
 	installinfoGet      = installinfo.Get
-	fetchSecurityConfig = configFetcher.FetchSecurityAgentConfig
+	fetchSecurityConfig = configFetcher.SecurityAgentConfig
+	fetchProcessConfig  = func(cfg model.Reader) (string, error) { return configFetcher.ProcessAgentConfig(cfg, true) }
 )
 
 type agentMetadata map[string]interface{}
@@ -203,12 +205,6 @@ func (ia *inventoryagent) initData() {
 	ia.data["config_apm_dd_url"] = clean(ia.conf.GetString("apm_config.apm_dd_url"))
 	ia.data["feature_apm_enabled"] = ia.conf.GetBool("apm_config.enabled")
 
-	// Process / process-agent
-
-	ia.data["feature_process_enabled"] = ia.conf.GetBool("process_config.process_collection.enabled")
-	ia.data["feature_process_language_detection_enabled"] = ia.conf.GetBool("language_detection.enabled")
-	ia.data["feature_processes_container_enabled"] = ia.conf.GetBool("process_config.container_collection.enabled")
-
 	// Cloud Workload Security / system-probe
 
 	ia.data["feature_cws_enabled"] = getBoolSysProbe("runtime_security_config.enabled")
@@ -258,31 +254,49 @@ func (ia *inventoryagent) initData() {
 	ia.refreshMetadata()
 }
 
-func (ia *inventoryagent) fetchSecurityAgentMetadata() {
-	type configGetter interface {
-		GetBool(string) bool
-	}
+type configGetter interface {
+	GetBool(string) bool
+}
 
-	securityCfg := configGetter(ia.conf)
-	// We query the configuration from the security agent itself to have accurate data. If the security-agent isn't
+// getCorrectConfig tries to fetch the configuration from another process. When successful it returns a new
+// configuration object and true. If not, the local config and false is returned.
+func (ia *inventoryagent) getCorrectConfig(name string, configFetcher func(config model.Reader) (string, error)) configGetter {
+	// We query the configuration from another agent itself to have accurate data. If the other process isn't
 	// available we fallback on the current configuration.
-	if securityConfig, err := fetchSecurityConfig(ia.conf); err == nil {
+	if remoteConfig, err := configFetcher(ia.conf); err == nil {
 		cfg := viper.New()
 		cfg.SetConfigType("yaml")
-		if err = cfg.ReadConfig(strings.NewReader(securityConfig)); err != nil {
-			ia.log.Error("Could not pars security-agent configuration: %s", err)
+		if err = cfg.ReadConfig(strings.NewReader(remoteConfig)); err != nil {
+			ia.log.Error("Could not parse '%s' configuration: %s", name, err)
 		} else {
-			securityCfg = cfg
+			return cfg
 		}
+	} else {
+		ia.log.Errorf("could not fetch %s process configuration: %s", name, err)
 	}
+	return configGetter(ia.conf)
+}
+
+func (ia *inventoryagent) fetchSecurityAgentMetadata() {
+	securityCfg := ia.getCorrectConfig("security-agent", fetchSecurityConfig)
 
 	ia.data["feature_cspm_enabled"] = securityCfg.GetBool("compliance_config.enabled")
 	ia.data["feature_cspm_host_benchmarks_enabled"] = securityCfg.GetBool("compliance_config.host_benchmarks.enabled")
-
 }
+
+func (ia *inventoryagent) fetchProcessAgentMetadata() {
+	processCfg := ia.getCorrectConfig("process-agent", fetchProcessConfig)
+
+	ia.data["feature_process_enabled"] = processCfg.GetBool("process_config.process_collection.enabled")
+	ia.data["feature_processes_container_enabled"] = processCfg.GetBool("process_config.container_collection.enabled")
+	ia.data["feature_process_language_detection_enabled"] = processCfg.GetBool("language_detection.enabled")
+}
+
 func (ia *inventoryagent) refreshMetadata() {
 	// Compliance / security-agent
 	ia.fetchSecurityAgentMetadata()
+	// Process / process-agent
+	ia.fetchProcessAgentMetadata()
 }
 
 // Set updates a metadata value in the payload. The given value will be stored in the cache without being copied. It is

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -307,7 +307,7 @@ func TestStatusHeaderProvider(t *testing.T) {
 
 func TestFetchSecurityAgent(t *testing.T) {
 	defer func() {
-		fetchSecurityConfig = configFetcher.FetchSecurityAgentConfig
+		fetchSecurityConfig = configFetcher.SecurityAgentConfig
 	}()
 	fetchSecurityConfig = func(config pkgconfigmodel.Reader) (string, error) {
 		return "", fmt.Errorf("some error")
@@ -331,4 +331,40 @@ func TestFetchSecurityAgent(t *testing.T) {
 
 	assert.True(t, ia.data["feature_cspm_enabled"].(bool))
 	assert.True(t, ia.data["feature_cspm_host_benchmarks_enabled"].(bool))
+}
+
+func TestFetchProcessAgent(t *testing.T) {
+	defer func(original func(cfg pkgconfigmodel.Reader) (string, error)) {
+		fetchProcessConfig = original
+	}(fetchProcessConfig)
+
+	fetchProcessConfig = func(config pkgconfigmodel.Reader) (string, error) {
+		return "", fmt.Errorf("some error")
+	}
+
+	ia := getTestInventoryPayload(t, nil, nil)
+	ia.fetchProcessAgentMetadata()
+
+	assert.False(t, ia.data["feature_process_enabled"].(bool))
+	assert.False(t, ia.data["feature_process_language_detection_enabled"].(bool))
+	// default to true in the process agent configuration
+	assert.True(t, ia.data["feature_processes_container_enabled"].(bool))
+
+	fetchProcessConfig = func(config pkgconfigmodel.Reader) (string, error) {
+		return `
+process_config:
+  process_collection:
+    enabled: true
+  container_collection:
+    enabled: true
+language_detection:
+  enabled: true
+`, nil
+	}
+
+	ia.fetchProcessAgentMetadata()
+
+	assert.True(t, ia.data["feature_process_enabled"].(bool))
+	assert.True(t, ia.data["feature_processes_container_enabled"].(bool))
+	assert.True(t, ia.data["feature_process_language_detection_enabled"].(bool))
 }

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -12,10 +12,11 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
-// FetchSecurityAgentConfig fetch the configuration from the security-agent process by querying its HTTPS API
-func FetchSecurityAgentConfig(config config.Reader) (string, error) {
+// SecurityAgentConfig fetch the configuration from the security-agent process by querying its HTTPS API
+func SecurityAgentConfig(config config.Reader) (string, error) {
 	err := util.SetAuthToken()
 	if err != nil {
 		return "", err
@@ -45,5 +46,34 @@ func TraceAgentConfig(config config.Reader) (string, error) {
 	ipcAddressWithPort := fmt.Sprintf("http://127.0.0.1:%d/config", port)
 
 	client := settingshttp.NewClient(c, ipcAddressWithPort, "trace-agent")
+	return client.FullConfig()
+}
+
+// ProcessAgentConfig fetch the configuration from the process-agent process by querying its HTTPS API
+func ProcessAgentConfig(config config.Reader, getEntireConfig bool) (string, error) {
+	err := util.SetAuthToken()
+	if err != nil {
+		return "", err
+	}
+
+	c := util.GetClient(false)
+
+	ipcAddress, err := setup.GetIPCAddress(config)
+	if err != nil {
+		return "", err
+	}
+
+	port := config.GetInt("process_config.cmd_port")
+	if port <= 0 {
+		return "", fmt.Errorf("invalid process_config.cmd_port -- %d", port)
+	}
+
+	ipcAddressWithPort := fmt.Sprintf("http://%s:%d/config", ipcAddress, port)
+	if getEntireConfig {
+		ipcAddressWithPort += "/all"
+	}
+
+	client := settingshttp.NewClient(c, ipcAddressWithPort, "process-agent")
+
 	return client.FullConfig()
 }

--- a/pkg/config/setup/ipc_address.go
+++ b/pkg/config/setup/ipc_address.go
@@ -15,28 +15,24 @@ import (
 
 // GetIPCAddress returns the IPC address or an error if the address is not local
 func GetIPCAddress(config pkgconfigmodel.Reader) (string, error) {
-	return getIPCAddress(config)
-}
-
-// GetIPCPort returns the IPC port
-func GetIPCPort() string {
-	return Datadog.GetString("cmd_port")
-}
-
-func getIPCAddress(cfg pkgconfigmodel.Reader) (string, error) {
 	var key string
 	// ipc_address is deprecated in favor of cmd_host, but we still need to support it
 	// if it is set, use it, otherwise use cmd_host
-	if cfg.IsSet("ipc_address") {
+	if config.IsSet("ipc_address") {
 		log.Warn("ipc_address is deprecated, use cmd_host instead")
 		key = "ipc_address"
 	} else {
 		key = "cmd_host"
 	}
 
-	address, err := system.IsLocalAddress(cfg.GetString(key))
+	address, err := system.IsLocalAddress(config.GetString(key))
 	if err != nil {
 		return "", fmt.Errorf("%s: %s", key, err)
 	}
 	return address, nil
+}
+
+// GetIPCPort returns the IPC port
+func GetIPCPort() string {
+	return Datadog.GetString("cmd_port")
 }

--- a/pkg/config/setup/ipc_address_test.go
+++ b/pkg/config/setup/ipc_address_test.go
@@ -22,7 +22,7 @@ const (
 func TestGetIPCAddress(t *testing.T) {
 	t.Run("default value", func(t *testing.T) {
 		cfg := getConfig()
-		val, err := getIPCAddress(cfg)
+		val, err := GetIPCAddress(cfg)
 		require.NoError(t, err)
 		require.Equal(t, localhostStr, val)
 	})
@@ -30,7 +30,7 @@ func TestGetIPCAddress(t *testing.T) {
 	t.Run("ipc_address from file", func(t *testing.T) {
 		cfg := getConfig()
 		cfg.Set("ipc_address", localhostV4, model.SourceFile)
-		val, err := getIPCAddress(cfg)
+		val, err := GetIPCAddress(cfg)
 		require.NoError(t, err)
 		require.Equal(t, localhostV4, val)
 	})
@@ -38,7 +38,7 @@ func TestGetIPCAddress(t *testing.T) {
 	t.Run("ipc_address from env", func(t *testing.T) {
 		cfg := getConfig()
 		t.Setenv("DD_IPC_ADDRESS", localhostV4)
-		val, err := getIPCAddress(cfg)
+		val, err := GetIPCAddress(cfg)
 		require.NoError(t, err)
 		require.Equal(t, localhostV4, val)
 	})
@@ -47,7 +47,7 @@ func TestGetIPCAddress(t *testing.T) {
 		cfg := getConfig()
 		cfg.Set("ipc_address", localhostV4, model.SourceFile)
 		cfg.Set("cmd_host", localhostV6, model.SourceFile)
-		val, err := getIPCAddress(cfg)
+		val, err := GetIPCAddress(cfg)
 		require.NoError(t, err)
 		require.Equal(t, localhostV4, val)
 	})
@@ -55,7 +55,7 @@ func TestGetIPCAddress(t *testing.T) {
 	t.Run("ipc_address takes precedence over cmd_host", func(t *testing.T) {
 		cfg := getConfig()
 		cfg.Set("cmd_host", localhostV6, model.SourceFile)
-		val, err := getIPCAddress(cfg)
+		val, err := GetIPCAddress(cfg)
 		require.NoError(t, err)
 		require.Equal(t, localhostV6, val)
 	})
@@ -63,7 +63,7 @@ func TestGetIPCAddress(t *testing.T) {
 	t.Run("error if not local", func(t *testing.T) {
 		cfg := getConfig()
 		cfg.Set("cmd_host", "111.111.111.111", model.SourceFile)
-		_, err := getIPCAddress(cfg)
+		_, err := GetIPCAddress(cfg)
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Fetch the process-agent metadata from the process agent process itself rather than the local configuration. In a k8s context, the process-agent runs in a different container with potentially a different config (the process-agent API is available from the core-agent container).

This also add a `--all` option to the process-agent `config` command to show the entire configuration instead of just the `process_config` section.

### Describe how to test/QA your changes

Test that `feature_process_enabled`, `feature_process_language_detection_enabled` and `feature_processes_container_enabled` correctly reflect the process-agent configuration when using our official helm chart and datadog-operator.

To see the payload: from the core-agent container `agent diagnose show-metadata inventory-agent`

For team processes:
- Check that the 3 metadata above are correctly sent when deploying the process-agent with helm chart.
- Check that the `config` command still works like before and the new `--all` option show the entire config.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
