### PR TITLE
[USM] Support all http2 methods

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -135,6 +135,9 @@ typedef struct {
 // If the path is huffman encoded then the length is 2, but if it is not, then the length is 3.
 #define HTTP2_STATUS_CODE_MAX_LEN 3
 
+// Max length of the method is 7.
+#define HTTP2_METHOD_MAX_LEN 7
+
 typedef struct {
     __u8 raw_buffer[HTTP2_STATUS_CODE_MAX_LEN];
     bool is_huffman_encoded;
@@ -142,6 +145,14 @@ typedef struct {
     __u8 indexed_value;
     bool finalized;
 } status_code_t;
+
+typedef struct {
+    __u8 raw_buffer[HTTP2_METHOD_MAX_LEN];
+    bool is_huffman_encoded;
+
+    __u8 indexed_value;
+    bool finalized;
+} method_t;
 
 typedef struct {
     __u64 response_last_seen;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -70,7 +70,7 @@
 #define HTTP2_END_OF_STREAM 0x1
 
 // Http2 max batch size.
-#define HTTP2_BATCH_SIZE 17
+#define HTTP2_BATCH_SIZE 15
 
 // The max number of events we can have in a single page in the batch_events array.
 // See more details in the comments of the USM_EVENTS_INIT.
@@ -142,7 +142,7 @@ typedef struct {
     __u8 raw_buffer[HTTP2_STATUS_CODE_MAX_LEN];
     bool is_huffman_encoded;
 
-    __u8 indexed_value;
+    __u8 static_table_entry;
     bool finalized;
 } status_code_t;
 
@@ -150,7 +150,8 @@ typedef struct {
     __u8 raw_buffer[HTTP2_METHOD_MAX_LEN];
     bool is_huffman_encoded;
 
-    __u8 indexed_value;
+    __u8 static_table_entry;
+    __u8 length;
     bool finalized;
 } method_t;
 
@@ -159,7 +160,7 @@ typedef struct {
     __u64 request_started;
 
     status_code_t status_code;
-    __u8 request_method;
+    method_t request_method;
     __u8 path_size;
     bool request_end_of_stream;
     bool is_huffman_encoded;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -346,6 +346,7 @@ static __always_inline void tls_process_headers(tls_dispatcher_arguments_t *info
                 current_stream->status_code.is_huffman_encoded = dynamic_value->is_huffman_encoded;
                 current_stream->status_code.finalized = true;
             } else if (is_method_index(dynamic_value->original_index)) {
+                current_stream->request_started = bpf_ktime_get_ns();
                 bpf_memcpy(current_stream->request_method.raw_buffer, dynamic_value->buffer, HTTP2_METHOD_MAX_LEN);
                 current_stream->request_method.is_huffman_encoded = dynamic_value->is_huffman_encoded;
                 current_stream->request_method.length = current_header->new_dynamic_value_size;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -120,7 +120,7 @@ static __always_inline bool tls_parse_field_literal(tls_dispatcher_arguments_t *
     // we skip it.
     if (is_path_index(index)) {
         update_path_size_telemetry(http2_tel, str_len);
-    } else if (!is_status_index(index)) {
+    } else if ((!is_status_index(index)) && (!is_method_index(index))) {
         goto end;
     }
 
@@ -314,10 +314,11 @@ static __always_inline void tls_process_headers(tls_dispatcher_arguments_t *info
             if (is_method_index(current_header->index)) {
                 // TODO: mark request
                 current_stream->request_started = bpf_ktime_get_ns();
-                current_stream->request_method = current_header->index;
+                current_stream->request_method.static_table_entry = current_header->index;
+                current_stream->request_method.finalized = true;
                 __sync_fetch_and_add(&http2_tel->request_seen, 1);
             } else if (is_status_index(current_header->index)) {
-                current_stream->status_code.indexed_value = current_header->index;
+                current_stream->status_code.static_table_entry = current_header->index;
                 current_stream->status_code.finalized = true;
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
             } else if (current_header->index == kEmptyPath) {
@@ -344,6 +345,11 @@ static __always_inline void tls_process_headers(tls_dispatcher_arguments_t *info
                 bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value->buffer, HTTP2_STATUS_CODE_MAX_LEN);
                 current_stream->status_code.is_huffman_encoded = dynamic_value->is_huffman_encoded;
                 current_stream->status_code.finalized = true;
+            } else if (is_method_index(dynamic_value->original_index)) {
+                bpf_memcpy(current_stream->request_method.raw_buffer, dynamic_value->buffer, HTTP2_METHOD_MAX_LEN);
+                current_stream->request_method.is_huffman_encoded = dynamic_value->is_huffman_encoded;
+                current_stream->request_method.length = current_header->new_dynamic_value_size;
+                current_stream->request_method.finalized = true;
             }
         } else {
             // We're in new dynamic header or new dynamic header not indexed states.
@@ -363,6 +369,12 @@ static __always_inline void tls_process_headers(tls_dispatcher_arguments_t *info
                 bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value.buffer, HTTP2_STATUS_CODE_MAX_LEN);
                 current_stream->status_code.is_huffman_encoded = current_header->is_huffman_encoded;
                 current_stream->status_code.finalized = true;
+            } else if (is_method_index(current_header->original_index)) {
+                current_stream->request_started = bpf_ktime_get_ns();
+                bpf_memcpy(current_stream->request_method.raw_buffer, dynamic_value.buffer, HTTP2_METHOD_MAX_LEN);
+                current_stream->request_method.is_huffman_encoded = current_header->is_huffman_encoded;
+                current_stream->request_method.length = current_header->new_dynamic_value_size;
+                current_stream->request_method.finalized = true;
             }
         }
     }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -343,6 +343,7 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 current_stream->status_code.is_huffman_encoded = dynamic_value->is_huffman_encoded;
                 current_stream->status_code.finalized = true;
             }  else if (is_method_index(dynamic_value->original_index)) {
+                current_stream->request_started = bpf_ktime_get_ns();
                 bpf_memcpy(current_stream->request_method.raw_buffer, dynamic_value->buffer, HTTP2_METHOD_MAX_LEN);
                 current_stream->request_method.is_huffman_encoded = dynamic_value->is_huffman_encoded;
                 current_stream->request_method.length = current_header->new_dynamic_value_size;

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -151,6 +151,11 @@ func stringToHTTPMethod(method string) (http.Method, error) {
 		return http.MethodGet, nil
 	case "POST":
 		return http.MethodPost, nil
+	// Currently unsupported methods due to lack of support in http.Method.
+	case "CONNECT":
+		return http.MethodUnknown, nil
+	case "TRACE":
+		return http.MethodUnknown, nil
 	default:
 		return 0, fmt.Errorf("unsupported HTTP method: %s", method)
 	}

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -254,7 +254,7 @@ func (tx *EbpfTx) RequestStarted() uint64 {
 }
 
 // SetRequestMethod sets the HTTP method of the transaction.
-func (tx *EbpfTx) SetRequestMethod(m http.Method) {
+func (tx *EbpfTx) SetRequestMethod(_ http.Method) {
 	// if we set Static_table_entry to be different from 0, and no indexed value, it will default to 0 which is "UNKNOWN"
 	tx.Stream.Request_method.Static_table_entry = 1
 }

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -30,6 +30,7 @@ type HTTP2DynamicTableIndex C.dynamic_table_index_t
 type HTTP2DynamicTableEntry C.dynamic_table_entry_t
 type http2StreamKey C.http2_stream_key_t
 type http2StatusCode C.status_code_t
+type http2requestMethod C.method_t
 type http2Stream C.http2_stream_t
 type EbpfTx C.http2_event_t
 type HTTP2Telemetry C.http2_telemetry_t

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -44,7 +44,14 @@ type http2StreamKey struct {
 type http2StatusCode struct {
 	Raw_buffer         [3]uint8
 	Is_huffman_encoded bool
-	Indexed_value      uint8
+	Static_table_entry uint8
+	Finalized          bool
+}
+type http2requestMethod struct {
+	Raw_buffer         [7]uint8
+	Is_huffman_encoded bool
+	Static_table_entry uint8
+	Length             uint8
 	Finalized          bool
 }
 type http2Stream struct {

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -44,18 +44,25 @@ type http2StreamKey struct {
 type http2StatusCode struct {
 	Raw_buffer         [3]uint8
 	Is_huffman_encoded bool
-	Indexed_value      uint8
+	Static_table_entry uint8
+	Finalized          bool
+}
+type http2requestMethod struct {
+	Raw_buffer         [7]uint8
+	Is_huffman_encoded bool
+	Static_table_entry uint8
+	Length             uint8
 	Finalized          bool
 }
 type http2Stream struct {
 	Response_last_seen    uint64
 	Request_started       uint64
 	Status_code           http2StatusCode
-	Request_method        uint8
+	Request_method        http2requestMethod
 	Path_size             uint8
 	Request_end_of_stream bool
 	Is_huffman_encoded    bool
-	Pad_cgo_0             [6]byte
+	Pad_cgo_0             [4]byte
 	Request_path          [160]uint8
 }
 type EbpfTx struct {

--- a/pkg/network/usm/testutil/generic_testutil_builder.go
+++ b/pkg/network/usm/testutil/generic_testutil_builder.go
@@ -25,7 +25,7 @@ func BuildUnixTransparentProxyServer(curDir, binaryDir string) (string, error) {
 		return cachedServerBinaryPath, nil
 	}
 
-	c := exec.Command("go", "build", "-buildvcs=false", "-a", "-tags=test", "-ldflags=-extldflags '-static'", "-o", cachedServerBinaryPath, serverSrcDir)
+	c := exec.Command("/home/vagrant/.gimme/versions/go1.21.5.linux.arm64/bin/go", "build", "-buildvcs=false", "-a", "-tags=test", "-ldflags=-extldflags '-static'", "-o", cachedServerBinaryPath, serverSrcDir)
 	out, err := c.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("could not build unix transparent proxy server test binary: %s\noutput: %s", err, string(out))

--- a/pkg/network/usm/testutil/generic_testutil_builder.go
+++ b/pkg/network/usm/testutil/generic_testutil_builder.go
@@ -25,7 +25,7 @@ func BuildUnixTransparentProxyServer(curDir, binaryDir string) (string, error) {
 		return cachedServerBinaryPath, nil
 	}
 
-	c := exec.Command("/home/vagrant/.gimme/versions/go1.21.5.linux.arm64/bin/go", "build", "-buildvcs=false", "-a", "-tags=test", "-ldflags=-extldflags '-static'", "-o", cachedServerBinaryPath, serverSrcDir)
+	c := exec.Command("go", "build", "-buildvcs=false", "-a", "-tags=test", "-ldflags=-extldflags '-static'", "-o", cachedServerBinaryPath, serverSrcDir)
 	out, err := c.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("could not build unix transparent proxy server test binary: %s\noutput: %s", err, string(out))

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -756,7 +756,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			name: "validate http methods",
 			// The purpose of this test is to validate that we are able to capture all http methods.
 			messageBuilder: func() [][]byte {
-				httpMethods = []string{http.MethodHead, http.MethodDelete, http.MethodPut, http.MethodPatch, http.MethodOptions}
+				httpMethods = []string{http.MethodGet, http.MethodPost, http.MethodHead, http.MethodDelete, http.MethodPut, http.MethodPatch, http.MethodOptions}
 				framer := newFramer()
 				for i, method := range httpMethods {
 					streamID := getStreamID(i)
@@ -767,6 +767,14 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 				return [][]byte{framer.bytes()}
 			},
 			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodGet,
+				}: 1,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodPost,
+				}: 1,
 				{
 					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
 					Method: usmhttp.MethodHead,

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -754,9 +754,9 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		},
 		{
 			name: "validate http methods",
-			// The purpose of this test is to validate that we are not supporting http2 methods different from POST and GET.
+			// The purpose of this test is to validate that we are able to capture all http methods.
 			messageBuilder: func() [][]byte {
-				httpMethods = []string{http.MethodHead, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions}
+				httpMethods = []string{http.MethodHead, http.MethodDelete, http.MethodPut, http.MethodPatch, http.MethodOptions}
 				framer := newFramer()
 				for i, method := range httpMethods {
 					streamID := getStreamID(i)
@@ -766,7 +766,28 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 				}
 				return [][]byte{framer.bytes()}
 			},
-			expectedEndpoints: nil,
+			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodHead,
+				}: 1,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodDelete,
+				}: 1,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodPut,
+				}: 1,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodPatch,
+				}: 1,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodOptions,
+				}: 1,
+			},
 		},
 		{
 			name: "validate max path length",

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -818,7 +818,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 					huffMethod := hpack.AppendHuffmanString([]byte{}, method)
 					// we are adding 128 to the length of the huffman encoded method,
 					// as it is the representation of the huffman encoding (MSB ofo the octet is on).
-					rawMethod := append([]byte{0x43}, byte(128+len(huffMethod)))
+					rawMethod := append([]byte{0x43}, byte(0x80|len(huffMethod)))
 					rawMethod = append(rawMethod, huffMethod...)
 					headersFrameWithRawMethod := append(rawMethod, headersFrame...)
 					streamID := getStreamID(i)

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -756,7 +756,10 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			name: "validate http methods",
 			// The purpose of this test is to validate that we are able to capture all http methods.
 			messageBuilder: func() [][]byte {
-				httpMethods = []string{http.MethodGet, http.MethodPost, http.MethodHead, http.MethodDelete, http.MethodPut, http.MethodPatch, http.MethodOptions}
+				httpMethods = []string{http.MethodGet, http.MethodPost, http.MethodHead, http.MethodDelete,
+					http.MethodPut, http.MethodPatch, http.MethodOptions, "TRACE", "CONNECT"}
+				// Currently, the methods TRACE and CONNECT are not supported by the http.Method package.
+				// Therefore, we mark those requests as incomplete and not expected to be captured.
 				framer := newFramer()
 				for i, method := range httpMethods {
 					streamID := getStreamID(i)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The PR introduces the support for methods that are not fully exist in the static table.

We're supporting the case of a method being passed as a literal header
instead of a fully indexed entry in the static table.

The PR creates a new struct status_code_t which covers the 2 options we have:

indexed_value - represents a fully indexed in the static table
literal - so we introduce is_huffman_encoded flag, length (which represents the string length of the method) and a buffer to save the raw value.
In the user mode we're converting the correct methods based on our options.

The PR decrease the `HTTP2_BATCH_SIZE` in order to support the method struct with in `http2_stream_t`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

While for the original purpose of gRPC monitoring the methods in the static table suffice, for HTTP2 monitoring (like an implicit upgrade of HTTPs connection) it is a gap, as there is not guarantee the methods are restricted to the list in the static table.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
