### PR TITLE
Use Invoke's run env parameter for Pulumis commands

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -177,6 +177,11 @@ def clean(ctx, locks=True, stacks=False, output=False):
         _clean_output()
 
 
+def _get_default_env():
+    return {
+        "PULUMI_SKIP_UPDATE_CHECK": "true"
+    }
+
 def _get_home_dir():
     # TODO: Go os.UserHomeDir() uses a different algorithm than Python Path.home()
     #       so a different directory may be returned in some cases.
@@ -250,7 +255,7 @@ def _clean_stacks(ctx: Context):
 
 def _get_existing_stacks(ctx: Context) -> List[str]:
     e2e_stacks: List[str] = []
-    output = ctx.run("PULUMI_SKIP_UPDATE_CHECK=true pulumi stack ls --all --project e2elocal --json", hide=True)
+    output = ctx.run("pulumi stack ls --all --project e2elocal --json", hide=True, env=_get_default_env())
     if output is None or not output:
         return []
     stacks_data = json.loads(output.stdout)
@@ -270,26 +275,27 @@ def _destroy_stack(ctx: Context, stack: str):
     # with resources removed by agent-sandbox clean up job
     with ctx.cd(tempfile.gettempdir()):
         ret = ctx.run(
-            f"PULUMI_SKIP_UPDATE_CHECK=true pulumi destroy --stack {stack} --yes --remove --skip-preview",
-            pty=True,
+            f"pulumi destroy --stack {stack} --yes --remove --skip-preview",
             warn=True,
             hide=True,
+            env=_get_default_env()
         )
         if ret is not None and ret.exited != 0:
             # run with refresh on first destroy attempt failure
             ctx.run(
-                f"PULUMI_SKIP_UPDATE_CHECK=true pulumi destroy --stack {stack} -r --yes --remove --skip-preview",
+                f"pulumi destroy --stack {stack} -r --yes --remove --skip-preview",
                 warn=True,
                 hide=True,
+                env=_get_default_env()
             )
 
 
 def _remove_stack(ctx: Context, stack: str):
-    ctx.run(f"PULUMI_SKIP_UPDATE_CHECK=true pulumi stack rm --force --yes --stack {stack}", hide=True)
+    ctx.run("pulumi stack rm --force --yes --stack {stack}", hide=True, env=_get_default_env())
 
 
 def _get_pulumi_about(ctx: Context) -> dict:
-    output = ctx.run("PULUMI_SKIP_UPDATE_CHECK=true pulumi about --json", hide=True)
+    output = ctx.run("pulumi about --json", hide=True, env=_get_default_env())
     if output is None or not output:
         return ""
     return json.loads(output.stdout)

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -291,7 +291,7 @@ def _destroy_stack(ctx: Context, stack: str):
 
 
 def _remove_stack(ctx: Context, stack: str):
-    ctx.run("pulumi stack rm --force --yes --stack {stack}", hide=True, env=_get_default_env())
+    ctx.run(f"pulumi stack rm --force --yes --stack {stack}", hide=True, env=_get_default_env())
 
 
 def _get_pulumi_about(ctx: Context) -> dict:

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -178,9 +178,8 @@ def clean(ctx, locks=True, stacks=False, output=False):
 
 
 def _get_default_env():
-    return {
-        "PULUMI_SKIP_UPDATE_CHECK": "true"
-    }
+    return {"PULUMI_SKIP_UPDATE_CHECK": "true"}
+
 
 def _get_home_dir():
     # TODO: Go os.UserHomeDir() uses a different algorithm than Python Path.home()
@@ -278,7 +277,7 @@ def _destroy_stack(ctx: Context, stack: str):
             f"pulumi destroy --stack {stack} --yes --remove --skip-preview",
             warn=True,
             hide=True,
-            env=_get_default_env()
+            env=_get_default_env(),
         )
         if ret is not None and ret.exited != 0:
             # run with refresh on first destroy attempt failure
@@ -286,7 +285,7 @@ def _destroy_stack(ctx: Context, stack: str):
                 f"pulumi destroy --stack {stack} -r --yes --remove --skip-preview",
                 warn=True,
                 hide=True,
-                env=_get_default_env()
+                env=_get_default_env(),
             )
 
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR changes the Pulumi's invoke tasks to use the `env` parameter.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
On Windows, it's not possible to pass environment's variables on the same command line, so we should use Invoke's run `env` parameter as it will do the right thing on each environment.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
