### PR TITLE
pkg/trace/api: Record short msgp decode errors separately from io EOF

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -492,8 +492,10 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		switch err {
 		case apiutil.ErrLimitedReaderLimitReached:
 			ts.TracesDropped.PayloadTooLarge.Add(tracen)
-		case io.EOF, io.ErrUnexpectedEOF, msgp.ErrShortBytes:
+		case io.EOF, io.ErrUnexpectedEOF:
 			ts.TracesDropped.EOF.Add(tracen)
+		case msgp.ErrShortBytes:
+			ts.TracesDropped.MSGPShortBytes.Add(tracen)
 		default:
 			if err, ok := err.(net.Error); ok && err.Timeout() {
 				ts.TracesDropped.Timeout.Add(tracen)

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -497,7 +497,7 @@ func TestReceiverUnexpectedEOF(t *testing.T) {
 
 	resp.Body.Close()
 	assert.Equal(400, resp.StatusCode)
-	assert.EqualValues(traceCount, r.Stats.GetTagStats(info.Tags{EndpointVersion: "v0.5"}).TracesDropped.EOF.Load())
+	assert.EqualValues(traceCount, r.Stats.GetTagStats(info.Tags{EndpointVersion: "v0.5"}).TracesDropped.MSGPShortBytes.Load())
 }
 
 func TestTraceCount(t *testing.T) {

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -515,6 +515,7 @@ func TestPublishReceiverStats(t *testing.T) {
 				"TraceIDZero":     4.0,
 				"SpanIDZero":      5.0,
 				"ForeignSpan":     6.0,
+				"MSGPShortBytes":  9.0,
 				"Timeout":         7.0,
 				"EOF":             8.0,
 			},

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -432,6 +432,7 @@ func TestPublishReceiverStats(t *testing.T) {
 				atom(6),
 				atom(7),
 				atom(8),
+				atom(9),
 			},
 			SpansMalformed: &SpansMalformed{
 				atom(1),

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -215,6 +215,8 @@ type TracesDropped struct {
 	// EOF is when an unexpected EOF is encountered, this can happen because the client has aborted
 	// or because a bad payload (i.e. shorter than claimed in Content-Length) was sent.
 	EOF atomic.Int64
+	// MSGPShortBytes is when a msgp payload is bad due to missing bytes
+	MSGPShortBytes atomic.Int64
 }
 
 func (s *TracesDropped) tagCounters() map[string]*atomic.Int64 {
@@ -227,6 +229,7 @@ func (s *TracesDropped) tagCounters() map[string]*atomic.Int64 {
 		"foreign_span":      &s.ForeignSpan,
 		"timeout":           &s.Timeout,
 		"unexpected_eof":    &s.EOF,
+		"msgp_short_bytes":  &s.MSGPShortBytes,
 	}
 }
 
@@ -422,6 +425,7 @@ func (s *Stats) update(recent *Stats) {
 	s.TracesDropped.PayloadTooLarge.Add(recent.TracesDropped.PayloadTooLarge.Load())
 	s.TracesDropped.Timeout.Add(recent.TracesDropped.Timeout.Load())
 	s.TracesDropped.EOF.Add(recent.TracesDropped.EOF.Load())
+	s.TracesDropped.MSGPShortBytes.Add(recent.TracesDropped.MSGPShortBytes.Load())
 	s.SpansMalformed.DuplicateSpanID.Add(recent.SpansMalformed.DuplicateSpanID.Load())
 	s.SpansMalformed.ServiceEmpty.Add(recent.SpansMalformed.ServiceEmpty.Load())
 	s.SpansMalformed.ServiceTruncate.Add(recent.SpansMalformed.ServiceTruncate.Load())

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -36,6 +36,7 @@ func TestTracesDropped(t *testing.T) {
 			"payload_too_large": 0,
 			"decoding_error":    1,
 			"foreign_span":      1,
+			"msgp_short_bytes":  0,
 			"trace_id_zero":     1,
 			"span_id_zero":      1,
 			"timeout":           0,
@@ -269,7 +270,7 @@ func TestReceiverStats(t *testing.T) {
 	t.Run("PublishAndReset", func(t *testing.T) {
 		rs := testStats()
 		rs.PublishAndReset()
-		assert.EqualValues(t, 41, statsclient.counts.Load())
+		assert.EqualValues(t, 42, statsclient.counts.Load())
 		assertStatsAreReset(t, rs)
 	})
 

--- a/releasenotes/notes/trace-agent-msgp-eof-3007beb09ef73648.yaml
+++ b/releasenotes/notes/trace-agent-msgp-eof-3007beb09ef73648.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Adds `msgp_short_bytes` reason for trace payloads dropped to distinguish them from EOF errors.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This adds a new tag in TracesDropped metric to distinguish msgp Too Few Bytes errors from io EOF errors.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Recently we were investigating some `400` responses from the trace agent and it would have been nice on the APM Agent Dashboard to be able to visually distinguish these msgp decode errors from io EOF errors. Namely because msgp decode errors typically indicate we successfully communicated over the network but received a bad payload - while io EOF errors typically indicate network timeouts (from either us or the tracer)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Modified unit test to pass is sufficient here. Also ran agent locally and send bad payload - verified the metric showed properly in the APM Agent Dashboard
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
