### PR TITLE
[ASCII-1179] add flare backend URL to error message to make debugging easier

### DIFF
--- a/comp/core/flare/helpers/send_flare.go
+++ b/comp/core/flare/helpers/send_flare.go
@@ -21,6 +21,7 @@ import (
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	hostnameUtil "github.com/DataDog/datadog-agent/pkg/util/hostname"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -205,7 +206,7 @@ func resolveFlarePOSTURL(url string, client *http.Client) (string, error) {
 	// at the end of the chain of redirects, we should either have a 200 OK or a 404 (since
 	// the server is expecting POST, not GET). Accept either one as successful.
 	if r.StatusCode != http.StatusOK && r.StatusCode != http.StatusNotFound {
-		return "", fmt.Errorf("Could not determine flare URL via redirects: %s", r.Status)
+		return "", fmt.Errorf("We couldn't reach the flare backend %s via redirects: %s", scrubber.ScrubLine(url), r.Status)
 	}
 
 	// return the URL used to make the latest request (at the end of the chain of redirects)

--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -116,8 +116,8 @@ func (c *Scrubber) ScrubFile(filePath string) ([]byte, error) {
 }
 
 // ScrubBytes scrubs credentials from slice of bytes
-func (c *Scrubber) ScrubBytes(file []byte) ([]byte, error) {
-	r := bytes.NewReader(file)
+func (c *Scrubber) ScrubBytes(data []byte) ([]byte, error) {
+	r := bytes.NewReader(data)
 	return c.scrubReader(r, r.Len())
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

During the last DR Exercise, we had an issue sending the flare to the backend
<img width="1227" alt="image" src="https://github.com/DataDog/datadog-agent/assets/4672858/a1e0525b-db45-4b2f-a35c-7d1e42bdfdfe">
We realized that the error message was not very informative. This PR adds the URL to the error message ensuring that it would be easier to debug in the future. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The PR included unit test for the changes 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
