### PR TITLE
[ASCII-1157] Remove event platform global receiver

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -243,6 +243,7 @@
 /comp/core/workloadmeta @DataDog/container-integrations
 /comp/dogstatsd/statsd @DataDog/agent-shared-components
 /comp/forwarder/eventplatform @DataDog/agent-metrics-logs
+/comp/forwarder/eventplatformreceiver @DataDog/agent-metrics-logs
 /comp/forwarder/orchestrator @DataDog/agent-metrics-logs
 /comp/forwarder/orchestrator/orchestratorinterface @DataDog/agent-metrics-logs
 /comp/metadata/packagesigning @DataDog/agent-platform

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
+
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
@@ -139,6 +141,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			fx.Provide(func() inventorychecks.Component { return nil }),
 			fx.Provide(func() packagesigning.Component { return nil }),
 			fx.Provide(func() status.Component { return nil }),
+			fx.Provide(func() eventplatformreceiver.Component { return nil }),
 			fx.Provide(tagger.NewTaggerParamsForCoreAgent),
 			tagger.Module(),
 		)

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -62,6 +62,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	langDetectionCl "github.com/DataDog/datadog-agent/comp/languagedetection/client"
 	langDetectionClimpl "github.com/DataDog/datadog-agent/comp/languagedetection/client/clientimpl"
@@ -363,6 +364,7 @@ func getSharedFxOption() fx.Option {
 		fx.Supply(orchestratorForwarderImpl.NewDefaultParams()),
 		eventplatformimpl.Module(),
 		fx.Supply(eventplatformimpl.NewDefaultParams()),
+		eventplatformreceiverimpl.Module(),
 
 		// injecting the shared Serializer to FX until we migrate it to a prpoper component. This allows other
 		// already migrated components to request it.

--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -38,6 +38,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent"
@@ -76,6 +77,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(orchestratorForwarderImpl.NewDisabledParams()),
 				eventplatformimpl.Module(),
 				fx.Supply(eventplatformimpl.NewDisabledParams()),
+				eventplatformreceiverimpl.Module(),
 				fx.Supply(demultiplexerimpl.NewDefaultParams()),
 				// setup workloadmeta
 				collectors.GetCatalog(),

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -39,6 +39,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent"
@@ -117,6 +118,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(orchestratorForwarderImpl.NewDefaultParams()),
 				eventplatformimpl.Module(),
 				fx.Supply(eventplatformimpl.NewDisabledParams()),
+				eventplatformreceiverimpl.Module(),
 				fx.Supply(demultiplexerimpl.NewDefaultParams()),
 				// setup workloadmeta
 				collectors.GetCatalog(),

--- a/cmd/dogstatsd/subcommands/start/command.go
+++ b/cmd/dogstatsd/subcommands/start/command.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	"github.com/DataDog/datadog-agent/comp/metadata/host"
 	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl"
@@ -140,6 +142,8 @@ func RunDogstatsdFct(cliParams *CLIParams, defaultConfPath string, defaultLogFil
 		orchestratorForwarderImpl.Module(),
 		fx.Supply(orchestratorForwarderImpl.NewDisabledParams()),
 		eventplatformimpl.Module(),
+		eventplatformreceiverimpl.Module(),
+		hostnameimpl.Module(),
 		fx.Supply(eventplatformimpl.NewDisabledParams()),
 		tagger.OptionalModule(),
 		// injecting the shared Serializer to FX until we migrate it to a prpoper component. This allows other

--- a/cmd/otel-agent/main.go
+++ b/cmd/otel-agent/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	"github.com/DataDog/datadog-agent/comp/logs"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
@@ -79,6 +80,7 @@ func main() {
 		fx.Supply(orchestratorForwarderImpl.NewDisabledParams()),
 		eventplatformimpl.Module(),
 		fx.Supply(eventplatformimpl.NewDefaultParams()),
+		eventplatformreceiverimpl.Module(),
 		fx.Provide(newSerializer),
 		fx.Provide(func(cfg config.Component) demultiplexerimpl.Params {
 			params := demultiplexerimpl.NewDefaultParams()

--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -38,6 +38,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -109,6 +110,7 @@ func (s *service) Run(svcctx context.Context) error {
 		fx.Supply(orchestratorForwarderImpl.NewDisabledParams()),
 		eventplatformimpl.Module(),
 		fx.Supply(eventplatformimpl.NewDisabledParams()),
+		eventplatformreceiverimpl.Module(),
 		fx.Supply(demultiplexerimpl.NewDefaultParams()),
 
 		// workloadmeta setup

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -45,6 +45,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -98,6 +99,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(orchestratorForwarderImpl.NewDisabledParams()),
 				eventplatformimpl.Module(),
 				fx.Supply(eventplatformimpl.NewDisabledParams()),
+				eventplatformreceiverimpl.Module(),
 				fx.Supply(demultiplexerimpl.NewDefaultParams()),
 				// workloadmeta setup
 				collectors.GetCatalog(),

--- a/cmd/serverless-init/metric/metric_test.go
+++ b/cmd/serverless-init/metric/metric_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -61,5 +62,5 @@ func TestAddShutdownMetric(t *testing.T) {
 }
 
 func createDemultiplexer(t *testing.T) demultiplexer.FakeSamplerMock {
-	return fxutil.Test[demultiplexer.FakeSamplerMock](t, logimpl.MockModule(), demultiplexerimpl.FakeSamplerMockModule())
+	return fxutil.Test[demultiplexer.FakeSamplerMock](t, logimpl.MockModule(), demultiplexerimpl.FakeSamplerMockModule(), hostnameimpl.MockModule())
 }

--- a/comp/README.md
+++ b/comp/README.md
@@ -169,6 +169,12 @@ Package defaultforwarder implements a component to send payloads to the backend
 
 Package eventplatform contains the logic for forwarding events to the event platform
 
+### [comp/forwarder/eventplatformreceiver](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver)
+
+*Datadog Team*: agent-metrics-logs
+
+Package eventplatformreceiver implements the receiver for the event platform package
+
 ### [comp/forwarder/orchestrator](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/forwarder/orchestrator)
 
 *Datadog Team*: agent-metrics-logs

--- a/comp/aggregator/demultiplexer/demultiplexerimpl/demultiplexer_fake_sampler_mock.go
+++ b/comp/aggregator/demultiplexer/demultiplexerimpl/demultiplexer_fake_sampler_mock.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	demultiplexerComp "github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -26,8 +27,9 @@ func FakeSamplerMockModule() fxutil.Module {
 
 type fakeSamplerMockDependencies struct {
 	fx.In
-	Lc  fx.Lifecycle
-	Log log.Component
+	Lc       fx.Lifecycle
+	Log      log.Component
+	Hostname hostname.Component
 }
 
 type fakeSamplerMock struct {
@@ -47,7 +49,7 @@ func (f *fakeSamplerMock) Stop(flush bool) {
 }
 
 func newFakeSamplerMock(deps fakeSamplerMockDependencies) demultiplexerComp.FakeSamplerMock {
-	demux := initTestAgentDemultiplexerWithFlushInterval(deps.Log, time.Hour)
+	demux := initTestAgentDemultiplexerWithFlushInterval(deps.Log, deps.Hostname, time.Hour)
 	mock := &fakeSamplerMock{
 		TestAgentDemultiplexer: demux,
 	}

--- a/comp/aggregator/demultiplexer/demultiplexerimpl/demultiplexer_mock.go
+++ b/comp/aggregator/demultiplexer/demultiplexerimpl/demultiplexer_mock.go
@@ -9,6 +9,7 @@ package demultiplexerimpl
 
 import (
 	demultiplexerComp "github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -45,7 +46,8 @@ func (m *mock) LazyGetSenderManager() (sender.SenderManager, error) {
 
 type mockDependencies struct {
 	fx.In
-	Log log.Component
+	Log      log.Component
+	Hostname hostname.Component
 }
 
 func newMock(deps mockDependencies) (demultiplexerComp.Component, demultiplexerComp.Mock) {
@@ -54,6 +56,7 @@ func newMock(deps mockDependencies) (demultiplexerComp.Component, demultiplexerC
 
 	aggDeps := aggregator.TestDeps{
 		Log:             deps.Log,
+		Hostname:        deps.Hostname,
 		SharedForwarder: defaultforwarder.NoopForwarder{},
 	}
 

--- a/comp/aggregator/demultiplexer/demultiplexerimpl/status_test.go
+++ b/comp/aggregator/demultiplexer/demultiplexerimpl/status_test.go
@@ -13,8 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
@@ -54,8 +53,7 @@ func TestStatusOutPut(t *testing.T) {
 	}
 
 	deps := fxutil.Test[dependencies](t, fx.Options(
-		config.MockModule(),
-		logimpl.MockModule(),
+		core.MockBundle(),
 		defaultforwarder.MockModule(),
 		orchestratorimpl.MockModule(),
 		eventplatformimpl.MockModule(),

--- a/comp/aggregator/demultiplexer/demultiplexerimpl/test_agent_demultiplexer.go
+++ b/comp/aggregator/demultiplexer/demultiplexerimpl/test_agent_demultiplexer.go
@@ -172,7 +172,7 @@ func (a *TestAgentDemultiplexer) Reset() {
 }
 
 // initTestAgentDemultiplexerWithFlushInterval inits a TestAgentDemultiplexer with the given flush interval.
-func initTestAgentDemultiplexerWithFlushInterval(log log.Component, flushInterval time.Duration) *TestAgentDemultiplexer {
+func initTestAgentDemultiplexerWithFlushInterval(log log.Component, hostname hostname.Component, flushInterval time.Duration) *TestAgentDemultiplexer {
 	opts := aggregator.DefaultAgentDemultiplexerOptions()
 	opts.FlushInterval = flushInterval
 	opts.DontStartForwarders = true

--- a/comp/aggregator/demultiplexer/demultiplexerimpl/test_agent_demultiplexer.go
+++ b/comp/aggregator/demultiplexer/demultiplexerimpl/test_agent_demultiplexer.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
@@ -181,7 +182,7 @@ func initTestAgentDemultiplexerWithFlushInterval(log log.Component, hostname hos
 	sharedForwarderOptions := defaultforwarder.NewOptions(config.Datadog, log, nil)
 	sharedForwarder := defaultforwarder.NewDefaultForwarder(config.Datadog, log, sharedForwarderOptions)
 	orchestratorForwarder := optional.NewOption[defaultforwarder.Forwarder](defaultforwarder.NoopForwarder{})
-	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder())
+	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder(hostname))
 	demux := aggregator.InitAndStartAgentDemultiplexer(log, sharedForwarder, &orchestratorForwarder, opts, eventPlatformForwarder, "hostname")
 	return NewTestAgentDemultiplexer(demux)
 }

--- a/comp/aggregator/diagnosesendermanager/diagnosesendermanagerimpl/sendermanager.go
+++ b/comp/aggregator/diagnosesendermanager/diagnosesendermanagerimpl/sendermanager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
@@ -18,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"go.uber.org/fx"
 )
@@ -31,8 +31,9 @@ func Module() fxutil.Module {
 
 type dependencies struct {
 	fx.In
-	Log    log.Component
-	Config config.Component
+	Log      log.Component
+	Config   config.Component
+	Hostname hostname.Component
 }
 
 type diagnoseSenderManager struct {
@@ -51,7 +52,7 @@ func (sender *diagnoseSenderManager) LazyGetSenderManager() (sender.SenderManage
 		return senderManager, nil
 	}
 
-	hostnameDetected, err := hostname.Get(context.TODO())
+	hostnameDetected, err := sender.deps.Hostname.Get(context.TODO())
 	if err != nil {
 		return nil, sender.deps.Log.Errorf("Error while getting hostname, exiting: %v", err)
 	}

--- a/comp/aggregator/diagnosesendermanager/diagnosesendermanagerimpl/sendermanager.go
+++ b/comp/aggregator/diagnosesendermanager/diagnosesendermanagerimpl/sendermanager.go
@@ -66,7 +66,7 @@ func (sender *diagnoseSenderManager) LazyGetSenderManager() (sender.SenderManage
 	config := sender.deps.Config
 	forwarder := defaultforwarder.NewDefaultForwarder(config, log, defaultforwarder.NewOptions(config, log, nil))
 	orchestratorForwarder := optional.NewOptionPtr[defaultforwarder.Forwarder](defaultforwarder.NoopForwarder{})
-	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder())
+	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder(sender.deps.Hostname))
 	senderManager = aggregator.InitAndStartAgentDemultiplexer(
 		log,
 		forwarder,

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -9,6 +9,8 @@ package apiimpl
 import (
 	"net"
 
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
+
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
@@ -40,53 +42,56 @@ func Module() fxutil.Module {
 }
 
 type apiServer struct {
-	flare           flare.Component
-	dogstatsdServer dogstatsdServer.Component
-	capture         replay.Component
-	serverDebug     dogstatsddebug.Component
-	hostMetadata    host.Component
-	invAgent        inventoryagent.Component
-	demux           demultiplexer.Component
-	invHost         inventoryhost.Component
-	secretResolver  secrets.Component
-	invChecks       inventorychecks.Component
-	pkgSigning      packagesigning.Component
-	statusComponent status.Component
+	flare                 flare.Component
+	dogstatsdServer       dogstatsdServer.Component
+	capture               replay.Component
+	serverDebug           dogstatsddebug.Component
+	hostMetadata          host.Component
+	invAgent              inventoryagent.Component
+	demux                 demultiplexer.Component
+	invHost               inventoryhost.Component
+	secretResolver        secrets.Component
+	invChecks             inventorychecks.Component
+	pkgSigning            packagesigning.Component
+	statusComponent       status.Component
+	eventPlatformReceiver eventplatformreceiver.Component
 }
 
 type dependencies struct {
 	fx.In
 
-	Flare           flare.Component
-	DogstatsdServer dogstatsdServer.Component
-	Capture         replay.Component
-	ServerDebug     dogstatsddebug.Component
-	HostMetadata    host.Component
-	InvAgent        inventoryagent.Component
-	Demux           demultiplexer.Component
-	InvHost         inventoryhost.Component
-	SecretResolver  secrets.Component
-	InvChecks       inventorychecks.Component
-	PkgSigning      packagesigning.Component
-	StatusComponent status.Component
+	Flare                 flare.Component
+	DogstatsdServer       dogstatsdServer.Component
+	Capture               replay.Component
+	ServerDebug           dogstatsddebug.Component
+	HostMetadata          host.Component
+	InvAgent              inventoryagent.Component
+	Demux                 demultiplexer.Component
+	InvHost               inventoryhost.Component
+	SecretResolver        secrets.Component
+	InvChecks             inventorychecks.Component
+	PkgSigning            packagesigning.Component
+	StatusComponent       status.Component
+	EventPlatformReceiver eventplatformreceiver.Component
 }
 
 var _ api.Component = (*apiServer)(nil)
 
 func newAPIServer(deps dependencies) api.Component {
 	return &apiServer{
-		flare:           deps.Flare,
-		dogstatsdServer: deps.DogstatsdServer,
-		capture:         deps.Capture,
-		serverDebug:     deps.ServerDebug,
-		hostMetadata:    deps.HostMetadata,
-		invAgent:        deps.InvAgent,
-		demux:           deps.Demux,
-		invHost:         deps.InvHost,
-		secretResolver:  deps.SecretResolver,
-		invChecks:       deps.InvChecks,
-		pkgSigning:      deps.PkgSigning,
-		statusComponent: deps.StatusComponent,
+		flare:                 deps.Flare,
+		dogstatsdServer:       deps.DogstatsdServer,
+		capture:               deps.Capture,
+		serverDebug:           deps.ServerDebug,
+		hostMetadata:          deps.HostMetadata,
+		invAgent:              deps.InvAgent,
+		demux:                 deps.Demux,
+		invHost:               deps.InvHost,
+		secretResolver:        deps.SecretResolver,
+		invChecks:             deps.InvChecks,
+		pkgSigning:            deps.PkgSigning,
+		statusComponent:       deps.StatusComponent,
+		eventPlatformReceiver: deps.EventPlatformReceiver,
 	}
 }
 
@@ -115,6 +120,7 @@ func (server *apiServer) StartServer(
 		server.invChecks,
 		server.pkgSigning,
 		server.statusComponent,
+		server.eventPlatformReceiver,
 	)
 }
 

--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -12,6 +12,8 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
+
 	"github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
@@ -79,6 +81,7 @@ func StartServers(
 	invChecks inventorychecks.Component,
 	pkgSigning packagesigning.Component,
 	statusComponent status.Component,
+	eventPlatformReceiver eventplatformreceiver.Component,
 ) error {
 	apiAddr, err := getIPCAddressPort()
 	if err != nil {
@@ -129,6 +132,7 @@ func StartServers(
 		invChecks,
 		pkgSigning,
 		statusComponent,
+		eventPlatformReceiver,
 	); err != nil {
 		return fmt.Errorf("unable to start CMD API server: %v", err)
 	}

--- a/comp/api/api/apiimpl/server_cmd.go
+++ b/comp/api/api/apiimpl/server_cmd.go
@@ -14,6 +14,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
+
 	gorilla "github.com/gorilla/mux"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -73,6 +75,7 @@ func startCMDServer(
 	invChecks inventorychecks.Component,
 	pkgSigning packagesigning.Component,
 	statusComponent status.Component,
+	eventPlatformReceiver eventplatformreceiver.Component,
 ) (err error) {
 	// get the transport we're going to use under HTTP
 	cmdListener, err = getListener(cmdAddr)
@@ -151,6 +154,7 @@ func startCMDServer(
 				invChecks,
 				pkgSigning,
 				statusComponent,
+				eventPlatformReceiver,
 			)))
 	cmdMux.Handle("/check/", http.StripPrefix("/check", check.SetupHandlers(checkMux)))
 	cmdMux.Handle("/", gwmux)

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/listeners"
@@ -1021,5 +1022,5 @@ func requireStart(t *testing.T, s Component, demux aggregator.Demultiplexer) {
 
 func createDemultiplexer(t *testing.T) demultiplexer.FakeSamplerMock {
 	return fxutil.Test[demultiplexer.FakeSamplerMock](t, logimpl.MockModule(),
-		demultiplexerimpl.FakeSamplerMockModule())
+		demultiplexerimpl.FakeSamplerMockModule(), hostnameimpl.MockModule())
 }

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -11,8 +11,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	aggsender "github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -20,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	logshttp "github.com/DataDog/datadog-agent/pkg/logs/client/http"
-	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sender"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -189,8 +190,6 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 	},
 }
 
-var globalReceiver *diagnostic.BufferedMessageReceiver
-
 // An EventPlatformForwarder forwards Messages to a destination based on their event type
 type EventPlatformForwarder interface {
 	SendEventPlatformEvent(e *message.Message, eventType string) error
@@ -215,7 +214,7 @@ func (s *defaultEventPlatformForwarder) SendEventPlatformEvent(e *message.Messag
 	}
 
 	// Stream to console if debug mode is enabled
-	p.diagnosticMessageReceiver.HandleMessage(e, []byte{}, eventType)
+	p.eventPlatformReceiver.HandleMessage(e, []byte{}, eventType)
 
 	select {
 	case p.in <- e:
@@ -280,7 +279,7 @@ func (s *defaultEventPlatformForwarder) SendEventPlatformEventBlocking(e *messag
 	}
 
 	// Stream to console if debug mode is enabled
-	p.diagnosticMessageReceiver.HandleMessage(e, []byte{}, eventType)
+	p.eventPlatformReceiver.HandleMessage(e, []byte{}, eventType)
 
 	p.in <- e
 	return nil
@@ -335,11 +334,11 @@ func (s *defaultEventPlatformForwarder) Stop() {
 }
 
 type passthroughPipeline struct {
-	sender                    *sender.Sender
-	strategy                  sender.Strategy
-	in                        chan *message.Message
-	auditor                   auditor.Auditor
-	diagnosticMessageReceiver *diagnostic.BufferedMessageReceiver
+	sender                *sender.Sender
+	strategy              sender.Strategy
+	in                    chan *message.Message
+	auditor               auditor.Auditor
+	eventPlatformReceiver eventplatformreceiver.Component
 }
 
 type passthroughPipelineDesc struct {
@@ -358,7 +357,7 @@ type passthroughPipelineDesc struct {
 
 // newHTTPPassthroughPipeline creates a new HTTP-only event platform pipeline that sends messages directly to intake
 // without any of the processing that exists in regular logs pipelines.
-func newHTTPPassthroughPipeline(desc passthroughPipelineDesc, destinationsContext *client.DestinationsContext, pipelineID int) (p *passthroughPipeline, err error) {
+func newHTTPPassthroughPipeline(eventPlatformReceiver eventplatformreceiver.Component, desc passthroughPipelineDesc, destinationsContext *client.DestinationsContext, pipelineID int) (p *passthroughPipeline, err error) {
 	configKeys := config.NewLogsConfigKeys(desc.endpointsConfigPrefix, pkgconfig.Datadog)
 	endpoints, err := config.BuildHTTPEndpointsWithConfig(pkgconfig.Datadog, configKeys, desc.hostnameEndpointPrefix, desc.intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeOrigin)
 	if err != nil {
@@ -418,11 +417,11 @@ func newHTTPPassthroughPipeline(desc passthroughPipelineDesc, destinationsContex
 	log.Debugf("Initialized event platform forwarder pipeline. eventType=%s mainHosts=%s additionalHosts=%s batch_max_concurrent_send=%d batch_max_content_size=%d batch_max_size=%d, input_chan_size=%d",
 		desc.eventType, joinHosts(endpoints.GetReliableEndpoints()), joinHosts(endpoints.GetUnReliableEndpoints()), endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxContentSize, endpoints.BatchMaxSize, endpoints.InputChanSize)
 	return &passthroughPipeline{
-		sender:                    sender.NewSender(senderInput, a.Channel(), destinations, 10),
-		strategy:                  strategy,
-		in:                        inputChan,
-		auditor:                   a,
-		diagnosticMessageReceiver: GetGlobalReceiver(),
+		sender:                sender.NewSender(senderInput, a.Channel(), destinations, 10),
+		strategy:              strategy,
+		in:                    inputChan,
+		auditor:               a,
+		eventPlatformReceiver: eventPlatformReceiver,
 	}, nil
 }
 
@@ -450,12 +449,12 @@ func joinHosts(endpoints []config.Endpoint) string {
 	return strings.Join(additionalHosts, ",")
 }
 
-func newDefaultEventPlatformForwarder() *defaultEventPlatformForwarder {
+func newDefaultEventPlatformForwarder(eventPlatformReceiver eventplatformreceiver.Component) *defaultEventPlatformForwarder {
 	destinationsCtx := client.NewDestinationsContext()
 	destinationsCtx.Start()
 	pipelines := make(map[string]*passthroughPipeline)
 	for i, desc := range passthroughPipelineDescs {
-		p, err := newHTTPPassthroughPipeline(desc, destinationsCtx, i)
+		p, err := newHTTPPassthroughPipeline(eventPlatformReceiver, desc, destinationsCtx, i)
 		if err != nil {
 			log.Errorf("Failed to initialize event platform forwarder pipeline. eventType=%s, error=%s", desc.eventType, err.Error())
 			continue
@@ -468,14 +467,21 @@ func newDefaultEventPlatformForwarder() *defaultEventPlatformForwarder {
 	}
 }
 
+type dependencies struct {
+	fx.In
+	Params                Params
+	EventPlatformReceiver eventplatformreceiver.Component
+	Hostname              hostnameinterface.Component
+}
+
 // newEventPlatformForwarder creates a new EventPlatformForwarder
-func newEventPlatformForwarder(params Params) eventplatform.Component {
+func newEventPlatformForwarder(deps dependencies) eventplatform.Component {
 	var forwarder EventPlatformForwarder
 
-	if params.UseNoopEventPlatformForwarder {
-		forwarder = NewNoopEventPlatformForwarder()
-	} else if params.UseEventPlatformForwarder {
-		forwarder = newDefaultEventPlatformForwarder()
+	if deps.Params.UseNoopEventPlatformForwarder {
+		forwarder = NewNoopEventPlatformForwarder(deps.Hostname)
+	} else if deps.Params.UseEventPlatformForwarder {
+		forwarder = newDefaultEventPlatformForwarder(deps.EventPlatformReceiver)
 	}
 	if forwarder == nil {
 		return optional.NewNoneOptionPtr[eventplatform.Forwarder]()
@@ -485,20 +491,11 @@ func newEventPlatformForwarder(params Params) eventplatform.Component {
 
 // NewNoopEventPlatformForwarder returns the standard event platform forwarder with sending disabled, meaning events
 // will build up in each pipeline channel without being forwarded to the intake
-func NewNoopEventPlatformForwarder() EventPlatformForwarder {
-	f := newDefaultEventPlatformForwarder()
+func NewNoopEventPlatformForwarder(hostname hostnameinterface.Component) EventPlatformForwarder {
+	f := newDefaultEventPlatformForwarder(eventplatformreceiverimpl.NewReceiver(hostname))
 	// remove the senders
 	for _, p := range f.pipelines {
 		p.strategy = nil
 	}
 	return f
-}
-
-// GetGlobalReceiver initializes and returns the global receiver for the epforwarder package
-func GetGlobalReceiver() *diagnostic.BufferedMessageReceiver {
-	if globalReceiver == nil {
-		globalReceiver = diagnostic.NewBufferedMessageReceiver(&epFormatter{}, hostnameimpl.NewHostnameService())
-	}
-
-	return globalReceiver
 }

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_mock.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_mock.go
@@ -23,5 +23,5 @@ func MockModule() fxutil.Module {
 }
 
 func newMockComponent(hostname hostname.Component) eventplatform.Component {
-	return optional.NewOptionPtr[eventplatform.Forwarder](NewNoopEventPlatformForwarder())
+	return optional.NewOptionPtr[eventplatform.Forwarder](NewNoopEventPlatformForwarder(hostname))
 }

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_mock.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_mock.go
@@ -8,6 +8,7 @@
 package eventplatformimpl
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -21,6 +22,6 @@ func MockModule() fxutil.Module {
 	)
 }
 
-func newMockComponent() eventplatform.Component {
+func newMockComponent(hostname hostname.Component) eventplatform.Component {
 	return optional.NewOptionPtr[eventplatform.Forwarder](NewNoopEventPlatformForwarder())
 }

--- a/comp/forwarder/eventplatformreceiver/component.go
+++ b/comp/forwarder/eventplatformreceiver/component.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package eventplatformreceiver implements the receiver for the event platform package
+package eventplatformreceiver
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// team: agent-metrics-logs
+
+// Component is the component type.
+type Component interface {
+	SetEnabled(e bool) bool
+	IsEnabled() bool
+	HandleMessage(m *message.Message, rendered []byte, eventType string)
+	Filter(filters *diagnostic.Filters, done <-chan struct{}) <-chan string
+}

--- a/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl/eventplatformreceiver.go
+++ b/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl/eventplatformreceiver.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package eventplatformreceiverimpl implements the event platform receiver component.
+package eventplatformreceiverimpl
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
+	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(NewReceiver),
+	)
+}
+
+// NewReceiver returns a new event platform receiver.
+func NewReceiver(hostname hostnameinterface.Component) eventplatformreceiver.Component {
+	return diagnostic.NewBufferedMessageReceiver(&epFormatter{}, hostname)
+}

--- a/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl/format.go
+++ b/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl/format.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package eventplatformimpl
+package eventplatformreceiverimpl
 
 import (
 	"encoding/json"

--- a/comp/netflow/server/server_test.go
+++ b/comp/netflow/server/server_test.go
@@ -20,9 +20,7 @@ import (
 	"go.uber.org/fx/fxtest"
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
-	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder/forwarderimpl"
 
@@ -66,11 +64,9 @@ var testOptions = fx.Options(
 	Module(),
 	nfconfig.MockModule(),
 	forwarderimpl.MockModule(),
-	hostnameimpl.MockModule(),
-	logimpl.MockModule(),
 	demultiplexerimpl.MockModule(),
 	defaultforwarder.MockModule(),
-	config.MockModule(),
+	core.MockBundle(),
 	fx.Invoke(func(lc fx.Lifecycle, c Component) {
 		// Set the internal flush frequency to a small number so tests don't take forever
 		c.(*Server).FlowAgg.FlushFlowsToSendInterval = 100 * time.Millisecond

--- a/comp/snmptraps/formatter/formatterimpl/formatter_test.go
+++ b/comp/snmptraps/formatter/formatterimpl/formatter_test.go
@@ -217,7 +217,6 @@ var (
 )
 
 var testOptions = fx.Options(
-	logimpl.MockModule(),
 	senderhelper.Opts,
 	oidresolverimpl.MockModule(),
 	Module(),

--- a/comp/snmptraps/forwarder/forwarderimpl/forwarder_test.go
+++ b/comp/snmptraps/forwarder/forwarderimpl/forwarder_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
-	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/config/configimpl"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/formatter"
@@ -42,9 +40,7 @@ type services struct {
 func setUp(t *testing.T) *services {
 	t.Helper()
 	s := fxutil.Test[services](t,
-		hostnameimpl.MockModule(),
 		configimpl.MockModule(),
-		logimpl.MockModule(),
 		senderhelper.Opts,
 		formatterimpl.MockModule(),
 		listenerimpl.MockModule(),

--- a/comp/snmptraps/listener/listenerimpl/listener_test.go
+++ b/comp/snmptraps/listener/listenerimpl/listener_test.go
@@ -12,9 +12,7 @@ import (
 
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/log"
-	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/config"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/config/configimpl"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/listener"
@@ -46,8 +44,6 @@ type services struct {
 func listenerTestSetup(t *testing.T, conf *config.TrapsConfig) *services {
 	conf.Enabled = true
 	s := fxutil.Test[services](t,
-		hostnameimpl.MockModule(),
-		logimpl.MockModule(),
 		configimpl.MockModule(),
 		statusimpl.MockModule(),
 		senderhelper.Opts,

--- a/comp/snmptraps/senderhelper/senderhelper.go
+++ b/comp/snmptraps/senderhelper/senderhelper.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
-	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -25,7 +25,7 @@ import (
 var Opts = fx.Options(
 	defaultforwarder.MockModule(),
 	demultiplexerimpl.MockModule(),
-	config.MockModule(),
+	core.MockBundle(),
 	fx.Provide(func() (*mocksender.MockSender, sender.Sender) {
 		mockSender := mocksender.NewMockSender("mock-sender")
 		mockSender.SetupAcceptAll()

--- a/comp/snmptraps/server/serverimpl/server_test.go
+++ b/comp/snmptraps/server/serverimpl/server_test.go
@@ -17,8 +17,6 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
-	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/senderhelper"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/server"
 	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
@@ -37,7 +35,6 @@ func TestServer(t *testing.T) {
 	freePort, err := ndmtestutils.GetFreePort()
 	require.NoError(t, err)
 	server := fxutil.Test[server.Component](t,
-		logimpl.MockModule(),
 		senderhelper.Opts,
 		fx.Replace(config.MockParams{
 			Overrides: map[string]interface{}{
@@ -47,7 +44,6 @@ func TestServer(t *testing.T) {
 				"network_devices.snmp_traps.community_strings": []string{"public"},
 			},
 		}),
-		hostnameimpl.MockModule(),
 		Module(),
 	)
 	assert.NotEmpty(t, server)
@@ -62,7 +58,6 @@ func TestNonBlockingFailure(t *testing.T) {
 	freePort, err := ndmtestutils.GetFreePort()
 	require.NoError(t, err)
 	server := fxutil.Test[server.Component](t,
-		logimpl.MockModule(),
 		senderhelper.Opts,
 		fx.Replace(config.MockParams{
 			Overrides: map[string]interface{}{
@@ -72,7 +67,6 @@ func TestNonBlockingFailure(t *testing.T) {
 				"network_devices.snmp_traps.community_strings": []string{"public"},
 			},
 		}),
-		hostnameimpl.MockModule(),
 		Module(),
 	)
 	assert.NotEmpty(t, server)
@@ -82,14 +76,12 @@ func TestNonBlockingFailure(t *testing.T) {
 
 func TestDisabled(t *testing.T) {
 	server := fxutil.Test[server.Component](t,
-		logimpl.MockModule(),
 		senderhelper.Opts,
 		fx.Replace(config.MockParams{
 			Overrides: map[string]interface{}{
 				"network_devices.snmp_traps.enabled": false,
 			},
 		}),
-		hostnameimpl.MockModule(),
 		Module(),
 	)
 	assert.NotNil(t, server)

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -17,8 +17,7 @@ import (
 	"time"
 
 	// 3p
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/collectors"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
@@ -689,7 +688,7 @@ type aggregatorDeps struct {
 }
 
 func createAggrDeps(t *testing.T) aggregatorDeps {
-	deps := fxutil.Test[TestDeps](t, defaultforwarder.MockModule(), config.MockModule(), logimpl.MockModule())
+	deps := fxutil.Test[TestDeps](t, defaultforwarder.MockModule(), core.MockBundle())
 
 	opts := demuxTestOptions()
 	return aggregatorDeps{

--- a/pkg/aggregator/check_sampler_bench_test.go
+++ b/pkg/aggregator/check_sampler_bench_test.go
@@ -8,11 +8,13 @@ package aggregator
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/log"
-	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	"go.uber.org/fx"
 
 	//nolint:revive // TODO(AML) Fix revive linter
 	forwarder "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
@@ -26,19 +28,25 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
+type benchmarkDeps struct {
+	fx.In
+	Log      log.Component
+	Hostname hostname.Component
+}
+
 func benchmarkAddBucket(bucketValue int64, b *testing.B) {
 	// Because these benchs can run for a long time, the aggregator is trying to
 	// flush and because the serializer is not initialized it panics with a nil.
 	// For some reasons using InitAggregator[WithInterval] doesn't fix the problem,
 	// but this do.
-	log := fxutil.Test[log.Component](b, logimpl.MockModule())
-	forwarderOpts := forwarder.NewOptionsWithResolvers(config.Datadog, log, resolver.NewSingleDomainResolvers(map[string][]string{"hello": {"world"}}))
+	deps := fxutil.Test[benchmarkDeps](b, core.MockBundle())
+	forwarderOpts := forwarder.NewOptionsWithResolvers(config.Datadog, deps.Log, resolver.NewSingleDomainResolvers(map[string][]string{"hello": {"world"}}))
 	options := DefaultAgentDemultiplexerOptions()
 	options.DontStartForwarders = true
-	sharedForwarder := forwarder.NewDefaultForwarder(config.Datadog, log, forwarderOpts)
+	sharedForwarder := forwarder.NewDefaultForwarder(config.Datadog, deps.Log, forwarderOpts)
 	orchestratorForwarder := optional.NewOption[defaultforwarder.Forwarder](defaultforwarder.NoopForwarder{})
 	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder())
-	demux := InitAndStartAgentDemultiplexer(log, sharedForwarder, &orchestratorForwarder, options, eventPlatformForwarder, "hostname")
+	demux := InitAndStartAgentDemultiplexer(deps.Log, sharedForwarder, &orchestratorForwarder, options, eventPlatformForwarder, "hostname")
 	defer demux.Stop(true)
 
 	checkSampler := newCheckSampler(1, true, true, 1000, tags.NewStore(true, "bench"), checkid.ID("hello:world:1234"))

--- a/pkg/aggregator/check_sampler_bench_test.go
+++ b/pkg/aggregator/check_sampler_bench_test.go
@@ -45,7 +45,7 @@ func benchmarkAddBucket(bucketValue int64, b *testing.B) {
 	options.DontStartForwarders = true
 	sharedForwarder := forwarder.NewDefaultForwarder(config.Datadog, deps.Log, forwarderOpts)
 	orchestratorForwarder := optional.NewOption[defaultforwarder.Forwarder](defaultforwarder.NoopForwarder{})
-	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder())
+	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder(deps.Hostname))
 	demux := InitAndStartAgentDemultiplexer(deps.Log, sharedForwarder, &orchestratorForwarder, options, eventPlatformForwarder, "hostname")
 	defer demux.Stop(true)
 

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -14,8 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
@@ -106,7 +105,7 @@ func TestDemuxNoAggOptionEnabled(t *testing.T) {
 
 func TestDemuxNoAggOptionIsDisabledByDefault(t *testing.T) {
 	opts := demuxTestOptions()
-	deps := fxutil.Test[TestDeps](t, defaultforwarder.MockModule(), config.MockModule(), logimpl.MockModule())
+	deps := fxutil.Test[TestDeps](t, defaultforwarder.MockModule(), core.MockBundle())
 	demux := InitAndStartAgentDemultiplexerForTest(deps, opts, "")
 
 	require.False(t, demux.Options().EnableNoAggregationPipeline, "the no aggregation pipeline should be disabled by default")
@@ -155,8 +154,7 @@ func createDemultiplexerAgentTestDeps(t *testing.T) DemultiplexerAgentTestDeps {
 	return fxutil.Test[DemultiplexerAgentTestDeps](
 		t,
 		defaultforwarder.MockModule(),
-		config.MockModule(),
-		logimpl.MockModule(),
+		core.MockBundle(),
 		orchestratorimpl.MockModule(),
 		eventplatformimpl.MockModule(),
 	)

--- a/pkg/aggregator/demultiplexer_mock.go
+++ b/pkg/aggregator/demultiplexer_mock.go
@@ -28,6 +28,6 @@ type TestDeps struct {
 // InitAndStartAgentDemultiplexerForTest initializes an aggregator for tests.
 func InitAndStartAgentDemultiplexerForTest(deps TestDeps, options AgentDemultiplexerOptions, hostname string) *AgentDemultiplexer {
 	orchestratorForwarder := optional.NewOption[defaultforwarder.Forwarder](defaultforwarder.NoopForwarder{})
-	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder())
+	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder(deps.Hostname))
 	return InitAndStartAgentDemultiplexer(deps.Log, deps.SharedForwarder, &orchestratorForwarder, options, eventPlatformForwarder, hostname)
 }

--- a/pkg/aggregator/demultiplexer_mock.go
+++ b/pkg/aggregator/demultiplexer_mock.go
@@ -8,6 +8,7 @@
 package aggregator
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
@@ -20,6 +21,7 @@ import (
 type TestDeps struct {
 	fx.In
 	Log             log.Component
+	Hostname        hostname.Component
 	SharedForwarder defaultforwarder.Component
 }
 

--- a/pkg/aggregator/demultiplexer_test.go
+++ b/pkg/aggregator/demultiplexer_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
@@ -296,8 +296,7 @@ func createDemuxDepsWithOrchestratorFwd(
 	eventPlatformParams eventplatformimpl.Params) aggregatorDeps {
 	modules := fx.Options(
 		defaultforwarder.MockModule(),
-		config.MockModule(),
-		logimpl.MockModule(),
+		core.MockBundle(),
 		orchestratorForwarderImpl.Module(),
 		fx.Supply(orchestratorParams),
 		eventplatformimpl.Module(),

--- a/pkg/aggregator/demultiplexer_test.go
+++ b/pkg/aggregator/demultiplexer_test.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core"
-	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarder "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
@@ -300,6 +300,7 @@ func createDemuxDepsWithOrchestratorFwd(
 		orchestratorForwarderImpl.Module(),
 		fx.Supply(orchestratorParams),
 		eventplatformimpl.Module(),
+		eventplatformreceiverimpl.Module(),
 		fx.Supply(eventPlatformParams),
 	)
 	deps := fxutil.Test[internalDemutiplexerDeps](t, modules)

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
@@ -40,7 +41,7 @@ func CreateDefaultDemultiplexer() *aggregator.AgentDemultiplexer {
 	log := logimpl.NewTemporaryLoggerWithoutInit()
 	sharedForwarder := forwarder.NewDefaultForwarder(config.Datadog, log, forwarder.NewOptions(config.Datadog, log, nil))
 	orchestratorForwarder := optional.NewOption[defaultforwarder.Forwarder](defaultforwarder.NoopForwarder{})
-	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder())
+	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder(hostnameimpl.NewHostnameService()))
 	return aggregator.InitAndStartAgentDemultiplexer(log, sharedForwarder, &orchestratorForwarder, opts, eventPlatformForwarder, "")
 
 }

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
@@ -54,7 +55,7 @@ func testDemux(log log.Component, hostname hostname.Component) *AgentDemultiplex
 	opts := DefaultAgentDemultiplexerOptions()
 	opts.DontStartForwarders = true
 	orchestratorForwarder := optional.NewOption[defaultforwarder.Forwarder](defaultforwarder.NoopForwarder{})
-	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder())
+	eventPlatformForwarder := optional.NewOptionPtr[eventplatform.Forwarder](eventplatformimpl.NewNoopEventPlatformForwarder(hostname))
 	demux := initAgentDemultiplexer(log, NewForwarderTest(log), &orchestratorForwarder, opts, eventPlatformForwarder, defaultHostname)
 	return demux
 }

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -48,6 +48,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	logagent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/comp/metadata/host"
@@ -180,6 +181,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 					params.UseNoopEventPlatformForwarder = true
 					return params
 				}),
+				eventplatformreceiverimpl.Module(),
 				fx.Provide(func() demultiplexerimpl.Params {
 					// Initializing the aggregator with a flush interval of 0 (to disable the flush goroutines)
 					params := demultiplexerimpl.NewDefaultParams()

--- a/pkg/collector/collector_demux_test.go
+++ b/pkg/collector/collector_demux_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/stub"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -31,7 +32,7 @@ type CollectorDemuxTestSuite struct {
 }
 
 func (suite *CollectorDemuxTestSuite) SetupTest() {
-	suite.demux = fxutil.Test[demultiplexer.FakeSamplerMock](suite.T(), logimpl.MockModule(), demultiplexerimpl.FakeSamplerMockModule())
+	suite.demux = fxutil.Test[demultiplexer.FakeSamplerMock](suite.T(), logimpl.MockModule(), demultiplexerimpl.FakeSamplerMockModule(), hostnameimpl.MockModule())
 	suite.c = NewCollector(suite.demux, 500*time.Millisecond).(*collector)
 
 	suite.c.Start()

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -22,9 +22,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
-	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
-	"github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -50,7 +49,7 @@ type deps struct {
 }
 
 func createDeps(t *testing.T) deps {
-	return fxutil.Test[deps](t, demultiplexerimpl.MockModule(), defaultforwarder.MockModule(), config.MockModule(), logimpl.MockModule())
+	return fxutil.Test[deps](t, demultiplexerimpl.MockModule(), defaultforwarder.MockModule(), core.MockBundle())
 }
 
 func Test_Run_simpleCase(t *testing.T) {

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -15,8 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -227,5 +226,5 @@ type deps struct {
 }
 
 func buildDeps(t *testing.T) deps {
-	return fxutil.Test[deps](t, defaultforwarder.MockModule(), config.MockModule(), logimpl.MockModule(), demultiplexerimpl.MockModule())
+	return fxutil.Test[deps](t, defaultforwarder.MockModule(), core.MockBundle(), demultiplexerimpl.MockModule())
 }

--- a/pkg/serverless/invocationlifecycle/lifecycle_test.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
@@ -1055,5 +1056,5 @@ func getEventFromFile(filename string) []byte {
 }
 
 func createDemultiplexer(t *testing.T) demultiplexer.FakeSamplerMock {
-	return fxutil.Test[demultiplexer.FakeSamplerMock](t, logimpl.MockModule(), demultiplexerimpl.FakeSamplerMockModule())
+	return fxutil.Test[demultiplexer.FakeSamplerMock](t, logimpl.MockModule(), demultiplexerimpl.FakeSamplerMockModule(), hostnameimpl.MockModule())
 }

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -1327,5 +1328,5 @@ func TestMultipleStartLogCollection(t *testing.T) {
 }
 
 func createDemultiplexer(t *testing.T) demultiplexer.FakeSamplerMock {
-	return fxutil.Test[demultiplexer.FakeSamplerMock](t, logimpl.MockModule(), demultiplexerimpl.FakeSamplerMockModule())
+	return fxutil.Test[demultiplexer.FakeSamplerMock](t, logimpl.MockModule(), demultiplexerimpl.FakeSamplerMockModule(), hostnameimpl.MockModule())
 }

--- a/pkg/serverless/metrics/enhanced_metrics_test.go
+++ b/pkg/serverless/metrics/enhanced_metrics_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	serverlessTags "github.com/DataDog/datadog-agent/pkg/serverless/tags"
@@ -470,5 +471,5 @@ func TestGenerateEnhancedMetricsFromRuntimeDoneLogOK(t *testing.T) {
 }
 
 func createDemultiplexer(t *testing.T) demultiplexer.FakeSamplerMock {
-	return fxutil.Test[demultiplexer.FakeSamplerMock](t, logimpl.MockModule(), demultiplexerimpl.FakeSamplerMockModule())
+	return fxutil.Test[demultiplexer.FakeSamplerMock](t, logimpl.MockModule(), demultiplexerimpl.FakeSamplerMockModule(), hostnameimpl.MockModule())
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR removes the Event platform global receiver.
It is recommended to review commit by commit.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Agent share component:
- Check `agent diagnose` command behaves the same as before

Metrics and logs:
- Create a [python custom check](https://docs.datadoghq.com/developers/custom_checks/write_agent_check/)
- Replace self.gauge('hello.world', 1) by self.database_monitoring_query_sample("{}")
- Start the Agent
- Run the Agent command stream-event-platform and check the behaviour is the same as the previous version

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
