### PR TITLE
[SMP] Remove 'erratic' setting from three experiments

### DIFF
--- a/test/regression/cases/file_to_blackhole/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole/experiment.yaml
@@ -1,5 +1,5 @@
 optimization_goal: cpu
-erratic: true
+erratic: false
 
 environment:
   DD_TELEMETRY_ENABLED: true

--- a/test/regression/cases/file_to_blackhole/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole/experiment.yaml
@@ -1,5 +1,5 @@
 optimization_goal: cpu
-erratic: false
+erratic: true
 
 environment:
   DD_TELEMETRY_ENABLED: true

--- a/test/regression/cases/file_tree/experiment.yaml
+++ b/test/regression/cases/file_tree/experiment.yaml
@@ -1,5 +1,5 @@
 optimization_goal: memory
-erratic: true
+erratic: false
 
 environment:
   DD_TELEMETRY_ENABLED: true

--- a/test/regression/cases/idle/experiment.yaml
+++ b/test/regression/cases/idle/experiment.yaml
@@ -1,5 +1,5 @@
 optimization_goal: memory
-erratic: true
+erratic: false
 
 environment:
   DD_TELEMETRY_ENABLED: true


### PR DESCRIPTION
This commit removes the 'erratic' setting from three experiments that use optimization goals which are not in themselves erratic. A consequence of the goal having been a previous value.
