### PR TITLE
[Test E2E] Enabled WithDevMode() only if environment variable E2E_DEV_MODE is set

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -223,10 +223,6 @@ func (bs *BaseSuite[Env]) IsDevMode() bool {
 }
 
 func (bs *BaseSuite[Env]) init(options []SuiteOption, self Suite[Env]) {
-	if _, err := runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.DevMode, false); err == nil {
-		options = append(options, WithDevMode())
-	}
-
 	for _, o := range options {
 		o(&bs.params)
 	}
@@ -521,6 +517,13 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 // Unfortunately, we cannot use `s Suite[Env]` as Go is not able to match it with a struct
 // However it's able to verify the same constraint on T
 func Run[Env any, T Suite[Env]](t *testing.T, s T, options ...SuiteOption) {
+	devMode, err := runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.DevMode, false)
+	if err != nil {
+		t.Logf("dev_mode parameter error : %s", err)
+	} else if devMode {
+		options = append(options, WithDevMode())
+	}
+
 	s.init(options, s)
 	suite.Run(t, s)
 }

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -223,11 +223,15 @@ func (bs *BaseSuite[Env]) IsDevMode() bool {
 }
 
 func (bs *BaseSuite[Env]) init(options []SuiteOption, self Suite[Env]) {
+	if _, err := runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.DevMode, false); err == nil {
+		options = append(options, WithDevMode())
+	}
+
 	for _, o := range options {
 		o(&bs.params)
 	}
 
-	if bs.params.devMode && !runner.GetProfile().AllowDevMode() {
+	if !runner.GetProfile().AllowDevMode() {
 		bs.params.devMode = false
 	}
 
@@ -517,7 +521,6 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 // Unfortunately, we cannot use `s Suite[Env]` as Go is not able to match it with a struct
 // However it's able to verify the same constraint on T
 func Run[Env any, T Suite[Env]](t *testing.T, s T, options ...SuiteOption) {
-	options = append(options, WithDevMode())
 	s.init(options, s)
 	suite.Run(t, s)
 }

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -519,7 +519,7 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 func Run[Env any, T Suite[Env]](t *testing.T, s T, options ...SuiteOption) {
 	devMode, err := runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.DevMode, false)
 	if err != nil {
-		t.Logf("dev_mode parameter error : %s", err)
+		t.Logf("Unable to get DevMode value, DevMode will be disabled, error: %v", err)
 	} else if devMode {
 		options = append(options, WithDevMode())
 	}

--- a/test/new-e2e/pkg/runner/parameters/const.go
+++ b/test/new-e2e/pkg/runner/parameters/const.go
@@ -43,4 +43,6 @@ const (
 	PulumiLogLevel StoreKey = "pulumi_log_level"
 	// PulumiLogToStdErr config file parameter name
 	PulumiLogToStdErr StoreKey = "pulumi_log_to_stderr"
+	// DevMode config flag parameter name
+	DevMode StoreKey = "devmode"
 )

--- a/test/new-e2e/pkg/runner/parameters/const.go
+++ b/test/new-e2e/pkg/runner/parameters/const.go
@@ -44,5 +44,5 @@ const (
 	// PulumiLogToStdErr config file parameter name
 	PulumiLogToStdErr StoreKey = "pulumi_log_to_stderr"
 	// DevMode config flag parameter name
-	DevMode StoreKey = "devmode"
+	DevMode StoreKey = "dev_mode"
 )

--- a/test/new-e2e/pkg/runner/parameters/store_config_file.go
+++ b/test/new-e2e/pkg/runner/parameters/store_config_file.go
@@ -38,6 +38,7 @@ type ConfigParams struct {
 	Agent     Agent  `yaml:"agent"`
 	OutputDir string `yaml:"outputDir"`
 	Pulumi    Pulumi `yaml:"pulumi"`
+	DevMode   string `yaml:"devMode"`
 }
 
 // AWS instance contains AWS related parameters
@@ -144,6 +145,8 @@ func (s configFileValueStore) get(key StoreKey) (string, error) {
 		value = s.config.ConfigParams.Pulumi.LogLevel
 	case PulumiLogToStdErr:
 		value = s.config.ConfigParams.Pulumi.LogToStdErr
+	case DevMode:
+		value = s.config.ConfigParams.DevMode
 	}
 
 	if value == "" {


### PR DESCRIPTION
### What does this PR do?

Enabled WithDevMode() only if environment variable E2E_DEV_MODE is set
This would avoid confusion when running locally and having the same behavior than CI by default

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
