### PR TITLE
[USMON-658] usm: http2: Wrap path in its own struct

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -92,13 +92,6 @@
 
 #define MAX_FRAME_SIZE 16384
 
-// Definitions representing empty and /index.html paths. These types are sent using the static table.
-// We include these to eliminate the necessity of copying the specified encoded path to the buffer.
-#define HTTP2_ROOT_PATH      "/"
-#define HTTP2_ROOT_PATH_LEN  (sizeof(HTTP2_ROOT_PATH) - 1)
-#define HTTP2_INDEX_PATH     "/index.html"
-#define HTTP2_INDEX_PATH_LEN (sizeof(HTTP2_INDEX_PATH) - 1)
-
 typedef enum {
     kGET = 2,
     kPOST = 3,
@@ -156,16 +149,22 @@ typedef struct {
 } method_t;
 
 typedef struct {
+    __u8 raw_buffer[HTTP2_MAX_PATH_LEN];
+    bool is_huffman_encoded;
+
+    __u8 static_table_entry;
+    __u8 length;
+    bool finalized;
+} path_t;
+
+typedef struct {
     __u64 response_last_seen;
     __u64 request_started;
 
     status_code_t status_code;
     method_t request_method;
-    __u8 path_size;
+    path_t path;
     bool request_end_of_stream;
-    bool is_huffman_encoded;
-
-    __u8 request_path[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
 } http2_stream_t;
 
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -321,12 +321,9 @@ static __always_inline void tls_process_headers(tls_dispatcher_arguments_t *info
                 current_stream->status_code.static_table_entry = current_header->index;
                 current_stream->status_code.finalized = true;
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
-            } else if (current_header->index == kEmptyPath) {
-                current_stream->path_size = HTTP2_ROOT_PATH_LEN;
-                bpf_memcpy(current_stream->request_path, HTTP2_ROOT_PATH, HTTP2_ROOT_PATH_LEN);
-            } else if (current_header->index == kIndexPath) {
-                current_stream->path_size = HTTP2_INDEX_PATH_LEN;
-                bpf_memcpy(current_stream->request_path, HTTP2_INDEX_PATH, HTTP2_INDEX_PATH_LEN);
+            } else if (is_path_index(current_header->index)) {
+                current_stream->path.static_table_entry = current_header->index;
+                current_stream->path.finalized = true;
             }
             continue;
         }
@@ -338,9 +335,10 @@ static __always_inline void tls_process_headers(tls_dispatcher_arguments_t *info
                 break;
             }
             if (is_path_index(dynamic_value->original_index)) {
-                current_stream->path_size = dynamic_value->string_len;
-                current_stream->is_huffman_encoded = dynamic_value->is_huffman_encoded;
-                bpf_memcpy(current_stream->request_path, dynamic_value->buffer, HTTP2_MAX_PATH_LEN);
+                current_stream->path.length = dynamic_value->string_len;
+                current_stream->path.is_huffman_encoded = dynamic_value->is_huffman_encoded;
+                current_stream->path.finalized = true;
+                bpf_memcpy(current_stream->path.raw_buffer, dynamic_value->buffer, HTTP2_MAX_PATH_LEN);
             } else if (is_status_index(dynamic_value->original_index)) {
                 bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value->buffer, HTTP2_STATUS_CODE_MAX_LEN);
                 current_stream->status_code.is_huffman_encoded = dynamic_value->is_huffman_encoded;
@@ -363,9 +361,10 @@ static __always_inline void tls_process_headers(tls_dispatcher_arguments_t *info
                 bpf_map_update_elem(&http2_dynamic_table, dynamic_index, &dynamic_value, BPF_ANY);
             }
             if (is_path_index(current_header->original_index)) {
-                current_stream->path_size = current_header->new_dynamic_value_size;
-                current_stream->is_huffman_encoded = current_header->is_huffman_encoded;
-                bpf_memcpy(current_stream->request_path, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
+                current_stream->path.length = current_header->new_dynamic_value_size;
+                current_stream->path.is_huffman_encoded = current_header->is_huffman_encoded;
+                current_stream->path.finalized = true;
+                bpf_memcpy(current_stream->path.raw_buffer, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
             } else if (is_status_index(current_header->original_index)) {
                 bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value.buffer, HTTP2_STATUS_CODE_MAX_LEN);
                 current_stream->status_code.is_huffman_encoded = current_header->is_huffman_encoded;

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -318,12 +318,9 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 current_stream->status_code.static_table_entry = current_header->index;
                 current_stream->status_code.finalized = true;
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
-            } else if (current_header->index == kEmptyPath) {
-                current_stream->path_size = HTTP2_ROOT_PATH_LEN;
-                bpf_memcpy(current_stream->request_path, HTTP2_ROOT_PATH, HTTP2_ROOT_PATH_LEN);
-            } else if (current_header->index == kIndexPath) {
-                current_stream->path_size = HTTP2_INDEX_PATH_LEN;
-                bpf_memcpy(current_stream->request_path, HTTP2_INDEX_PATH, HTTP2_INDEX_PATH_LEN);
+            } else if (is_path_index(current_header->index)) {
+                current_stream->path.static_table_entry = current_header->index;
+                current_stream->path.finalized = true;
             }
             continue;
         }
@@ -335,9 +332,10 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 break;
             }
             if (is_path_index(dynamic_value->original_index)) {
-                current_stream->path_size = dynamic_value->string_len;
-                current_stream->is_huffman_encoded = dynamic_value->is_huffman_encoded;
-                bpf_memcpy(current_stream->request_path, dynamic_value->buffer, HTTP2_MAX_PATH_LEN);
+                current_stream->path.length = dynamic_value->string_len;
+                current_stream->path.is_huffman_encoded = dynamic_value->is_huffman_encoded;
+                current_stream->path.finalized = true;
+                bpf_memcpy(current_stream->path.raw_buffer, dynamic_value->buffer, HTTP2_MAX_PATH_LEN);
             } else if (is_status_index(dynamic_value->original_index)) {
                 bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value->buffer, HTTP2_STATUS_CODE_MAX_LEN);
                 current_stream->status_code.is_huffman_encoded = dynamic_value->is_huffman_encoded;
@@ -360,9 +358,10 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 bpf_map_update_elem(&http2_dynamic_table, dynamic_index, &dynamic_value, BPF_ANY);
             }
             if (is_path_index(current_header->original_index)) {
-                current_stream->path_size = current_header->new_dynamic_value_size;
-                current_stream->is_huffman_encoded = current_header->is_huffman_encoded;
-                bpf_memcpy(current_stream->request_path, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
+                current_stream->path.length = current_header->new_dynamic_value_size;
+                current_stream->path.is_huffman_encoded = current_header->is_huffman_encoded;
+                current_stream->path.finalized = true;
+                bpf_memcpy(current_stream->path.raw_buffer, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
             } else if (is_status_index(current_header->original_index)) {
                 bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value.buffer, HTTP2_STATUS_CODE_MAX_LEN);
                 current_stream->status_code.is_huffman_encoded = current_header->is_huffman_encoded;

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -75,25 +75,36 @@ func decodeHTTP2Path(buf [maxHTTP2Path]byte, pathSize uint8) ([]byte, error) {
 
 // Path returns the URL from the request fragment captured in eBPF.
 func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
+	if tx.Stream.Path.Static_table_entry != 0 {
+		switch tx.Stream.Path.Static_table_entry {
+		case EmptyPathValue:
+			return []byte("/"), true
+		case IndexPathValue:
+			return []byte("/index.html"), true
+		default:
+			return nil, false
+		}
+	}
+
 	var res []byte
 	var err error
-	if tx.Stream.Is_huffman_encoded {
-		res, err = decodeHTTP2Path(tx.Stream.Request_path, tx.Stream.Path_size)
+	if tx.Stream.Path.Is_huffman_encoded {
+		res, err = decodeHTTP2Path(tx.Stream.Path.Raw_buffer, tx.Stream.Path.Length)
 		if err != nil {
 			if oversizedLogLimit.ShouldLog() {
-				log.Warnf("unable to decode HTTP2 path (%#v) due to: %s", tx.Stream.Request_path[:tx.Stream.Path_size], err)
+				log.Warnf("unable to decode HTTP2 path (%#v) due to: %s", tx.Stream.Path.Raw_buffer[:tx.Stream.Path.Length], err)
 			}
 			return nil, false
 		}
 	} else {
-		if err = validatePathSize(tx.Stream.Path_size); err != nil {
+		if err = validatePathSize(tx.Stream.Path.Length); err != nil {
 			if oversizedLogLimit.ShouldLog() {
-				log.Warnf("path size: %d is invalid due to: %s", tx.Stream.Path_size, err)
+				log.Warnf("path size: %d is invalid due to: %s", tx.Stream.Path.Length, err)
 			}
 			return nil, false
 		}
 
-		res = tx.Stream.Request_path[:tx.Stream.Path_size]
+		res = tx.Stream.Path.Raw_buffer[:tx.Stream.Path.Length]
 		if err = validatePath(string(res)); err != nil {
 			if oversizedLogLimit.ShouldLog() {
 				log.Warnf("path %s is invalid due to: %s", string(res), err)
@@ -101,7 +112,7 @@ func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
 			return nil, false
 		}
 
-		res = tx.Stream.Request_path[:tx.Stream.Path_size]
+		res = tx.Stream.Path.Raw_buffer[:tx.Stream.Path.Length]
 	}
 
 	n := copy(buffer, res)
@@ -119,7 +130,7 @@ func (tx *EbpfTx) RequestLatency() float64 {
 // Incomplete returns true if the transaction contains only the request or response information
 // This happens in the context of localhost with NAT, in which case we join the two parts in userspace
 func (tx *EbpfTx) Incomplete() bool {
-	return tx.Stream.Request_started == 0 || tx.Stream.Response_last_seen == 0 || tx.StatusCode() == 0 || tx.Stream.Path_size == 0 || tx.Method() == http.MethodUnknown
+	return tx.Stream.Request_started == 0 || tx.Stream.Response_last_seen == 0 || tx.StatusCode() == 0 || !tx.Stream.Path.Finalized || tx.Method() == http.MethodUnknown
 }
 
 // ConnTuple returns the connections tuple of the transaction.
@@ -292,8 +303,8 @@ func (tx *EbpfTx) String() string {
 	output.WriteString("http2.ebpfTx{")
 	output.WriteString(fmt.Sprintf("[%s] [%s ⇄ %s] ", tx.family(), tx.sourceEndpoint(), tx.destEndpoint()))
 	output.WriteString(" Method: '" + tx.Method().String() + "', ")
-	fullBufferSize := len(tx.Stream.Request_path)
-	if tx.Stream.Is_huffman_encoded {
+	fullBufferSize := len(tx.Stream.Path.Raw_buffer)
+	if tx.Stream.Path.Is_huffman_encoded {
 		// If the path is huffman encoded, then the path is compressed (with an upper bound to compressed size of maxHTTP2Path)
 		// thus, we need more room for the decompressed path, therefore using 2*maxHTTP2Path.
 		fullBufferSize = 2 * maxHTTP2Path

--- a/pkg/network/protocols/http2/model_test.go
+++ b/pkg/network/protocols/http2/model_test.go
@@ -58,9 +58,11 @@ func TestHTTP2Path(t *testing.T) {
 
 				request := &EbpfTx{
 					Stream: http2Stream{
-						Is_huffman_encoded: huffmanEnabled,
-						Request_path:       arr,
-						Path_size:          uint8(len(buf)),
+						Path: http2Path{
+							Is_huffman_encoded: huffmanEnabled,
+							Raw_buffer:         arr,
+							Length:             uint8(len(buf)),
+						},
 					},
 				}
 

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -31,6 +31,7 @@ type HTTP2DynamicTableEntry C.dynamic_table_entry_t
 type http2StreamKey C.http2_stream_key_t
 type http2StatusCode C.status_code_t
 type http2requestMethod C.method_t
+type http2Path C.path_t
 type http2Stream C.http2_stream_t
 type EbpfTx C.http2_event_t
 type HTTP2Telemetry C.http2_telemetry_t

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -54,16 +54,21 @@ type http2requestMethod struct {
 	Length             uint8
 	Finalized          bool
 }
+type http2Path struct {
+	Raw_buffer         [160]uint8
+	Is_huffman_encoded bool
+	Static_table_entry uint8
+	Length             uint8
+	Finalized          bool
+}
 type http2Stream struct {
 	Response_last_seen    uint64
 	Request_started       uint64
 	Status_code           http2StatusCode
 	Request_method        http2requestMethod
-	Path_size             uint8
+	Path                  http2Path
 	Request_end_of_stream bool
-	Is_huffman_encoded    bool
-	Pad_cgo_0             [4]byte
-	Request_path          [160]uint8
+	Pad_cgo_0             [2]byte
 }
 type EbpfTx struct {
 	Tuple  connTuple


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The PR wraps the path related fields in the `http2_stream_t` in its own struct.
The change is a preliminary change for the new http2 dynamic table, and meant to reduce difference in the other PR.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Simplification of the http2 dynamic table PR.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
