### PR TITLE
Provide empty flare provider to avoid segfault because of nil provider

### DIFF
--- a/comp/core/flare/types/types.go
+++ b/comp/core/flare/types/types.go
@@ -153,3 +153,10 @@ func NewProvider(callback FlareCallback) Provider {
 		Provider: callback,
 	}
 }
+
+// NewEmptyProvider returns a new Provider with an empty callback
+func NewEmptyProvider() Provider {
+	return Provider{
+		Provider: func(fb FlareBuilder) error { return nil },
+	}
+}

--- a/comp/logs/agent/agent.go
+++ b/comp/logs/agent/agent.go
@@ -131,6 +131,7 @@ func newLogsAgent(deps dependencies) provides {
 	return provides{
 		Comp:           optional.NewNoneOption[Component](),
 		StatusProvider: statusComponent.NewInformationProvider(NewStatusProvider()),
+		FlareProvider:  flaretypes.NewProvider(func(flaretypes.FlareBuilder) error { return nil }),
 	}
 }
 

--- a/comp/logs/agent/agent.go
+++ b/comp/logs/agent/agent.go
@@ -131,7 +131,7 @@ func newLogsAgent(deps dependencies) provides {
 	return provides{
 		Comp:           optional.NewNoneOption[Component](),
 		StatusProvider: statusComponent.NewInformationProvider(NewStatusProvider()),
-		FlareProvider:  flaretypes.NewProvider(func(flaretypes.FlareBuilder) error { return nil }),
+		FlareProvider:  flaretypes.NewEmptyProvider(),
 	}
 }
 

--- a/comp/logs/agent/agent_test.go
+++ b/comp/logs/agent/agent_test.go
@@ -303,12 +303,12 @@ func (suite *AgentTestSuite) TestFlareProvider() {
 		{
 			"logs enabled",
 			true,
-			flaretypes.FlareCallback(flareController.NewFlareController().FillFlare),
+			flaretypes.NewProvider(flareController.NewFlareController().FillFlare),
 		},
 		{
 			"logs disabled",
 			false,
-			flaretypes.FlareCallback(func(flaretypes.FlareBuilder) error { return nil }),
+			flaretypes.NewEmptyProvider(),
 		},
 	}
 
@@ -324,7 +324,8 @@ func (suite *AgentTestSuite) TestFlareProvider() {
 
 			provides := newLogsAgent(deps)
 
-			assert.IsType(suite.T(), test.expected, provides.FlareProvider.Provider)
+			assert.IsType(suite.T(), test.expected, provides.FlareProvider)
+			assert.NotNil(suite.T(), provides.FlareProvider.Provider)
 		})
 	}
 }

--- a/comp/logs/agent/agent_test.go
+++ b/comp/logs/agent/agent_test.go
@@ -22,9 +22,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
+
+	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/inventoryagentimpl"
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
@@ -287,6 +290,41 @@ func (suite *AgentTestSuite) TestStatusOut() {
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {
 			test.assertFunc(suite.T())
+		})
+	}
+}
+
+func (suite *AgentTestSuite) TestFlareProvider() {
+	tests := []struct {
+		name     string
+		enabled  bool
+		expected interface{}
+	}{
+		{
+			"logs enabled",
+			true,
+			flaretypes.FlareCallback(flareController.NewFlareController().FillFlare),
+		},
+		{
+			"logs disabled",
+			false,
+			flaretypes.FlareCallback(func(flaretypes.FlareBuilder) error { return nil }),
+		},
+	}
+
+	for _, test := range tests {
+		suite.T().Run(test.name, func(*testing.T) {
+			suite.configOverrides["logs_enabled"] = test.enabled
+
+			deps := fxutil.Test[dependencies](suite.T(), fx.Options(
+				core.MockBundle(),
+				fx.Replace(configComponent.MockParams{Overrides: suite.configOverrides}),
+				inventoryagentimpl.MockModule(),
+			))
+
+			provides := newLogsAgent(deps)
+
+			assert.IsType(suite.T(), test.expected, provides.FlareProvider.Provider)
 		})
 	}
 }


### PR DESCRIPTION

### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/22010 introduced a Flare provider for logs but this provider is `nil` when the Logs Agent is disabled. This leads to a segfault because the [flare code](https://github.com/DataDog/datadog-agent/blob/2f1f3a8ca2b53439343d7fb27a1fed623841f8c8/comp/core/flare/flare.go#L130) is not expecting a `nil` provider

### Motivation

Fix a bug caught by e2e tests

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
