### PR TITLE
[windows][cws] consolidate ETW parsing

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -68,6 +68,7 @@ var (
       <data name="FileName" inType="win:UnicodeString"/>
 */
 type createHandleArgs struct {
+	etw.DDEventHeader
 	irp              uint64            // actually a pointer
 	fileObject       fileObjectPointer // pointer
 	threadID         uint64            // actually a pointer
@@ -94,7 +95,9 @@ The Parameters.Create.FileAttributes and Parameters.Create.EaLength members are 
 	the Installable File System (IFS) documentation.
 */
 func parseCreateHandleArgs(e *etw.DDEventRecord) (*createHandleArgs, error) {
-	ca := &createHandleArgs{}
+	ca := &createHandleArgs{
+		DDEventHeader: e.EventHeader,
+	}
 	data := unsafe.Slice((*byte)(e.UserData), uint64(e.UserDataLength))
 	if e.EventHeader.EventDescriptor.Version == 0 {
 		ca.irp = binary.LittleEndian.Uint64(data[0:8])
@@ -135,7 +138,7 @@ func parseCreateNewFileArgs(e *etw.DDEventRecord) (*createNewFileArgs, error) {
 func (ca *createHandleArgs) string() string {
 	var output strings.Builder
 
-	output.WriteString("  Create TID: " + strconv.Itoa(int(ca.threadID)) + "\n")
+	output.WriteString("  Create PID: " + strconv.Itoa(int(ca.ProcessID)) + "\n")
 	output.WriteString("         Name: " + ca.fileName + "\n")
 	output.WriteString("         Opts: " + strconv.FormatUint(uint64(ca.createOptions), 16) + " Attrs: " + strconv.FormatUint(uint64(ca.createAttributes), 16) + " Share: " + strconv.FormatUint(uint64(ca.shareAccess), 16) + "\n")
 	output.WriteString("         OBJ:  " + strconv.FormatUint(uint64(ca.fileObject), 16) + "\n")
@@ -168,6 +171,7 @@ func (ca *createNewFileArgs) string() string {
 */
 
 type setInformationArgs struct {
+	etw.DDEventHeader
 	irp        uint64
 	threadID   uint64
 	fileObject fileObjectPointer
@@ -178,7 +182,9 @@ type setInformationArgs struct {
 }
 
 func parseInformationArgs(e *etw.DDEventRecord) (*setInformationArgs, error) {
-	sia := &setInformationArgs{}
+	sia := &setInformationArgs{
+		DDEventHeader: e.EventHeader,
+	}
 	data := unsafe.Slice((*byte)(e.UserData), uint64(e.UserDataLength))
 
 	if e.EventHeader.EventDescriptor.Version == 0 {
@@ -232,6 +238,7 @@ func (sia *setInformationArgs) string() string {
 */
 
 type cleanupArgs struct {
+	etw.DDEventHeader
 	irp        uint64
 	threadID   uint64
 	fileObject fileObjectPointer
@@ -246,7 +253,9 @@ type closeArgs cleanupArgs
 type flushArgs cleanupArgs
 
 func parseCleanupArgs(e *etw.DDEventRecord) (*cleanupArgs, error) {
-	ca := &cleanupArgs{}
+	ca := &cleanupArgs{
+		DDEventHeader: e.EventHeader,
+	}
 	data := unsafe.Slice((*byte)(e.UserData), uint64(e.UserDataLength))
 
 	if e.EventHeader.EventDescriptor.Version == 0 {

--- a/pkg/security/probe/probe_kernel_reg_windows_test.go
+++ b/pkg/security/probe/probe_kernel_reg_windows_test.go
@@ -9,15 +9,13 @@
 package probe
 
 import (
-	"fmt"
 	"os"
 	"os/user"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/etw"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -25,96 +23,63 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-// createTestProbe and teardownTestProbe are implemented in the file test, but
-// the same one can be used.
-
-func (et *etwTester) runTestEtwRegistry() error {
-
-	var once sync.Once
-	mypid := os.Getpid()
-	err := et.p.fimSession.StartTracing(func(e *etw.DDEventRecord) {
-		/*
-			 	* this works because we're registered on the whole system.  Therefore, we'll get
-			 	* some file or registry callback events from other processes we're not interested in.
-				*
-				* so sooner or later we'll get one.  If we don't, we'll deadlock in the test init routine below
-		*/
-		once.Do(func() {
-			close(et.etwStarted)
-		})
-
-		// since this is for testing, skip any notification not from our pid
-		if e.EventHeader.ProcessID != uint32(mypid) {
-			return
-		}
-		switch e.EventHeader.ProviderID {
-		case etw.DDGUID(et.p.regguid):
-			switch e.EventHeader.EventDescriptor.ID {
-			case idRegCreateKey:
-				if cka, err := parseCreateRegistryKey(e); err == nil {
-					select {
-					case et.notify <- cka:
-						// message sent
-					default:
-						// message dropped.  Which is OK.  In the test code, we want to leave the receive loop
-						// running, but only catch messages when we're expecting them
-						fmt.Printf("Dropped message\n")
-					}
-				}
-			case idRegOpenKey:
-				if cka, err := parseCreateRegistryKey(e); err == nil {
-					log.Debugf("Got idRegOpenKey %s", cka.string())
-				}
-
-			case idRegDeleteKey:
-				if dka, err := parseDeleteRegistryKey(e); err == nil {
-					log.Infof("Got idRegDeleteKey %v", dka.string())
-				}
-			case idRegFlushKey:
-				if dka, err := parseDeleteRegistryKey(e); err == nil {
-					log.Infof("Got idRegFlushKey %v", dka.string())
-				}
-			case idRegCloseKey:
-				if dka, err := parseDeleteRegistryKey(e); err == nil {
-					log.Debugf("Got idRegCloseKey %s", dka.string())
-					delete(regPathResolver, dka.keyObject)
-				}
-			case idQuerySecurityKey:
-				if dka, err := parseDeleteRegistryKey(e); err == nil {
-					log.Infof("Got idQuerySecurityKey %v", dka.keyName)
-				}
-			case idSetSecurityKey:
-				if dka, err := parseDeleteRegistryKey(e); err == nil {
-					log.Infof("Got idSetSecurityKey %v", dka.keyName)
-				}
-			case idRegSetValueKey:
-				if svk, err := parseSetValueKey(e); err == nil {
-					log.Infof("Got idRegSetValueKey %s", svk.string())
-				}
-
-			}
-		}
-	})
-	return err
-}
-
 func processUntilRegOpen(t *testing.T, et *etwTester) {
 
+	skippedObjects := make(map[fileObjectPointer]struct{})
 	defer func() {
 		et.loopExited <- struct{}{}
 	}()
 	et.loopStarted <- struct{}{}
 	for {
+
 		select {
 		case <-et.stopLoop:
 			return
 
 		case n := <-et.notify:
-			et.notifications = append(et.notifications, n)
+
 			switch n.(type) {
 			case *createKeyArgs:
+				et.notifications = append(et.notifications, n)
 				return
+			case *createHandleArgs:
+				ca := n.(*createHandleArgs)
+				// we get all sorts of notifications of DLLs being loaded.
+				// skip those
+
+				// check the last 4 chars of the filename
+				if l := len(ca.fileName); l >= 4 {
+					// see if it's a .dll
+					ext := ca.fileName[l-4:]
+
+					// check to see if it's a dll
+					if strings.EqualFold(ext, ".dll") {
+						skippedObjects[ca.fileObject] = struct{}{}
+						// don't add
+						continue
+					}
+				}
+			case *cleanupArgs:
+				ca := n.(*cleanupArgs)
+
+				// check to see if we already saw the createHandle for this, and if
+				// so, just skip
+				if _, ok := skippedObjects[ca.fileObject]; ok {
+					continue
+				}
+			case *closeArgs:
+				ca := n.(*closeArgs)
+				// check to see if we already saw the createHandle for this, and if
+				// so, just skip
+				if _, ok := skippedObjects[ca.fileObject]; ok {
+					// remove it from the map, since it's being closed.  it could be
+					// reused.
+					delete(skippedObjects, ca.fileObject)
+					continue
+				}
+
 			}
+			et.notifications = append(et.notifications, n)
 		}
 	}
 
@@ -139,7 +104,22 @@ func TestETWRegistryNotifications(t *testing.T) {
 	wp.fimwg.Add(1)
 	go func() {
 		defer wp.fimwg.Done()
-		err := et.runTestEtwRegistry()
+		var once sync.Once
+		mypid := os.Getpid()
+
+		err := et.p.setupEtw(func(n interface{}, pid uint32) {
+			once.Do(func() {
+				close(et.etwStarted)
+			})
+			if pid != uint32(mypid) {
+				return
+			}
+			select {
+			case et.notify <- n:
+				// message sent
+			default:
+			}
+		})
 		assert.NoError(t, err)
 	}()
 

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -61,6 +61,13 @@ type WindowsProbe struct {
 	fimwg      sync.WaitGroup
 }
 
+/*
+ * callback function for every etw notification, after it's been parsed.
+ * pid is provided for testing purposes, to allow filtering on pid.  it is
+ * not expected to be used at runtime
+ */
+type etwCallback func(n interface{}, pid uint32)
+
 // Init initializes the probe
 func (p *WindowsProbe) Init() error {
 
@@ -188,7 +195,7 @@ func (p *WindowsProbe) Stop() {
 	}
 }
 
-func (p *WindowsProbe) setupEtw() error {
+func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 
 	log.Info("Starting tracing...")
 	err := p.fimSession.StartTracing(func(e *etw.DDEventRecord) {
@@ -199,21 +206,29 @@ func (p *WindowsProbe) setupEtw() error {
 			case idCreate:
 				if ca, err := parseCreateHandleArgs(e); err == nil {
 					log.Tracef("Received idCreate event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
+					ecb(ca, e.EventHeader.ProcessID)
 				}
 
 			case idCreateNewFile:
 				if ca, err := parseCreateNewFileArgs(e); err == nil {
-					log.Tracef("Received NewFile event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
+					ecb(ca, e.EventHeader.ProcessID)
 				}
 			case idCleanup:
-				fallthrough
-			case idFlush:
-				// idCleanup and idFlush can be parsed with parseCleanupArgs if necessary.
-				// don't fall through
-			case idClose:
 				if ca, err := parseCleanupArgs(e); err == nil {
-					log.Tracef("got id %v args %s", e.EventHeader.EventDescriptor.ID, ca.string())
-					delete(filePathResolver, ca.fileObject)
+					ecb(ca, e.EventHeader.ProcessID)
+				}
+
+			case idClose:
+				if ca, err := parseCloseArgs(e); err == nil {
+					//fmt.Printf("Received Close event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
+					ecb(ca, e.EventHeader.ProcessID)
+					if e.EventHeader.EventDescriptor.ID == idClose {
+						delete(filePathResolver, ca.fileObject)
+					}
+				}
+			case idFlush:
+				if fa, err := parseFlushArgs(e); err == nil {
+					ecb(fa, e.EventHeader.ProcessID)
 				}
 			case idSetInformation:
 				fallthrough
@@ -236,6 +251,7 @@ func (p *WindowsProbe) setupEtw() error {
 			case idRegCreateKey:
 				if cka, err := parseCreateRegistryKey(e); err == nil {
 					log.Tracef("Got idRegCreateKey %s", cka.string())
+					ecb(cka, e.EventHeader.ProcessID)
 				}
 			case idRegOpenKey:
 				if cka, err := parseCreateRegistryKey(e); err == nil {
@@ -283,9 +299,22 @@ func (p *WindowsProbe) Start() error {
 		// log at Warning right now because it's not expected to be enabled
 		log.Warnf("Enabling FIM processing")
 		p.fimwg.Add(1)
+
 		go func() {
 			defer p.fimwg.Done()
-			err := p.setupEtw()
+			err := p.setupEtw(func(n interface{}, pid uint32) {
+				// pid will most likely be ignored here.
+
+				// handle incoming events here
+
+				// each event will come in as a different type
+				// parse it with
+				switch n.(type) {
+				case *createKeyArgs:
+					// do something
+				}
+				// etc.
+			})
 			log.Infof("Done StartTracing %v", err)
 		}()
 	}


### PR DESCRIPTION
Consolidate the translatiion of ETW event records into structures into a single function.  Allows the test code to use more of the runtime code (instead of copy/paste) than originally implemented.



### Describe how to test/QA your changes

PR is automated tests.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
