### PR TITLE
[CI/Tooling] Raise warning if there are tools version mismatches before running linters

### DIFF
--- a/tasks/libs/common/check_tools_version.py
+++ b/tasks/libs/common/check_tools_version.py
@@ -1,0 +1,71 @@
+import json
+import sys
+from typing import List
+
+from invoke import Context
+
+# VPATH as in version path
+GO_VPATH = ".go-version"
+GOLANGCI_LINT_VPATH = "internal/tools/go.mod"
+
+
+def expected_go_repo_v() -> str:
+    """
+    Returns the repository go version by reading the .go-version file.
+    """
+    with open(GO_VPATH, 'r', encoding='utf-8') as f:
+        return f.read().strip()
+
+
+def current_go_v(ctx: Context) -> str:
+    """
+    Returns the current user go version by running go version
+    """
+    cmd = "go version"
+    return ctx.run(cmd, hide=True).stdout.split(' ')[2][2:]
+
+
+def expected_golangci_lint_repo_v(ctx: Context) -> str:
+    """
+    Returns the installed golangci-lint version by parsing the internal/tools/go.mod file.
+    """
+    mod_name = "github.com/golangci/golangci-lint"
+    go_mod_json = json.loads(ctx.run(f"go mod edit -json {GOLANGCI_LINT_VPATH}", hide=True).stdout)
+    for mod in go_mod_json['Require']:
+        if mod['Path'] == mod_name:
+            return mod['Version']
+    return ""
+
+
+def current_golangci_lint_v(ctx: Context) -> str:
+    """
+    Returns the current user golangci-lint version by running golangci-lint --version
+    """
+    cmd = "golangci-lint --version"
+    return ctx.run(cmd, hide=True).stdout.split(' ')[3]
+
+
+def check_tools_version(ctx: Context, tools_list: List[str]) -> bool:
+    """
+    Check that each installed tool in tools_list is the version expected for the repo.
+    """
+    is_expected_versions = True
+    tools_versions = {
+        'go': {'current_v': current_go_v(ctx), 'expected_v': expected_go_repo_v()},
+        'golangci-lint': {'current_v': current_golangci_lint_v(ctx), 'expected_v': expected_golangci_lint_repo_v(ctx)},
+    }
+    for tool in tools_list:
+        if tool not in tools_versions:
+            print(
+                f"Warning: Couldn't check '{tool}' expected version. Supported tools: {list(tools_versions.keys())}",
+                file=sys.stderr,
+            )
+        else:
+            current_v, expected_v = tools_versions[tool]['current_v'], tools_versions[tool]['expected_v']
+            if current_v != expected_v:
+                is_expected_versions = False
+                print(
+                    f"Warning: Expecting {tool} '{expected_v}' but you have {tool} '{current_v}'. Please fix this as you might encounter issues using the tooling.",
+                    file=sys.stderr,
+                )
+    return is_expected_versions

--- a/tasks/linter_tasks.py
+++ b/tasks/linter_tasks.py
@@ -7,6 +7,7 @@ from invoke import Exit, task
 from tasks.build_tags import compute_build_tags_for_flavor
 from tasks.flavor import AgentFlavor
 from tasks.go import run_golangci_lint
+from tasks.libs.common.check_tools_version import check_tools_version
 from tasks.libs.common.utils import DEFAULT_BRANCH, color_message
 from tasks.libs.copyright import CopyrightLinter
 from tasks.modules import GoModule
@@ -114,6 +115,9 @@ def lint_go(
         inv lint-go --targets=./pkg/collector/check,./pkg/aggregator
         inv lint-go --module=.
     """
+
+    if not check_tools_version(ctx, ['go', 'golangci-lint']):
+        print("Warning: If you have linter errors it might be due to version mismatches.", file=sys.stderr)
 
     # Format:
     # {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds a warning before running the go linters if there are tools version mismatches.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This is one of the main reasons making the linters fail. A lot of people ask question when this happened so this should make us gain a lot of time.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
