### PR TITLE
Fetch system-probe metadata from the system-probe process

### DIFF
--- a/cmd/system-probe/api/client/client.go
+++ b/cmd/system-probe/api/client/client.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package api contains the API exposed by system-probe
-package api
+// Package client contains the client for the API exposed by system-probe
+package client
 
 import (
 	"context"
@@ -13,8 +13,8 @@ import (
 	"time"
 )
 
-// GetClient returns a http client configured to talk to the system-probe
-func GetClient(socketPath string) *http.Client {
+// Get returns a http client configured to talk to the system-probe
+func Get(socketPath string) *http.Client {
 	return &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{

--- a/cmd/system-probe/api/client/client_linux.go
+++ b/cmd/system-probe/api/client/client_linux.go
@@ -5,7 +5,7 @@
 
 //go:build linux
 
-package api
+package client
 
 const (
 	netType = "unix"

--- a/cmd/system-probe/api/client/client_others.go
+++ b/cmd/system-probe/api/client/client_others.go
@@ -5,7 +5,7 @@
 
 //go:build !linux && !windows
 
-package api
+package client
 
 const (
 	netType = "tcp"

--- a/cmd/system-probe/api/client/client_windows.go
+++ b/cmd/system-probe/api/client/client_windows.go
@@ -5,7 +5,7 @@
 
 //go:build windows
 
-package api
+package client
 
 const (
 	netType = "tcp"

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package api contains the API exposed by system-probe
 package api
 
 import (

--- a/cmd/system-probe/subcommands/config/command.go
+++ b/cmd/system-probe/subcommands/config/command.go
@@ -12,13 +12,14 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/cmd/system-probe/api"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
+	"github.com/DataDog/datadog-agent/pkg/config/fetcher"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -95,17 +96,12 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 func getClient(sysprobeconfig sysprobeconfig.Component) (settings.Client, error) {
 	cfg := sysprobeconfig.SysProbeObject()
-	hc := api.GetClient(cfg.SocketAddress)
+	hc := client.Get(cfg.SocketAddress)
 	return settingshttp.NewClient(hc, "http://localhost/config", "system-probe"), nil
 }
 
 func showRuntimeConfiguration(sysprobeconfig sysprobeconfig.Component, _ *cliParams) error {
-	c, err := getClient(sysprobeconfig)
-	if err != nil {
-		return err
-	}
-
-	runtimeConfig, err := c.FullConfig()
+	runtimeConfig, err := fetcher.SystemProbeConfig(sysprobeconfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/system-probe/subcommands/debug/command.go
+++ b/cmd/system-probe/subcommands/debug/command.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/cmd/system-probe/api"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -63,7 +63,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 func debugRuntime(sysprobeconfig sysprobeconfig.Component, cliParams *cliParams) error {
 	cfg := sysprobeconfig.SysProbeObject()
-	client := api.GetClient(cfg.SocketAddress)
+	client := client.Get(cfg.SocketAddress)
 
 	var path string
 	if len(cliParams.args) == 1 {

--- a/cmd/system-probe/subcommands/modrestart/command.go
+++ b/cmd/system-probe/subcommands/modrestart/command.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/cmd/system-probe/api"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -61,7 +61,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 func moduleRestart(sysprobeconfig sysprobeconfig.Component, cliParams *cliParams) error {
 	cfg := sysprobeconfig.SysProbeObject()
-	client := api.GetClient(cfg.SocketAddress)
+	client := client.Get(cfg.SocketAddress)
 	url := fmt.Sprintf("http://localhost/module-restart/%s", cliParams.args[0])
 	resp, err := client.Post(url, "", nil)
 	if err != nil {

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -47,10 +47,11 @@ func Module() fxutil.Module {
 
 var (
 	// for testing
-	installinfoGet      = installinfo.Get
-	fetchSecurityConfig = configFetcher.SecurityAgentConfig
-	fetchProcessConfig  = func(cfg model.Reader) (string, error) { return configFetcher.ProcessAgentConfig(cfg, true) }
-	fetchTraceConfig    = configFetcher.TraceAgentConfig
+	installinfoGet         = installinfo.Get
+	fetchSecurityConfig    = configFetcher.SecurityAgentConfig
+	fetchProcessConfig     = func(cfg model.Reader) (string, error) { return configFetcher.ProcessAgentConfig(cfg, true) }
+	fetchTraceConfig       = configFetcher.TraceAgentConfig
+	fetchSystemProbeConfig = configFetcher.SystemProbeConfig
 )
 
 type agentMetadata map[string]interface{}
@@ -129,34 +130,14 @@ func newInventoryAgentProvider(deps dependencies) provides {
 	}
 }
 
-func clean(s string) string {
+func scrub(s string) string {
 	// Errors come from internal use of a Reader interface. Since we are reading from a buffer, no errors
 	// are possible.
-	cleanString, _ := scrubber.ScrubString(s)
-	return cleanString
+	scrubString, _ := scrubber.ScrubString(s)
+	return scrubString
 }
 
 func (ia *inventoryagent) initData() {
-	cfgSlice := func(name string) []string {
-		if ia.conf.IsSet(name) {
-			ss := ia.conf.GetStringSlice(name)
-			rv := make([]string, len(ss))
-			for i, s := range ss {
-				rv[i] = clean(s)
-			}
-			return rv
-		}
-		return []string{}
-	}
-
-	// if system probe configuration was loaded we use it, if not we default to false
-	getBoolSysProbe := func(key string) bool { return false }
-	getIntSysProbe := func(key string) int { return 0 }
-	if sysprobeConf, isset := ia.sysprobeConf.Get(); isset {
-		getBoolSysProbe = func(key string) bool { return sysprobeConf.GetBool(key) }
-		getIntSysProbe = func(key string) int { return sysprobeConf.GetInt(key) }
-	}
-
 	tool := "undefined"
 	toolVersion := ""
 	installerVersion := ""
@@ -180,36 +161,109 @@ func (ia *inventoryagent) initData() {
 		ia.log.Warnf("could not fetch 'hostname_source': %v", err)
 	}
 
-	// core-agent
-
 	ia.data["agent_version"] = version.AgentVersion
 	ia.data["flavor"] = flavor.GetFlavor()
+}
 
-	ia.data["config_dd_url"] = clean(ia.conf.GetString("dd_url"))
-	ia.data["config_site"] = clean(ia.conf.GetString("dd_site"))
-	ia.data["config_logs_dd_url"] = clean(ia.conf.GetString("logs_config.logs_dd_url"))
-	ia.data["config_logs_socks5_proxy_address"] = clean(ia.conf.GetString("logs_config.socks5_proxy_address"))
+type configGetter interface {
+	GetBool(string) bool
+	GetInt(string) int
+	GetString(string) string
+}
+
+// getCorrectConfig tries to fetch the configuration from another process. It returns a new
+// configuration object on success and the fallback upon failure.
+func (ia *inventoryagent) getCorrectConfig(name string, configFetcher func(config model.Reader) (string, error), fallback configGetter) configGetter {
+	// We query the configuration from another agent itself to have accurate data. If the other process isn't
+	// available we fallback on the current configuration.
+	if remoteConfig, err := configFetcher(ia.conf); err == nil {
+		cfg := viper.New()
+		cfg.SetConfigType("yaml")
+		if err = cfg.ReadConfig(strings.NewReader(remoteConfig)); err != nil {
+			ia.log.Error("Could not parse '%s' configuration: %s", name, err)
+		} else {
+			return cfg
+		}
+	} else {
+		ia.log.Errorf("could not fetch %s process configuration: %s", name, err)
+	}
+	return fallback
+}
+
+func (ia *inventoryagent) fetchCoreAgentMetadata() {
+	cfgSlice := func(name string) []string {
+		if ia.conf.IsSet(name) {
+			ss := ia.conf.GetStringSlice(name)
+			rv := make([]string, len(ss))
+			for i, s := range ss {
+				rv[i] = scrub(s)
+			}
+			return rv
+		}
+		return []string{}
+	}
+
+	ia.data["config_dd_url"] = scrub(ia.conf.GetString("dd_url"))
+	ia.data["config_site"] = scrub(ia.conf.GetString("dd_site"))
+	ia.data["config_logs_dd_url"] = scrub(ia.conf.GetString("logs_config.logs_dd_url"))
+	ia.data["config_logs_socks5_proxy_address"] = scrub(ia.conf.GetString("logs_config.socks5_proxy_address"))
 	ia.data["config_no_proxy"] = cfgSlice("proxy.no_proxy")
-	ia.data["config_process_dd_url"] = clean(ia.conf.GetString("process_config.process_dd_url"))
-	ia.data["config_proxy_http"] = clean(ia.conf.GetString("proxy.http"))
-	ia.data["config_proxy_https"] = clean(ia.conf.GetString("proxy.https"))
+	ia.data["config_process_dd_url"] = scrub(ia.conf.GetString("process_config.process_dd_url"))
+	ia.data["config_proxy_http"] = scrub(ia.conf.GetString("proxy.http"))
+	ia.data["config_proxy_https"] = scrub(ia.conf.GetString("proxy.https"))
 	ia.data["feature_fips_enabled"] = ia.conf.GetBool("fips.enabled")
 	ia.data["feature_logs_enabled"] = ia.conf.GetBool("logs_enabled")
 	ia.data["feature_imdsv2_enabled"] = ia.conf.GetBool("ec2_prefer_imdsv2")
-
 	ia.data["feature_remote_configuration_enabled"] = ia.conf.GetBool("remote_configuration.enabled")
-
 	ia.data["feature_container_images_enabled"] = ia.conf.GetBool("container_image.enabled")
+
+	ia.data["feature_csm_vm_containers_enabled"] = ia.conf.GetBool("sbom.enabled") && ia.conf.GetBool("container_image.enabled") && ia.conf.GetBool("sbom.container_image.enabled")
+	ia.data["feature_csm_vm_hosts_enabled"] = ia.conf.GetBool("sbom.enabled") && ia.conf.GetBool("sbom.host.enabled")
+}
+
+func (ia *inventoryagent) fetchSecurityAgentMetadata() {
+	securityCfg := ia.getCorrectConfig("security-agent", fetchSecurityConfig, ia.conf)
+
+	ia.data["feature_cspm_enabled"] = securityCfg.GetBool("compliance_config.enabled")
+	ia.data["feature_cspm_host_benchmarks_enabled"] = securityCfg.GetBool("compliance_config.host_benchmarks.enabled")
+}
+
+func (ia *inventoryagent) fetchTraceAgentMetadata() {
+	traceCfg := ia.getCorrectConfig("trace-agent", fetchTraceConfig, ia.conf)
+
+	ia.data["config_apm_dd_url"] = scrub(traceCfg.GetString("apm_config.apm_dd_url"))
+	ia.data["feature_apm_enabled"] = traceCfg.GetBool("apm_config.enabled")
+}
+
+func (ia *inventoryagent) fetchProcessAgentMetadata() {
+	processCfg := ia.getCorrectConfig("process-agent", fetchProcessConfig, ia.conf)
+
+	ia.data["feature_process_enabled"] = processCfg.GetBool("process_config.process_collection.enabled")
+	ia.data["feature_processes_container_enabled"] = processCfg.GetBool("process_config.container_collection.enabled")
+	ia.data["feature_process_language_detection_enabled"] = processCfg.GetBool("language_detection.enabled")
+}
+
+func (ia *inventoryagent) fetchSystemProbeMetadata() {
+	// If the system-probe configuration is not loaded we fallback on zero value for all metadata
+	getBoolSysProbe := func(key string) bool { return false }
+	getIntSysProbe := func(key string) int { return 0 }
+
+	localSysProbeConf, isSet := ia.sysprobeConf.Get()
+	if isSet {
+		// If we can fetch the configuration from the system-probe process, we use it. If not we fallback on the
+		// local instance.
+		sysProbeConf := ia.getCorrectConfig("system-probe", fetchSystemProbeConfig, localSysProbeConf)
+
+		getBoolSysProbe = sysProbeConf.GetBool
+		getIntSysProbe = sysProbeConf.GetInt
+	}
 
 	// Cloud Workload Security / system-probe
 
 	ia.data["feature_cws_enabled"] = getBoolSysProbe("runtime_security_config.enabled")
-	ia.data["feature_cws_network_enabled"] = getBoolSysProbe("event_monitoring_config.network.enabled")
 	ia.data["feature_cws_security_profiles_enabled"] = getBoolSysProbe("runtime_security_config.activity_dump.enabled")
 	ia.data["feature_cws_remote_config_enabled"] = getBoolSysProbe("runtime_security_config.remote_configuration.enabled")
-
-	ia.data["feature_csm_vm_containers_enabled"] = ia.conf.GetBool("sbom.enabled") && ia.conf.GetBool("container_image.enabled") && ia.conf.GetBool("sbom.container_image.enabled")
-	ia.data["feature_csm_vm_hosts_enabled"] = ia.conf.GetBool("sbom.enabled") && ia.conf.GetBool("sbom.host.enabled")
+	ia.data["feature_cws_network_enabled"] = getBoolSysProbe("event_monitoring_config.network.enabled")
 
 	// Service monitoring / system-probe
 
@@ -230,6 +284,7 @@ func (ia *inventoryagent) initData() {
 	ia.data["feature_tcp_queue_length_enabled"] = getBoolSysProbe("system_probe_config.enable_tcp_queue_length")
 	ia.data["feature_oom_kill_enabled"] = getBoolSysProbe("system_probe_config.enable_oom_kill")
 	ia.data["feature_windows_crash_detection_enabled"] = getBoolSysProbe("windows_crash_detection.enabled")
+	ia.data["feature_dynamic_instrumentation_enabled"] = getBoolSysProbe("dynamic_instrumentation.enabled")
 
 	ia.data["system_probe_core_enabled"] = getBoolSysProbe("system_probe_config.enable_co_re")
 	ia.data["system_probe_runtime_compilation_enabled"] = getBoolSysProbe("system_probe_config.enable_runtime_compiler")
@@ -244,65 +299,19 @@ func (ia *inventoryagent) initData() {
 	ia.data["system_probe_protocol_classification_enabled"] = getBoolSysProbe("network_config.enable_protocol_classification")
 	ia.data["system_probe_gateway_lookup_enabled"] = getBoolSysProbe("network_config.enable_gateway_lookup")
 	ia.data["system_probe_root_namespace_enabled"] = getBoolSysProbe("network_config.enable_root_netns")
-
-	ia.data["feature_dynamic_instrumentation_enabled"] = getBoolSysProbe("dynamic_instrumentation.enabled")
-
-	ia.refreshMetadata()
-}
-
-type configGetter interface {
-	GetBool(string) bool
-	GetString(string) string
-}
-
-// getCorrectConfig tries to fetch the configuration from another process. It returns a new
-// configuration object on success and the local config on failure.
-func (ia *inventoryagent) getCorrectConfig(name string, configFetcher func(config model.Reader) (string, error)) configGetter {
-	// We query the configuration from another agent itself to have accurate data. If the other process isn't
-	// available we fallback on the current configuration.
-	if remoteConfig, err := configFetcher(ia.conf); err == nil {
-		cfg := viper.New()
-		cfg.SetConfigType("yaml")
-		if err = cfg.ReadConfig(strings.NewReader(remoteConfig)); err != nil {
-			ia.log.Error("Could not parse '%s' configuration: %s", name, err)
-		} else {
-			return cfg
-		}
-	} else {
-		ia.log.Errorf("could not fetch %s process configuration: %s", name, err)
-	}
-	return configGetter(ia.conf)
-}
-
-func (ia *inventoryagent) fetchSecurityAgentMetadata() {
-	securityCfg := ia.getCorrectConfig("security-agent", fetchSecurityConfig)
-
-	ia.data["feature_cspm_enabled"] = securityCfg.GetBool("compliance_config.enabled")
-	ia.data["feature_cspm_host_benchmarks_enabled"] = securityCfg.GetBool("compliance_config.host_benchmarks.enabled")
-}
-
-func (ia *inventoryagent) fetchTraceAgentMetadata() {
-	traceCfg := ia.getCorrectConfig("trace-agent", fetchTraceConfig)
-
-	ia.data["config_apm_dd_url"] = clean(traceCfg.GetString("apm_config.apm_dd_url"))
-	ia.data["feature_apm_enabled"] = traceCfg.GetBool("apm_config.enabled")
-}
-
-func (ia *inventoryagent) fetchProcessAgentMetadata() {
-	processCfg := ia.getCorrectConfig("process-agent", fetchProcessConfig)
-
-	ia.data["feature_process_enabled"] = processCfg.GetBool("process_config.process_collection.enabled")
-	ia.data["feature_processes_container_enabled"] = processCfg.GetBool("process_config.container_collection.enabled")
-	ia.data["feature_process_language_detection_enabled"] = processCfg.GetBool("language_detection.enabled")
 }
 
 func (ia *inventoryagent) refreshMetadata() {
+	// Core Agent / agent
+	ia.fetchCoreAgentMetadata()
 	// Compliance / security-agent
 	ia.fetchSecurityAgentMetadata()
 	// Process / process-agent
 	ia.fetchProcessAgentMetadata()
 	// APM / trace-agent
 	ia.fetchTraceAgentMetadata()
+	// system-probe ecosystem
+	ia.fetchSystemProbeMetadata()
 }
 
 // Set updates a metadata value in the payload. The given value will be stored in the cache without being copied. It is

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
@@ -158,6 +159,7 @@ func TestInitData(t *testing.T) {
 		"sbom.host.enabled":                           true,
 	}
 	ia := getTestInventoryPayload(t, overrides, sysprobeOverrides)
+	ia.refreshMetadata()
 
 	expected := map[string]any{
 		"agent_version":                    version.AgentVersion,
@@ -399,4 +401,192 @@ apm_config:
 	ia.fetchTraceAgentMetadata()
 	assert.True(t, ia.data["feature_apm_enabled"].(bool))
 	assert.Equal(t, "https://user:********@some_url_for_trace", ia.data["config_apm_dd_url"].(string))
+}
+
+func TestFetchSystemProbeAgent(t *testing.T) {
+	defer func() {
+		fetchSystemProbeConfig = configFetcher.SystemProbeConfig
+	}()
+	fetchSystemProbeConfig = func(config pkgconfigmodel.Reader) (string, error) {
+		return "", fmt.Errorf("some error")
+	}
+
+	ia := getTestInventoryPayload(t, nil, nil)
+	ia.fetchSystemProbeMetadata()
+
+	// We test default value when the system-probe could not be contacted
+	assert.False(t, ia.data["feature_cws_enabled"].(bool))
+	assert.True(t, ia.data["feature_cws_network_enabled"].(bool))
+	assert.False(t, ia.data["feature_cws_security_profiles_enabled"].(bool))
+	assert.True(t, ia.data["feature_cws_remote_config_enabled"].(bool))
+	assert.False(t, ia.data["feature_networks_enabled"].(bool))
+	assert.False(t, ia.data["feature_networks_http_enabled"].(bool))
+	assert.False(t, ia.data["feature_networks_https_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_kafka_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_java_tls_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_http2_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_istio_enabled"].(bool))
+	assert.True(t, ia.data["feature_usm_http_by_status_code_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_go_tls_enabled"].(bool))
+	assert.False(t, ia.data["feature_tcp_queue_length_enabled"].(bool))
+	assert.False(t, ia.data["feature_oom_kill_enabled"].(bool))
+	assert.False(t, ia.data["feature_windows_crash_detection_enabled"].(bool))
+	assert.True(t, ia.data["system_probe_core_enabled"].(bool))
+	assert.False(t, ia.data["system_probe_runtime_compilation_enabled"].(bool))
+	assert.False(t, ia.data["system_probe_kernel_headers_download_enabled"].(bool))
+	assert.True(t, ia.data["system_probe_prebuilt_fallback_enabled"].(bool))
+	assert.False(t, ia.data["system_probe_telemetry_enabled"].(bool))
+	assert.Equal(t, 600, ia.data["system_probe_max_connections_per_message"].(int))
+	assert.True(t, ia.data["system_probe_track_tcp_4_connections"].(bool))
+	assert.True(t, ia.data["system_probe_track_udp_4_connections"].(bool))
+	if !kernel.IsIPv6Enabled() {
+		assert.False(t, ia.data["system_probe_track_tcp_6_connections"].(bool))
+		assert.False(t, ia.data["system_probe_track_udp_6_connections"].(bool))
+	} else {
+		assert.True(t, ia.data["system_probe_track_tcp_6_connections"].(bool))
+		assert.True(t, ia.data["system_probe_track_udp_6_connections"].(bool))
+	}
+	assert.True(t, ia.data["system_probe_protocol_classification_enabled"].(bool))
+	assert.True(t, ia.data["system_probe_gateway_lookup_enabled"].(bool))
+	assert.True(t, ia.data["system_probe_root_namespace_enabled"].(bool))
+	assert.False(t, ia.data["feature_dynamic_instrumentation_enabled"].(bool))
+
+	// Testing an inventoryagent without system-probe object
+	p := newInventoryAgentProvider(
+		fxutil.Test[dependencies](
+			t,
+			logimpl.MockModule(),
+			config.MockModule(),
+			sysprobeconfig.NoneModule(),
+			fx.Provide(func() serializer.MetricSerializer { return &serializer.MockSerializer{} }),
+		),
+	)
+	ia = p.Comp.(*inventoryagent)
+	ia.fetchSystemProbeMetadata()
+
+	assert.False(t, ia.data["feature_cws_enabled"].(bool))
+	assert.False(t, ia.data["feature_cws_network_enabled"].(bool))
+	assert.False(t, ia.data["feature_cws_security_profiles_enabled"].(bool))
+	assert.False(t, ia.data["feature_cws_remote_config_enabled"].(bool))
+	assert.False(t, ia.data["feature_networks_enabled"].(bool))
+	assert.False(t, ia.data["feature_networks_http_enabled"].(bool))
+	assert.False(t, ia.data["feature_networks_https_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_kafka_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_java_tls_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_http2_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_istio_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_http_by_status_code_enabled"].(bool))
+	assert.False(t, ia.data["feature_usm_go_tls_enabled"].(bool))
+	assert.False(t, ia.data["feature_tcp_queue_length_enabled"].(bool))
+	assert.False(t, ia.data["feature_oom_kill_enabled"].(bool))
+	assert.False(t, ia.data["feature_windows_crash_detection_enabled"].(bool))
+	assert.False(t, ia.data["system_probe_core_enabled"].(bool))
+	assert.False(t, ia.data["system_probe_runtime_compilation_enabled"].(bool))
+	assert.False(t, ia.data["system_probe_kernel_headers_download_enabled"].(bool))
+	assert.False(t, ia.data["system_probe_prebuilt_fallback_enabled"].(bool))
+	assert.False(t, ia.data["system_probe_telemetry_enabled"].(bool))
+	assert.Equal(t, 0, ia.data["system_probe_max_connections_per_message"].(int))
+	assert.False(t, ia.data["system_probe_track_tcp_4_connections"].(bool))
+	assert.False(t, ia.data["system_probe_track_tcp_6_connections"].(bool))
+	assert.False(t, ia.data["system_probe_track_udp_4_connections"].(bool))
+	assert.False(t, ia.data["system_probe_track_udp_6_connections"].(bool))
+	assert.False(t, ia.data["system_probe_protocol_classification_enabled"].(bool))
+	assert.False(t, ia.data["system_probe_gateway_lookup_enabled"].(bool))
+	assert.False(t, ia.data["system_probe_root_namespace_enabled"].(bool))
+	assert.False(t, ia.data["feature_dynamic_instrumentation_enabled"].(bool))
+
+	// Testing an inventoryagent where we can contact the system-probe process
+	fetchSystemProbeConfig = func(_ pkgconfigmodel.Reader) (string, error) {
+		return `
+runtime_security_config:
+  enabled: true
+  activity_dump:
+    enabled: true
+  remote_configuration:
+    enabled: true
+
+event_monitoring_config:
+  network:
+    enabled: true
+
+network_config:
+  enabled: true
+  collect_tcp_v4: true
+  collect_tcp_v6: true
+  collect_udp_v4: true
+  collect_udp_v6: true
+  enable_protocol_classification: true
+  enable_gateway_lookup: true
+  enable_root_netns: true
+
+service_monitoring_config:
+  enable_http_monitoring: true
+  tls:
+    native:
+      enabled: true
+    java:
+      enabled: true
+    istio:
+      enabled: true
+    go:
+      enabled: true
+  enabled: true
+  enable_kafka_monitoring: true
+  enable_http2_monitoring: true
+  enable_http_stats_by_status_code: true
+
+windows_crash_detection:
+  enabled: true
+
+system_probe_config:
+  enable_tcp_queue_length: true
+  enable_oom_kill: true
+  enable_co_re: true
+  enable_runtime_compiler: true
+  enable_kernel_header_download: true
+  allow_precompiled_fallback: true
+  telemetry_enabled: true
+  max_conns_per_message: 123
+
+dynamic_instrumentation:
+  enabled: true
+`, nil
+	}
+
+	ia = getTestInventoryPayload(t, nil, nil)
+	ia.fetchSystemProbeMetadata()
+
+	assert.True(t, ia.data["feature_cws_enabled"].(bool))
+	assert.True(t, ia.data["feature_cws_network_enabled"].(bool))
+	assert.True(t, ia.data["feature_cws_security_profiles_enabled"].(bool))
+	assert.True(t, ia.data["feature_cws_remote_config_enabled"].(bool))
+	assert.True(t, ia.data["feature_networks_enabled"].(bool))
+	assert.True(t, ia.data["feature_networks_http_enabled"].(bool))
+	assert.True(t, ia.data["feature_networks_https_enabled"].(bool))
+	assert.True(t, ia.data["feature_usm_enabled"].(bool))
+	assert.True(t, ia.data["feature_usm_kafka_enabled"].(bool))
+	assert.True(t, ia.data["feature_usm_java_tls_enabled"].(bool))
+	assert.True(t, ia.data["feature_usm_http2_enabled"].(bool))
+	assert.True(t, ia.data["feature_usm_istio_enabled"].(bool))
+	assert.True(t, ia.data["feature_usm_http_by_status_code_enabled"].(bool))
+	assert.True(t, ia.data["feature_usm_go_tls_enabled"].(bool))
+	assert.True(t, ia.data["feature_tcp_queue_length_enabled"].(bool))
+	assert.True(t, ia.data["feature_oom_kill_enabled"].(bool))
+	assert.True(t, ia.data["feature_windows_crash_detection_enabled"].(bool))
+	assert.True(t, ia.data["system_probe_core_enabled"].(bool))
+	assert.True(t, ia.data["system_probe_runtime_compilation_enabled"].(bool))
+	assert.True(t, ia.data["system_probe_kernel_headers_download_enabled"].(bool))
+	assert.True(t, ia.data["system_probe_prebuilt_fallback_enabled"].(bool))
+	assert.True(t, ia.data["system_probe_telemetry_enabled"].(bool))
+	assert.Equal(t, 123, ia.data["system_probe_max_connections_per_message"].(int))
+	assert.True(t, ia.data["system_probe_track_tcp_4_connections"].(bool))
+	assert.True(t, ia.data["system_probe_track_udp_4_connections"].(bool))
+	assert.True(t, ia.data["system_probe_track_tcp_6_connections"].(bool))
+	assert.True(t, ia.data["system_probe_track_udp_6_connections"].(bool))
+	assert.True(t, ia.data["system_probe_protocol_classification_enabled"].(bool))
+	assert.True(t, ia.data["system_probe_gateway_lookup_enabled"].(bool))
+	assert.True(t, ia.data["system_probe_root_namespace_enabled"].(bool))
+	assert.True(t, ia.data["feature_dynamic_instrumentation_enabled"].(bool))
 }

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -9,6 +9,7 @@ package fetcher
 import (
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
@@ -76,4 +77,12 @@ func ProcessAgentConfig(config config.Reader, getEntireConfig bool) (string, err
 	client := settingshttp.NewClient(c, ipcAddressWithPort, "process-agent")
 
 	return client.FullConfig()
+}
+
+// SystemProbeConfig fetch the configuration from the system-probe process by querying its API
+func SystemProbeConfig(config config.Reader) (string, error) {
+	hc := client.Get(config.GetString("system_probe_config.sysprobe_socket"))
+
+	c := settingshttp.NewClient(hc, "http://localhost/config", "system-probe")
+	return c.FullConfig()
 }


### PR DESCRIPTION
### What does this PR do?

Fetch system-probe metadata from the system-probe process.

I also split the `cmd/system-probe/api/client` to its own package to avoid circular import.

### Describe how to test/QA your changes

Test that all system-probe metadata correctly reflect the system-probe configuration when using our official helm chart and datadog-operator.

To see the payload: from the core-agent container `agent diagnose show-metadata inventory-agent`

For team epbf:
- Check that the metadata above are correctly sent when deploying with helm chart (test that enabling all product possible in system-probe are correctly represented in the metadata paylaod).
- Check that the `config` command for system-probe still works like before.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
