### PR TITLE
[oracle] Add ddagenthostname tag (DBMON-3490)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -332,20 +332,12 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	agentVersion, _ := version.Agent()
 	c.agentVersion = agentVersion.GetNumberAndPre()
 
-	agentHostname, err := hostname.Get(context.Background())
-	if err == nil {
-		c.agentHostname = agentHostname
-	} else {
-		log.Errorf("%s failed to retrieve agent hostname: %s", err)
-	}
-
 	c.checkInterval = float64(c.config.InitConfig.MinCollectionInterval)
 
 	tags := make([]string, len(c.config.Tags))
 	copy(tags, c.config.Tags)
 
 	tags = append(tags, fmt.Sprintf("dbms:%s", common.IntegrationName), fmt.Sprintf("ddagentversion:%s", c.agentVersion))
-	tags = append(tags, fmt.Sprintf("ddagenthostname:%s", c.agentHostname))
 	tags = append(tags, fmt.Sprintf("dbm:%t", c.dbmEnabled))
 	if c.config.TnsAlias != "" {
 		tags = append(tags, fmt.Sprintf("tns-alias:%s", c.config.TnsAlias))
@@ -365,6 +357,14 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	copy(c.tags, tags)
 
 	c.logPrompt = config.GetLogPrompt(c.config.InstanceConfig)
+
+	agentHostname, err := hostname.Get(context.Background())
+	if err == nil {
+		c.agentHostname = agentHostname
+	} else {
+		log.Errorf("%s failed to retrieve agent hostname: %s", c.logPrompt)
+	}
+	tags = append(tags, fmt.Sprintf("ddagenthostname:%s", c.agentHostname))
 
 	return nil
 }

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -8,6 +8,7 @@
 package oracle
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -76,6 +78,7 @@ type Check struct {
 	connection                              *go_ora.Connection
 	dbmEnabled                              bool
 	agentVersion                            string
+	agentHostname                           string
 	checkInterval                           float64
 	tags                                    []string
 	tagsWithoutDbRole                       []string
@@ -329,12 +332,20 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	agentVersion, _ := version.Agent()
 	c.agentVersion = agentVersion.GetNumberAndPre()
 
+	agentHostname, err := hostname.Get(context.Background())
+	if err == nil {
+		c.agentHostname = agentHostname
+	} else {
+		log.Errorf("%s failed to retrieve agent hostname: %s", err)
+	}
+
 	c.checkInterval = float64(c.config.InitConfig.MinCollectionInterval)
 
 	tags := make([]string, len(c.config.Tags))
 	copy(tags, c.config.Tags)
 
 	tags = append(tags, fmt.Sprintf("dbms:%s", common.IntegrationName), fmt.Sprintf("ddagentversion:%s", c.agentVersion))
+	tags = append(tags, fmt.Sprintf("ddagenthostname:%s", c.agentHostname))
 	tags = append(tags, fmt.Sprintf("dbm:%t", c.dbmEnabled))
 	if c.config.TnsAlias != "" {
 		tags = append(tags, fmt.Sprintf("tns-alias:%s", c.config.TnsAlias))

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -362,7 +362,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	if err == nil {
 		c.agentHostname = agentHostname
 	} else {
-		log.Errorf("%s failed to retrieve agent hostname: %s", c.logPrompt)
+		log.Errorf("%s failed to retrieve agent hostname: %s", c.logPrompt, err)
 	}
 	tags = append(tags, fmt.Sprintf("ddagenthostname:%s", c.agentHostname))
 

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -351,10 +351,6 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	if c.config.ServiceName != "" {
 		tags = append(tags, fmt.Sprintf("service:%s", c.config.ServiceName))
 	}
-	c.configTags = make([]string, len(tags))
-	copy(c.configTags, tags)
-	c.tags = make([]string, len(tags))
-	copy(c.tags, tags)
 
 	c.logPrompt = config.GetLogPrompt(c.config.InstanceConfig)
 
@@ -365,6 +361,11 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 		log.Errorf("%s failed to retrieve agent hostname: %s", c.logPrompt, err)
 	}
 	tags = append(tags, fmt.Sprintf("ddagenthostname:%s", c.agentHostname))
+
+	c.configTags = make([]string, len(tags))
+	copy(c.configTags, tags)
+	c.tags = make([]string, len(tags))
+	copy(c.tags, tags)
 
 	return nil
 }

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -846,6 +846,7 @@ func (c *Check) StatementMetrics() (int, error) {
 		MinCollectionInterval: c.checkInterval,
 		Tags:                  c.tags,
 		AgentVersion:          c.agentVersion,
+		AgentHostname:         c.agentHostname,
 		OracleRows:            oracleRows,
 		OracleVersion:         c.dbVersion,
 	}

--- a/releasenotes/notes/oracle-ddagenthostname-d62827239fe3d644.yaml
+++ b/releasenotes/notes/oracle-ddagenthostname-d62827239fe3d644.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ``ddagenthostname`` tag.

--- a/releasenotes/notes/oracle-ddagenthostname-d62827239fe3d644.yaml
+++ b/releasenotes/notes/oracle-ddagenthostname-d62827239fe3d644.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add ``ddagenthostname`` tag.
+    [oracle] Add ``ddagenthostname`` tag.


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Add `ddagenthostname` tag.

### Additional Notes

The tag is emitted with each metric and also in query metrics payload.

### Describe how to test/QA your changes

Check if the tag is appearing in the metrics and host panel.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
