### PR TITLE
Adding a config command to the trace CLI

### DIFF
--- a/cmd/trace-agent/command/command.go
+++ b/cmd/trace-agent/command/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands"
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands/config"
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands/controlsvc"
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands/info"
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands/run"
@@ -45,6 +46,7 @@ func makeCommands(globalParams *subcommands.GlobalParams) *cobra.Command {
 		run.MakeCommand(globalConfGetter),
 		info.MakeCommand(globalConfGetter),
 		version.MakeCommand("trace-agent"),
+		config.MakeCommand(globalConfGetter),
 	}
 
 	commands = append(commands, controlsvc.Commands(globalConfGetter)...)

--- a/cmd/trace-agent/subcommands/config/command.go
+++ b/cmd/trace-agent/subcommands/config/command.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package config implements 'trace-agent config' cli.
+package config
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/config/fetcher"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"go.uber.org/fx"
+
+	"github.com/spf13/cobra"
+)
+
+// MakeCommand returns a command for the `config` CLI command
+func MakeCommand(globalParamsGetter func() *subcommands.GlobalParams) *cobra.Command {
+	return &cobra.Command{
+		Use:   "config",
+		Short: "Print the runtime configuration of a running trace-agent",
+		Long:  ``,
+		RunE: func(*cobra.Command, []string) error {
+			return fxutil.OneShot(printConfig,
+				fx.Supply(config.NewAgentParams(globalParamsGetter().ConfPath)),
+				config.Module(),
+			)
+		},
+		SilenceUsage: true,
+	}
+}
+
+func printConfig(config config.Component) error {
+	fullConfig, err := fetcher.TraceAgentConfig(config)
+	if err != nil {
+		return fmt.Errorf("error fetching trace-agent configuration: %s", err)
+	}
+	fmt.Print(fullConfig)
+	return nil
+}

--- a/cmd/trace-agent/subcommands/config/command_test.go
+++ b/cmd/trace-agent/subcommands/config/command_test.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/subcommands"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/spf13/cobra"
+)
+
+func TestInfoCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		[]*cobra.Command{MakeCommand(func() *subcommands.GlobalParams {
+			return &subcommands.GlobalParams{}
+		})},
+		[]string{"config"},
+		printConfig,
+		func() {
+			// No panic is good enough
+		})
+}

--- a/comp/trace/config/component.go
+++ b/comp/trace/config/component.go
@@ -32,8 +32,11 @@ type Component interface {
 	// Warnings returns config warnings collected during setup.
 	Warnings() *config.Warnings
 
-	// SetHandler sets http handler for config
+	// SetHandler returns a handler for runtime configuration changes.
 	SetHandler() http.Handler
+
+	// GetConfigHandler returns a handler to fetch the runtime configuration.
+	GetConfigHandler() http.Handler
 
 	// SetMaxMemCPU
 	SetMaxMemCPU(isContainerized bool)

--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"html/template"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,8 +27,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
+	"gopkg.in/yaml.v2"
 
 	corecomp "github.com/DataDog/datadog-agent/comp/core/config"
+	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 
@@ -2530,4 +2533,45 @@ func TestMockConfig(t *testing.T) {
 	// but can be set by the mock
 	// config.(Mock).Set("app_key", "newvalue")
 	// require.Equal(t, "newvalue", config.GetString("app_key"))
+}
+
+func TestGetCoreConfigHandler(t *testing.T) {
+	config := fxutil.Test[Component](t, fx.Options(
+		fx.Supply(corecomp.Params{}),
+		corecomp.MockModule(),
+		MockModule(),
+	))
+
+	handler := config.GetConfigHandler().(http.HandlerFunc)
+
+	// Refuse non Get query
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/config", nil)
+	handler(resp, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.Code)
+
+	// Refuse missing auth token
+	resp = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/config", nil)
+	handler(resp, req)
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+
+	// Refuse invalid auth token
+	resp = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/config", nil)
+	req.Header.Set("Authorization", "Bearer ABCDE")
+	handler(resp, req)
+	assert.Equal(t, http.StatusForbidden, resp.Code)
+
+	// Accept valid auth token and returning a valid YAML conf
+	resp = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/config", nil)
+	req.Header.Set("Authorization", "Bearer "+apiutil.GetAuthToken())
+	handler(resp, req)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	conf := map[string]interface{}{}
+	err := yaml.Unmarshal(resp.Body.Bytes(), &conf)
+	assert.NoError(t, err, "Error loading YAML configuration from the API")
+	assert.Contains(t, conf, "apm_config")
 }

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -27,3 +27,23 @@ func FetchSecurityAgentConfig(config config.Reader) (string, error) {
 	client := settingshttp.NewClient(c, apiConfigURL, "security-agent")
 	return client.FullConfig()
 }
+
+// TraceAgentConfig fetch the configuration from the trace-agent process by querying its HTTPS API
+func TraceAgentConfig(config config.Reader) (string, error) {
+	err := util.SetAuthToken()
+	if err != nil {
+		return "", err
+	}
+
+	c := util.GetClient(false)
+
+	port := config.GetInt("apm_config.debug.port")
+	if port <= 0 {
+		return "", fmt.Errorf("invalid apm_config.debug.port -- %d", port)
+	}
+
+	ipcAddressWithPort := fmt.Sprintf("http://127.0.0.1:%d/config", port)
+
+	client := settingshttp.NewClient(c, ipcAddressWithPort, "trace-agent")
+	return client.FullConfig()
+}


### PR DESCRIPTION
### What does this PR do?
Adding a config command to the trace CLI
    
The trace agent was the only agent process not offering a way to query its runtime configuration.
The core-agent will soon need to query the runtime configuration of each process. This is prep work for this.
    
We inject the new endpoint from the comp side of the trace agent to avoid linking pkg/config into pkg/trace.

### Describe how to test/QA your changes

Test the trace agent new `config` CLI works fine:
```
trace-agent config
```

This new command should print a valid YAML for the runtime config for the trace-agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
