### PR TITLE
tasks: remove windows args in system probe and security agent tasks

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -139,8 +139,7 @@ build do
   if sysprobe_support
     if not bundled_agents.include? "system-probe"
       if windows_target?
-        ## don't bother with system probe build on x86.
-        command "invoke -e system-probe.build --windows"
+        command "invoke -e system-probe.build"
       elsif linux_target?
         command "invoke -e system-probe.build-sysprobe-binary --install-path=#{install_dir} --no-bundle"
       end

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -371,10 +371,9 @@ def build_functional_tests(
     skip_linters=False,
     race=False,
     kernel_release=None,
-    windows=False,
     debug=False,
 ):
-    if not windows:
+    if not is_windows:
         build_cws_object_files(
             ctx,
             major_version=major_version,
@@ -391,7 +390,7 @@ def build_functional_tests(
         env["GOARCH"] = "386"
 
     build_tags = build_tags.split(",")
-    if not windows:
+    if not is_windows:
         build_tags.append("linux_bpf")
         build_tags.append("trivy")
         build_tags.append("containerd")
@@ -831,14 +830,14 @@ def go_generate_check(ctx):
 
 
 @task
-def kitchen_prepare(ctx, windows=is_windows, skip_linters=False):
+def kitchen_prepare(ctx, skip_linters=False):
     """
     Compile test suite for kitchen
     """
 
     out_binary = "testsuite"
     race = True
-    if windows:
+    if is_windows:
         out_binary = "testsuite.exe"
         race = False
 
@@ -855,9 +854,8 @@ def kitchen_prepare(ctx, windows=is_windows, skip_linters=False):
         debug=True,
         output=testsuite_out_path,
         skip_linters=skip_linters,
-        windows=windows,
     )
-    if windows:
+    if is_windows:
         # build the ETW tests binary also
         testsuite_out_path = os.path.join(KITCHEN_ARTIFACT_DIR, "tests", "etw", out_binary)
         srcpath = 'pkg/security/probe'
@@ -869,7 +867,6 @@ def kitchen_prepare(ctx, windows=is_windows, skip_linters=False):
             race=race,
             debug=True,
             skip_linters=skip_linters,
-            windows=windows,
         )
 
         return

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -339,10 +339,10 @@ def ninja_runtime_compilation_files(nw, gobin):
         )
 
 
-def ninja_cgo_type_files(nw, windows):
+def ninja_cgo_type_files(nw):
     # TODO we could probably preprocess the input files to find out the dependencies
     nw.pool(name="cgo_pool", depth=1)
-    if windows:
+    if is_windows:
         go_platform = "windows"
         def_files = {
             "pkg/network/driver/types.go": [
@@ -443,7 +443,6 @@ def ninja_cgo_type_files(nw, windows):
 def ninja_generate(
     ctx,
     ninja_path,
-    windows,
     major_version='7',
     arch=CURRENT_ARCH,
     debug=False,
@@ -457,7 +456,7 @@ def ninja_generate(
     with open(ninja_path, 'w') as ninja_file:
         nw = NinjaWriter(ninja_file, width=120)
 
-        if windows:
+        if is_windows:
             if arch == "x86":
                 raise Exit(message="system probe not supported on x86")
 
@@ -489,7 +488,7 @@ def ninja_generate(
             ninja_container_integrations_ebpf_programs(nw, co_re_build_dir)
             ninja_runtime_compilation_files(nw, gobin)
 
-        ninja_cgo_type_files(nw, windows)
+        ninja_cgo_type_files(nw)
 
 
 @task
@@ -500,7 +499,6 @@ def build(
     major_version='7',
     python_runtimes='3',
     go_mod="mod",
-    windows=is_windows,
     arch=CURRENT_ARCH,
     bundle_ebpf=False,
     kernel_release=None,
@@ -515,7 +513,6 @@ def build(
     """
     build_object_files(
         ctx,
-        windows=windows,
         major_version=major_version,
         arch=arch,
         kernel_release=kernel_release,
@@ -541,12 +538,10 @@ def build(
 @task
 def clean(
     ctx,
-    windows=is_windows,
     arch=CURRENT_ARCH,
 ):
     clean_object_files(
         ctx,
-        windows=windows,
         arch=arch,
     )
     ctx.run("go clean -cache")
@@ -623,7 +618,6 @@ def test(
     skip_linters=False,
     skip_object_files=False,
     run=None,
-    windows=is_windows,
     failfast=False,
     kernel_release=None,
     timeout=None,
@@ -641,20 +635,19 @@ def test(
             "preserve your environment",
         )
 
-    if not skip_linters and not windows:
+    if not skip_linters and not is_windows:
         clang_format(ctx)
         clang_tidy(ctx)
 
     if not skip_object_files:
         build_object_files(
             ctx,
-            windows=windows,
             kernel_release=kernel_release,
         )
 
     build_tags = [NPM_TAG]
     build_tags.extend(UNIT_TEST_TAGS)
-    if not windows:
+    if not is_windows:
         build_tags.append(BPF_TAG)
         if bundle_ebpf:
             build_tags.append(BUNDLE_TAG)
@@ -663,7 +656,7 @@ def test(
     args["output_params"] = f"-c -o {output_path}" if output_path else ""
     args["run"] = f"-run {run}" if run else ""
     args["go"] = "go"
-    args["sudo"] = "sudo -E " if not windows and not output_path and not is_root() else ""
+    args["sudo"] = "sudo -E " if not is_windows and not output_path and not is_root() else ""
 
     _, _, env = get_build_flags(ctx)
     env["DD_SYSTEM_PROBE_BPF_DIR"] = EMBEDDED_SHARE_DIR
@@ -710,7 +703,6 @@ def test_debug(
     runtime_compiled=False,
     co_re=False,
     skip_object_files=False,
-    windows=is_windows,
     failfast=False,
     kernel_release=None,
 ):
@@ -728,13 +720,12 @@ def test_debug(
     if not skip_object_files:
         build_object_files(
             ctx,
-            windows=windows,
             kernel_release=kernel_release,
         )
 
     build_tags = [NPM_TAG]
     build_tags.extend(UNIT_TEST_TAGS)
-    if not windows:
+    if not is_windows:
         build_tags.append(BPF_TAG)
         if bundle_ebpf:
             build_tags.append(BUNDLE_TAG)
@@ -742,7 +733,7 @@ def test_debug(
     args = get_common_test_args(build_tags, failfast)
     args["run"] = run
     args["dlv"] = "dlv"
-    args["sudo"] = "sudo -E " if not windows and not is_root() else ""
+    args["sudo"] = "sudo -E " if not is_windows and not is_root() else ""
     args["dir"] = package
 
     _, _, env = get_build_flags(ctx)
@@ -820,12 +811,12 @@ def full_pkg_path(name):
 
 
 @task
-def kitchen_prepare(ctx, windows=is_windows, kernel_release=None, ci=False, packages=""):
+def kitchen_prepare(ctx, kernel_release=None, ci=False, packages=""):
     """
     Compile test suite for kitchen
     """
     build_tags = [NPM_TAG]
-    if not windows:
+    if not is_windows:
         build_tags.append(BPF_TAG)
 
     target_packages = go_package_dirs(TEST_PACKAGES_LIST, build_tags)
@@ -862,7 +853,7 @@ def kitchen_prepare(ctx, windows=is_windows, kernel_release=None, ci=False, pack
     for i, pkg in enumerate(target_packages):
         target_path = os.path.join(KITCHEN_ARTIFACT_DIR, re.sub("^.*datadog-agent.", "", pkg))
         target_bin = "testsuite"
-        if windows:
+        if is_windows:
             target_bin = "testsuite.exe"
 
         test(
@@ -886,7 +877,7 @@ def kitchen_prepare(ctx, windows=is_windows, kernel_release=None, ci=False, pack
 
         for gobin in ["gotls_client", "grpc_external_server", "external_unix_proxy_server", "fmapper", "prefetch_file"]:
             src_file_path = os.path.join(pkg, f"{gobin}.go")
-            if not windows and os.path.isdir(pkg) and os.path.isfile(src_file_path):
+            if not is_windows and os.path.isdir(pkg) and os.path.isfile(src_file_path):
                 binary_path = os.path.join(target_path, gobin)
                 with chdir(pkg):
                     ctx.run(f"go build -o {binary_path} -tags=\"test\" -ldflags=\"-extldflags '-static'\" {gobin}.go")
@@ -1269,7 +1260,6 @@ def run_ninja(
     task="",
     target="",
     explain=False,
-    windows=is_windows,
     major_version='7',
     arch=CURRENT_ARCH,
     kernel_release=None,
@@ -1279,9 +1269,7 @@ def run_ninja(
 ):
     check_for_ninja(ctx)
     nf_path = os.path.join(ctx.cwd, 'system-probe.ninja')
-    ninja_generate(
-        ctx, nf_path, windows, major_version, arch, debug, strip_object_files, kernel_release, with_unit_test
-    )
+    ninja_generate(ctx, nf_path, major_version, arch, debug, strip_object_files, kernel_release, with_unit_test)
     explain_opt = "-d explain" if explain else ""
     if task:
         ctx.run(f"ninja {explain_opt} -f {nf_path} -t {task}")
@@ -1337,7 +1325,6 @@ def verify_system_clang_version(ctx):
 
 def build_object_files(
     ctx,
-    windows=is_windows,
     major_version='7',
     arch=CURRENT_ARCH,
     kernel_release=None,
@@ -1347,7 +1334,7 @@ def build_object_files(
 ):
     build_dir = os.path.join("pkg", "ebpf", "bytecode", "build")
 
-    if not windows:
+    if not is_windows:
         verify_system_clang_version(ctx)
         # if clang is missing, subsequent calls to ctx.run("clang ...") will fail silently
         setup_runtime_clang(ctx)
@@ -1363,7 +1350,6 @@ def build_object_files(
     run_ninja(
         ctx,
         explain=True,
-        windows=windows,
         major_version=major_version,
         arch=arch,
         kernel_release=kernel_release,
@@ -1372,7 +1358,7 @@ def build_object_files(
         with_unit_test=with_unit_test,
     )
 
-    if not windows:
+    if not is_windows:
         sudo = "" if is_root() else "sudo"
         ctx.run(f"{sudo} mkdir -p {EMBEDDED_SHARE_DIR}")
 
@@ -1432,12 +1418,11 @@ def object_files(ctx, kernel_release=None, with_unit_test=False):
 
 
 def clean_object_files(
-    ctx, windows, major_version='7', arch=CURRENT_ARCH, kernel_release=None, debug=False, strip_object_files=False
+    ctx, major_version='7', arch=CURRENT_ARCH, kernel_release=None, debug=False, strip_object_files=False
 ):
     run_ninja(
         ctx,
         task="clean",
-        windows=windows,
         major_version=major_version,
         arch=arch,
         debug=debug,
@@ -1447,8 +1432,8 @@ def clean_object_files(
 
 
 @task
-def generate_lookup_tables(ctx, windows=is_windows):
-    if windows:
+def generate_lookup_tables(ctx):
+    if is_windows:
         return
 
     lookup_table_generate_files = [
@@ -1743,8 +1728,8 @@ def print_failed_tests(_, output_dir):
 
 
 @task
-def save_test_dockers(ctx, output_dir, arch, windows=is_windows, use_crane=False):
-    if windows:
+def save_test_dockers(ctx, output_dir, arch, use_crane=False):
+    if is_windows:
         return
 
     # only download images not present in preprepared vm disk


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR removes all argument passing related to `windows/is_windows` platform and replaces everything with top level `is_windows` based on current running platform.

The end goal of this is to allow a future `is_darwin` to co-exist with this.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
