### PR TITLE
[EBPF-232] Fix panics in ebpfcheck entry count

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -15,7 +15,6 @@ import (
 	"hash/fnv"
 	"io"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 	"unsafe"
@@ -56,7 +55,6 @@ type Probe struct {
 	links                 []link.Link
 	mapBuffers            entryCountBuffers
 	entryCountMaxRestarts int
-	entryCountLock        sync.Mutex
 
 	nrcpus uint32
 }
@@ -211,8 +209,6 @@ func (k *Probe) Close() {
 
 // GetAndFlush gets the stats
 func (k *Probe) GetAndFlush() (results model.EBPFStats) {
-	k.entryCountLock.Lock()
-	defer k.entryCountLock.Unlock()
 	if err := k.getMapStats(&results); err != nil {
 		log.Debugf("error getting map stats: %s", err)
 		return

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -838,7 +838,6 @@ func hashMapNumberOfEntriesWithIteration(mp *ebpf.Map, buffers *entryCountBuffer
 			restarts++
 			buffers.firstBatchKeys.clear()
 			buffers.firstBatchKeys.load(buffers.cursor, 1)
-			fmt.Println("restart")
 			continue
 		}
 

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -271,7 +271,7 @@ func TestHashMapNumberOfEntriesNoExtraAllocations(t *testing.T) {
 			})
 			require.NoError(t, err)
 			t.Cleanup(func() { _ = m.Close() })
-			require.True(t, buffers.tryEnsureSizeForFullBatch(m))
+			buffers.tryEnsureSizeForFullBatch(m)
 
 			for i := uint32(0); i < filledEntries; i++ {
 				require.NoError(t, m.Put(&i, &i))
@@ -297,7 +297,7 @@ func TestHashMapNumberOfEntriesNoExtraAllocations(t *testing.T) {
 						keysBufferSizeLimit:   4 * 100,
 						valuesBufferSizeLimit: 4 * 100,
 					}
-					require.False(t, limitedBuffers.tryEnsureSizeForFullBatch(m))
+					limitedBuffers.tryEnsureSizeForFullBatch(m)
 					limitedBuffers.prepareFirstBatchKeys(m)
 
 					allocs := testing.AllocsPerRun(10, func() {
@@ -347,7 +347,7 @@ func TestHashMapNumberOfEntriesMapTypeSupport(t *testing.T) {
 		})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = m.Close() })
-		require.True(t, buffers.tryEnsureSizeForFullBatch(m))
+		buffers.tryEnsureSizeForFullBatch(m)
 		require.Equal(t, expectedReturn, hashMapNumberOfEntries(m, &buffers, 1))
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes how the limits are implemented for the entry count buffers in #21820, in turn fixing panics that were caused due to memory corruption

The main bug was due to how the batch size was calculated when the buffers were limited. Given that keys and values have different sizes, they could fit a different number of entries each. The batch size was calculated based on the keys buffer, which meant that in some cases we would be passing to the system a buffer for the values that was not big enough. This would cause memory corruption that showed up as panics in different places of the code.  


### Motivation

Reduce memory usage in staging and fix panics

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
