### PR TITLE
[AMLII-1410] Remove global dogstatsd server usage

### DIFF
--- a/cmd/agent/dogstatsd/global.go
+++ b/cmd/agent/dogstatsd/global.go
@@ -1,7 +1,0 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
-// Package dogstatsd contains the dogstatsd subcommands.
-package dogstatsd

--- a/cmd/agent/dogstatsd/global.go
+++ b/cmd/agent/dogstatsd/global.go
@@ -5,13 +5,3 @@
 
 // Package dogstatsd contains the dogstatsd subcommands.
 package dogstatsd
-
-import (
-	"github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-)
-
-// DSD is the global dogstatsd instance
-// TODO: (components) This is currently only used by JMXFetch.
-// Once core check runners are refactored to not use init hooks,
-// we can remove this global.
-var DSD server.Component

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -28,7 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common/misconfig"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/path"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
-	global "github.com/DataDog/datadog-agent/cmd/agent/dogstatsd"
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	"github.com/DataDog/datadog-agent/cmd/agent/subcommands/run/internal/clcrunnerapi"
 	"github.com/DataDog/datadog-agent/cmd/manager"
@@ -573,6 +572,9 @@ func startAgent(
 	// TODO: (components) - Until the checks are components we set there context so they can depends on components.
 	check.InitializeInventoryChecksContext(invChecks)
 
+	// Register JMX Check Loader and inject dogstatsd component
+	jmx.RegisterJMXCheckLoader(server)
+
 	// Set up check collector
 	commonchecks.RegisterChecks(wmeta)
 	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll, demultiplexer), true)
@@ -582,7 +584,7 @@ func startAgent(
 
 	// start dogstatsd
 	if pkgconfig.Datadog.GetBool("use_dogstatsd") {
-		global.DSD = server
+		// global.DSD = server
 		err := server.Start(demultiplexer)
 		if err != nil {
 			log.Errorf("Could not start dogstatsd: %s", err)

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -572,8 +572,8 @@ func startAgent(
 	// TODO: (components) - Until the checks are components we set there context so they can depends on components.
 	check.InitializeInventoryChecksContext(invChecks)
 
-	// Register JMX Check Loader and inject dogstatsd component
-	jmx.RegisterJMXCheckLoader(server)
+	// Init JMX runner and inject dogstatsd component
+	jmx.InitRunner(server)
 
 	// Set up check collector
 	commonchecks.RegisterChecks(wmeta)

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -584,7 +584,6 @@ func startAgent(
 
 	// start dogstatsd
 	if pkgconfig.Datadog.GetBool("use_dogstatsd") {
-		// global.DSD = server
 		err := server.Start(demultiplexer)
 		if err != nil {
 			log.Errorf("Could not start dogstatsd: %s", err)

--- a/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
+++ b/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
@@ -8,7 +8,10 @@ package settings
 import (
 	"testing"
 
-	global "github.com/DataDog/datadog-agent/cmd/agent/dogstatsd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
@@ -16,9 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -47,7 +47,7 @@ func TestDogstatsdMetricsStats(t *testing.T) {
 	))
 
 	demux := deps.Demultiplexer
-	global.DSD = deps.Server
+	// global.DSD = deps.Server
 	deps.Server.Start(demux)
 
 	require.Nil(t, err)

--- a/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
+++ b/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
@@ -47,7 +47,6 @@ func TestDogstatsdMetricsStats(t *testing.T) {
 	))
 
 	demux := deps.Demultiplexer
-	// global.DSD = deps.Server
 	deps.Server.Start(demux)
 
 	require.Nil(t, err)

--- a/pkg/collector/corechecks/embed/jmx/loader.go
+++ b/pkg/collector/corechecks/embed/jmx/loader.go
@@ -12,6 +12,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
+	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -23,8 +24,8 @@ import (
 type JMXCheckLoader struct{}
 
 // NewJMXCheckLoader creates a loader for go checks
-func NewJMXCheckLoader() (*JMXCheckLoader, error) {
-	state.runner.initRunner()
+func NewJMXCheckLoader(server dogstatsdServer.Component) (*JMXCheckLoader, error) {
+	state.runner.initRunner(server)
 	return &JMXCheckLoader{}, nil
 }
 
@@ -72,9 +73,10 @@ func (jl *JMXCheckLoader) String() string {
 	return "JMX Check Loader"
 }
 
-func init() {
+// RegisterJMXCheckLoader explicitly registers the JMXCheckLoader and injects the dogstatsd server component
+func RegisterJMXCheckLoader(server dogstatsdServer.Component) {
 	factory := func(sender.SenderManager) (check.Loader, error) {
-		return NewJMXCheckLoader()
+		return NewJMXCheckLoader(server)
 	}
 
 	loaders.RegisterLoader(10, factory)

--- a/pkg/collector/corechecks/embed/jmx/loader.go
+++ b/pkg/collector/corechecks/embed/jmx/loader.go
@@ -24,8 +24,7 @@ import (
 type JMXCheckLoader struct{}
 
 // NewJMXCheckLoader creates a loader for go checks
-func NewJMXCheckLoader(server dogstatsdServer.Component) (*JMXCheckLoader, error) {
-	state.runner.initRunner(server)
+func NewJMXCheckLoader() (*JMXCheckLoader, error) {
 	return &JMXCheckLoader{}, nil
 }
 
@@ -73,10 +72,14 @@ func (jl *JMXCheckLoader) String() string {
 	return "JMX Check Loader"
 }
 
-// RegisterJMXCheckLoader explicitly registers the JMXCheckLoader and injects the dogstatsd server component
-func RegisterJMXCheckLoader(server dogstatsdServer.Component) {
+// InitRunner inits the runner and injects the dogstatsd server component
+func InitRunner(server dogstatsdServer.Component) {
+	state.runner.initRunner(server)
+}
+
+func init() {
 	factory := func(sender.SenderManager) (check.Loader, error) {
-		return NewJMXCheckLoader(server)
+		return NewJMXCheckLoader()
 	}
 
 	loaders.RegisterLoader(10, factory)

--- a/pkg/collector/corechecks/embed/jmx/loader_test.go
+++ b/pkg/collector/corechecks/embed/jmx/loader_test.go
@@ -32,7 +32,9 @@ func getFile() (string, error) {
 func TestLoadCheckConfig(t *testing.T) {
 	ctx := context.Background()
 
-	jl, err := NewJMXCheckLoader(nil)
+	InitRunner(nil)
+
+	jl, err := NewJMXCheckLoader()
 	assert.Nil(t, err)
 	assert.NotNil(t, jl)
 

--- a/pkg/collector/corechecks/embed/jmx/loader_test.go
+++ b/pkg/collector/corechecks/embed/jmx/loader_test.go
@@ -32,7 +32,7 @@ func getFile() (string, error) {
 func TestLoadCheckConfig(t *testing.T) {
 	ctx := context.Background()
 
-	jl, err := NewJMXCheckLoader()
+	jl, err := NewJMXCheckLoader(nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, jl)
 

--- a/pkg/collector/corechecks/embed/jmx/runner.go
+++ b/pkg/collector/corechecks/embed/jmx/runner.go
@@ -10,6 +10,7 @@ package jmx
 import (
 	"time"
 
+	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
@@ -21,9 +22,10 @@ type runner struct {
 	started  bool
 }
 
-func (r *runner) initRunner() {
+func (r *runner) initRunner(server dogstatsdServer.Component) {
 	r.jmxfetch = &jmxfetch.JMXFetch{}
 	r.jmxfetch.LogLevel = config.Datadog.GetString("log_level")
+	r.jmxfetch.DSD = server
 }
 
 func (r *runner) startRunner() error {

--- a/pkg/collector/corechecks/embed/jmx/runner_test.go
+++ b/pkg/collector/corechecks/embed/jmx/runner_test.go
@@ -16,7 +16,7 @@ import (
 func TestConfigureRunner(t *testing.T) {
 	r := &runner{}
 
-	r.initRunner()
+	r.initRunner(nil)
 
 	// Test for no instances in jmx check conf file
 	initConfYaml := []byte("")

--- a/pkg/collector/corechecks/embed/jmx/stub.go
+++ b/pkg/collector/corechecks/embed/jmx/stub.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !jmx
+
+package jmx
+
+import dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
+
+// RegisterJMXCheckLoader explicitly registers the JMXCheckLoader and injects the dogstatsd server component
+func RegisterJMXCheckLoader(server dogstatsdServer.Component) {}

--- a/pkg/collector/corechecks/embed/jmx/stub.go
+++ b/pkg/collector/corechecks/embed/jmx/stub.go
@@ -9,5 +9,5 @@ package jmx
 
 import dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 
-// RegisterJMXCheckLoader explicitly registers the JMXCheckLoader and injects the dogstatsd server component
-func RegisterJMXCheckLoader(server dogstatsdServer.Component) {}
+// RegisterJMXCheckLoader is a stub for builds that do not include jmx
+func RegisterJMXCheckLoader(_server dogstatsdServer.Component) {}

--- a/pkg/collector/corechecks/embed/jmx/stub.go
+++ b/pkg/collector/corechecks/embed/jmx/stub.go
@@ -9,5 +9,5 @@ package jmx
 
 import dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 
-// RegisterJMXCheckLoader is a stub for builds that do not include jmx
-func RegisterJMXCheckLoader(_ dogstatsdServer.Component) {}
+// InitRunner is a stub for builds that do not include jmx
+func InitRunner(_ dogstatsdServer.Component) {}

--- a/pkg/collector/corechecks/embed/jmx/stub.go
+++ b/pkg/collector/corechecks/embed/jmx/stub.go
@@ -10,4 +10,4 @@ package jmx
 import dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 
 // RegisterJMXCheckLoader is a stub for builds that do not include jmx
-func RegisterJMXCheckLoader(_server dogstatsdServer.Component) {}
+func RegisterJMXCheckLoader(_ dogstatsdServer.Component) {}

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -21,7 +21,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/path"
-	global "github.com/DataDog/datadog-agent/cmd/agent/dogstatsd"
+	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	api "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -73,6 +73,7 @@ type JMXFetch struct {
 	Command            string
 	Reporter           JMXReporter
 	Checks             []string
+	DSD                dogstatsdServer.Component
 	IPCPort            int
 	IPCHost            string
 	Output             func(...interface{})
@@ -199,7 +200,7 @@ func (j *JMXFetch) Start(manage bool) error {
 	case ReporterJSON:
 		reporter = "json"
 	default:
-		if global.DSD != nil && global.DSD.UdsListenerRunning() {
+		if j.DSD != nil && j.DSD.UdsListenerRunning() {
 			reporter = fmt.Sprintf("statsd:unix://%s", config.Datadog.GetString("dogstatsd_socket"))
 		} else {
 			bindHost := config.GetBindHost()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR removes the usage of the global `var DSD server.Component` in the `dogstatsd/global.go` file. 

The `runner` that starts the JMXFetch process will now be explicitly innited and the `JMXFetch` struct now has a reference to the `DSD dogstatsdServer.Component`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Favor injecting the component over using a global
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
These changes should only affect JMXFetch as [this was the only place where the global `DSD` was still being used.](https://github.com/DataDog/datadog-agent/blob/070f8d1fb2afbe904ee933283cefca107350663b/pkg/jmxfetch/jmxfetch.go#L202)
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
1. Make sure JMXFetch still works
One way to do this:
  - Edit the misbehaving-server  docker-compose file with the agent image `datadog/agent-dev:raymond-zhao-remove-global-dogstatsd-reference-py3-jmx` https://github.com/DataDog/jmxfetch/blob/master/tools/misbehaving-jmx-server/docker-compose.yaml
  - Enable dogstatsd and uds by setting `DD_USE_DOGSTATSD` and `DD_DOGSTATSD_SOCKET`
  - `docker-compose up`
  - Make sure that JMXFetch is still working properly and metrics are being sent
2. Make sure jmx subcommand still works
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
