### PR TITLE
[invoke] Query macOS workflows less frequently to avoid rate limits

### DIFF
--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -99,7 +99,7 @@ def follow_workflow_run(run):
 
     print(color_message("Workflow run link: " + color_message(run.html_url, "green"), "blue"))
 
-    tries = 0
+    minutes = 0
     failures = 0
     # Wait time (in minutes) between two queries of the workflow status
     interval = 5
@@ -125,12 +125,12 @@ def follow_workflow_run(run):
         if status == "completed":
             return conclusion, run_url
         else:
-            print(f"Workflow still running... ({tries*interval}m)")
+            print(f"Workflow still running... ({minutes}m)")
             # For some unknown reason, in Gitlab these lines do not get flushed, leading to not being
             # able to see where's the job at in the logs. The following line forces the flush.
             sys.stdout.flush()
 
-        tries += interval
+        minutes += interval
         sleep(60 * interval)
 
 

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -101,6 +101,8 @@ def follow_workflow_run(run):
 
     minutes = 0
     failures = 0
+    # Wait time (in minutes) between two queries of the workflow status
+    interval = 5
     MAX_FAILURES = 5
     while True:
         # Do not fail outright for temporary failures
@@ -123,13 +125,13 @@ def follow_workflow_run(run):
         if status == "completed":
             return conclusion, run_url
         else:
-            print(f"Workflow still running... ({minutes}m)")
+            print(f"Workflow still running... ({minutes*interval}m)")
             # For some unknown reason, in Gitlab these lines do not get flushed, leading to not being
             # able to see where's the job at in the logs. The following line forces the flush.
             sys.stdout.flush()
 
-        minutes += 1
-        sleep(60)
+        minutes += interval
+        sleep(60 * interval)
 
 
 def print_workflow_conclusion(conclusion, workflow_uri):

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -99,7 +99,7 @@ def follow_workflow_run(run):
 
     print(color_message("Workflow run link: " + color_message(run.html_url, "green"), "blue"))
 
-    minutes = 0
+    tries = 0
     failures = 0
     # Wait time (in minutes) between two queries of the workflow status
     interval = 5
@@ -125,12 +125,12 @@ def follow_workflow_run(run):
         if status == "completed":
             return conclusion, run_url
         else:
-            print(f"Workflow still running... ({minutes*interval}m)")
+            print(f"Workflow still running... ({tries*interval}m)")
             # For some unknown reason, in Gitlab these lines do not get flushed, leading to not being
             # able to see where's the job at in the logs. The following line forces the flush.
             sys.stdout.flush()
 
-        minutes += interval
+        tries += interval
         sleep(60 * interval)
 
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Increases the interval between each query of the status of the tracked GitHub Action workflow, from 1 minute to 5 minutes.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We are querying the GitHub API too often, causing us to hit rate limits.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

This means macOS jobs could be up to 4 minutes slower than before, due to the reduced refresh frequency.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Verify that the jobs tracking macOS GitHub Actions still work.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
