### PR TITLE
dogstatsd: add more latency buckets

### DIFF
--- a/comp/dogstatsd/listeners/telemetry.go
+++ b/comp/dogstatsd/listeners/telemetry.go
@@ -27,7 +27,11 @@ var (
 		[]string{"listener_id", "transport"}, "Dogstatsd UDS connections count")
 
 	tlmListener            = telemetry.NewHistogramNoOp()
-	defaultListenerBuckets = []float64{300, 500, 1000, 1500, 2000, 2500, 3000, 10000, 20000, 50000}
+	defaultListenerBuckets = []float64{
+		300, 500, 1000, // nanoseconds
+		1500, 2_000, 2_500, 3_000, 10_000, 20_000, 50_000, 100_000, 200_000, 500_000, // milliseconds
+		1_000_000, 2_000_000, 5_000_000, 10_000_000, 20_000_000, 50_000_000, 100_000_000, 200_000_000, 500_000_000, // milliseconds
+	}
 )
 
 // InitTelemetry initialize the telemetry.Histogram buckets for the internal


### PR DESCRIPTION
### What does this PR do?

It adds many more latency buckets to cover latency up to 500ms.

### Motivation

We're mostly blind when the agent is overloaded since it's always with latencies of more than 50usec

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

N/A

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
