### PR TITLE
usm: http2: Introduce dedicated incomplete mechanism

### DIFF
--- a/pkg/network/protocols/http2/incomplete_stats.go
+++ b/pkg/network/protocols/http2/incomplete_stats.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package http2
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
+)
+
+const (
+	defaultMinAge = 30 * time.Second
+)
+
+// incompleteBuffer is responsible for buffering incomplete transactions
+type incompleteBuffer struct {
+	data       []*EbpfTx
+	maxEntries int
+	minAgeNano int64
+}
+
+// NewIncompleteBuffer returns a new incompleteBuffer.
+func NewIncompleteBuffer(c *config.Config) http.IncompleteBuffer {
+	return &incompleteBuffer{
+		data:       make([]*EbpfTx, 0),
+		maxEntries: c.MaxHTTPStatsBuffered,
+		minAgeNano: defaultMinAge.Nanoseconds(),
+	}
+}
+
+// Add adds a transaction to the buffer.
+func (b *incompleteBuffer) Add(tx http.Transaction) {
+	if len(b.data) >= b.maxEntries {
+		return
+	}
+
+	// Copy underlying EbpfTx value.
+	ebpfTX, ok := tx.(*EbpfTx)
+	if !ok {
+		// should never happen
+		return
+	}
+
+	ebpfTxCopy := new(EbpfTx)
+	*ebpfTxCopy = *ebpfTX
+
+	b.data = append(b.data, ebpfTxCopy)
+}
+
+// Flush flushes the buffer and returns the joined transactions.
+func (b *incompleteBuffer) Flush(now time.Time) []http.Transaction {
+	var (
+		joined   []http.Transaction
+		previous = b.data
+		nowUnix  = now.UnixNano()
+	)
+
+	b.data = make([]*EbpfTx, 0)
+	for _, entry := range previous {
+		// now that we have finished matching requests and responses
+		// we check if we should keep orphan requests a little longer
+		if !entry.Incomplete() {
+			joined = append(joined, entry)
+		} else if b.shouldKeep(entry, nowUnix) {
+			b.data = append(b.data, entry)
+		}
+	}
+
+	return joined
+}
+
+func (b *incompleteBuffer) shouldKeep(tx http.Transaction, now int64) bool {
+	then := int64(tx.RequestStarted())
+	diff := now - then
+	return diff < b.minAgeNano
+}

--- a/pkg/network/protocols/http2/incomplete_stats_test.go
+++ b/pkg/network/protocols/http2/incomplete_stats_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
+//go:build linux_bpf
+
 package http2
 
 import (

--- a/pkg/network/protocols/http2/incomplete_stats_test.go
+++ b/pkg/network/protocols/http2/incomplete_stats_test.go
@@ -8,12 +8,13 @@
 package http2
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
 
 func TestIncompleteBuffer(t *testing.T) {

--- a/pkg/network/protocols/http2/incomplete_stats_test.go
+++ b/pkg/network/protocols/http2/incomplete_stats_test.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package http2
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIncompleteBuffer(t *testing.T) {
+	t.Run("becoming complete", func(t *testing.T) {
+		// Testing the scenario where an incomplete request becomes complete.
+		buffer := NewIncompleteBuffer(config.New()).(*incompleteBuffer)
+		now := time.Now()
+		buffer.minAgeNano = (30 * time.Second).Nanoseconds()
+		request := &EbpfTx{
+			Tuple: connTuple{
+				Sport: 6000,
+			},
+			Stream: http2Stream{
+				Response_last_seen: 0, // Required to make the request incomplete.
+				Request_started:    uint64(now.UnixNano()),
+				Status_code: http2StatusCode{
+					Static_table_entry: K200Value,
+					Finalized:          true,
+				},
+				Request_method: http2requestMethod{
+					Static_table_entry: GetValue,
+					Finalized:          true,
+				},
+				Path: http2Path{
+					Static_table_entry: EmptyPathValue,
+					Finalized:          true,
+				},
+			},
+		}
+		buffer.Add(request)
+		transactions := buffer.Flush(now)
+		require.Empty(t, transactions)
+		assert.True(t, len(buffer.data) == 1)
+
+		buffer.data[0].Stream.Response_last_seen = uint64(now.Add(time.Second).UnixNano())
+		transactions = buffer.Flush(now)
+		require.Len(t, transactions, 1)
+		assert.True(t, len(buffer.data) == 0)
+	})
+
+	t.Run("removing old incomplete", func(t *testing.T) {
+		// Testing the scenario where an incomplete request is removed after a certain time.
+		buffer := NewIncompleteBuffer(config.New()).(*incompleteBuffer)
+		now := time.Now()
+		buffer.minAgeNano = (30 * time.Second).Nanoseconds()
+		request := &EbpfTx{
+			Tuple: connTuple{
+				Sport: 6000,
+			},
+			Stream: http2Stream{
+				Path: http2Path{
+					Static_table_entry: EmptyPathValue,
+				},
+				Request_started: uint64(now.UnixNano()),
+			},
+		}
+		buffer.Add(request)
+		_ = buffer.Flush(now)
+
+		assert.True(t, len(buffer.data) > 0)
+		now = now.Add(35 * time.Second)
+		_ = buffer.Flush(now)
+		assert.True(t, len(buffer.data) == 0)
+	})
+}

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -30,11 +30,9 @@ import (
 
 // Protocol implements the interface that represents a protocol supported by USM for HTTP/2.
 type Protocol struct {
-	cfg *config.Config
-	mgr *manager.Manager
-	// TODO: Do we need to duplicate?
-	telemetry *http.Telemetry
-	// TODO: Do we need to duplicate?
+	cfg                     *config.Config
+	mgr                     *manager.Manager
+	telemetry               *http.Telemetry
 	statkeeper              *http.StatKeeper
 	http2InFlightMapCleaner *ddebpf.MapCleaner[http2StreamKey, EbpfTx]
 	eventsConsumer          *events.Consumer[EbpfTx]
@@ -252,7 +250,7 @@ func (p *Protocol) PreStart(mgr *manager.Manager) (err error) {
 		return
 	}
 
-	p.statkeeper = http.NewStatkeeper(p.cfg, p.telemetry, http.NewIncompleteBuffer(p.cfg, p.telemetry))
+	p.statkeeper = http.NewStatkeeper(p.cfg, p.telemetry, NewIncompleteBuffer(p.cfg))
 	p.eventsConsumer.Start()
 
 	return


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The HTTP2 monitoring does not have a logic of attaching request-responses, as we get the full stream from the kernel. Thus, the dedicated mechanism keeps incomplete requests until those become complete

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Preliminary change for the http2 dynamic table refactor.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
