### PR TITLE
[Codecov] Remove coverage report when 0 tests were run

### DIFF
--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -210,10 +210,12 @@ def test_flavor(
         else:
             lines = res.stdout.splitlines()
             if lines is not None and 'DONE 0 tests' in lines[-1]:
-                print(color_message("No tests were run, skipping coverage report", "orange"))
                 cov_path = os.path.join(module_path, PROFILE_COV)
-                if os.path.exists(cov_path):
+                print(color_message(f"No tests were run, skipping coverage report. Removing {cov_path}.", "orange"))
+                try:
                     os.remove(cov_path)
+                except FileNotFoundError as e:
+                    print(f"Couldn't remove coverage file {cov_path}\n{e}")
                 return
 
         if save_result_json:

--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -151,7 +151,7 @@ powershell.exe -executionpolicy Bypass -file test_with_coverage.ps1"""
             ]
             if not files_to_delete:
                 print(
-                    f"Error: Could not find coverage files starting with '{TMP_PROFILE_COV_PREFIX}.'",
+                    f"Error: Could not find coverage files starting with '{TMP_PROFILE_COV_PREFIX}.' in {self.module_path}",
                     file=sys.stderr,
                 )
             else:

--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -31,7 +31,7 @@ from tasks.modules import DEFAULT_MODULES, GoModule
 from tasks.test_core import ModuleTestResult, process_input_args, process_module_results, test_core
 from tasks.trace_agent import integration_tests as trace_integration_tests
 
-PROFILE_COV = "\"coverage.out\""
+PROFILE_COV = "coverage.out"
 TMP_PROFILE_COV_PREFIX = "coverage.out.rerun"
 GO_COV_TEST_PATH = "test_with_coverage"
 GO_TEST_RESULT_TMP_JSON = 'module_test_output.json'
@@ -155,7 +155,9 @@ powershell.exe -executionpolicy Bypass -file test_with_coverage.ps1"""
                     file=sys.stderr,
                 )
             else:
-                self.ctx.run(f"gocovmerge {' '.join(files_to_delete)} > {PROFILE_COV}")
+                self.ctx.run(
+                    f"gocovmerge {' '.join(files_to_delete)} > \"{os.path.join(self.module_path, PROFILE_COV)}\""
+                )
                 for f in files_to_delete:
                     os.remove(f)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR remove the coverage file for a module if 0 tests were run.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We had errors on codecov UI:
![image](https://github.com/DataDog/datadog-agent/assets/47357713/2a0bce00-6d2b-44ce-a12e-ad927fa216d1)


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
