### PR TITLE
[CWS] fix eval context creation when handling filter actions

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -161,9 +161,7 @@ func (p *Probe) GetDebugStats() map[string]interface{} {
 
 // HandleActions executes the actions of a triggered rule
 func (p *Probe) HandleActions(rule *rules.Rule, event eval.Event) {
-	ctx := &eval.Context{
-		Event: event.(*model.Event),
-	}
+	ctx := eval.NewContext(event.(*model.Event))
 
 	p.PlatformProbe.HandleActions(ctx, rule)
 }


### PR DESCRIPTION
### What does this PR do?

The eval context is currently not correctly initialized (especially missing cache maps init), causing some panic when access to those caches is performed (for example when accessing `process.ancestors.envp`)

```
panic: assignment to entry in nil map
goroutine 891 [running]:
github.com/DataDog/datadog-agent/pkg/security/secl/model.(*Model).GetEvaluator.func416(0x4007efbc20)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/model/accessors_unix.go:4238 +0x1c4
github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval.StringArrayMatches.func3(0x4003c76fc8?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval/operators.go:664 +0x38
github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval.Or.func3(0x4003c77008?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval/operators.go:64 +0x50
github.com/DataDog/datadog-agent/pkg/security/secl/rules.(*ActionDefinition).IsAccepted(...)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/rules/actions.go:95
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).HandleActions(0x40073fa900, 0x4007efbc20, 0x4007643360)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1920 +0x9c
github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).HandleActions(...)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:168
github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleEngine).RuleMatch(0x4007950a20, 0x4007643360, {0x60518c0?, 0x40061b4000})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/rules/engine.go:401 +0x11c
github.com/DataDog/datadog-agent/pkg/security/secl/rules.(*RuleSet).NotifyRuleMatch(0x4552300?, 0x400616bb90?, {0x60518c0, 0x40061b4000})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/rules/ruleset.go:472 +0x114
github.com/DataDog/datadog-agent/pkg/security/secl/rules.(*RuleSet).Evaluate(0x4002473ba0, {0x60518c0?, 0x40061b4000})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/rules/ruleset.go:651 +0x36c
github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleEngine).HandleEvent(0x4007950a20?, 0x40061b4000)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/rules/engine.go:528 +0x13c
github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).sendEventToWildcardHandlers(...)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:202
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).DispatchEvent(0x40073fa900, 0x40061b4000)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:407 +0xa8
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleEvent(0x40073fa900, 0x4b54e0?, {0x40002ac820, 0x190, 0x190})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:929 +0x3448
github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer.(*RingBuffer).handleEvent(0x4006452090, 0x4002a8caa0, 0x4003b83f68?, 0x4003c77f40?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go:63 +0x40
github.com/DataDog/ebpf-manager.(*RingBuffer).Start.func1()
	/go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.4.0/ringbuffer.go:142 +0x134
created by github.com/DataDog/ebpf-manager.(*RingBuffer).Start in goroutine 1
	/go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.4.0/ringbuffer.go:116 +0x15c
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
