### PR TITLE
[process-agent] Move workloadmeta and tagger module out of the process bundle

### DIFF
--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -119,6 +119,12 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 		// Provide remote config client module
 		rcclient.Module(),
 
+		// Provide workloadmeta module
+		workloadmeta.Module(),
+
+		// Provide tagger module
+		tagger.Module(),
+
 		// Provide statsd client module
 		compstatsd.Module(),
 

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -241,6 +241,7 @@ type miscDeps struct {
 	Syscfg       sysprobeconfig.Component
 	HostInfo     hostinfo.Component
 	WorkloadMeta workloadmeta.Component
+	Logger       logComponent.Component
 }
 
 // initMisc initializes modules that cannot, or have not yet been componetized.
@@ -248,12 +249,12 @@ type miscDeps struct {
 // Todo: move metadata/workloadmeta/collector to workloadmeta
 func initMisc(deps miscDeps) error {
 	if err := statsd.Configure(ddconfig.GetBindHost(), deps.Config.GetInt("dogstatsd_port"), deps.Statsd.CreateForHostPort); err != nil {
-		log.Criticalf("Error configuring statsd: %s", err)
+		deps.Logger.Criticalf("Error configuring statsd: %s", err)
 		return err
 	}
 
 	if err := ddutil.SetupCoreDump(deps.Config); err != nil {
-		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
+		deps.Logger.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 
 	processCollectionServer := collector.NewProcessCollector(deps.Config, deps.Syscfg)
@@ -267,7 +268,7 @@ func initMisc(deps miscDeps) error {
 
 			err := manager.ConfigureAutoExit(startCtx, deps.Config)
 			if err != nil {
-				log.Criticalf("Unable to configure auto-exit, err: %w", err)
+				deps.Logger.Criticalf("Unable to configure auto-exit, err: %w", err)
 				return err
 			}
 

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -258,7 +258,7 @@ func initMisc(deps miscDeps) error {
 
 	processCollectionServer := collector.NewProcessCollector(deps.Config, deps.Syscfg)
 
-	// TODO(components): still unclear how the initialization of workoadmeta
+	// TODO(components): still unclear how the initialization of workloadmeta
 	//                   store and tagger should be performed.
 	// appCtx is a context that cancels when the OnStop hook is called
 	appCtx, stopApp := context.WithCancel(context.Background())

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -91,6 +91,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(runCheckCmd,
 				fx.Supply(cliParams, bundleParams),
 				core.Bundle(),
+				// Provide workloadmeta module
+				workloadmeta.Module(),
 				// Provide the corresponding workloadmeta Params to configure the catalog
 				collectors.GetCatalog(),
 				fx.Provide(func(config config.Component) workloadmeta.Params {
@@ -105,6 +107,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					return workloadmeta.Params{AgentType: catalog}
 				}),
 
+				// Provide tagger module
+				tagger.Module(),
 				// Tagger must be initialized after agent config has been setup
 				fx.Provide(func(c config.Component) tagger.Params {
 					if c.GetBool("process_config.remote_tagger") {

--- a/comp/process/bundle.go
+++ b/comp/process/bundle.go
@@ -12,8 +12,6 @@
 package process
 
 import (
-	"github.com/DataDog/datadog-agent/comp/core/tagger"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/comp/process/apiserver"
 	"github.com/DataDog/datadog-agent/comp/process/connectionscheck/connectionscheckimpl"
 	"github.com/DataDog/datadog-agent/comp/process/containercheck/containercheckimpl"
@@ -53,6 +51,5 @@ func Bundle() fxutil.BundleOptions {
 		expvarsimpl.Module(),
 		apiserver.Module(),
 		forwardersimpl.Module(),
-		workloadmeta.Module(),
-		tagger.Module())
+	)
 }

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -33,6 +33,7 @@ func TestBundleDependencies(t *testing.T) {
 		fx.Supply(workloadmeta.NewParams()),
 		fx.Provide(func() types.CheckComponent { return nil }),
 		core.MockBundle(),
+		workloadmeta.Module(),
 		fx.Supply(tagger.NewFakeTaggerParams()),
 		fx.Provide(func() context.Context { return context.TODO() }),
 	)


### PR DESCRIPTION
### What does this PR do?
Move workloadmeta and tagger out of the process bundle as those components are not owned by this package. 

Per the Fx guide on modules: https://uber-go.github.io/fx/modules.html#use-result-objects

> Fx modules should provide only those types to the application that are within their purview. Modules should not provide values they happen to use to the application. Nor should modules bundle other modules wholesale.
> 
> **Rationale**: This leaves consumers free to choose how and where your dependencies come from. They can use the method you recommend (e.g., "include zapfx.Module"), or build their own variant of that dependency.

### Motivation
The core agent already includes the workloadmeta and tagger bundles. This change will allow importing the process bundle into the core agent and avoid bundle conflicts.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

#### Setup
Setup a running container
**Example:** `docker run --name my-redis -d redis`

#### Test process agent
Test the process agent is able to collect container and process data

Enable the process check in datadog.yaml
```yaml
process_config:
  process_collection:
    enabled: true
```

- Verify container data is visible in Live Containers
  - Verify container has container tags associated with it
- Verify process data is visible in Live Processes
  - Verify process has container tags associated with it

#### Test the process agent check subcommands and verify they work accordingly
Setup a running container in your testing environment
  - Example: `docker run --name my-redis -d redis`

- `process-agent check process`
  - Verify process and container data shows up
- `process-agent check container`
  - Verify container data shows up
- `process-agent check process_discovery`
  - Verify process discovery data shows up

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
