### PR TITLE
[CWS] optimization to SECL macro store

### DIFF
--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -8,37 +8,41 @@ package eval
 
 // MacroStore represents a store of SECL Macros
 type MacroStore struct {
-	Macros map[MacroID]*Macro
+	macros []*Macro
 }
 
 // Add adds a macro
 func (s *MacroStore) Add(macro *Macro) *MacroStore {
-	if s.Macros == nil {
-		s.Macros = make(map[string]*Macro)
-	}
-	s.Macros[macro.ID] = macro
+	s.macros = append(s.macros, macro)
 	return s
 }
 
 // List lists macros
 func (s *MacroStore) List() []*Macro {
-	if s == nil || s.Macros == nil {
+	if s == nil {
 		return nil
 	}
 
-	macros := make([]*Macro, 0, len(s.Macros))
-	for _, macro := range s.Macros {
-		macros = append(macros, macro)
-	}
-	return macros
+	return s.macros
 }
 
 // Get returns the marcro
 func (s *MacroStore) Get(id string) *Macro {
-	if s == nil || s.Macros == nil {
+	if s == nil {
 		return nil
 	}
-	return s.Macros[id]
+
+	for _, m := range s.macros {
+		if m.ID == id {
+			return m
+		}
+	}
+	return nil
+}
+
+// Contains returns returns true is there is already a macro with this ID in the store
+func (s *MacroStore) Contains(id string) bool {
+	return s.Get(id) != nil
 }
 
 // VariableStore represents a store of SECL variables

--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -22,12 +22,11 @@ func (s *MacroStore) Add(macro *Macro) *MacroStore {
 
 // List lists macros
 func (s *MacroStore) List() []*Macro {
-	var macros []*Macro
-
 	if s == nil || s.Macros == nil {
-		return macros
+		return nil
 	}
 
+	macros := make([]*Macro, 0, len(s.Macros))
 	for _, macro := range s.Macros {
 		macros = append(macros, macro)
 	}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -207,7 +207,7 @@ func (rs *RuleSet) AddMacros(parsingContext *ast.ParsingContext, macros []*Macro
 func (rs *RuleSet) AddMacro(parsingContext *ast.ParsingContext, macroDef *MacroDefinition) (*eval.Macro, error) {
 	var err error
 
-	if macro := rs.evalOpts.MacroStore.Get(macroDef.ID); macro != nil {
+	if rs.evalOpts.MacroStore.Contains(macroDef.ID) {
 		return nil, &ErrMacroLoad{Definition: macroDef, Err: ErrDefinitionIDConflict}
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR:
- changes the backing store of `MacroStore` to use a simple slice. This is important since `.List()` is called a lot (in discarder computation, representing ~5% of the total CPU used by system probe on general2), and the `Get/Contains` functions is only used during macro loading during startup.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
