### PR TITLE
test/new-e2e/tests/apm: fix flaky TestVMFakeintakeSuiteUDS

### DIFF
--- a/test/new-e2e/tests/apm/tests.go
+++ b/test/new-e2e/tests/apm/tests.go
@@ -14,23 +14,22 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func testBasicTraces(c *assert.CollectT, service string, intake *components.FakeIntake, agent agentclient.Agent) {
 	traces, err := intake.Client().GetTraces()
-	require.NoError(c, err)
-	require.NotEmpty(c, traces)
+	assert.NoError(c, err)
+	assert.NotEmpty(c, traces)
 
 	trace := traces[0]
 	assert.Equal(c, agent.Hostname(), trace.HostName)
 	assert.Equal(c, "none", trace.Env)
-	require.NotEmpty(c, trace.TracerPayloads)
+	assert.NotEmpty(c, trace.TracerPayloads)
 
 	tp := trace.TracerPayloads[0]
 	assert.Equal(c, "go", tp.LanguageName)
-	require.NotEmpty(c, tp.Chunks)
-	require.NotEmpty(c, tp.Chunks[0].Spans)
+	assert.NotEmpty(c, tp.Chunks)
+	assert.NotEmpty(c, tp.Chunks[0].Spans)
 	spans := tp.Chunks[0].Spans
 	for _, sp := range spans {
 		assert.Equal(c, service, sp.Service)

--- a/test/new-e2e/tests/apm/tests.go
+++ b/test/new-e2e/tests/apm/tests.go
@@ -19,27 +19,27 @@ import (
 func testBasicTraces(c *assert.CollectT, service string, intake *components.FakeIntake, agent agentclient.Agent) {
 	traces, err := intake.Client().GetTraces()
 	assert.NoError(c, err)
-	assert.NotEmpty(c, traces)
+	if assert.NotEmpty(c, traces) {
+		trace := traces[0]
+		assert.Equal(c, agent.Hostname(), trace.HostName)
+		assert.Equal(c, "none", trace.Env)
+		assert.NotEmpty(c, trace.TracerPayloads)
 
-	trace := traces[0]
-	assert.Equal(c, agent.Hostname(), trace.HostName)
-	assert.Equal(c, "none", trace.Env)
-	assert.NotEmpty(c, trace.TracerPayloads)
-
-	tp := trace.TracerPayloads[0]
-	assert.Equal(c, "go", tp.LanguageName)
-	assert.NotEmpty(c, tp.Chunks)
-	assert.NotEmpty(c, tp.Chunks[0].Spans)
-	spans := tp.Chunks[0].Spans
-	for _, sp := range spans {
-		assert.Equal(c, service, sp.Service)
-		assert.Contains(c, sp.Name, "tracegen")
-		assert.Contains(c, sp.Meta, "language")
-		assert.Equal(c, "go", sp.Meta["language"])
-		assert.Contains(c, sp.Metrics, "_sampling_priority_v1")
-		if sp.ParentID == 0 {
-			assert.Equal(c, float64(1), sp.Metrics["_dd.top_level"])
-			assert.Equal(c, float64(1), sp.Metrics["_top_level"])
+		tp := trace.TracerPayloads[0]
+		assert.Equal(c, "go", tp.LanguageName)
+		assert.NotEmpty(c, tp.Chunks)
+		assert.NotEmpty(c, tp.Chunks[0].Spans)
+		spans := tp.Chunks[0].Spans
+		for _, sp := range spans {
+			assert.Equal(c, service, sp.Service)
+			assert.Contains(c, sp.Name, "tracegen")
+			assert.Contains(c, sp.Meta, "language")
+			assert.Equal(c, "go", sp.Meta["language"])
+			assert.Contains(c, sp.Metrics, "_sampling_priority_v1")
+			if sp.ParentID == 0 {
+				assert.Equal(c, float64(1), sp.Metrics["_dd.top_level"])
+				assert.Equal(c, float64(1), sp.Metrics["_top_level"])
+			}
 		}
 	}
 }

--- a/test/new-e2e/tests/apm/tests.go
+++ b/test/new-e2e/tests/apm/tests.go
@@ -19,27 +19,33 @@ import (
 func testBasicTraces(c *assert.CollectT, service string, intake *components.FakeIntake, agent agentclient.Agent) {
 	traces, err := intake.Client().GetTraces()
 	assert.NoError(c, err)
-	if assert.NotEmpty(c, traces) {
-		trace := traces[0]
-		assert.Equal(c, agent.Hostname(), trace.HostName)
-		assert.Equal(c, "none", trace.Env)
-		assert.NotEmpty(c, trace.TracerPayloads)
-
-		tp := trace.TracerPayloads[0]
-		assert.Equal(c, "go", tp.LanguageName)
-		assert.NotEmpty(c, tp.Chunks)
-		assert.NotEmpty(c, tp.Chunks[0].Spans)
-		spans := tp.Chunks[0].Spans
-		for _, sp := range spans {
-			assert.Equal(c, service, sp.Service)
-			assert.Contains(c, sp.Name, "tracegen")
-			assert.Contains(c, sp.Meta, "language")
-			assert.Equal(c, "go", sp.Meta["language"])
-			assert.Contains(c, sp.Metrics, "_sampling_priority_v1")
-			if sp.ParentID == 0 {
-				assert.Equal(c, float64(1), sp.Metrics["_dd.top_level"])
-				assert.Equal(c, float64(1), sp.Metrics["_top_level"])
-			}
+	if !assert.NotEmpty(c, traces) {
+		return
+	}
+	trace := traces[0]
+	assert.Equal(c, agent.Hostname(), trace.HostName)
+	assert.Equal(c, "none", trace.Env)
+	if !assert.NotEmpty(c, trace.TracerPayloads) {
+		return
+	}
+	tp := trace.TracerPayloads[0]
+	assert.Equal(c, "go", tp.LanguageName)
+	if !assert.NotEmpty(c, tp.Chunks) {
+		return
+	}
+	if !assert.NotEmpty(c, tp.Chunks[0].Spans) {
+		return
+	}
+	spans := tp.Chunks[0].Spans
+	for _, sp := range spans {
+		assert.Equal(c, service, sp.Service)
+		assert.Contains(c, sp.Name, "tracegen")
+		assert.Contains(c, sp.Meta, "language")
+		assert.Equal(c, "go", sp.Meta["language"])
+		assert.Contains(c, sp.Metrics, "_sampling_priority_v1")
+		if sp.ParentID == 0 {
+			assert.Equal(c, float64(1), sp.Metrics["_dd.top_level"])
+			assert.Equal(c, float64(1), sp.Metrics["_top_level"])
 		}
 	}
 }

--- a/test/new-e2e/tests/apm/vm_test.go
+++ b/test/new-e2e/tests/apm/vm_test.go
@@ -85,7 +85,8 @@ func (s *VMFakeintakeSuite) TestTraceAgentMetrics() {
 	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 	s.Require().NoError(err)
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		s.T().Log(s.Env().RemoteHost.MustExecute("sudo systemctl status datadog-agent-trace"))
+		status, _ := s.Env().RemoteHost.Execute("sudo systemctl status datadog-agent-trace")
+		s.T().Log(status)
 		testTraceAgentMetrics(s.T(), c, s.Env().FakeIntake)
 		s.T().Log(s.Env().RemoteHost.MustExecute("sudo journalctl -n1000 -xu datadog-agent-trace"))
 	}, 3*time.Minute, 10*time.Second, "Failed finding datadog.trace_agent.* metrics")
@@ -109,7 +110,8 @@ func (s *VMFakeintakeSuite) TestTracesHaveContainerTag() {
 	defer shutdown()
 
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		s.T().Log(s.Env().RemoteHost.MustExecute("sudo systemctl status datadog-agent-trace"))
+		status, _ := s.Env().RemoteHost.Execute("sudo systemctl status datadog-agent-trace")
+		s.T().Log(status)
 		testTracesHaveContainerTag(s.T(), c, service, s.Env().FakeIntake)
 		s.T().Log(s.Env().RemoteHost.MustExecute("sudo journalctl -n1000 -xu datadog-agent-trace"))
 	}, 3*time.Minute, 10*time.Second, "Failed finding traces with container tags")
@@ -127,7 +129,8 @@ func (s *VMFakeintakeSuite) TestStatsForService() {
 	defer shutdown()
 
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		s.T().Log(s.Env().RemoteHost.MustExecute("sudo systemctl status datadog-agent-trace"))
+		status, _ := s.Env().RemoteHost.Execute("sudo systemctl status datadog-agent-trace")
+		s.T().Log(status)
 		testStatsForService(s.T(), c, service, s.Env().FakeIntake)
 		s.T().Log(s.Env().RemoteHost.MustExecute("sudo journalctl -n1000 -xu datadog-agent-trace"))
 	}, 3*time.Minute, 10*time.Second, "Failed finding stats")
@@ -146,7 +149,8 @@ func (s *VMFakeintakeSuite) TestBasicTrace() {
 
 	s.T().Log("Waiting for traces.")
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		s.T().Log(s.Env().RemoteHost.MustExecute("sudo systemctl status datadog-agent-trace"))
+		status, _ := s.Env().RemoteHost.Execute("sudo systemctl status datadog-agent-trace")
+		s.T().Log(status)
 		testBasicTraces(c, service, s.Env().FakeIntake, s.Env().Agent.Client)
 		s.T().Log(s.Env().RemoteHost.MustExecute("sudo journalctl -n1000 -xu datadog-agent-trace"))
 	}, 3*time.Minute, 10*time.Second, "Failed to find traces with basic properties")

--- a/test/new-e2e/tests/apm/vm_test.go
+++ b/test/new-e2e/tests/apm/vm_test.go
@@ -63,8 +63,7 @@ apm_config.enabled: true
 	e2e.Run(t, &VMFakeintakeSuite{transport: tcp}, options...)
 }
 
-func (s *VMFakeintakeSuite) SetupSuite() {
-	s.BaseSuite.SetupSuite()
+func fixAgent(s *VMFakeintakeSuite) {
 	h := s.Env().RemoteHost
 	// Agent must be in the docker group to be able to open and
 	// read container info from the docker socket.
@@ -84,6 +83,7 @@ func (s *VMFakeintakeSuite) SetupSuite() {
 func (s *VMFakeintakeSuite) TestTraceAgentMetrics() {
 	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 	s.Require().NoError(err)
+	fixAgent(s)
 	s.EventuallyWithTf(func(c *assert.CollectT) {
 		status, _ := s.Env().RemoteHost.Execute("sudo systemctl status datadog-agent-trace")
 		s.T().Log(status)
@@ -101,6 +101,7 @@ func (s *VMFakeintakeSuite) TestTracesHaveContainerTag() {
 
 	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 	s.Require().NoError(err)
+	fixAgent(s)
 
 	service := fmt.Sprintf("tracegen-container-tag-%s", s.transport)
 
@@ -120,6 +121,7 @@ func (s *VMFakeintakeSuite) TestTracesHaveContainerTag() {
 func (s *VMFakeintakeSuite) TestStatsForService() {
 	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 	s.Require().NoError(err)
+	fixAgent(s)
 
 	service := fmt.Sprintf("tracegen-stats-%s", s.transport)
 
@@ -139,6 +141,7 @@ func (s *VMFakeintakeSuite) TestStatsForService() {
 func (s *VMFakeintakeSuite) TestBasicTrace() {
 	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 	s.Require().NoError(err)
+	fixAgent(s)
 
 	service := fmt.Sprintf("tracegen-basic-trace-%s", s.transport)
 

--- a/test/new-e2e/tests/apm/vm_test.go
+++ b/test/new-e2e/tests/apm/vm_test.go
@@ -34,9 +34,6 @@ func vmSuiteOpts(tr transport, opts ...awshost.ProvisionerOption) []e2e.SuiteOpt
 
 // TestVMFakeintakeSuiteUDS runs basic Trace Agent tests over the UDS transport
 func TestVMFakeintakeSuiteUDS(t *testing.T) {
-	// FIXME: fix flakiness reaching the agent then enable the test
-	t.Skip("Skipping flaky test - incident-25117 AIT-9390")
-
 	cfg := `
 apm_config.enabled: true
 apm_config.receiver_socket: /var/run/datadog/apm.socket
@@ -51,9 +48,6 @@ apm_config.receiver_socket: /var/run/datadog/apm.socket
 
 // TestVMFakeintakeSuiteTCP runs basic Trace Agent tests over the TCP transport
 func TestVMFakeintakeSuiteTCP(t *testing.T) {
-	// FIXME: fix flakiness reaching the agent then enable the test
-	t.Skip("Skipping flaky test - incident-25117 AIT-9390")
-
 	cfg := `
 apm_config.enabled: true
 `


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

AIT-9736

Fixes flaky TestVMFakeintakeSuiteUDS.

In TestVMFakeintakeSuiteUDS the agent was crashlooping after installation since the socket directory /var/run/datadog didn’t exist the moment the agent started. After that, systemd can refuse to restart the agent because of a restart backoff. This results in persisting the failure even after the socket dir /var/run/datadog is created in SetupSuite.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Example failure we're fixing https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/426504501
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
