### PR TITLE
usm: http2: Add cyclic map

### DIFF
--- a/pkg/network/protocols/http2/cyclic_map.go
+++ b/pkg/network/protocols/http2/cyclic_map.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package http2
+
+import "sync"
+
+// CyclicMap represents a map with a fixed capacity circular map. When the map is full, adding a new element
+// will remove the oldest one.
+type CyclicMap[K comparable, V any] struct {
+	// mux allows concurrent access to the map.
+	mux sync.RWMutex
+	// capacity is the maximum number of elements the map can hold.
+	capacity int
+	// head is the index of the first element in the list.
+	head int
+	// tail is the index of the last element in the list.
+	tail int
+	// len is the number of elements in the list.
+	len int
+	// list of keys in the map.
+	list []K
+	// values is the map of keys to values.
+	values map[K]V
+	// onEvict is the callback called when an element is evicted.
+	onEvict func(key K, value V)
+}
+
+// NewCyclicMap returns a new CyclicMap with the given capacity and onEvict callback.
+func NewCyclicMap[K comparable, V any](capacity int, onEvict func(key K, value V)) *CyclicMap[K, V] {
+	return &CyclicMap[K, V]{
+		capacity: capacity,
+		list:     make([]K, 0, capacity),
+		values:   make(map[K]V),
+		onEvict:  onEvict,
+	}
+}
+
+// Add adds a new element to the map. If the map is full, the oldest element is removed.
+func (c *CyclicMap[K, V]) Add(key K, value V) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	// If the list is full, remove the currentElement
+	if c.len == c.capacity {
+		c.removeOldestNoLock()
+		c.list[c.head] = key
+	} else {
+		c.list = append(c.list, key)
+	}
+	c.head = (c.head + 1) % c.capacity
+	c.len++
+	c.values[key] = value
+}
+
+// Get returns the value associated with the given key, and a boolean indicating if the key was found.
+func (c *CyclicMap[K, V]) Get(key K) (V, bool) {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+
+	value, ok := c.values[key]
+	return value, ok
+}
+
+// Pop removes the value associated with the given key and returns it if exists.
+func (c *CyclicMap[K, V]) Pop(key K) (V, bool) {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+
+	value, ok := c.values[key]
+	if ok {
+		delete(c.values, key)
+		c.len--
+	}
+	return value, ok
+}
+
+// Len returns the number of elements in the map.
+func (c *CyclicMap[K, V]) Len() int {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+
+	return c.len
+}
+
+// RemoveOldest removes the oldest element from the map.
+func (c *CyclicMap[K, V]) RemoveOldest() {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	c.removeOldestNoLock()
+}
+
+// removeOldestNoLock removes the oldest element from the map. Does not lock the map, the caller is responsible
+// for locking it.
+func (c *CyclicMap[K, V]) removeOldestNoLock() {
+	if c.len == 0 {
+		return
+	}
+
+	// Get the key to remove
+	keyToRemove := c.list[c.tail]
+	// Call the onEvict callback
+	if c.onEvict != nil {
+		c.onEvict(keyToRemove, c.values[keyToRemove])
+	}
+	// Remove the key from the map
+	delete(c.values, keyToRemove)
+
+	c.tail = (c.tail + 1) % c.capacity
+	c.len--
+}

--- a/pkg/network/protocols/http2/cyclic_map_test.go
+++ b/pkg/network/protocols/http2/cyclic_map_test.go
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package http2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	capacity   = 10
+	iterations = 35
+)
+
+func TestCyclicMap(t *testing.T) {
+	require.Greater(t, iterations, capacity)
+
+	c := NewCyclicMap[int, int](capacity, nil)
+	// Add elements until the list is full
+	for i := 0; i < capacity; i++ {
+		c.Add(i, i)
+	}
+	// We should have the first 10 elements in the list
+	for i := 0; i < capacity; i++ {
+		require.Equal(t, i, c.list[i])
+	}
+	// Now add more elements, and exceed the capacity. The first elements should be evicted
+	// and replaced by the new ones.
+	for i := capacity; i < iterations; i++ {
+		c.Add(i, i)
+	}
+
+	require.Equal(t, capacity, c.Len())
+	// We should have the last 10 elements in the list
+	for i := iterations - capacity; i < iterations; i++ {
+		require.Equal(t, i, c.values[i])
+	}
+}
+
+func TestCyclicMapEviction(t *testing.T) {
+	require.Greater(t, iterations, capacity)
+
+	evictedList := make([]int, 0)
+	onEvict := func(k int, v int) {
+		// Ensuring we're getting the correct value and key.
+		require.Equal(t, k, v)
+		evictedList = append(evictedList, k)
+	}
+
+	c := NewCyclicMap[int, int](capacity, onEvict)
+	// Add elements until the list is full
+	for i := 0; i < iterations; i++ {
+		c.Add(i, i)
+	}
+	require.Equal(t, capacity, c.Len())
+
+	// We should have the last 10 elements in the list
+	for i := iterations - capacity; i < iterations; i++ {
+		require.Equal(t, i, c.values[i])
+	}
+
+	for i := 0; i < iterations-capacity; i++ {
+		require.Equal(t, i, evictedList[i])
+	}
+}
+
+func TestCyclicMapCheckLength(t *testing.T) {
+	require.Greater(t, iterations, capacity)
+
+	c := NewCyclicMap[int, int](capacity, nil)
+	// Add elements until the list is full
+	for i := 0; i < iterations; i++ {
+		c.Add(i, i)
+		if i < capacity {
+			require.Equal(t, i+1, c.Len())
+		} else {
+			require.Equal(t, capacity, c.Len())
+		}
+	}
+	require.Equal(t, capacity, c.Len())
+}
+
+func TestCyclicMapRemoveOldest(t *testing.T) {
+	require.Greater(t, iterations, capacity)
+
+	c := NewCyclicMap[int, int](capacity, nil)
+	// Add elements until the list is full
+	for i := 0; i < capacity; i++ {
+		c.Add(i, i)
+	}
+
+	for i := 0; i < capacity; i++ {
+		c.RemoveOldest()
+		require.Equal(t, capacity-1-i, c.Len())
+		_, ok := c.values[i]
+		require.False(t, ok)
+	}
+}
+
+func TestCyclicMapPop(t *testing.T) {
+	require.Greater(t, iterations, capacity)
+
+	c := NewCyclicMap[int, int](capacity, nil)
+	// Add elements until the list is full
+	for i := 0; i < capacity; i++ {
+		c.Add(i, i)
+	}
+
+	for i := 0; i < capacity; i++ {
+		v, ok := c.Pop(i)
+		require.True(t, ok)
+		require.Equal(t, i, v)
+		require.Equal(t, capacity-1-i, c.Len())
+		_, ok = c.values[i]
+		require.False(t, ok)
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The PR implements a size limited cyclic map.
Meaning:
1. The map has a fixed size it cannot overgrow
2. Once the map is full - it automatically evicts the oldest entry in the map

The purpose of the map is to represents the http2 dynamic table.
The usage of the map will come in a future PR, the reason for the split is to ease on the review of the larger PR.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Refactoring the http2 dynamic table management in USM. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
