### PR TITLE
Added debug log for evictions from registry after ttl expires

### DIFF
--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -221,6 +221,7 @@ func (a *RegistryAuditor) cleanupRegistry() {
 	expireBefore := time.Now().UTC().Add(-a.entryTTL)
 	for path, entry := range a.registry {
 		if entry.LastUpdated.Before(expireBefore) {
+			log.Debug("TTL for %s expired, removing from registry.", path)
 			delete(a.registry, path)
 		}
 	}

--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -221,7 +221,7 @@ func (a *RegistryAuditor) cleanupRegistry() {
 	expireBefore := time.Now().UTC().Add(-a.entryTTL)
 	for path, entry := range a.registry {
 		if entry.LastUpdated.Before(expireBefore) {
-			log.Debug("TTL for %s expired, removing from registry.", path)
+			log.Debugf("TTL for %s expired, removing from registry.", path)
 			delete(a.registry, path)
 		}
 	}

--- a/releasenotes/notes/add-debug-log-for-files-evicted-from-registry-9811327329dbca7e.yaml
+++ b/releasenotes/notes/add-debug-log-for-files-evicted-from-registry-9811327329dbca7e.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Add debug level logs when files are evicted from ```registry.log```
+    Add debug level logs when files are evicted from ``registry.log``
     after their TTL expires.

--- a/releasenotes/notes/add-debug-log-for-files-evicted-from-registry-9811327329dbca7e.yaml
+++ b/releasenotes/notes/add-debug-log-for-files-evicted-from-registry-9811327329dbca7e.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Add debug level logs when files are evicted from ``registry.log``
+    Add debug level logs when files are evicted from ``registry.json``
     after their TTL expires.

--- a/releasenotes/notes/add-debug-log-for-files-evicted-from-registry-9811327329dbca7e.yaml
+++ b/releasenotes/notes/add-debug-log-for-files-evicted-from-registry-9811327329dbca7e.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add debug level logs when files are evicted from ```registry.log```
+    after their TTL expires.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds a debug level log whenever a file is evicted from the registry.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This would make it easier to debug support cases where log files age out of the registry because their TTL is shorter than their log production frequency. The current default TTL for log files is 23 hours, so the agent will evict any log files from any app that produces logs less frequently than every 23 hours, causing the whole file to be read again when the agent picks it up.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

N/A

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

N/A

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1. Set `logs_config.auditor_ttl` to a very low value (I used 0.001)
2. Set `log_level` to debug
3. Run the agent with `logs_enabled` set to true
4. Check the agent logs to see if it's emitting the proper logs noting log file eviction.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
