### PR TITLE
usm: http2: Support various status codes

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-common.h
@@ -12,6 +12,21 @@
 #include "protocols/http2/maps-defs.h"
 #include "protocols/classification/defs.h"
 
+// Returns true if the given index represents a path index.
+static __always_inline bool is_path_index(const __u64 index) {
+    return index == kEmptyPath || index == kIndexPath;
+}
+
+// Returns true is the given index represents a method index.
+static __always_inline bool is_method_index(const __u64 index) {
+    return index == kGET || index == kPOST;
+}
+
+// Returns true if the given index represents a status index.
+static __always_inline bool is_status_index(const __u64 index) {
+    return k200 <= index && index <= k500;
+}
+
 // returns true if the given index is one of the relevant headers we care for in the static table.
 // The full table can be found in the user mode code `createStaticTable`.
 static __always_inline bool is_interesting_static_entry(const __u64 index) {

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -117,6 +117,7 @@ typedef enum {
 
 typedef struct {
     char buffer[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
+    __u32 original_index;
     __u8 string_len;
     bool is_huffman_encoded;
 } dynamic_table_entry_t;
@@ -162,6 +163,7 @@ typedef enum {
 } __attribute__((packed)) http2_header_type_t;
 
 typedef struct {
+    __u32 original_index;
     __u32 index;
     __u32 new_dynamic_value_offset;
     __u32 new_dynamic_value_size;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -132,11 +132,22 @@ typedef struct {
     __u32 stream_id;
 } http2_stream_key_t;
 
+// If the path is huffman encoded then the length is 2, but if it is not, then the length is 3.
+#define HTTP2_STATUS_CODE_MAX_LEN 3
+
+typedef struct {
+    __u8 raw_buffer[HTTP2_STATUS_CODE_MAX_LEN];
+    bool is_huffman_encoded;
+
+    __u8 indexed_value;
+    bool finalized;
+} status_code_t;
+
 typedef struct {
     __u64 response_last_seen;
     __u64 request_started;
 
-    __u16 response_status_code;
+    status_code_t status_code;
     __u8 request_method;
     __u8 path_size;
     bool request_end_of_stream;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -118,7 +118,7 @@ static __always_inline bool tls_parse_field_literal(tls_dispatcher_arguments_t *
     // with an indexed name, literal value, reusing the index 4 and 5 in the
     // static table. A different index means that the header is not a path, so
     // we skip it.
-    if (index != kIndexPath && index != kEmptyPath) {
+    if (!is_path_index(index)) {
         goto end;
     }
     update_path_size_telemetry(http2_tel, str_len);
@@ -309,12 +309,12 @@ static __always_inline void tls_process_headers(tls_dispatcher_arguments_t *info
         current_header = &headers_to_process[iteration];
 
         if (current_header->type == kStaticHeader) {
-            if (current_header->index == kPOST || current_header->index == kGET) {
+            if (is_method_index(current_header->index)) {
                 // TODO: mark request
                 current_stream->request_started = bpf_ktime_get_ns();
                 current_stream->request_method = current_header->index;
                 __sync_fetch_and_add(&http2_tel->request_seen, 1);
-            } else if (current_header->index >= k200 && current_header->index <= k500) {
+            } else if (is_status_index(current_header->index)) {
                 current_stream->response_status_code = current_header->index;
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
             } else if (current_header->index == kEmptyPath) {

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -116,10 +116,11 @@ static __always_inline bool parse_field_literal(struct __sk_buff *skb, skb_info_
     // with an indexed name, literal value, reusing the index 4 and 5 in the
     // static table. A different index means that the header is not a path, so
     // we skip it.
-    if (!is_path_index(index)) {
+    if (is_path_index(index)) {
+        update_path_size_telemetry(http2_tel, str_len);
+    } else if (!is_status_index(index)) {
         goto end;
     }
-    update_path_size_telemetry(http2_tel, str_len);
 
     // We skip if:
     // - The string is too big
@@ -313,7 +314,8 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 current_stream->request_method = current_header->index;
                 __sync_fetch_and_add(&http2_tel->request_seen, 1);
             } else if (is_status_index(current_header->index)) {
-                current_stream->response_status_code = current_header->index;
+                current_stream->status_code.indexed_value = current_header->index;
+                current_stream->status_code.finalized = true;
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
             } else if (current_header->index == kEmptyPath) {
                 current_stream->path_size = HTTP2_ROOT_PATH_LEN;
@@ -335,6 +337,10 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 current_stream->path_size = dynamic_value->string_len;
                 current_stream->is_huffman_encoded = dynamic_value->is_huffman_encoded;
                 bpf_memcpy(current_stream->request_path, dynamic_value->buffer, HTTP2_MAX_PATH_LEN);
+            } else if (is_status_index(dynamic_value->original_index)) {
+                bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value->buffer, HTTP2_STATUS_CODE_MAX_LEN);
+                current_stream->status_code.is_huffman_encoded = dynamic_value->is_huffman_encoded;
+                current_stream->status_code.finalized = true;
             }
         } else {
             // create the new dynamic value which will be added to the internal table.
@@ -350,6 +356,10 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 current_stream->path_size = current_header->new_dynamic_value_size;
                 current_stream->is_huffman_encoded = current_header->is_huffman_encoded;
                 bpf_memcpy(current_stream->request_path, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
+            } else if (is_status_index(current_header->original_index)) {
+                bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value.buffer, HTTP2_STATUS_CODE_MAX_LEN);
+                current_stream->status_code.is_huffman_encoded = current_header->is_huffman_encoded;
+                current_stream->status_code.finalized = true;
             }
         }
     }
@@ -911,7 +921,7 @@ int socket__http2_eos_parser(struct __sk_buff *skb) {
         // When we accept an RST, it means that the current stream is terminated.
         // See: https://datatracker.ietf.org/doc/html/rfc7540#section-6.4
         // If rst, and stream is empty (no status code, or no response) then delete from inflight
-        if (is_rst && (current_stream->response_status_code == 0 || current_stream->request_started == 0)) {
+        if (is_rst && (!current_stream->status_code.finalized || current_stream->request_started == 0)) {
             bpf_map_delete_elem(&http2_in_flight, &http2_ctx->http2_stream_key);
             continue;
         }

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -191,7 +191,7 @@ func (tx *EbpfTx) StatusCode() uint16 {
 // SetStatusCode sets the HTTP status code of the transaction.
 func (tx *EbpfTx) SetStatusCode(code uint16) {
 	val := strconv.Itoa(int(code))
-	if len(val) > 3 {
+	if len(val) > http2RawStatusCodeMaxLength {
 		return
 	}
 	copy(tx.Stream.Status_code.Raw_buffer[:], val)

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -146,27 +146,55 @@ func (tx *EbpfTx) Method() http.Method {
 	}
 }
 
-// StatusCode returns the HTTP status code of the transaction.
+// StatusCode returns the status code of the transaction.
+// If the status code is indexed, then we return the corresponding value.
+// Otherwise, f the status code is huffman encoded, then we decode it and convert it from string to int.
+// Otherwise, we convert the status code from byte array to int.
 func (tx *EbpfTx) StatusCode() uint16 {
-	switch tx.Stream.Response_status_code {
-	case uint16(K200Value):
-		return 200
-	case uint16(K204Value):
-		return 204
-	case uint16(K206Value):
-		return 206
-	case uint16(K400Value):
-		return 400
-	case uint16(K500Value):
-		return 500
-	default:
+	if tx.Stream.Status_code.Indexed_value != 0 {
+		switch tx.Stream.Status_code.Indexed_value {
+		case K200Value:
+			return 200
+		case K204Value:
+			return 204
+		case K206Value:
+			return 206
+		case K400Value:
+			return 400
+		case K500Value:
+			return 500
+		default:
+			return 0
+		}
+	}
+
+	if tx.Stream.Status_code.Is_huffman_encoded {
+		// The final form of the status code is 3 characters.
+		statusCode, err := hpack.HuffmanDecodeToString(tx.Stream.Status_code.Raw_buffer[:2])
+		if err != nil {
+			return 0
+		}
+		code, err := strconv.Atoi(statusCode)
+		if err != nil {
+			return 0
+		}
+		return uint16(code)
+	}
+
+	code, err := strconv.Atoi(string(tx.Stream.Status_code.Raw_buffer[:]))
+	if err != nil {
 		return 0
 	}
+	return uint16(code)
 }
 
 // SetStatusCode sets the HTTP status code of the transaction.
 func (tx *EbpfTx) SetStatusCode(code uint16) {
-	tx.Stream.Response_status_code = code
+	val := strconv.Itoa(int(code))
+	if len(val) > 3 {
+		return
+	}
+	copy(tx.Stream.Status_code.Raw_buffer[:], val)
 }
 
 // ResponseLastSeen returns the last seen response.

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -24,6 +24,7 @@ type connTuple = C.conn_tuple_t
 type HTTP2DynamicTableIndex C.dynamic_table_index_t
 type HTTP2DynamicTableEntry C.dynamic_table_entry_t
 type http2StreamKey C.http2_stream_key_t
+type http2StatusCode C.status_code_t
 type http2Stream C.http2_stream_t
 type EbpfTx C.http2_event_t
 type HTTP2Telemetry C.http2_telemetry_t

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -18,6 +18,9 @@ const (
 	http2PathBuckets = C.HTTP2_TELEMETRY_PATH_BUCKETS
 	// The kernel limit per page in the per-cpu array of the http2 terminated connections map.
 	HTTP2TerminatedBatchSize = C.HTTP2_TERMINATED_BATCH_SIZE
+	// The upper limit for the size of the raw status code.
+	// If the status code is huffman encoded, the size is 2 characters, while if it is not encoded, the size is 3 characters.
+	http2RawStatusCodeMaxLength = C.HTTP2_STATUS_CODE_MAX_LEN
 )
 
 type connTuple = C.conn_tuple_t

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -8,6 +8,8 @@ const (
 	http2PathBuckets = 0x7
 
 	HTTP2TerminatedBatchSize = 0x50
+
+	http2RawStatusCodeMaxLength = 0x3
 )
 
 type connTuple = struct {

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -27,24 +27,31 @@ type HTTP2DynamicTableIndex struct {
 }
 type HTTP2DynamicTableEntry struct {
 	Buffer             [160]int8
+	Original_index     uint32
 	String_len         uint8
 	Is_huffman_encoded bool
-	Pad_cgo_0          [6]byte
+	Pad_cgo_0          [2]byte
 }
 type http2StreamKey struct {
 	Tup       connTuple
 	Id        uint32
 	Pad_cgo_0 [4]byte
 }
+type http2StatusCode struct {
+	Raw_buffer         [3]uint8
+	Is_huffman_encoded bool
+	Indexed_value      uint8
+	Finalized          bool
+}
 type http2Stream struct {
 	Response_last_seen    uint64
 	Request_started       uint64
-	Response_status_code  uint16
+	Status_code           http2StatusCode
 	Request_method        uint8
 	Path_size             uint8
 	Request_end_of_stream bool
 	Is_huffman_encoded    bool
-	Pad_cgo_0             [2]byte
+	Pad_cgo_0             [6]byte
 	Request_path          [160]uint8
 }
 type EbpfTx struct {

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -1100,7 +1100,14 @@ func (s *usmHTTP2Suite) TestRawHuffmanEncoding() {
 func validateStats(usmMonitor *Monitor, res, expectedEndpoints map[usmhttp.Key]int) bool {
 	for key, stat := range getHTTPLikeProtocolStats(usmMonitor, protocols.HTTP2) {
 		if key.DstPort == srvPort || key.SrcPort == srvPort {
-			count := stat.Data[200].Count
+			statusCode := testutil.StatusFromPath(key.Path.Content.Get())
+			// statusCode 0 represents and error returned from the function, which means the URL is not in the special
+			// form which contains the expected status code (form - `/status/{statusCode}`). So by default we use
+			// 200 as the status code.
+			if statusCode == 0 {
+				statusCode = 200
+			}
+			count := stat.Data[statusCode].Count
 			newKey := usmhttp.Key{
 				Path:   usmhttp.Path{Content: key.Path.Content},
 				Method: key.Method,

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -739,7 +739,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			name: "validate various status codes",
 			// The purpose of this test is to verify that we support status codes that do not appear in the static table.
 			messageBuilder: func() [][]byte {
-				statusCodes := []int{201, 300, 401, 504}
+				statusCodes := []int{http.StatusCreated, http.StatusMultipleChoices, http.StatusUnauthorized, http.StatusGatewayTimeout}
 				const iterationsPerStatusCode = 3
 				messages := make([][]byte, 0, len(statusCodes)*iterationsPerStatusCode)
 				for statusCodeIteration, statusCode := range statusCodes {

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -736,32 +736,41 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			expectedEndpoints: nil,
 		},
 		{
-			name: "validate 300 status code",
-			// The purpose of this test is to verify that currently we do not support status code 300.
+			name: "validate various status codes",
+			// The purpose of this test is to verify that we support status codes that do not appear in the static table.
 			messageBuilder: func() [][]byte {
-				framer := newFramer()
-				return [][]byte{
-					framer.
-						writeHeaders(t, 1, usmhttp2.HeadersFrameOptions{Headers: headersWithGivenEndpoint("/status/300")}).
-						writeData(t, 1, true, emptyBody).
-						bytes(),
+				statusCodes := []int{201, 300, 401, 504}
+				const iterationsPerStatusCode = 3
+				messages := make([][]byte, 0, len(statusCodes)*iterationsPerStatusCode)
+				for statusCodeIteration, statusCode := range statusCodes {
+					for i := 0; i < iterationsPerStatusCode; i++ {
+						streamID := getStreamID(statusCodeIteration*iterationsPerStatusCode + i)
+						messages = append(messages, newFramer().
+							writeHeaders(t, streamID, usmhttp2.HeadersFrameOptions{Headers: headersWithGivenEndpoint(fmt.Sprintf("/status/%d", statusCode))}).
+							writeData(t, streamID, true, emptyBody).
+							bytes())
+					}
 				}
+				return messages
 			},
-			expectedEndpoints: nil,
-		},
-		{
-			name: "validate 401 status code",
-			// The purpose of this test is to verify that currently we do not support status code 401.
-			messageBuilder: func() [][]byte {
-				framer := newFramer()
-				return [][]byte{
-					framer.
-						writeHeaders(t, 1, usmhttp2.HeadersFrameOptions{Headers: headersWithGivenEndpoint("/status/401")}).
-						writeData(t, 1, true, emptyBody).
-						bytes(),
-				}
+			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/201")},
+					Method: usmhttp.MethodPost,
+				}: 3,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/300")},
+					Method: usmhttp.MethodPost,
+				}: 3,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/401")},
+					Method: usmhttp.MethodPost,
+				}: 3,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/504")},
+					Method: usmhttp.MethodPost,
+				}: 3,
 			},
-			expectedEndpoints: nil,
 		},
 		{
 			name: "validate http methods",

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -1110,7 +1110,7 @@ func validateStats(usmMonitor *Monitor, res, expectedEndpoints map[usmhttp.Key]i
 	for key, stat := range getHTTPLikeProtocolStats(usmMonitor, protocols.HTTP2) {
 		if key.DstPort == srvPort || key.SrcPort == srvPort {
 			statusCode := testutil.StatusFromPath(key.Path.Content.Get())
-			// statusCode 0 represents and error returned from the function, which means the URL is not in the special
+			// statusCode 0 represents an error returned from the function, which means the URL is not in the special
 			// form which contains the expected status code (form - `/status/{statusCode}`). So by default we use
 			// 200 as the status code.
 			if statusCode == 0 {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
The PR introduces the support for status codes that are not fully exist in the static table.

The PR introduces a new field `original_index` in two structs - `http2_header_t` and `dynamic_table_entry_t`.
In `dynamic_table_entry_t` the purpose is to cache the original index and to know
if the future calls whether the value represents a path, a method or a status code.
In `http2_header_t` the purpose is to populate the value for its first appearance
in a new dynamic header case.

We're supporting the case of a status code being passed as a literal header
instead of a fully indexed entry in the static table.

The PR creates a new struct `status_code_t` which covers the 2 options we have:
1. indexed_value - represents a fully indexed in the static table
2. literal - so we introduce is_huffman_encoded flag, and a buffer to save the raw value.

In the user mode we're converting the correct status code based on our options.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
While for the original purpose of gRPC monitoring the status codes in the static table suffice, for HTTP2 monitoring (like an implicit upgrade of HTTPs connection) it is a gap, as there is not guarantee the status codes are restricted to the list in the static table.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
The PR sets the infrastructure for a future PR to support all methods as well.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
