### PR TITLE
[USM] fix panic in http2 method creation

### DIFF
--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -180,21 +180,21 @@ func (tx *EbpfTx) Method() http.Method {
 			log.Errorf("method length %d is greater than the buffer: %v and is huffman encoded: %v",
 				tx.Stream.Request_method.Length, tx.Stream.Request_method.Raw_buffer, tx.Stream.Request_method.Is_huffman_encoded)
 		}
-		return 0
+		return http.MethodUnknown
 	}
 
 	// Case which the method is literal.
 	if tx.Stream.Request_method.Is_huffman_encoded {
 		method, err = hpack.HuffmanDecodeToString(tx.Stream.Request_method.Raw_buffer[:tx.Stream.Request_method.Length])
 		if err != nil {
-			return 0
+			return http.MethodUnknown
 		}
 	} else {
 		method = string(tx.Stream.Request_method.Raw_buffer[:tx.Stream.Request_method.Length])
 	}
 	http2Method, err := stringToHTTPMethod(method)
 	if err != nil {
-		return 0
+		return http.MethodUnknown
 	}
 	return http2Method
 }

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -176,7 +176,7 @@ func (tx *EbpfTx) Method() http.Method {
 
 	// if the length of the method is greater than the buffer, then we return 0.
 	if tx.Stream.Request_method.Length > 0 && int(tx.Stream.Request_method.Length) > len(tx.Stream.Request_method.Raw_buffer) {
-		log.Errorf("method length is greater than the buffer: %d", tx.Stream.Request_method.Length)
+		log.Errorf("method length %d is greater than the buffer: %v", tx.Stream.Request_method.Length, tx.Stream.Request_method.Raw_buffer)
 		return 0
 	}
 

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -167,17 +167,21 @@ func (tx *EbpfTx) Method() http.Method {
 	var err error
 
 	// Case which the method is indexed.
-	switch tx.Stream.Request_method.Static_table_entry {
-	case GetValue:
-		return http.MethodGet
-	case PostValue:
-		return http.MethodPost
+	if tx.Stream.Request_method.Static_table_entry != 0 {
+		switch tx.Stream.Request_method.Static_table_entry {
+		case GetValue:
+			return http.MethodGet
+		case PostValue:
+			return http.MethodPost
+		default:
+			return http.MethodUnknown
+		}
 	}
 
 	// if the length of the method is greater than the buffer, then we return 0.
 	if int(tx.Stream.Request_method.Length) > len(tx.Stream.Request_method.Raw_buffer) || tx.Stream.Request_method.Length == 0 {
 		if oversizedLogLimit.ShouldLog() {
-			log.Errorf("method length %d is greater than the buffer: %v and is huffman encoded: %v",
+			log.Errorf("method length %d is longer than the size buffer: %v and is huffman encoded: %v",
 				tx.Stream.Request_method.Length, tx.Stream.Request_method.Raw_buffer, tx.Stream.Request_method.Is_huffman_encoded)
 		}
 		return http.MethodUnknown

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -176,7 +176,9 @@ func (tx *EbpfTx) Method() http.Method {
 
 	// if the length of the method is greater than the buffer, then we return 0.
 	if tx.Stream.Request_method.Length > 0 && int(tx.Stream.Request_method.Length) > len(tx.Stream.Request_method.Raw_buffer) {
-		log.Errorf("method length %d is greater than the buffer: %v", tx.Stream.Request_method.Length, tx.Stream.Request_method.Raw_buffer)
+		if oversizedLogLimit.ShouldLog() {
+			log.Errorf("method length %d is greater than the buffer: %v", tx.Stream.Request_method.Length, tx.Stream.Request_method.Raw_buffer)
+		}
 		return 0
 	}
 

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -174,6 +174,12 @@ func (tx *EbpfTx) Method() http.Method {
 		return http.MethodPost
 	}
 
+	// if the length of the method is greater than the buffer, then we return 0.
+	if tx.Stream.Request_method.Length > 0 && int(tx.Stream.Request_method.Length) > len(tx.Stream.Request_method.Raw_buffer) {
+		log.Errorf("method length is greater than the buffer: %d", tx.Stream.Request_method.Length)
+		return 0
+	}
+
 	// Case which the method is literal.
 	if tx.Stream.Request_method.Is_huffman_encoded {
 		method, err = hpack.HuffmanDecodeToString(tx.Stream.Request_method.Raw_buffer[:tx.Stream.Request_method.Length])

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -175,9 +175,10 @@ func (tx *EbpfTx) Method() http.Method {
 	}
 
 	// if the length of the method is greater than the buffer, then we return 0.
-	if tx.Stream.Request_method.Length > 0 && int(tx.Stream.Request_method.Length) > len(tx.Stream.Request_method.Raw_buffer) {
+	if int(tx.Stream.Request_method.Length) > len(tx.Stream.Request_method.Raw_buffer) || tx.Stream.Request_method.Length == 0 {
 		if oversizedLogLimit.ShouldLog() {
-			log.Errorf("method length %d is greater than the buffer: %v", tx.Stream.Request_method.Length, tx.Stream.Request_method.Raw_buffer)
+			log.Errorf("method length %d is greater than the buffer: %v and is huffman encoded: %v",
+				tx.Stream.Request_method.Length, tx.Stream.Request_method.Raw_buffer, tx.Stream.Request_method.Is_huffman_encoded)
 		}
 		return 0
 	}

--- a/pkg/network/protocols/http2/model_test.go
+++ b/pkg/network/protocols/http2/model_test.go
@@ -85,7 +85,7 @@ func TestHTTP2Method(t *testing.T) {
 		want   http.Method
 	}{
 		{
-			name: "Sanity method test Method",
+			name: "Sanity method test",
 			Stream: http2Stream{
 				Request_method: http2requestMethod{
 					Raw_buffer:         [7]uint8{0x50, 0x55, 0x54},

--- a/pkg/network/protocols/http2/model_test.go
+++ b/pkg/network/protocols/http2/model_test.go
@@ -79,49 +79,55 @@ func TestHTTP2Path(t *testing.T) {
 }
 
 func TestHTTP2Method(t *testing.T) {
-	type fields struct {
-		Stream http2Stream
-	}
 	tests := []struct {
 		name   string
-		fields fields
+		Stream http2Stream
 		want   http.Method
 	}{
 		{
-			name: "Test Method length is bigger then raw buffer size",
-			fields: fields{
-				Stream: http2Stream{
-					Request_method: http2requestMethod{
-						Raw_buffer:         [7]uint8{1, 2},
-						Is_huffman_encoded: false,
-						Static_table_entry: 0,
-						Length:             8,
-						Finalized:          false,
-					},
+			name: "Sanity method test Method",
+			Stream: http2Stream{
+				Request_method: http2requestMethod{
+					Raw_buffer:         [7]uint8{0x50, 0x55, 0x54},
+					Is_huffman_encoded: false,
+					Static_table_entry: 0,
+					Length:             3,
+					Finalized:          false,
 				},
 			},
-			want: 0,
+			want: http.MethodPut,
 		},
 		{
-			name: "Test Method length is zero",
-			fields: fields{
-				Stream: http2Stream{
-					Request_method: http2requestMethod{
-						Raw_buffer:         [7]uint8{1, 2},
-						Is_huffman_encoded: true,
-						Static_table_entry: 0,
-						Length:             0,
-						Finalized:          false,
-					},
+			name: "Test method length is bigger than raw buffer size",
+			Stream: http2Stream{
+				Request_method: http2requestMethod{
+					Raw_buffer:         [7]uint8{1, 2},
+					Is_huffman_encoded: false,
+					Static_table_entry: 0,
+					Length:             8,
+					Finalized:          false,
 				},
 			},
-			want: 0,
+			want: http.MethodUnknown,
+		},
+		{
+			name: "Test method length is zero",
+			Stream: http2Stream{
+				Request_method: http2requestMethod{
+					Raw_buffer:         [7]uint8{1, 2},
+					Is_huffman_encoded: true,
+					Static_table_entry: 0,
+					Length:             0,
+					Finalized:          false,
+				},
+			},
+			want: http.MethodUnknown,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tx := &EbpfTx{
-				Stream: tt.fields.Stream,
+				Stream: tt.Stream,
 			}
 			assert.Equalf(t, tt.want, tx.Method(), "Method()")
 		})

--- a/pkg/network/protocols/http2/model_test.go
+++ b/pkg/network/protocols/http2/model_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/http2/hpack"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 )
 
 func TestHTTP2Path(t *testing.T) {
@@ -73,5 +75,55 @@ func TestHTTP2Path(t *testing.T) {
 				assert.Equal(t, tt.rawPath, string(path))
 			})
 		}
+	}
+}
+
+func TestHTTP2Method(t *testing.T) {
+	type fields struct {
+		Stream http2Stream
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   http.Method
+	}{
+		{
+			name: "Test Method length is bigger then raw buffer size",
+			fields: fields{
+				Stream: http2Stream{
+					Request_method: http2requestMethod{
+						Raw_buffer:         [7]uint8{1, 2},
+						Is_huffman_encoded: false,
+						Static_table_entry: 0,
+						Length:             8,
+						Finalized:          false,
+					},
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "Test Method length is zero",
+			fields: fields{
+				Stream: http2Stream{
+					Request_method: http2requestMethod{
+						Raw_buffer:         [7]uint8{1, 2},
+						Is_huffman_encoded: true,
+						Static_table_entry: 0,
+						Length:             0,
+						Finalized:          false,
+					},
+				},
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &EbpfTx{
+				Stream: tt.fields.Stream,
+			}
+			assert.Equalf(t, tt.want, tx.Method(), "Method()")
+		})
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes a panic in HTTP/2 method creation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
