### PR TITLE
[SMP] Update lading version to 0.20.8

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -18,7 +18,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.12.0
-    LADING_VERSION: 0.20.4
+    LADING_VERSION: 0.20.6
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -18,7 +18,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.12.0
-    LADING_VERSION: 0.20.6
+    LADING_VERSION: 0.20.7
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -18,7 +18,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.12.0
-    LADING_VERSION: 0.20.7
+    LADING_VERSION: 0.20.8
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the


### PR DESCRIPTION
This commit updates the lading version to 0.20.8 which improves how memory telemetry is collected compared to .4. No user-facing changes are intended.

