### PR TITLE
Revert "Distribute microvm VCPUs across host CPUs on launch (#22356)"

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -300,7 +300,7 @@ upload_minimized_btfs_arm64:
   script:
     - echo "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE" > $STACK_DIR
     - pulumi login $(cat $STACK_DIR | tr -d '\n')
-    - inv -e kmt.gen-config --ci --arch=$ARCH --output-file=$VMCONFIG_FILE --sets=$TEST_SETS --host-cpus=$AVAILABLE_CPUS
+    - inv -e kmt.gen-config --ci --arch=$ARCH --output-file=$VMCONFIG_FILE --sets=$TEST_SETS
     - inv -e system-probe.start-microvms --provision --vmconfig=$VMCONFIG_FILE $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$ARCH-$CI_PIPELINE_ID --run-agent
     - jq -r '.' $CI_PROJECT_DIR/stack.output
     - pulumi logout
@@ -330,7 +330,6 @@ kernel_matrix_testing_setup_env_arm64:
     ARCH: arm64
     AMI_ID_ARG: "--arm-ami-id=$KERNEL_MATRIX_TESTING_ARM_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-arm
-    AVAILABLE_CPUS: "64"
 
 kernel_matrix_testing_setup_env_x64:
   extends:
@@ -341,7 +340,6 @@ kernel_matrix_testing_setup_env_x64:
     ARCH: x86_64
     AMI_ID_ARG: "--x86-ami-id=$KERNEL_MATRIX_TESTING_X86_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-x86
-    AVAILABLE_CPUS: "96"
 
 .kernel_matrix_testing_run_tests:
   stage: kernel_matrix_testing

--- a/tasks/kernel_matrix_testing/vmconfig.py
+++ b/tasks/kernel_matrix_testing/vmconfig.py
@@ -2,7 +2,6 @@ import copy
 import itertools
 import json
 import math
-import multiprocessing
 import os
 import platform
 from urllib.parse import urlparse
@@ -370,10 +369,6 @@ def add_console(vmset):
     vmset["console_type"] = "file"
 
 
-def add_available_cpus(vmset, cpus):
-    vmset["host"] = {"available_cpus": cpus}
-
-
 def url_to_fspath(url):
     source = urlparse(url)
     filename = os.path.basename(source.path)
@@ -465,7 +460,7 @@ def build_vmsets(normalized_vm_defs, sets):
     return vmsets
 
 
-def generate_vmconfig(vm_config, normalized_vm_defs, vcpu, memory, sets, ci, host_cpus):
+def generate_vmconfig(vm_config, normalized_vm_defs, vcpu, memory, sets, ci):
     with open(platforms_file) as f:
         platforms = json.load(f)
 
@@ -502,8 +497,6 @@ def generate_vmconfig(vm_config, normalized_vm_defs, vcpu, memory, sets, ci, hos
         if ci:
             add_console(vmset)
 
-        add_available_cpus(vmset, host_cpus)
-
     return vm_config
 
 
@@ -528,7 +521,9 @@ def build_normalized_vm_def_set(vms):
     return normalized_vms
 
 
-def gen_config_for_stack(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, host_cpus):
+def gen_config_for_stack(
+    ctx, stack=None, vms="", sets="", init_stack=False, vcpu="4", memory="8192", new=False, ci=False
+):
     stack = check_and_get_stack(stack)
     if not stack_exists(stack) and not init_stack:
         raise Exit(
@@ -549,7 +544,7 @@ def gen_config_for_stack(ctx, stack, vms, sets, init_stack, vcpu, memory, new, c
         orig_vm_config = f.read()
     vm_config = json.loads(orig_vm_config)
 
-    vm_config = generate_vmconfig(vm_config, build_normalized_vm_def_set(vms), vcpu, memory, sets, ci, host_cpus)
+    vm_config = generate_vmconfig(vm_config, build_normalized_vm_def_set(vms), vcpu, memory, sets, ci)
     vm_config_str = json.dumps(vm_config, indent=4)
 
     tmpfile = "/tmp/vm.json"
@@ -584,7 +579,7 @@ def list_all_distro_normalized_vms(archs):
     return vms
 
 
-def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file, host_cpus):
+def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file):
     vcpu_ls = vcpu.split(',')
     memory_ls = memory.split(',')
 
@@ -595,19 +590,8 @@ def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, o
         set_ls = sets.split(",")
 
     if not ci:
-        if host_cpus is None:
-            host_cpus = multiprocessing.cpu_count()
         return gen_config_for_stack(
-            ctx,
-            stack,
-            vms,
-            set_ls,
-            init_stack,
-            ls_to_int(vcpu_ls),
-            ls_to_int(memory_ls),
-            new,
-            ci,
-            int(host_cpus),
+            ctx, stack, vms, set_ls, init_stack, ls_to_int(vcpu_ls), ls_to_int(memory_ls), new, ci
         )
 
     arch_ls = ["x86_64", "arm64"]
@@ -615,17 +599,7 @@ def gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, o
         arch_ls = [arch_mapping[arch]]
 
     vms_to_generate = list_all_distro_normalized_vms(arch_ls)
-    if host_cpus is None:
-        raise Exit("no value for available cpus provided")
-    vm_config = generate_vmconfig(
-        {"vmsets": []},
-        vms_to_generate,
-        ls_to_int(vcpu_ls),
-        ls_to_int(memory_ls),
-        set_ls,
-        ci,
-        int(host_cpus),
-    )
+    vm_config = generate_vmconfig({"vmsets": []}, vms_to_generate, ls_to_int(vcpu_ls), ls_to_int(memory_ls), set_ls, ci)
 
     with open(output_file, "w") as f:
         f.write(json.dumps(vm_config, indent=4))

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -62,7 +62,6 @@ def gen_config(
     output_file="vmconfig.json",
     from_ci_pipeline=None,
     use_local_if_possible=False,
-    host_cpus=None,
 ):
     """
     Generate a vmconfig.json file with the given VMs.
@@ -84,7 +83,7 @@ def gen_config(
     else:
         vcpu = DEFAULT_VCPU if vcpu is None else vcpu
         memory = DEFAULT_MEMORY if memory is None else memory
-        vmconfig.gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file, host_cpus)
+        vmconfig.gen_config(ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file)
 
 
 def gen_config_from_ci_pipeline(
@@ -142,7 +141,6 @@ def gen_config_from_ci_pipeline(
                 if vcpu is None and len(vcpu_list) > 0:
                     vcpu = str(vcpu_list[0])
                     info(f"[+] setting vcpu to {vcpu}")
-
         elif name.startswith("kernel_matrix_testing_run") and job["status"] == "failed":
             arch = "x86" if "x64" in name else "arm64"
             match = re.search(r"\[(.*)\]", name)


### PR DESCRIPTION
This reverts commit fe0d66b6c4d819c783da67e0bbae598c12b06da3.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR reverts https://github.com/DataDog/datadog-agent/pull/22356.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The original PR https://github.com/DataDog/datadog-agent/pull/22356 was intended to solve time synchronization issues which it did not correctly address. 
These were solved by https://github.com/DataDog/datadog-agent/pull/22486.
Moreover, it seems that this PR may have cause some tests in KMT to become more flaky.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
