### PR TITLE
usm: http2: Fixed an incorrect handling of a frame header split from frame payload

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -471,6 +471,15 @@ static __always_inline bool tls_get_first_frame(tls_dispatcher_arguments_t *info
     //  4. We failed reading any frame. Aborting.
 
     // Frame-header-remainder.
+    if (frame_state != NULL && frame_state->header_length == HTTP2_FRAME_HEADER_SIZE) {
+        // A case where we read an interesting valid frame header in the previous call, and now we're trying to read the
+        // rest of the frame payload. But, since we already read a valid frame, we just fill it as an interesting frame,
+        // and continue to the next tail call.
+        // Copy the cached frame header to the current frame.
+        bpf_memcpy((char *)current_frame, frame_state->buf, HTTP2_FRAME_HEADER_SIZE);
+        frame_state->remainder = 0;
+        return true;
+    }
     if (frame_state->header_length > 0) {
         tls_fix_header_frame(info, (char *)current_frame, frame_state);
         if (format_http2_frame_header(current_frame)) {
@@ -622,22 +631,6 @@ int uprobe__http2_tls_handle_first_frame(struct pt_regs *ctx) {
         return 0;
     }
 
-    // A case where we read an interesting valid frame header in the previous call, and now we're trying to read the
-    // rest of the frame payload. But, since we already read a valid frame, we just fill it as an interesting frame,
-    // and continue to the next tail call.
-    if (frame_state != NULL && frame_state->header_length == HTTP2_FRAME_HEADER_SIZE) {
-        // Copy the cached frame header to the current frame.
-        bpf_memcpy((char *)&current_frame, frame_state->buf, HTTP2_FRAME_HEADER_SIZE);
-        // Delete the cached frame header.
-        bpf_map_delete_elem(&http2_remainder, &dispatcher_args_copy.tup);
-        // Save the frame as an interesting frame (a.k.a, restoring the state we had in the previous call).
-        // We need to do so, as we're zeroing the iteration_value at the beginning of this function.
-        iteration_value->frames_array[0].frame = current_frame;
-        iteration_value->frames_array[0].offset = 0;
-        iteration_value->frames_count = 1;
-        // Continuing to the next tail call.
-        bpf_tail_call_compat(ctx, &tls_process_progs, TLS_HTTP2_FILTER);
-    }
     if (!tls_get_first_frame(&dispatcher_args_copy, frame_state, &current_frame, http2_tel)) {
         return 0;
     }
@@ -668,6 +661,7 @@ int uprobe__http2_tls_handle_first_frame(struct pt_regs *ctx) {
             bpf_memcpy(new_frame_state.buf, (char *)&current_frame, HTTP2_FRAME_HEADER_SIZE);
         }
 
+        iteration_value->frames_count = 0;
         bpf_map_update_elem(&http2_remainder, &dispatcher_args_copy.tup, &new_frame_state, BPF_ANY);
         // Not calling the next tail call as we have nothing to process.
         return 0;

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -394,3 +394,30 @@ func (t HTTP2DynamicTableEntry) String() string {
 
 	return str
 }
+
+// String returns a string representation of the http2 eBPF telemetry.
+func (t *HTTP2Telemetry) String() string {
+	return fmt.Sprintf(`
+HTTP2Telemetry{
+	"requests seen": %d,
+	"responses seen": %d,
+	"end of stream seen": %d,
+	"reset frames seen": %d,
+	"literal values exceed message count": %d,
+	"messages with more frames than we can filter": %d,
+	"messages with more interesting frames than we can process": %d,
+	"path headers length distribution": {
+		"in range [0, 120)": %d,
+		"in range [120, 130)": %d,
+		"in range [130, 140)": %d,
+		"in range [140, 150)": %d,
+		"in range [150, 160)": %d,
+		"in range [160, 170)": %d,
+		"in range [170, 180)": %d,
+		"in range [180, infinity)": %d
+	}
+}`, t.Request_seen, t.Response_seen, t.End_of_stream, t.End_of_stream_rst, t.Path_exceeds_frame,
+		t.Exceeding_max_frames_to_filter, t.Exceeding_max_interesting_frames, t.Path_size_bucket[0], t.Path_size_bucket[1],
+		t.Path_size_bucket[2], t.Path_size_bucket[3], t.Path_size_bucket[4], t.Path_size_bucket[5], t.Path_size_bucket[6],
+		t.Path_size_bucket[7])
+}

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -1160,7 +1160,11 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 						t.Logf("key: %v was not found in res", key.Path.Content.Get())
 					}
 				}
-				ebpftest.DumpMapsTestHelper(t, usmMonitor.DumpMaps, "http2_in_flight")
+				ebpftest.DumpMapsTestHelper(t, usmMonitor.DumpMaps, "http2_in_flight", "http2_dynamic_table")
+				telem, err := getHTTP2KernelTelemetry(usmMonitor, s.isTLS)
+				if err == nil {
+					t.Logf("telemetry: %+v", telem)
+				}
 			}
 		})
 	}
@@ -1388,6 +1392,7 @@ func writeInput(c net.Conn, timeout time.Duration, inputs ...[]byte) error {
 		if _, err := c.Write(input); err != nil {
 			return err
 		}
+		time.Sleep(time.Millisecond * 10)
 	}
 	// Since we don't know when to stop reading from the socket, we set a timeout.
 	if err := c.SetReadDeadline(time.Now().Add(timeout)); err != nil {


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The PR moves the handling of the scenario (frame header is separated from the payload) inside `get_first_frame`
and relying on the mechanism we had there already.

The PR adds a small sleep in the tests to ensure data is sent separately.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

In case the frame header was sent in a different socket or TLS call from the frame payload we didn't handle the use-case correctly and it caused flakiness in the CI.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
