### PR TITLE
fix(updater): ZipSlip and Decompression bomb.

### DIFF
--- a/pkg/updater/download.go
+++ b/pkg/updater/download.go
@@ -130,12 +130,7 @@ func extractTarGz(archivePath string, destinationPath string) error {
 		target := filepath.Join(destinationPath, cleanName)
 
 		// Check for zip-slip attacks
-		outPath, err := filepath.Abs(target)
-		if err != nil {
-			return fmt.Errorf("could not get absolute path for %s: %w", cleanName, err)
-		}
-		// Ensure the file is within the destination directory
-		if !strings.HasPrefix(outPath, destinationPath) {
+		if !strings.HasPrefix(target, filepath.Clean(destinationPath)+string(os.PathSeparator)) {
 			return fmt.Errorf("tar entry %s is trying to escape the destination directory", header.Name)
 		}
 

--- a/pkg/updater/download.go
+++ b/pkg/updater/download.go
@@ -68,7 +68,7 @@ func (d *downloader) Download(ctx context.Context, pkg Package, destinationPath 
 	}
 	defer resp.Body.Close()
 	hashWriter := sha256.New()
-	reader := io.TeeReader(io.LimitReader(req.Body, maxArchiveSize), hashWriter)
+	reader := io.TeeReader(io.LimitReader(resp.Body, maxArchiveSize), hashWriter)
 	archivePath := filepath.Join(tmpDir, agentArchiveFileName)
 	archiveFile, err := os.Create(archivePath)
 	if err != nil {

--- a/pkg/updater/download.go
+++ b/pkg/updater/download.go
@@ -178,6 +178,13 @@ func extractTarGzFile(targetPath string, reader io.Reader) error {
 	n, err := io.Copy(f, limitedReader)
 	if err != nil {
 		if errors.Is(err, io.EOF) && n == maxFileSize {
+			defer func() {
+				if err := os.Remove(targetPath); err != nil {
+					log.Errorf("Could not remove truncated file %q: %v", targetPath, err)
+				} else {
+					log.Debug("Removing truncated file %q", targetPath)
+				}
+			}()
 			return fmt.Errorf("content truncated: file %q is too large: %w", targetPath, err)
 		}
 		return fmt.Errorf("could not write file: %w", err)


### PR DESCRIPTION
### What does this PR do?

* Fix identified ZipSlip and Decompression bomb in the updater code.

### Motivation

* Security fixes

### Possible Drawbacks / Trade-offs

* The decompression bomb introduces a maxFileSize which should be tuned

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
