### PR TITLE
[RC] Add RC e2e tests for the core agent components

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1057,6 +1057,18 @@ workflow:
   - when: manual
     allow_failure: true
 
+.on_rc_or_e2e_changes_or_manual:
+  - <<: *if_disable_e2e
+    when: never
+  - <<: *if_main_branch
+    when: on_success
+  - <<: *if_mergequeue
+    when: never
+  - changes:
+      paths:
+        - pkg/config/remote/**/*
+        - comp/remote-config/**/*
+        - test/new-e2e/tests/remote-config/**/*
 
 .on_install_script_release_manual:
   - <<: *if_not_version_7

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -92,6 +92,7 @@ new-e2e-cws*                      @DataDog/agent-security
 new-e2e-windows-agent*            @DataDog/windows-agent
 new-e2e-orchestrator*             @DataDog/container-app
 e2e_pre_test*                     @DataDog/agent-platform
+new-e2e-remote-config*            @DataDog/remote-config
 
 # Kernel version testing
 package_dependencies*             @DataDog/ebpf-platform

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -133,6 +133,15 @@ new-e2e-containers:
       - EXTRA_PARAMS: --run TestECSSuite
       - EXTRA_PARAMS: --skip "Test(Kind|EKS|ECS)Suite"
 
+new-e2e-remote-config:
+  extends: .new_e2e_template
+  rules:
+    !reference [.on_rc_or_e2e_changes_or_manual]
+  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
+  variables:
+    TARGETS: ./tests/remote-config
+    TEAM: remote-config
+
 new-e2e-agent-shared-components-dev:
   extends: .new_e2e_template
   rules:

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -121,3 +121,4 @@ e2e_test_junit_upload:
     - new-e2e-cws-main
     - new-e2e-orchestrator-main
     - new-e2e-apm-main
+    - new-e2e-remote-config

--- a/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
@@ -131,6 +131,11 @@ func (agent *agentCommandRunner) IsReady() bool {
 	return err == nil
 }
 
+// RemoteConfig runs remote-config command and returns the output
+func (agent *agentCommandRunner) RemoteConfig(commandArgs ...agentclient.AgentArgsOption) string {
+	return agent.executeCommand("remote-config", commandArgs...)
+}
+
 // Status runs status command and returns a Status struct
 func (agent *agentCommandRunner) Status(commandArgs ...agentclient.AgentArgsOption) *agentclient.Status {
 	return &agentclient.Status{

--- a/test/new-e2e/pkg/utils/e2e/client/agentclient/agent.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agentclient/agent.go
@@ -38,6 +38,9 @@ type Agent interface {
 	// IntegrationWithError run integration command and returns the output
 	IntegrationWithError(commandArgs ...AgentArgsOption) (string, error)
 
+	// RemoteConfig runs the remote-config command and returns the output
+	RemoteConfig(commandArgs ...AgentArgsOption) string
+
 	// Secret runs the secret command
 	Secret(commandArgs ...AgentArgsOption) string
 

--- a/test/new-e2e/tests/remote-config/fixtures/rc-enabled.yaml
+++ b/test/new-e2e/tests/remote-config/fixtures/rc-enabled.yaml
@@ -1,0 +1,7 @@
+hostname: rc-e2e-ec2-host
+logs_enabled: true
+log_level: debug
+
+remote_configuration:
+  enabled: true
+  refresh_interval: 5s

--- a/test/new-e2e/tests/remote-config/fixtures/ssl_mismatch.yaml
+++ b/test/new-e2e/tests/remote-config/fixtures/ssl_mismatch.yaml
@@ -1,0 +1,8 @@
+hostname: rc-e2e-ec2-host
+logs_enabled: true
+log_level: debug
+skip_ssl_validation: true #disable https during requests to dd backend but don't explicitly enabled remote_configuration.no_tls_validation
+
+remote_configuration:
+  enabled: true
+  refresh_interval: 5s

--- a/test/new-e2e/tests/remote-config/fixtures/tracer-payload.json
+++ b/test/new-e2e/tests/remote-config/fixtures/tracer-payload.json
@@ -1,0 +1,22 @@
+{
+  "client": {
+    "id": "e2e_tests",
+    "name": "e2e_service",
+    "products": ["TESTING1"],
+    "version": "e2e-client-version",
+    "state": {
+      "root_version": 1
+    },
+    "is_tracer": true,
+    "client_tracer": {
+      "runtime_id": "3att30cca30bd6ffx47814cfef849e3z",
+      "language": "python",
+      "tracer_version": "1.0.0",
+      "service": "e2e-service",
+      "env": "staging",
+      "app_version": "e2e",
+      "tags": []
+    }
+  },
+  "cached_target_files": []
+}

--- a/test/new-e2e/tests/remote-config/rc_ssl_config_test.go
+++ b/test/new-e2e/tests/remote-config/rc_ssl_config_test.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package remoteconfig
+
+import (
+	_ "embed"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+)
+
+type sslConfigSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+//go:embed fixtures/ssl_mismatch.yaml
+var sslMismatchConfig string
+
+func TestSslConfigSuite(t *testing.T) {
+	e2e.Run(t, &sslConfigSuite{},
+		e2e.WithProvisioner(
+			awshost.ProvisionerNoFakeIntake(
+				awshost.WithAgentOptions(
+					agentparams.WithAgentConfig(sslMismatchConfig),
+				),
+			),
+		),
+	)
+}
+
+// TestRemoteConfigSSLConfigMismatch tests the startup condition where the agent's SSL config is disabled but RC's TLS validation is not explicitly disabled
+func (s *sslConfigSuite) TestRemoteConfigSSLConfigMismatch() {
+	// Check if the agent is ready
+	isReady := s.Env().Agent.Client.IsReady()
+	assert.Equal(s.T(), isReady, true, "Agent is not ready")
+
+	// Ensure the remote config service starts
+	// TODO uncomment the following line in https://github.com/DataDog/datadog-agent/pull/22582 (once fx lifecycle startup logging is added)
+	//assertLogsWithRetry(a.T(), a.Env().RemoteHost, "agent", "remote config service started", 60, 500*time.Millisecond)
+
+	// Ensure the agent logs a warning about the SSL config mismatch
+	assertLogsWithRetry(s.T(), s.Env().RemoteHost, "agent", "remote Configuration does not allow skipping TLS validation by default", 120, 1*time.Second)
+	// Ensure the remote config service stops, and the client stops because the service is not longer responding
+	assertLogsWithRetry(s.T(), s.Env().RemoteHost, "agent", "remote configuration isn't enabled, disabling client", 120, 1*time.Second)
+
+	// Ensure the agent remains running despite the remote config service initialization failure
+	isReady = s.Env().Agent.Client.IsReady()
+	assert.Equal(s.T(), isReady, true, "Agent shut down after remote config initialization failed")
+}

--- a/test/new-e2e/tests/remote-config/remoteconfig.go
+++ b/test/new-e2e/tests/remote-config/remoteconfig.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package remoteconfig contains tests for the remote config components of the agent
+package remoteconfig

--- a/test/new-e2e/tests/remote-config/tracer_test.go
+++ b/test/new-e2e/tests/remote-config/tracer_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package remoteconfig
+
+import (
+	_ "embed"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+)
+
+type tracerSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+//go:embed fixtures/rc-enabled.yaml
+var rcEnabledConfig string
+
+//go:embed fixtures/tracer-payload.json
+var tracerPayloadJSON string
+
+func TestRcTracerSuite(t *testing.T) {
+	e2e.Run(t, &tracerSuite{},
+		e2e.WithProvisioner(
+			awshost.ProvisionerNoFakeIntake(
+				awshost.WithAgentOptions(
+					agentparams.WithAgentConfig(rcEnabledConfig),
+				),
+			),
+		),
+	)
+}
+
+// TestRemoteConfigTracerUpdate tests the remote-config service by attempting to retrieve RC payloads as if a tracer were calling it
+func (s *tracerSuite) TestRemoteConfigTracerUpdate() {
+	// Check if the agent is ready
+	isReady := s.Env().Agent.Client.IsReady()
+	assert.Equal(s.T(), isReady, true, "Agent is not ready")
+
+	// Ensure the remote config service starts
+	// TODO uncomment the following line in https://github.com/DataDog/datadog-agent/pull/22582 (once fx lifecycle startup logging is added)
+	//assertLogsWithRetry(a.T(), a.Env().RemoteHost, "agent", "remote config service started", 60, 500*time.Millisecond)
+
+	// Wait until we've started querying for configs
+	assertLogsWithRetry(s.T(), s.Env().RemoteHost, "agent", "/api/v0.1/configurations", 120, 1*time.Second)
+
+	// Get configs as though we are a tracer
+	// But first, prime by continuously curling until the api is responding successfully just in case it is slow to start
+	curlAgentRcServiceWithRetry(s.T(), s.Env().RemoteHost, tracerPayloadJSON, 120, 1*time.Second)
+	getConfigsOutput := s.Env().RemoteHost.MustExecute(fmt.Sprintf("curl -sS localhost:8126/v0.7/config -d @- <<EOF\n%sEOF", tracerPayloadJSON))
+	require.Contains(s.T(), getConfigsOutput, "roots", "expected a roots key in the tracer config output")
+	require.Contains(s.T(), getConfigsOutput, "targets", "expected a targets key in the tracer config output")
+
+	// Check remote-config command output for our e2e test client that we fetched configs for
+	remoteConfigOutput := s.Env().Agent.Client.RemoteConfig()
+	require.Contains(s.T(), remoteConfigOutput, "=== Remote config DB state ===", "could not find the expected header in the core agent remote-config output")
+	require.Contains(s.T(), remoteConfigOutput, "Client e2e_tests", "could not find the e2e_tests client in the core agent remote-config output")
+}

--- a/test/new-e2e/tests/remote-config/utils_test.go
+++ b/test/new-e2e/tests/remote-config/utils_test.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package remoteconfig
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/stretchr/testify/require"
+)
+
+// assertLogsWithRetry will verify that a given `agentName` component's logs contain a pattern.
+// It will continually retry until the `expectedLogPattern` is found or the `maxRetries` is reached,
+// waiting `retryInterval` between each attempt.
+// If the `expectedLogPattern` is not found or an error occurs, the calling test will fail.
+func assertLogsWithRetry(t *testing.T, rh *components.RemoteHost, agentName string, expectedLogPattern string, maxRetries int, retryInterval time.Duration) {
+	err := backoff.Retry(func() error {
+		output, err := rh.Execute(fmt.Sprintf("cat /var/log/datadog/%s.log", agentName))
+		if err != nil {
+			return err
+		}
+		if strings.Contains(output, expectedLogPattern) {
+			return nil
+		}
+		return errors.New("pattern not found")
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(retryInterval), uint64(maxRetries)))
+
+	require.NoError(t, err, fmt.Sprintf("failed to find log with pattern `%s`", expectedLogPattern))
+}
+
+func curlAgentRcServiceWithRetry(t *testing.T, rh *components.RemoteHost, payload string, maxRetries int, retryInterval time.Duration) {
+	err := backoff.Retry(func() error {
+		_, err := rh.Execute(fmt.Sprintf("curl -sS localhost:8126/v0.7/config -d @- <<EOF\n%sEOF", payload))
+		if err != nil {
+			return err
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(retryInterval), uint64(maxRetries)))
+
+	require.NoError(t, err, "failed to curl remote config service")
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR introduces Remote Config e2e tests to the agent CI pipeline, including two new e2e tests for the Remote Config service component of the agent. These tests will run on non-main branches only when there are changes to remote-config-owned files. The two tests are basic for now, and mostly test that:
- the RC Service performs it's basic functions when configured correctly, 
- and the RC Service does not have any unintended impacts on the rest of the agent when failing to initialize/start correctly

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This should help validate that changes to the remote config components of the agent do not introduce unintended side effects in non-local environments that are otherwise difficult to test/validate without deploying. In particular, this will help in validating the [PR](https://github.com/DataDog/datadog-agent/pull/22582) to refactor the RC service to be managed by the fx lifecycle.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

No functional changes in this PR. These tests will be executed in CI ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/427084905)). For running the tests locally, see also the `readme` in this PR.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
