### PR TITLE
[CI] Automatically add the Milestone on a Merged PR

### DIFF
--- a/.github/workflows/add_milestone.yml
+++ b/.github/workflows/add_milestone.yml
@@ -13,35 +13,42 @@ jobs:
     steps:
       - name: Get PR from which the commit is from
         id: source-pr
-        run: echo "NUMBER=$(gh pr list --search "$GITHUB_SHA" --state merged --json url --jq '.[0].url' | sed 's|.*pull/\(.*\)|\1|g')" >> "$GITHUB_OUTPUT"
+        run: |
+          NUMBER=$(gh pr list --search "$GITHUB_SHA" --state merged --json url --jq '.[0].url' | sed 's|.*pull/\(.*\)|\1|g')
+          if [ -z "$NUMBER" ]; then
+            echo "Error: Couldn't find the PR commit $GITHUB_SHA originating from, milestone not assigned."
+            exit 1
+          fi
+          echo "NUMBER=$NUMBER" >> "$GITHUB_OUTPUT"
       - name: Get repo current milestone
         id: current-milestone
         run: |
           if [[ ${GITHUB_REF##*/} =~ ^7\.[0-9]+\.[0-9]+$ ]]; then
             # If we're on a release branch, set the milestone to the latest release milestone found.
             MILESTONE=$(gh release list | grep -o $(echo ${GITHUB_REF##*/} | sed 's/x/[0-9]*/g') | sort -uV | tail -1)
+            if [ -z "$MILESTONE" ]; then
+              echo "Error: Couldn't get the latest release milestone from Github."
+              exit 1
+            fi
           else
             # Else use the current_milestone field in the release.json file.
             MILESTONE=$(cat release.json | jq -r .current_milestone)" >> "$GITHUB_OUTPUT"
+            if [ -z "$MILESTONE" ]; then
+              echo "Error: Couldn't find the current_milestone field in the release.json file."
+              exit 1
+            fi
+          fi
+          if [[ $MILESTONE !~ ^7\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Malformed milestone $MILESTONE. It should be of the form '7.x.y'."
+            exit 1
           fi
           echo "MILESTONE=$MILESTONE" >> "$GITHUB_OUTPUT"
 
       - name: Set the merged PR milestone to current_milestone from release.json
         run: |
-          if [ -z "$NUMBER" ]; then
-            echo "Error: Couldn't find the PR commit $GITHUB_SHA originating from, milestone not assigned."
-            exit 1
-          elif [ -z "$MILESTONE" ]; then
-            echo "Error: Couldn't find the current_milestone field in the release.json file."
-            exit 1
-          elif [[ $MILESTONE !~ ^7\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: Malformed milestone $MILESTONE. It should be of the form '7.x.y'."
-            exit 1
-          else
-            echo "Setting milestone $MILESTONE to PR #$NUMBER."
-            gh issue edit "$NUMBER" --milestone "$MILESTONE"
-            exit 0
-          fi
+          echo "Setting milestone $MILESTONE to PR #$NUMBER."
+          gh issue edit "$NUMBER" --milestone "$MILESTONE"
+          exit 0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/add_milestone.yml
+++ b/.github/workflows/add_milestone.yml
@@ -1,0 +1,49 @@
+name: Add Milestone on a Merged PR
+
+on:
+  push:
+    branches:
+      - main
+      - "[0-9]+.[0-9]+.x"
+
+jobs:
+  add-milestone-pr:
+    name: Add Milestone on PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR from which the commit is from
+        id: source-pr
+        run: echo "NUMBER=$(gh pr list --search "$GITHUB_SHA" --state merged --json url --jq '.[0].url' | sed 's|.*pull/\(.*\)|\1|g')" >> "$GITHUB_OUTPUT"
+      - name: Get repo current milestone
+        id: current-milestone
+        run: |
+          if [[ ${GITHUB_REF##*/} =~ ^7\.[0-9]+\.[0-9]+$ ]]; then
+            # If we're on a release branch, set the milestone to the latest release milestone found.
+            MILESTONE=$(gh release list | grep -o $(echo ${GITHUB_REF##*/} | sed 's/x/[0-9]*/g') | sort -uV | tail -1)
+          else
+            # Else use the current_milestone field in the release.json file.
+            MILESTONE=$(cat release.json | jq -r .current_milestone)" >> "$GITHUB_OUTPUT"
+          fi
+          echo "MILESTONE=$MILESTONE" >> "$GITHUB_OUTPUT"
+
+      - name: Set the merged PR milestone to current_milestone from release.json
+        run: |
+          if [ -z "$NUMBER" ]; then
+            echo "Error: Couldn't find the PR commit $GITHUB_SHA originating from, milestone not assigned."
+            exit 1
+          elif [ -z "$MILESTONE" ]; then
+            echo "Error: Couldn't find the current_milestone field in the release.json file."
+            exit 1
+          elif [[ $MILESTONE !~ ^7\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Malformed milestone $MILESTONE. It should be of the form '7.x.y'."
+            exit 1
+          else
+            echo "Setting milestone $MILESTONE to PR #$NUMBER."
+            gh issue edit "$NUMBER" --milestone "$MILESTONE"
+            exit 0
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ steps.source-pr.outputs.NUMBER }}
+          MILESTONE: ${{ steps.current-milestone.outputs.MILESTONE }}

--- a/.github/workflows/add_milestone.yml
+++ b/.github/workflows/add_milestone.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Set the merged PR milestone to current_milestone from release.json
         run: |
-          echo "Setting milestone $MILESTONE to PR #$NUMBER."
+          echo "Setting milestone $MILESTONE to PR $NUMBER."
           gh issue edit "$NUMBER" --milestone "$MILESTONE"
           exit 0
         env:

--- a/release.json
+++ b/release.json
@@ -1,5 +1,6 @@
 {
     "base_branch": "main",
+    "current_milestone": "7.52.0",
     "last_stable": {
         "6": "6.50.1",
         "7": "7.50.1"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds a Github workflow automating the Milestone setting on each PR merged.
The source of truth becomes the merge time.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- Increased developer experience.
- Facilitate the reviewer checklist lightening as proposed in #22487.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
