### PR TITLE
[TestE2E] NPM agent running under RHEL9 SELinux

### DIFF
--- a/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
@@ -24,7 +24,8 @@ func TestEC2VMSELinuxSuite(t *testing.T) {
 	s := &ec2VMSELinuxSuite{}
 
 	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(
-		e2e.NewTypedPulumiProvisioner("hostHttpbin", hostDockerHttpbinEnvProvisioner(awshost.WithEC2InstanceOptions(ec2.WithAMI("ami-0339ee0a14a92573d", compos.AmazonLinux2, compos.ARM64Arch), ec2.WithInstanceType("c6g.medium"))), nil)),
+		e2e.NewTypedPulumiProvisioner("hostHttpbin", hostDockerHttpbinEnvProvisioner(awshost.WithEC2InstanceOptions(
+			ec2.WithAMI("ami-0fe630eb857a6ec83", compos.AmazonLinux2, compos.AMD64Arch), ec2.WithInstanceType("t3.medium"))), nil)),
 	}
 
 	// Source of our kitchen CI images test/kitchen/platforms.json

--- a/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
@@ -25,6 +25,7 @@ func TestEC2VMSELinuxSuite(t *testing.T) {
 
 	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(
 		e2e.NewTypedPulumiProvisioner("hostHttpbin", hostDockerHttpbinEnvProvisioner(awshost.WithEC2InstanceOptions(
+			// RHEL9
 			ec2.WithAMI("ami-0fe630eb857a6ec83", compos.AmazonLinux2, compos.AMD64Arch), ec2.WithInstanceType("t3.medium"))), nil)),
 	}
 
@@ -58,9 +59,9 @@ func (v *ec2VMSELinuxSuite) SetupSuite() {
 	v.Env().RemoteHost.ReconnectSSH()
 
 	// prefetch docker image locally
-	v.Env().RemoteHost.MustExecute("docker run curlimages/curl --version")
-	v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -V")
-	v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig")
+	v.Env().RemoteHost.MustExecute("docker pull public.ecr.aws/k8m1l3p1/alpine/curler:latest")
+	v.Env().RemoteHost.MustExecute("docker pull public.ecr.aws/docker/library/httpd:latest")
+	v.Env().RemoteHost.MustExecute("docker pull public.ecr.aws/patrickc/troubleshoot-util:latest")
 }
 
 // TestFakeIntakeNPM Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
@@ -84,7 +85,7 @@ func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM() {
 		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
 		// generate a connection
-		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
+		v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/k8m1l3p1/alpine/curler curl " + testURL)
 
 		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
 	})
@@ -111,7 +112,7 @@ func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM_600cnx_bucket() {
 		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
 		// generate connections
-		v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -n 600 -c 600 " + testURL)
+		v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/docker/library/httpd ab -n 600 -c 600 " + testURL)
 
 		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 	})
@@ -137,8 +138,8 @@ func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
 		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
 		// generate connections
-		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
-		v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig @8.8.8.8 www.google.ch")
+		v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/k8m1l3p1/alpine/curler curl " + testURL)
+		v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/patrickc/troubleshoot-util dig @8.8.8.8 www.google.ch")
 
 		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
 	})

--- a/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
@@ -38,10 +38,7 @@ func TestEC2VMSELinuxSuite(t *testing.T) {
 // BeforeTest will be called before each test
 func (v *ec2VMSELinuxSuite) BeforeTest(suiteName, testName string) {
 	v.BaseSuite.BeforeTest(suiteName, testName)
-	v.beforeTest(suiteName, testName)
-}
 
-func (v *ec2VMSELinuxSuite) beforeTest(_, _ string) {
 	// default is to reset the current state of the fakeintake aggregators
 	if !v.BaseSuite.IsDevMode() {
 		v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
@@ -64,83 +61,78 @@ func (v *ec2VMSELinuxSuite) SetupSuite() {
 	v.Env().RemoteHost.MustExecute("docker pull public.ecr.aws/patrickc/troubleshoot-util:latest")
 }
 
-// TestFakeIntakeNPM Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
+// TestFakeIntakeNPM_HostRequests Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
 // 2 tests generate the request on the host and on docker
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
-func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM() {
-	vt := v.T()
+func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
-	vt.Run("host_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		// generate a connection
-		v.Env().RemoteHost.MustExecute("curl " + testURL)
+	// generate a connection
+	v.Env().RemoteHost.MustExecute("curl " + testURL)
 
-		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
-	})
-	vt.Run("docker_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
-
-		// generate a connection
-		v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/k8m1l3p1/alpine/curler curl " + testURL)
-
-		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
-	})
+	test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
 }
 
-// TestFakeIntakeNPM_600cnx_bucket Validate the agent can communicate with the (fake) backend and send connections
+// TestFakeIntakeNPM_DockerRequests Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
+// 2 tests generate the request on the host and on docker
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
+func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM_DockerRequests() {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+
+	// generate a connection
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/k8m1l3p1/alpine/curler curl " + testURL)
+
+	test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
+}
+
+// TestFakeIntakeNPM600cnxBucket_HostRequests Validate the agent can communicate with the (fake) backend and send connections
 // every 30 seconds with a maximum of 600 connections per payloads, if more another payload will follow.
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for n payloads and check if the last 2 have a maximum span of 100ms
-func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM_600cnx_bucket() {
-	vt := v.T()
+func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM600cnxBucket_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
-	vt.Run("host_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		// generate connections
-		v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
+	// generate connections
+	v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
 
-		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
-	})
-	vt.Run("docker_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
-
-		// generate connections
-		v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/docker/library/httpd ab -n 600 -c 600 " + testURL)
-
-		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
-	})
+	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 }
 
-// TestFakeIntakeNPM_TCP_UDP_DNS validate we received tcp, udp, and DNS connections
-// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
-func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
-	vt := v.T()
+// TestFakeIntakeNPM600cnxBucket_DockerRequests Validate the agent can communicate with the (fake) backend and send connections
+// every 30 seconds with a maximum of 600 connections per payloads, if more another payload will follow.
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for n payloads and check if the last 2 have a maximum span of 100ms
+func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM600cnxBucket_DockerRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
-	vt.Run("host_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
 
-		// generate connections
-		v.Env().RemoteHost.MustExecute("curl " + testURL)
-		v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
+	// generate connections
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/docker/library/httpd ab -n 600 -c 600 " + testURL)
 
-		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
-	})
-	vt.Run("docker_requests", func(t *testing.T) {
-		v.BaseSuite.SetT(t)
-		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
+	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
+}
 
-		// generate connections
-		v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/k8m1l3p1/alpine/curler curl " + testURL)
-		v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/patrickc/troubleshoot-util dig @8.8.8.8 www.google.ch")
+// TestFakeIntakeNPM_TCP_UDP_DNS_HostRequests validate we received tcp, udp, and DNS connections
+// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
+func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM_TCP_UDP_DNS_HostRequests() {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
-		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
-	})
+	// generate connections
+	v.Env().RemoteHost.MustExecute("curl " + testURL)
+	v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
+
+	test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
+}
+
+// TestFakeIntakeNPM_TCP_UDP_DNS_DockerRequests validate we received tcp, udp, and DNS connections
+// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
+func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM_TCP_UDP_DNS_DockerRequests() {
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+
+	// generate connections
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/k8m1l3p1/alpine/curler curl " + testURL)
+	v.Env().RemoteHost.MustExecute("docker run public.ecr.aws/patrickc/troubleshoot-util dig @8.8.8.8 www.google.ch")
+
+	test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
 }

--- a/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
@@ -1,0 +1,144 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package npm
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+
+	compos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+)
+
+type ec2VMSELinuxSuite struct {
+	e2e.BaseSuite[hostHttpbinEnv]
+}
+
+// TestEC2VMSuite will validate running the agent on a single EC2 VM
+func TestEC2VMSELinuxSuite(t *testing.T) {
+	s := &ec2VMSELinuxSuite{}
+
+	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(
+		e2e.NewTypedPulumiProvisioner("hostHttpbin", hostDockerHttpbinEnvProvisioner(awshost.WithEC2InstanceOptions(ec2.WithAMI("ami-0339ee0a14a92573d", compos.AmazonLinux2, compos.ARM64Arch), ec2.WithInstanceType("c6g.medium"))), nil)),
+	}
+
+	// Source of our kitchen CI images test/kitchen/platforms.json
+	// Other VM image can be used, our kitchen CI images test/kitchen/platforms.json
+	// ec2params.WithImageName("ami-a4dc46db", os.AMD64Arch, ec2os.AmazonLinuxOS) // ubuntu-16-04-4.4
+	e2e.Run(t, s, e2eParams...)
+}
+
+// BeforeTest will be called before each test
+func (v *ec2VMSELinuxSuite) BeforeTest(suiteName, testName string) {
+	v.BaseSuite.BeforeTest(suiteName, testName)
+	v.beforeTest(suiteName, testName)
+}
+
+func (v *ec2VMSELinuxSuite) beforeTest(_, _ string) {
+	// default is to reset the current state of the fakeintake aggregators
+	if !v.BaseSuite.IsDevMode() {
+		v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	}
+}
+
+func (v *ec2VMSELinuxSuite) SetupSuite() {
+	v.BaseSuite.SetupSuite()
+
+	v.Env().RemoteHost.MustExecute("sudo yum install -y bind-utils httpd-tools")
+	v.Env().RemoteHost.MustExecute("sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo")
+	v.Env().RemoteHost.MustExecute("sudo yum install -y docker-ce docker-ce-cli")
+	v.Env().RemoteHost.MustExecute("sudo systemctl start docker")
+	v.Env().RemoteHost.MustExecute("sudo usermod -a -G docker $(whoami)")
+	v.Env().RemoteHost.ReconnectSSH()
+
+	// prefetch docker image locally
+	v.Env().RemoteHost.MustExecute("docker run curlimages/curl --version")
+	v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -V")
+	v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig")
+}
+
+// TestFakeIntakeNPM Validate the agent can communicate with the (fake) backend and send connections every 30 seconds
+// 2 tests generate the request on the host and on docker
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
+func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM() {
+	vt := v.T()
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+	vt.Run("host_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
+
+		// generate a connection
+		v.Env().RemoteHost.MustExecute("curl " + testURL)
+
+		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
+	})
+	vt.Run("docker_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
+
+		// generate a connection
+		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
+
+		test1HostFakeIntakeNPM(&v.BaseSuite, v.Env().FakeIntake)
+	})
+}
+
+// TestFakeIntakeNPM_600cnx_bucket Validate the agent can communicate with the (fake) backend and send connections
+// every 30 seconds with a maximum of 600 connections per payloads, if more another payload will follow.
+//   - looking for 1 host to send CollectorConnections payload to the fakeintake
+//   - looking for n payloads and check if the last 2 have a maximum span of 100ms
+func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM_600cnx_bucket() {
+	vt := v.T()
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+	vt.Run("host_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
+
+		// generate connections
+		v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
+
+		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
+	})
+	vt.Run("docker_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
+
+		// generate connections
+		v.Env().RemoteHost.MustExecute("docker run devth/alpine-bench -n 600 -c 600 " + testURL)
+
+		test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
+	})
+}
+
+// TestFakeIntakeNPM_TCP_UDP_DNS validate we received tcp, udp, and DNS connections
+// with some basic checks, like IPs/Ports present, DNS query has been captured, ...
+func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM_TCP_UDP_DNS() {
+	vt := v.T()
+	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
+	vt.Run("host_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
+
+		// generate connections
+		v.Env().RemoteHost.MustExecute("curl " + testURL)
+		v.Env().RemoteHost.MustExecute("dig @8.8.8.8 www.google.ch")
+
+		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
+	})
+	vt.Run("docker_requests", func(t *testing.T) {
+		v.BaseSuite.SetT(t)
+		v.beforeTest("TestEC2VMSELinuxSuite", t.Name()) // workaround as suite doesn't call BeforeTest before each sub tests
+
+		// generate connections
+		v.Env().RemoteHost.MustExecute("docker run curlimages/curl curl " + testURL)
+		v.Env().RemoteHost.MustExecute("docker run makocchi/alpine-dig dig @8.8.8.8 www.google.ch")
+
+		test1HostFakeIntakeNPMTCPUDPDNS(&v.BaseSuite, v.Env().FakeIntake)
+	})
+}

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -30,7 +30,7 @@ type ec2VMSuite struct {
 	e2e.BaseSuite[hostHttpbinEnv]
 }
 
-func hostDockerHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[hostHttpbinEnv] {
+func hostDockerHttpbinEnvProvisioner(opt ...awshost.ProvisionerOption) e2e.PulumiEnvRunFunc[hostHttpbinEnv] {
 	return func(ctx *pulumi.Context, env *hostHttpbinEnv) error {
 		awsEnv, err := aws.NewEnvironment(ctx)
 		if err != nil {
@@ -40,6 +40,9 @@ func hostDockerHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[hostHttpbinEnv] {
 
 		opts := []awshost.ProvisionerOption{
 			awshost.WithAgentOptions(agentparams.WithSystemProbeConfig(systemProbeConfigNPM)),
+		}
+		if len(opt) > 0 {
+			opts = append(opts, opt...)
 		}
 		params := awshost.GetProvisionerParams(opts...)
 		awshost.Run(ctx, &env.Host, params)


### PR DESCRIPTION
### What does this PR do?

Run the E2E tests under SELinux environment

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
