### PR TITLE
[process] [e2e] Skip WindowsTestSuite/TestManualProcessCheckWithIO

### DIFF
--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -132,6 +132,9 @@ func (s *windowsTestSuite) TestManualProcessDiscoveryCheck() {
 }
 
 func (s *windowsTestSuite) TestManualProcessCheckWithIO() {
+	s.T().Skip("skipping due to flakiness")
+	// MsMpEng.exe process missing IO stats
+
 	s.UpdateEnv(awshost.Provisioner(
 		awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
 		awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr)),

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -134,6 +134,7 @@ func (s *windowsTestSuite) TestManualProcessDiscoveryCheck() {
 func (s *windowsTestSuite) TestManualProcessCheckWithIO() {
 	s.T().Skip("skipping due to flakiness")
 	// MsMpEng.exe process missing IO stats
+	// Investigation & fix tracked in https://datadoghq.atlassian.net/browse/PROCS-3757
 
 	s.UpdateEnv(awshost.Provisioner(
 		awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Skip WindowsTestSuite/TestManualProcessCheckWithIO

### Motivation

This test is flaky: [CI Visibility](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3Agithub.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fprocess%20%40test.name%3ATestWindowsTestSuite%2FTestManualProcessCheckWithIO&currentTab=overview&eventStack=&index=citest&start=1706864694963&end=1707469494963&paused=true)

<img width="613" alt="image" src="https://github.com/DataDog/datadog-agent/assets/1155971/3c3554ed-0bf1-45ac-9aaa-4d0325c407b4">

Failed runs are due to `no MsMpEng.exe process had all data populated`, and we can see that the `ioStat` is empty:

```
            {
              "pid": 2700,
              "command": {
                "args": [
                  "MsMpEng.exe"
                ],
                "ppid": 644,
                "exe": "MsMpEng.exe"
              },
              "user": {
                "name": "NT AUTHORITY\\SYSTEM"
              },
              "memory": {
                "rss": 301490176,
                "vms": 555312
              },
              "cpu": {
                "lastCpu": "cpu",
                "totalPct": 4.530834,
                "userPct": 4.530834,
                "numThreads": 35,
                "userTime": 3591875000,
                "systemTime": 204062500
              },
              "createTime": 1707440248179,
              "openFdCount": 943,
              "ioStat": {}
            },
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
