### PR TITLE
add FailLogLevel helper to log only if test failed

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestEBPFPerfBufferLength(t *testing.T) {
+	ebpftest.FailLogLevel(t, "trace")
+
 	err := rlimit.RemoveMemlock()
 	require.NoError(t, err)
 

--- a/pkg/ebpf/ebpftest/fail_log.go
+++ b/pkg/ebpf/ebpftest/fail_log.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ebpftest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// FailLogLevel sets the logger level for this test only and only outputs if the test fails
+func FailLogLevel(t testing.TB, level string) {
+	t.Helper()
+	inner := &failureTestLogger{TB: t}
+	t.Cleanup(func() {
+		t.Helper()
+		log.SetupLogger(seelog.Default, "off")
+		inner.outputIfFailed()
+	})
+	logger, err := seelog.LoggerFromCustomReceiver(inner)
+	if err != nil {
+		return
+	}
+	log.SetupLogger(logger, level)
+}
+
+type failureTestLogger struct {
+	testing.TB
+	logData []byte
+}
+
+// ReceiveMessage implements logger.CustomReceiver
+func (l *failureTestLogger) ReceiveMessage(message string, level seelog.LogLevel, context seelog.LogContextInterface) error {
+	l.logData = append(l.logData, fmt.Sprintf("%s:%d: %s | %s | %s\n", context.FileName(), context.Line(), context.CallTime().Format("2006-01-02 15:04:05.000 MST"), strings.ToUpper(level.String()), message)...)
+	return nil
+}
+
+// AfterParse implements logger.CustomReceiver
+func (l *failureTestLogger) AfterParse(initArgs seelog.CustomReceiverInitArgs) error { //nolint:revive // TODO fix revive unused-parameter
+	return nil
+}
+
+// Flush implements logger.CustomReceiver
+func (l *failureTestLogger) Flush() {
+}
+
+func (l *failureTestLogger) outputIfFailed() {
+	l.Helper()
+	if l.Failed() {
+		l.TB.Logf("\n%s", l.logData)
+	}
+	l.logData = nil
+}
+
+// Close implements logger.CustomReceiver
+func (l *failureTestLogger) Close() error {
+	return nil
+}

--- a/pkg/ebpf/ebpftest/log.go
+++ b/pkg/ebpf/ebpftest/log.go
@@ -31,7 +31,7 @@ type testLogger struct {
 }
 
 func (t testLogger) ReceiveMessage(message string, level seelog.LogLevel, context seelog.LogContextInterface) error {
-	t.Logf("%s | %s | %s", context.CallTime().Format("2006-01-02 15:04:05 MST"), strings.ToUpper(level.String()), message)
+	t.Logf("%s:%d: %s | %s | %s", context.FileName(), context.Line(), context.CallTime().Format("2006-01-02 15:04:05.000 MST"), strings.ToUpper(level.String()), message)
 	return nil
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

- Adds `ebpftest.FailLogLevel` to log lines at specified level ONLY if the test fails
- Adds file+line and millisecond context information to `ebpftest.LogLevel`
- Use `ebpftest.FailLogLevel` in `TestEBPFPerfBufferLength` because it is flaky

### Motivation

Debugging flaky tests

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
