### PR TITLE
[CONTINT-3329] Increase the time-out of the `TestOOMKillProbe` test

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
@@ -95,7 +95,7 @@ func TestOOMKillProbe(t *testing.T) {
 				}
 			}
 			return false
-		}, 5*time.Second, 500*time.Millisecond, "failed to find an OOM killed process with pid %d", cmd.Process.Pid)
+		}, 10*time.Second, 500*time.Millisecond, "failed to find an OOM killed process with pid %d", cmd.Process.Pid)
 
 		assert.Regexp(t, regexp.MustCompile("run-([0-9|a-z]*).scope"), result.CgroupName, "cgroup name")
 		assert.Equal(t, result.TPid, result.Pid, "tpid == pid")


### PR DESCRIPTION
### What does this PR do?

Increase the time-out of the `TestOOMKillProbe` test.

### Motivation

[This test is flaky. It usually passes. But it sometimes fails.](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.name%3ATestOOMKillProbe%2FCO-RE&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=&index=citest&mode=sliding&saved-view-id=2236559&start=1706016837222&end=1706621637222&paused=false)

### Additional Notes

When a test is timing out, there’s always the question to know if increasing the time-out value would help.
A good indicator that might give a clue is whether the test sometimes passes close to the time-out expiration.
The answer seems to be yes here. It sometimes passes after around 5s:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/8cf0c49a-d80f-4d90-adf8-4c3b2b5735cd)


### Possible Drawbacks / Trade-offs

In case of real bug, the test will last more time before failing.

### Describe how to test/QA your changes

Validate that `TestOOMKillProbe/CO-RE` is less flaky.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
