### PR TITLE
[AGNTR-158] Add check to stop workflow in case of no new changes

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -37,10 +37,24 @@ jobs:
               with:
                 ref: ${{ env.RELEASE_BRANCH }}
                 fetch-depth: 0
-              
-            - name: Create RC PR
+
+            - name: Check for changes since last RC
+              id: check_for_changes
               run: |
-                git config user.name "GitHub Actions"
+                last_rc_commit=$(git log -1 --format=%H --grep="Update release.json and Go modules")
+                count=$(git rev-list --count HEAD ^"$last_rc_commit")
+                echo COUNT=$count >> $GITHUB_OUTPUT
+                  
+                if [ $count -eq '0' ]; then
+                    echo "No changes since last RC. Quitting workflow."
+                else
+                    echo "$count new commits found since last RC. Proceeding with the RC PR creation."
+                fi
+                  
+            - name: Create RC PR
+              if: ${{ steps.check_for_changes.outputs.COUNT != '0'}}
+              run: |
+                git config user.name "github-actions[bot]"
                 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                 git fetch
                 inv -e release.create-rc


### PR DESCRIPTION
### What does this PR do?

This PR extends `Create RC PR` github workflow with check for recent changes,
This workflow is meant to be run on daily schedule and in case there are no new changes merged for release between two runs, then there is no need to build new RC.

The changes check makes an assumption that the last RC was build on top of the commit like https://github.com/DataDog/datadog-agent/commit/6b1c2347a718550fc3b13176e9fd9a7812c93155. This is a simplification in some way but it should be 99% true (mentioned commit is generated by script so it should stay the same). I think that trying to make it more bulletproof makes the workflow script messy and does not provide much benefit.

Additionally - user.name of the github user is changed to the one used commonly by other github actions. I hope this will solve the problem with github-actions[bot] failing CLA check.

### Motivation

Automation of the Agent release process.

### Additional Notes

Changes to the workflow are merged piece by piece in different PRs to avoid difficult debugging, because there is no way to test e2e whole workflow in the real conditions if it is not merged to the main branch.

### Describe how to test/QA your changes

Change was tested locally as much as possible. Real test will be performed after merge to main with the next RC build opportunity.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
