### PR TITLE
[CI] Fix label analysis using GH

### DIFF
--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -8,6 +8,10 @@ on:
       - main
       - "[0-9]+.[0-9]+.x"
 
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_REPO: ${{ github.repository }}
+
 jobs:
   team-label:
     if: github.triggering_actor != 'dd-devflow[bot]'
@@ -15,7 +19,7 @@ jobs:
     steps:
       - name: Check team assignment
         run: |
-          labels="${{join(github.event.pull_request.labels.*.name, ' ')}}"
+          labels=$(gh pr view ${{github.event.number}} --json labels --jq '.labels[].name')
           for label in $labels; do
             if [[ "$label" =~ ^qa/ ]]; then
               echo "A label to skip QA is set -- no need for team assignment"
@@ -37,7 +41,7 @@ jobs:
           skip=0
           done=0
           noChange=0
-          labels="${{join(github.event.pull_request.labels.*.name, ' ')}}"
+          labels=$(gh pr view ${{github.event.number}} --json labels --jq '.labels[].name')
           for label in $labels; do
             if [[ "$label" == "qa/skip-qa" ]]; then
               skip=1


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

It fixes the `label analysis` workflow not being able to get the actualized list of labels of a PR, preventing the devs from getting a green retry.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Explanation: 
In the workflow we're using `github.event.pull_request.labels.*.name` to get the PR's labels.
From [Github doc](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), the `github.event.pull_request.*` variables are set when the workflow is triggered. This workflow triggers are:
```
on:
  pull_request:
    types: [opened, synchronize, reopened]
```
This means if someone changes the label and rerun the workflow it won't refresh the `github.event.pull_request.labels.*.name` unless the PR gets open (`opened`), a commit is pushed (`synchronize`) or the PR is closed and reopen (`reopened`).

Best solution would have been to use the `labeled` type for the workflow, but we have constraints:

Constraints:
- The Merge Queue prevents us from using the `labeled` type for the workflow, else it'll create a race condition.
- The developers should be able to rerun the workflow at anytime to check if they have the right labels.

This leaves us with only one solution: use Github API directly (here `gh`).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
