### PR TITLE
Fix process bundle one shot test to avoid long timeouts

### DIFF
--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -65,6 +65,10 @@ func TestBundleOneShot(t *testing.T) {
 
 			mockCoreBundleParams,
 		),
+		// sets a static hostname to avoid grpc call to get hostname from core-agent
+		fx.Replace(configComp.MockParams{Overrides: map[string]interface{}{
+			"hostname": "testhost",
+		}}),
 		core.MockBundle(),
 		Bundle(),
 	)


### PR DESCRIPTION
### What does this PR do?
Fixes a test which takes a minute to timeout trying to reach the core-agent to retrieve a hostname before falling back on the local hostname. 
https://github.com/DataDog/datadog-agent/blob/3030ec2d30f9080f490fcc1e69d88101ba43d6ef/pkg/process/checks/host_info.go#L87

This sets a static hostname to bypass the core-agent check completely.

- Before the change
<img width="1158" alt="image" src="https://github.com/DataDog/datadog-agent/assets/7888158/b305d47c-36c2-4dd2-9ec0-4676d64032c9">

- After the change
<img width="1208" alt="image" src="https://github.com/DataDog/datadog-agent/assets/7888158/708e2419-7b9e-4fcf-bdfb-aab532f24c00">


### Motivation
Test speed and hygiene

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
