### PR TITLE
Fixed previous PR (#22664) typo

### DIFF
--- a/pkg/util/winutil/etw/etw.go
+++ b/pkg/util/winutil/etw/etw.go
@@ -161,8 +161,7 @@ func StartEtw(subscriptionName string, etwProviders ProviderType, sub Subscriber
 // See above note about http-centrism
 func StopEtw(subscriptionName string) {
 	subs := getSubscribers()
-
-	if len(subscribers) != 0 {
+	if len(subs) != 0 {
 		C.StopEtwSubscription()
 		for _, s := range subs {
 			s.OnStop()

--- a/releasenotes/notes/legacy-etw-race-incident-25148-v2-13185809525258bc.yaml
+++ b/releasenotes/notes/legacy-etw-race-incident-25148-v2-13185809525258bc.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    Fix recent PR #22664 which in turn fixes race condition in ETW package.
+    Fix recent PR #22664 which in turn fixes a race condition in the ETW package.
     The previous PR introduces minor error which addressed in this PR

--- a/releasenotes/notes/legacy-etw-race-incident-25148-v2-13185809525258bc.yaml
+++ b/releasenotes/notes/legacy-etw-race-incident-25148-v2-13185809525258bc.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix recent PR #22664 which in turn fixes race condition in ETW package.
+    The previous PR introduces minor error which addressed in this PR

--- a/releasenotes/notes/legacy-etw-race-incident-25148-v2-13185809525258bc.yaml
+++ b/releasenotes/notes/legacy-etw-race-incident-25148-v2-13185809525258bc.yaml
@@ -9,4 +9,4 @@
 fixes:
   - |
     Fix recent PR #22664 which in turn fixes a race condition in the ETW package.
-    The previous PR introduces minor error which addressed in this PR
+    The previous PR introduced a minor error addressed in this PR.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Previous PR (https://github.com/DataDog/datadog-agent/pull/22664) contains a subtle bug. It will not affect a critical path of race-condition which starts when C.StopEtwSubscription() is invoked still it needs to be addressed
### Motivation
n/a
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
n/a
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
the same as previous PR, make sure that all unit and kitchen tests are passing.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
