### PR TITLE
[CWS] increase CWS activation test timeout

### DIFF
--- a/test/new-e2e/tests/cws/ec2_test.go
+++ b/test/new-e2e/tests/cws/ec2_test.go
@@ -73,7 +73,7 @@ func TestAgentSuite(t *testing.T) {
 	)
 }
 
-func (a *agentSuite) TestOpenSignal() {
+func (a *agentSuite) Test00OpenSignal() {
 	apiClient := api.NewClient()
 
 	// Create temporary directory
@@ -161,7 +161,7 @@ func (a *agentSuite) TestOpenSignal() {
 }
 
 // TestFeatureCWSEnabled tests that the CWS activation is properly working
-func (a *agentSuite) TestFeatureCWSEnabled() {
+func (a *agentSuite) Test01FeatureCWSEnabled() {
 	apiKey, err := runner.GetProfile().SecretStore().Get(parameters.APIKey)
 	a.Require().NoError(err, "could not get API key")
 	appKey, err := runner.GetProfile().SecretStore().Get(parameters.APPKey)

--- a/test/new-e2e/tests/cws/ec2_test.go
+++ b/test/new-e2e/tests/cws/ec2_test.go
@@ -169,7 +169,7 @@ func (a *agentSuite) TestFeatureCWSEnabled() {
 	ddSQLClient := api.NewDDSQLClient(apiKey, appKey)
 
 	query := fmt.Sprintf("SELECT h.hostname, a.feature_cws_enabled FROM host h JOIN datadog_agent a USING (datadog_agent_key) WHERE h.hostname = '%s'", a.Env().Agent.Client.Hostname())
-	a.Assert().EventuallyWithT(func(collect *assert.CollectT) {
+	a.Assert().EventuallyWithTf(func(collect *assert.CollectT) {
 		resp, err := ddSQLClient.Do(query)
 		if !assert.NoErrorf(collect, err, "ddsql query failed") {
 			return
@@ -213,7 +213,7 @@ func (a *agentSuite) TestFeatureCWSEnabled() {
 				return
 			}
 		}
-	}, 10*time.Minute, 1*time.Minute, "cws activation check timeout")
+	}, 16*time.Minute, 2*time.Minute, "cws activation test timed out for host %s", a.Env().Agent.Client.Hostname())
 }
 
 func (a *agentSuite) waitAgentLogs(agentName string, pattern string) error {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

- increase the `TestFeatureCWSEnabled` test timeout to reduce its flakiness.
- switch the order the tests are performed to achieve the same goal.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
