### PR TITLE
[CWS][SEC-12369] rename evt.suppressed field

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -225,10 +225,6 @@ CSM Threats logs have the following JSON schema:
                 "origin": {
                     "type": "string",
                     "description": "Origin of the event"
-                },
-                "suppressed": {
-                    "type": "boolean",
-                    "description": "True if the event has been suppressed"
                 }
             },
             "additionalProperties": false,
@@ -1212,6 +1208,10 @@ CSM Threats logs have the following JSON schema:
                     },
                     "type": "array",
                     "description": "List of tags associated to this profile"
+                },
+                "event_in_profile": {
+                    "type": "boolean",
+                    "description": "True if the corresponding event is part of this profile"
                 }
             },
             "additionalProperties": false,
@@ -1219,7 +1219,8 @@ CSM Threats logs have the following JSON schema:
             "required": [
                 "name",
                 "version",
-                "tags"
+                "tags",
+                "event_in_profile"
             ],
             "description": "SecurityProfileContextSerializer serializes the security profile context in an event"
         },
@@ -1765,10 +1766,6 @@ CSM Threats logs have the following JSON schema:
         "origin": {
             "type": "string",
             "description": "Origin of the event"
-        },
-        "suppressed": {
-            "type": "boolean",
-            "description": "True if the event has been suppressed"
         }
     },
     "additionalProperties": false,
@@ -1786,7 +1783,6 @@ CSM Threats logs have the following JSON schema:
 | `async` | True if the event was asynchronous |
 | `matched_rules` | The list of rules that the event matched (only valid in the context of an anomaly) |
 | `origin` | Origin of the event |
-| `suppressed` | True if the event has been suppressed |
 
 
 ## `ExitEvent`
@@ -3197,6 +3193,10 @@ CSM Threats logs have the following JSON schema:
             },
             "type": "array",
             "description": "List of tags associated to this profile"
+        },
+        "event_in_profile": {
+            "type": "boolean",
+            "description": "True if the corresponding event is part of this profile"
         }
     },
     "additionalProperties": false,
@@ -3204,7 +3204,8 @@ CSM Threats logs have the following JSON schema:
     "required": [
         "name",
         "version",
-        "tags"
+        "tags",
+        "event_in_profile"
     ],
     "description": "SecurityProfileContextSerializer serializes the security profile context in an event"
 }
@@ -3216,6 +3217,7 @@ CSM Threats logs have the following JSON schema:
 | `name` | Name of the security profile |
 | `version` | Version of the profile in use |
 | `tags` | List of tags associated to this profile |
+| `event_in_profile` | True if the corresponding event is part of this profile |
 
 
 ## `SignalEvent`

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -209,10 +209,6 @@
         "origin": {
           "type": "string",
           "description": "Origin of the event"
-        },
-        "suppressed": {
-          "type": "boolean",
-          "description": "True if the event has been suppressed"
         }
       },
       "additionalProperties": false,
@@ -1196,6 +1192,10 @@
           },
           "type": "array",
           "description": "List of tags associated to this profile"
+        },
+        "event_in_profile": {
+          "type": "boolean",
+          "description": "True if the corresponding event is part of this profile"
         }
       },
       "additionalProperties": false,
@@ -1203,7 +1203,8 @@
       "required": [
         "name",
         "version",
-        "tags"
+        "tags",
+        "event_in_profile"
       ],
       "description": "SecurityProfileContextSerializer serializes the security profile context in an event"
     },

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -51,8 +51,6 @@ type EventContextSerializer struct {
 	MatchedRules []MatchedRuleSerializer `json:"matched_rules,omitempty"`
 	// Origin of the event
 	Origin string `json:"origin,omitempty"`
-	// True if the event has been suppressed
-	Suppressed bool `json:"suppressed,omitempty"`
 }
 
 // ProcessContextSerializer serializes a process context to JSON
@@ -219,9 +217,8 @@ func NewBaseEventSerializer(event *model.Event) *BaseEventSerializer {
 
 	s := &BaseEventSerializer{
 		EventContextSerializer: EventContextSerializer{
-			Name:       eventType.String(),
-			Origin:     event.Origin,
-			Suppressed: event.Suppressed,
+			Name:   eventType.String(),
+			Origin: event.Origin,
 		},
 		ProcessContextSerializer: newProcessContextSerializer(pc, event),
 		Date:                     utils.NewEasyjsonTime(event.ResolveEventTime()),

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -952,8 +952,6 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 			}
 		case "origin":
 			out.Origin = string(in.String())
-		case "suppressed":
-			out.Suppressed = bool(in.Bool())
 		default:
 			in.SkipRecursive()
 		}
@@ -1032,16 +1030,6 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 			out.RawString(prefix)
 		}
 		out.String(string(in.Origin))
-	}
-	if in.Suppressed {
-		const prefix string = ",\"suppressed\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Bool(bool(in.Suppressed))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -451,6 +451,8 @@ type SecurityProfileContextSerializer struct {
 	Version string `json:"version"`
 	// List of tags associated to this profile
 	Tags []string `json:"tags"`
+	// True if the corresponding event is part of this profile
+	EventInProfile bool `json:"event_in_profile"`
 }
 
 // AnomalyDetectionSyscallEventSerializer serializes an anomaly detection for a syscall event
@@ -913,13 +915,14 @@ func newNetworkContextSerializer(e *model.Event) *NetworkContextSerializer {
 	}
 }
 
-func newSecurityProfileContextSerializer(e *model.SecurityProfileContext) *SecurityProfileContextSerializer {
+func newSecurityProfileContextSerializer(event *model.Event, e *model.SecurityProfileContext) *SecurityProfileContextSerializer {
 	tags := make([]string, len(e.Tags))
 	copy(tags, e.Tags)
 	return &SecurityProfileContextSerializer{
-		Name:    e.Name,
-		Version: e.Version,
-		Tags:    tags,
+		Name:           e.Name,
+		Version:        e.Version,
+		Tags:           tags,
+		EventInProfile: event.IsInProfile(),
 	}
 }
 
@@ -958,7 +961,7 @@ func NewEventSerializer(event *model.Event) *EventSerializer {
 	}
 
 	if event.SecurityProfileContext.Name != "" {
-		s.SecurityProfileContextSerializer = newSecurityProfileContextSerializer(&event.SecurityProfileContext)
+		s.SecurityProfileContextSerializer = newSecurityProfileContextSerializer(event, &event.SecurityProfileContext)
 	}
 
 	if ctx, exists := event.FieldHandlers.ResolveContainerContext(event); exists {

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -3406,6 +3406,8 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(
 				}
 				in.Delim(']')
 			}
+		case "event_in_profile":
+			out.EventInProfile = bool(in.Bool())
 		default:
 			in.SkipRecursive()
 		}
@@ -3445,6 +3447,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(
 			}
 			out.RawByte(']')
 		}
+	}
+	{
+		const prefix string = ",\"event_in_profile\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.EventInProfile))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Rename the `evt.suppressed` field to `security_profile.event_in_profile`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
