### PR TITLE
create symlink to last test run output for local profiles

### DIFF
--- a/test/new-e2e/pkg/runner/local_profile.go
+++ b/test/new-e2e/pkg/runner/local_profile.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
@@ -113,4 +114,22 @@ func (p localProfile) NamePrefix() string {
 // AllowDevMode returns if DevMode is allowed
 func (p localProfile) AllowDevMode() bool {
 	return true
+}
+
+// GetOutputDir extends baseProfile.GetOutputDir to create a symlink to the latest run
+func (p localProfile) GetOutputDir() (string, error) {
+	outDir, err := p.baseProfile.GetOutputDir()
+	if err != nil {
+		return "", err
+	}
+
+	// Create a symlink to the latest run for user convenience
+	latestLink := filepath.Join(filepath.Dir(outDir), "latest")
+	_ = os.Remove(latestLink)
+	err = os.Symlink(outDir, latestLink)
+	if err != nil {
+		return "", err
+	}
+
+	return outDir, nil
 }

--- a/test/new-e2e/pkg/runner/local_profile.go
+++ b/test/new-e2e/pkg/runner/local_profile.go
@@ -125,7 +125,13 @@ func (p localProfile) GetOutputDir() (string, error) {
 
 	// Create a symlink to the latest run for user convenience
 	latestLink := filepath.Join(filepath.Dir(outDir), "latest")
-	_ = os.Remove(latestLink)
+	// Remove the symlink if it already exists
+	if _, err := os.Lstat(latestLink); err == nil {
+		err = os.Remove(latestLink)
+		if err != nil {
+			return "", err
+		}
+	}
 	err = os.Symlink(outDir, latestLink)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
create a symlink to the last test run output for local profiles

```
$ tree -d -L 1 ~/e2e-output
/home/brandenclark/e2e-output
├── 2024-01-31_15-25-27_3733236386
├── 2024-01-31_21-19-38_1584804161
├── 2024-01-31_21-28-59_3766096043
└── latest -> /home/brandenclark/e2e-output/2024-01-31_21-28-59_3766096043
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
make it easier to examine results from previous test run

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
