### PR TITLE
Fix Docker+SSH protocol with private key

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -86,7 +86,7 @@ k8s-e2e-otlp-main:
     - export AWS_PROFILE=agent-qa-ci
     # Now all `aws` commands target the agent-qa profile
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.ssh_public_key_rsa --with-decryption --query "Parameter.Value" --out text > $E2E_PUBLIC_KEY_PATH
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.ssh_key_rsa --with-decryption --query "Parameter.Value" --out text > $E2E_PRIVATE_KEY_PATH
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.ssh_key_rsa --with-decryption --query "Parameter.Value" --out text > $E2E_PRIVATE_KEY_PATH && chmod 600 $E2E_PRIVATE_KEY_PATH
     # Use S3 backend
     - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
   variables:

--- a/test/new-e2e/pkg/environments/dockerhost.go
+++ b/test/new-e2e/pkg/environments/dockerhost.go
@@ -8,6 +8,8 @@ package environments
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 )
 
@@ -26,8 +28,12 @@ var _ e2e.Initializable = &DockerHost{}
 
 // Init initializes the environment
 func (e *DockerHost) Init(ctx e2e.Context) error {
-	var err error
-	e.Docker, err = client.NewDocker(ctx.T(), e.Host.HostOutput)
+	privateKeyPath, err := runner.GetProfile().ParamStore().GetWithDefault(parameters.PrivateKeyPath, "")
+	if err != nil {
+		return err
+	}
+
+	e.Docker, err = client.NewDocker(ctx.T(), e.Host.HostOutput, privateKeyPath)
 	if err != nil {
 		return err
 	}

--- a/test/new-e2e/pkg/utils/e2e/client/docker.go
+++ b/test/new-e2e/pkg/utils/e2e/client/docker.go
@@ -28,10 +28,16 @@ type Docker struct {
 }
 
 // NewDocker creates a new instance of Docker
-func NewDocker(t *testing.T, host remote.HostOutput) (*Docker, error) {
+// NOTE: docker+ssh does not support password protected SSH keys.
+func NewDocker(t *testing.T, host remote.HostOutput, privateKeyPath string) (*Docker, error) {
 	deamonURL := fmt.Sprintf("ssh://%v@%v", host.Username, host.Address)
 
-	helper, err := connhelper.GetConnectionHelperWithSSHOpts(deamonURL, []string{"-o", "StrictHostKeyChecking no"})
+	sshOpts := []string{"-o", "StrictHostKeyChecking no"}
+	if privateKeyPath != "" {
+		sshOpts = append(sshOpts, "-i", privateKeyPath)
+	}
+
+	helper, err := connhelper.GetConnectionHelperWithSSHOpts(deamonURL, sshOpts)
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to docker %v: %v", deamonURL, err)
 	}


### PR DESCRIPTION
### What does this PR do?

Fix Docker+SSH protocol with private key.

### Motivation

Fix `docker+ssh` access in CI.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

E2E APM tests work.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
