### PR TITLE
[clusteragent/admission/auto_instrumentation] Move namespace check to a webhook label selector

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/common.go
+++ b/pkg/clusteragent/admission/controllers/webhook/common.go
@@ -125,3 +125,30 @@ func azureAKSLabelSelectorRequirement() []metav1.LabelSelectorRequirement {
 		},
 	}
 }
+
+func mergedLabelSelector(labelSelector1 *metav1.LabelSelector, labelSelector2 *metav1.LabelSelector) *metav1.LabelSelector {
+	if labelSelector1 == nil && labelSelector2 == nil {
+		return nil
+	}
+
+	merged := metav1.LabelSelector{
+		MatchLabels: map[string]string{},
+	}
+
+	for _, labelSelector := range []*metav1.LabelSelector{labelSelector1, labelSelector2} {
+		if labelSelector == nil {
+			continue
+		}
+
+		merged.MatchExpressions = append(
+			merged.MatchExpressions,
+			labelSelector.MatchExpressions...,
+		)
+
+		for label, value := range labelSelector.MatchLabels {
+			merged.MatchLabels[label] = value
+		}
+	}
+
+	return &merged
+}

--- a/pkg/clusteragent/admission/controllers/webhook/common_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/common_test.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMergedLabelSelector(t *testing.T) {
+	tests := []struct {
+		name                  string
+		labelSelector1        *metav1.LabelSelector
+		labelSelector2        *metav1.LabelSelector
+		expectedLabelSelector *metav1.LabelSelector
+	}{
+		{
+			name: "non-nil label selectors",
+			labelSelector1: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"label1": "val1",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "label2",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"val2"},
+					},
+				},
+			},
+			labelSelector2: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"label3": "val3",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "label4",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"val4"},
+					},
+				},
+			},
+			expectedLabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"label1": "val1",
+					"label3": "val3",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "label2",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"val2"},
+					},
+					{
+						Key:      "label4",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"val4"},
+					},
+				},
+			},
+		},
+		{
+			name:                  "both label selectors are nil",
+			labelSelector1:        nil,
+			labelSelector2:        nil,
+			expectedLabelSelector: nil,
+		},
+		{
+			name:           "first label selector is nil",
+			labelSelector1: nil,
+			labelSelector2: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+			expectedLabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+		},
+		{
+			name: "second label selector is nil",
+			labelSelector1: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+			labelSelector2: nil,
+			expectedLabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedLabelSelector, mergedLabelSelector(test.labelSelector1, test.labelSelector2))
+		})
+	}
+}

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -225,7 +226,10 @@ func (c *ControllerV1) generateTemplates() {
 	// Auto instrumentation - lib injection
 	if config.Datadog.GetBool("admission_controller.auto_instrumentation.enabled") {
 		// generate selectors
-		nsSelector, objSelector := buildLabelSelectors(c.config.useNamespaceSelector())
+		commonNamespaceSelector, objSelector := buildLabelSelectors(c.config.useNamespaceSelector())
+		libInjectionNamespaceSelector := mutate.LibIbjectionNamespaceLabelSelector()
+
+		namespaceSelector := mergedLabelSelector(commonNamespaceSelector, libInjectionNamespaceSelector)
 
 		webhook := c.getWebhookSkeleton(
 			"auto-instrumentation",
@@ -234,7 +238,7 @@ func (c *ControllerV1) generateTemplates() {
 				admiv1.Create,
 			},
 			[]string{"pods"},
-			nsSelector,
+			namespaceSelector,
 			objSelector,
 		)
 		webhooks = append(webhooks, webhook)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -349,12 +349,54 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 			},
 		},
 		{
+			name: "lib injection, mutate labelled, with APM instrumentation and some namespaces included",
+			setupConfig: func() {
+				mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.enabled", true)
+				mockConfig.SetWithoutSource("admission_controller.inject_config.enabled", false)
+				mockConfig.SetWithoutSource("admission_controller.inject_tags.enabled", false)
+				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", false)
+				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
+				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled_namespaces", []string{"ns1", "ns2"})
+			},
+			configFunc: func() Config { return NewConfig(false, false) },
+			want: func() []admiv1beta1.MutatingWebhook {
+				webhook := webhook(
+					"datadog.webhook.auto.instrumentation",
+					"/injectlib",
+					&metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "admission.datadoghq.com/enabled",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"false"},
+							},
+						},
+					},
+					&metav1.LabelSelector{
+						MatchLabels: map[string]string{},
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      corev1.LabelMetadataName,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"ns1", "ns2"},
+							},
+						},
+					},
+					[]admiv1beta1.OperationType{admiv1beta1.Create},
+					[]string{"pods"},
+				)
+				return []admiv1beta1.MutatingWebhook{webhook}
+			},
+		},
+		{
 			name: "config and tags injection, mutate labelled",
 			setupConfig: func() {
 				mockConfig.SetWithoutSource("admission_controller.inject_config.enabled", true)
 				mockConfig.SetWithoutSource("admission_controller.inject_tags.enabled", true)
 				mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.enabled", false)
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", false)
+				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", false)
+				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled_namespaces", []string{})
 			},
 			configFunc: func() Config { return NewConfig(false, false) },
 			want: func() []admiv1beta1.MutatingWebhook {

--- a/pkg/clusteragent/admission/mutate/common_test.go
+++ b/pkg/clusteragent/admission/mutate/common_test.go
@@ -216,42 +216,6 @@ func Test_shouldInject(t *testing.T) {
 			want:        false,
 		},
 		{
-			name: "instrumentation on with disabled namespace, no label",
-			pod:  fakePodWithNamespaceAndLabel("ns", "", ""),
-			setupConfig: func() {
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
-				mockConfig.SetWithoutSource("apm_config.instrumentation.disabled_namespaces", []string{"ns"})
-			},
-			want: false,
-		},
-		{
-			name: "instrumentation on with disabled namespace, no label",
-			pod:  fakePodWithNamespaceAndLabel("ns", "", ""),
-			setupConfig: func() {
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
-				mockConfig.SetWithoutSource("apm_config.instrumentation.disabled_namespaces", []string{"ns2"})
-			},
-			want: true,
-		},
-		{
-			name: "instrumentation on with disabled namespace, disabled label",
-			pod:  fakePodWithNamespaceAndLabel("ns", "admission.datadoghq.com/enabled", "false"),
-			setupConfig: func() {
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
-				mockConfig.SetWithoutSource("apm_config.instrumentation.disabled_namespaces", []string{"ns"})
-			},
-			want: false,
-		},
-		{
-			name: "instrumentation on with disabled namespace, label enabled",
-			pod:  fakePodWithNamespaceAndLabel("ns", "admission.datadoghq.com/enabled", "true"),
-			setupConfig: func() {
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
-				mockConfig.SetWithoutSource("apm_config.instrumentation.disabled_namespaces", []string{"ns"})
-			},
-			want: true,
-		},
-		{
 			name:        "instrumentation off, label enabled",
 			pod:         fakePodWithNamespaceAndLabel("ns", "admission.datadoghq.com/enabled", "true"),
 			setupConfig: func() { mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", false) },
@@ -262,68 +226,6 @@ func Test_shouldInject(t *testing.T) {
 			pod:         fakePodWithNamespaceAndLabel("ns", "", ""),
 			setupConfig: func() { mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", false) },
 			want:        false,
-		},
-		{
-			name: "instrumentation off with enabled namespace, label enabled",
-			pod:  fakePodWithNamespaceAndLabel("ns", "admission.datadoghq.com/enabled", "true"),
-			setupConfig: func() {
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled_namespaces", []string{"ns"})
-			},
-			want: true,
-		},
-		{
-			name: "instrumentation off with enabled namespace, label disabled",
-			pod:  fakePodWithNamespaceAndLabel("ns", "admission.datadoghq.com/enabled", "false"),
-			setupConfig: func() {
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", false)
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled_namespaces", []string{"ns"})
-			},
-			want: false,
-		},
-		{
-			name: "instrumentation off with enabled namespace, no label",
-			pod:  fakePodWithNamespaceAndLabel("ns", "", ""),
-			setupConfig: func() {
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", false)
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled_namespaces", []string{"ns"})
-			},
-			want: false,
-		},
-		{
-			name: "instrumentation on with enabled namespace, no label",
-			pod:  fakePodWithNamespaceAndLabel("ns", "", ""),
-			setupConfig: func() {
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled_namespaces", []string{"ns"})
-			},
-			want: true,
-		},
-		{
-			name: "instrumentation on with enabled other namespace, no label",
-			pod:  fakePodWithNamespaceAndLabel("ns", "", ""),
-			setupConfig: func() {
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled_namespaces", []string{"n2s"})
-			},
-			want: false,
-		},
-		{
-			name: "instrumentation on in kube-system namespace, no label",
-			pod:  fakePodWithNamespaceAndLabel("kube-system", "", ""),
-			setupConfig: func() {
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
-			},
-			want: false,
-		},
-		{
-			name: "instrumentation on in default (datadog) namespace, no label",
-			pod:  fakePodWithNamespaceAndLabel("default", "", ""),
-			setupConfig: func() {
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
-				mockConfig.SetWithoutSource("kube_resources_namespace", "default")
-			},
-			want: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?

Refactors the auto instrumentation endpoint of the admission controller. This PR moves the namespace filtering logic to the webhook configuration by using label selectors. This way the namespace filtering does not need to be done on every request in our own code.


### Describe how to test/QA your changes

Enable APM autoinstrumentation and verify that libs are injected in the pods deployed as expected.
Try with the 4 combinations of setting/not setting `DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES` and `DD_APM_INSTRUMENTATION_DISABLED_NAMESPACES`.

The only change in the behavior should be that now it's possible to force the injection in the 2 namespaces that are excluded by default: "kube-system" and datadog if they're included in `DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES` . All the rest should be the same.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
