### PR TITLE
[CWS] more optimization to rule evaluation discarder path

### DIFF
--- a/pkg/security/secl/compiler/eval/macro.go
+++ b/pkg/security/secl/compiler/eval/macro.go
@@ -26,9 +26,11 @@ type Macro struct {
 
 // MacroEvaluator - Evaluation part of a Macro
 type MacroEvaluator struct {
-	Value       interface{}
-	EventTypes  []EventType
-	FieldValues map[Field][]FieldValue
+	Value      interface{}
+	EventTypes []EventType
+
+	fieldValues map[Field][]FieldValue
+	fields      []Field
 }
 
 // NewMacro parses an expression and returns a new macro
@@ -121,9 +123,11 @@ func macroToEvaluator(macro *ast.Macro, model Model, opts *Opts, field Field) (*
 	}
 
 	return &MacroEvaluator{
-		Value:       eval,
-		EventTypes:  events,
-		FieldValues: state.fieldValues,
+		Value:      eval,
+		EventTypes: events,
+
+		fieldValues: state.fieldValues,
+		fields:      KeysOfMap(state.fieldValues),
 	}, nil
 }
 
@@ -165,9 +169,9 @@ func (m *Macro) GetFields() []Field {
 
 // GetFields - Returns all the Field that the MacroEvaluator handles
 func (m *MacroEvaluator) GetFields() []Field {
-	fields := make([]Field, len(m.FieldValues))
+	fields := make([]Field, len(m.fieldValues))
 	i := 0
-	for key := range m.FieldValues {
+	for key := range m.fieldValues {
 		fields[i] = key
 		i++
 	}

--- a/pkg/security/secl/compiler/eval/rule.go
+++ b/pkg/security/secl/compiler/eval/rule.go
@@ -34,9 +34,11 @@ type Rule struct {
 
 // RuleEvaluator - Evaluation part of a Rule
 type RuleEvaluator struct {
-	Eval        BoolEvalFnc
-	EventTypes  []EventType
-	FieldValues map[Field][]FieldValue
+	Eval       BoolEvalFnc
+	EventTypes []EventType
+
+	fieldValues map[Field][]FieldValue
+	fields      []Field
 
 	partialEvals map[Field]BoolEvalFnc
 }
@@ -77,13 +79,7 @@ func (r *RuleEvaluator) setPartial(field string, partialEval BoolEvalFnc) {
 
 // GetFields - Returns all the Field that the RuleEvaluator handles
 func (r *RuleEvaluator) GetFields() []Field {
-	fields := make([]Field, len(r.FieldValues))
-	i := 0
-	for key := range r.FieldValues {
-		fields[i] = key
-		i++
-	}
-	return fields
+	return r.fields
 }
 
 // Eval - Evaluates
@@ -93,7 +89,7 @@ func (r *Rule) Eval(ctx *Context) bool {
 
 // GetFieldValues returns the values of the given field
 func (r *Rule) GetFieldValues(field Field) []FieldValue {
-	return r.evaluator.FieldValues[field]
+	return r.evaluator.fieldValues[field]
 }
 
 // PartialEval - Partial evaluation with the given Field
@@ -205,7 +201,8 @@ func NewRuleEvaluator(rule *ast.Rule, model Model, opts *Opts) (*RuleEvaluator, 
 	return &RuleEvaluator{
 		Eval:        evalBool.EvalFnc,
 		EventTypes:  events,
-		FieldValues: state.fieldValues,
+		fieldValues: state.fieldValues,
+		fields:      KeysOfMap(state.fieldValues),
 	}, nil
 }
 

--- a/pkg/security/secl/compiler/eval/utils.go
+++ b/pkg/security/secl/compiler/eval/utils.go
@@ -56,6 +56,7 @@ func IntToIP(ipInt *big.Int, bits int) net.IP {
 	return ret
 }
 
+// KeysOfMap returns a slice of the keys contained in the given map
 func KeysOfMap[M ~map[K]V, K comparable, V any](m M) []K {
 	r := make([]K, 0, len(m))
 	for k := range m {

--- a/pkg/security/secl/compiler/eval/utils.go
+++ b/pkg/security/secl/compiler/eval/utils.go
@@ -55,3 +55,11 @@ func IntToIP(ipInt *big.Int, bits int) net.IP {
 	}
 	return ret
 }
+
+func KeysOfMap[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}


### PR DESCRIPTION
### What does this PR do?

Similar to https://github.com/DataDog/datadog-agent/pull/22602, those functions are called in the `IsDiscarder` path and are allocating, resulting in a lot of allocations. This PR improves the situation by pre-allocating the `fields` allowing for alloc-free access.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
