### PR TITLE
[CWS][SEC-12495] Do not send auto-suppressed events

### DIFF
--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -142,11 +142,6 @@ func (ce *CustomEvent) GetActions() []*model.ActionTriggered {
 	return nil
 }
 
-// IsSuppressed returns true if the event is suppressed
-func (ce *CustomEvent) IsSuppressed() bool {
-	return false
-}
-
 // GetWorkloadID returns the workload id
 func (ce *CustomEvent) GetWorkloadID() string {
 	return ""

--- a/pkg/security/events/event.go
+++ b/pkg/security/events/event.go
@@ -46,7 +46,6 @@ type Event interface {
 	GetTags() []string
 	GetType() string
 	GetActions() []*model.ActionTriggered
-	IsSuppressed() bool
 }
 
 // EventSender defines an event sender

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -47,9 +47,6 @@ type CWSConsumer struct {
 	ruleEngine    *rulesmodule.RuleEngine
 	selfTester    *selftests.SelfTester
 	reloader      ReloaderInterface
-
-	eventSuppressionsLock  sync.Mutex
-	eventSuppressionsStats map[string]*int64
 }
 
 // NewCWSConsumer initializes the module with options
@@ -68,15 +65,14 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 		probe:        evm.Probe,
 		statsdClient: evm.StatsdClient,
 		// internals
-		ctx:                    ctx,
-		cancelFnc:              cancelFnc,
-		apiServer:              NewAPIServer(cfg, evm.Probe, evm.StatsdClient, selfTester),
-		rateLimiter:            events.NewRateLimiter(cfg, evm.StatsdClient),
-		sendStatsChan:          make(chan chan bool, 1),
-		grpcServer:             NewGRPCServer(family, address),
-		selfTester:             selfTester,
-		reloader:               NewReloader(),
-		eventSuppressionsStats: make(map[string]*int64),
+		ctx:           ctx,
+		cancelFnc:     cancelFnc,
+		apiServer:     NewAPIServer(cfg, evm.Probe, evm.StatsdClient, selfTester),
+		rateLimiter:   events.NewRateLimiter(cfg, evm.StatsdClient),
+		sendStatsChan: make(chan chan bool, 1),
+		grpcServer:    NewGRPCServer(family, address),
+		selfTester:    selfTester,
+		reloader:      NewReloader(),
 	}
 
 	// set sender
@@ -236,10 +232,6 @@ func (c *CWSConsumer) HandleCustomEvent(rule *rules.Rule, event *events.CustomEv
 
 // SendEvent sends an event to the backend after checking that the rate limiter allows it for the provided rule
 func (c *CWSConsumer) SendEvent(rule *rules.Rule, event events.Event, extTagsCb func() []string, service string) {
-	if event.IsSuppressed() {
-		c.countEventSuppression(rule.ID)
-	}
-
 	if c.rateLimiter.Allow(rule.ID, event) {
 		c.apiServer.SendEvent(rule, event, extTagsCb, service)
 	} else {
@@ -266,16 +258,11 @@ func (c *CWSConsumer) sendStats() {
 	if err := c.apiServer.SendStats(); err != nil {
 		seclog.Debugf("failed to send api server stats: %s", err)
 	}
-
-	c.eventSuppressionsLock.Lock()
-	for ruleID, counter := range c.eventSuppressionsStats {
-		value := *counter
-		if value > 0 {
-			*counter = 0
-			_ = c.statsdClient.Count(metrics.MetricRulesSuppressed, value, []string{fmt.Sprintf("rule_id:%s", ruleID)}, 1.0)
+	for ruleID, counter := range c.ruleEngine.AutoSuppressions.GetStats() {
+		if counter > 0 {
+			_ = c.statsdClient.Count(metrics.MetricRulesSuppressed, counter, []string{fmt.Sprintf("rule_id:%s", ruleID)}, 1.0)
 		}
 	}
-	c.eventSuppressionsLock.Unlock()
 }
 
 func (c *CWSConsumer) statsSender() {
@@ -300,13 +287,4 @@ func (c *CWSConsumer) statsSender() {
 // GetRuleEngine returns new current rule engine
 func (c *CWSConsumer) GetRuleEngine() *rulesmodule.RuleEngine {
 	return c.ruleEngine
-}
-
-func (c *CWSConsumer) countEventSuppression(ruleID string) {
-	c.eventSuppressionsLock.Lock()
-	defer c.eventSuppressionsLock.Unlock()
-	if _, ok := c.eventSuppressionsStats[ruleID]; !ok {
-		c.eventSuppressionsStats[ruleID] = new(int64)
-	}
-	*(c.eventSuppressionsStats[ruleID])++
 }

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -265,12 +265,10 @@ func (a *APIServer) GetConfig(_ context.Context, _ *api.GetConfigParams) (*api.S
 func (a *APIServer) SendEvent(rule *rules.Rule, e events.Event, extTagsCb func() []string, service string) {
 	var ruleActions []events.RuleActionContext
 
-	if !e.IsSuppressed() {
-		// report only kill action for now
-		for _, action := range e.GetActions() {
-			if action.Name == rules.KillAction {
-				ruleActions = append(ruleActions, events.RuleActionContext{Name: action.Name, Signal: action.Value})
-			}
+	// report only kill action for now
+	for _, action := range e.GetActions() {
+		if action.Name == rules.KillAction {
+			ruleActions = append(ruleActions, events.RuleActionContext{Name: action.Name, Signal: action.Value})
 		}
 	}
 

--- a/pkg/security/rules/autosuppression.go
+++ b/pkg/security/rules/autosuppression.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package rules holds rules related files
+package rules
+
+import (
+	"strconv"
+	"sync"
+
+	"go.uber.org/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+type EventsAutoSuppressions struct {
+	lock    sync.RWMutex
+	enabled bool
+	stats   map[string]*atomic.Int64
+}
+
+func (s *EventsAutoSuppressions) apply(ruleSet *rules.RuleSet) {
+	if !s.enabled {
+		return
+	}
+
+	newStats := make(map[string]*atomic.Int64)
+	for _, rule := range ruleSet.GetRules() {
+		if isAllowAutosuppressionRule(rule) {
+			newStats[rule.ID] = atomic.NewInt64(0)
+		}
+	}
+
+	s.lock.Lock()
+	s.stats = newStats
+	s.lock.Unlock()
+}
+
+func (s *EventsAutoSuppressions) inc(ruleID string) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	if stat, ok := s.stats[ruleID]; ok {
+		stat.Inc()
+	}
+}
+
+func (s *EventsAutoSuppressions) GetStats() map[string]int64 {
+	if !s.enabled {
+		return nil
+	}
+
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	stats := make(map[string]int64, len(s.stats))
+	for ruleID, stat := range s.stats {
+		stats[string(ruleID)] = stat.Swap(0)
+	}
+	return stats
+}
+
+func isAllowAutosuppressionRule(rule *rules.Rule) bool {
+	if val, ok := rule.Definition.GetTag("allow_autosuppression"); ok {
+		b, err := strconv.ParseBool(val)
+		return err == nil && b
+	}
+	return false
+}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -270,11 +270,6 @@ func (e *Event) GetActions() []*ActionTriggered {
 	return e.Actions
 }
 
-// IsSuppressed returns true if the event is suppressed
-func (e *Event) IsSuppressed() bool {
-	return e.Suppressed
-}
-
 // GetWorkloadID returns an ID that represents the workload
 func (e *Event) GetWorkloadID() string {
 	return e.SecurityProfileContext.Name


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Suppress events that are part of a security profile if the corresponding rule allows it and the `runtime_security_config.security_profile.auto_suppression.enabled` config parameter is set to true.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
