### PR TITLE
Include ebpf-manager support for multiple instruction patchers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.4.0
 	// do not update datadog-operator to 1.2.1 because the indirect dependency github.com/DataDog/datadog-api-client-go/v2 v2.15.0 is trigger a huge Go heap memory increase.
 	github.com/DataDog/datadog-operator v1.1.0
-	github.com/DataDog/ebpf-manager v0.4.0
+	github.com/DataDog/ebpf-manager v0.5.0
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.3
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/DataDog/datadog-go/v5 v5.4.0 h1:Ea3eXUVwrVV28F/fo3Dr3aa+TL/Z7Xi6SUPKW
 github.com/DataDog/datadog-go/v5 v5.4.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator v1.1.0 h1:cSZqKarzM66GR0T1pPPZVopz4oPm3ltcRyqJ/h/6eJg=
 github.com/DataDog/datadog-operator v1.1.0/go.mod h1:3aWOjI4EaE1jYVN6llOXygA9nasy70GCa1XnTIWNoCY=
-github.com/DataDog/ebpf-manager v0.4.0 h1:ZxOnHD9h4qrmGKEdt0TmSdDd0mRNJ+HfsG0ZH4wQaB0=
-github.com/DataDog/ebpf-manager v0.4.0/go.mod h1:GQ0AnVyn0Oi+NzBOBP1UB5kHGa5YZRxlFDhg4VGAo3s=
+github.com/DataDog/ebpf-manager v0.5.0 h1:oPWTcpKzUf6Do71htiAfVa6YNOsoCCmhftVS7kTVuos=
+github.com/DataDog/ebpf-manager v0.5.0/go.mod h1:6RXMEfMNvqDmPr6pdYbkFq6ctA2uoE5kHNBwTLayoAg=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG5603WQxNP/UX63E7k=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=

--- a/pkg/ebpf/manager.go
+++ b/pkg/ebpf/manager.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package ebpf
+
+import (
+	"fmt"
+	"io"
+
+	manager "github.com/DataDog/ebpf-manager"
+	"golang.org/x/exp/slices"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// Manager wraps ebpf-manager.Manager, adding a property with the list of enabled modifiers
+// for this instance.
+type Manager struct {
+	*manager.Manager
+	EnabledModifiers []string // List of enabled modifiers
+}
+
+// Names of modifiers are defined here to avoid duplication and so that they can be
+// used in the list of default modifiers
+const (
+	// NoModifiers is a constant to be used when creating a new manager to avoid initializing the default modifiers
+	NoModifiers = "NO_MODIFIERS"
+	// PrintkModifier is the name of the modifier that patches the printk function
+	PrintkModifier = "printk"
+)
+
+// defaultModifiers is a list of modifiers that are enabled by default when the callers don't provide
+// a specific list
+var defaultModifiers = []string{PrintkModifier}
+
+// NewManager creates a manager wrapper.
+// If the modifiers list is empty, it will be initialized with the default modifiers.
+// Pass manager.NO_MODIFIERS to avoid initializing the default modifiers.
+func NewManager(mgr *manager.Manager, modifiers ...string) *Manager {
+	if len(modifiers) == 0 {
+		modifiers = defaultModifiers
+	} else if len(modifiers) == 1 && modifiers[0] == NoModifiers {
+		modifiers = []string{}
+	}
+
+	log.Debugf("Creating new manager with modifiers: %v", modifiers)
+
+	return &Manager{
+		Manager:          mgr,
+		EnabledModifiers: modifiers,
+	}
+}
+
+// Modifier is an interface that can be implemented by a package to
+// add functionality to the ebpf.Manager. It exposes a name to identify the modifier,
+// two functions that will be called before and after the ebpf.Manager.InitWithOptions
+// call, and a function that will be called when the manager is stopped.
+type Modifier interface {
+	// Name returns the name of the modifier. Should be unique, although it's not enforced for now.
+	Name() string
+
+	// BeforeInit is called before the ebpf.Manager.InitWithOptions call
+	BeforeInit(*Manager, *manager.Options) error
+
+	// AfterInit is called after the ebpf.Manager.InitWithOptions call
+	AfterInit(*Manager, *manager.Options) error
+}
+
+// Internal state with all registered modifiers. This is populated via the
+// RegisterModifier function below by packages that want to add a modifier.
+var modifiers []Modifier
+
+// RegisterModifier registers a Modifier to be run whenever a new manager is
+// initialized. This is used to add functionality to the manager, such as telemetry or
+// the newline patching
+// This should be called on init() functions of packages that want to add a modifier.
+func RegisterModifier(mod Modifier) {
+	modifiers = append(modifiers, mod)
+}
+
+// enabledModifiers is a shorthand to return a list of all enabled modifiers
+// for this manager
+func (m *Manager) getEnabledModifiers() []Modifier {
+	var enabled []Modifier
+	for _, mod := range modifiers {
+		if slices.Contains(m.EnabledModifiers, mod.Name()) {
+			enabled = append(enabled, mod)
+		}
+	}
+	return enabled
+}
+
+// InitWithOptions is a wrapper around ebpf-manager.Manager.InitWithOptions
+func (m *Manager) InitWithOptions(bytecode io.ReaderAt, opts *manager.Options) error {
+	for _, mod := range m.getEnabledModifiers() {
+		log.Debugf("Running %s manager modifier", mod.Name())
+		if err := mod.BeforeInit(m, opts); err != nil {
+			return fmt.Errorf("error running %s manager modifier: %w", mod.Name(), err)
+		}
+	}
+
+	if err := m.Manager.InitWithOptions(bytecode, *opts); err != nil {
+		return err
+	}
+
+	for _, mod := range m.getEnabledModifiers() {
+		log.Debugf("Running %s manager modifier", mod.Name())
+		if err := mod.AfterInit(m, opts); err != nil {
+			return fmt.Errorf("error running %s manager modifier: %w", mod.Name(), err)
+		}
+	}
+	return nil
+}

--- a/pkg/ebpf/manager.go
+++ b/pkg/ebpf/manager.go
@@ -12,7 +12,6 @@ import (
 	"io"
 
 	manager "github.com/DataDog/ebpf-manager"
-	"golang.org/x/exp/slices"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -60,7 +59,7 @@ func NewManager(mgr *manager.Manager, modifiers ...string) *Manager {
 // two functions that will be called before and after the ebpf.Manager.InitWithOptions
 // call, and a function that will be called when the manager is stopped.
 type Modifier interface {
-	// Name returns the name of the modifier. Should be unique, although it's not enforced for now.
+	// Name returns the name of the modifier, must be unique.
 	Name() string
 
 	// BeforeInit is called before the ebpf.Manager.InitWithOptions call
@@ -72,31 +71,48 @@ type Modifier interface {
 
 // Internal state with all registered modifiers. This is populated via the
 // RegisterModifier function below by packages that want to add a modifier.
-var modifiers []Modifier
+var modifiers = make(map[string]Modifier)
 
 // RegisterModifier registers a Modifier to be run whenever a new manager is
 // initialized. This is used to add functionality to the manager, such as telemetry or
 // the newline patching
 // This should be called on init() functions of packages that want to add a modifier.
 func RegisterModifier(mod Modifier) {
-	modifiers = append(modifiers, mod)
+	if _, ok := modifiers[mod.Name()]; ok {
+		// panic so that we fail loudly and callers can correct their mistake
+		panic(fmt.Sprintf("Modifier with name %s already registered, choose another name", mod.Name()))
+	}
+	modifiers[mod.Name()] = mod
+}
+
+// UnregisterModifier removes a Modifier from the list of registered modifiers
+// This should mainly be used in tests to avoid modifying the global state
+func UnregisterModifier(modName string) {
+	delete(modifiers, modName)
 }
 
 // enabledModifiers is a shorthand to return a list of all enabled modifiers
 // for this manager
-func (m *Manager) getEnabledModifiers() []Modifier {
+func (m *Manager) getEnabledModifiers() ([]Modifier, error) {
 	var enabled []Modifier
-	for _, mod := range modifiers {
-		if slices.Contains(m.EnabledModifiers, mod.Name()) {
+	for _, modName := range m.EnabledModifiers {
+		if mod, ok := modifiers[modName]; ok {
 			enabled = append(enabled, mod)
+		} else {
+			return nil, fmt.Errorf("Modifier %s is not registered, skipping", modName)
 		}
 	}
-	return enabled
+	return enabled, nil
 }
 
 // InitWithOptions is a wrapper around ebpf-manager.Manager.InitWithOptions
 func (m *Manager) InitWithOptions(bytecode io.ReaderAt, opts *manager.Options) error {
-	for _, mod := range m.getEnabledModifiers() {
+	mods, err := m.getEnabledModifiers()
+	if err != nil {
+		return err
+	}
+
+	for _, mod := range mods {
 		log.Debugf("Running %s manager modifier", mod.Name())
 		if err := mod.BeforeInit(m, opts); err != nil {
 			return fmt.Errorf("error running %s manager modifier: %w", mod.Name(), err)
@@ -107,7 +123,7 @@ func (m *Manager) InitWithOptions(bytecode io.ReaderAt, opts *manager.Options) e
 		return err
 	}
 
-	for _, mod := range m.getEnabledModifiers() {
+	for _, mod := range mods {
 		log.Debugf("Running %s manager modifier", mod.Name())
 		if err := mod.AfterInit(m, opts); err != nil {
 			return fmt.Errorf("error running %s manager modifier: %w", mod.Name(), err)

--- a/pkg/ebpf/modifiers/printk_patcher.go
+++ b/pkg/ebpf/modifiers/printk_patcher.go
@@ -221,7 +221,7 @@ func (t *printkPatcherModifier) Name() string {
 }
 
 func (t *printkPatcherModifier) BeforeInit(m *ddebpf.Manager, _ *manager.Options) error {
-	m.InstructionPatcher = PatchPrintkNewline
+	m.InstructionPatchers = append(m.InstructionPatchers, PatchPrintkNewline)
 	return nil
 }
 

--- a/pkg/ebpf/modifiers/printk_patcher.go
+++ b/pkg/ebpf/modifiers/printk_patcher.go
@@ -13,7 +13,7 @@ package modifiers
 import (
 	"errors"
 
-	ebpfmanager "github.com/DataDog/ebpf-manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
 
@@ -31,7 +31,7 @@ import (
 // that adds a newline to the message before calling bpf_trace_printk. In older kernels
 // this ensures that a newline is added. In newer ones it would mean that two newlines are
 // added, so this patcher removes that newline in those cases.
-func PatchPrintkNewline(m *ebpfmanager.Manager) error {
+func PatchPrintkNewline(m *manager.Manager) error {
 	kernelVersion, err := kernel.HostVersion()
 	if err != nil {
 		return err // can't detect kernel version, don't patch
@@ -220,12 +220,12 @@ func (t *printkPatcherModifier) Name() string {
 	return ddebpf.PrintkModifier
 }
 
-func (t *printkPatcherModifier) BeforeInit(m *ddebpf.Manager, _ *ebpfmanager.Options) error {
+func (t *printkPatcherModifier) BeforeInit(m *ddebpf.Manager, _ *manager.Options) error {
 	m.InstructionPatcher = PatchPrintkNewline
 	return nil
 }
 
-func (t *printkPatcherModifier) AfterInit(_ *ddebpf.Manager, _ *ebpfmanager.Options) error {
+func (t *printkPatcherModifier) AfterInit(_ *ddebpf.Manager, _ *manager.Options) error {
 	return nil
 }
 

--- a/pkg/ebpf/modifiers/printk_patcher_test.go
+++ b/pkg/ebpf/modifiers/printk_patcher_test.go
@@ -5,7 +5,7 @@
 
 //go:build linux_bpf
 
-package runtime
+package modifiers
 
 import (
 	"bufio"
@@ -18,28 +18,18 @@ import (
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/DataDog/ebpf-manager/tracefs"
-	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	ebpfkernel "github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 //go:generate $GOPATH/bin/include_headers pkg/ebpf/testdata/c/runtime/logdebug-test.c pkg/ebpf/bytecode/build/runtime/logdebug-test.c pkg/ebpf/c pkg/network/ebpf/c/runtime pkg/network/ebpf/c
 //go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/logdebug-test.c pkg/ebpf/bytecode/runtime/logdebug-test.go runtime
-
-func TestMain(m *testing.M) {
-	logLevel := os.Getenv("DD_LOG_LEVEL")
-	if logLevel == "" {
-		logLevel = "info"
-	}
-	log.SetupLogger(seelog.Default, logLevel)
-	os.Exit(m.Run())
-}
 
 func TestPatchPrintkNewline(t *testing.T) {
 	kernelVersion, err := ebpfkernel.NewKernelVersion()
@@ -61,7 +51,7 @@ func TestPatchPrintkNewline(t *testing.T) {
 		cfg := ddebpf.NewConfig()
 		require.NotNil(t, cfg)
 
-		buf, err := LogdebugTest.Compile(cfg, []string{"-g", "-DDEBUG=1"}, nil)
+		buf, err := runtime.LogdebugTest.Compile(cfg, []string{"-g", "-DDEBUG=1"}, nil)
 		require.NoError(t, err)
 		defer buf.Close()
 

--- a/pkg/ebpf/modifiers/printk_patcher_test.go
+++ b/pkg/ebpf/modifiers/printk_patcher_test.go
@@ -76,7 +76,7 @@ func TestPatchPrintkNewline(t *testing.T) {
 			},
 			MapEditors: make(map[string]*ebpf.Map),
 		}
-		mgr.InstructionPatcher = PatchPrintkNewline
+		mgr.InstructionPatchers = append(mgr.InstructionPatchers, PatchPrintkNewline)
 
 		tp, err := tracefs.OpenFile("trace_pipe", os.O_RDONLY, 0)
 		require.NoError(t, err)

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -208,9 +208,9 @@ func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetr
 	if err != nil {
 		return err
 	}
-	m.InstructionPatcher = func(m *manager.Manager) error {
+	m.InstructionPatchers = append(m.InstructionPatchers, func(m *manager.Manager) error {
 		return patchEBPFTelemetry(m, activateBPFTelemetry, bpfTelemetry)
-	}
+	})
 
 	if activateBPFTelemetry {
 		// add telemetry maps to list of maps, if not present

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -312,7 +312,7 @@ def ninja_runtime_compilation_files(nw, gobin):
         "pkg/network/tracer/compile.go": "conntrack",
         "pkg/network/tracer/connection/kprobe/compile.go": "tracer",
         "pkg/network/tracer/offsetguess_test.go": "offsetguess-test",
-        "pkg/ebpf/bytecode/runtime/printk_patcher_test.go": "logdebug-test",
+        "pkg/ebpf/modifiers/printk_patcher_test.go": "logdebug-test",
         "pkg/security/ebpf/compile.go": "runtime-security",
     }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR bumps ebpf-manager to v0.5.0, bringing in support for multiple instruction patchers.

### Motivation

Related to  and https://github.com/DataDog/datadog-agent/pull/21657 and https://github.com/DataDog/ebpf-manager/pull/168, the ebpf-manager needed to support multiple instruction patchers so that we can have both the telemetry patchers and the printk patchers in the same manager.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
