### PR TITLE
[windows] [CWS] Fix CWS tests

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -47,36 +46,68 @@ func teardownTestProbe(wp *WindowsProbe) {
 	// do not call Close(), as that expects the driver to be loaded.
 }
 
-func (p *WindowsProbe) runTestEtwFile(started chan struct{}, ch chan interface{}) error {
+type etwTester struct {
+	etwStarted    chan struct{}
+	loopStarted   chan struct{}
+	stopLoop      chan struct{}
+	loopExited    chan struct{}
+	notify        chan interface{}
+	p             *WindowsProbe
+	notifications []interface{}
+}
+
+func createEtwTester(p *WindowsProbe) *etwTester {
+	return &etwTester{
+		etwStarted:    make(chan struct{}),
+		loopStarted:   make(chan struct{}),
+		stopLoop:      make(chan struct{}),
+		loopExited:    make(chan struct{}),
+		notify:        make(chan interface{}, 20),
+		p:             p,
+		notifications: make([]interface{}, 0),
+	}
+}
+func (et *etwTester) runTestEtwFile() error {
 
 	var once sync.Once
 	mypid := os.Getpid()
-	err := p.fimSession.StartTracing(func(e *etw.DDEventRecord) {
+	err := et.p.fimSession.StartTracing(func(e *etw.DDEventRecord) {
 		/*
 			 	* this works because we're registered on the whole system.  Therefore, we'll get
 			 	* some file or registry callback events from other processes we're not interested in.
 				*
 				* so sooner or later we'll get one.  If we don't, we'll deadlock in the test init routine below
 		*/
-		once.Do(func() { started <- struct{}{} })
+		once.Do(func() {
+			close(et.etwStarted)
+		})
+
 		// since this is for testing, skip any notification not from our pid
 		if e.EventHeader.ProcessID != uint32(mypid) {
 			return
 		}
 		switch e.EventHeader.ProviderID {
-		case etw.DDGUID(p.fileguid):
+		case etw.DDGUID(et.p.fileguid):
 			switch e.EventHeader.EventDescriptor.ID {
 			case idCreate:
-				if ca, err := parseCreateArgs(e); err == nil {
-					fmt.Printf("Received idCreate event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
+				if ca, err := parseCreateHandleArgs(e); err == nil {
+					//fmt.Printf("Received idCreate event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
+					select {
+					case et.notify <- ca:
+						// message sent
+					default:
+						// message dropped.  Which is OK.  In the test code, we want to leave the receive loop
+						// running, but only catch messages when we're expecting them
+						fmt.Printf("Dropped message\n")
+					}
 				}
 
 			case idCreateNewFile:
 				//fmt.Printf("Received event %d for PID %d\n", e.EventHeader.EventDescriptor.ID, e.EventHeader.ProcessID)
-				if ca, err := parseCreateArgs(e); err == nil {
-					fmt.Printf("Received NewFile event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
+				if ca, err := parseCreateNewFileArgs(e); err == nil {
+					//fmt.Printf("Received NewFile event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
 					select {
-					case ch <- ca:
+					case et.notify <- ca:
 						// message sent
 					default:
 						// message dropped.  Which is OK.  In the test code, we want to leave the receive loop
@@ -85,14 +116,45 @@ func (p *WindowsProbe) runTestEtwFile(started chan struct{}, ch chan interface{}
 					}
 				}
 			case idCleanup:
-				fallthrough
-			case idClose:
-				fallthrough
-			case idFlush:
-				// don't fall through
 				if ca, err := parseCleanupArgs(e); err == nil {
-					log.Infof("got id %v args %s", e.EventHeader.EventDescriptor.ID, ca.string())
-					delete(filePathResolver, ca.fileObject)
+					//fmt.Printf("Received Cleanup event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
+					select {
+					case et.notify <- ca:
+						// message sent
+					default:
+						// message dropped.  Which is OK.  In the test code, we want to leave the receive loop
+						// running, but only catch messages when we're expecting them
+						fmt.Printf("Dropped message\n")
+					}
+				}
+
+			case idClose:
+				if ca, err := parseCloseArgs(e); err == nil {
+					//fmt.Printf("Received Close event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
+					select {
+					case et.notify <- ca:
+						// message sent
+					default:
+						// message dropped.  Which is OK.  In the test code, we want to leave the receive loop
+						// running, but only catch messages when we're expecting them
+						fmt.Printf("Dropped message\n")
+					}
+					if e.EventHeader.EventDescriptor.ID == idClose {
+						delete(filePathResolver, ca.fileObject)
+					}
+				}
+			case idFlush:
+				if fa, err := parseFlushArgs(e); err == nil {
+					//fmt.Printf("got id %v args %s", e.EventHeader.EventDescriptor.ID, fa.string())
+					select {
+					case et.notify <- fa:
+						// message sent
+					default:
+						// message dropped.  Which is OK.  In the test code, we want to leave the receive loop
+						// running, but only catch messages when we're expecting them
+						fmt.Printf("Dropped message\n")
+					}
+
 				}
 			case idSetInformation:
 				fallthrough
@@ -133,90 +195,203 @@ func isSameFile(drive, device string) bool {
 	return strings.EqualFold(cmpstr, drive)
 
 }
-func TestETWFileNotifications(t *testing.T) {
-	//p := runtime.GOMAXPROCS(0)
-	//fmt.Printf("maxprocs is %d\n", p)
-	//runtime.GOMAXPROCS(8)
-	//os.Getpid()
-	wp, err := createTestProbe()
-	assert.NoError(t, err)
-	assert.NotNil(t, wp)
-	defer teardownTestProbe(wp)
 
-	loopstarted := make(chan struct{})
-	etwstarted := make(chan struct{})
-	endloop := make(chan struct{})
-	notifications := make(chan interface{})
-	wp.fimwg.Add(1)
-	go func() {
-		defer wp.fimwg.Done()
-		fmt.Printf("calling etw\n")
-		err := wp.runTestEtwFile(etwstarted, notifications)
-		assert.NoError(t, err)
+func processUntilClose(t *testing.T, et *etwTester) {
+
+	defer func() {
+		et.loopExited <- struct{}{}
 	}()
+	et.loopStarted <- struct{}{}
+	for {
+		select {
+		case <-et.stopLoop:
+			return
 
-	//var file *os.File
+		case n := <-et.notify:
+			et.notifications = append(et.notifications, n)
+			switch n.(type) {
+			case *closeArgs:
+				return
+			}
+		}
+	}
 
-	//t.Run("testCreateFile", func(t *testing.T) {
+}
 
-	var notified atomic.Bool
+func stopLoop(et *etwTester, wg *sync.WaitGroup) {
+	select {
+	case et.stopLoop <- struct{}{}:
 
-	ex, err := os.Executable()
-	require.NoError(t, err, "could not get executable path")
-	testfilename := ex + ".testfile"
+	default:
+		// do nothing
+	}
+
+	wg.Wait()
+
+	// do this little dance.  Once the wg is stopped, clear out the channel.
+	// because the stopLoop above may have occurred after the loop exited,
+	// and we want the channel clean for the next execution
+	select {
+	case <-et.stopLoop:
+		break
+	default:
+		// we just want to poll and remove one if there is one
+	}
+
+}
+
+// will leave file left over for use in future tests.
+func testSimpleCreate(t *testing.T, et *etwTester, testfilename string) {
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		processUntilClose(t, et)
+	}()
+	// wait till we're sure the listening loop is running
+	<-et.loopStarted
+
+	f, err := os.Create(testfilename)
+	assert.NoError(t, err)
+	if err == nil {
+		// don't remove as it will be used in subsequent test
+		//defer os.Remove(testfilename)
+	}
+	f.Close()
+	assert.Eventually(t, func() bool {
+		select {
+		case <-et.loopExited:
+			return true
+		}
+		return false
+	}, 4*time.Second, 250*time.Millisecond, "did not get notification")
+
+	stopLoop(et, &wg)
+
+	// now walk the list of notifications.
+
+	// expect to see in this order
+	// 12 (idCreate)
+	// 30 (createNewFile)
+	// 13 (cleanup)
+	// 14 (close)
+
+	assert.Equal(t, 4, len(et.notifications), "expected 4 notifications, got %d", len(et.notifications))
+
+	if c, ok := et.notifications[0].(*createHandleArgs); ok {
+		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
+	} else {
+		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
+	}
+
+	if cf, ok := et.notifications[1].(*createNewFileArgs); ok {
+		assert.True(t, isSameFile(testfilename, cf.fileName), "expected %s, got %s", testfilename, cf.fileName)
+	} else {
+		t.Errorf("expected createNewFileArgs, got %T", et.notifications[1])
+	}
+
+	if cu, ok := et.notifications[2].(*cleanupArgs); ok {
+		assert.True(t, isSameFile(testfilename, cu.fileName), "expected %s, got %s", testfilename, cu.fileName)
+	} else {
+		t.Errorf("expected cleanupArgs, got %T", et.notifications[2])
+	}
+
+	if cl, ok := et.notifications[3].(*closeArgs); ok {
+		assert.True(t, isSameFile(testfilename, cl.fileName), "expected %s, got %s", testfilename, cl.fileName)
+	} else {
+		t.Errorf("expected closeArgs, got %T", et.notifications[3])
+	}
+	et.notifications = et.notifications[:0]
+}
+
+func testFileOpen(t *testing.T, et *etwTester, testfilename string) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// listen for the notifications
-		loopstarted <- struct{}{}
-		for {
-			select {
-			case <-endloop:
-				return
-
-			case n := <-notifications:
-				switch n.(type) {
-				case *createArgs:
-					ca := n.(*createArgs)
-					assert.NotNil(t, ca)
-
-					if !isSameFile(testfilename, ca.fileName) {
-						continue
-					}
-					notified.Store(true)
-					return
-				}
-			}
-		}
+		processUntilClose(t, et)
 	}()
 	// wait till we're sure the listening loop is running
-	<-loopstarted
+	<-et.loopStarted
+
+	h, err := windows.CreateFile(windows.StringToUTF16Ptr(testfilename), windows.GENERIC_READ, windows.FILE_SHARE_READ, nil, windows.OPEN_EXISTING, 0, 0)
+	require.NoError(t, err, "could not open file")
+	assert.NotEqual(t, h, windows.InvalidHandle, "could not open file")
+	windows.CloseHandle(h)
+
+	assert.Eventually(t, func() bool {
+		select {
+		case <-et.loopExited:
+			return true
+		}
+		return false
+	}, 4*time.Second, 250*time.Millisecond, "did not get notification")
+
+	stopLoop(et, &wg)
+
+	// we expect a handle create (12), a cleanup and a close.
+	assert.Equal(t, 3, len(et.notifications), "expected 4 notifications, got %d", len(et.notifications))
+
+	if c, ok := et.notifications[0].(*createHandleArgs); ok {
+		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
+	} else {
+		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
+	}
+
+	if cu, ok := et.notifications[1].(*cleanupArgs); ok {
+		assert.True(t, isSameFile(testfilename, cu.fileName), "expected %s, got %s", testfilename, cu.fileName)
+	} else {
+		t.Errorf("expected cleanupArgs, got %T", et.notifications[2])
+	}
+
+	if cl, ok := et.notifications[2].(*closeArgs); ok {
+		assert.True(t, isSameFile(testfilename, cl.fileName), "expected %s, got %s", testfilename, cl.fileName)
+	} else {
+		t.Errorf("expected closeArgs, got %T", et.notifications[3])
+	}
+	et.notifications = et.notifications[:0]
+
+}
+func TestETWFileNotifications(t *testing.T) {
+	ex, err := os.Executable()
+	require.NoError(t, err, "could not get executable path")
+	testfilename := ex + ".testfile"
+
+	wp, err := createTestProbe()
+	require.NoError(t, err)
+	require.NotNil(t, wp)
+
+	// teardownTestProe calls the stop function on etw, which will
+	// in turn wait on wp.fimgw
+	defer teardownTestProbe(wp)
+
+	et := createEtwTester(wp)
+
+	wp.fimwg.Add(1)
+	go func() {
+		defer wp.fimwg.Done()
+		err := et.runTestEtwFile()
+		assert.NoError(t, err)
+	}()
 
 	// wait until we're sure that the ETW listener is up and running.
 	// as noted above, this _could_ cause an infinite deadlock if no notifications are received.
 	// but, since we're getting the notifications from the entire system, we should be getting
 	// a steady stream as soon as it's fired up.
-	<-etwstarted
+	<-et.etwStarted
 
-	_, err = os.Create(testfilename)
-	assert.NoError(t, err)
-	if err == nil {
-		defer os.Remove(testfilename)
-	}
+	t.Run("testSimpleCreate", func(t *testing.T) {
+		testSimpleCreate(t, et, testfilename)
+	})
 
-	assert.Eventually(t, func() bool {
-		return notified.Load()
-	}, 4*time.Second, 250*time.Millisecond, "did not get notification")
-
-	select {
-	case endloop <- struct{}{}:
-		// message sent
-	default:
-		// message dropped.  Which is OK.  In the test code, we want to leave the receive loop
-		// running, but only catch messages when we're expecting them
-	}
-	wg.Wait()
-	//})
+	require.Equal(t, 0, len(et.notifications), "expected 0 notifications, got %d", len(et.notifications))
+	// note the testFileOpen expects that the file is already created,
+	// and left over from testSimpleCreate
+	t.Run("testFileOpen", func(t *testing.T) {
+		testFileOpen(t, et, testfilename)
+	})
+	assert.NoError(t, os.Remove(testfilename), "failed to remove")
 }

--- a/pkg/security/probe/probe_kernel_reg_windows_test.go
+++ b/pkg/security/probe/probe_kernel_reg_windows_test.go
@@ -11,14 +11,15 @@ package probe
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/etw"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
@@ -27,21 +28,32 @@ import (
 // createTestProbe and teardownTestProbe are implemented in the file test, but
 // the same one can be used.
 
-func (p *WindowsProbe) runTestEtwRegistry(ch chan interface{}) error {
+func (et *etwTester) runTestEtwRegistry() error {
+
+	var once sync.Once
 	mypid := os.Getpid()
-	err := p.fimSession.StartTracing(func(e *etw.DDEventRecord) {
+	err := et.p.fimSession.StartTracing(func(e *etw.DDEventRecord) {
+		/*
+			 	* this works because we're registered on the whole system.  Therefore, we'll get
+			 	* some file or registry callback events from other processes we're not interested in.
+				*
+				* so sooner or later we'll get one.  If we don't, we'll deadlock in the test init routine below
+		*/
+		once.Do(func() {
+			close(et.etwStarted)
+		})
 
 		// since this is for testing, skip any notification not from our pid
 		if e.EventHeader.ProcessID != uint32(mypid) {
 			return
 		}
 		switch e.EventHeader.ProviderID {
-		case etw.DDGUID(p.regguid):
+		case etw.DDGUID(et.p.regguid):
 			switch e.EventHeader.EventDescriptor.ID {
 			case idRegCreateKey:
 				if cka, err := parseCreateRegistryKey(e); err == nil {
 					select {
-					case ch <- cka:
+					case et.notify <- cka:
 						// message sent
 					default:
 						// message dropped.  Which is OK.  In the test code, we want to leave the receive loop
@@ -86,70 +98,89 @@ func (p *WindowsProbe) runTestEtwRegistry(ch chan interface{}) error {
 	return err
 }
 
+func processUntilRegOpen(t *testing.T, et *etwTester) {
+
+	defer func() {
+		et.loopExited <- struct{}{}
+	}()
+	et.loopStarted <- struct{}{}
+	for {
+		select {
+		case <-et.stopLoop:
+			return
+
+		case n := <-et.notify:
+			et.notifications = append(et.notifications, n)
+			switch n.(type) {
+			case *createKeyArgs:
+				return
+			}
+		}
+	}
+
+}
 func TestETWRegistryNotifications(t *testing.T) {
-	os.Getpid()
 	wp, err := createTestProbe()
-	assert.NoError(t, err)
-	assert.NotNil(t, wp)
+	require.NoError(t, err)
+	require.NotNil(t, wp)
+
+	// get the current user sid, since we're going to use the current user registry.
+	u, err := user.Current()
+	require.NoError(t, err)
+
+	sidstr := u.Uid
+
+	// teardownTestProe calls the stop function on etw, which will
+	// in turn wait on wp.fimgw
 	defer teardownTestProbe(wp)
 
-	loopstarted := make(chan struct{})
-	endloop := make(chan struct{})
-	notifications := make(chan interface{})
+	et := createEtwTester(wp)
+
 	wp.fimwg.Add(1)
 	go func() {
 		defer wp.fimwg.Done()
-		err := wp.runTestEtwRegistry(notifications)
+		err := et.runTestEtwRegistry()
 		assert.NoError(t, err)
 	}()
-
-	//t.Run("testCreateFile", func(t *testing.T) {
-
-	var notified atomic.Bool
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// listen for the notifications
-		loopstarted <- struct{}{}
-		for {
-			select {
-			case <-endloop:
-				return
-
-			case n := <-notifications:
-				switch n.(type) {
-				case *createKeyArgs:
-					cka := n.(*createKeyArgs)
-					assert.NotNil(t, cka)
-
-					notified.Store(true)
-					return
-				}
-			}
-		}
+		processUntilRegOpen(t, et)
 	}()
-	// wait till we're sure the listening loop is running
-	<-loopstarted
 
+	// wait until we're sure that the ETW listener is up and running.
+	// as noted above, this _could_ cause an infinite deadlock if no notifications are received.
+	// but, since we're getting the notifications from the entire system, we should be getting
+	// a steady stream as soon as it's fired up.
+	<-et.etwStarted
+	<-et.loopStarted
+
+	keyname := "Software\\Test"
+	expected := "\\REGISTRY\\USER\\" + sidstr + "\\" + keyname
 	// create the key
-	key, _, err := registry.CreateKey(windows.HKEY_CURRENT_USER, "Software\\Test", windows.KEY_READ|windows.KEY_WRITE)
+	key, _, err := registry.CreateKey(windows.HKEY_CURRENT_USER, keyname, windows.KEY_READ|windows.KEY_WRITE)
 	assert.NoError(t, err)
 	if err == nil {
 		defer key.Close()
 	}
-	assert.Eventually(t, func() bool {
-		return notified.Load()
-	}, 2*time.Second, 250*time.Millisecond, "did not get notification")
 
-	select {
-	case endloop <- struct{}{}:
-		// message sent
-	default:
-		// message dropped.  Which is OK.  In the test code, we want to leave the receive loop
-		// running, but only catch messages when we're expecting them
+	assert.Eventually(t, func() bool {
+		select {
+		case <-et.loopExited:
+			return true
+		}
+		return false
+	}, 4*time.Second, 250*time.Millisecond, "did not get notification")
+
+	stopLoop(et, &wg)
+
+	assert.Equal(t, 1, len(et.notifications), "expected 1 notifications, got %d", len(et.notifications))
+
+	if c, ok := et.notifications[0].(*createKeyArgs); ok {
+		assert.Equal(t, expected, c.computedFullPath, "expected %s, got %s", expected, c.computedFullPath)
+	} else {
+		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
 	}
-	wg.Wait()
-	//})
 }

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -185,10 +185,13 @@ func (p *WindowsProbe) setupEtw() error {
 		case etw.DDGUID(p.fileguid):
 			switch e.EventHeader.EventDescriptor.ID {
 			case idCreate:
-			case idCreateNewFile:
-				if ca, err := parseCreateArgs(e); err == nil {
-					log.Tracef("Got create/create new file on file %s", ca.string())
+				if ca, err := parseCreateHandleArgs(e); err == nil {
+					log.Tracef("Received idCreate event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
+				}
 
+			case idCreateNewFile:
+				if ca, err := parseCreateNewFileArgs(e); err == nil {
+					log.Tracef("Received NewFile event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
 				}
 			case idCleanup:
 				fallthrough


### PR DESCRIPTION
Broken tests inadvertently checked in due to mistaken merge.

### What does this PR do?

Fixes broken tests checked in with #21698 

That PR included half working tests inadvertently


- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
