### PR TITLE
Update debian 11 image for system-probe kitchen tests

### DIFF
--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -47,7 +47,7 @@
             },
             "arm64": {
                 "debian-10": "ami-0108ade0d057c8eba",
-                "debian-11": "ami-03ea090ddd75eb738",
+                "debian-11": "ami-0d3b78362fc3d8e61",
                 "debian-12": "ami-02aab8d5301cb8d68"
             }
         }

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -42,7 +42,7 @@
         "ec2": {
             "x86_64": {
                 "debian-10": "ami-041540a5c191757a0",
-                "debian-11": "ami-02ba6eae41e089e8d",
+                "debian-11": "ami-0fd320e6b2de9e34a",
                 "debian-12": "ami-07edaec601cf2b6d3"
             },
             "arm64": {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Update the system-probe kitchen images for Debian 11, fixing a broken build on main due to a missing package.

### Motivation

Debian removed the linux headers package for the AMIs we were using in kitchen tests, causing the preparation step to fail. Updating the image to a more recent one with supported kernels.

### Additional Notes

The x64 image was a copy of ami-09e24b0cfe072ecef in our own account. This PR moves to use a public AMI again as a temporary fix, the issue of whether to use public/private images can be decided later.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
