### PR TITLE
[CWS] Add setting to disable enforcement capabilities

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -107,4 +107,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// CWS -eBPF Less
 	cfg.BindEnvAndSetDefault("runtime_security_config.ebpfless.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.ebpfless.socket", constants.DefaultEBPFLessProbeAddr)
+
+	// CWS enforcement capabilities
+	cfg.BindEnvAndSetDefault("runtime_security_config.enforcement.enabled", true)
 }

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -212,6 +212,9 @@ type RuntimeSecurityConfig struct {
 	EBPFLessEnabled bool
 	// EBPFLessSocket defines the socket used for the communication between system-probe and the ebpfless source
 	EBPFLessSocket string
+
+	// Enforcement capabilities
+	EnforcementEnabled bool
 }
 
 // Config defines a security config
@@ -337,6 +340,9 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		AnomalyDetectionTagRulesEnabled:              coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.anomaly_detection.tag_rules.enabled"),
 		AnomalyDetectionSilentRuleEventsEnabled:      coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.anomaly_detection.silent_rule_events.enabled"),
 		AnomalyDetectionEnabled:                      coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.anomaly_detection.enabled"),
+
+		// enforcement
+		EnforcementEnabled: coreconfig.SystemProbe.GetBool("runtime_security_config.enforcement.enabled"),
 
 		// User Sessions
 		UserSessionsCacheSize: coreconfig.SystemProbe.GetInt("runtime_security_config.user_sessions.cache_size"),

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -142,8 +142,9 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}, wg *
 	ruleFilters = append(ruleFilters, seclRuleFilter)
 
 	e.policyOpts = rules.PolicyLoaderOpts{
-		MacroFilters: macroFilters,
-		RuleFilters:  ruleFilters,
+		MacroFilters:       macroFilters,
+		RuleFilters:        ruleFilters,
+		DisableEnforcement: !e.config.EnforcementEnabled,
 	}
 
 	if err := e.LoadPolicies(e.policyProviders, true); err != nil {

--- a/pkg/security/secl/rules/actions.go
+++ b/pkg/security/secl/rules/actions.go
@@ -35,7 +35,7 @@ type ActionDefinition struct {
 }
 
 // Check returns an error if the action in invalid
-func (a *ActionDefinition) Check() error {
+func (a *ActionDefinition) Check(opts PolicyLoaderOpts) error {
 	if a.Set == nil && a.InternalCallback == nil && a.Kill == nil {
 		return errors.New("either 'set' or 'kill' section of an action must be specified")
 	}
@@ -53,8 +53,13 @@ func (a *ActionDefinition) Check() error {
 			return errors.New("either 'value' or 'field' must be specified")
 		}
 	} else if a.Kill != nil {
+		if opts.DisableEnforcement {
+			a.Kill = nil
+			return errors.New("'kill' action is disabled globally")
+		}
+
 		if a.Kill.Signal == "" {
-			return fmt.Errorf("a valid signal has to be specified to the 'kill' action")
+			return errors.New("a valid signal has to be specified to the 'kill' action")
 		}
 
 		if _, found := model.SignalConstants[a.Kill.Signal]; !found {

--- a/pkg/security/secl/rules/evaluation_set.go
+++ b/pkg/security/secl/rules/evaluation_set.go
@@ -118,7 +118,7 @@ func (es *EvaluationSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpt
 					errs = multierror.Append(errs, err)
 				}
 
-				if err := rs.populateFieldsWithRuleActionsData(ruleList); err.ErrorOrNil() != nil {
+				if err := rs.populateFieldsWithRuleActionsData(ruleList, opts); err.ErrorOrNil() != nil {
 					errs = multierror.Append(errs, err)
 				}
 

--- a/pkg/security/secl/rules/evaluation_set_test.go
+++ b/pkg/security/secl/rules/evaluation_set_test.go
@@ -887,6 +887,109 @@ func TestEvaluationSet_LoadPolicies_RuleSetTags(t *testing.T) {
 	}
 }
 
+func TestEvaluationSet_LoadPolicies_DisableEnforcement(t *testing.T) {
+	type args struct {
+		policy    *PolicyDef
+		tagValues []eval.RuleSetTagValue
+	}
+	tests := []struct {
+		name               string
+		disableEnforcement bool
+		args               args
+		want               func(t assert.TestingT, args args, got *EvaluationSet, msgs ...interface{})
+		wantErr            func(t assert.TestingT, err *multierror.Error, msgs ...interface{})
+	}{
+		{
+			name: "enforcing policy",
+			args: args{
+				policy: &PolicyDef{
+					Rules: []*RuleDefinition{
+						{
+							ID:         "ruleA",
+							Expression: `exec.file.path == "/tmp/test"`,
+							Actions: []*ActionDefinition{
+								{
+									Kill: &KillDefinition{
+										Signal: "SIGKILL",
+									},
+								}, {
+									Set: &SetDefinition{
+										Name:  "var1",
+										Value: "foo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: func(t assert.TestingT, args args, got *EvaluationSet, msgs ...interface{}) {
+				assert.Equal(t, 1, len(got.RuleSets))
+
+				gotNumProbeEvalRules := len(got.RuleSets[DefaultRuleSetTagValue].rules)
+				assert.Equal(t, 1, gotNumProbeEvalRules)
+
+				rule := got.RuleSets[DefaultRuleSetTagValue].rules["ruleA"]
+				assert.NotNil(t, rule)
+
+				assert.Equal(t, 2, len(rule.Definition.Actions))
+				assert.NotNil(t, rule.Definition.Actions[0].Kill)
+				assert.Equal(t, "SIGKILL", rule.Definition.Actions[0].Kill.Signal)
+			},
+			wantErr: func(t assert.TestingT, err *multierror.Error, msgs ...interface{}) {
+				assert.Nil(t, err, msgs)
+			},
+		},
+		{
+			name:               "enforcing policy with enforcement disabled",
+			disableEnforcement: true,
+			args: args{
+				policy: &PolicyDef{
+					Rules: []*RuleDefinition{
+						{
+							ID:         "ruleA",
+							Expression: `exec.file.path == "/tmp/test"`,
+							Actions: []*ActionDefinition{
+								{
+									Kill: &KillDefinition{
+										Signal: "SIGKILL",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: func(t assert.TestingT, args args, got *EvaluationSet, msgs ...interface{}) {
+				assert.Equal(t, 1, len(got.RuleSets))
+
+				gotNumProbeEvalRules := len(got.RuleSets[DefaultRuleSetTagValue].rules)
+				assert.Equal(t, 1, gotNumProbeEvalRules)
+
+				rule := got.RuleSets[DefaultRuleSetTagValue].rules["ruleA"]
+				assert.NotNil(t, rule)
+
+				assert.Equal(t, 1, len(rule.Definition.Actions))
+				assert.Nil(t, rule.Definition.Actions[0].Kill)
+			},
+			wantErr: func(t assert.TestingT, err *multierror.Error, msgs ...interface{}) {
+				assert.ErrorContains(t, err, "action is disabled")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policyLoaderOpts := PolicyLoaderOpts{DisableEnforcement: tt.disableEnforcement}
+			loader, es := loadPolicySetup(t, tt.args.policy, tt.args.tagValues)
+
+			err := es.LoadPolicies(loader, policyLoaderOpts)
+			tt.want(t, tt.args, es)
+			tt.wantErr(t, err)
+		})
+	}
+}
+
 func TestNewEvaluationSet(t *testing.T) {
 	ruleSet := newRuleSet()
 	ruleSetWithThreatScoreTag := newRuleSet()

--- a/pkg/security/secl/rules/policy_loader.go
+++ b/pkg/security/secl/rules/policy_loader.go
@@ -26,8 +26,9 @@ var (
 
 // PolicyLoaderOpts options used during the loading
 type PolicyLoaderOpts struct {
-	MacroFilters []MacroFilter
-	RuleFilters  []RuleFilter
+	MacroFilters       []MacroFilter
+	RuleFilters        []RuleFilter
+	DisableEnforcement bool
 }
 
 // PolicyLoader defines a policy loader

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -244,12 +244,12 @@ func (rs *RuleSet) AddRules(parsingContext *ast.ParsingContext, rules []*RuleDef
 	return result
 }
 
-func (rs *RuleSet) populateFieldsWithRuleActionsData(policyRules []*RuleDefinition) *multierror.Error {
+func (rs *RuleSet) populateFieldsWithRuleActionsData(policyRules []*RuleDefinition, opts PolicyLoaderOpts) *multierror.Error {
 	var errs *multierror.Error
 
 	for _, rule := range policyRules {
 		for _, action := range rule.Actions {
-			if err := action.Check(); err != nil {
+			if err := action.Check(opts); err != nil {
 				errs = multierror.Append(errs, fmt.Errorf("invalid action: %w", err))
 				continue
 			}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add a runtime_security_config.enforcement.enabled config flag to disable
enforcement capabilities. Rules using this capability will still apply but the
action will be ignored.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Ability to disable any enforcement capabilities.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Create a rule making use of the 'kill' action.
- Check the rule works properly.
- Set runtime_security_config.enforcement.enabled to false and check that the rule action is not executed.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
