### PR TITLE
Gather experimental data about the single-binary Agent impact

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -18,7 +18,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.12.0
-    LADING_VERSION: 0.20.4
+    LADING_VERSION: 0.20.6
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the

--- a/docs/dev/agent_build.md
+++ b/docs/dev/agent_build.md
@@ -74,7 +74,7 @@ invoke agent.build --bundle process-agent --bundle security-agent
 To disable bundling entirely:
 
 ```
-invoke agent.build --bundle
+invoke agent.build --bundle agent
 ```
 
 One binary per Agent can still be built by using its own invoke task and passing the

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -79,7 +79,7 @@ build do
     command "inv -e rtloader.clean"
     command "inv -e rtloader.make --python-runtimes #{py_runtimes_arg} --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0 -I#{install_dir}/embedded/include\" -DCMAKE_C_FLAGS:=\"-I#{install_dir}/embedded/include\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER'", :env => env
     command "inv -e rtloader.install"
-    bundle_arg = bundled_agents ? bundled_agents.map { |k| "--bundle #{k}" }.join(" ") : "--bundle"
+    bundle_arg = bundled_agents ? bundled_agents.map { |k| "--bundle #{k}" }.join(" ") : "--bundle agent"
     command "inv -e agent.build --exclude-rtloader --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --rebuild --no-development --install-path=#{install_dir} --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded --flavor #{flavor_arg} #{bundle_arg}", env: env
   end
 


### PR DESCRIPTION
### What does this PR do?

This PR disables the build of the single-binary Agent, intention to drive the Regression Detector. See:

* https://app.datadoghq.com/notebook/7398088/single-agent-binary-the-single-machine-performance-data
* https://app.datadoghq.com/notebook/7409548/single-agent-binary-the-single-machine-performance-data-pt2

### Motivation

We want to understand the impact of single-binary Agent on runtime performance.

