### PR TITLE
Add task to get active release branch in the Create RC PR workflow

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -39,3 +39,4 @@ jobs:
               run: |
                 git fetch
                 inv -e release.create-rc
+                

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -24,7 +24,18 @@ jobs:
                 pip install -r requirements.txt
                 pip install -r tasks/libs/requirements-github.txt
 
-            - name: Create RC PR
+            - name: Determine the release active branch
               run: |
                 export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+                echo "RELEASE_BRANCH=$(inv -e release.get-active-release-branch)" >> $GITHUB_ENV
+            
+            - name: Checkout release branch
+              uses: actions/checkout@v4
+              with:
+                ref: ${{ env.RELEASE_BRANCH }}
+                fetch-depth: 0
+              
+            - name: Create RC PR
+              run: |
+                git fetch
                 inv -e release.create-rc

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1525,3 +1525,21 @@ def _create_build_links_patterns(current_version, new_version):
     patterns[current_minor_version.replace("-rc", "~rc")] = new_minor_version.replace("-rc", "~rc")
 
     return patterns
+
+
+@task
+def get_active_release_branch(_ctx):
+    """
+    Determine what is the current active release branch for the Agent.
+    If release started and code freeze is in place - main branch is considered active.
+    If release started and code freeze is over - release branch is considered active.
+    """
+    gh = GithubAPI('datadog/datadog-agent')
+    latest_release = gh.latest_release()
+    version = _create_version_from_match(VERSION_RE.search(latest_release))
+    next_version = version.next_version(bump_minor=True)
+    release_branch = gh.get_branch(next_version.branch())
+    if release_branch:
+        print(f"{release_branch.name}")
+    else:
+        print("main")


### PR DESCRIPTION
### What does this PR do?

This PR adds two elements:
1. New invoke task `get-active-release-branch` which prints out the name of the active release branch,
2. Call for the new task within 'Create RC PR' github action to determine where to create new Agent Release Candidate PR

### Motivation

Automation of the Agent release process

### Possible Drawbacks / Trade-offs

This change is required to have scheduled Agent RC builds triggered by the GH workflow. 
This is step 1 - creation of PR. It has to have a human reviewer to meet compliance requirements so the idea is to create it during the working day.
Step 2 (coming soon) - merge of PR and triggering RC build pipeline.

### Describe how to test/QA your changes

It was tested on the mock repository. The full verification is possible only after merging to the main branch.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
