### PR TITLE
[Doc] Add linters documentation

### DIFF
--- a/docs/dev/linters.md
+++ b/docs/dev/linters.md
@@ -53,6 +53,4 @@ A: This could have several causes:
 
 Introducing the `revive` linter in the codebase caused hundreds of errors to appear in the CI. As such, [the `new-from-rev` parameter](https://github.com/DataDog/datadog-agent/blob/fcb19ce078e7969d285565beec5d374c5fd623e1/.golangci.yml#L65-L68) was added to only display linter issues from changes made after the commit that enabled `revive`. [See the Golang documentation](https://golangci-lint.run/usage/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues) for more information.
 
-We quickly realized [the debt that such a feature](https://github.com/golangci/golangci-lint/issues/4349) introduced:
-
-Let's say I have a legacy file hello.go with 100 lints (i.e linter errors). The new-from-rev parameter will silence them all. But if I rename this file to hello_world.go or move it to another folder then all the lints will rise again.
+In a scenario where you have a legacy file hello.go with 100 linter issues, the new-from-rev parameter removes them all. But if you rename the file to hello_world.go, or move it to another folder, all the linter issues reappear. See [issue 4349](https://github.com/golangci/golangci-lint/issues/4349) in the golangci repo for more information.

--- a/docs/dev/linters.md
+++ b/docs/dev/linters.md
@@ -1,0 +1,58 @@
+# Linting the datadog-agent repository
+
+Welcome to our linters documentation ! Linters are tools that check our source code for errors, bugs, and stylistic inconsistencies. They're essential for maintaining code quality and consistency.
+
+<!-- Those linters are running in the CI as required checks. -->
+
+Here are the linters we're using on the datadog-agent repository depending on the language:
+
+## Go
+
+For Go we're using [golangci-lint](https://golangci-lint.run/), a Go linters aggregator. Its configuration is defined [in the .golangci.yml file](https://github.com/DataDog/datadog-agent/blob/main/.golangci.yml).
+
+The `linters` key define the list of linters we're using:
+https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/.golangci.yml#L65-L79
+
+To run the linters locally run `inv lint-go`.
+
+> [!TIP]
+> In your code, you can ignore a lint on line by prepending it with [the nolint directive](https://golangci-lint.run/usage/false-positives/#nolint-directive) e.g  `//nolint:linter_name`.
+> Example [here](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/cmd/agent/common/import.go/#L252) and [here](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/cmd/agent/common/misconfig/global.go/#L27-L32).
+
+
+## Python
+
+For Python we're using ([see invoke task](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/tasks/linter_tasks.py/#L17-L33)):
+- [flake8](https://flake8.pycqa.org/en/latest) a style linter.
+- [black](https://black.readthedocs.io/en/stable/) a code formatter.
+- [isort](https://pycqa.github.io/isort/) to sort the imports.
+- [vulture](https://github.com/jendrikseipp/vulture) to find unused code.
+
+Their configuration is defined in both the [setup.cfg](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/setup.cfg) and the [pyproject.toml](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/pyproject.toml) files.
+
+To run the linters locally run `inv lint-python`.
+
+> [!TIP]
+> In your code, you can ignore a lint on line by prepending it with `# noqa: error_code`.
+> Example [here](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/tasks/new_e2e_tests.py/#L40-L42) and [here](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/tasks/release.py/#L257).
+
+## Troubleshooting
+
+### Go Q&A
+
+Q: I get a lot of errors locally that I don't get in the CI, why ?
+
+A: This could come from several reasons:
+- Your tools versions are not aligned with ours:
+    - `go version` should output the same as [the repository .go-version](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/.go-version).
+    - `golangci-lint --version` should output the same as [the repository internal/tools/go.mod](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/internal/tools/go.mod/#L8).
+- You're testing OS specific code, running locally the linters will only get the results for your local OS.
+- You didn't run `inv tidy-all` in the repository making some dependencies in the remote env outdated compare to your local env.
+
+### About the new-from-rev golangci-lint parameter
+
+At some point we wanted to introduce the `revive` linter in th codebase. It was burdensome because enabling it made hundreds of errors appear in the CI. [We hence started using the `new-from-rev` parameter](https://github.com/DataDog/datadog-agent/blob/fcb19ce078e7969d285565beec5d374c5fd623e1/.golangci.yml#L65-L68) ([see doc](https://golangci-lint.run/usage/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues)) to only display lints from changes made after commit `f40667d3841c6339be0d00d53e54a4a63f43f11e` (i.e when we enabled back `revive`).
+
+We quickly realized [the debt that such a feature](https://github.com/golangci/golangci-lint/issues/4349) introduced:
+
+Let's say I have a legacy file hello.go with 100 lints (i.e linter errors). The new-from-rev parameter will silence them all. But if I rename this file to hello_world.go or move it to another folder then all the lints will rise again.

--- a/docs/dev/linters.md
+++ b/docs/dev/linters.md
@@ -51,7 +51,7 @@ A: This could have several causes:
 
 ### About the new-from-rev golangci-lint parameter
 
-At some point we wanted to introduce the `revive` linter in th codebase. It was burdensome because enabling it made hundreds of errors appear in the CI. [We hence started using the `new-from-rev` parameter](https://github.com/DataDog/datadog-agent/blob/fcb19ce078e7969d285565beec5d374c5fd623e1/.golangci.yml#L65-L68) ([see doc](https://golangci-lint.run/usage/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues)) to only display lints from changes made after commit `f40667d3841c6339be0d00d53e54a4a63f43f11e` (i.e when we enabled back `revive`).
+Introducing the `revive` linter in the codebase caused hundreds of errors to appear in the CI. As such, [the `new-from-rev` parameter](https://github.com/DataDog/datadog-agent/blob/fcb19ce078e7969d285565beec5d374c5fd623e1/.golangci.yml#L65-L68) was added to only display linter issues from changes made after the commit that enabled `revive`. [See the Golang documentation](https://golangci-lint.run/usage/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues) for more information.
 
 We quickly realized [the debt that such a feature](https://github.com/golangci/golangci-lint/issues/4349) introduced:
 

--- a/docs/dev/linters.md
+++ b/docs/dev/linters.md
@@ -1,53 +1,53 @@
 # Linting the datadog-agent repository
 
-Welcome to our linters documentation ! Linters are tools that check our source code for errors, bugs, and stylistic inconsistencies. They're essential for maintaining code quality and consistency.
+Welcome to the Datadog Agent linters documentation! Linters are tools that check our source code for errors, bugs, and stylistic inconsistencies. They're essential for maintaining code quality and consistency.
 
 <!-- Those linters are running in the CI as required checks. -->
 
-Here are the linters we're using on the datadog-agent repository depending on the language:
+Here are the linters used on the datadog-agent repository depending on the language:
 
 ## Go
 
-For Go we're using [golangci-lint](https://golangci-lint.run/), a Go linters aggregator. Its configuration is defined [in the .golangci.yml file](https://github.com/DataDog/datadog-agent/blob/main/.golangci.yml).
+For Go, we're using [golangci-lint](https://golangci-lint.run/), a Go linters aggregator. Its configuration is defined [in the .golangci.yml file](https://github.com/DataDog/datadog-agent/blob/main/.golangci.yml).
 
-The `linters` key define the list of linters we're using:
+The `linters` key defines the list of linters we're using:
 https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/.golangci.yml#L65-L79
 
-To run the linters locally run `inv lint-go`.
+To run the linters locally, run `inv lint-go`.
 
 > [!TIP]
-> In your code, you can ignore a lint on line by prepending it with [the nolint directive](https://golangci-lint.run/usage/false-positives/#nolint-directive) e.g  `//nolint:linter_name`.
+> In your code, you can ignore linter issues on a line by prepending it with [the nolint directive](https://golangci-lint.run/usage/false-positives/#nolint-directive), for example,  `//nolint:linter_name`.
 > Example [here](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/cmd/agent/common/import.go/#L252) and [here](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/cmd/agent/common/misconfig/global.go/#L27-L32).
 
 
 ## Python
 
-For Python we're using ([see invoke task](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/tasks/linter_tasks.py/#L17-L33)):
-- [flake8](https://flake8.pycqa.org/en/latest) a style linter.
-- [black](https://black.readthedocs.io/en/stable/) a code formatter.
-- [isort](https://pycqa.github.io/isort/) to sort the imports.
-- [vulture](https://github.com/jendrikseipp/vulture) to find unused code.
+For Python, we're using ([see invoke task](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/tasks/linter_tasks.py/#L17-L33)):
+- [flake8](https://flake8.pycqa.org/en/latest), a style linter.
+- [black](https://black.readthedocs.io/en/stable/), a code formatter.
+- [isort](https://pycqa.github.io/isort/), to sort the imports.
+- [vulture](https://github.com/jendrikseipp/vulture), to find unused code.
 
 Their configuration is defined in both the [setup.cfg](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/setup.cfg) and the [pyproject.toml](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/pyproject.toml) files.
 
-To run the linters locally run `inv lint-python`.
+To run the linters locally, run `inv lint-python`.
 
 > [!TIP]
-> In your code, you can ignore a lint on line by prepending it with `# noqa: error_code`.
+> In your code, you can ignore linter issues on a line by prepending it with `# noqa: error_code`.
 > Example [here](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/tasks/new_e2e_tests.py/#L40-L42) and [here](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/tasks/release.py/#L257).
 
 ## Troubleshooting
 
-### Go Q&A
+### Go
 
 Q: I get a lot of errors locally that I don't get in the CI, why ?
 
-A: This could come from several reasons:
-- Your tools versions are not aligned with ours:
+A: This could have several causes:
+- Your tool versions are not aligned with ours:
     - `go version` should output the same as [the repository .go-version](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/.go-version).
     - `golangci-lint --version` should output the same as [the repository internal/tools/go.mod](https://github.com/DataDog/datadog-agent/blob/dffd3262934a5540b9bf8e4bd3a743732637ef37/internal/tools/go.mod/#L8).
-- You're testing OS specific code, running locally the linters will only get the results for your local OS.
-- You didn't run `inv tidy-all` in the repository making some dependencies in the remote env outdated compare to your local env.
+- You're testing OS specific code; running locally, the linters only get the results for your local OS.
+- You didn't run `inv tidy-all` in the repository, making some dependencies in the remote env outdated compared to your local env.
 
 ### About the new-from-rev golangci-lint parameter
 

--- a/docs/dev/linters.md
+++ b/docs/dev/linters.md
@@ -54,3 +54,5 @@ A: This could have several causes:
 Introducing the `revive` linter in the codebase caused hundreds of errors to appear in the CI. As such, [the `new-from-rev` parameter](https://github.com/DataDog/datadog-agent/blob/fcb19ce078e7969d285565beec5d374c5fd623e1/.golangci.yml#L65-L68) was added to only display linter issues from changes made after the commit that enabled `revive`. [See the Golang documentation](https://golangci-lint.run/usage/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues) for more information.
 
 In a scenario where you have a legacy file hello.go with 100 linter issues, the new-from-rev parameter removes them all. But if you rename the file to hello_world.go, or move it to another folder, all the linter issues reappear. See [issue 4349](https://github.com/golangci/golangci-lint/issues/4349) in the golangci repo for more information.
+
+This case added technical debt so [we removed it](https://github.com/DataDog/datadog-agent/pull/21266) and used the [the nolint directive](https://golangci-lint.run/usage/false-positives/#nolint-directive) instead.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds some documentation about the linters we're using on the datadog-agent repository.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Better developer experience.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
