### PR TITLE
[NPM-3068] Don't listen on 127.0.0.1 for test dns server

### DIFF
--- a/pkg/network/dns/snooper_test.go
+++ b/pkg/network/dns/snooper_test.go
@@ -252,14 +252,14 @@ func TestDNSFailedResponseCount(t *testing.T) {
 		"failedserver.com",
 		"failedservertoo.com",
 	}
-	queryIP, queryPort, reps = testdns.SendDNSQueriesAndCheckError(t, domains, net.ParseIP(localhost), "udp")
+	queryIP, queryPort, reps = testdns.SendDNSQueriesAndCheckError(t, domains, testdns.GetServerIP(t), "udp")
 	for _, rep := range reps {
 		require.NotNil(t, rep)
 		require.Equal(t, rep.Rcode, mdns.RcodeServerFailure) // All the queries should have failed
 	}
 
 	// Next check the one sent over UDP. Expected error type: ServFail
-	key2 := getKey(queryIP, queryPort, localhost, syscall.IPPROTO_UDP)
+	key2 := getKey(queryIP, queryPort, testdns.GetServerIP(t).String(), syscall.IPPROTO_UDP)
 	require.Eventually(t, func() bool {
 		allStats = statKeeper.Snapshot()
 		return hasDomains(allStats[key2], domains...)

--- a/pkg/network/tracer/testutil/testdns/test_dns_server.go
+++ b/pkg/network/tracer/testutil/testdns/test_dns_server.go
@@ -24,7 +24,7 @@ var globalTCPError error
 var globalUDPError error
 var serverOnce sync.Once
 
-const localhostAddr = "127.0.0.1"
+const localhostAddr = "127.0.0.153"
 
 // GetServerIP returns the IP address of the test DNS server. The test DNS server returns canned responses for several
 // known domains that are used in integration tests.

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1386,7 +1386,7 @@ func (s *TracerSuite) TestDNSStatsWithNAT() {
 	testutil.IptablesSave(t)
 	// Setup a NAT rule to translate 2.2.2.2 to 8.8.8.8 and issue a DNS request to 2.2.2.2
 	cmds := []string{"iptables -t nat -A OUTPUT -d 2.2.2.2 -j DNAT --to-destination 8.8.8.8"}
-	testutil.RunCommands(t, cmds, true)
+	testutil.RunCommands(t, cmds, false)
 
 	cfg := testConfig()
 	cfg.CollectDNSStats = true


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes failures like https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/428304565#L1877

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
