### PR TITLE
Fix minimum cursor size in ebpfcheck

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -613,7 +613,8 @@ func (e *entryCountBuffers) prepareFirstBatchKeys(referenceMap *ebpf.Map) {
 }
 
 func (e *entryCountBuffers) ensureSizeCursor(referenceMap *ebpf.Map) {
-	e.cursor, e.maxCursorSize = growBufferWithLimit(e.cursor, max(e.maxCursorSize, referenceMap.KeySize()), 0) // No limit with cursors, they are always small
+	// hash maps require at least 4 bytes for the cursor, ensure we never allocate less than that.
+	e.cursor, e.maxCursorSize = growBufferWithLimit(e.cursor, max(4, e.maxCursorSize, referenceMap.KeySize()), 0) // No limit with cursors, they are always small
 }
 
 // resetBuffers resets the buffers to nil, so that they can be garbage collected


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR is a fix for two types of system-probe panics that have happened sporadically over the weekend in the staging environment.

* Panic 1: out of bounds access on a slice that's not as big as expected. The batch lookup syscall returns a number of elements (13107) that's bigger than what fits with the allocated batch size (capacity 524288 bytes / 56 bytes for key size =~9300 elements)
* Panic 2: attempt to index a nil slice

Both happen in the same function (`inplaceSet.hash`, called by `inplaceSet.load` or `inplaceSet.containsAny`). Both of them are impossible situations, as the bounds checking is already done and sizes should be appropriate. 


<details>
<summary>panic 1 stack trace</summary>
```
2024/02/04 20:27:49 http: panic serving @: runtime error: slice bounds out of range [:524300] with capacity 524288
goroutine 64222 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1868 +0xb0
panic({0x4ac1580?, 0x4002919c80?})
	/usr/local/go/src/runtime/panic.go:920 +0x26c
github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck.(*inplaceSet).hash(0x4005648158, {0x4008f10000, 0x506ba5b8?, 0x80000}, 0x7ffdc)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go:672 +0xb8
github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck.(*inplaceSet).containsAny(0x4005648158, {0x4008f10000, 0x80000, 0x80000}, 0x2fbe)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go:690 +0x70
github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck.hashMapNumberOfEntriesWithBatch(0x40084d8230, 0x4005648128, 0x3)
``` 
</details>

<details>
<summary>panic 2 stack trace</summary>
```
2024/02/05 04:14:49 http: panic serving @: runtime error: slice bounds out of range [:8] with capacity 0
goroutine 1077 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1868 +0xb0
panic({0x4ac1580?, 0x4008dc4018?})
	/usr/local/go/src/runtime/panic.go:920 +0x26c
github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck.(*inplaceSet).hash(0x40057c03f8, {0x0, 0x4008e01520?, 0x0}, 0x0)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go:672 +0xb8
github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck.(*inplaceSet).load(0x40057c03f8, {0x0, 0x0, 0x0}, 0xfe)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go:682 +0x6c
github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck.hashMapNumberOfEntriesWithBatch(0x40057add10, 0x40057c03c8, 0x3)
``` 
</details>

After some investigation, it looks like hash maps assume a cursor that is 4 bytes in size. One map in the system-probe has keys that have just one byte size, which means that if that map is probed first, the kernel could be overwriting other buffers, causing these problems. This seems the most likely cause as of now: while the expected size of the cursor is not documented anywhere, the ebpf library has a similar provision to ensure cursors are at least 4 bytes in size.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
