### PR TITLE
upgrade(remote-config): Retry client first run errors faster

### DIFF
--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -281,7 +281,6 @@ func (c *Client) Subscribe(product string, fn func(update map[string]state.RawCo
 	}
 
 	c.listeners[product] = append(c.listeners[product], fn)
-	fn(c.state.GetConfigs(product), c.state.UpdateApplyStatus)
 }
 
 // GetConfigs returns the current configs applied of a product.
@@ -307,9 +306,34 @@ func (c *Client) startFn() {
 // pollLoop should never be called manually and only be called via the client's `sync.Once`
 // structure in startFn.
 func (c *Client) pollLoop() {
-	successfulFirstRun := false
+	successfulFirstRun := true
+	// First run
+	err := c.update()
+	if err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			// Remote Configuration is disabled as the server isn't initialized
+			//
+			// As this is not a transient error (that would be codes.Unavailable),
+			// stop the client: it shouldn't keep contacting a server that doesn't
+			// exist.
+			log.Debugf("remote configuration isn't enabled, disabling client")
+			return
+		}
+
+		// As some clients may start before the core-agent server is up, we log the first error
+		// as a debug log as the race is expected. If the error persists, we log with error logs
+		log.Infof("retrying the first update of remote-config state (%v)", err)
+		successfulFirstRun = false
+	}
+
 	for {
 		interval := c.backoffPolicy.GetBackoffDuration(c.backoffErrorCount)
+		if !successfulFirstRun && c.pollInterval > time.Second {
+			// If we never managed to contact the RC service, we want to retry faster (max every second)
+			// to get a first state as soon as possible.
+			// Some products may not start correctly without a first state.
+			interval = -c.pollInterval + time.Second
+		}
 		select {
 		case <-c.ctx.Done():
 			return

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -321,7 +321,7 @@ func (c *Client) pollLoop() {
 		}
 
 		// As some clients may start before the core-agent server is up, we log the first error
-		// as a debug log as the race is expected. If the error persists, we log with error logs
+		// as an Info log as the race is expected. If the error persists, we log with error logs
 		log.Infof("retrying the first update of remote-config state (%v)", err)
 		successfulFirstRun = false
 	}
@@ -352,7 +352,7 @@ func (c *Client) pollLoop() {
 
 				if !successfulFirstRun {
 					// As some clients may start before the core-agent server is up, we log the first error
-					// as a debug log as the race is expected. If the error persists, we log with error logs
+					// as an Info log as the race is expected. If the error persists, we log with error logs
 					log.Infof("retrying the first update of remote-config state (%v)", err)
 				} else {
 					c.lastUpdateError = err

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -306,7 +306,7 @@ func (c *Client) startFn() {
 // pollLoop should never be called manually and only be called via the client's `sync.Once`
 // structure in startFn.
 func (c *Client) pollLoop() {
-	successfulFirstRun := true
+	successfulFirstRun := false
 	// First run
 	err := c.update()
 	if err != nil {
@@ -323,7 +323,8 @@ func (c *Client) pollLoop() {
 		// As some clients may start before the core-agent server is up, we log the first error
 		// as an Info log as the race is expected. If the error persists, we log with error logs
 		log.Infof("retrying the first update of remote-config state (%v)", err)
-		successfulFirstRun = false
+	} else {
+		successfulFirstRun = true
 	}
 
 	for {

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -327,17 +327,17 @@ func (c *Client) pollLoop() {
 	}
 
 	for {
-		interval := c.backoffPolicy.GetBackoffDuration(c.backoffErrorCount)
-		if !successfulFirstRun && c.pollInterval > time.Second {
+		interval := c.pollInterval + c.backoffPolicy.GetBackoffDuration(c.backoffErrorCount)
+		if !successfulFirstRun && interval > time.Second {
 			// If we never managed to contact the RC service, we want to retry faster (max every second)
 			// to get a first state as soon as possible.
 			// Some products may not start correctly without a first state.
-			interval = -c.pollInterval + time.Second
+			interval = time.Second
 		}
 		select {
 		case <-c.ctx.Done():
 			return
-		case <-time.After(c.pollInterval + interval):
+		case <-time.After(interval):
 			err := c.update()
 			if err != nil {
 				if status.Code(err) == codes.Unimplemented {


### PR DESCRIPTION
### What does this PR do?
1. Adds an update in agent Remote Config clients before the poll loop wait
2. Retries faster first run errors (max every second) as to not wait `c.pollInterval` if there is a race condition between the startups of the service & the client
3. Don't call the callback on product subscription as it may return an empty state before the client can contact the service

### Motivation
[RC-1573]

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
If the service returns some errors showing up at startup (that are not `Unavailable`) the clients will poll it every second forever instead of every 5s. Though, tracers do exactly the same all the time and it's not a big problem for the agent.

### Describe how to test/QA your changes
1. Build the agent & remove the RC DB
2. Run `watch -n 0.25 "./bin/agent/agent remote-config -c ./dev/dist/datadog.yaml"` in one terminal
3. Launch the agent in another terminal
4. Check that you receive configurations in a second or so

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[RC-1573]: https://datadoghq.atlassian.net/browse/RC-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ