### PR TITLE
[windows] [cws] Make FIM processing configurable.

### DIFF
--- a/cmd/system-probe/config/adjust_security.go
+++ b/cmd/system-probe/config/adjust_security.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"runtime"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -30,7 +31,11 @@ func adjustSecurity(cfg config.Config) {
 
 	if cfg.GetBool(secNS("enabled")) {
 		// if runtime is enabled then we force fim
-		cfg.Set(secNS("fim_enabled"), true, model.SourceAgentRuntime)
+
+		// except, temporarily, for Windows
+		if runtime.GOOS != "windows" {
+			cfg.Set(secNS("fim_enabled"), true, model.SourceAgentRuntime)
+		}
 	} else {
 		// if runtime is disabled then we force disable activity dumps and security profiles
 		cfg.Set(secNS("activity_dump.enabled"), false, model.SourceAgentRuntime)

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -71,6 +71,16 @@ func (p *WindowsProbe) Init() error {
 		}
 		p.pm = pm
 	}
+	return p.initEtwFIM()
+}
+
+func (p *WindowsProbe) initEtwFIM() error {
+
+	if !p.config.RuntimeSecurity.FIMEnabled {
+		return nil
+	}
+	// log at Warning right now because it's not expected to be enabled
+	log.Warnf("Enabling FIM processing")
 
 	etwSessionName := "SystemProbeFIM_ETW"
 	etwcomp, err := etwimpl.NewEtw()
@@ -169,8 +179,10 @@ func (p *WindowsProbe) Setup() error {
 
 // Stop the probe
 func (p *WindowsProbe) Stop() {
-	_ = p.fimSession.StopTracing()
-	p.fimwg.Wait()
+	if p.fimSession != nil {
+		_ = p.fimSession.StopTracing()
+		p.fimwg.Wait()
+	}
 	if p.pm != nil {
 		p.pm.Stop()
 	}
@@ -264,12 +276,16 @@ func (p *WindowsProbe) setupEtw() error {
 func (p *WindowsProbe) Start() error {
 
 	log.Infof("Windows probe started")
-	p.fimwg.Add(1)
-	go func() {
-		defer p.fimwg.Done()
-		err := p.setupEtw()
-		log.Infof("Done StartTracing %v", err)
-	}()
+	if p.fimSession != nil {
+		// log at Warning right now because it's not expected to be enabled
+		log.Warnf("Enabling FIM processing")
+		p.fimwg.Add(1)
+		go func() {
+			defer p.fimwg.Done()
+			err := p.setupEtw()
+			log.Infof("Done StartTracing %v", err)
+		}()
+	}
 	if p.pm == nil {
 		return nil
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -724,6 +724,7 @@ func genTestConfigs(cfgDir string, opts testOpts) (*emconfig.Config, *secconfig.
 		"RuntimeSecurityEnabled":                     runtimeSecurityEnabled,
 		"SBOMEnabled":                                opts.enableSBOM,
 		"EBPFLessEnabled":                            ebpfLessEnabled,
+		"FIMEnabled":                                 opts.enableFIM,  // should only be enabled/disabled on windows
 	}); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -113,6 +113,7 @@ runtime_security_config:
     enabled: false
   sbom:
     enabled: {{ .SBOMEnabled }}
+  fim_enabled: {{ .FIMEnabled }}
   activity_dump:
     enabled: {{ .EnableActivityDump }}
 {{if .EnableActivityDump}}

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -48,7 +48,6 @@ type testOpts struct {
 	preStartCallback                           func(test *testModule)
 	tagsResolver                               tags.Resolver
 	snapshotRuleMatchHandler                   func(*testModule, *model.Event, *rules.Rule)
-	enableEBPFLess                             bool
 	enableFIM                                  bool // only valid on windows
 }
 

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -48,6 +48,8 @@ type testOpts struct {
 	preStartCallback                           func(test *testModule)
 	tagsResolver                               tags.Resolver
 	snapshotRuleMatchHandler                   func(*testModule, *model.Event, *rules.Rule)
+	enableEBPFLess                             bool
+	enableFIM                                  bool // only valid on windows
 }
 
 type dynamicTestOpts struct {


### PR DESCRIPTION
For current release, make FIM processing configurable, and disabled by default.

### Motivation

disable feature for initial release

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Install agent.
Enable CWS
on default config, note that FIM is not enabled.

Enable FIM
```
runtime_security_config:
  fim_enabled: true
  ```
  
Note warning level message in log that it's enabled.

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
