### PR TITLE
Fix flaky test for maximum allocations in entry count

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -252,7 +252,8 @@ func TestHashMapNumberOfEntries(t *testing.T) {
 
 func TestHashMapNumberOfEntriesNoExtraAllocations(t *testing.T) {
 	ebpftest.RequireKernelVersion(t, minimumKernelVersion)
-	entriesToTest := []uint32{24, 104, 1000, 10000} // We will divide by 8 in total to get some limits for the MultipleBatch test, ensure all numbers are divisible by 8
+	minBatchSize := uint32(8) // Ensure all numbers are divisible by 8 so that we can have whole numbers in the MultipleBatch case
+	entriesToTest := []uint32{minBatchSize * 5, minBatchSize * 15, minBatchSize * 125, minBatchSize * 1250}
 
 	for _, maxEntries := range entriesToTest {
 		t.Run(fmt.Sprintf("%dMaxEntries", maxEntries), func(t *testing.T) {

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -256,8 +256,7 @@ func TestHashMapNumberOfEntriesNoExtraAllocations(t *testing.T) {
 
 	for _, maxEntries := range entriesToTest {
 		t.Run(fmt.Sprintf("%dMaxEntries", maxEntries), func(t *testing.T) {
-			maxEntries := uint32(1000)
-			filledEntries := uint32(500)
+			filledEntries := maxEntries / 2
 			buffers := entryCountBuffers{
 				keysBufferSizeLimit:   0, // No limit
 				valuesBufferSizeLimit: 0, // No limit
@@ -294,8 +293,8 @@ func TestHashMapNumberOfEntriesNoExtraAllocations(t *testing.T) {
 
 				t.Run("MultipleBatch", func(t *testing.T) {
 					limitedBuffers := entryCountBuffers{
-						keysBufferSizeLimit:   4 * 100,
-						valuesBufferSizeLimit: 4 * 100,
+						keysBufferSizeLimit:   m.KeySize() * filledEntries / 4,
+						valuesBufferSizeLimit: m.ValueSize() * filledEntries / 4,
 					}
 					limitedBuffers.tryEnsureSizeForFullBatch(m)
 					limitedBuffers.prepareFirstBatchKeys(m)
@@ -303,7 +302,7 @@ func TestHashMapNumberOfEntriesNoExtraAllocations(t *testing.T) {
 					allocs := testing.AllocsPerRun(10, func() {
 						hashMapNumberOfEntriesWithBatch(m, &limitedBuffers, 1)
 					})
-					require.LessOrEqual(t, allocs, 0.0)
+					require.LessOrEqual(t, allocs, 6.0) // Multiple batches mean we need to use a map to keep track of the keys, that causes allocations for the values
 				})
 			}
 

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -252,7 +252,7 @@ func TestHashMapNumberOfEntries(t *testing.T) {
 
 func TestHashMapNumberOfEntriesNoExtraAllocations(t *testing.T) {
 	ebpftest.RequireKernelVersion(t, minimumKernelVersion)
-	entriesToTest := []uint32{10, 100, 1000, 10000}
+	entriesToTest := []uint32{24, 104, 1000, 10000} // We will divide by 8 in total to get some limits for the MultipleBatch test, ensure all numbers are divisible by 8
 
 	for _, maxEntries := range entriesToTest {
 		t.Run(fmt.Sprintf("%dMaxEntries", maxEntries), func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes a flaky test in the ebpfcheck entry count. It was flaking due to not accounting for possible allocations in the map that's used for tracking the first batch.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
