### PR TITLE
[CONTINT-3547] Add a retry loop for `TestTCPQueueLengthTracer`

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
@@ -50,10 +51,12 @@ func TestTCPQueueLengthTracer(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(tcpTracer.Close)
 
-		beforeStats := extractGlobalStats(t, tcpTracer)
-		if beforeStats.ReadBufferMaxUsage > 10 {
-			t.Errorf("max usage of read buffer is too big before the stress test: %d > 10", beforeStats.ReadBufferMaxUsage)
-		}
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			beforeStats := extractGlobalStats(t, tcpTracer)
+			if beforeStats.ReadBufferMaxUsage > 10 {
+				c.Errorf("max usage of read buffer is too big before the stress test: %d > 10", beforeStats.ReadBufferMaxUsage)
+			}
+		}, 3*time.Second, 1*time.Second)
 
 		err = runTCPLoadTest()
 		require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

Add a retry loop for `TestTCPQueueLengthTracer`.

### Motivation

[This test is currently flaky](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.name%3ATestTCPQueueLengthTracer%2Fruntime_compiled%20%40test.status%3Afail&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=&index=citest&mode=sliding&saved-view-id=2236559&start=1706036491034&end=1706641291034&paused=false).

### Additional Notes

When it fails, it’s with errors like:
```
tcp_queue_length_test.go:55: max usage of read buffer is too big before the stress test: 14 > 10
```

That’s because the background network traffic that happened during the start of the test wasn’t as low as expected.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
