### PR TITLE
Fixed memory bug and added nonexistent file test for flare controller

### DIFF
--- a/comp/logs/agent/flare/flare_controller.go
+++ b/comp/logs/agent/flare/flare_controller.go
@@ -54,9 +54,9 @@ func (fc *FlareController) FillFlare(fb flaretypes.FlareBuilder) error {
 			default:
 				fi, err := os.Stat(file)
 				if err != nil {
-					fileInfo = fmt.Sprintf("%s %s\n", fi.Name(), err.Error())
+					fileInfo = fmt.Sprintf("%s\n", err.Error())
 				} else {
-					fileInfo = fmt.Sprintf("%s %s\n", fi.Name(), fi.Mode().String())
+					fileInfo = fmt.Sprintf("%s %s\n", file, fi.Mode().String())
 				}
 				writer = append(writer, []byte(fileInfo)...)
 			}

--- a/comp/logs/agent/flare/flare_controller_test.go
+++ b/comp/logs/agent/flare/flare_controller_test.go
@@ -6,6 +6,7 @@
 package flare
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -38,4 +39,21 @@ func TestAllFiles(t *testing.T) {
 
 	fc.SetAllFiles([]string{})
 	assert.Equal(t, fc.allFiles, []string{})
+}
+
+func TestNonexistantFile(t *testing.T) {
+	fc := NewFlareController()
+	f := helpers.NewFlareBuilderMock(t, false)
+	name := "file.log"
+
+	fc.SetAllFiles([]string{name})
+	fc.FillFlare(f.Fb)
+
+	fi, err := os.Stat(name)
+	if fi != nil {
+		fmt.Println("stop")
+	}
+
+	f.AssertFileExists("logs_file_permissions.log")
+	f.AssertFileContent(err.Error(), "logs_file_permissions.log")
 }

--- a/comp/logs/agent/flare/flare_controller_test.go
+++ b/comp/logs/agent/flare/flare_controller_test.go
@@ -6,7 +6,6 @@
 package flare
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -51,7 +50,7 @@ func TestNonexistantFile(t *testing.T) {
 
 	fi, err := os.Stat(name)
 	if fi != nil {
-		fmt.Println("stop")
+		t.Fail()
 	}
 
 	f.AssertFileExists("logs_file_permissions.log")

--- a/comp/logs/agent/flare/flare_controller_test.go
+++ b/comp/logs/agent/flare/flare_controller_test.go
@@ -50,7 +50,7 @@ func TestNonexistantFile(t *testing.T) {
 
 	fi, err := os.Stat(name)
 	if fi != nil {
-		t.Fail()
+		t.FailNow()
 	}
 
 	f.AssertFileExists("logs_file_permissions.log")

--- a/releasenotes/notes/fix-flare-controller-nonexistent-file-memory-bug-215f1df1eeb94cea.yaml
+++ b/releasenotes/notes/fix-flare-controller-nonexistent-file-memory-bug-215f1df1eeb94cea.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a memory exception where the flare controller tries to
+    ``stat`` a file that doesn't exist.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes a small memory bug in the flare controller when it would try to `os.stat()` a nonexistent file.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Got a memory error when testing it.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
N/A

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

No functional or behavioral changes, should be covered by the test.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
