### PR TITLE
Use "Gb" instead of "g" in Regression Detector settings

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -20,7 +20,7 @@ single-machine-performance-regression_detector:
     SMP_VERSION: 0.12.0
     LADING_VERSION: 0.20.4
     CPUS: 7
-    MEMORY: "30g"
+    MEMORY: "30 Gb"
   # At present we require two artifacts to exist for the 'baseline' and the
   # 'comparison'. We are guaranteed by the structure of the pipeline that
   # 'comparison' exists, not so much with 'baseline' as it has to come from main


### PR DESCRIPTION
### What does this PR do?

This commit adjusts the unit on the memory setting to the more explicit "Gb". We think there might be a backward incompatibility in a dependency that parses these units, this change future-proofs CI.

REF SMPTNG-171

