### PR TITLE
[NDMII-2461] Use enum for device ping_status

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -41,15 +41,16 @@ import (
 )
 
 const (
-	snmpLoaderTag           = "loader:core"
-	serviceCheckName        = "snmp.can_check"
-	deviceReachableMetric   = "snmp.device.reachable"
-	deviceUnreachableMetric = "snmp.device.unreachable"
-	pingCanConnectMetric    = "ndm.ping.canConnect"
-	pingPacketLoss          = "ndm.ping.packetLoss"
-	pingAvgRttMetric        = "ndm.ping.avgRtt"
-	deviceHostnamePrefix    = "device:"
-	checkDurationThreshold  = 30 // Thirty seconds
+	snmpLoaderTag             = "loader:core"
+	serviceCheckName          = "snmp.can_check"
+	deviceReachableMetric     = "snmp.device.reachable"
+	deviceUnreachableMetric   = "snmp.device.unreachable"
+	pingCanConnectMetric      = "networkdevice.ping.canConnect"
+	pingCanConnectFalseMetric = "networkdevice.ping.canConnect.false"
+	pingPacketLoss            = "networkdevice.ping.packetLoss"
+	pingAvgRttMetric          = "networkdevice.ping.avgRtt"
+	deviceHostnamePrefix      = "device:"
+	checkDurationThreshold    = 30 // Thirty seconds
 )
 
 // define timeNow as variable to make it possible to mock it during test
@@ -147,7 +148,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	// Fetch and report metrics
 	var checkErr error
 	var deviceStatus metadata.DeviceStatus
-	var pingCanConnect *bool
+	pingCanConnect := metadata.DeviceCanConnectUnknown
 
 	deviceReachable, dynamicTags, values, checkErr := d.getValuesAndTags()
 	tags := common.CopyStrings(staticTags)
@@ -177,7 +178,11 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 		} else {
 			// if ping succeeds, set pingCanConnect for use in metadata and send metrics
 			log.Debugf("%s: ping returned: %+v", d.config.IPAddress, pingResult)
-			pingCanConnect = &pingResult.CanConnect
+			if pingResult.CanConnect {
+				pingCanConnect = metadata.DeviceCanConnectTrue
+			} else {
+				pingCanConnect = metadata.DeviceCanConnectFalse
+			}
 			d.submitPingMetrics(pingResult, tags)
 		}
 	} else {
@@ -416,5 +421,6 @@ func createPinger(cfg pinger.Config) (pinger.Pinger, error) {
 func (d *DeviceCheck) submitPingMetrics(pingResult *pinger.Result, tags []string) {
 	d.sender.Gauge(pingAvgRttMetric, float64(pingResult.AvgRtt/time.Millisecond), tags)
 	d.sender.Gauge(pingCanConnectMetric, common.BoolToFloat64(pingResult.CanConnect), tags)
+	d.sender.Gauge(pingCanConnectFalseMetric, common.BoolToFloat64(!pingResult.CanConnect), tags)
 	d.sender.Gauge(pingPacketLoss, pingResult.PacketLoss, tags)
 }

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -1100,7 +1100,7 @@ profiles:
 	assert.Len(t, deviceCk.config.MetricTags, 2)
 
 	// Assert Ping Metrics
-	sender.AssertMetric(t, "Gauge", pingCanConnectMetric, float64(1), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", pingReachableMetric, float64(1), "", snmpTags)
 	sender.AssertMetric(t, "Gauge", pingAvgRttMetric, 4, "", snmpTags)
 	sender.AssertMetric(t, "Gauge", pingPacketLoss, 0.57, "", snmpTags)
 }
@@ -1242,7 +1242,7 @@ profiles:
 	assert.Len(t, deviceCk.config.MetricTags, 2)
 
 	// Assert Ping Metrics not sent
-	sender.AssertNotCalled(t, "Gauge", pingCanConnectMetric, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "Gauge", pingReachableMetric, mock.Anything, mock.Anything, mock.Anything)
 	sender.AssertNotCalled(t, "Gauge", pingAvgRttMetric, mock.Anything, mock.Anything, mock.Anything)
 	sender.AssertNotCalled(t, "Gauge", pingPacketLoss, mock.Anything, mock.Anything, mock.Anything)
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -50,13 +50,13 @@ var supportedDeviceTypes = map[string]bool{
 }
 
 // ReportNetworkDeviceMetadata reports device metadata
-func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckConfig, store *valuestore.ResultValueStore, origTags []string, collectTime time.Time, deviceStatus devicemetadata.DeviceStatus, pingCanConnect devicemetadata.DeviceCanConnect, diagnoses []devicemetadata.DiagnosisMetadata) {
+func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckConfig, store *valuestore.ResultValueStore, origTags []string, collectTime time.Time, deviceStatus devicemetadata.DeviceStatus, pingStatus devicemetadata.DeviceStatus, diagnoses []devicemetadata.DiagnosisMetadata) {
 	tags := common.CopyStrings(origTags)
 	tags = util.SortUniqInPlace(tags)
 
 	metadataStore := buildMetadataStore(config.Metadata, store)
 
-	devices := []devicemetadata.DeviceMetadata{buildNetworkDeviceMetadata(config.DeviceID, config.DeviceIDTags, config, metadataStore, tags, deviceStatus, pingCanConnect)}
+	devices := []devicemetadata.DeviceMetadata{buildNetworkDeviceMetadata(config.DeviceID, config.DeviceIDTags, config, metadataStore, tags, deviceStatus, pingStatus)}
 
 	interfaces := buildNetworkInterfacesMetadata(config.DeviceID, metadataStore)
 	ipAddresses := buildNetworkIPAddressesMetadata(config.DeviceID, metadataStore)
@@ -190,7 +190,7 @@ func buildMetadataStore(metadataConfigs profiledefinition.MetadataConfig, values
 	return metadataStore
 }
 
-func buildNetworkDeviceMetadata(deviceID string, idTags []string, config *checkconfig.CheckConfig, store *metadata.Store, tags []string, deviceStatus devicemetadata.DeviceStatus, pingCanConnect devicemetadata.DeviceCanConnect) devicemetadata.DeviceMetadata {
+func buildNetworkDeviceMetadata(deviceID string, idTags []string, config *checkconfig.CheckConfig, store *metadata.Store, tags []string, deviceStatus devicemetadata.DeviceStatus, pingStatus devicemetadata.DeviceStatus) devicemetadata.DeviceMetadata {
 	var vendor, sysName, sysDescr, sysObjectID, location, serialNumber, version, productName, model, osName, osVersion, osHostname, deviceType string
 	if store != nil {
 		sysName = store.GetScalarAsString("device.name")
@@ -227,7 +227,7 @@ func buildNetworkDeviceMetadata(deviceID string, idTags []string, config *checkc
 		Tags:           tags,
 		Subnet:         config.ResolvedSubnetName,
 		Status:         deviceStatus,
-		PingCanConnect: pingCanConnect,
+		PingStatus:     pingStatus,
 		SerialNumber:   serialNumber,
 		Version:        version,
 		ProductName:    productName,

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -50,7 +50,7 @@ var supportedDeviceTypes = map[string]bool{
 }
 
 // ReportNetworkDeviceMetadata reports device metadata
-func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckConfig, store *valuestore.ResultValueStore, origTags []string, collectTime time.Time, deviceStatus devicemetadata.DeviceStatus, pingCanConnect *bool, diagnoses []devicemetadata.DiagnosisMetadata) {
+func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckConfig, store *valuestore.ResultValueStore, origTags []string, collectTime time.Time, deviceStatus devicemetadata.DeviceStatus, pingCanConnect devicemetadata.DeviceCanConnect, diagnoses []devicemetadata.DiagnosisMetadata) {
 	tags := common.CopyStrings(origTags)
 	tags = util.SortUniqInPlace(tags)
 
@@ -190,7 +190,7 @@ func buildMetadataStore(metadataConfigs profiledefinition.MetadataConfig, values
 	return metadataStore
 }
 
-func buildNetworkDeviceMetadata(deviceID string, idTags []string, config *checkconfig.CheckConfig, store *metadata.Store, tags []string, deviceStatus devicemetadata.DeviceStatus, pingCanConnect *bool) devicemetadata.DeviceMetadata {
+func buildNetworkDeviceMetadata(deviceID string, idTags []string, config *checkconfig.CheckConfig, store *metadata.Store, tags []string, deviceStatus devicemetadata.DeviceStatus, pingCanConnect devicemetadata.DeviceCanConnect) devicemetadata.DeviceMetadata {
 	var vendor, sysName, sysDescr, sysObjectID, location, serialNumber, version, productName, model, osName, osVersion, osHostname, deviceType string
 	if store != nil {
 		sysName = store.GetScalarAsString("device.name")

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -28,11 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
 )
 
-var (
-	trueVal  = true
-	falseVal = false
-)
-
 func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
@@ -134,7 +129,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, storeWithoutIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, &trueVal, nil)
+	ms.ReportNetworkDeviceMetadata(config, storeWithoutIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectTrue, nil)
 
 	// language=json
 	event := []byte(`
@@ -153,7 +148,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect": true,
+			"can_connect":1,
             "name": "my-sys-name",
             "description": "my-sys-descr",
             "location": "my-sys-location",
@@ -215,7 +210,7 @@ profiles:
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, storeWithoutIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, &trueVal, nil)
+	ms.ReportNetworkDeviceMetadata(config, storeWithoutIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectTrue, nil)
 
 	// language=json
 	event := []byte(`
@@ -235,7 +230,7 @@ profiles:
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect": true,
+			"can_connect":1,
             "profile": "f5-big-ip",
             "vendor": "f5",
             "subnet": "127.0.0.0/29",
@@ -354,7 +349,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 	str := "2014-11-12 11:45:26"
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
-	ms.ReportNetworkDeviceMetadata(config, storeWithIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, &falseVal, diagnosis)
+	ms.ReportNetworkDeviceMetadata(config, storeWithIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectFalse, diagnosis)
 
 	ifTags1 := []string{"tag1", "tag2", "status:down", "interface:21", "interface_alias:ifAlias1", "interface_index:1", "oper_status:up", "admin_status:down"}
 	ifTags2 := []string{"tag1", "tag2", "status:off", "interface:22", "interface_index:2", "oper_status:down", "admin_status:down", "muted", "someKey:someValue"}
@@ -378,7 +373,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect": false,
+			"can_connect":2,
             "subnet": "127.0.0.0/29",
 			"device_type": "switch"
         }
@@ -468,7 +463,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_fallbackOnFieldValue(t *testi
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, &trueVal, nil)
+	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectFalse, nil)
 
 	// language=json
 	event := []byte(`
@@ -487,7 +482,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_fallbackOnFieldValue(t *testi
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect": true,
+			"can_connect":2,
             "name": "my-fallback-value",
             "subnet": "127.0.0.0/29",
 			"device_type": "firewall"
@@ -539,7 +534,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_Nil(t *testing
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, nil, nil)
+	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectUnknown, nil)
 
 	// language=json
 	event := []byte(`
@@ -609,7 +604,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_True(t *testin
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, &trueVal, nil)
+	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectFalse, nil)
 
 	// language=json
 	event := []byte(`
@@ -628,7 +623,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_True(t *testin
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect": true,
+			"can_connect":2,
             "name": "my-fallback-value",
             "subnet": "127.0.0.0/29",
 			"device_type": "other"
@@ -680,7 +675,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_False(t *testi
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, &falseVal, nil)
+	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectFalse, nil)
 
 	// language=json
 	event := []byte(`
@@ -699,7 +694,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_False(t *testi
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect": false,
+			"can_connect":2,
             "name": "my-fallback-value",
             "subnet": "127.0.0.0/29",
 			"device_type": "other"

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -129,7 +129,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, storeWithoutIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectTrue, nil)
+	ms.ReportNetworkDeviceMetadata(config, storeWithoutIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusReachable, nil)
 
 	// language=json
 	event := []byte(`
@@ -148,7 +148,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect":1,
+			"ping_status":1,
             "name": "my-sys-name",
             "description": "my-sys-descr",
             "location": "my-sys-location",
@@ -210,7 +210,7 @@ profiles:
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, storeWithoutIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectTrue, nil)
+	ms.ReportNetworkDeviceMetadata(config, storeWithoutIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusReachable, nil)
 
 	// language=json
 	event := []byte(`
@@ -230,7 +230,7 @@ profiles:
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect":1,
+			"ping_status":1,
             "profile": "f5-big-ip",
             "vendor": "f5",
             "subnet": "127.0.0.0/29",
@@ -349,7 +349,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 	str := "2014-11-12 11:45:26"
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
-	ms.ReportNetworkDeviceMetadata(config, storeWithIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectFalse, diagnosis)
+	ms.ReportNetworkDeviceMetadata(config, storeWithIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, diagnosis)
 
 	ifTags1 := []string{"tag1", "tag2", "status:down", "interface:21", "interface_alias:ifAlias1", "interface_index:1", "oper_status:up", "admin_status:down"}
 	ifTags2 := []string{"tag1", "tag2", "status:off", "interface:22", "interface_index:2", "oper_status:down", "admin_status:down", "muted", "someKey:someValue"}
@@ -373,7 +373,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect":2,
+			"ping_status":2,
             "subnet": "127.0.0.0/29",
 			"device_type": "switch"
         }
@@ -463,7 +463,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_fallbackOnFieldValue(t *testi
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectFalse, nil)
+	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, nil)
 
 	// language=json
 	event := []byte(`
@@ -482,7 +482,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_fallbackOnFieldValue(t *testi
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect":2,
+			"ping_status":2,
             "name": "my-fallback-value",
             "subnet": "127.0.0.0/29",
 			"device_type": "firewall"
@@ -534,7 +534,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_Nil(t *testing
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectUnknown, nil)
+	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, 0, nil)
 
 	// language=json
 	event := []byte(`
@@ -604,7 +604,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_True(t *testin
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectFalse, nil)
+	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, nil)
 
 	// language=json
 	event := []byte(`
@@ -623,7 +623,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_True(t *testin
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect":2,
+			"ping_status":2,
             "name": "my-fallback-value",
             "subnet": "127.0.0.0/29",
 			"device_type": "other"
@@ -675,7 +675,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_False(t *testi
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceCanConnectFalse, nil)
+	ms.ReportNetworkDeviceMetadata(config, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, nil)
 
 	// language=json
 	event := []byte(`
@@ -694,7 +694,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_False(t *testi
             ],
             "ip_address": "1.2.3.4",
             "status":1,
-			"can_connect":2,
+			"ping_status":2,
             "name": "my-fallback-value",
             "subnet": "127.0.0.0/29",
 			"device_type": "other"

--- a/pkg/networkdevice/metadata/payload.go
+++ b/pkg/networkdevice/metadata/payload.go
@@ -13,25 +13,11 @@ const PayloadMetadataBatchSize = 100
 // DeviceStatus enum type
 type DeviceStatus int32
 
-// DeviceCanConnect enum type
-type DeviceCanConnect int32
-
 const (
 	// DeviceStatusReachable means the device can be reached by snmp integration
 	DeviceStatusReachable = DeviceStatus(1)
 	// DeviceStatusUnreachable means the device cannot be reached by snmp integration
 	DeviceStatusUnreachable = DeviceStatus(2)
-)
-
-// needs its own const block to avoid overlapping with device status
-const (
-	// DeviceCanConnectUnknown is used when the device is not being pinged or there's
-	// an agent error
-	DeviceCanConnectUnknown DeviceCanConnect = iota
-	// DeviceCanConnectTrue is used when the device is responding to ping
-	DeviceCanConnectTrue
-	// DeviceCanConnectFalse is used when the device is not reachable by ping
-	DeviceCanConnectFalse
 )
 
 //nolint:revive // TODO(NDM) Fix revive linter
@@ -61,29 +47,29 @@ type NetworkDevicesMetadata struct {
 
 // DeviceMetadata contains device metadata
 type DeviceMetadata struct {
-	ID             string           `json:"id"`
-	IDTags         []string         `json:"id_tags"` // id_tags is the input to produce device.id, it's also used to correlated with device metrics.
-	Tags           []string         `json:"tags"`
-	IPAddress      string           `json:"ip_address"`
-	Status         DeviceStatus     `json:"status"`
-	PingCanConnect DeviceCanConnect `json:"can_connect,omitempty"`
-	Name           string           `json:"name,omitempty"`
-	Description    string           `json:"description,omitempty"`
-	SysObjectID    string           `json:"sys_object_id,omitempty"`
-	Location       string           `json:"location,omitempty"`
-	Profile        string           `json:"profile,omitempty"`
-	ProfileVersion uint64           `json:"profile_version,omitempty"`
-	Vendor         string           `json:"vendor,omitempty"`
-	Subnet         string           `json:"subnet,omitempty"`
-	SerialNumber   string           `json:"serial_number,omitempty"`
-	Version        string           `json:"version,omitempty"`
-	ProductName    string           `json:"product_name,omitempty"`
-	Model          string           `json:"model,omitempty"`
-	OsName         string           `json:"os_name,omitempty"`
-	OsVersion      string           `json:"os_version,omitempty"`
-	OsHostname     string           `json:"os_hostname,omitempty"`
-	Integration    string           `json:"integration,omitempty"` // indicates the source of the data SNMP, meraki_api, etc.
-	DeviceType     string           `json:"device_type,omitempty"`
+	ID             string       `json:"id"`
+	IDTags         []string     `json:"id_tags"` // id_tags is the input to produce device.id, it's also used to correlated with device metrics.
+	Tags           []string     `json:"tags"`
+	IPAddress      string       `json:"ip_address"`
+	Status         DeviceStatus `json:"status"`
+	PingStatus     DeviceStatus `json:"ping_status,omitempty"`
+	Name           string       `json:"name,omitempty"`
+	Description    string       `json:"description,omitempty"`
+	SysObjectID    string       `json:"sys_object_id,omitempty"`
+	Location       string       `json:"location,omitempty"`
+	Profile        string       `json:"profile,omitempty"`
+	ProfileVersion uint64       `json:"profile_version,omitempty"`
+	Vendor         string       `json:"vendor,omitempty"`
+	Subnet         string       `json:"subnet,omitempty"`
+	SerialNumber   string       `json:"serial_number,omitempty"`
+	Version        string       `json:"version,omitempty"`
+	ProductName    string       `json:"product_name,omitempty"`
+	Model          string       `json:"model,omitempty"`
+	OsName         string       `json:"os_name,omitempty"`
+	OsVersion      string       `json:"os_version,omitempty"`
+	OsHostname     string       `json:"os_hostname,omitempty"`
+	Integration    string       `json:"integration,omitempty"` // indicates the source of the data SNMP, meraki_api, etc.
+	DeviceType     string       `json:"device_type,omitempty"`
 }
 
 // InterfaceMetadata contains interface metadata

--- a/pkg/networkdevice/metadata/payload.go
+++ b/pkg/networkdevice/metadata/payload.go
@@ -13,11 +13,25 @@ const PayloadMetadataBatchSize = 100
 // DeviceStatus enum type
 type DeviceStatus int32
 
+// DeviceCanConnect enum type
+type DeviceCanConnect int32
+
 const (
 	// DeviceStatusReachable means the device can be reached by snmp integration
 	DeviceStatusReachable = DeviceStatus(1)
 	// DeviceStatusUnreachable means the device cannot be reached by snmp integration
 	DeviceStatusUnreachable = DeviceStatus(2)
+)
+
+// needs its own const block to avoid overlapping with device status
+const (
+	// DeviceCanConnectUnknown is used when the device is not being pinged or there's
+	// an agent error
+	DeviceCanConnectUnknown DeviceCanConnect = iota
+	// DeviceCanConnectTrue is used when the device is responding to ping
+	DeviceCanConnectTrue
+	// DeviceCanConnectFalse is used when the device is not reachable by ping
+	DeviceCanConnectFalse
 )
 
 //nolint:revive // TODO(NDM) Fix revive linter
@@ -47,29 +61,29 @@ type NetworkDevicesMetadata struct {
 
 // DeviceMetadata contains device metadata
 type DeviceMetadata struct {
-	ID             string       `json:"id"`
-	IDTags         []string     `json:"id_tags"` // id_tags is the input to produce device.id, it's also used to correlated with device metrics.
-	Tags           []string     `json:"tags"`
-	IPAddress      string       `json:"ip_address"`
-	Status         DeviceStatus `json:"status"`
-	PingCanConnect *bool        `json:"can_connect,omitempty"`
-	Name           string       `json:"name,omitempty"`
-	Description    string       `json:"description,omitempty"`
-	SysObjectID    string       `json:"sys_object_id,omitempty"`
-	Location       string       `json:"location,omitempty"`
-	Profile        string       `json:"profile,omitempty"`
-	ProfileVersion uint64       `json:"profile_version,omitempty"`
-	Vendor         string       `json:"vendor,omitempty"`
-	Subnet         string       `json:"subnet,omitempty"`
-	SerialNumber   string       `json:"serial_number,omitempty"`
-	Version        string       `json:"version,omitempty"`
-	ProductName    string       `json:"product_name,omitempty"`
-	Model          string       `json:"model,omitempty"`
-	OsName         string       `json:"os_name,omitempty"`
-	OsVersion      string       `json:"os_version,omitempty"`
-	OsHostname     string       `json:"os_hostname,omitempty"`
-	Integration    string       `json:"integration,omitempty"` // indicates the source of the data SNMP, meraki_api, etc.
-	DeviceType     string       `json:"device_type,omitempty"`
+	ID             string           `json:"id"`
+	IDTags         []string         `json:"id_tags"` // id_tags is the input to produce device.id, it's also used to correlated with device metrics.
+	Tags           []string         `json:"tags"`
+	IPAddress      string           `json:"ip_address"`
+	Status         DeviceStatus     `json:"status"`
+	PingCanConnect DeviceCanConnect `json:"can_connect,omitempty"`
+	Name           string           `json:"name,omitempty"`
+	Description    string           `json:"description,omitempty"`
+	SysObjectID    string           `json:"sys_object_id,omitempty"`
+	Location       string           `json:"location,omitempty"`
+	Profile        string           `json:"profile,omitempty"`
+	ProfileVersion uint64           `json:"profile_version,omitempty"`
+	Vendor         string           `json:"vendor,omitempty"`
+	Subnet         string           `json:"subnet,omitempty"`
+	SerialNumber   string           `json:"serial_number,omitempty"`
+	Version        string           `json:"version,omitempty"`
+	ProductName    string           `json:"product_name,omitempty"`
+	Model          string           `json:"model,omitempty"`
+	OsName         string           `json:"os_name,omitempty"`
+	OsVersion      string           `json:"os_version,omitempty"`
+	OsHostname     string           `json:"os_hostname,omitempty"`
+	Integration    string           `json:"integration,omitempty"` // indicates the source of the data SNMP, meraki_api, etc.
+	DeviceType     string           `json:"device_type,omitempty"`
 }
 
 // InterfaceMetadata contains interface metadata


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Changes the type of canConnect for ping to an enum instead of using a bool pointer.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
