### PR TITLE
First cut of internal Agent Telemetry

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -31,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	"github.com/DataDog/datadog-agent/cmd/agent/subcommands/run/internal/clcrunnerapi"
 	"github.com/DataDog/datadog-agent/cmd/manager"
+	"github.com/DataDog/datadog-agent/comp/core/agenttelemetry"
 
 	// checks implemented as components
 
@@ -210,6 +211,7 @@ func run(log log.Component,
 	_ packagesigning.Component,
 	statusComponent status.Component,
 	collector collector.Component,
+	_ agenttelemetry.Component,
 ) error {
 	defer func() {
 		stopAgent(cliParams, server, agentAPI)

--- a/cmd/agent/subcommands/run/command_windows.go
+++ b/cmd/agent/subcommands/run/command_windows.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/checks/winregistry"
 	winregistryimpl "github.com/DataDog/datadog-agent/comp/checks/winregistry/impl"
+	"github.com/DataDog/datadog-agent/comp/core/agenttelemetry"
 
 	"go.uber.org/fx"
 
@@ -109,6 +110,7 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 			agentAPI internalAPI.Component,
 			pkgSigning packagesigning.Component,
 			statusComponent status.Component,
+			_ agenttelemetry.Component,
 			collector collector.Component,
 		) error {
 

--- a/comp/core/agenttelemetry/component.go
+++ b/comp/core/agenttelemetry/component.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package agenttelemetry implements a component to generate agent telemetry
+package agenttelemetry
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"go.uber.org/fx"
+)
+
+// Component is the component type
+type Component interface {
+	// GetAsJSON returns the payload as a JSON string. Useful to be displayed in the CLI or added to a flare.
+	GetAsJSON() ([]byte, error)
+}
+
+// Module defines the fx options for this component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newAgentTelemetryProvider))
+}

--- a/comp/core/agenttelemetry/config.go
+++ b/comp/core/agenttelemetry/config.go
@@ -1,0 +1,418 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agenttelemetry
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	defaultSheduleStartAfter = 30  // 30 seconds
+	defaultShedulePeriod     = 900 // 15 minutes
+)
+
+// Config is the top-level config for agent telemetry
+type Config struct {
+	Enabled  bool      `yaml:"enabled"`
+	Profiles []Profile `yaml:"profiles"`
+
+	// compiled
+	schedule map[Schedule][]*Profile
+}
+
+// Profile is a single agent telemetry profile
+type Profile struct {
+	// parsed
+	Name     string             `yaml:"name"`
+	Metric   *AgentMetricConfig `yaml:"metric,omitempty"`
+	Status   *AgentStatusConfig `yaml:"status"`
+	Schedule *Schedule          `yaml:"schedule"`
+
+	// compiled
+	statusExtraBuilder []jBuilder
+	metricsMap         map[string]*MetricConfig
+	excludeZeroMetric  bool
+	excludeTags        map[string]any
+}
+
+// AgentMetricConfig specifies agent telemetry metrics payloads to be generated and emitted
+type AgentMetricConfig struct {
+	Exclude *ExcludeMetricConfig `yaml:"exclude,omitempty"`
+	Metrics []MetricConfig       `yaml:"metrics,omitempty"`
+}
+
+// ExcludeMetricConfig specifies agent telemetry metrics to be excluded from the agent telemetry
+type ExcludeMetricConfig struct {
+	ZeroMetric *bool    `yaml:"zero_metric,omitempty"`
+	Tags       []string `yaml:"tags,omitempty"`
+}
+
+// MetricConfig is a list of metric selecting subset of telemetry.Gather() metrics to be included in agent
+type MetricConfig struct {
+	Name string `yaml:"name"` // required
+}
+
+// AgentStatusConfig is a single agent telemetry status payload
+type AgentStatusConfig struct {
+	Template string            `yaml:"template"`
+	Extra    map[string]string `yaml:"extra,omitempty"`
+}
+
+// Schedule is a schedule for agent telemetry payloads to be generated and emitted
+type Schedule struct {
+	// parsed
+	StartAfter uint `yaml:"start_after"`
+	Iterations uint `yaml:"iterations"`
+	Period     uint `yaml:"period"`
+}
+
+// profiles[].metric.metrics (optional)
+// --------------------------
+// When included, agent telemetry metrics payloads will be generated and emitted.
+//
+// profiles[].metric.exclude (optional)
+// -------------------------------------
+// When included, specifies agent telemetry metrics to be excluded from the agent telemetry.
+//
+// profiles[].metric.exclude.zero_metric (optional)
+// ------------------------------------------------
+// When included, specifies whether metrics with zero value should be excluded from the
+// agent telemetry metrics payloads. If not specified, default value of `false` will be used.
+//
+// profiles[].metric.exclude.tags[] (optional)
+// ------------------------------------------
+// When included, specifies metrics with its tags and optionally values to beexcluded from
+// the agent telemetry metrics payloads. A tag value can be specified with or without values.
+// If specified without value, all metrics with the tag will be excluded. If specified with
+// value, only metrics with the matching tag and the value will be excluded.
+//
+// profiles[].metric.metrics[].name (required)
+// -------------------------------------------
+// Metric's full name typically in the form of "<metric group>.<metric name>".
+// It is required parameter to avoid emitting all available metrics unintentionally.
+//
+// profiles[].status (optional)
+// --------------------------------
+// When included, agent telemetry status payloads will be generated and emitted.
+//
+// profiles[].status.template (optional)
+// --------------------------------------
+// Name of agent status JSON rendering template which generates agent telemetry status
+// payload. Used as a suffix to
+//   "pkg\status\render\templates\agent-telemetry-<template name>.tmpl" file path. Currently
+// two templates ("basic" and "none") are supported. When "none" template is used for a
+// profile, agent telemetry status payload will not be generated for that profile (unless
+// "extra" configuration is specified).
+//
+// profiles[].status.extra (optional)
+// ----------------------------------
+// Map of extra telemetry JSON objects/attributes selected or calculated from the main Agent
+// Status JSON object. Each map entry specifies a single JSON object and its single
+// attribute to be added to the agent status telemetry payload.
+//
+//    key - "." separated elements specifying "target" JSON path to the additional JSON object
+//      to be added to the agent status telemetry payload. The rightmost component is the
+//      object's attribute name.
+//
+//    value - JQ expression to be applied to the full agent status JSON to compute a value for
+//      for the specified in the key agent telemetry status JSON attribute. For privacy and
+//      security reasons, claculated value can  only be int, float or bool. Strings will be
+//      allowed as exceptions provided they had been approved.
+//
+//       Example. If agent status JSON is ...
+//           {
+//             "runnerStats": {
+//               "Workers": {
+//                 "Count": 2,
+//                 "Instances": {
+//                   "worker_1": {
+//                     "Utilization": 0.05
+//                   },
+//                   "worker_2": {
+//                     "Utilization": 0.17
+//                   }
+//                 }
+//               }
+//             }
+//           }
+//
+//       ... with "extra" like this ...
+//           ...
+//           extra:
+//             workers.count: '.runnerStats.Workers.Count'
+//             workers.utilization: '[.runnerStats.Workers | .. | objects | .Utilization] | add'
+//
+//       ... the following JSON object will be added to the agent telemetry statys payload ...
+//           "workers": {
+//             "count": 2,
+//             "utilization": 0.22
+//           }
+//
+// profiles[].schedule (optional)
+// --------------------------------
+// Specified when agent telemetry payloads to be generated and emitted. If not specified,
+// configured payloads willbe generated and emitted on the following schedule (the details
+// are described in the comments below.
+//
+//    (legend - 300s=5m, 900s=15m, 1800s=30m, 3600s=1h, 86400s=1d)
+//
+//        schedule:
+//          start_after: 30
+//          iterations: 0
+//          period: 900
+//
+// profiles[].schedule.start_after (optional)
+// ------------------------------------------
+// Number of seconds to wait after agent start before starting telemetry collection for the
+// profile. If not specified, default values are specified above.
+//
+// profiles[].schedule.iterations (optional)
+// -----------------------------------------
+// Number of telemetry collection iterations to perform for the profile. To indicate infinite
+// number of iterations, use 0. If not specified, default value of 0 will be used.
+//
+// profiles[].schedule.period (optional)
+// -------------------------------------
+// Number of seconds to wait between telemetry collection iteration for the profile. If not
+// specified, default values are specified above.
+
+// ----------------------------------------------------------------------------------
+//
+// Default agent telemetry profiles config if not specified in the agent config file.
+var defaultProfiles = `
+  profiles:
+  - name: core-metrics
+    metric:
+      exclude:
+        zero_metric: true
+        tags:
+          - "check_name:cpu"
+          - "check_name:memory"
+          - "check_name:uptime"
+          - "check_name:network"
+          - "check_name:io"
+          - "check_name:file_handle"
+      metrics:  
+        - name: checks.runs
+        - name: checks.execution_time
+        - name: checks.warnings
+        - name: checks.metrics_samples
+        - name: checks.events
+        - name: logs.decoded
+        - name: logs.processed
+        - name: logs.sent
+        - name: logs.network_errors
+        - name: logs.dropped
+        - name: logs.sender_latency
+        - name: logs.destination_http_resp
+        - name: transactions.input_count
+        - name: transactions.requeued
+        - name: transactions.retries
+        - name: dogstatsd.udp_packets
+        - name: dogstatsd.uds_packets
+        - name: dogstatsd.uds_origin_detection_error
+        - name: dogstatsd.uds_connections
+    schedule:
+      start_after: 30
+      iterations: 0
+      period: 900
+  - name: core-status
+    status:
+      template: basic
+      extra:
+        runner.workers.count: '.runnerStats.Workers.Count'
+        runner.workers.utilization: '[.runnerStats.Workers | .. | objects | .Utilization] | add'
+    schedule:
+      start_after: 30
+      iterations: 0
+      period: 900
+`
+
+func compileAgentTelemetryProfile(p *Profile) error {
+	var err error
+
+	// Profile requires name
+	if len(p.Name) == 0 {
+		return fmt.Errorf("profile requires 'name' attribute to be specified")
+	}
+
+	// -----------------------------------
+	// "Compile" metric section (optional)
+	//
+	if p.Metric != nil {
+		// Exclude (optional)
+		if p.Metric.Exclude != nil {
+			if p.Metric.Exclude.ZeroMetric == nil && len(p.Metric.Exclude.Tags) == 0 {
+				return fmt.Errorf("profile '%s' requires either 'metric.exclude.zero_metric' or 'metric.exclude.tags' attribute to be specified", p.Name)
+			}
+
+			// Exclude zero metric (optional with default "false")
+			if p.Metric.Exclude.ZeroMetric != nil {
+				p.excludeZeroMetric = *p.Metric.Exclude.ZeroMetric
+			} else {
+				p.excludeZeroMetric = false
+			}
+
+			// Exclude tags (optional)
+			p.excludeTags = make(map[string]any)
+			for _, t := range p.Metric.Exclude.Tags {
+				tv := strings.SplitN(t, ":", 2)
+				// Setup for 2 cases - exclude a tag with any value or only with a specific value
+				if len(tv) == 1 {
+					// previous value does not matter, we do not care about tag values anymore
+					p.excludeTags[tv[0]] = struct{}{}
+					continue
+				}
+
+				// let's see if the tag is already in the map ...
+				if v, ok := p.excludeTags[tv[0]]; ok {
+					// ... and it value-less meaning any value is excluded
+					if _, ok := v.(struct{}); !ok {
+						(v.(map[string]struct{})[tv[1]]) = struct{}{}
+					}
+				} else {
+					// If the tag and value is not in the map yet, let's add it
+					vals := make(map[string]struct{})
+					vals[tv[1]] = struct{}{}
+					p.excludeTags[tv[0]] = vals
+				}
+			}
+		}
+
+		// Compile metrics themselves
+		p.metricsMap = make(map[string]*MetricConfig)
+		for i := 0; i < len(p.Metric.Metrics); i++ {
+			metric := &p.Metric.Metrics[i]
+
+			// Validate name (required)
+			if len(metric.Name) == 0 {
+				return fmt.Errorf("profile '%s' requires 'metrics[].name' attribute to be specified", p.Name)
+			}
+			// Split metric name into metric group and metric name to convert it to Prometheus metric name
+			metricNames := strings.Split(metric.Name, ".")
+			if len(metricNames) != 2 {
+				return fmt.Errorf("profile '%s' 'metrics[].name' '(%s)' attribute should have two elements separated by '.'", p.Name, metric.Name)
+			}
+
+			// Convert Datadog metric name to Prometheus metric name (used for quick(er) matching)
+			promName := fmt.Sprintf("%s__%s", metricNames[0], metricNames[1])
+			p.metricsMap[promName] = metric
+		}
+	}
+
+	// -----------------------------------
+	// "Compile" status section (optional)
+	//
+	if p.Status != nil {
+		// Validate template (optional with default "basic". "none" is also supported)
+		if len(p.Status.Template) == 0 {
+			p.Status.Template = "basic"
+		} else if p.Status.Template != "basic" && p.Status.Template != "none" {
+			return fmt.Errorf("profile '%s' template attribute can have 'basic' or 'none' value but %s is provided", p.Name, p.Status.Template)
+		}
+
+		// Compile status extra
+		p.statusExtraBuilder, err = compileJBuilders(p.Status.Extra)
+		if err != nil {
+			return fmt.Errorf("failed to compile 'extra' attribute for profile '%s'. Error: %w", p.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func compileAgentTelemetrySchedules(cfg *Config) error {
+	cfg.schedule = make(map[Schedule][]*Profile)
+
+	for i := 0; i < len(cfg.Profiles); i++ {
+		p := &cfg.Profiles[i]
+
+		// Setup default schedule if it is not specified partially or at all
+		if p.Schedule == nil {
+			p.Schedule = &Schedule{
+				StartAfter: defaultSheduleStartAfter,
+				Iterations: 0,
+				Period:     defaultShedulePeriod,
+			}
+		} else {
+			// Validate StartAfter (optional)
+			if p.Schedule.StartAfter == 0 {
+				p.Schedule.StartAfter = defaultSheduleStartAfter
+			}
+
+			// Validate Period (optional)
+			if p.Schedule.Period == 0 {
+				p.Schedule.Period = defaultShedulePeriod
+			}
+		}
+
+		// Aggregate schedules (one schedule correspond to one or more profiles)
+		if pp, ok := cfg.schedule[*p.Schedule]; ok {
+			pp = append(pp, p)
+			cfg.schedule[*p.Schedule] = pp
+		} else {
+			pp = []*Profile{p}
+			cfg.schedule[*p.Schedule] = pp
+		}
+	}
+
+	return nil
+}
+
+func compileConfig(cfg *Config) error {
+	for i := 0; i < len(cfg.Profiles); i++ {
+		err := compileAgentTelemetryProfile(&cfg.Profiles[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := compileAgentTelemetrySchedules(cfg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Parse agent telemetry config
+func parseConfig(cfg config.Component) (*Config, error) {
+	// Is it enabled?
+	if !cfg.GetBool("agent_telemetry.enabled") {
+		return &Config{
+			Enabled: false,
+		}, nil
+	}
+
+	// Parse agent telemetry config
+	var atCfg Config
+	err := cfg.UnmarshalKey("agent_telemetry", &atCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add default profiles if not specified
+	if len(atCfg.Profiles) == 0 {
+		err = yaml.Unmarshal([]byte(defaultProfiles), &atCfg)
+		if err != nil {
+			return nil, err
+		}
+
+		atCfg.Enabled = true
+	}
+
+	// Compile agent telemetry config
+	err = compileConfig(&atCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Successful parsing
+	return &atCfg, nil
+}

--- a/comp/core/agenttelemetry/runner.go
+++ b/comp/core/agenttelemetry/runner.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agenttelemetry
+
+import (
+	"context"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+type runner interface {
+	start()
+	stop() context.Context
+	addJob(j job)
+}
+
+type runnerImpl struct {
+	taskCron *cron.Cron
+}
+
+type runnerSchedule struct {
+	schedule Schedule
+	firstRun time.Time
+	iterated uint
+}
+
+// Agent telemetry runner currently able to "prosecute" only schedulers expressed
+// in the following format
+//
+//   "schedule": {
+// 	     "period": xxxx,
+// 	     "iterations": xxxx,
+// 	     "start_after": xxxx
+//   }
+//
+//   ... where ...
+//      "period" is the period (time between one job to another) in seconds,
+//      "iterations" is the number of time the job should be executed (0 means forever),
+//	    "start_after" is the time to wait before the first run in seconds (effectively a delay after initialization)
+//
+
+// Using well-know robfig/cron package to schedule jobs without complex tracking of multiple schedules
+// and to avoid reinventing the wheel. The package is well tested and maintained. Its source tracks multiuple
+// job scheduling in simple and elegant way.
+
+func (rs *runnerSchedule) Next(now time.Time) time.Time {
+	// Is it first time?
+	if rs.firstRun.IsZero() {
+		rs.firstRun = now.Add(time.Second * time.Duration(rs.schedule.StartAfter))
+		return rs.firstRun
+	}
+
+	// By this point, we have run or will be run shortly
+	rs.iterated++
+
+	// Is it time to stop?
+	if rs.schedule.Iterations > 0 && rs.iterated >= rs.schedule.Iterations {
+		// return zero time to stop the schedule
+		return time.Time{}
+
+		// In future we may want to remove the schedule from the cron it cannot be done from this function,
+		// by the way (I have tried) because cron.Remove(taskId) requires Lock which is already taken
+		// the this function runs. It has to be done externally.
+	}
+
+	// Return next run time
+	return now.Add(time.Second * time.Duration(rs.schedule.Period))
+}
+
+// newRunner registers callback.
+func newRunnerImpl() runner {
+	return &runnerImpl{}
+}
+
+func (r *runnerImpl) start() {
+	r.taskCron = cron.New()
+	r.taskCron.Start()
+}
+
+func (r *runnerImpl) stop() context.Context {
+	return r.taskCron.Stop()
+}
+
+func (r *runnerImpl) addJob(j job) {
+	schedule := &runnerSchedule{
+		schedule: j.schedule,
+	}
+	r.taskCron.Schedule(schedule, j)
+}

--- a/comp/core/agenttelemetry/sender.go
+++ b/comp/core/agenttelemetry/sender.go
@@ -1,0 +1,393 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package agenttelemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/metadata/host"
+	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+	"github.com/DataDog/datadog-agent/pkg/version"
+	dto "github.com/prometheus/client_model/go"
+)
+
+const (
+	telemetryEndpointPrefix = "https://instrumentation-telemetry-intake."
+
+	httpClientResetInterval = 5 * time.Minute
+	httpClientTimeout       = 10 * time.Second
+	maximumNumberOfPayloads = 50
+)
+
+// ---------------
+// interfaces
+type sender interface {
+	startSession(cancelCtx context.Context) *senderSession
+	flushSession(ss *senderSession) error
+	sendAgentStatusPayload(session *senderSession, agentStatusPayload map[string]interface{}) error
+	sendAgentMetricPayloads(session *senderSession, metrics []*agentmetric) error
+}
+
+type client interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// ---------------
+// senderImpl
+type senderImpl struct {
+	cfgComp  config.Reader
+	logComp  log.Component
+	hostComp host.Component
+
+	client client
+
+	endpointURL  string
+	agentVersion string
+
+	// pre-fill parts of payload which are not changing during run-time
+	payloadTemplate             Payload
+	metadataPayloadTemplate     AgentMetadataPayload
+	agentMetricsPayloadTemplate AgentMetricsPayload
+	agentStatusPayloadTemplate  AgentStatusPayload
+}
+
+// HostPayload defines the host payload object. It is currently used only as payload's header
+// and it is not stored with backend. It could be removed in the future completly. It is expected
+// by backend to be present in the payload and currently tootaly reducted.
+type HostPayload struct {
+	Hostname      string `json:"hostname"`
+	OS            string `json:"os"`
+	Arch          string `json:"architecture"`
+	KernelName    string `json:"kernel_name"`
+	KernelRelease string `json:"kernel_release"`
+	KernelVersion string `json:"kernel_version"`
+}
+
+// AgentMetadataPayload should be top level object in the payload but currently tucked into specific payloads
+// until backend will be adjusted properly
+type AgentMetadataPayload struct {
+	HostID string `json:"hostid"`
+}
+
+// Payload defines the top level object in the payload
+type Payload struct {
+	APIVersion  string      `json:"api_version"`
+	RequestType string      `json:"request_type"`
+	EventTime   int64       `json:"event_time"`
+	DebugFlag   bool        `json:"debug"`
+	Host        HostPayload `json:"host"`
+	Payload     interface{} `json:"payload"`
+}
+
+// ---------------
+// BATCH PAYLOAD WRAPPER
+//
+// part of payload batching
+type payloadInfo struct {
+	requestType string
+	payload     interface{}
+}
+
+// senderSession is also use to batch payloads
+type senderSession struct {
+	cancelCtx context.Context
+	payloads  []payloadInfo
+}
+
+// BatchPayloadWrapper exported so it can be turned into json
+type BatchPayloadWrapper struct {
+	RequestType string      `json:"request_type"`
+	Payload     interface{} `json:"payload"`
+}
+
+// ---------------
+// AGENT METRICS
+//
+
+// AgentMetricsPayload defines Metrics object
+type AgentMetricsPayload struct {
+	Message string                 `json:"message"`
+	Metrics map[string]interface{} `json:"metrics"`
+}
+
+// MetricPayload defines Metric object
+type MetricPayload struct {
+	Value   float64                `json:"value"`
+	Type    string                 `json:"type"`
+	Tags    map[string]interface{} `json:"tags,omitempty"`
+	Buckets map[string]interface{} `json:"buckets,omitempty"`
+}
+
+// -------------
+// AGENT STATUS
+//
+
+// AgentStatusPayload defines AgentStatus object
+type AgentStatusPayload struct {
+	Message     string                 `json:"message"`
+	AgentStatus map[string]interface{} `json:"agent_status"`
+}
+
+func httpClientFactory(cfg config.Reader, timeout time.Duration) func() *http.Client {
+	return func() *http.Client {
+		return &http.Client{
+			Timeout: timeout,
+			// reusing core agent HTTP transport to benefit from proxy settings.
+			Transport: httputils.CreateHTTPTransport(cfg),
+		}
+	}
+}
+
+func newSenderClientImpl(agentCfg config.Component) client {
+	return httputils.NewResetClient(httpClientResetInterval, httpClientFactory(agentCfg, httpClientTimeout))
+}
+
+func newSenderImpl(
+	cfgComp config.Component,
+	logComp log.Component,
+	hostComp host.Component,
+	client client) (sender, error) {
+	// Form Agent Telemetry endpoint
+	endpoint := utils.GetMainEndpoint(cfgComp, telemetryEndpointPrefix, "dd_url")
+	endpointURL, err := url.JoinPath(endpoint, "/api/v2/apmtelemetry")
+	if err != nil {
+		return nil, fmt.Errorf("failed to form agent telemetry endpoint URL from configuration: %v", err)
+	}
+
+	// Get host information (only hostid is used for now)
+	info := hostComp.GetInformation()
+
+	// Redact all host info for now until we have a proper way to handle it
+	host := HostPayload{
+		Hostname:      "[REDACTED]", // info.Hostname,
+		OS:            "[REDACTED]", // info.OS,
+		Arch:          "[REDACTED]", // info.KernelArch,
+		KernelName:    "[REDACTED]", // info.Platform,
+		KernelRelease: "[REDACTED]", // info.PlatformVersion,
+		KernelVersion: "[REDACTED]", // info.KernelVersion,
+	}
+
+	agentVersion, _ := version.Agent()
+
+	return &senderImpl{
+		cfgComp:  cfgComp,
+		logComp:  logComp,
+		hostComp: hostComp,
+
+		client:       client,
+		endpointURL:  endpointURL,
+		agentVersion: agentVersion.GetNumberAndPre(),
+		// pre-fill parts of payload which are not changing during run-time
+		payloadTemplate: Payload{
+			APIVersion: "v2",
+			DebugFlag:  false,
+			Host:       host,
+		},
+		metadataPayloadTemplate: AgentMetadataPayload{
+			HostID: info.HostID,
+		},
+		agentMetricsPayloadTemplate: AgentMetricsPayload{
+			Message: "Agent metrics",
+		},
+		agentStatusPayloadTemplate: AgentStatusPayload{
+			Message: "Agent status",
+		},
+	}, nil
+}
+
+func (s *senderImpl) addMetricPayload(
+	metricName string,
+	metricFamily *dto.MetricFamily,
+	metric *dto.Metric,
+	metricsPayload *AgentMetricsPayload) {
+
+	// Copy template
+	payload := MetricPayload{}
+
+	// Add metric value
+	metricType := metricFamily.GetType()
+	switch metricType {
+	case dto.MetricType_COUNTER:
+		payload.Type = "monotonic"
+		payload.Value = metric.GetCounter().GetValue()
+	case dto.MetricType_GAUGE:
+		payload.Type = "gauge"
+		payload.Value = metric.GetGauge().GetValue()
+	case dto.MetricType_HISTOGRAM:
+		payload.Type = "histogram"
+		payload.Buckets = make(map[string]interface{}, 0)
+		histogram := metric.GetHistogram()
+		for _, bucket := range histogram.GetBucket() {
+			boundName := fmt.Sprintf("upperbound_%v", bucket.GetUpperBound())
+			payload.Buckets[boundName] = bucket.GetCumulativeCount()
+		}
+	}
+
+	// Add metric tags
+	if len(metric.GetLabel()) != 0 {
+		payload.Tags = make(map[string]interface{}, 0)
+		for _, labelPair := range metric.GetLabel() {
+			payload.Tags[labelPair.GetName()] = labelPair.GetValue()
+		}
+	}
+
+	// Finally add metric to the payload
+	metricsPayload.Metrics[metricName] = payload
+}
+
+func (s *senderImpl) startSession(cancelCtx context.Context) *senderSession {
+	return &senderSession{
+		cancelCtx: cancelCtx,
+	}
+}
+
+func (s *senderImpl) flushSession(ss *senderSession) error {
+	// There is nothing to do if there are no payloads
+	if len(ss.payloads) == 0 {
+		return nil
+	}
+
+	s.logComp.Infof("Flushing Agent Telemetery session with %d payloads", len(ss.payloads))
+
+	// Defer cleanup of payloads. Even if there is an error, we want to cleanup
+	// but in future we may want to add retry logic.
+	defer func() {
+		ss.payloads = nil
+	}()
+
+	// Create a payload with a single message or batch of messages
+	payload := s.payloadTemplate
+	payload.EventTime = time.Now().Unix()
+	if len(ss.payloads) == 1 {
+		// Single payload will be sent directly using the request type of the payload
+		payload.RequestType = ss.payloads[0].requestType
+		payload.Payload = ss.payloads[0].payload
+	} else {
+		// Batch up multiple payloads into single "batch" payload type
+		payload.RequestType = "message-batch"
+		payloadWrappers := make([]BatchPayloadWrapper, 0)
+		for _, p := range ss.payloads {
+			payloadWrappers = append(payloadWrappers,
+				BatchPayloadWrapper{
+					RequestType: p.requestType,
+					Payload:     p.payload,
+				})
+		}
+		payload.Payload = payloadWrappers
+	}
+
+	// Marshal the payload to a byte array
+	reqBody, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	// Send the payload
+	req, err := http.NewRequest("POST", s.endpointURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+	s.addHeaders(req, payload.RequestType, s.cfgComp.GetString("api_key"), strconv.Itoa(len(reqBody)))
+	resp, err := s.client.Do(req.WithContext(ss.cancelCtx))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	// Log return status
+	s.logComp.Infof("Telemetery request response status: %s, status code: %d", resp.Status, resp.StatusCode)
+
+	return nil
+}
+
+func (s *senderImpl) sendAgentMetricPayloads(session *senderSession, metrics []*agentmetric) error {
+	// Are there any metrics
+	if len(metrics) == 0 {
+		return nil
+	}
+
+	// Create one or more metric payloads batching different metrics into a single payload,
+	// but the same metric (with multiple tag sets) into different payloads. This is needed
+	// to avoid creating JSON payloads which contains arrays (otherwise we could not
+	// effectively query and or aggregate these values). Metrics are batchup where first
+	// slice of all tag sets goes to first payload entry, second to second, etc. Effectively
+	// we are creating a "transposed" matrix of metrics and tag sets, where each
+	// message/payload contains multiples metrics for a single index of tag set. Essentially
+	// the number of message/payloads is equal to the maximum number of tag sets for a single
+	// metric.
+	var payloads []*AgentMetricsPayload
+	for _, am := range metrics {
+		for idx, m := range am.filteredMetrics {
+			var payload *AgentMetricsPayload
+
+			// reuse or add a payload
+			if idx+1 > len(payloads) {
+				newPayload := s.agentMetricsPayloadTemplate
+				newPayload.Metrics = make(map[string]interface{}, 0)
+				newPayload.Metrics["agent_metadata"] = s.metadataPayloadTemplate
+				payloads = append(payloads, &newPayload)
+			}
+			payload = payloads[idx]
+			s.addMetricPayload(am.metricName, am.promMetricFamily, m, payload)
+		}
+	}
+
+	// We will batch multiples metrics payloads into single "batch" payload type
+	// but for now send it one by one
+	for _, payload := range payloads {
+		if err := s.sendPayload(session, "agent-metrics", payload); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *senderImpl) sendAgentStatusPayload(session *senderSession, agentStatusPayload map[string]interface{}) error {
+	payload := s.agentStatusPayloadTemplate
+	payload.AgentStatus = agentStatusPayload
+	payload.AgentStatus["agent_metadata"] = s.metadataPayloadTemplate
+
+	return s.sendPayload(session, "agent-status", payload)
+}
+
+func (s *senderImpl) sendPayload(session *senderSession, requestType string, payload interface{}) error {
+	// Add payload to session
+	session.payloads = append(session.payloads, payloadInfo{requestType, payload})
+
+	// Flush session if it is full
+	if len(session.payloads) >= maximumNumberOfPayloads {
+		return s.flushSession(session)
+	}
+
+	return nil
+}
+
+func (s *senderImpl) addHeaders(req *http.Request, requesttype, apikey, bodylen string) {
+	req.Header.Add("DD-Api-Key", apikey)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Content-Length", bodylen)
+	req.Header.Add("DD-Telemetry-api-version", "v2")
+	req.Header.Add("DD-Telemetry-request-type", requesttype)
+	req.Header.Add("DD-Telemetry-Product", "agent")
+	req.Header.Add("DD-Telemetry-Product-Version", s.agentVersion)
+	// Not clear how to acquire that. Appears that EVP adds it automatically
+	req.Header.Add("datadog-container-id", "")
+}

--- a/comp/core/agenttelemetry/telemetry.go
+++ b/comp/core/agenttelemetry/telemetry.go
@@ -1,0 +1,431 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agenttelemetry
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	"github.com/DataDog/datadog-agent/comp/metadata/host"
+	"github.com/DataDog/datadog-agent/pkg/status/render"
+
+	dto "github.com/prometheus/client_model/go"
+	"go.uber.org/fx"
+)
+
+type agenttelemetry struct {
+	cfgComp    config.Component
+	logComp    log.Component
+	telComp    telemetry.Component
+	statusComp status.Component
+	hostComp   host.Component
+
+	enabled bool
+	sender  sender
+	runner  runner
+	atelCfg *Config
+
+	cancelCtx context.Context
+	cancel    context.CancelFunc
+}
+
+// FX-in compatibility
+type dependencies struct {
+	fx.In
+
+	Log       log.Component
+	Config    config.Component
+	Telemetry telemetry.Component
+	Status    status.Component
+	Host      host.Component
+
+	Lifecycle fx.Lifecycle
+}
+
+// FX-out compatibility
+type provides struct {
+	fx.Out
+
+	Comp Component
+}
+
+// Interfacing with runner.
+type job struct {
+	atel     *agenttelemetry
+	profiles []*Profile
+	schedule Schedule
+}
+
+func (j job) Run() {
+	j.atel.run(j.profiles)
+}
+
+// Passing metrics to sender Interfacing with sender
+type agentmetric struct {
+	metricName       string
+	filteredMetrics  []*dto.Metric
+	promMetricFamily *dto.MetricFamily
+}
+
+func createAgentTelemetrySender(
+	cfgComp config.Component,
+	logComp log.Component,
+	hostComp host.Component,
+) (sender, error) {
+	client := newSenderClientImpl(cfgComp)
+	sender, err := newSenderImpl(cfgComp, logComp, hostComp, client)
+	if err != nil {
+		logComp.Errorf("Failed to create agent telemetry sender: %s", err.Error())
+	}
+	return sender, err
+}
+
+func createAgentTelemetryProvider(
+	cfgComp config.Component,
+	logComp log.Component,
+	telComp telemetry.Component,
+	statusComp status.Component,
+	hostComp host.Component,
+	sender sender,
+	runner runner) *agenttelemetry {
+	// Parse Agent Telemetry Configuration configuration
+	atelCfg, err := parseConfig(cfgComp)
+	if err != nil {
+		logComp.Errorf("Failed to parse agent telemetry config: %s", err.Error())
+		return &agenttelemetry{}
+	}
+	if !atelCfg.Enabled {
+		logComp.Info("Agent telemetry is disabled")
+		return &agenttelemetry{}
+	}
+
+	return &agenttelemetry{
+		enabled:    true,
+		cfgComp:    cfgComp,
+		logComp:    logComp,
+		telComp:    telComp,
+		statusComp: statusComp,
+		hostComp:   hostComp,
+		sender:     sender,
+		runner:     runner,
+		atelCfg:    atelCfg,
+	}
+}
+
+// Factory function to create a new agent telemetry provider
+func newAgentTelemetryProvider(deps dependencies) provides {
+	sender, err := createAgentTelemetrySender(deps.Config, deps.Log, deps.Host)
+	if err != nil {
+		return provides{Comp: &agenttelemetry{}}
+	}
+
+	runner := newRunnerImpl()
+
+	// Wire up the agent telemetry provider (TODO: use FX for sender, client and runner?)
+	atel := createAgentTelemetryProvider(
+		deps.Config,
+		deps.Log,
+		deps.Telemetry,
+		deps.Status,
+		deps.Host,
+		sender,
+		runner,
+	)
+
+	// If agent telemetry is enabled, add the start and stop hooks
+	if atel.enabled {
+		// Instruct FX to start and stop the agent telemetry
+		deps.Lifecycle.Append(fx.Hook{
+			OnStart: func(ctx context.Context) error {
+				return atel.start()
+			},
+			OnStop: func(ctx context.Context) error {
+				return atel.stop()
+			},
+		})
+	}
+
+	return provides{Comp: atel}
+}
+
+func (atel *agenttelemetry) filterMetric(profile *Profile, promMetricFamily *dto.MetricFamily) *agentmetric {
+	var amc *MetricConfig
+	var ok bool
+
+	// Check if the metric is included in the profile
+	if amc, ok = profile.metricsMap[promMetricFamily.GetName()]; !ok {
+		return nil
+	}
+
+	// Filter the metric according to the profile configuration
+	// Currently we only support filtering out zero values if specified in the profile
+	var filteredMetrics []*dto.Metric
+	for _, m := range promMetricFamily.Metric {
+		mt := promMetricFamily.GetType()
+
+		// Filter out not supported types
+		if !isSupportedMetricType(mt) {
+			continue
+		}
+
+		// filter out zero values if specified in the profile
+		if profile.excludeZeroMetric && isZeroValueMetric(mt, m) {
+			continue
+		}
+
+		// filter out if contains excluded tags
+		if len(profile.excludeTags) > 0 && areTagsMatching(m.GetLabel(), profile.excludeTags) {
+			continue
+		}
+
+		// and now we can add the metric to the filtered metrics
+		filteredMetrics = append(filteredMetrics, m)
+	}
+
+	// nothing to report
+	if len(filteredMetrics) == 0 {
+		return nil
+	}
+
+	return &agentmetric{
+		metricName:       amc.Name,
+		filteredMetrics:  filteredMetrics,
+		promMetricFamily: promMetricFamily,
+	}
+}
+
+func (atel *agenttelemetry) reportAgentMetrics(session *senderSession, profile *Profile) {
+	// If no metrics are configured nothing to report
+	if len(profile.metricsMap) == 0 {
+		return
+	}
+
+	atel.logComp.Debugf("Collect Agent Metric telemetry for profile %s", profile.Name)
+
+	// Gather all prom metrircs. Currently Gather() does not allow filtering by
+	// matric name, so we need to gather all metrics and filter them on our own.
+	//	pms, err := atel.telemetry.Gather(false)
+	pms, err := atel.telComp.Gather(false)
+	if err != nil {
+		atel.logComp.Errorf("failed to get filtered telemetry metrics: %s", err)
+		return
+	}
+
+	// ... and filter them according to the profile configuration
+	var metrics []*agentmetric
+	for _, pm := range pms {
+		if am := atel.filterMetric(profile, pm); am != nil {
+			metrics = append(metrics, am)
+		}
+	}
+
+	// Send the metrics if any were filtered
+	if len(metrics) == 0 {
+		atel.logComp.Debug("No Agent Metric telemetry collected")
+		return
+	}
+
+	// Send the metrics if any were filtered
+	atel.logComp.Debugf("Reporting Agent Metric telemetry for profile %s", profile.Name)
+
+	err = atel.sender.sendAgentMetricPayloads(session, metrics)
+	if err != nil {
+		atel.logComp.Errorf("failed to get filtered telemetry metrics: %s", err)
+	}
+}
+
+func (atel *agenttelemetry) renderAgentStatus(profile *Profile, fullStatus map[string]interface{}, statusOutput map[string]interface{}) {
+	// Render template if needed
+	if profile.Status.Template != "none" {
+		// Filter full Agent Status JSON via template which is selected by appending template suffix
+		// to "pkg\status\render\templates\agent-telemetry-<suffix>.tmpl" file name. Currently we
+		// support only "basic" suffix/template with future extensions to use other templates.
+		statusBytes, err := render.FormatAgentTelemetry(fullStatus, profile.Status.Template)
+		if err != nil {
+			atel.logComp.Errorf("Failed to collect Agent Status telemetry. Error: %s", err.Error())
+			return
+		}
+		if len(statusBytes) == 0 {
+			atel.logComp.Debug("Agent status rendering to agent telemetry payloads return empty payload")
+			return
+		}
+
+		// Convert byte slice to JSON object
+		if err := json.Unmarshal(statusBytes, &statusOutput); err != nil {
+			atel.logComp.Errorf("Failed to collect Agent Status telemetry. Error: %s", err.Error())
+			return
+		}
+	}
+}
+
+func (atel *agenttelemetry) addAgentStatusExtra(profile *Profile, fullStatus map[string]interface{}, statusOutput map[string]interface{}) {
+	for _, builder := range profile.statusExtraBuilder {
+		// Evaluate JQ expression against the agent status JSON object
+		jqResult := builder.jqSource.Run(fullStatus)
+		jqValue, ok := jqResult.Next()
+		if !ok {
+			atel.logComp.Errorf("Failed to apply JQ expression for JSON path '%s' to Agent Status payload. Error unknown",
+				strings.Join(builder.jpathTarget, "."))
+			continue
+		}
+
+		// Validate JQ expression result
+		if err, ok := jqValue.(error); ok {
+			atel.logComp.Errorf("Failed to apply JQ expression for JSON path '%s' to Agent Status payload. Error: %s",
+				strings.Join(builder.jpathTarget, "."), err.Error())
+			continue
+		}
+
+		// Validate JQ expression result type
+		var attrVal interface{}
+		switch jqValueType := jqValue.(type) {
+		case int:
+			attrVal = jqValueType
+		case float64:
+			attrVal = jqValueType
+		case bool:
+			attrVal = jqValueType
+		case nil:
+			atel.logComp.Debugf("JQ expression return 'nil' value for JSON path '%s'", strings.Join(builder.jpathTarget, "."))
+			continue
+		case string:
+			atel.logComp.Errorf("string value (%v) for JSON path '%s' for extra status atttribute is not currently allowed",
+				strings.Join(builder.jpathTarget, "."), attrVal)
+			continue
+		default:
+			atel.logComp.Errorf("'%v' value (%v) for JSON path '%s' for extra status atttribute is not currently allowed",
+				reflect.TypeOf(jqValueType), reflect.ValueOf(jqValueType), strings.Join(builder.jpathTarget, "."))
+			continue
+		}
+
+		// Add resulting value to the agent status telemetry payload (recursively creating missing JSON objects)
+		curNode := statusOutput
+		for i, p := range builder.jpathTarget {
+			// last element is the attribute name
+			if i == len(builder.jpathTarget)-1 {
+				curNode[p] = attrVal
+				break
+			}
+
+			existSubNode, ok := curNode[p]
+
+			// if the node doesn't exist, create it
+			if !ok {
+				newSubNode := make(map[string]interface{})
+				curNode[p] = newSubNode
+				curNode = newSubNode
+			} else {
+				existSubNodeCasted, ok := existSubNode.(map[string]interface{})
+				if !ok {
+					atel.logComp.Errorf("JSON path '%s' points to non-object element", strings.Join(builder.jpathTarget[:i], "."))
+					break
+				}
+				curNode = existSubNodeCasted
+			}
+		}
+	}
+}
+
+func (atel *agenttelemetry) reportAgentStatus(session *senderSession, profile *Profile) {
+	// If no status is configured nothing to report
+	if profile.Status == nil {
+		return
+	}
+
+	atel.logComp.Debugf("Collect Agent Status telemetry for profile %s", profile.Name)
+
+	// Get Agent Status JSON object
+	statusBytes, err := atel.statusComp.GetStatus("json", true)
+	if err != nil {
+		atel.logComp.Errorf("failed to get agent status: %s", err)
+		return
+	}
+
+	var statusJSON = make(map[string]interface{})
+	err = json.Unmarshal(statusBytes, &statusJSON)
+	if err != nil {
+		atel.logComp.Errorf("failed to unmarshall agent status: %s", err)
+		return
+	}
+
+	// Render Agent Status JSON object (using template if needed and adding extra attributes)
+	var statusPayloadJSON = make(map[string]interface{})
+	atel.renderAgentStatus(profile, statusJSON, statusPayloadJSON)
+	atel.addAgentStatusExtra(profile, statusJSON, statusPayloadJSON)
+	if len(statusPayloadJSON) == 0 {
+		atel.logComp.Debug("No Agent Status telemetry collected")
+		return
+	}
+
+	atel.logComp.Debugf("Reporting Agent Status telemetry for profile %s", profile.Name)
+
+	// Send the Agent Telemetry status payload
+	err = atel.sender.sendAgentStatusPayload(session, statusPayloadJSON)
+	if err != nil {
+		atel.logComp.Errorf("failed to send agent status: %s", err)
+		return
+	}
+}
+
+// run runs the agent telemetry for a given profile. It is triggered by the runner
+// according to the profiles schedule.
+func (atel *agenttelemetry) run(profiles []*Profile) {
+	session := atel.sender.startSession(atel.cancelCtx)
+
+	for _, p := range profiles {
+		atel.reportAgentMetrics(session, p)
+		atel.reportAgentStatus(session, p)
+	}
+
+	err := atel.sender.flushSession(session)
+	if err != nil {
+		atel.logComp.Errorf("failed to flush agent telemetry session: %s", err)
+		return
+	}
+}
+
+// TODO: implement when CLI tool will be implemented
+func (atel *agenttelemetry) GetAsJSON() ([]byte, error) {
+	return nil, nil
+}
+
+// start is called by FX when the application starts.
+func (atel *agenttelemetry) start() error {
+	atel.logComp.Info("Starting agent telemetry")
+
+	atel.cancelCtx, atel.cancel = context.WithCancel(context.Background())
+
+	// Start the runner and add the jobs.
+	atel.runner.start()
+	for sh, pp := range atel.atelCfg.schedule {
+		atel.runner.addJob(job{
+			atel:     atel,
+			profiles: pp,
+			schedule: sh,
+		})
+	}
+
+	return nil
+}
+
+// stop is called by FX when the application stops.
+func (atel *agenttelemetry) stop() error {
+	atel.logComp.Info("Stopping agent telemetry")
+	atel.cancel()
+
+	runnerCtx := atel.runner.stop()
+	<-runnerCtx.Done()
+
+	<-atel.cancelCtx.Done()
+	atel.logComp.Info("Agent telemetry is stopped")
+	return nil
+}

--- a/comp/core/agenttelemetry/telemetry_test.go
+++ b/comp/core/agenttelemetry/telemetry_test.go
@@ -1,0 +1,188 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agenttelemetry
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	gopsutilhost "github.com/shirou/gopsutil/v3/host"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	"github.com/DataDog/datadog-agent/comp/metadata/host"
+	telemetrypkg "github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// HTTP client mock
+type clientMock struct {
+	body []byte
+}
+
+func (c *clientMock) Do(req *http.Request) (*http.Response, error) {
+	c.body, _ = io.ReadAll(req.Body)
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+	}, nil
+}
+
+func newClientMock() client {
+	return &clientMock{}
+}
+
+// Runner mock (TODO: use use mock.Mock)
+type runnerMock struct {
+	mock.Mock
+	jobs []job
+}
+
+func (r *runnerMock) run() {
+	for _, j := range r.jobs {
+		j.atel.run(j.profiles)
+	}
+}
+
+func (r *runnerMock) start() {
+}
+
+func (r *runnerMock) stop() context.Context {
+	return context.Background()
+}
+
+func (r *runnerMock) addJob(j job) {
+	r.jobs = append(r.jobs, j)
+}
+
+func newRunnerMock() runner {
+	return &runnerMock{}
+}
+
+// Host component currently does not have a mock
+type hostMock struct {
+}
+
+func (s hostMock) GetPayloadAsJSON(context.Context) ([]byte, error) {
+	return []byte{}, nil
+}
+func (s hostMock) GetInformation() *gopsutilhost.InfoStat {
+	return &gopsutilhost.InfoStat{}
+}
+func newHostMock() hostMock {
+	return hostMock{}
+}
+
+// Status component currently has mock but it appears to be not compatible with fx  fx fails
+type statusMock struct {
+}
+
+func (s statusMock) GetStatus(string, bool, ...string) ([]byte, error) {
+	return []byte{}, nil
+}
+func (s statusMock) GetStatusBySection(string, string, bool) ([]byte, error) {
+	return []byte{}, nil
+}
+func newStatusMock() statusMock {
+	return statusMock{}
+}
+
+// aggregator mock function
+func getTestAgentTelemetry(t *testing.T,
+	tel telemetry.Component,
+	confOverrides map[string]any,
+	client client,
+	runner runner) *agenttelemetry {
+
+	cfg := fxutil.Test[config.Component](t, config.MockModule(),
+		fx.Replace(config.MockParams{Overrides: confOverrides}))
+	log := fxutil.Test[log.Component](t, logimpl.MockModule())
+	status := fxutil.Test[status.Component](t,
+		func() fxutil.Module {
+			return fxutil.Component(
+				fx.Provide(newStatusMock),
+				fx.Provide(func(s statusMock) status.Component { return s }))
+		}())
+	host := fxutil.Test[host.Component](t,
+		func() fxutil.Module {
+			return fxutil.Component(
+				fx.Provide(newHostMock),
+				fx.Provide(func(m hostMock) host.Component { return m }))
+		}())
+
+	sndr, err := newSenderImpl(cfg, log, host, client)
+	assert.NoError(t, err)
+
+	atel := createAgentTelemetryProvider(cfg, log, tel, status, host, sndr, runner)
+	return atel
+}
+
+func TestEnabled(t *testing.T) {
+	tel := fxutil.Test[telemetry.Component](t, telemetry.MockModule())
+	override := map[string]any{
+		"agent_telemetry.enabled": true,
+	}
+	client := newClientMock()
+	runner := newRunnerMock()
+
+	// setup and initiate atel
+	atel := getTestAgentTelemetry(t, tel, override, client, runner)
+
+	assert.True(t, atel.enabled)
+}
+
+func TestRun(t *testing.T) {
+	tel := fxutil.Test[telemetry.Component](t, telemetry.MockModule())
+	override := map[string]any{
+		"agent_telemetry.enabled": true,
+	}
+	client := newClientMock()
+	runner := newRunnerMock()
+
+	// setup and initiate atel
+	atel := getTestAgentTelemetry(t, tel, override, client, runner)
+	atel.start()
+
+	// default configuration has 1 job with 2 profiles (more configurations needs to be tested)
+	// will be improved in future by providing deterministic configuration
+	assert.Equal(t, 1, len(runner.(*runnerMock).jobs))
+	assert.Equal(t, 2, len(runner.(*runnerMock).jobs[0].profiles))
+}
+
+func TestTelemetryReportMetricBasic(t *testing.T) {
+	// Little hack. Telemetry component is not fully componentized, and relies on global registry so far
+	// so we need to reset it before running the test. This is not ideal and will be improved in the future.
+	// TODO: moved Status and Metric collection to an interface and use a mock for testing
+	tel := fxutil.Test[telemetry.Mock](t, telemetry.MockModule())
+	tel.Reset()
+	counter := telemetrypkg.NewCounter("checks", "execution_time", []string{"check_name"}, "")
+	counter.Inc("mycheck")
+	override := map[string]any{
+		"agent_telemetry.enabled": true,
+	}
+	client := newClientMock()
+	runner := newRunnerMock()
+
+	// setup and initiate atel
+	atel := getTestAgentTelemetry(t, tel, override, client, runner)
+	atel.start()
+
+	// run the runner to trigger the telemetry report
+	runner.(*runnerMock).run()
+
+	assert.True(t, len(client.(*clientMock).body) > 0)
+
+	// for more sophisticated comparison, we could unmarshal the body and check the content
+	// will use jsondiff.CompareJSON(src, dest, jsondiff.Equivalent())	"github.com/wI2L/jsondiff")
+}

--- a/comp/core/agenttelemetry/utils.go
+++ b/comp/core/agenttelemetry/utils.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agenttelemetry
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/itchyny/gojq"
+	dto "github.com/prometheus/client_model/go"
+)
+
+type jBuilder struct {
+	jqSource    *gojq.Query
+	jpathTarget []string
+}
+
+// compileJBuilders compiles a map of JSON path and JQ query into a slice of jBuilder
+func compileJBuilders(params map[string]string) ([]jBuilder, error) {
+	var builders []jBuilder
+	for jpath, query := range params {
+		// Validate JSON/attribute path
+		jpaths := strings.Split(jpath, ".")
+		if len(jpaths) < 2 {
+			return nil, fmt.Errorf("jpath `%s` should contain at leat two elements", jpath)
+		}
+
+		// Compile JQ expression
+		q, err := gojq.Parse(query)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse jq query %s for jpath '%s': %s", query, jpath, err.Error())
+		}
+
+		builder := jBuilder{jqSource: q, jpathTarget: jpaths}
+		builders = append(builders, builder)
+	}
+
+	return builders, nil
+}
+
+// select only supported metric types
+func isSupportedMetricType(mt dto.MetricType) bool {
+	return mt == dto.MetricType_COUNTER || mt == dto.MetricType_GAUGE || mt == dto.MetricType_HISTOGRAM
+}
+
+// isZeroValueMetric checks if a metric is a zero value metric
+func isZeroValueMetric(mt dto.MetricType, m *dto.Metric) bool {
+	switch mt {
+	case dto.MetricType_COUNTER:
+		if m.GetCounter().GetValue() == 0 {
+			return true
+		}
+	case dto.MetricType_GAUGE:
+		if m.GetGauge().GetValue() == 0 {
+			return true
+		}
+	case dto.MetricType_HISTOGRAM:
+		// makes sure that all buckets are not zero (sufficient to check the last one)
+		h := m.GetHistogram()
+		c := len(h.GetBucket())
+		if c == 0 || h.GetBucket()[c-1].GetCumulativeCount() == 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// areTagsMatching checks if the metric tags match the given set of tags
+// It is currently used to filter (exclude) metrics based on tags.
+func areTagsMatching(metricTags []*dto.LabelPair, matchTags map[string]interface{}) bool {
+	if len(metricTags) == 0 || len(matchTags) == 0 {
+		return false
+	}
+
+	for _, tv := range metricTags {
+		if valToMatch, ok := matchTags[tv.GetName()]; ok {
+			// If matching tag value is not specified then there is match if the tag exists
+			if _, ok := valToMatch.(struct{}); ok {
+				return true
+			}
+
+			// valToMatch is a map of tag values, check if we now have a match
+			if valsToMatch, ok := valToMatch.(map[string]struct{}); ok {
+				if _, ok := valsToMatch[tv.GetValue()]; ok {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/comp/core/bundle.go
+++ b/comp/core/bundle.go
@@ -15,6 +15,7 @@ package core
 import (
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/agenttelemetry"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
@@ -40,5 +41,6 @@ func Bundle() fxutil.BundleOptions {
 		fx.Provide(func(params BundleParams) secrets.Params { return params.SecretParams }),
 		sysprobeconfigimpl.Module(),
 		telemetry.Module(),
-		hostnameimpl.Module())
+		hostnameimpl.Module(),
+		agenttelemetry.Module())
 }

--- a/comp/core/telemetry/component.go
+++ b/comp/core/telemetry/component.go
@@ -64,8 +64,8 @@ type Component interface {
 	// NewSimpleHistogramWithOpts creates a new SimpleHistogram.
 	NewSimpleHistogramWithOpts(subsystem, name, help string, buckets []float64, opts Options) SimpleHistogram
 
-	// GatherDefault exposes metrics from the default telemetry registry (see options.DefaultMetric)
-	GatherDefault() ([]*dto.MetricFamily, error)
+	// Gather exposes metrics from the general or default telemetry registry (see options.DefaultMetric)
+	Gather(defaultGather bool) ([]*dto.MetricFamily, error)
 }
 
 // Mock implements mock-specific methods.

--- a/comp/core/telemetry/telemetry.go
+++ b/comp/core/telemetry/telemetry.go
@@ -238,6 +238,13 @@ func (t *telemetryImpl) mustRegister(c prometheus.Collector, opts Options) {
 	}
 }
 
-func (t *telemetryImpl) GatherDefault() ([]*dto.MetricFamily, error) {
-	return t.defaultRegistry.Gather()
+func (t *telemetryImpl) Gather(defaultGather bool) ([]*dto.MetricFamily, error) {
+	if defaultGather {
+		return t.defaultRegistry.Gather()
+	}
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	return registry.Gather()
 }

--- a/comp/metadata/host/component.go
+++ b/comp/metadata/host/component.go
@@ -8,6 +8,8 @@ package host
 
 import (
 	"context"
+
+	"github.com/shirou/gopsutil/v3/host"
 )
 
 // team: agent-shared-components
@@ -15,4 +17,5 @@ import (
 // Component is the component type.
 type Component interface {
 	GetPayloadAsJSON(ctx context.Context) ([]byte, error)
+	GetInformation() *host.InfoStat
 }

--- a/comp/metadata/host/hostimpl/host.go
+++ b/comp/metadata/host/hostimpl/host.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"time"
 
+	gopsutilhost "github.com/shirou/gopsutil/v3/host"
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -19,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	hostComp "github.com/DataDog/datadog-agent/comp/metadata/host"
+	metadatautils "github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl/utils"
 	"github.com/DataDog/datadog-agent/comp/metadata/resources"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
@@ -118,6 +120,10 @@ func (h *host) collect(ctx context.Context) time.Duration {
 
 func (h *host) GetPayloadAsJSON(ctx context.Context) ([]byte, error) {
 	return json.MarshalIndent(h.getPayload(ctx), "", "    ")
+}
+
+func (h *host) GetInformation() *gopsutilhost.InfoStat {
+	return metadatautils.GetInformation()
 }
 
 func (h *host) fillFlare(fb flaretypes.FlareBuilder) error {

--- a/comp/metadata/host/hostimpl/utils/host_windows.go
+++ b/comp/metadata/host/hostimpl/utils/host_windows.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/shirou/gopsutil/v3/host"
 	"github.com/shirou/w32"
 	"golang.org/x/sys/windows"
 
@@ -37,29 +38,12 @@ var (
 	procGetTickCount64 = modkernel.NewProc("GetTickCount64")
 )
 
-// InfoStat describes the host status.  This is not in the psutil but it useful.
-type InfoStat struct {
-	Hostname             string `json:"hostname"`
-	Uptime               uint64 `json:"uptime"`
-	BootTime             uint64 `json:"bootTime"`
-	Procs                uint64 `json:"procs"`           // number of processes
-	OS                   string `json:"os"`              // ex: freebsd, linux
-	Platform             string `json:"platform"`        // ex: ubuntu, linuxmint
-	PlatformFamily       string `json:"platformFamily"`  // ex: debian, rhel
-	PlatformVersion      string `json:"platformVersion"` // version of the complete OS
-	KernelVersion        string `json:"kernelVersion"`   // version of the OS kernel (if available)
-	KernelArch           string `json:"kernelArch"`
-	VirtualizationSystem string `json:"virtualizationSystem"`
-	VirtualizationRole   string `json:"virtualizationRole"` // guest or host
-	HostID               string `json:"hostid"`             // ex: uuid
-}
-
 // GetInformation returns an InfoStat object, filled in with various operating system metadata
-func GetInformation() *InfoStat {
-	info, _ := cache.Get[*InfoStat](
+func GetInformation() *host.InfoStat {
+	info, _ := cache.Get[*host.InfoStat](
 		hostInfoCacheKey,
-		func() (*InfoStat, error) {
-			info := &InfoStat{}
+		func() (*host.InfoStat, error) {
+			info := &host.InfoStat{}
 			info.Hostname, _ = os.Hostname()
 
 			upTime := time.Duration(getTickCount64()) * time.Millisecond

--- a/comp/metadata/host/hostimpl/utils/host_windows_test.go
+++ b/comp/metadata/host/hostimpl/utils/host_windows_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/shirou/gopsutil/v3/host"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
@@ -45,7 +46,7 @@ func TestGetHostInfo(t *testing.T) {
 func TestGetHostInfoCache(t *testing.T) {
 	defer cache.Cache.Delete(hostInfoCacheKey)
 
-	fakeInfo := &InfoStat{Hostname: "hostname from cache"}
+	fakeInfo := &host.InfoStat{Hostname: "hostname from cache"}
 	cache.Cache.Set(hostInfoCacheKey, fakeInfo, cache.NoExpiration)
 
 	assert.Equal(t, fakeInfo, GetInformation())

--- a/pkg/collector/corechecks/telemetry/check.go
+++ b/pkg/collector/corechecks/telemetry/check.go
@@ -32,7 +32,7 @@ type checkImpl struct {
 }
 
 func (c *checkImpl) Run() error {
-	mfs, err := telemetry.GetCompatComponent().GatherDefault()
+	mfs, err := telemetry.GetCompatComponent().Gather(true)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1086,6 +1086,11 @@ func InitConfig(config pkgconfigmodel.Config) {
 	// The histogram buckets use to track the time in nanoseconds it takes for a DogStatsD listeners to push data to the server
 	config.BindEnvAndSetDefault("telemetry.dogstatsd.listeners_channel_latency_buckets", []string{})
 
+	// Agent Telemetry
+	// Enable various telemetry on the internals of the Agent.
+	// This will not tirgger any billable custom metrics.
+	config.BindEnvAndSetDefault("agent_telemetry.enabled", false)
+
 	// Declare other keys that don't have a default/env var.
 	// Mostly, keys we use IsSet() on, because IsSet always returns true if a key has a default.
 	config.SetKnown("metadata_providers")

--- a/pkg/config/utils/telemetry.go
+++ b/pkg/config/utils/telemetry.go
@@ -12,6 +12,11 @@ import (
 // IsCheckTelemetryEnabled returns if we want telemetry for the given check.
 // Returns true if a * is present in the telemetry.checks list.
 func IsCheckTelemetryEnabled(checkName string, cfg pkgconfigmodel.Reader) bool {
+	// when agent_telemetry is enabled, we enable telemetry for every check
+	if IsAgentTelemetryEnabled(cfg) {
+		return true
+	}
+
 	// false if telemetry is disabled
 	if !IsTelemetryEnabled(cfg) {
 		return false
@@ -32,5 +37,11 @@ func IsCheckTelemetryEnabled(checkName string, cfg pkgconfigmodel.Reader) bool {
 
 // IsTelemetryEnabled returns whether or not telemetry is enabled
 func IsTelemetryEnabled(cfg pkgconfigmodel.Reader) bool {
-	return cfg.IsSet("telemetry.enabled") && cfg.GetBool("telemetry.enabled")
+	return cfg.IsSet("telemetry.enabled") && cfg.GetBool("telemetry.enabled") ||
+		(IsAgentTelemetryEnabled(cfg))
+}
+
+// IsAgentTelemetryEnabled returns whether or not agent telemetry is enabled
+func IsAgentTelemetryEnabled(cfg pkgconfigmodel.Reader) bool {
+	return cfg.IsSet("agent_telemetry.enabled") && cfg.GetBool("agent_telemetry.enabled")
 }

--- a/pkg/status/render/render.go
+++ b/pkg/status/render/render.go
@@ -221,6 +221,31 @@ func FormatCheckStats(data []byte) (string, error) {
 	return b.String(), nil
 }
 
+// FormatAgentTelemetry takes a json bytestring and prints out the formatted agent telemetry template.
+func FormatAgentTelemetry(stats map[string]interface{}, renderTmplSuffix string) ([]byte, error) {
+	telemetrystats := make(map[string]interface{})
+
+	// Pluck the relevant parts of the status JSON
+	if rs, ok := stats["runnerStats"]; ok {
+		telemetrystats["RunnerStats"] = rs
+	}
+	if dsd, ok := stats["dogstatsdStats"]; ok {
+		telemetrystats["DogStatsdStats"] = dsd
+	}
+
+	var b = new(bytes.Buffer)
+	var errs []error
+	telemetryTemplate := fmt.Sprintf("/agent-telemetry-%s.tmpl", renderTmplSuffix)
+	if err := ParseTemplate(b, telemetryTemplate, telemetrystats); err != nil {
+		errs = append(errs, err)
+	}
+	if err := renderErrors(b, errs); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
+
 //go:embed templates
 var templatesFS embed.FS
 

--- a/pkg/status/render/templates/agent-telemetry-basic.tmpl
+++ b/pkg/status/render/templates/agent-telemetry-basic.tmpl
@@ -1,0 +1,18 @@
+{
+  {{- with .RunnerStats }}
+  "checks": {
+    "running_checks": {{.RunningChecks}},
+    "runs": {{.Runs}}
+  },
+  {{- end }}
+  {{- with .DogStatsdStats -}}
+  {{- $alreadyIterated := 0 }}
+  "dogstatsd": {
+  {{- range $key, $value := .}}
+    {{- if (gt $alreadyIterated 0)}},{{- end }}
+    "{{$key}}": {{$value}}
+    {{- $alreadyIterated = 1 }}
+  {{- end }}
+  }
+  {{- end }}
+}  


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Adds ability to send and query cross-org telemetry on a few internal Agent metrics. Specifically
* Sending a few internal and built-in checks.*, logs.*, transactions.*, dogstatsd.* metrics as well as small part of agent status
* Disabled by default.
* Default schedule sent 30 seconds after agent start and every 15 minutes after that
* Sent to the org's instrumentation-telemetry-intake

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Lack of Agent own observability for insight, optimization and troubleshooting.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
* Agent check telemetry (telemetry.check) is activated when agent_telemetry.enabled.
* We need to makes sure that agent memory usage will not grow and RSS remains stables (e.g. in cases if large number of metrics is collected and thrown away from Gather() method.

### Possible Drawbacks / Trade-offs
Additional cost for Datadog to process and store additional telemetry from many agents

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
* Set agent_telemetry.enabled: true
* Restart agent
* Wait a minute
* Paste in a search bar `source:agent-telemetry` - you should see a handful of messages with `Agent status` and `Agent metric` content, which contain JSON payload.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
