### PR TITLE
[USM] Changed path_exceeds_frame to support different literal values

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -222,7 +222,7 @@ typedef struct {
 // response_seen                        Count of HTTP/2 responses seen
 // end_of_stream                        Count of END STREAM flag seen
 // end_of_stream_rst                    Count of RST flags seen
-// path_exceeds_frame                   Count of times we couldn't retrieve the path due to reaching the end of the frame.
+// literal_value_exceeds_frame          Count of times we couldn't retrieve the literal value due to reaching the end of the frame.
 // exceeding_max_interesting_frames		Count of times we reached the max number of frames per iteration.
 // exceeding_max_frames_to_filter		Count of times we have left with more frames to filter than the max number of frames to filter.
 // path_size_bucket                     Count of path sizes and divided into buckets.
@@ -231,7 +231,7 @@ typedef struct {
     __u64 response_seen;
     __u64 end_of_stream;
     __u64 end_of_stream_rst;
-    __u64 path_exceeds_frame;
+    __u64 literal_value_exceeds_frame;
     __u64 exceeding_max_interesting_frames;
     __u64 exceeding_max_frames_to_filter;
     __u64 path_size_bucket[HTTP2_TELEMETRY_PATH_BUCKETS+1];

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -133,7 +133,7 @@ static __always_inline bool tls_parse_field_literal(tls_dispatcher_arguments_t *
     }
 
     if (info->data_off + str_len > info->data_end) {
-        __sync_fetch_and_add(&http2_tel->path_exceeds_frame, 1);
+        __sync_fetch_and_add(&http2_tel->literal_value_exceeds_frame, 1);
         goto end;
     }
 

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -131,7 +131,7 @@ static __always_inline bool parse_field_literal(struct __sk_buff *skb, skb_info_
     }
 
     if (skb_info->data_off + str_len > skb_info->data_end) {
-        __sync_fetch_and_add(&http2_tel->path_exceeds_frame, 1);
+        __sync_fetch_and_add(&http2_tel->literal_value_exceeds_frame, 1);
         goto end;
     }
 

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -416,7 +416,7 @@ HTTP2Telemetry{
 		"in range [170, 180)": %d,
 		"in range [180, infinity)": %d
 	}
-}`, t.Request_seen, t.Response_seen, t.End_of_stream, t.End_of_stream_rst, t.Path_exceeds_frame,
+}`, t.Request_seen, t.Response_seen, t.End_of_stream, t.End_of_stream_rst, t.Literal_value_exceeds_frame,
 		t.Exceeding_max_frames_to_filter, t.Exceeding_max_interesting_frames, t.Path_size_bucket[0], t.Path_size_bucket[1],
 		t.Path_size_bucket[2], t.Path_size_bucket[3], t.Path_size_bucket[4], t.Path_size_bucket[5], t.Path_size_bucket[6],
 		t.Path_size_bucket[7])

--- a/pkg/network/protocols/http2/telemetry.go
+++ b/pkg/network/protocols/http2/telemetry.go
@@ -60,8 +60,8 @@ type kernelTelemetry struct {
 	endOfStreamRST *tlsAwareCounter
 	// pathSizeBucket Count of path sizes divided into buckets.
 	pathSizeBucket [http2PathBuckets + 1]*tlsAwareCounter
-	// pathExceedsFrame Count of times we couldn't retrieve the path due to reaching the end of the frame.
-	pathExceedsFrame *tlsAwareCounter
+	// literalValueExceedsFrame Count of times we couldn't retrieve the literal value due to reaching the end of the frame.
+	literalValueExceedsFrame *tlsAwareCounter
 	// exceedingMaxInterestingFrames Count of times we reached the max number of frames per iteration.
 	exceedingMaxInterestingFrames *tlsAwareCounter
 	// exceedingMaxFramesToFilter Count of times we have left with more frames to filter than the max number of frames to filter.
@@ -80,7 +80,7 @@ func newHTTP2KernelTelemetry() *kernelTelemetry {
 		http2responses:                newTLSAwareCounter(metricGroup, "responses"),
 		endOfStream:                   newTLSAwareCounter(metricGroup, "eos"),
 		endOfStreamRST:                newTLSAwareCounter(metricGroup, "rst"),
-		pathExceedsFrame:              newTLSAwareCounter(metricGroup, "path_exceeds_frame"),
+		literalValueExceedsFrame:      newTLSAwareCounter(metricGroup, "literal_value_exceeds_frame"),
 		exceedingMaxInterestingFrames: newTLSAwareCounter(metricGroup, "exceeding_max_interesting_frames"),
 		exceedingMaxFramesToFilter:    newTLSAwareCounter(metricGroup, "exceeding_max_frames_to_filter")}
 	for bucketIndex := range http2KernelTel.pathSizeBucket {
@@ -98,7 +98,7 @@ func (t *kernelTelemetry) update(tel *HTTP2Telemetry, isTLS bool) {
 	t.http2responses.add(int64(telemetryDelta.Response_seen), isTLS)
 	t.endOfStream.add(int64(telemetryDelta.End_of_stream), isTLS)
 	t.endOfStreamRST.add(int64(telemetryDelta.End_of_stream_rst), isTLS)
-	t.pathExceedsFrame.add(int64(telemetryDelta.Path_exceeds_frame), isTLS)
+	t.literalValueExceedsFrame.add(int64(telemetryDelta.Literal_value_exceeds_frame), isTLS)
 	t.exceedingMaxInterestingFrames.add(int64(telemetryDelta.Exceeding_max_interesting_frames), isTLS)
 	t.exceedingMaxFramesToFilter.add(int64(telemetryDelta.Exceeding_max_frames_to_filter), isTLS)
 	for bucketIndex := range t.pathSizeBucket {
@@ -119,7 +119,7 @@ func (t *HTTP2Telemetry) Sub(other HTTP2Telemetry) *HTTP2Telemetry {
 		Response_seen:                    t.Response_seen - other.Response_seen,
 		End_of_stream:                    t.End_of_stream - other.End_of_stream,
 		End_of_stream_rst:                t.End_of_stream_rst - other.End_of_stream_rst,
-		Path_exceeds_frame:               t.Path_exceeds_frame - other.Path_exceeds_frame,
+		Literal_value_exceeds_frame:      t.Literal_value_exceeds_frame - other.Literal_value_exceeds_frame,
 		Exceeding_max_interesting_frames: t.Exceeding_max_interesting_frames - other.Exceeding_max_interesting_frames,
 		Exceeding_max_frames_to_filter:   t.Exceeding_max_frames_to_filter - other.Exceeding_max_frames_to_filter,
 		Path_size_bucket:                 computePathSizeBucketDifferences(t.Path_size_bucket, other.Path_size_bucket),

--- a/pkg/network/protocols/http2/telemetry_test.go
+++ b/pkg/network/protocols/http2/telemetry_test.go
@@ -43,7 +43,7 @@ func testKernelTelemetryUpdate(t *testing.T, isTLS bool) {
 		Response_seen:                    5,
 		End_of_stream:                    10,
 		End_of_stream_rst:                11,
-		Path_exceeds_frame:               20,
+		Literal_value_exceeds_frame:      20,
 		Exceeding_max_interesting_frames: 30,
 		Exceeding_max_frames_to_filter:   40,
 		Path_size_bucket:                 [8]uint64{1, 2, 3, 4, 5, 6, 7, 8},
@@ -58,7 +58,7 @@ func testKernelTelemetryUpdate(t *testing.T, isTLS bool) {
 	http2Telemetry.Response_seen = 10
 	http2Telemetry.End_of_stream = 11
 	http2Telemetry.End_of_stream_rst = 18
-	http2Telemetry.Path_exceeds_frame = 26
+	http2Telemetry.Literal_value_exceeds_frame = 26
 	http2Telemetry.Exceeding_max_interesting_frames = 32
 	http2Telemetry.Exceeding_max_frames_to_filter = 42
 	http2Telemetry.Path_size_bucket = [8]uint64{2, 3, 4, 5, 6, 7, 8, 9}
@@ -71,7 +71,7 @@ func assertTelemetryEquality(t *testing.T, http2Telemetry *HTTP2Telemetry, kerne
 	assert.Equal(t, http2Telemetry.Response_seen, uint64(kernelTelemetryGroup.http2responses.get(isTLS)))
 	assert.Equal(t, http2Telemetry.End_of_stream, uint64(kernelTelemetryGroup.endOfStream.get(isTLS)))
 	assert.Equal(t, http2Telemetry.End_of_stream_rst, uint64(kernelTelemetryGroup.endOfStreamRST.get(isTLS)))
-	assert.Equal(t, http2Telemetry.Path_exceeds_frame, uint64(kernelTelemetryGroup.pathExceedsFrame.get(isTLS)))
+	assert.Equal(t, http2Telemetry.Literal_value_exceeds_frame, uint64(kernelTelemetryGroup.literalValueExceedsFrame.get(isTLS)))
 	assert.Equal(t, http2Telemetry.Exceeding_max_interesting_frames, uint64(kernelTelemetryGroup.exceedingMaxInterestingFrames.get(isTLS)))
 	assert.Equal(t, http2Telemetry.Exceeding_max_frames_to_filter, uint64(kernelTelemetryGroup.exceedingMaxFramesToFilter.get(isTLS)))
 	for i, bucket := range kernelTelemetryGroup.pathSizeBucket {

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -74,7 +74,7 @@ type HTTP2Telemetry struct {
 	Response_seen                    uint64
 	End_of_stream                    uint64
 	End_of_stream_rst                uint64
-	Path_exceeds_frame               uint64
+	Literal_value_exceeds_frame      uint64
 	Exceeding_max_interesting_frames uint64
 	Exceeding_max_frames_to_filter   uint64
 	Path_size_bucket                 [8]uint64

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -392,7 +392,7 @@ func (s *usmHTTP2Suite) TestHTTP2KernelTelemetry() {
 				if telemetry.Response_seen != tt.expectedTelemetry.Response_seen {
 					return false
 				}
-				if telemetry.Path_exceeds_frame != tt.expectedTelemetry.Path_exceeds_frame {
+				if telemetry.Literal_value_exceeds_frame != tt.expectedTelemetry.Literal_value_exceeds_frame {
 					return false
 				}
 				if telemetry.Exceeding_max_interesting_frames != tt.expectedTelemetry.Exceeding_max_interesting_frames {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

 Renames `path_exceeds_frame` to `literal_value_exceeds_frame`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

After the latest changes, the name of path_exceeds_frame is not correct because we support different literal values such as status codes and methods.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
