### PR TITLE
Support remote tagger fallback to loacal tagger in trace-agent

### DIFF
--- a/cmd/trace-agent/subcommands/run/command.go
+++ b/cmd/trace-agent/subcommands/run/command.go
@@ -85,7 +85,7 @@ func runTraceAgentProcess(ctx context.Context, cliParams *RunParams, defaultConf
 		statsd.Module(),
 		fx.Provide(func(coreConfig coreconfig.Component) tagger.Params {
 			if coreConfig.GetBool("apm_config.remote_tagger") {
-				return tagger.NewNodeRemoteTaggerParams()
+				return tagger.NewNodeRemoteTaggerParamsWithFallback()
 			}
 			return tagger.NewTaggerParams()
 		}),

--- a/comp/core/tagger/params.go
+++ b/comp/core/tagger/params.go
@@ -53,7 +53,7 @@ func NewNodeRemoteTaggerParams() Params {
 		fallBackToLocalIfRemoteTaggerFails: false}
 }
 
-// NewNodeRemoteTaggerParams creates a Params struct with the NodeRemoteTagger type
+// NewNodeRemoteTaggerParamsWithFallback creates a Params struct with the NodeRemoteTagger type
 // and fallback to local tagger if remote tagger fails
 func NewNodeRemoteTaggerParamsWithFallback() Params {
 	return Params{agentTypeForTagger: NodeRemoteTaggerAgent,

--- a/comp/core/tagger/params.go
+++ b/comp/core/tagger/params.go
@@ -23,7 +23,8 @@ const (
 
 // Params provides the kind of agent we're instantiating workloadmeta for
 type Params struct {
-	agentTypeForTagger AgentTypeForTagger
+	agentTypeForTagger                 AgentTypeForTagger
+	fallBackToLocalIfRemoteTaggerFails bool
 }
 
 // NewTaggerParamsForCoreAgent is a constructor function for creating core agent tagger params
@@ -36,20 +37,31 @@ func NewTaggerParamsForCoreAgent(_ config.Component) Params {
 
 // NewTaggerParams creates a Params struct with the default LocalTagger type
 func NewTaggerParams() Params {
-	return Params{agentTypeForTagger: LocalTaggerAgent}
+	return Params{agentTypeForTagger: LocalTaggerAgent,
+		fallBackToLocalIfRemoteTaggerFails: false}
 }
 
 // NewFakeTaggerParams creates a Params struct with the FakeTagger type and for testing purposes
 func NewFakeTaggerParams() Params {
-	return Params{agentTypeForTagger: FakeTagger}
+	return Params{agentTypeForTagger: FakeTagger,
+		fallBackToLocalIfRemoteTaggerFails: false}
 }
 
 // NewNodeRemoteTaggerParams creates a Params struct with the NodeRemoteTagger type
 func NewNodeRemoteTaggerParams() Params {
-	return Params{agentTypeForTagger: NodeRemoteTaggerAgent}
+	return Params{agentTypeForTagger: NodeRemoteTaggerAgent,
+		fallBackToLocalIfRemoteTaggerFails: false}
+}
+
+// NewNodeRemoteTaggerParams creates a Params struct with the NodeRemoteTagger type
+// and fallback to local tagger if remote tagger fails
+func NewNodeRemoteTaggerParamsWithFallback() Params {
+	return Params{agentTypeForTagger: NodeRemoteTaggerAgent,
+		fallBackToLocalIfRemoteTaggerFails: true}
 }
 
 // NewCLCRunnerRemoteTaggerParams creates a Params struct with the CLCRunnerRemoteTagger type
 func NewCLCRunnerRemoteTaggerParams() Params {
-	return Params{agentTypeForTagger: CLCRunnerRemoteTaggerAgent}
+	return Params{agentTypeForTagger: CLCRunnerRemoteTaggerAgent,
+		fallBackToLocalIfRemoteTaggerFails: false}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
[CONTINT-3
](https://datadoghq.atlassian.net/browse/CONTINT-3)
This pr will support trace agent fallback to local tagger when remote tagger fails to start. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- This fallback was previously supported in trace-agent (but not other agents).  
- It is broken by this [migration](https://github.com/DataDog/datadog-agent/pull/21314/files#diff-282a78a15ca060518acc8d52626c717fbf0614a1c961d3d0ae1ff58c9e6857b7L72).
- When remote tagger start fails, the trace-agent process exits unexpectedly and prints the help message:
```
2024-02-01 13:12:50 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:13:01 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:13:19 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
Usage:
  trace-agent [command] [flags]
  trace-agent [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  info        Gather Datadog trace-agent information.
  run         Start datadog trace-agent.
  version     Print the version info which is not expected. 
```

A new param is added in this pr to support fallback (in trace-agent only).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1. build trace-agent with `inv trace-agent.build`
2. ensure no datadog agent is running
3. run the trace-agent with `./bin/trace-agent/trace-agent` and it should not exit.
```
2024-02-01 13:16:51 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:16:52 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:16:53 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:16:55 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:16:56 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:16:59 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:17:01 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:17:08 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:17:15 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:17:25 EST | TRACE | INFO | (comp/core/tagger/remote/tagger.go:388 in func1) | unable to establish stream, will possibly retry: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:17:25 EST | TRACE | WARN | (fx@v1.18.2/internal/lifecycle/lifecycle.go:130 in runStartHook) | Starting remote tagger failed. Falling back to local tagger: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :5051: connect: connection refused"
2024-02-01 13:17:25 EST | TRACE | INFO | (comp/core/tagger/collectors/workloadmeta_main.go:132 in stream) | workloadmeta tagger collector started
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
