### PR TITLE
[CWS] fix testsuite duplicated init functions

### DIFF
--- a/pkg/security/tests/main_test.go
+++ b/pkg/security/tests/main_test.go
@@ -3,133 +3,48 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && (functionaltests || stresstests)
+//go:build functionaltests || stresstests
 
 // Package tests holds tests related files
 package tests
 
 import (
 	"flag"
-	"fmt"
 	"math/rand"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/cihub/seelog"
-	"golang.org/x/exp/slices"
-
-	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
-	"github.com/DataDog/datadog-agent/pkg/security/ptracer"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
-
-var (
-	testEnvironment  string
-	logLevelStr      string
-	logPatterns      stringSlice
-	logTags          stringSlice
-	logStatusMetrics bool
-	withProfile      bool
-	trace            bool
-	ebpfLessEnabled  bool
-)
-
-func SkipIfNotAvailable(t *testing.T) {
-	if ebpfLessEnabled {
-		available := []string{
-			"~TestProcess",
-			"~TestOpen",
-			"~TestUnlink",
-			"~KillAction",
-			"~TestRmdir",
-			"~TestRename",
-			"~TestMkdir",
-			"~TestUtimes",
-		}
-
-		exclude := []string{
-			"TestMkdir/io_uring",
-			"TestOpenDiscarded",
-			"TestOpenDiscarded/pipefs",
-			"TestOpen/truncate",
-			"TestOpen/io_uring",
-			"TestProcessContext/inode",
-			"TestProcessContext/pid1",
-			"~TestProcessBusybox",
-			"TestRename/io_uring",
-			"TestRenameReuseInode",
-			"TestUnlink/io_uring",
-			"TestRmdir/unlinkat-io_uring",
-		}
-
-		match := func(list []string) bool {
-			var match bool
-
-			for _, value := range list {
-				if value[0] == '~' {
-					if strings.HasPrefix(t.Name(), value[1:]) {
-						match = true
-						break
-					}
-				} else if value == t.Name() {
-					match = true
-					break
-				}
-			}
-
-			return match
-		}
-
-		if !match(available) || match(exclude) {
-			t.Skip("test not available for ebpfless")
-		}
-	}
-}
 
 // TestMain is the entry points for functional tests
 func TestMain(m *testing.M) {
 	flag.Parse()
 
-	if trace {
-		args := slices.DeleteFunc(os.Args, func(arg string) bool {
-			return arg == "-trace"
-		})
-		args = append(args, "-ebpfless")
-
-		envs := os.Environ()
-
-		err := ptracer.StartCWSPtracer(args, envs, constants.DefaultEBPFLessProbeAddr, ptracer.Creds{}, false /* verbose */, true /* async */, false /* disableStats */)
-		if err != nil {
-			fmt.Printf("unable to trace [%v]: %s", args, err)
-			os.Exit(-1)
-		}
-		return
-	}
-
+	preTestsHook()
 	retCode := m.Run()
-	if testMod != nil {
-		testMod.cleanup()
-	}
+	postTestsHook()
 
 	if commonCfgDir != "" {
 		_ = os.RemoveAll(commonCfgDir)
 	}
+
 	os.Exit(retCode)
 }
 
+var (
+	logLevelStr     string
+	logPatterns     stringSlice
+	logTags         stringSlice
+	ebpfLessEnabled bool
+)
+
 func init() {
-	flag.StringVar(&testEnvironment, "env", HostEnvironment, "environment used to run the test suite: ex: host, docker")
 	flag.StringVar(&logLevelStr, "loglevel", seelog.WarnStr, "log level")
 	flag.Var(&logPatterns, "logpattern", "List of log pattern")
 	flag.Var(&logTags, "logtag", "List of log tag")
-	flag.BoolVar(&logStatusMetrics, "status-metrics", false, "display status metrics")
-	flag.BoolVar(&withProfile, "with-profile", false, "enable profile per test")
-	flag.BoolVar(&trace, "trace", false, "wrap the test suite with the ptracer")
 	flag.BoolVar(&ebpfLessEnabled, "ebpfless", false, "enabled the ebpfless mode")
 
 	rand.Seed(time.Now().UnixNano())
-
-	testSuitePid = utils.Getpid()
 }

--- a/pkg/security/tests/main_windows.go
+++ b/pkg/security/tests/main_windows.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows && (functionaltests || stresstests)
+
+// Package tests holds tests related files
+package tests
+
+func preTestsHook() {}
+
+func postTestsHook() {}

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -12,10 +12,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io/fs"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -61,14 +59,11 @@ import (
 
 var (
 	logger seelog.LoggerInterface
-	//nolint:deadcode,unused
-	testSuitePid uint32
 )
 
 const testConfig = `---
 log_level: DEBUG
 system_probe_config:
-  enabled: true
   sysprobe_socket: /tmp/test-sysprobe.sock
   enable_kernel_header_download: true
   enable_runtime_compiler: true
@@ -163,7 +158,7 @@ runtime_security_config:
     - {{.}}
   {{end}}
   ebpfless:
-    enabled: {{.EnableEBPFLess}}
+    enabled: {{.EBPFLessEnabled}}
 `
 
 const testPolicy = `---
@@ -569,10 +564,6 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		opt(&opts)
 	}
 
-	if env := os.Getenv("EBPFLESS"); env != "" {
-		opts.staticOpts.enableEBPFLess = true
-	}
-
 	if commonCfgDir == "" {
 		cd, err := os.MkdirTemp("", "test-cfgdir")
 		if err != nil {
@@ -614,24 +605,19 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	}
 
 	var cmdWrapper cmdWrapper
-	if testEnvironment == DockerEnvironment {
+	if testEnvironment == DockerEnvironment || ebpfLessEnabled {
 		cmdWrapper = newStdCmdWrapper()
 	} else {
-		if opts.staticOpts.enableEBPFLess {
-			// docker not supported by ebpf less
-			cmdWrapper = newStdCmdWrapper()
+		wrapper, err := newDockerCmdWrapper(st.Root(), st.Root(), "ubuntu")
+		if err == nil {
+			cmdWrapper = newMultiCmdWrapper(wrapper, newStdCmdWrapper())
 		} else {
-			wrapper, err := newDockerCmdWrapper(st.Root(), st.Root(), "ubuntu")
-			if err == nil {
-				cmdWrapper = newMultiCmdWrapper(wrapper, newStdCmdWrapper())
-			} else {
-				// docker not present run only on host
-				cmdWrapper = newStdCmdWrapper()
-			}
+			// docker not present run only on host
+			cmdWrapper = newStdCmdWrapper()
 		}
 	}
 
-	if testMod != nil && opts.staticOpts.enableEBPFLess {
+	if testMod != nil && ebpfLessEnabled {
 		testMod.st = st
 		testMod.cmdWrapper = cmdWrapper
 		testMod.t = t
@@ -655,7 +641,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		testMod.t = t
 		testMod.opts.dynamicOpts = opts.dynamicOpts
 
-		if !opts.staticOpts.enableEBPFLess {
+		if !ebpfLessEnabled {
 			if testMod.tracePipe, err = testMod.startTracing(); err != nil {
 				return testMod, err
 			}
@@ -707,7 +693,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 			PathResolutionEnabled:  true,
 			SyscallsMonitorEnabled: true,
 			TTYFallbackEnabled:     true,
-			EBPFLessEnabled:        opts.staticOpts.enableEBPFLess,
+			EBPFLessEnabled:        ebpfLessEnabled,
 		},
 	}
 	if opts.staticOpts.tagsResolver != nil {
@@ -767,7 +753,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		opts.staticOpts.preStartCallback(testMod)
 	}
 
-	if !opts.staticOpts.enableEBPFLess {
+	if !ebpfLessEnabled {
 		if testMod.tracePipe, err = testMod.startTracing(); err != nil {
 			return nil, err
 		}
@@ -793,7 +779,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		t.Logf("%s entry stats: %s", t.Name(), GetEBPFStatusMetrics(testMod.probe))
 	}
 
-	if opts.staticOpts.enableEBPFLess {
+	if ebpfLessEnabled {
 		t.Logf("EBPFLess mode, waiting for a client to connect")
 		err := retry.Do(func() error {
 			if testMod.probe.PlatformProbe.(*sprobe.EBPFLessProbe).GetClientsCount() > 0 {
@@ -1067,20 +1053,6 @@ func waitForProbeEvent(test *testModule, action func() error, key string, value 
 //nolint:deadcode,unused
 func waitForOpenProbeEvent(test *testModule, action func() error, filename string) error {
 	return waitForProbeEvent(test, action, "open.file.path", filename, model.FileOpenEventType)
-}
-
-func init() {
-	flag.StringVar(&testEnvironment, "env", HostEnvironment, "environment used to run the test suite: ex: host, docker")
-	flag.StringVar(&logLevelStr, "loglevel", seelog.WarnStr, "log level")
-	flag.Var(&logPatterns, "logpattern", "List of log pattern")
-	flag.Var(&logTags, "logtag", "List of log tag")
-	flag.BoolVar(&logStatusMetrics, "status-metrics", false, "display status metrics")
-	flag.BoolVar(&withProfile, "with-profile", false, "enable profile per test")
-	flag.BoolVar(&trace, "trace", false, "wrap the test suite with the ptracer")
-
-	rand.Seed(time.Now().UnixNano())
-
-	testSuitePid = utils.Getpid()
 }
 
 //nolint:deadcode,unused

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
@@ -27,7 +29,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/tests/statsdclient"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/hashicorp/go-multierror"
 )
 
 var (
@@ -80,8 +81,6 @@ rules:
 
 const testConfig = `---
 log_level: DEBUG
-system_probe_config:
-  enabled: true
 
 event_monitoring_config:
   remote_tagger: false
@@ -169,7 +168,7 @@ runtime_security_config:
     - {{.}}
   {{end}}
   ebpfless:
-    enabled: {{.EnableEBPFLess}}
+    enabled: {{.EBPFLessEnabled}}
 `
 
 type onRuleHandler func(*model.Event, *rules.Rule)
@@ -201,22 +200,10 @@ type testModule struct {
 	statsdClient  *statsdclient.StatsdClient
 	proFile       *os.File
 	ruleEngine    *rulesmodule.RuleEngine
-	//tracePipe     *tracePipeLogger
 }
 
-var (
-	testMod      *testModule
-	commonCfgDir string
-	// for now, add this to resolve variable; should be unused in windows
-	testEnvironment  string
-	logLevelStr      string
-	logPatterns      stringSlice
-	logTags          stringSlice
-	logStatusMetrics bool
-	withProfile      bool
-	trace            bool
-	ebpfLessEnabled  bool
-)
+var testMod *testModule
+var commonCfgDir string
 
 func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []*rules.RuleDefinition, fopts ...optFunc) (*testModule, error) {
 

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -48,7 +48,6 @@ type testOpts struct {
 	preStartCallback                           func(test *testModule)
 	tagsResolver                               tags.Resolver
 	snapshotRuleMatchHandler                   func(*testModule, *model.Event, *rules.Rule)
-	enableEBPFLess                             bool
 }
 
 type dynamicTestOpts struct {
@@ -102,6 +101,5 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.disableRuntimeSecurity == opts.disableRuntimeSecurity &&
 		to.enableSBOM == opts.enableSBOM &&
 		to.snapshotRuleMatchHandler == nil && opts.snapshotRuleMatchHandler == nil &&
-		to.preStartCallback == nil && opts.preStartCallback == nil &&
-		to.enableEBPFLess == opts.enableEBPFLess
+		to.preStartCallback == nil && opts.preStartCallback == nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

- Fixes a panic in the pkg/security testsuite caused by duplicated CLI flags.
- It also reintroduces some of the changes introduced in #21805 that were most-likely lost during a previous rebase

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
