### PR TITLE
fix(CI): Allow failures on new-e2e-process tests until complete investigation

### DIFF
--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -37,6 +37,7 @@ func (s *linuxTestSuite) SetupSuite() {
 
 func (s *linuxTestSuite) TestProcessCheck() {
 	t := s.T()
+	t.Skip("PROCS-3574: consistent failures on process tests")
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process", "rtprocess"}, false, "sudo datadog-agent status --json")
@@ -56,8 +57,9 @@ func (s *linuxTestSuite) TestProcessCheck() {
 }
 
 func (s *linuxTestSuite) TestProcessDiscoveryCheck() {
-	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processDiscoveryCheckConfigStr))))
 	t := s.T()
+	t.Skip("PROCS-3574: consistent failures on process tests")
+	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processDiscoveryCheckConfigStr))))
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process_discovery"}, false, "sudo datadog-agent status --json")
@@ -75,12 +77,12 @@ func (s *linuxTestSuite) TestProcessDiscoveryCheck() {
 }
 
 func (s *linuxTestSuite) TestProcessCheckWithIO() {
+	t := s.T()
+	t.Skip("PROCS-3574: consistent failures on process tests")
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr))))
 
 	// Flush fake intake to remove payloads that won't have IO stats
 	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
-
-	t := s.T()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process", "rtprocess"}, true, "sudo datadog-agent status --json")

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -44,6 +44,7 @@ func (s *windowsTestSuite) SetupSuite() {
 
 func (s *windowsTestSuite) TestProcessCheck() {
 	t := s.T()
+	t.Skip("PROCS-3644: consistent failures on process tests")
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		command := "& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe\" status --json"
@@ -64,11 +65,12 @@ func (s *windowsTestSuite) TestProcessCheck() {
 }
 
 func (s *windowsTestSuite) TestProcessDiscoveryCheck() {
+	t := s.T()
+	t.Skip("PROCS-3644: consistent failures on process tests")
 	s.UpdateEnv(awshost.Provisioner(
 		awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
 		awshost.WithAgentOptions(agentparams.WithAgentConfig(processDiscoveryCheckConfigStr)),
 	))
-	t := s.T()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		command := "& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe\" status --json"
@@ -87,6 +89,8 @@ func (s *windowsTestSuite) TestProcessDiscoveryCheck() {
 }
 
 func (s *windowsTestSuite) TestProcessCheckIO() {
+	t := s.T()
+	t.Skip("PROCS-3644: consistent failures on process tests")
 	s.UpdateEnv(awshost.Provisioner(
 		awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
 		awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr)),
@@ -94,8 +98,6 @@ func (s *windowsTestSuite) TestProcessCheckIO() {
 
 	// Flush fake intake to remove payloads that won't have IO stats
 	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
-
-	t := s.T()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		command := "& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe\" status --json"
@@ -127,7 +129,7 @@ func (s *windowsTestSuite) TestManualProcessCheck() {
 func (s *windowsTestSuite) TestManualProcessDiscoveryCheck() {
 	// Skipping due to flakiness
 	// Responses with more than 100 processes end up being chunked, which fails JSON unmarshalling
-	s.T().Skip()
+	s.T().Skip("PROCS-3644: consistent failures on process tests")
 
 	check := s.Env().RemoteHost.
 		MustExecute("& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent\\process-agent.exe\" check process_discovery --json")
@@ -135,6 +137,7 @@ func (s *windowsTestSuite) TestManualProcessDiscoveryCheck() {
 }
 
 func (s *windowsTestSuite) TestManualProcessCheckWithIO() {
+	s.T().Skip("PROCS-3644: consistent failures on process tests")
 	s.UpdateEnv(awshost.Provisioner(
 		awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
 		awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr)),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Prevent failing tests to impact success rate of main branch pipeline
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Send relevant figures wrt to datadog-agent CI. More information on [#incident-24978](https://app.datadoghq.com/incidents/24978)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Skipped 7 tests based on [ci-visibility stats](https://app.datadoghq.com/metric/explorer?fullscreen_end_ts=1706715416213&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_start_ts=1706629016213&graph_layout=multi&start=1706630696893&end=1706717096893&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiBQnhhOGvjaAMZKyCDxEE4I5pZUIhjqykHaWGQGIKICxPphIABUIAC6VPE4qvIESaAYMDBGMJ6S0slNeCJIfCDd+PJOAEY0YaCCGIleAAIZGggAdDl5VGg+4uQArFSx2oSgbgLaygIa8SWd3XC9ElLKQyMgPDwNIFoYBLMIgFOYqcxONBwABucDQyHWCAABGtzJs-NCIIlkJEEBgoDgYABaTpwEYoxHovDiODIAA643EjDw002TVUAHoACJRLmEjm4-GEknwEYcxEckRwMBEuAAJjg4syHPk2hwiQ0GgZFLRG08eA0yEWEDQ31+VFc7jwmFC4UtqmtGHyZkKxXN-zkUJkIHkGChCAyt0JTniNo0WJK+yl6QUSX+OH2UEjojgTnoTGUIjcHlNYygEHsmCwMcUymmgMsvx+p3k+wQAGEpMIYCgRNa0DwgA)
Jira cards for test already exist on [linux](https://datadoghq.atlassian.net/browse/PROCS-3574) and [windows](https://datadoghq.atlassian.net/browse/PROCS-3644) test suite 

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
