### PR TITLE
Fixed race condition between StartETW() and StopETW()

### DIFF
--- a/pkg/util/winutil/etw/etw.go
+++ b/pkg/util/winutil/etw/etw.go
@@ -8,6 +8,7 @@
 package etw
 
 import (
+	"sync"
 	"syscall"
 	"unsafe"
 )
@@ -27,7 +28,8 @@ type Subscriber interface {
 }
 
 var (
-	subscribers = make(map[ProviderType]Subscriber)
+	subscribers      = make(map[ProviderType]Subscriber)
+	subscribersMutex sync.Mutex
 )
 
 // ProviderType identifies an ETW provider
@@ -72,10 +74,45 @@ func isHTTPServiceSubscriptionEnabled(etwProviders ProviderType) bool {
 	return (etwProviders & EtwProviderHTTPService) == EtwProviderHTTPService
 }
 
+func addToSubscriber(etwProviders ProviderType, sub Subscriber) {
+	subscribersMutex.Lock()
+	defer subscribersMutex.Unlock()
+
+	subscribers[etwProviders] = sub
+}
+
+func getSubscribers() []Subscriber {
+	subscribersMutex.Lock()
+	defer subscribersMutex.Unlock()
+
+	var subs []Subscriber
+	for _, s := range subscribers {
+		subs = append(subs, s)
+	}
+
+	return subs
+}
+
+func deleteSubscribers() {
+	subscribersMutex.Lock()
+	defer subscribersMutex.Unlock()
+
+	subscribers = make(map[ProviderType]Subscriber)
+}
+
 //export etwCallbackC
 func etwCallbackC(eventInfo *C.DD_ETW_EVENT_INFO) {
 	switch eventInfo.provider {
 	case C.DD_ETW_TRACE_PROVIDER_HttpService:
+		// This function needs to be as fast as possible because HTTP ETW providers send a
+		// very high volume of events so we don't want to block the ETW thread. On the other
+		// hand it is safe to access global map here because system invokes this function
+		// but only if ETW session is not closed, which means that while a call to
+		// C.StartEtwSubscription() from StartEtw() is in progress, this function is safe
+		// to access global map and reversely when before and after a call to
+		// C.StartEtwSubscription(), this function will not be invoked. It is also safe to
+		// presume that this function will not be invoked after a call to
+		// C.StopEtwSubscription() initiated from StopEtw() is completed.
 		if sub, ok := subscribers[EtwProviderHTTPService]; ok {
 			sub.OnEvent((*DDEtwEventInfo)(unsafe.Pointer(eventInfo)))
 		}
@@ -93,10 +130,13 @@ func etwCallbackC(eventInfo *C.DD_ETW_EVENT_INFO) {
 func StartEtw(subscriptionName string, etwProviders ProviderType, sub Subscriber) error {
 
 	if isHTTPServiceSubscriptionEnabled(etwProviders) {
-		subscribers[etwProviders] = sub
+		addToSubscriber(etwProviders, sub)
 		sub.OnStart()
 	}
 
+	// This call is blocking and will not return until the ETW session is stopped
+	// or an error occurs. This is by design. There is a race condition between
+	// this function and StopEtw() which will unblock C.StartEtwSubscription().
 	ret := C.StartEtwSubscription(
 		C.CString(subscriptionName),
 		providersToNativeProviders(etwProviders),
@@ -104,7 +144,7 @@ func StartEtw(subscriptionName string, etwProviders ProviderType, sub Subscriber
 		(C.ETW_EVENT_CALLBACK)(unsafe.Pointer(C.etwCallbackC)))
 
 	if isHTTPServiceSubscriptionEnabled(etwProviders) {
-		delete(subscribers, etwProviders)
+		deleteSubscribers()
 		sub.OnStop()
 
 	}
@@ -120,12 +160,12 @@ func StartEtw(subscriptionName string, etwProviders ProviderType, sub Subscriber
 //
 // See above note about http-centrism
 func StopEtw(subscriptionName string) {
+	subs := getSubscribers()
+
 	if len(subscribers) != 0 {
 		C.StopEtwSubscription()
-
-		if sub, ok := subscribers[EtwProviderHTTPService]; ok {
+		for _, s := range subs {
 			sub.OnStop()
 		}
-
 	}
 }

--- a/pkg/util/winutil/etw/etw.go
+++ b/pkg/util/winutil/etw/etw.go
@@ -165,7 +165,7 @@ func StopEtw(subscriptionName string) {
 	if len(subscribers) != 0 {
 		C.StopEtwSubscription()
 		for _, s := range subs {
-			sub.OnStop()
+			s.OnStop()
 		}
 	}
 }

--- a/releasenotes/notes/legacy-etw-race-incident-25148-fdcdea78a80dde9b.yaml
+++ b/releasenotes/notes/legacy-etw-race-incident-25148-fdcdea78a80dde9b.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed race conditions caused by concurrent execution of etw.StartEtw()
+    and etw.StopEtw() functions which may concurrently access and modify a
+    global map.


### PR DESCRIPTION
The fix is based on the few following facts
* StartETW() will be block on call to C.StartEtwSubscription()
* StartETW() will be unblocked by call StopETW() and specifically C.StopEtwSubscription()
* etwCallbackC() will not be invoked after ETW session is stopped (C.StopEtwSubscription() is completed and C.StartEtwSubscription() is unllocked)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Fixes race condition in the ETW package by adding mutex for access a global map.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fix the bug

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
n/a
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
n/a
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Make sure that all unit and kitchen tests are passing.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
