### PR TITLE
[CONTINT-3749] Return an error when `kube_node` tags can't be retrieved

### DIFF
--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -20,7 +20,7 @@ import (
 // GetTags gets the tags from the kubernetes apiserver and the kubelet
 func GetTags(ctx context.Context) ([]string, error) {
 	var tags []string
-	tags, err := appendNodeInfoTags(ctx, tags)
+	tags, err := getNodeInfoTags(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,9 @@ func GetTags(ctx context.Context) ([]string, error) {
 	return tags, nil
 }
 
-func appendNodeInfoTags(ctx context.Context, tags []string) ([]string, error) {
+// getNodeInfoTags gets the tags from the kubelet and the cluster-agent
+func getNodeInfoTags(ctx context.Context) ([]string, error) {
+	var tags []string
 	nodeInfo, err := NewNodeInfo()
 	if err != nil {
 		log.Debugf("Unable to auto discover node info tags: %s", err)
@@ -65,7 +67,7 @@ func appendNodeInfoTags(ctx context.Context, tags []string) ([]string, error) {
 	var nodeLabels map[string]string
 	nodeLabels, err = nodeInfo.GetNodeLabels(ctx)
 	if err != nil {
-		log.Errorf("Unable to auto discover node labels: %s", err)
+		_ = log.Errorf("Unable to auto discover node labels: %s", err)
 		return nil, err
 	}
 	if len(nodeLabels) > 0 {

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -18,23 +18,25 @@ import (
 )
 
 // GetTags gets the tags from the kubernetes apiserver and the kubelet
-func GetTags(ctx context.Context) (tags []string, err error) {
-	tags, e := appendNodeInfoTags(ctx, tags)
-	if e != nil {
-		err = e
+func GetTags(ctx context.Context) ([]string, error) {
+	var tags []string
+	tags, err := appendNodeInfoTags(ctx, tags)
+	if err != nil {
+		return nil, err
 	}
 
 	annotationsToTags := getAnnotationsToTags()
-	if len(annotationsToTags) > 0 {
-		nodeAnnotations, e := GetNodeAnnotations(ctx)
-		if e != nil {
-			err = e
-		} else {
-			tags = append(tags, extractTags(nodeAnnotations, annotationsToTags)...)
-		}
+	if len(annotationsToTags) == 0 {
+		return tags, nil
 	}
 
-	return
+	nodeAnnotations, err := GetNodeAnnotations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tags = append(tags, extractTags(nodeAnnotations, annotationsToTags)...)
+
+	return tags, nil
 }
 
 func appendNodeInfoTags(ctx context.Context, tags []string) ([]string, error) {

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -19,7 +19,6 @@ import (
 
 // GetTags gets the tags from the kubernetes apiserver and the kubelet
 func GetTags(ctx context.Context) ([]string, error) {
-	var tags []string
 	tags, err := getNodeInfoTags(ctx)
 	if err != nil {
 		return nil, err
@@ -41,7 +40,6 @@ func GetTags(ctx context.Context) ([]string, error) {
 
 // getNodeInfoTags gets the tags from the kubelet and the cluster-agent
 func getNodeInfoTags(ctx context.Context) ([]string, error) {
-	var tags []string
 	nodeInfo, err := NewNodeInfo()
 	if err != nil {
 		log.Debugf("Unable to auto discover node info tags: %s", err)
@@ -49,23 +47,19 @@ func getNodeInfoTags(ctx context.Context) ([]string, error) {
 	}
 
 	nodeName, err := nodeInfo.GetNodeName(ctx)
-	if err != nil {
+	if err != nil || nodeName == "" {
 		log.Debugf("Unable to auto discover node name: %s", err)
 		// We can return an error here because nodeName needs to be retrieved
 		// for node labels and node annotations.
 		return nil, err
 	}
-
-	if nodeName != "" {
-		tags = append(tags, "kube_node:"+nodeName)
-	}
+	tags := []string{"kube_node:" + nodeName}
 	labelsToTags := getLabelsToTags()
 	if len(labelsToTags) == 0 {
 		return tags, nil
 	}
 
-	var nodeLabels map[string]string
-	nodeLabels, err = nodeInfo.GetNodeLabels(ctx)
+	nodeLabels, err := nodeInfo.GetNodeLabels(ctx)
 	if err != nil {
 		_ = log.Errorf("Unable to auto discover node labels: %s", err)
 		return nil, err

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -61,7 +61,7 @@ func getNodeInfoTags(ctx context.Context) ([]string, error) {
 
 	nodeLabels, err := nodeInfo.GetNodeLabels(ctx)
 	if err != nil {
-		_ = log.Errorf("Unable to auto discover node labels: %s", err)
+		log.Errorf("Unable to auto discover node labels: %s", err)
 		return nil, err
 	}
 	if len(nodeLabels) > 0 {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR changes the kubernetes host tag provider to return an error when the kubelet is unreachable.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Avoid caching incomplete results.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent on Kubernetes. Make sure the agent still shows the following tags:
```
  host tags:
    kube_node:ali-cluster-control-plane
    kube_node_role:control-plane
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
