### PR TITLE
Remove allow_failure from stabilized test

### DIFF
--- a/.gitlab/new-e2e_testing/windows.yml
+++ b/.gitlab/new-e2e_testing/windows.yml
@@ -14,8 +14,6 @@
     # LAST_STABLE_VERSION is used for upgrade test
     - export LAST_STABLE_VERSION=$(invoke release.get-release-json-value "last_stable::$AGENT_MAJOR_VERSION")
     - !reference [.new_e2e_template, script]
-  # temporarily allow failure so we can collect any new system snapshot files we need to add to the ignore list
-  allow_failure: true
 
 # Agent 6
 .new-e2e_windows_a6_x86_64:

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -9,7 +9,6 @@ go 1.21
 replace (
 	github.com/DataDog/datadog-agent/pkg/proto => ../../pkg/proto
 	github.com/DataDog/datadog-agent/pkg/util/pointer => ../../pkg/util/pointer
-	github.com/DataDog/datadog-agent/pkg/util/testutil => ../../pkg/util/testutil
 	github.com/DataDog/datadog-agent/pkg/version => ../../pkg/version
 	github.com/DataDog/datadog-agent/test/fakeintake => ../fakeintake
 )

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -9,6 +9,7 @@ go 1.21
 replace (
 	github.com/DataDog/datadog-agent/pkg/proto => ../../pkg/proto
 	github.com/DataDog/datadog-agent/pkg/util/pointer => ../../pkg/util/pointer
+	github.com/DataDog/datadog-agent/pkg/util/testutil => ../../pkg/util/testutil
 	github.com/DataDog/datadog-agent/pkg/version => ../../pkg/version
 	github.com/DataDog/datadog-agent/test/fakeintake => ../fakeintake
 )

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -17,6 +17,7 @@ replace (
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.103-0.20240118142331-3069f58aa284
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.51.0-rc.2
+	github.com/DataDog/datadog-agent/pkg/util/testutil v0.51.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/version v0.51.0-rc.2
 	github.com/DataDog/datadog-agent/test/fakeintake v0.51.0-rc.2
 	github.com/DataDog/datadog-api-client-go v1.16.0

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -17,7 +17,6 @@ replace (
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.103-0.20240118142331-3069f58aa284
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.51.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/util/testutil v0.51.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/version v0.51.0-rc.2
 	github.com/DataDog/datadog-agent/test/fakeintake v0.51.0-rc.2
 	github.com/DataDog/datadog-api-client-go v1.16.0

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common"
 	windows "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
@@ -217,6 +218,12 @@ func (t *Tester) testDoesNotChangeSystemFiles(tt *testing.T) bool {
 		output, err := t.host.Execute(cmd)
 		require.NoError(tt, err, "should compare system files")
 		output = strings.TrimSpace(output)
+		// Log the output if it's not empty so we have a record of what changed.
+		// Normally require.Empty would log this but flake.Mark might Skip the test before its called.
+		if output != "" {
+			tt.Logf("should not remove system files: %s", output)
+		}
+		flake.Mark(tt)
 		require.Empty(tt, output, "should not remove system files")
 	})
 }

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common"
 	windows "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
@@ -218,12 +217,6 @@ func (t *Tester) testDoesNotChangeSystemFiles(tt *testing.T) bool {
 		output, err := t.host.Execute(cmd)
 		require.NoError(tt, err, "should compare system files")
 		output = strings.TrimSpace(output)
-		// Log the output if it's not empty so we have a record of what changed.
-		// Normally require.Empty would log this but flake.Mark might Skip the test before its called.
-		if output != "" {
-			tt.Logf("should not remove system files: %s", output)
-		}
-		flake.Mark(tt)
 		require.Empty(tt, output, "should not remove system files")
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Remove `allow_failure` from our test, it's been over a week now since https://github.com/DataDog/datadog-agent/pull/22185 and we've seen no additional failures.

Keeps `flake.Mark` on the test because its result could change due to things outside of our control.

See also https://github.com/DataDog/datadog-agent/pull/22201

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-625

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
