### PR TITLE
Add step to set github actions bot as the git user

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -37,6 +37,9 @@ jobs:
               with:
                 ref: ${{ env.RELEASE_BRANCH }}
                 fetch-depth: 0
+            
+            - name: Set git user
+              uses: fregante/setup-git-user@v2
               
             - name: Create RC PR
               run: |

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -37,11 +37,10 @@ jobs:
               with:
                 ref: ${{ env.RELEASE_BRANCH }}
                 fetch-depth: 0
-            
-            - name: Set git user
-              uses: fregante/setup-git-user@v2
               
             - name: Create RC PR
               run: |
+                git config user.name "GitHub Actions"
+                git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                 git fetch
                 inv -e release.create-rc


### PR DESCRIPTION
### What does this PR do?

Set github-actions bot as git user which is required to commit changes made during the workflow.

### Motivation

Automation of the Agent release process.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
