### PR TITLE
usm: http2: Refactor dynamic table

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-common.h
@@ -57,7 +57,8 @@ static __always_inline http2_stream_t *http2_fetch_stream(const http2_stream_key
 
 // get_dynamic_counter returns the current dynamic counter by the conn tuple.
 static __always_inline __u64 *get_dynamic_counter(conn_tuple_t *tup) {
-    __u64 counter = 0;
+    // The dynamic table index starts from 62, and we need to add 1 to the counter to match the index.
+    const __u64 counter = MAX_STATIC_TABLE_INDEX + 1;
     bpf_map_update_elem(&http2_dynamic_counter_table, tup, &counter, BPF_NOEXIST);
     return bpf_map_lookup_elem(&http2_dynamic_counter_table, tup);
 }

--- a/pkg/network/ebpf/c/protocols/http2/decoding-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-common.h
@@ -50,19 +50,13 @@ static __always_inline bool is_static_table_entry(const __u64 index) {
 }
 
 // http2_fetch_stream returns the current http2 in flight stream.
-static __always_inline http2_stream_t *http2_fetch_stream(const http2_stream_key_t *http2_stream_key) {
+static __always_inline http2_stream_t *http2_fetch_stream(const http2_stream_key_t *http2_stream_key, http2_stream_t *base) {
     http2_stream_t *http2_stream_ptr = bpf_map_lookup_elem(&http2_in_flight, http2_stream_key);
     if (http2_stream_ptr != NULL) {
         return http2_stream_ptr;
     }
 
-    const __u32 zero = 0;
-    http2_stream_ptr = bpf_map_lookup_elem(&http2_stream_heap, &zero);
-    if (http2_stream_ptr == NULL) {
-        return NULL;
-    }
-    bpf_memset(http2_stream_ptr, 0, sizeof(http2_stream_t));
-    bpf_map_update_elem(&http2_in_flight, http2_stream_key, http2_stream_ptr, BPF_NOEXIST);
+    bpf_map_update_elem(&http2_in_flight, http2_stream_key, base, BPF_NOEXIST);
     return bpf_map_lookup_elem(&http2_in_flight, http2_stream_key);
 }
 

--- a/pkg/network/ebpf/c/protocols/http2/decoding-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-common.h
@@ -27,6 +27,17 @@ static __always_inline bool is_status_index(const __u64 index) {
     return k200 <= index && index <= k500;
 }
 
+// Returns kHeaderMethod if the given index represents a method index, kHeaderPath if the given index represents a path
+// index, and kHeaderStatus if the given index represents a status index, and kHeaderUnknown otherwise.
+static __always_inline interesting_header_type_t get_header_type(const __u64 index) {
+    // each method (is_status, is_path, and is_method) returns 1 if the index is relevant to the header type, and 0
+    // otherwise. The values of the enum interesting_header_type_t are multiplication of 2, so we can form the following
+    // calculation to get the relevant header type.
+    return kHeaderStatus * is_status_index(index) +
+           kHeaderPath * is_path_index(index) +
+           kHeaderMethod * is_method_index(index);
+}
+
 // returns true if the given index is one of the relevant headers we care for in the static table.
 // The full table can be found in the user mode code `createStaticTable`.
 static __always_inline bool is_interesting_static_entry(const __u64 index) {

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -160,6 +160,7 @@ typedef struct {
     interesting_value_t request_method;
     interesting_value_t path;
     bool request_end_of_stream;
+    bool conn_tuple_flipped;
 } http2_stream_t;
 
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -159,22 +159,11 @@ typedef struct {
     bool temporary;
 } interesting_value_t;
 
-// If the path is huffman encoded then the length is 2, but if it is not, then the length is 3.
-#define HTTP2_STATUS_CODE_MAX_LEN 3
-
-typedef struct {
-    __u8 raw_buffer[HTTP2_STATUS_CODE_MAX_LEN];
-    bool is_huffman_encoded;
-
-    __u8 static_table_entry;
-    bool finalized;
-} status_code_t;
-
 typedef struct {
     __u64 response_last_seen;
     __u64 request_started;
 
-    status_code_t status_code;
+    interesting_value_t status_code;
     interesting_value_t request_method;
     interesting_value_t path;
     bool request_end_of_stream;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -130,6 +130,25 @@ typedef struct {
     conn_tuple_t tup;
 } dynamic_table_index_t;
 
+// The struct represents a dynamic-table value being sent to the user mode.
+typedef struct {
+    // The key of the dynamic table value. Contains a connection tuple and the index.
+    dynamic_table_index_t key;
+    // The type of the header (method, path, status).
+    interesting_header_type_t type;
+    // This boolean is used to mark the entry as temporary, which means the value came from Literal Header Field
+    // Without Indexing or Literal Header Field Never Indexed, in opposed to regular Literal Headers.
+    bool temporary;
+    // Whether the value is huffman encoded or passed as is.
+    bool is_huffman_encoded;
+    // The length of the value.
+    __u8 string_len;
+    // The raw buffer of the value. We need to use the max size among all dynamic table options. We care for path,
+    // method, and status. Path is the only value that does not have known "options", and can be very long, thus we use
+    // its max path.
+    char buf[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
+} dynamic_table_value_t;
+
 typedef struct {
     conn_tuple_t tup;
     __u32 stream_id;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -202,7 +202,6 @@ typedef struct {
 } http2_event_t;
 
 typedef struct {
-    dynamic_table_index_t dynamic_index;
     http2_stream_key_t http2_stream_key;
 } http2_ctx_t;
 

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -154,6 +154,11 @@ typedef struct {
     __u32 stream_id;
 } http2_stream_key_t;
 
+typedef struct {
+    __u64 index;
+    bool temporary;
+} interesting_value_t;
+
 // If the path is huffman encoded then the length is 2, but if it is not, then the length is 3.
 #define HTTP2_STATUS_CODE_MAX_LEN 3
 

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -119,13 +119,6 @@ typedef enum {
 } __attribute__((packed)) interesting_header_type_t;
 
 typedef struct {
-    char buffer[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
-    __u32 original_index;
-    __u8 string_len;
-    bool is_huffman_encoded;
-} dynamic_table_entry_t;
-
-typedef struct {
     __u64 index;
     conn_tuple_t tup;
 } dynamic_table_index_t;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -201,10 +201,6 @@ typedef struct {
     http2_stream_t stream;
 } http2_event_t;
 
-typedef struct {
-    http2_stream_key_t http2_stream_key;
-} http2_ctx_t;
-
 typedef enum {
     kStaticHeader = 0,
     kExistingDynamicHeader = 1,

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -171,21 +171,12 @@ typedef struct {
 } status_code_t;
 
 typedef struct {
-    __u8 raw_buffer[HTTP2_MAX_PATH_LEN];
-    bool is_huffman_encoded;
-
-    __u8 static_table_entry;
-    __u8 length;
-    bool finalized;
-} path_t;
-
-typedef struct {
     __u64 response_last_seen;
     __u64 request_started;
 
     status_code_t status_code;
     interesting_value_t request_method;
-    path_t path;
+    interesting_value_t path;
     bool request_end_of_stream;
 } http2_stream_t;
 

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -108,6 +108,16 @@ typedef enum {
     __MAX_STATIC_TABLE_INDEX = 255,
 } __attribute__((packed)) static_table_value_t;
 
+// The enum represents the different types of interesting headers we look for.
+typedef enum {
+    kHeaderUnknown = 0,
+    kHeaderMethod = 1 << 0, // 1
+    kHeaderPath = 1 << 1, // 2
+    kHeaderStatus = 1 << 2, // 4
+
+    __MAX_INTERESTING_HEADER_TYPE = 255,
+} __attribute__((packed)) interesting_header_type_t;
+
 typedef struct {
     char buffer[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
     __u32 original_index;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -162,9 +162,6 @@ typedef struct {
 // If the path is huffman encoded then the length is 2, but if it is not, then the length is 3.
 #define HTTP2_STATUS_CODE_MAX_LEN 3
 
-// Max length of the method is 7.
-#define HTTP2_METHOD_MAX_LEN 7
-
 typedef struct {
     __u8 raw_buffer[HTTP2_STATUS_CODE_MAX_LEN];
     bool is_huffman_encoded;
@@ -172,15 +169,6 @@ typedef struct {
     __u8 static_table_entry;
     bool finalized;
 } status_code_t;
-
-typedef struct {
-    __u8 raw_buffer[HTTP2_METHOD_MAX_LEN];
-    bool is_huffman_encoded;
-
-    __u8 static_table_entry;
-    __u8 length;
-    bool finalized;
-} method_t;
 
 typedef struct {
     __u8 raw_buffer[HTTP2_MAX_PATH_LEN];
@@ -196,7 +184,7 @@ typedef struct {
     __u64 request_started;
 
     status_code_t status_code;
-    method_t request_method;
+    interesting_value_t request_method;
     path_t path;
     bool request_end_of_stream;
 } http2_stream_t;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -791,7 +791,8 @@ int uprobe__http2_tls_headers_parser(struct pt_regs *ctx) {
 
     bpf_memset(http2_stream_key, 0, sizeof(http2_stream_key_t));
     http2_stream_key->tup = dispatcher_args_copy.tup;
-    normalize_tuple(&http2_stream_key->tup);
+    http2_stream_t base_stream = {0};
+    base_stream.conn_tuple_flipped = normalize_tuple(&http2_stream_key->tup);
 
     http2_stream_t *current_stream = NULL;
 
@@ -812,7 +813,7 @@ int uprobe__http2_tls_headers_parser(struct pt_regs *ctx) {
         }
 
         http2_stream_key->stream_id = current_frame.frame.stream_id;
-        current_stream = http2_fetch_stream(http2_stream_key);
+        current_stream = http2_fetch_stream(http2_stream_key, &base_stream);
         if (current_stream == NULL) {
             continue;
         }
@@ -877,7 +878,8 @@ int uprobe__http2_tls_eos_parser(struct pt_regs *ctx) {
     }
     bpf_memset(http2_stream_key, 0, sizeof(http2_stream_key_t));
     http2_stream_key->tup = dispatcher_args_copy.tup;
-    normalize_tuple(&http2_stream_key->tup);
+    http2_stream_t base_stream = {0};
+    base_stream.conn_tuple_flipped = normalize_tuple(&http2_stream_key->tup);
 
     bool is_rst = false, is_end_of_stream = false;
     http2_stream_t *current_stream = NULL;
@@ -902,7 +904,7 @@ int uprobe__http2_tls_eos_parser(struct pt_regs *ctx) {
         }
 
         http2_stream_key->stream_id = current_frame.frame.stream_id;
-        current_stream = http2_fetch_stream(http2_stream_key);
+        current_stream = http2_fetch_stream(http2_stream_key, &base_stream);
         if (current_stream == NULL) {
             continue;
         }

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -298,7 +298,7 @@ static __always_inline __u8 tls_filter_relevant_headers(tls_dispatcher_arguments
 
 // tls_process_headers processes the headers that were filtered in
 // tls_filter_relevant_headers, looking for requests path, status code, and method.
-static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatcher_arguments_t *info, dynamic_table_index_t *dynamic_index, dynamic_table_value_t *dynamic_table_value, http2_stream_t *current_stream, http2_header_t *headers_to_process, __u8 interesting_headers, http2_telemetry_t *http2_tel) {
+static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatcher_arguments_t *info, dynamic_table_value_t *dynamic_table_value, http2_stream_t *current_stream, http2_header_t *headers_to_process, __u8 interesting_headers, http2_telemetry_t *http2_tel) {
     u32 cpu = bpf_get_smp_processor_id();
     http2_header_t *current_header;
     dynamic_table_entry_t dynamic_value = {};
@@ -329,9 +329,9 @@ static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatc
             continue;
         }
 
-        dynamic_index->index = current_header->index;
+        dynamic_table_value->key.index = current_header->index;
         if (current_header->type == kExistingDynamicHeader) {
-            dynamic_table_entry_t *dynamic_value = bpf_map_lookup_elem(&http2_dynamic_table, dynamic_index);
+            dynamic_table_entry_t *dynamic_value = bpf_map_lookup_elem(&http2_dynamic_table, &dynamic_table_value->key);
             if (dynamic_value == NULL) {
                 break;
             }
@@ -359,7 +359,7 @@ static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatc
                 dynamic_value.string_len = current_header->new_dynamic_value_size;
                 dynamic_value.is_huffman_encoded = current_header->is_huffman_encoded;
                 dynamic_value.original_index = current_header->original_index;
-                bpf_map_update_elem(&http2_dynamic_table, dynamic_index, &dynamic_value, BPF_ANY);
+                bpf_map_update_elem(&http2_dynamic_table, &dynamic_table_value->key, &dynamic_value, BPF_ANY);
             }
             dynamic_table_value->type = get_header_type(current_header->original_index);
             dynamic_table_value->temporary = current_header->type != kNewDynamicHeader;
@@ -386,7 +386,6 @@ static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatc
             }
 
             // Send dynamic value over a per-event to the user mode.
-            dynamic_table_value->key.index = current_header->index;
             dynamic_table_value->string_len = current_header->new_dynamic_value_size;
             dynamic_table_value->is_huffman_encoded = current_header->is_huffman_encoded;
             bpf_memcpy(dynamic_table_value->buf, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
@@ -395,7 +394,7 @@ static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatc
     }
 }
 
-static __always_inline void tls_process_headers_frame(struct pt_regs *ctx, tls_dispatcher_arguments_t *info, http2_stream_t *current_stream, dynamic_table_index_t *dynamic_index, dynamic_table_value_t *dynamic_table_value, http2_frame_t *current_frame_header, http2_telemetry_t *http2_tel) {
+static __always_inline void tls_process_headers_frame(struct pt_regs *ctx, tls_dispatcher_arguments_t *info, http2_stream_t *current_stream, dynamic_table_value_t *dynamic_table_value, http2_frame_t *current_frame_header, http2_telemetry_t *http2_tel) {
     const __u32 zero = 0;
 
     // Allocating an array of headers, to hold all interesting headers from the frame.
@@ -405,8 +404,8 @@ static __always_inline void tls_process_headers_frame(struct pt_regs *ctx, tls_d
     }
     bpf_memset(headers_to_process, 0, HTTP2_MAX_HEADERS_COUNT_FOR_PROCESSING * sizeof(http2_header_t));
 
-    __u8 interesting_headers = tls_filter_relevant_headers(info, dynamic_index, headers_to_process, current_frame_header->length, http2_tel);
-    tls_process_headers(ctx, info, dynamic_index, dynamic_table_value, current_stream, headers_to_process, interesting_headers, http2_tel);
+    __u8 interesting_headers = tls_filter_relevant_headers(info, &dynamic_table_value->key, headers_to_process, current_frame_header->length, http2_tel);
+    tls_process_headers(ctx, info, dynamic_table_value, current_stream, headers_to_process, interesting_headers, http2_tel);
 }
 
 // tls_skip_preface is a helper function to check for the HTTP2 magic sent at the beginning
@@ -812,7 +811,6 @@ int uprobe__http2_tls_headers_parser(struct pt_regs *ctx) {
     bpf_memset(http2_ctx, 0, sizeof(http2_ctx_t));
     http2_ctx->http2_stream_key.tup = dispatcher_args_copy.tup;
     normalize_tuple(&http2_ctx->http2_stream_key.tup);
-    http2_ctx->dynamic_index.tup = dispatcher_args_copy.tup;
 
     http2_stream_t *current_stream = NULL;
 
@@ -838,7 +836,7 @@ int uprobe__http2_tls_headers_parser(struct pt_regs *ctx) {
             continue;
         }
         dispatcher_args_copy.data_off = current_frame.offset;
-        tls_process_headers_frame(ctx, &dispatcher_args_copy, current_stream, &http2_ctx->dynamic_index, dynamic_table_value, &current_frame.frame, http2_tel);
+        tls_process_headers_frame(ctx, &dispatcher_args_copy, current_stream, dynamic_table_value, &current_frame.frame, http2_tel);
     }
 
     if (tail_call_state->iteration < HTTP2_MAX_FRAMES_ITERATIONS &&

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -318,8 +318,7 @@ static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatc
                 current_stream->request_method.index = current_header->index;
                 __sync_fetch_and_add(&http2_tel->request_seen, 1);
             } else if (is_status_index(current_header->index)) {
-                current_stream->status_code.static_table_entry = current_header->index;
-                current_stream->status_code.finalized = true;
+                current_stream->status_code.index = current_header->index;
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
             } else if (is_path_index(current_header->index)) {
                 current_stream->path.index = current_header->index;
@@ -336,9 +335,7 @@ static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatc
             if (is_path_index(dynamic_value->original_index)) {
                 current_stream->path.index = current_header->index;
             } else if (is_status_index(dynamic_value->original_index)) {
-                bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value->buffer, HTTP2_STATUS_CODE_MAX_LEN);
-                current_stream->status_code.is_huffman_encoded = dynamic_value->is_huffman_encoded;
-                current_stream->status_code.finalized = true;
+                current_stream->status_code.index = current_header->index;
             } else if (is_method_index(dynamic_value->original_index)) {
                 current_stream->request_started = bpf_ktime_get_ns();
                 current_stream->request_method.index = current_header->index;
@@ -364,9 +361,8 @@ static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatc
                 current_stream->path.index = dynamic_table_value->key.index;
                 current_stream->path.temporary = dynamic_table_value->temporary;
             } else if (dynamic_table_value->type == kHeaderStatus) {
-                bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value.buffer, HTTP2_STATUS_CODE_MAX_LEN);
-                current_stream->status_code.is_huffman_encoded = current_header->is_huffman_encoded;
-                current_stream->status_code.finalized = true;
+                current_stream->status_code.index = dynamic_table_value->key.index;
+                current_stream->status_code.temporary = dynamic_table_value->temporary;
             } else {
                 current_stream->request_started = bpf_ktime_get_ns();
                 current_stream->request_method.index = dynamic_table_value->key.index;
@@ -916,7 +912,7 @@ int uprobe__http2_tls_eos_parser(struct pt_regs *ctx) {
         // When we accept an RST, it means that the current stream is terminated.
         // See: https://datatracker.ietf.org/doc/html/rfc7540#section-6.4
         // If rst, and stream is empty (no status code, or no response) then delete from inflight
-        if (is_rst && (!current_stream->status_code.finalized || current_stream->request_started == 0)) {
+        if (is_rst && (current_stream->status_code.index == 0 || current_stream->request_started == 0)) {
             bpf_map_delete_elem(&http2_in_flight, http2_stream_key);
             continue;
         }

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -298,7 +298,8 @@ static __always_inline __u8 tls_filter_relevant_headers(tls_dispatcher_arguments
 
 // tls_process_headers processes the headers that were filtered in
 // tls_filter_relevant_headers, looking for requests path, status code, and method.
-static __always_inline void tls_process_headers(tls_dispatcher_arguments_t *info, dynamic_table_index_t *dynamic_index, http2_stream_t *current_stream, http2_header_t *headers_to_process, __u8 interesting_headers, http2_telemetry_t *http2_tel) {
+static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatcher_arguments_t *info, dynamic_table_index_t *dynamic_index, dynamic_table_value_t *dynamic_table_value, http2_stream_t *current_stream, http2_header_t *headers_to_process, __u8 interesting_headers, http2_telemetry_t *http2_tel) {
+    u32 cpu = bpf_get_smp_processor_id();
     http2_header_t *current_header;
     dynamic_table_entry_t dynamic_value = {};
 
@@ -360,27 +361,41 @@ static __always_inline void tls_process_headers(tls_dispatcher_arguments_t *info
                 dynamic_value.original_index = current_header->original_index;
                 bpf_map_update_elem(&http2_dynamic_table, dynamic_index, &dynamic_value, BPF_ANY);
             }
-            if (is_path_index(current_header->original_index)) {
+            dynamic_table_value->type = get_header_type(current_header->original_index);
+            dynamic_table_value->temporary = current_header->type != kNewDynamicHeader;
+            dynamic_table_value->key.index = current_header->index;
+            if (dynamic_table_value->temporary) {
+                // If the key is temporary, we need to have a unique index, thus taking the current time.
+                dynamic_table_value->key.index = bpf_ktime_get_ns();
+            }
+            if (dynamic_table_value->type == kHeaderPath) {
                 current_stream->path.length = current_header->new_dynamic_value_size;
                 current_stream->path.is_huffman_encoded = current_header->is_huffman_encoded;
                 current_stream->path.finalized = true;
                 bpf_memcpy(current_stream->path.raw_buffer, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
-            } else if (is_status_index(current_header->original_index)) {
+            } else if (dynamic_table_value->type == kHeaderStatus) {
                 bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value.buffer, HTTP2_STATUS_CODE_MAX_LEN);
                 current_stream->status_code.is_huffman_encoded = current_header->is_huffman_encoded;
                 current_stream->status_code.finalized = true;
-            } else if (is_method_index(current_header->original_index)) {
+            } else {
                 current_stream->request_started = bpf_ktime_get_ns();
                 bpf_memcpy(current_stream->request_method.raw_buffer, dynamic_value.buffer, HTTP2_METHOD_MAX_LEN);
                 current_stream->request_method.is_huffman_encoded = current_header->is_huffman_encoded;
                 current_stream->request_method.length = current_header->new_dynamic_value_size;
                 current_stream->request_method.finalized = true;
             }
+
+            // Send dynamic value over a per-event to the user mode.
+            dynamic_table_value->key.index = current_header->index;
+            dynamic_table_value->string_len = current_header->new_dynamic_value_size;
+            dynamic_table_value->is_huffman_encoded = current_header->is_huffman_encoded;
+            bpf_memcpy(dynamic_table_value->buf, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
+            bpf_perf_event_output(ctx, &http2_dynamic_table_perf_buffer, cpu, dynamic_table_value, sizeof(dynamic_table_value_t));
         }
     }
 }
 
-static __always_inline void tls_process_headers_frame(tls_dispatcher_arguments_t *info, http2_stream_t *current_stream, dynamic_table_index_t *dynamic_index, http2_frame_t *current_frame_header, http2_telemetry_t *http2_tel) {
+static __always_inline void tls_process_headers_frame(struct pt_regs *ctx, tls_dispatcher_arguments_t *info, http2_stream_t *current_stream, dynamic_table_index_t *dynamic_index, dynamic_table_value_t *dynamic_table_value, http2_frame_t *current_frame_header, http2_telemetry_t *http2_tel) {
     const __u32 zero = 0;
 
     // Allocating an array of headers, to hold all interesting headers from the frame.
@@ -391,7 +406,7 @@ static __always_inline void tls_process_headers_frame(tls_dispatcher_arguments_t
     bpf_memset(headers_to_process, 0, HTTP2_MAX_HEADERS_COUNT_FOR_PROCESSING * sizeof(http2_header_t));
 
     __u8 interesting_headers = tls_filter_relevant_headers(info, dynamic_index, headers_to_process, current_frame_header->length, http2_tel);
-    tls_process_headers(info, dynamic_index, current_stream, headers_to_process, interesting_headers, http2_tel);
+    tls_process_headers(ctx, info, dynamic_index, dynamic_table_value, current_stream, headers_to_process, interesting_headers, http2_tel);
 }
 
 // tls_skip_preface is a helper function to check for the HTTP2 magic sent at the beginning
@@ -784,6 +799,12 @@ int uprobe__http2_tls_headers_parser(struct pt_regs *ctx) {
         goto delete_iteration;
     }
 
+    dynamic_table_value_t *dynamic_table_value = bpf_map_lookup_elem(&http2_dynamic_table_heap, &zero);
+    if (dynamic_table_value == NULL) {
+        goto delete_iteration;
+    }
+    dynamic_table_value->key.tup = dispatcher_args_copy.tup;
+
     http2_frame_with_offset *frames_array = tail_call_state->frames_array;
     http2_frame_with_offset current_frame;
 
@@ -817,7 +838,7 @@ int uprobe__http2_tls_headers_parser(struct pt_regs *ctx) {
             continue;
         }
         dispatcher_args_copy.data_off = current_frame.offset;
-        tls_process_headers_frame(&dispatcher_args_copy, current_stream, &http2_ctx->dynamic_index, &current_frame.frame, http2_tel);
+        tls_process_headers_frame(ctx, &dispatcher_args_copy, current_stream, &http2_ctx->dynamic_index, dynamic_table_value, &current_frame.frame, http2_tel);
     }
 
     if (tail_call_state->iteration < HTTP2_MAX_FRAMES_ITERATIONS &&

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -301,7 +301,6 @@ static __always_inline __u8 tls_filter_relevant_headers(tls_dispatcher_arguments
 static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatcher_arguments_t *info, dynamic_table_value_t *dynamic_table_value, http2_stream_t *current_stream, http2_header_t *headers_to_process, __u8 interesting_headers, http2_telemetry_t *http2_tel) {
     u32 cpu = bpf_get_smp_processor_id();
     http2_header_t *current_header;
-    dynamic_table_entry_t dynamic_value = {};
 
 #pragma unroll(HTTP2_MAX_HEADERS_COUNT_FOR_PROCESSING)
     for (__u8 iteration = 0; iteration < HTTP2_MAX_HEADERS_COUNT_FOR_PROCESSING; ++iteration) {
@@ -328,30 +327,23 @@ static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatc
 
         dynamic_table_value->key.index = current_header->index;
         if (current_header->type == kExistingDynamicHeader) {
-            dynamic_table_entry_t *dynamic_value = bpf_map_lookup_elem(&http2_dynamic_table, &dynamic_table_value->key);
-            if (dynamic_value == NULL) {
+            interesting_header_type_t *type = bpf_map_lookup_elem(&http2_dynamic_table, &dynamic_table_value->key);
+            if (type == NULL) {
                 break;
             }
-            if (is_path_index(dynamic_value->original_index)) {
+            if (*type == kHeaderPath) {
                 current_stream->path.index = current_header->index;
-            } else if (is_status_index(dynamic_value->original_index)) {
+            } else if (*type == kHeaderStatus) {
                 current_stream->status_code.index = current_header->index;
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
-            } else if (is_method_index(dynamic_value->original_index)) {
+            } else {
                 current_stream->request_started = bpf_ktime_get_ns();
                 current_stream->request_method.index = current_header->index;
                 __sync_fetch_and_add(&http2_tel->request_seen, 1);
             }
         } else {
             // We're in new dynamic header or new dynamic header not indexed states.
-            read_into_user_buffer_http2_path(dynamic_value.buffer, info->buffer_ptr + current_header->new_dynamic_value_offset);
-            // If the value is indexed - add it to the dynamic table.
-            if (current_header->type == kNewDynamicHeader) {
-                dynamic_value.string_len = current_header->new_dynamic_value_size;
-                dynamic_value.is_huffman_encoded = current_header->is_huffman_encoded;
-                dynamic_value.original_index = current_header->original_index;
-                bpf_map_update_elem(&http2_dynamic_table, &dynamic_table_value->key, &dynamic_value, BPF_ANY);
-            }
+            read_into_user_buffer_http2_path(dynamic_table_value->buf, info->buffer_ptr + current_header->new_dynamic_value_offset);
             dynamic_table_value->type = get_header_type(current_header->original_index);
             dynamic_table_value->temporary = current_header->type != kNewDynamicHeader;
             dynamic_table_value->key.index = current_header->index;
@@ -376,8 +368,10 @@ static __always_inline void tls_process_headers(struct pt_regs *ctx, tls_dispatc
             // Send dynamic value over a per-event to the user mode.
             dynamic_table_value->string_len = current_header->new_dynamic_value_size;
             dynamic_table_value->is_huffman_encoded = current_header->is_huffman_encoded;
-            bpf_memcpy(dynamic_table_value->buf, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
             bpf_perf_event_output(ctx, &http2_dynamic_table_perf_buffer, cpu, dynamic_table_value, sizeof(dynamic_table_value_t));
+            if (!dynamic_table_value->temporary) {
+                bpf_map_update_elem(&http2_dynamic_table, &dynamic_table_value->key, &dynamic_table_value->type, BPF_ANY);
+            }
         }
     }
 }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -298,7 +298,6 @@ static __always_inline __u8 filter_relevant_headers(struct __sk_buff *skb, skb_i
 static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table_value_t *dynamic_table_value, http2_stream_t *current_stream, http2_header_t *headers_to_process, __u8 interesting_headers,  http2_telemetry_t *http2_tel) {
     u32 cpu = bpf_get_smp_processor_id();
     http2_header_t *current_header;
-    dynamic_table_entry_t dynamic_value = {};
 
 #pragma unroll(HTTP2_MAX_HEADERS_COUNT_FOR_PROCESSING)
     for (__u8 iteration = 0; iteration < HTTP2_MAX_HEADERS_COUNT_FOR_PROCESSING; ++iteration) {
@@ -325,30 +324,23 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
 
         dynamic_table_value->key.index = current_header->index;
         if (current_header->type == kExistingDynamicHeader) {
-            dynamic_table_entry_t *dynamic_value = bpf_map_lookup_elem(&http2_dynamic_table, &dynamic_table_value->key);
-            if (dynamic_value == NULL) {
+            interesting_header_type_t *type = bpf_map_lookup_elem(&http2_dynamic_table, &dynamic_table_value->key);
+            if (type == NULL) {
                 break;
             }
-            if (is_path_index(dynamic_value->original_index)) {
+            if (*type == kHeaderPath) {
                 current_stream->path.index = current_header->index;
-            } else if (is_status_index(dynamic_value->original_index)) {
+            } else if (*type == kHeaderStatus) {
                 current_stream->status_code.index = current_header->index;
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
-            }  else if (is_method_index(dynamic_value->original_index)) {
+            } else {
                 current_stream->request_started = bpf_ktime_get_ns();
                 current_stream->request_method.index = current_header->index;
                 __sync_fetch_and_add(&http2_tel->request_seen, 1);
             }
         } else {
             // create the new dynamic value which will be added to the internal table.
-            read_into_buffer_path(dynamic_value.buffer, skb, current_header->new_dynamic_value_offset);
-            // If the value is indexed - add it to the dynamic table.
-            if (current_header->type == kNewDynamicHeader) {
-                dynamic_value.string_len = current_header->new_dynamic_value_size;
-                dynamic_value.is_huffman_encoded = current_header->is_huffman_encoded;
-                dynamic_value.original_index = current_header->original_index;
-                bpf_map_update_elem(&http2_dynamic_table, &dynamic_table_value->key, &dynamic_value, BPF_ANY);
-            }
+            read_into_buffer_path(dynamic_table_value->buf, skb, current_header->new_dynamic_value_offset);
             dynamic_table_value->type = get_header_type(current_header->original_index);
             dynamic_table_value->temporary = current_header->type != kNewDynamicHeader;
             dynamic_table_value->key.index = current_header->index;
@@ -373,8 +365,10 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
             // Send dynamic value over a per-event to the user mode.
             dynamic_table_value->string_len = current_header->new_dynamic_value_size;
             dynamic_table_value->is_huffman_encoded = current_header->is_huffman_encoded;
-            bpf_memcpy(dynamic_table_value->buf, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
             bpf_perf_event_output(skb, &http2_dynamic_table_perf_buffer, cpu, dynamic_table_value, sizeof(dynamic_table_value_t));
+            if (!dynamic_table_value->temporary) {
+                bpf_map_update_elem(&http2_dynamic_table, &dynamic_table_value->key, &dynamic_table_value->type, BPF_ANY);
+            }
         }
     }
 }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -333,9 +333,11 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 current_stream->path.index = current_header->index;
             } else if (is_status_index(dynamic_value->original_index)) {
                 current_stream->status_code.index = current_header->index;
+                __sync_fetch_and_add(&http2_tel->response_seen, 1);
             }  else if (is_method_index(dynamic_value->original_index)) {
                 current_stream->request_started = bpf_ktime_get_ns();
                 current_stream->request_method.index = current_header->index;
+                __sync_fetch_and_add(&http2_tel->request_seen, 1);
             }
         } else {
             // create the new dynamic value which will be added to the internal table.
@@ -360,10 +362,12 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
             } else if (dynamic_table_value->type == kHeaderStatus) {
                 current_stream->status_code.index = dynamic_table_value->key.index;
                 current_stream->status_code.temporary = dynamic_table_value->temporary;
+                __sync_fetch_and_add(&http2_tel->response_seen, 1);
             } else {
                 current_stream->request_started = bpf_ktime_get_ns();
                 current_stream->request_method.index = dynamic_table_value->key.index;
                 current_stream->request_method.temporary = dynamic_table_value->temporary;
+                __sync_fetch_and_add(&http2_tel->request_seen, 1);
             }
 
             // Send dynamic value over a per-event to the user mode.

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -295,7 +295,8 @@ static __always_inline __u8 filter_relevant_headers(struct __sk_buff *skb, skb_i
 
 // process_headers processes the headers that were filtered in filter_relevant_headers,
 // looking for requests path, status code, and method.
-static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table_index_t *dynamic_index, http2_stream_t *current_stream, http2_header_t *headers_to_process, __u8 interesting_headers,  http2_telemetry_t *http2_tel) {
+static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table_index_t *dynamic_index, dynamic_table_value_t *dynamic_table_value, http2_stream_t *current_stream, http2_header_t *headers_to_process, __u8 interesting_headers,  http2_telemetry_t *http2_tel) {
+    u32 cpu = bpf_get_smp_processor_id();
     http2_header_t *current_header;
     dynamic_table_entry_t dynamic_value = {};
 
@@ -357,27 +358,41 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 dynamic_value.original_index = current_header->original_index;
                 bpf_map_update_elem(&http2_dynamic_table, dynamic_index, &dynamic_value, BPF_ANY);
             }
-            if (is_path_index(current_header->original_index)) {
+            dynamic_table_value->type = get_header_type(current_header->original_index);
+            dynamic_table_value->temporary = current_header->type != kNewDynamicHeader;
+            dynamic_table_value->key.index = current_header->index;
+            if (dynamic_table_value->temporary) {
+                // If the key is temporary, we need to have a unique index, thus taking the current time.
+                dynamic_table_value->key.index = bpf_ktime_get_ns();
+            }
+            if (dynamic_table_value->type == kHeaderPath) {
                 current_stream->path.length = current_header->new_dynamic_value_size;
                 current_stream->path.is_huffman_encoded = current_header->is_huffman_encoded;
                 current_stream->path.finalized = true;
                 bpf_memcpy(current_stream->path.raw_buffer, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
-            } else if (is_status_index(current_header->original_index)) {
+            } else if (dynamic_table_value->type == kHeaderStatus) {
                 bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value.buffer, HTTP2_STATUS_CODE_MAX_LEN);
                 current_stream->status_code.is_huffman_encoded = current_header->is_huffman_encoded;
                 current_stream->status_code.finalized = true;
-            } else if (is_method_index(current_header->original_index)) {
+            } else {
                 current_stream->request_started = bpf_ktime_get_ns();
                 bpf_memcpy(current_stream->request_method.raw_buffer, dynamic_value.buffer, HTTP2_METHOD_MAX_LEN);
                 current_stream->request_method.is_huffman_encoded = current_header->is_huffman_encoded;
                 current_stream->request_method.length = current_header->new_dynamic_value_size;
                 current_stream->request_method.finalized = true;
             }
+
+            // Send dynamic value over a per-event to the user mode.
+            dynamic_table_value->key.index = current_header->index;
+            dynamic_table_value->string_len = current_header->new_dynamic_value_size;
+            dynamic_table_value->is_huffman_encoded = current_header->is_huffman_encoded;
+            bpf_memcpy(dynamic_table_value->buf, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
+            bpf_perf_event_output(skb, &http2_dynamic_table_perf_buffer, cpu, dynamic_table_value, sizeof(dynamic_table_value_t));
         }
     }
 }
 
-static __always_inline void process_headers_frame(struct __sk_buff *skb, http2_stream_t *current_stream, skb_info_t *skb_info, conn_tuple_t *tup, dynamic_table_index_t *dynamic_index, http2_frame_t *current_frame_header, http2_telemetry_t *http2_tel) {
+static __always_inline void process_headers_frame(struct __sk_buff *skb, http2_stream_t *current_stream, skb_info_t *skb_info, conn_tuple_t *tup, dynamic_table_index_t *dynamic_index, dynamic_table_value_t *dynamic_table_value, http2_frame_t *current_frame_header, http2_telemetry_t *http2_tel) {
     const __u32 zero = 0;
 
     // Allocating an array of headers, to hold all interesting headers from the frame.
@@ -388,7 +403,7 @@ static __always_inline void process_headers_frame(struct __sk_buff *skb, http2_s
     bpf_memset(headers_to_process, 0, HTTP2_MAX_HEADERS_COUNT_FOR_PROCESSING * sizeof(http2_header_t));
 
     __u8 interesting_headers = filter_relevant_headers(skb, skb_info, tup, dynamic_index, headers_to_process, current_frame_header->length, http2_tel);
-    process_headers(skb, dynamic_index, current_stream, headers_to_process, interesting_headers, http2_tel);
+    process_headers(skb, dynamic_index, dynamic_table_value, current_stream, headers_to_process, interesting_headers, http2_tel);
 }
 
 // skip_preface is a helper function to check for the HTTP2 magic sent at the beginning
@@ -808,6 +823,12 @@ int socket__http2_headers_parser(struct __sk_buff *skb) {
         goto delete_iteration;
     }
 
+    dynamic_table_value_t *dynamic_table_value = bpf_map_lookup_elem(&http2_dynamic_table_heap, &zero);
+    if (dynamic_table_value == NULL) {
+        goto delete_iteration;
+    }
+    dynamic_table_value->key.tup = dispatcher_args_copy.tup;
+
     http2_frame_with_offset *frames_array = tail_call_state->frames_array;
     http2_frame_with_offset current_frame;
 
@@ -841,7 +862,7 @@ int socket__http2_headers_parser(struct __sk_buff *skb) {
             continue;
         }
         dispatcher_args_copy.skb_info.data_off = current_frame.offset;
-        process_headers_frame(skb, current_stream, &dispatcher_args_copy.skb_info, &dispatcher_args_copy.tup, &http2_ctx->dynamic_index, &current_frame.frame, http2_tel);
+        process_headers_frame(skb, current_stream, &dispatcher_args_copy.skb_info, &dispatcher_args_copy.tup, &http2_ctx->dynamic_index, dynamic_table_value, &current_frame.frame, http2_tel);
     }
 
     if (tail_call_state->iteration < HTTP2_MAX_FRAMES_ITERATIONS &&

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -312,8 +312,7 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
             if (is_method_index(current_header->index)) {
                 // TODO: mark request
                current_stream->request_started = bpf_ktime_get_ns();
-               current_stream->request_method.static_table_entry = current_header->index;
-               current_stream->request_method.finalized = true;
+               current_stream->request_method.index = current_header->index;
                 __sync_fetch_and_add(&http2_tel->request_seen, 1);
             } else if (is_status_index(current_header->index)) {
                 current_stream->status_code.static_table_entry = current_header->index;
@@ -343,10 +342,7 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 current_stream->status_code.finalized = true;
             }  else if (is_method_index(dynamic_value->original_index)) {
                 current_stream->request_started = bpf_ktime_get_ns();
-                bpf_memcpy(current_stream->request_method.raw_buffer, dynamic_value->buffer, HTTP2_METHOD_MAX_LEN);
-                current_stream->request_method.is_huffman_encoded = dynamic_value->is_huffman_encoded;
-                current_stream->request_method.length = current_header->new_dynamic_value_size;
-                current_stream->request_method.finalized = true;
+                current_stream->request_method.index = current_header->index;
             }
         } else {
             // create the new dynamic value which will be added to the internal table.
@@ -376,10 +372,8 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 current_stream->status_code.finalized = true;
             } else {
                 current_stream->request_started = bpf_ktime_get_ns();
-                bpf_memcpy(current_stream->request_method.raw_buffer, dynamic_value.buffer, HTTP2_METHOD_MAX_LEN);
-                current_stream->request_method.is_huffman_encoded = current_header->is_huffman_encoded;
-                current_stream->request_method.length = current_header->new_dynamic_value_size;
-                current_stream->request_method.finalized = true;
+                current_stream->request_method.index = dynamic_table_value->key.index;
+                current_stream->request_method.temporary = dynamic_table_value->temporary;
             }
 
             // Send dynamic value over a per-event to the user mode.

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -319,8 +319,7 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 current_stream->status_code.finalized = true;
                 __sync_fetch_and_add(&http2_tel->response_seen, 1);
             } else if (is_path_index(current_header->index)) {
-                current_stream->path.static_table_entry = current_header->index;
-                current_stream->path.finalized = true;
+                current_stream->path.index = current_header->index;
             }
             continue;
         }
@@ -332,10 +331,7 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 break;
             }
             if (is_path_index(dynamic_value->original_index)) {
-                current_stream->path.length = dynamic_value->string_len;
-                current_stream->path.is_huffman_encoded = dynamic_value->is_huffman_encoded;
-                current_stream->path.finalized = true;
-                bpf_memcpy(current_stream->path.raw_buffer, dynamic_value->buffer, HTTP2_MAX_PATH_LEN);
+                current_stream->path.index = current_header->index;
             } else if (is_status_index(dynamic_value->original_index)) {
                 bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value->buffer, HTTP2_STATUS_CODE_MAX_LEN);
                 current_stream->status_code.is_huffman_encoded = dynamic_value->is_huffman_encoded;
@@ -362,10 +358,8 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
                 dynamic_table_value->key.index = bpf_ktime_get_ns();
             }
             if (dynamic_table_value->type == kHeaderPath) {
-                current_stream->path.length = current_header->new_dynamic_value_size;
-                current_stream->path.is_huffman_encoded = current_header->is_huffman_encoded;
-                current_stream->path.finalized = true;
-                bpf_memcpy(current_stream->path.raw_buffer, dynamic_value.buffer, HTTP2_MAX_PATH_LEN);
+                current_stream->path.index = dynamic_table_value->key.index;
+                current_stream->path.temporary = dynamic_table_value->temporary;
             } else if (dynamic_table_value->type == kHeaderStatus) {
                 bpf_memcpy(current_stream->status_code.raw_buffer, dynamic_value.buffer, HTTP2_STATUS_CODE_MAX_LEN);
                 current_stream->status_code.is_huffman_encoded = current_header->is_huffman_encoded;

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -815,7 +815,8 @@ int socket__http2_headers_parser(struct __sk_buff *skb) {
 
     bpf_memset(http2_stream_key, 0, sizeof(http2_stream_key_t));
     http2_stream_key->tup = dispatcher_args_copy.tup;
-    normalize_tuple(&http2_stream_key->tup);
+    http2_stream_t base_stream = {0};
+    base_stream.conn_tuple_flipped = normalize_tuple(&http2_stream_key->tup);
 
     http2_stream_t *current_stream = NULL;
 
@@ -836,7 +837,7 @@ int socket__http2_headers_parser(struct __sk_buff *skb) {
         }
 
         http2_stream_key->stream_id = current_frame.frame.stream_id;
-        current_stream = http2_fetch_stream(http2_stream_key);
+        current_stream = http2_fetch_stream(http2_stream_key, &base_stream);
         if (current_stream == NULL) {
             continue;
         }
@@ -903,7 +904,8 @@ int socket__http2_eos_parser(struct __sk_buff *skb) {
     }
     bpf_memset(http2_stream_key, 0, sizeof(http2_stream_key_t));
     http2_stream_key->tup = dispatcher_args_copy.tup;
-    normalize_tuple(&http2_stream_key->tup);
+    http2_stream_t base_stream = {0};
+    base_stream.conn_tuple_flipped = normalize_tuple(&http2_stream_key->tup);
 
     bool is_rst = false, is_end_of_stream = false;
     http2_stream_t *current_stream = NULL;
@@ -928,7 +930,7 @@ int socket__http2_eos_parser(struct __sk_buff *skb) {
         }
 
         http2_stream_key->stream_id = current_frame.frame.stream_id;
-        current_stream = http2_fetch_stream(http2_stream_key);
+        current_stream = http2_fetch_stream(http2_stream_key, &base_stream);
         if (current_stream == NULL) {
             continue;
         }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -812,8 +812,8 @@ int socket__http2_headers_parser(struct __sk_buff *skb) {
     }
 
     const __u32 zero = 0;
-    http2_ctx_t *http2_ctx = bpf_map_lookup_elem(&http2_ctx_heap, &zero);
-    if (http2_ctx == NULL) {
+    http2_stream_key_t *http2_stream_key = bpf_map_lookup_elem(&http2_stream_key_heap, &zero);
+    if (http2_stream_key == NULL) {
         goto delete_iteration;
     }
 
@@ -831,10 +831,9 @@ int socket__http2_headers_parser(struct __sk_buff *skb) {
     http2_frame_with_offset *frames_array = tail_call_state->frames_array;
     http2_frame_with_offset current_frame;
 
-    // create the http2 ctx for the current http2 frame.
-    bpf_memset(http2_ctx, 0, sizeof(http2_ctx_t));
-    http2_ctx->http2_stream_key.tup = dispatcher_args_copy.tup;
-    normalize_tuple(&http2_ctx->http2_stream_key.tup);
+    bpf_memset(http2_stream_key, 0, sizeof(http2_stream_key_t));
+    http2_stream_key->tup = dispatcher_args_copy.tup;
+    normalize_tuple(&http2_stream_key->tup);
 
     http2_stream_t *current_stream = NULL;
 
@@ -854,8 +853,8 @@ int socket__http2_headers_parser(struct __sk_buff *skb) {
             continue;
         }
 
-        http2_ctx->http2_stream_key.stream_id = current_frame.frame.stream_id;
-        current_stream = http2_fetch_stream(&http2_ctx->http2_stream_key);
+        http2_stream_key->stream_id = current_frame.frame.stream_id;
+        current_stream = http2_fetch_stream(http2_stream_key);
         if (current_stream == NULL) {
             continue;
         }
@@ -916,13 +915,13 @@ int socket__http2_eos_parser(struct __sk_buff *skb) {
     http2_frame_with_offset *frames_array = tail_call_state->frames_array;
     http2_frame_with_offset current_frame;
 
-    http2_ctx_t *http2_ctx = bpf_map_lookup_elem(&http2_ctx_heap, &zero);
-    if (http2_ctx == NULL) {
+    http2_stream_key_t *http2_stream_key = bpf_map_lookup_elem(&http2_stream_key_heap, &zero);
+    if (http2_stream_key == NULL) {
         goto delete_iteration;
     }
-    bpf_memset(http2_ctx, 0, sizeof(http2_ctx_t));
-    http2_ctx->http2_stream_key.tup = dispatcher_args_copy.tup;
-    normalize_tuple(&http2_ctx->http2_stream_key.tup);
+    bpf_memset(http2_stream_key, 0, sizeof(http2_stream_key_t));
+    http2_stream_key->tup = dispatcher_args_copy.tup;
+    normalize_tuple(&http2_stream_key->tup);
 
     bool is_rst = false, is_end_of_stream = false;
     http2_stream_t *current_stream = NULL;
@@ -946,8 +945,8 @@ int socket__http2_eos_parser(struct __sk_buff *skb) {
             continue;
         }
 
-        http2_ctx->http2_stream_key.stream_id = current_frame.frame.stream_id;
-        current_stream = http2_fetch_stream(&http2_ctx->http2_stream_key);
+        http2_stream_key->stream_id = current_frame.frame.stream_id;
+        current_stream = http2_fetch_stream(http2_stream_key);
         if (current_stream == NULL) {
             continue;
         }
@@ -956,7 +955,7 @@ int socket__http2_eos_parser(struct __sk_buff *skb) {
         // See: https://datatracker.ietf.org/doc/html/rfc7540#section-6.4
         // If rst, and stream is empty (no status code, or no response) then delete from inflight
         if (is_rst && (!current_stream->status_code.finalized || current_stream->request_started == 0)) {
-            bpf_map_delete_elem(&http2_in_flight, &http2_ctx->http2_stream_key);
+            bpf_map_delete_elem(&http2_in_flight, http2_stream_key);
             continue;
         }
 
@@ -965,7 +964,7 @@ int socket__http2_eos_parser(struct __sk_buff *skb) {
         } else if ((current_frame.frame.flags & HTTP2_END_OF_STREAM) == HTTP2_END_OF_STREAM) {
             __sync_fetch_and_add(&http2_tel->end_of_stream, 1);
         }
-        handle_end_of_stream(current_stream, &http2_ctx->http2_stream_key, http2_tel);
+        handle_end_of_stream(current_stream, http2_stream_key, http2_tel);
     }
 
     if (tail_call_state->iteration < HTTP2_MAX_FRAMES_ITERATIONS &&

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -6,9 +6,8 @@
 // packet, to the current one.
 BPF_HASH_MAP(http2_remainder, conn_tuple_t, frame_header_remainder_t, 2048)
 
-/* http2_dynamic_table is the map that holding the supported dynamic values - the index is the static index and the
-   conn tuple and it is value is the buffer which contains the dynamic string. */
-BPF_HASH_MAP(http2_dynamic_table, dynamic_table_index_t, dynamic_table_entry_t, 0)
+// http2_dynamic_table maps a conn tuple and a dynamic index into the type (method, path, or status) of the header.
+BPF_HASH_MAP(http2_dynamic_table, dynamic_table_index_t, interesting_header_type_t, 0)
 
 /* http2_dynamic_counter_table is a map that holding the current dynamic values amount, in order to use for the
    internal calculation of the internal index in the http2_dynamic_table, it is hold by conn_tup to support different

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -40,8 +40,8 @@ BPF_PERCPU_ARRAY_MAP(http2_stream_heap, http2_stream_t, 1)
    enqueued. The primary motivation here is to save eBPF stack memory. */
 BPF_PERCPU_ARRAY_MAP(http2_scratch_buffer, http2_event_t, 1)
 
-/* Allocating a ctx on the heap, in order to save the ctx between the current stream. */
-BPF_PERCPU_ARRAY_MAP(http2_ctx_heap, http2_ctx_t, 1)
+// Allocating a stream_key on the heap to reduce stack pressure.
+BPF_PERCPU_ARRAY_MAP(http2_stream_key_heap, http2_stream_key_t, 1)
 
 /* This map is used for telemetry in kernelspace
  * only key 0 is used

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -32,9 +32,6 @@ BPF_PERCPU_ARRAY_MAP(http2_headers_to_process, http2_header_t[HTTP2_MAX_HEADERS_
 /* Allocating an array of frame, to hold all interesting frames from the packet. */
 BPF_PERCPU_ARRAY_MAP(http2_frames_to_process, http2_tail_call_state_t, 1)
 
-/* Allocating a stream on the heap, the stream is used to save the current stream info. */
-BPF_PERCPU_ARRAY_MAP(http2_stream_heap, http2_stream_t, 1)
-
 /* This map acts as a scratch buffer for "preparing" http2_event_t objects before they're
    enqueued. The primary motivation here is to save eBPF stack memory. */
 BPF_PERCPU_ARRAY_MAP(http2_scratch_buffer, http2_event_t, 1)

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -50,4 +50,10 @@ BPF_PERCPU_ARRAY_MAP(http2_ctx_heap, http2_ctx_t, 1)
 BPF_ARRAY_MAP(http2_telemetry, http2_telemetry_t, 1)
 BPF_ARRAY_MAP(tls_http2_telemetry, http2_telemetry_t, 1)
 
+// A map to hold the dynamic table values on the heap.
+BPF_PERCPU_ARRAY_MAP(http2_dynamic_table_heap, dynamic_table_value_t, 1)
+
+// A perf buffer to send dynamic table value to the user mode.
+BPF_PERF_EVENT_ARRAY_MAP(http2_dynamic_table_perf_buffer, __u32)
+
 #endif

--- a/pkg/network/protocols/http2/cyclic_map.go
+++ b/pkg/network/protocols/http2/cyclic_map.go
@@ -7,7 +7,10 @@
 
 package http2
 
-import "sync"
+import (
+	"slices"
+	"sync"
+)
 
 // CyclicMap represents a map with a fixed capacity circular map. When the map is full, adding a new element
 // will remove the oldest one.
@@ -34,7 +37,7 @@ type CyclicMap[K comparable, V any] struct {
 func NewCyclicMap[K comparable, V any](capacity int, onEvict func(key K, value V)) *CyclicMap[K, V] {
 	return &CyclicMap[K, V]{
 		capacity: capacity,
-		list:     make([]K, 0, capacity),
+		list:     make([]K, 0),
 		values:   make(map[K]V),
 		onEvict:  onEvict,
 	}
@@ -47,6 +50,7 @@ func (c *CyclicMap[K, V]) Add(key K, value V) {
 
 	// If the list is full, remove the currentElement
 	if c.len == c.capacity {
+		c.list = slices.Clip(c.list)
 		c.removeOldestNoLock()
 		c.list[c.head] = key
 	} else {

--- a/pkg/network/protocols/http2/dynamic_table.go
+++ b/pkg/network/protocols/http2/dynamic_table.go
@@ -206,10 +206,16 @@ func (dt *DynamicTable) setupDynamicTableMapCleaner(cfg *config.Config) error {
 func (dt *DynamicTable) handleNewDynamicTableEntry(val *http2DynamicTableValue) {
 	var err error
 	var dynamicValue string
-	if err := validatePathSize(val.String_len); err != nil {
-		log.Errorf("failed handling a new dynamic table entry: %s", err)
+
+	if val.String_len == 0 {
+		log.Error("failed handling a new dynamic table entry: got an empty value")
 		return
 	}
+	if val.String_len > maxHTTP2Path {
+		log.Errorf("failed handling a new dynamic table entry: value size (%d) has exceeded the maximum limit", val.String_len)
+		return
+	}
+
 	if val.Is_huffman_encoded {
 		dynamicValue, err = hpack.HuffmanDecodeToString(val.Buf[:val.String_len])
 		if err != nil {

--- a/pkg/network/protocols/http2/dynamic_table.go
+++ b/pkg/network/protocols/http2/dynamic_table.go
@@ -9,7 +9,15 @@ package http2
 
 import (
 	"fmt"
+	"math"
+	"os"
+	"slices"
 	"sync"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"go.uber.org/atomic"
+	"golang.org/x/net/http2/hpack"
 
 	manager "github.com/DataDog/ebpf-manager"
 
@@ -17,16 +25,45 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
 	terminatedConnectionsEventStream = "terminated_http2"
 
 	defaultMapCleanerBatchSize = 1024
+
+	// We want to ensure the user-mode dynamic table is slightly smaller than the kernel one, to ensure we'll never
+	// have a fully filled kernel map. When the user mode map will be full, we'll start evicting entries from the user
+	// mode map, and the kernel map will be updated accordingly. Thus, keeping a small buffer in the user mode map
+	// ensures we'll never fail to insert a new entry in the kernel map.
+	dynamicTableDefaultBufferFactor = 0.9
 )
 
 // DynamicTable encapsulates the management of the dynamic table in the user mode.
 type DynamicTable struct {
+	// wg is used to wait for the dynamic table to stop
+	wg sync.WaitGroup
+	// mux is used to protect the dynamic table from concurrent access
+	mux sync.RWMutex
+	// stopChannel is used to mark our main goroutine to stop
+	stopChannel chan struct{}
+	// perfHandler is the perf handler used to receive dynamic table entries from the kernel
+	perfHandler *ddebpf.PerfHandler
+	// kernelDynamicTableSize is the size of the eBPF dynamic table map
+	kernelDynamicTableSize int
+	// kernelDynamicTableMap is the eBPF dynamic table map
+	kernelDynamicTableMap *ebpf.Map
+	// userModeDynamicTableSize is the size of the dynamic table
+	userModeDynamicTableSize int
+	// datastore is the datastore used to store the dynamic table entries
+	datastore map[netebpf.ConnTuple]*CyclicMap[uint64, string]
+	// datastoreSize is the size of the datastore
+	datastoreSize atomic.Int64
+	// temporaryDatastore is the datastore used to store the dynamic table entries
+	temporaryDatastore map[netebpf.ConnTuple]*CyclicMap[uint64, string]
+	// temporaryDatastoreSize is the size of the temporaryDatastore
+	temporaryDatastoreSize atomic.Int64
 	// terminatedConnectionsEventsConsumer is the consumer used to receive terminated connections events from the kernel.
 	terminatedConnectionsEventsConsumer *events.Consumer[netebpf.ConnTuple]
 	// terminatedConnections is the list of terminated connections received from the kernel.
@@ -38,17 +75,56 @@ type DynamicTable struct {
 }
 
 // NewDynamicTable creates a new dynamic table.
-func NewDynamicTable() *DynamicTable {
-	return &DynamicTable{}
+func NewDynamicTable(dynamicTableSize int) *DynamicTable {
+	// We want to ensure the user-mode dynamic table is slightly smaller than the kernel one, to ensure we'll never
+	// have a fully filled kernel map. When the user mode map will be full, we'll start evicting entries from the user
+	// mode map, and the kernel map will be updated accordingly. Thus, keeping a small buffer in the user mode map
+	// ensures we'll never fail to insert a new entry in the kernel map.
+	return &DynamicTable{
+		kernelDynamicTableSize:   dynamicTableSize,
+		userModeDynamicTableSize: int(math.Ceil(float64(dynamicTableSize) * dynamicTableDefaultBufferFactor)),
+		perfHandler:              ddebpf.NewPerfHandler(dynamicTableSize),
+		stopChannel:              make(chan struct{}),
+		datastore:                make(map[netebpf.ConnTuple]*CyclicMap[uint64, string], 0),
+		temporaryDatastore:       make(map[netebpf.ConnTuple]*CyclicMap[uint64, string], 0),
+	}
 }
 
 // configureOptions configures the perf handler options for the map cleaner.
 func (dt *DynamicTable) configureOptions(mgr *manager.Manager, opts *manager.Options) {
 	events.Configure(terminatedConnectionsEventStream, mgr, opts)
+
+	if !slices.ContainsFunc(mgr.PerfMaps, func(p *manager.PerfMap) bool { return p.Map.Name == http2DynamicTablePerfBuffer }) {
+		mgr.PerfMaps = append(mgr.PerfMaps, &manager.PerfMap{
+			Map: manager.Map{Name: http2DynamicTablePerfBuffer},
+			PerfMapOptions: manager.PerfMapOptions{
+				PerfRingBufferSize: 16 * os.Getpagesize(),
+				Watermark:          1,
+				RecordHandler:      dt.perfHandler.RecordHandler,
+				LostHandler:        dt.perfHandler.LostHandler,
+				RecordGetter:       dt.perfHandler.RecordGetter,
+			},
+		})
+	}
+
+	opts.MapSpecEditors[dynamicTable] = manager.MapSpecEditor{
+		MaxEntries: uint32(dt.kernelDynamicTableSize),
+		EditorFlag: manager.EditMaxEntries,
+	}
+	opts.MapSpecEditors[dynamicTableCounter] = manager.MapSpecEditor{
+		MaxEntries: uint32(dt.kernelDynamicTableSize),
+		EditorFlag: manager.EditMaxEntries,
+	}
 }
 
 // preStart sets up the terminated connections events consumer.
 func (dt *DynamicTable) preStart(mgr *manager.Manager) (err error) {
+	dynamicTableMap, _, err := mgr.GetMap(dynamicTable)
+	if err != nil {
+		return fmt.Errorf("error getting %s map: %w", dynamicTable, err)
+	}
+	dt.kernelDynamicTableMap = dynamicTableMap
+
 	dt.terminatedConnectionsEventsConsumer, err = events.NewConsumer(
 		terminatedConnectionsEventStream,
 		mgr,
@@ -60,12 +136,12 @@ func (dt *DynamicTable) preStart(mgr *manager.Manager) (err error) {
 
 	dt.terminatedConnectionsEventsConsumer.Start()
 
-	return nil
+	return dt.launchPerfHandlerProcessor()
 }
 
 // postStart sets up the dynamic table map cleaner.
-func (dt *DynamicTable) postStart(mgr *manager.Manager, cfg *config.Config) error {
-	return dt.setupDynamicTableMapCleaner(mgr, cfg)
+func (dt *DynamicTable) postStart(_ *manager.Manager, cfg *config.Config) error {
+	return dt.setupDynamicTableMapCleaner(cfg)
 }
 
 // processTerminatedConnections processes the terminated connections received from the kernel.
@@ -76,13 +152,8 @@ func (dt *DynamicTable) processTerminatedConnections(events []netebpf.ConnTuple)
 }
 
 // setupDynamicTableMapCleaner sets up the map cleaner used to clear entries of terminated connections from the kernel map.
-func (dt *DynamicTable) setupDynamicTableMapCleaner(mgr *manager.Manager, cfg *config.Config) error {
-	dynamicTableMap, _, err := mgr.GetMap(dynamicTable)
-	if err != nil {
-		return fmt.Errorf("error getting http2 dynamic table map: %w", err)
-	}
-
-	mapCleaner, err := ddebpf.NewMapCleaner[HTTP2DynamicTableIndex, HTTP2DynamicTableEntry](dynamicTableMap, defaultMapCleanerBatchSize)
+func (dt *DynamicTable) setupDynamicTableMapCleaner(cfg *config.Config) error {
+	mapCleaner, err := ddebpf.NewMapCleaner[HTTP2DynamicTableIndex, HTTP2DynamicTableEntry](dt.kernelDynamicTableMap, defaultMapCleanerBatchSize)
 	if err != nil {
 		return fmt.Errorf("error creating a map cleaner for http2 dynamic table: %w", err)
 	}
@@ -101,6 +172,18 @@ func (dt *DynamicTable) setupDynamicTableMapCleaner(mgr *manager.Manager, cfg *c
 			return len(terminatedConnectionsMap) > 0
 		},
 		func() {
+			dt.mux.Lock()
+			for conn := range terminatedConnectionsMap {
+				if _, ok := dt.datastore[conn]; ok {
+					dt.datastoreSize.Sub(int64(dt.datastore[conn].Len()))
+					delete(dt.datastore, conn)
+				}
+				if _, ok := dt.temporaryDatastore[conn]; ok {
+					dt.temporaryDatastoreSize.Sub(int64(dt.temporaryDatastore[conn].Len()))
+					delete(dt.temporaryDatastore, conn)
+				}
+			}
+			dt.mux.Unlock()
 			terminatedConnectionsMap = make(map[netebpf.ConnTuple]struct{})
 		},
 		func(_ int64, key HTTP2DynamicTableIndex, _ HTTP2DynamicTableEntry) bool {
@@ -109,25 +192,132 @@ func (dt *DynamicTable) setupDynamicTableMapCleaner(mgr *manager.Manager, cfg *c
 				return true
 			}
 			// Checking the flipped tuple as well.
-			_, ok = terminatedConnectionsMap[netebpf.ConnTuple{
-				Saddr_h:  key.Tup.Daddr_h,
-				Saddr_l:  key.Tup.Daddr_l,
-				Daddr_h:  key.Tup.Saddr_h,
-				Daddr_l:  key.Tup.Saddr_l,
-				Sport:    key.Tup.Dport,
-				Dport:    key.Tup.Sport,
-				Netns:    key.Tup.Netns,
-				Pid:      key.Tup.Pid,
-				Metadata: key.Tup.Metadata,
-			}]
+			_, ok = terminatedConnectionsMap[flipTuple(key.Tup)]
 			return ok
 		})
 	dt.mapCleaner = mapCleaner
 	return nil
 }
 
+// handleNewDynamicTableEntry handles a new dynamic table entry received from the eBPF programs (socket filter or
+// uprobe). A new entry is added to the dynamic datastore if the value came from a Literal Header Field With Incremental
+// Indexing, and to the temporary datastore if the value came from a Literal Header Field Without Indexing or Literal
+// Header Field Never Indexed. If the value is Huffman encoded, it is decoded before being added to the datastores.
+func (dt *DynamicTable) handleNewDynamicTableEntry(val *http2DynamicTableValue) {
+	var err error
+	var dynamicValue string
+	if err := validatePathSize(val.String_len); err != nil {
+		log.Errorf("failed handling a new dynamic table entry: %s", err)
+		return
+	}
+	if val.Is_huffman_encoded {
+		dynamicValue, err = hpack.HuffmanDecodeToString(val.Buf[:val.String_len])
+		if err != nil {
+			log.Errorf("failed to decode huffman encoded string: %s", err)
+			return
+		}
+	} else {
+		dynamicValue = string(val.Buf[:val.String_len])
+	}
+
+	ds := dt.datastore
+	dsSize := dt.datastoreSize
+	kernelCleanup := func(val *HTTP2DynamicTableIndex) {
+		_ = dt.kernelDynamicTableMap.Delete(unsafe.Pointer(val))
+	}
+
+	if val.Temporary {
+		ds = dt.temporaryDatastore
+		dsSize = dt.temporaryDatastoreSize
+		// If the value is temporary and not indexed, then we don't need to clean the kernel map.
+		kernelCleanup = func(*HTTP2DynamicTableIndex) {}
+	}
+	// save to dynamic
+	dt.mux.Lock()
+	defer dt.mux.Unlock()
+	if _, ok := ds[val.Key.Tup]; !ok {
+		ds[val.Key.Tup] = NewCyclicMap[uint64, string](dt.userModeDynamicTableSize, func(idx uint64, _ string) {
+			kernelCleanup(&HTTP2DynamicTableIndex{Index: idx, Tup: val.Key.Tup})
+			dsSize.Dec()
+		})
+	}
+	// Check total length - if it's too long, we'll evict the oldest entry.
+	if dsSize.Load() >= int64(dt.userModeDynamicTableSize) {
+		maxCyclicMapSize := 0
+		var maxCyclicMap *CyclicMap[uint64, string]
+		for _, cyclicMap := range ds {
+			if cyclicMap.Len() > maxCyclicMapSize {
+				maxCyclicMapSize = cyclicMap.Len()
+				maxCyclicMap = cyclicMap
+			}
+		}
+		maxCyclicMap.RemoveOldest()
+	}
+
+	// Adding the new path to the dynamic table and the string.
+	// This may trigger an eviction in the LRU datastore, and maybe remove the evicted entry from the kernel map.
+	ds[val.Key.Tup].Add(val.Key.Index, dynamicValue)
+	dsSize.Inc()
+}
+
+// launchPerfHandlerProcessor starts the perf handler used to receive new paths from the kernel.
+func (dt *DynamicTable) launchPerfHandlerProcessor() error {
+	dt.wg.Add(1)
+	go func() {
+		defer dt.wg.Done()
+		for {
+			select {
+			case <-dt.stopChannel:
+				return
+			case data, ok := <-dt.perfHandler.DataChannel:
+				if !ok {
+					return
+				}
+				dt.handleNewDynamicTableEntry((*http2DynamicTableValue)(unsafe.Pointer(&data.Data[0])))
+				data.Done()
+			case _, ok := <-dt.perfHandler.LostChannel:
+				if !ok {
+					return
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// resolveValue resolves the value of the dynamic table for a given connection tuple and index and a temporary flag.
+// If the temporary flag is set, the value will be resolved from the temporary datastore, otherwise it will be resolved
+// from the datastore. The temporary datastore is used to store the values that are either Literal Header Field Without
+// Indexing or Literal Header Field Never Indexed, and the datastore is used to store the values that are Literal
+// Header Field With Incremental Indexing.
+func (dt *DynamicTable) resolveValue(connTuple netebpf.ConnTuple, index uint64, temporary bool) (string, bool) {
+	dt.mux.RLock()
+	defer dt.mux.RUnlock()
+
+	if temporary {
+		cyclicMap, ok := dt.temporaryDatastore[connTuple]
+		if ok {
+			value, ok := cyclicMap.Pop(index)
+			if ok {
+				dt.temporaryDatastoreSize.Dec()
+				return value, ok
+			}
+		}
+	} else {
+		cyclicMap, ok := dt.datastore[connTuple]
+		if ok {
+			return cyclicMap.Get(index)
+		}
+	}
+	return "", false
+}
+
 // stop stops all the goroutines used by the dynamic table.
 func (dt *DynamicTable) stop() {
+	close(dt.stopChannel)
+	dt.wg.Wait()
+
 	dt.mapCleaner.Stop()
 
 	if dt.terminatedConnectionsEventsConsumer != nil {

--- a/pkg/network/protocols/http2/incomplete_stats_test.go
+++ b/pkg/network/protocols/http2/incomplete_stats_test.go
@@ -35,9 +35,8 @@ func TestIncompleteBuffer(t *testing.T) {
 						Static_table_entry: K200Value,
 						Finalized:          true,
 					},
-					Request_method: http2requestMethod{
-						Static_table_entry: GetValue,
-						Finalized:          true,
+					Request_method: http2InterestingValue{
+						Index: uint64(GetValue),
 					},
 					Path: http2Path{
 						Static_table_entry: EmptyPathValue,

--- a/pkg/network/protocols/http2/incomplete_stats_test.go
+++ b/pkg/network/protocols/http2/incomplete_stats_test.go
@@ -31,9 +31,8 @@ func TestIncompleteBuffer(t *testing.T) {
 				Stream: http2Stream{
 					Response_last_seen: 0, // Required to make the request incomplete.
 					Request_started:    uint64(now.UnixNano()),
-					Status_code: http2StatusCode{
-						Static_table_entry: K200Value,
-						Finalized:          true,
+					Status_code: http2InterestingValue{
+						Index: uint64(K200Value),
 					},
 					Request_method: http2InterestingValue{
 						Index: uint64(GetValue),

--- a/pkg/network/protocols/http2/incomplete_stats_test.go
+++ b/pkg/network/protocols/http2/incomplete_stats_test.go
@@ -23,24 +23,26 @@ func TestIncompleteBuffer(t *testing.T) {
 		buffer := NewIncompleteBuffer(config.New()).(*incompleteBuffer)
 		now := time.Now()
 		buffer.minAgeNano = (30 * time.Second).Nanoseconds()
-		request := &EbpfTx{
-			Tuple: connTuple{
-				Sport: 6000,
-			},
-			Stream: http2Stream{
-				Response_last_seen: 0, // Required to make the request incomplete.
-				Request_started:    uint64(now.UnixNano()),
-				Status_code: http2StatusCode{
-					Static_table_entry: K200Value,
-					Finalized:          true,
+		request := &ebpfTXWrapper{
+			EbpfTx: &EbpfTx{
+				Tuple: connTuple{
+					Sport: 6000,
 				},
-				Request_method: http2requestMethod{
-					Static_table_entry: GetValue,
-					Finalized:          true,
-				},
-				Path: http2Path{
-					Static_table_entry: EmptyPathValue,
-					Finalized:          true,
+				Stream: http2Stream{
+					Response_last_seen: 0, // Required to make the request incomplete.
+					Request_started:    uint64(now.UnixNano()),
+					Status_code: http2StatusCode{
+						Static_table_entry: K200Value,
+						Finalized:          true,
+					},
+					Request_method: http2requestMethod{
+						Static_table_entry: GetValue,
+						Finalized:          true,
+					},
+					Path: http2Path{
+						Static_table_entry: EmptyPathValue,
+						Finalized:          true,
+					},
 				},
 			},
 		}
@@ -60,15 +62,17 @@ func TestIncompleteBuffer(t *testing.T) {
 		buffer := NewIncompleteBuffer(config.New()).(*incompleteBuffer)
 		now := time.Now()
 		buffer.minAgeNano = (30 * time.Second).Nanoseconds()
-		request := &EbpfTx{
-			Tuple: connTuple{
-				Sport: 6000,
-			},
-			Stream: http2Stream{
-				Path: http2Path{
-					Static_table_entry: EmptyPathValue,
+		request := &ebpfTXWrapper{
+			EbpfTx: &EbpfTx{
+				Tuple: connTuple{
+					Sport: 6000,
 				},
-				Request_started: uint64(now.UnixNano()),
+				Stream: http2Stream{
+					Path: http2Path{
+						Static_table_entry: EmptyPathValue,
+					},
+					Request_started: uint64(now.UnixNano()),
+				},
 			},
 		}
 		buffer.Add(request)

--- a/pkg/network/protocols/http2/incomplete_stats_test.go
+++ b/pkg/network/protocols/http2/incomplete_stats_test.go
@@ -38,9 +38,8 @@ func TestIncompleteBuffer(t *testing.T) {
 					Request_method: http2InterestingValue{
 						Index: uint64(GetValue),
 					},
-					Path: http2Path{
-						Static_table_entry: EmptyPathValue,
-						Finalized:          true,
+					Path: http2InterestingValue{
+						Index: uint64(EmptyPathValue),
 					},
 				},
 			},
@@ -67,8 +66,8 @@ func TestIncompleteBuffer(t *testing.T) {
 					Sport: 6000,
 				},
 				Stream: http2Stream{
-					Path: http2Path{
-						Static_table_entry: EmptyPathValue,
+					Path: http2InterestingValue{
+						Index: uint64(EmptyPathValue),
 					},
 					Request_started: uint64(now.UnixNano()),
 				},

--- a/pkg/network/protocols/http2/kernel_requirements.go
+++ b/pkg/network/protocols/http2/kernel_requirements.go
@@ -16,11 +16,13 @@ import (
 var MinimumKernelVersion kernel.Version
 
 func init() {
-	MinimumKernelVersion = kernel.VersionCode(5, 2, 0)
+	MinimumKernelVersion = kernel.VersionCode(5, 4, 0)
 }
 
-// Supported We only support http2 with kernel >= 5.2.0, as the kernel implementation exceeds the instruction limit
-// on kernels prior to that. In 5.2.0 the instruction limit was bumped to 1M instead of 4K.
+// Supported We only support http2 with kernel >= 5.4.0. The kernel implementation exceeds the instruction limit
+// on kernels prior to 5.2.0. In 5.2.0 the instruction limit was bumped to 1M instead of 4K. Furthermore, we're sending
+// dynamic values from the eBPF probes (socket filter and uprobes) to the userspace using bpf_perf_event_output.
+// The ability to call bpf_perf_event_output directly from a socket filter added in 5.4.0.
 func Supported() bool {
 	kversion, err := kernel.HostVersion()
 	if err != nil {

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -68,6 +68,7 @@ type ebpfTXWrapper struct {
 	dynamicTable *DynamicTable
 	method       interestingValue[http.Method]
 	path         interestingValue[string]
+	statusCode   interestingValue[uint16]
 }
 
 func (tx *ebpfTXWrapper) resolvePath() bool {
@@ -128,7 +129,7 @@ func (tx *ebpfTXWrapper) RequestLatency() float64 {
 // Incomplete returns true if the transaction contains only the request or response information
 // This happens in the context of localhost with NAT, in which case we join the two parts in userspace
 func (tx *ebpfTXWrapper) Incomplete() bool {
-	return tx.Stream.Request_started == 0 || tx.Stream.Response_last_seen == 0 || tx.StatusCode() == 0 || !tx.resolvePath() || !tx.resolveMethod()
+	return tx.Stream.Request_started == 0 || tx.Stream.Response_last_seen == 0 || !tx.resolveStatusCode() || !tx.resolvePath() || !tx.resolveMethod()
 }
 
 // ConnTuple returns the connections tuple of the transaction.
@@ -214,55 +215,62 @@ func (tx *ebpfTXWrapper) Method() http.Method {
 	return http.MethodUnknown
 }
 
+func (tx *ebpfTXWrapper) resolveStatusCode() bool {
+	if tx.statusCode.malformed {
+		return false
+	}
+	if tx.statusCode.value != 0 {
+		return true
+	}
+
+	if tx.Stream.Status_code.Index <= http2staticTableMaxEntry {
+		switch uint8(tx.Stream.Status_code.Index) {
+		case K200Value:
+			tx.statusCode.value = 200
+		case K204Value:
+			tx.statusCode.value = 204
+		case K206Value:
+			tx.statusCode.value = 206
+		case K400Value:
+			tx.statusCode.value = 400
+		case K500Value:
+			tx.statusCode.value = 500
+		default:
+			tx.statusCode.malformed = true
+		}
+		return !tx.statusCode.malformed
+	}
+
+	tup := tx.Tuple
+	// TODO: Support flipped tuples.
+
+	stringStatusCode, exists := tx.dynamicTable.resolveValue(tup, tx.Stream.Status_code.Index, tx.Stream.Status_code.Temporary)
+	if !exists {
+		return false
+	}
+	code, err := strconv.Atoi(stringStatusCode)
+	if err != nil {
+		tx.statusCode.malformed = true
+		return false
+	}
+	tx.statusCode.value = uint16(code)
+	return true
+}
+
 // StatusCode returns the status code of the transaction.
 // If the status code is indexed, then we return the corresponding value.
 // Otherwise, f the status code is huffman encoded, then we decode it and convert it from string to int.
 // Otherwise, we convert the status code from byte array to int.
 func (tx *ebpfTXWrapper) StatusCode() uint16 {
-	if tx.Stream.Status_code.Static_table_entry != 0 {
-		switch tx.Stream.Status_code.Static_table_entry {
-		case K200Value:
-			return 200
-		case K204Value:
-			return 204
-		case K206Value:
-			return 206
-		case K400Value:
-			return 400
-		case K500Value:
-			return 500
-		default:
-			return 0
-		}
+	if tx.resolveStatusCode() {
+		return tx.statusCode.value
 	}
-
-	if tx.Stream.Status_code.Is_huffman_encoded {
-		// The final form of the status code is 3 characters.
-		statusCode, err := hpack.HuffmanDecodeToString(tx.Stream.Status_code.Raw_buffer[:http2RawStatusCodeMaxLength-1])
-		if err != nil {
-			return 0
-		}
-		code, err := strconv.Atoi(statusCode)
-		if err != nil {
-			return 0
-		}
-		return uint16(code)
-	}
-
-	code, err := strconv.Atoi(string(tx.Stream.Status_code.Raw_buffer[:]))
-	if err != nil {
-		return 0
-	}
-	return uint16(code)
+	return 0
 }
 
 // SetStatusCode sets the HTTP status code of the transaction.
 func (tx *ebpfTXWrapper) SetStatusCode(code uint16) {
-	val := strconv.Itoa(int(code))
-	if len(val) > http2RawStatusCodeMaxLength {
-		return
-	}
-	copy(tx.Stream.Status_code.Raw_buffer[:], val)
+	tx.statusCode.value = code
 }
 
 // ResponseLastSeen returns the last seen response.

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -27,6 +27,21 @@ import (
 
 var oversizedLogLimit = util.NewLogLimit(10, time.Minute*10)
 
+// flipTuple returns a new connection tuple with the source and destination fields flipped.
+func flipTuple(t connTuple) connTuple {
+	return connTuple{
+		Saddr_h:  t.Daddr_h,
+		Saddr_l:  t.Daddr_l,
+		Daddr_h:  t.Saddr_h,
+		Daddr_l:  t.Saddr_l,
+		Sport:    t.Dport,
+		Dport:    t.Sport,
+		Netns:    t.Netns,
+		Pid:      t.Pid,
+		Metadata: t.Metadata,
+	}
+}
+
 // validatePath validates the given path.
 func validatePath(str string) error {
 	if len(str) == 0 {

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -61,17 +61,6 @@ func validatePath(str string) error {
 	return nil
 }
 
-// validatePathSize validates the given path size.
-func validatePathSize(size uint8) error {
-	if size == 0 {
-		return errors.New("empty path")
-	}
-	if size > maxHTTP2Path {
-		return fmt.Errorf("path size has exceeded the maximum limit: %d", size)
-	}
-	return nil
-}
-
 // ebpfTXWrapper is a wrapper around the eBPF transaction.
 // It extends the basic type with a pointer to an interned string, which will be filled by processHTTP2 method.
 type ebpfTXWrapper struct {

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -88,8 +88,15 @@ func decodeHTTP2Path(buf [maxHTTP2Path]byte, pathSize uint8) ([]byte, error) {
 	return []byte(str), nil
 }
 
+// ebpfTXWrapper is a wrapper around the eBPF transaction.
+// It extends the basic type with a pointer to an interned string, which will be filled by processHTTP2 method.
+type ebpfTXWrapper struct {
+	*EbpfTx
+	dynamicTable *DynamicTable
+}
+
 // Path returns the URL from the request fragment captured in eBPF.
-func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
+func (tx *ebpfTXWrapper) Path(buffer []byte) ([]byte, bool) {
 	if tx.Stream.Path.Static_table_entry != 0 {
 		switch tx.Stream.Path.Static_table_entry {
 		case EmptyPathValue:
@@ -135,7 +142,7 @@ func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
 }
 
 // RequestLatency returns the latency of the request in nanoseconds
-func (tx *EbpfTx) RequestLatency() float64 {
+func (tx *ebpfTXWrapper) RequestLatency() float64 {
 	if uint64(tx.Stream.Request_started) == 0 || uint64(tx.Stream.Response_last_seen) == 0 {
 		return 0
 	}
@@ -144,12 +151,12 @@ func (tx *EbpfTx) RequestLatency() float64 {
 
 // Incomplete returns true if the transaction contains only the request or response information
 // This happens in the context of localhost with NAT, in which case we join the two parts in userspace
-func (tx *EbpfTx) Incomplete() bool {
+func (tx *ebpfTXWrapper) Incomplete() bool {
 	return tx.Stream.Request_started == 0 || tx.Stream.Response_last_seen == 0 || tx.StatusCode() == 0 || !tx.Stream.Path.Finalized || tx.Method() == http.MethodUnknown
 }
 
 // ConnTuple returns the connections tuple of the transaction.
-func (tx *EbpfTx) ConnTuple() types.ConnectionKey {
+func (tx *ebpfTXWrapper) ConnTuple() types.ConnectionKey {
 	return types.ConnectionKey{
 		SrcIPHigh: tx.Tuple.Saddr_h,
 		SrcIPLow:  tx.Tuple.Saddr_l,
@@ -188,7 +195,7 @@ func stringToHTTPMethod(method string) (http.Method, error) {
 }
 
 // Method returns the HTTP method of the transaction.
-func (tx *EbpfTx) Method() http.Method {
+func (tx *ebpfTXWrapper) Method() http.Method {
 	var method string
 	var err error
 
@@ -233,7 +240,7 @@ func (tx *EbpfTx) Method() http.Method {
 // If the status code is indexed, then we return the corresponding value.
 // Otherwise, f the status code is huffman encoded, then we decode it and convert it from string to int.
 // Otherwise, we convert the status code from byte array to int.
-func (tx *EbpfTx) StatusCode() uint16 {
+func (tx *ebpfTXWrapper) StatusCode() uint16 {
 	if tx.Stream.Status_code.Static_table_entry != 0 {
 		switch tx.Stream.Status_code.Static_table_entry {
 		case K200Value:
@@ -272,7 +279,7 @@ func (tx *EbpfTx) StatusCode() uint16 {
 }
 
 // SetStatusCode sets the HTTP status code of the transaction.
-func (tx *EbpfTx) SetStatusCode(code uint16) {
+func (tx *ebpfTXWrapper) SetStatusCode(code uint16) {
 	val := strconv.Itoa(int(code))
 	if len(val) > http2RawStatusCodeMaxLength {
 		return
@@ -281,39 +288,39 @@ func (tx *EbpfTx) SetStatusCode(code uint16) {
 }
 
 // ResponseLastSeen returns the last seen response.
-func (tx *EbpfTx) ResponseLastSeen() uint64 {
+func (tx *ebpfTXWrapper) ResponseLastSeen() uint64 {
 	return tx.Stream.Response_last_seen
 }
 
 // SetResponseLastSeen sets the last seen response.
-func (tx *EbpfTx) SetResponseLastSeen(lastSeen uint64) {
+func (tx *ebpfTXWrapper) SetResponseLastSeen(lastSeen uint64) {
 	tx.Stream.Response_last_seen = lastSeen
 
 }
 
 // RequestStarted returns the timestamp of the request start.
-func (tx *EbpfTx) RequestStarted() uint64 {
+func (tx *ebpfTXWrapper) RequestStarted() uint64 {
 	return tx.Stream.Request_started
 }
 
 // SetRequestMethod sets the HTTP method of the transaction.
-func (tx *EbpfTx) SetRequestMethod(_ http.Method) {
+func (tx *ebpfTXWrapper) SetRequestMethod(_ http.Method) {
 	// if we set Static_table_entry to be different from 0, and no indexed value, it will default to 0 which is "UNKNOWN"
 	tx.Stream.Request_method.Static_table_entry = 1
 }
 
 // StaticTags returns the static tags of the transaction.
-func (tx *EbpfTx) StaticTags() uint64 {
+func (tx *ebpfTXWrapper) StaticTags() uint64 {
 	return 0
 }
 
 // DynamicTags returns the dynamic tags of the transaction.
-func (tx *EbpfTx) DynamicTags() []string {
+func (tx *ebpfTXWrapper) DynamicTags() []string {
 	return nil
 }
 
 // String returns a string representation of the transaction.
-func (tx *EbpfTx) String() string {
+func (tx *ebpfTXWrapper) String() string {
 	var output strings.Builder
 	output.WriteString("http2.ebpfTx{")
 	output.WriteString(fmt.Sprintf("[%s] [%s ⇄ %s] ", tx.family(), tx.sourceEndpoint(), tx.destEndpoint()))
@@ -333,32 +340,32 @@ func (tx *EbpfTx) String() string {
 	return output.String()
 }
 
-func (tx *EbpfTx) family() ebpf.ConnFamily {
+func (tx *ebpfTXWrapper) family() ebpf.ConnFamily {
 	if tx.Tuple.Metadata&uint32(ebpf.IPv6) != 0 {
 		return ebpf.IPv6
 	}
 	return ebpf.IPv4
 }
 
-func (tx *EbpfTx) sourceAddress() util.Address {
+func (tx *ebpfTXWrapper) sourceAddress() util.Address {
 	if tx.family() == ebpf.IPv4 {
 		return util.V4Address(uint32(tx.Tuple.Saddr_l))
 	}
 	return util.V6Address(tx.Tuple.Saddr_l, tx.Tuple.Saddr_h)
 }
 
-func (tx *EbpfTx) sourceEndpoint() string {
+func (tx *ebpfTXWrapper) sourceEndpoint() string {
 	return net.JoinHostPort(tx.sourceAddress().String(), strconv.Itoa(int(tx.Tuple.Sport)))
 }
 
-func (tx *EbpfTx) destAddress() util.Address {
+func (tx *ebpfTXWrapper) destAddress() util.Address {
 	if tx.family() == ebpf.IPv4 {
 		return util.V4Address(uint32(tx.Tuple.Daddr_l))
 	}
 	return util.V6Address(tx.Tuple.Daddr_l, tx.Tuple.Daddr_h)
 }
 
-func (tx *EbpfTx) destEndpoint() string {
+func (tx *ebpfTXWrapper) destEndpoint() string {
 	return net.JoinHostPort(tx.destAddress().String(), strconv.Itoa(int(tx.Tuple.Dport)))
 }
 

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -27,7 +27,6 @@ import (
 
 var oversizedLogLimit = util.NewLogLimit(10, time.Minute*10)
 
-// flipTuple returns a new connection tuple with the source and destination fields flipped.
 func flipTuple(t connTuple) connTuple {
 	return connTuple{
 		Saddr_h:  t.Daddr_h,
@@ -40,6 +39,14 @@ func flipTuple(t connTuple) connTuple {
 		Pid:      t.Pid,
 		Metadata: t.Metadata,
 	}
+}
+
+// interestingValue represents a valuable header (static or dynamic) for the HTTP2 monitoring. It is either a path,
+// a method, or a status code. It can be malformed if we're unable to resolve it in case of a dynamic value, or if the
+// static table entry does not match to the predefined allowed list.
+type interestingValue[V any] struct {
+	value     V
+	malformed bool
 }
 
 // validatePath validates the given path.

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -90,7 +90,9 @@ func (tx *ebpfTXWrapper) resolvePath() bool {
 	}
 
 	tup := tx.Tuple
-	// TODO: Support flipped tuples.
+	if tx.Stream.Conn_tuple_flipped {
+		tup = flipTuple(tup)
+	}
 
 	path, exists := tx.dynamicTable.resolveValue(tup, tx.Stream.Path.Index, tx.Stream.Path.Temporary)
 	if !exists {
@@ -190,7 +192,9 @@ func (tx *ebpfTXWrapper) resolveMethod() bool {
 	}
 
 	tup := tx.Tuple
-	// TODO: Support flipped tuples.
+	if tx.Stream.Conn_tuple_flipped {
+		tup = flipTuple(tup)
+	}
 
 	stringMethod, exists := tx.dynamicTable.resolveValue(tup, tx.Stream.Request_method.Index, tx.Stream.Request_method.Temporary)
 	if !exists {
@@ -239,8 +243,10 @@ func (tx *ebpfTXWrapper) resolveStatusCode() bool {
 		return !tx.statusCode.malformed
 	}
 
-	tup := tx.Tuple
-	// TODO: Support flipped tuples.
+	tup := flipTuple(tx.Tuple)
+	if tx.Stream.Conn_tuple_flipped {
+		tup = tx.Tuple
+	}
 
 	stringStatusCode, exists := tx.dynamicTable.resolveValue(tup, tx.Stream.Status_code.Index, tx.Stream.Status_code.Temporary)
 	if !exists {

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/http2/hpack"
-
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
@@ -386,23 +384,18 @@ func (t http2StreamKey) String() string {
 	)
 }
 
-// String returns a string representation of the http2 dynamic table.
-func (t HTTP2DynamicTableEntry) String() string {
-	if t.String_len == 0 {
-		return ""
+// String returns a string representation of interestingHeaderType.
+func (t InterestingHeaderType) String() string {
+	switch t {
+	case HeaderMethod:
+		return "method"
+	case HeaderPath:
+		return "path"
+	case HeaderStatus:
+		return "status"
+	default:
+		return "unknown"
 	}
-
-	b := make([]byte, t.String_len)
-	for i := uint8(0); i < t.String_len; i++ {
-		b[i] = byte(t.Buffer[i])
-	}
-	// trim null byte + after
-	str, err := hpack.HuffmanDecodeToString(b)
-	if err != nil {
-		return fmt.Sprintf("FAILED: %s", err)
-	}
-
-	return str
 }
 
 // String returns a string representation of the http2 eBPF telemetry.

--- a/pkg/network/protocols/http2/model_test.go
+++ b/pkg/network/protocols/http2/model_test.go
@@ -56,12 +56,14 @@ func TestHTTP2Path(t *testing.T) {
 				}
 				copy(arr[:], buf)
 
-				request := &EbpfTx{
-					Stream: http2Stream{
-						Path: http2Path{
-							Is_huffman_encoded: huffmanEnabled,
-							Raw_buffer:         arr,
-							Length:             uint8(len(buf)),
+				request := &ebpfTXWrapper{
+					EbpfTx: &EbpfTx{
+						Stream: http2Stream{
+							Path: http2Path{
+								Is_huffman_encoded: huffmanEnabled,
+								Raw_buffer:         arr,
+								Length:             uint8(len(buf)),
+							},
 						},
 					},
 				}
@@ -128,8 +130,10 @@ func TestHTTP2Method(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tx := &EbpfTx{
-				Stream: tt.Stream,
+			tx := &ebpfTXWrapper{
+				EbpfTx: &EbpfTx{
+					Stream: tt.Stream,
+				},
 			}
 			assert.Equalf(t, tt.want, tx.Method(), "Method()")
 		})

--- a/pkg/network/protocols/http2/model_test.go
+++ b/pkg/network/protocols/http2/model_test.go
@@ -59,17 +59,19 @@ func TestHTTP2Path(t *testing.T) {
 				dynamicTable := NewDynamicTable(10)
 				dynamicTable.handleNewDynamicTableEntry(&http2DynamicTableValue{
 					Key: HTTP2DynamicTableIndex{
-						Index: 1,
+						Index: http2staticTableMaxEntry + 1,
 					},
 					Is_huffman_encoded: huffmanEnabled,
 					String_len:         uint8(len(buf)),
 					Buf:                arr,
+					Temporary:          true,
 				})
 				request := &ebpfTXWrapper{
 					EbpfTx: &EbpfTx{
 						Stream: http2Stream{
 							Path: http2InterestingValue{
-								Index: http2staticTableMaxEntry + 1,
+								Index:     http2staticTableMaxEntry + 1,
+								Temporary: true,
 							},
 						},
 					},
@@ -128,12 +130,14 @@ func TestHTTP2Method(t *testing.T) {
 				},
 				String_len: tt.length,
 				Buf:        arr,
+				Temporary:  true,
 			})
 			tx := &ebpfTXWrapper{
 				EbpfTx: &EbpfTx{
 					Stream: http2Stream{
 						Request_method: http2InterestingValue{
-							Index: http2staticTableMaxEntry + 1,
+							Index:     http2staticTableMaxEntry + 1,
+							Temporary: true,
 						},
 					},
 				},

--- a/pkg/network/protocols/http2/model_test.go
+++ b/pkg/network/protocols/http2/model_test.go
@@ -56,16 +56,24 @@ func TestHTTP2Path(t *testing.T) {
 				}
 				copy(arr[:], buf)
 
+				dynamicTable := NewDynamicTable(10)
+				dynamicTable.handleNewDynamicTableEntry(&http2DynamicTableValue{
+					Key: HTTP2DynamicTableIndex{
+						Index: 1,
+					},
+					Is_huffman_encoded: huffmanEnabled,
+					String_len:         uint8(len(buf)),
+					Buf:                arr,
+				})
 				request := &ebpfTXWrapper{
 					EbpfTx: &EbpfTx{
 						Stream: http2Stream{
-							Path: http2Path{
-								Is_huffman_encoded: huffmanEnabled,
-								Raw_buffer:         arr,
-								Length:             uint8(len(buf)),
+							Path: http2InterestingValue{
+								Index: http2staticTableMaxEntry + 1,
 							},
 						},
 					},
+					dynamicTable: dynamicTable,
 				}
 
 				outBuf := make([]byte, 200)

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -97,7 +97,7 @@ var Spec = &protocols.ProtocolSpec{
 			Name: "http2_stream_heap",
 		},
 		{
-			Name: "http2_ctx_heap",
+			Name: "http2_stream_key_heap",
 		},
 	},
 	TailCalls: []manager.TailCallRoute{

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -348,7 +348,7 @@ func (p *Protocol) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map) {
 		io.WriteString(w, "Map: '"+mapName+"', key: 'ConnTuple', value: 'httpTX'\n")
 		iter := currentMap.Iterate()
 		var key HTTP2DynamicTableIndex
-		var value HTTP2DynamicTableEntry
+		var value InterestingHeaderType
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			spew.Fdump(w, key, value)
 		}

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -95,9 +95,6 @@ var Spec = &protocols.ProtocolSpec{
 			Name: "http2_frames_to_process",
 		},
 		{
-			Name: "http2_stream_heap",
-		},
-		{
 			Name: "http2_stream_key_heap",
 		},
 	},

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -357,7 +357,11 @@ func (p *Protocol) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map) {
 
 func (p *Protocol) processHTTP2(events []EbpfTx) {
 	for i := range events {
-		tx := &events[i]
+		event := events[i]
+		tx := &ebpfTXWrapper{
+			EbpfTx:       &event,
+			dynamicTable: p.dynamicTable,
+		}
 		p.telemetry.Count(tx)
 		p.statkeeper.Process(tx)
 	}

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -45,16 +45,17 @@ type Protocol struct {
 }
 
 const (
-	inFlightMap               = "http2_in_flight"
-	dynamicTable              = "http2_dynamic_table"
-	dynamicTableCounter       = "http2_dynamic_counter_table"
-	http2IterationsTable      = "http2_iterations"
-	tlsHTTP2IterationsTable   = "tls_http2_iterations"
-	firstFrameHandlerTailCall = "socket__http2_handle_first_frame"
-	filterTailCall            = "socket__http2_filter"
-	headersParserTailCall     = "socket__http2_headers_parser"
-	eosParserTailCall         = "socket__http2_eos_parser"
-	eventStream               = "http2"
+	inFlightMap                 = "http2_in_flight"
+	dynamicTable                = "http2_dynamic_table"
+	dynamicTableCounter         = "http2_dynamic_counter_table"
+	http2IterationsTable        = "http2_iterations"
+	tlsHTTP2IterationsTable     = "tls_http2_iterations"
+	firstFrameHandlerTailCall   = "socket__http2_handle_first_frame"
+	filterTailCall              = "socket__http2_filter"
+	headersParserTailCall       = "socket__http2_headers_parser"
+	eosParserTailCall           = "socket__http2_eos_parser"
+	eventStream                 = "http2"
+	http2DynamicTablePerfBuffer = "http2_dynamic_table_perf_buffer"
 
 	// TelemetryMap is the name of the map used to retrieve plaintext metrics from the kernel
 	TelemetryMap = "http2_telemetry"
@@ -184,7 +185,7 @@ func newHTTP2Protocol(cfg *config.Config) (protocols.Protocol, error) {
 		telemetry:                  telemetry,
 		http2Telemetry:             http2KernelTelemetry,
 		kernelTelemetryStopChannel: make(chan struct{}),
-		dynamicTable:               NewDynamicTable(),
+		dynamicTable:               NewDynamicTable(int(cfg.MaxUSMConcurrentRequests)),
 	}, nil
 }
 
@@ -194,8 +195,7 @@ func (p *Protocol) Name() string {
 }
 
 const (
-	mapSizeValue        = 1024
-	dynamicMapSizeValue = 10240
+	mapSizeValue = 1024
 )
 
 // ConfigureOptions add the necessary options for http2 monitoring to work,
@@ -209,14 +209,6 @@ func (p *Protocol) ConfigureOptions(mgr *manager.Manager, opts *manager.Options)
 		EditorFlag: manager.EditMaxEntries,
 	}
 
-	opts.MapSpecEditors[dynamicTable] = manager.MapSpecEditor{
-		MaxEntries: dynamicMapSizeValue,
-		EditorFlag: manager.EditMaxEntries,
-	}
-	opts.MapSpecEditors[dynamicTableCounter] = manager.MapSpecEditor{
-		MaxEntries: dynamicMapSizeValue,
-		EditorFlag: manager.EditMaxEntries,
-	}
 	opts.MapSpecEditors[http2IterationsTable] = manager.MapSpecEditor{
 		MaxEntries: mapSizeValue,
 		EditorFlag: manager.EditMaxEntries,

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -25,7 +25,6 @@ const (
 
 type connTuple = C.conn_tuple_t
 type HTTP2DynamicTableIndex C.dynamic_table_index_t
-type HTTP2DynamicTableEntry C.dynamic_table_entry_t
 type http2StreamKey C.http2_stream_key_t
 type http2InterestingValue C.interesting_value_t
 type http2Stream C.http2_stream_t

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -18,9 +18,6 @@ const (
 	http2PathBuckets = C.HTTP2_TELEMETRY_PATH_BUCKETS
 	// The kernel limit per page in the per-cpu array of the http2 terminated connections map.
 	HTTP2TerminatedBatchSize = C.HTTP2_TERMINATED_BATCH_SIZE
-	// The upper limit for the size of the raw status code.
-	// If the status code is huffman encoded, the size is 2 characters, while if it is not encoded, the size is 3 characters.
-	http2RawStatusCodeMaxLength = C.HTTP2_STATUS_CODE_MAX_LEN
 	// The max number of headers we process in the request/response.
 	Http2MaxHeadersCountPerFiltering = C.HTTP2_MAX_HEADERS_COUNT_FOR_FILTERING
 	http2staticTableMaxEntry         = C.MAX_STATIC_TABLE_INDEX
@@ -30,7 +27,6 @@ type connTuple = C.conn_tuple_t
 type HTTP2DynamicTableIndex C.dynamic_table_index_t
 type HTTP2DynamicTableEntry C.dynamic_table_entry_t
 type http2StreamKey C.http2_stream_key_t
-type http2StatusCode C.status_code_t
 type http2InterestingValue C.interesting_value_t
 type http2Stream C.http2_stream_t
 type http2DynamicTableValue C.dynamic_table_value_t

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -23,6 +23,7 @@ const (
 	http2RawStatusCodeMaxLength = C.HTTP2_STATUS_CODE_MAX_LEN
 	// The max number of headers we process in the request/response.
 	Http2MaxHeadersCountPerFiltering = C.HTTP2_MAX_HEADERS_COUNT_FOR_FILTERING
+	http2staticTableMaxEntry         = C.MAX_STATIC_TABLE_INDEX
 )
 
 type connTuple = C.conn_tuple_t

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -33,6 +33,7 @@ type http2StreamKey C.http2_stream_key_t
 type http2StatusCode C.status_code_t
 type http2requestMethod C.method_t
 type http2Path C.path_t
+type http2InterestingValue C.interesting_value_t
 type http2Stream C.http2_stream_t
 type http2DynamicTableValue C.dynamic_table_value_t
 type EbpfTx C.http2_event_t

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -34,6 +34,7 @@ type http2StatusCode C.status_code_t
 type http2requestMethod C.method_t
 type http2Path C.path_t
 type http2Stream C.http2_stream_t
+type http2DynamicTableValue C.dynamic_table_value_t
 type EbpfTx C.http2_event_t
 type HTTP2Telemetry C.http2_telemetry_t
 

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -31,7 +31,6 @@ type HTTP2DynamicTableIndex C.dynamic_table_index_t
 type HTTP2DynamicTableEntry C.dynamic_table_entry_t
 type http2StreamKey C.http2_stream_key_t
 type http2StatusCode C.status_code_t
-type http2Path C.path_t
 type http2InterestingValue C.interesting_value_t
 type http2Stream C.http2_stream_t
 type http2DynamicTableValue C.dynamic_table_value_t

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -52,3 +52,12 @@ const (
 	K404Value      StaticTableEnumValue = C.k404
 	K500Value      StaticTableEnumValue = C.k500
 )
+
+type InterestingHeaderType C.interesting_header_type_t
+
+const (
+	HeaderUnknown InterestingHeaderType = C.kHeaderUnknown
+	HeaderMethod  InterestingHeaderType = C.kHeaderMethod
+	HeaderPath    InterestingHeaderType = C.kHeaderPath
+	HeaderStatus  InterestingHeaderType = C.kHeaderStatus
+)

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -31,7 +31,6 @@ type HTTP2DynamicTableIndex C.dynamic_table_index_t
 type HTTP2DynamicTableEntry C.dynamic_table_entry_t
 type http2StreamKey C.http2_stream_key_t
 type http2StatusCode C.status_code_t
-type http2requestMethod C.method_t
 type http2Path C.path_t
 type http2InterestingValue C.interesting_value_t
 type http2Stream C.http2_stream_t

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -48,13 +48,6 @@ type http2StatusCode struct {
 	Static_table_entry uint8
 	Finalized          bool
 }
-type http2Path struct {
-	Raw_buffer         [160]uint8
-	Is_huffman_encoded bool
-	Static_table_entry uint8
-	Length             uint8
-	Finalized          bool
-}
 type http2InterestingValue struct {
 	Index     uint64
 	Temporary bool
@@ -65,9 +58,9 @@ type http2Stream struct {
 	Request_started       uint64
 	Status_code           http2StatusCode
 	Request_method        http2InterestingValue
-	Path                  http2Path
+	Path                  http2InterestingValue
 	Request_end_of_stream bool
-	Pad_cgo_0             [3]byte
+	Pad_cgo_0             [7]byte
 }
 type http2DynamicTableValue struct {
 	Key                HTTP2DynamicTableIndex

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -12,6 +12,7 @@ const (
 	http2RawStatusCodeMaxLength = 0x3
 
 	Http2MaxHeadersCountPerFiltering = 0x21
+	http2staticTableMaxEntry         = 0x3d
 )
 
 type connTuple = struct {

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -102,3 +102,12 @@ const (
 	K404Value      StaticTableEnumValue = 0xd
 	K500Value      StaticTableEnumValue = 0xe
 )
+
+type InterestingHeaderType uint8
+
+const (
+	HeaderUnknown InterestingHeaderType = 0x0
+	HeaderMethod  InterestingHeaderType = 0x1
+	HeaderPath    InterestingHeaderType = 0x2
+	HeaderStatus  InterestingHeaderType = 0x4
+)

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -62,6 +62,11 @@ type http2Path struct {
 	Length             uint8
 	Finalized          bool
 }
+type http2InterestingValue struct {
+	Index     uint64
+	Temporary bool
+	Pad_cgo_0 [7]byte
+}
 type http2Stream struct {
 	Response_last_seen    uint64
 	Request_started       uint64

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -45,7 +45,8 @@ type http2Stream struct {
 	Request_method        http2InterestingValue
 	Path                  http2InterestingValue
 	Request_end_of_stream bool
-	Pad_cgo_0             [7]byte
+	Conn_tuple_flipped    bool
+	Pad_cgo_0             [6]byte
 }
 type http2DynamicTableValue struct {
 	Key                HTTP2DynamicTableIndex

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -28,13 +28,6 @@ type HTTP2DynamicTableIndex struct {
 	Index uint64
 	Tup   connTuple
 }
-type HTTP2DynamicTableEntry struct {
-	Buffer             [160]int8
-	Original_index     uint32
-	String_len         uint8
-	Is_huffman_encoded bool
-	Pad_cgo_0          [2]byte
-}
 type http2StreamKey struct {
 	Tup       connTuple
 	Id        uint32

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -48,13 +48,6 @@ type http2StatusCode struct {
 	Static_table_entry uint8
 	Finalized          bool
 }
-type http2requestMethod struct {
-	Raw_buffer         [7]uint8
-	Is_huffman_encoded bool
-	Static_table_entry uint8
-	Length             uint8
-	Finalized          bool
-}
 type http2Path struct {
 	Raw_buffer         [160]uint8
 	Is_huffman_encoded bool
@@ -71,10 +64,10 @@ type http2Stream struct {
 	Response_last_seen    uint64
 	Request_started       uint64
 	Status_code           http2StatusCode
-	Request_method        http2requestMethod
+	Request_method        http2InterestingValue
 	Path                  http2Path
 	Request_end_of_stream bool
-	Pad_cgo_0             [2]byte
+	Pad_cgo_0             [3]byte
 }
 type http2DynamicTableValue struct {
 	Key                HTTP2DynamicTableIndex

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -71,6 +71,15 @@ type http2Stream struct {
 	Request_end_of_stream bool
 	Pad_cgo_0             [2]byte
 }
+type http2DynamicTableValue struct {
+	Key                HTTP2DynamicTableIndex
+	Type               uint8
+	Temporary          bool
+	Is_huffman_encoded bool
+	String_len         uint8
+	Pad_cgo_0          [4]byte
+	Buf                [160]byte
+}
 type EbpfTx struct {
 	Tuple  connTuple
 	Stream http2Stream

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -9,8 +9,6 @@ const (
 
 	HTTP2TerminatedBatchSize = 0x50
 
-	http2RawStatusCodeMaxLength = 0x3
-
 	Http2MaxHeadersCountPerFiltering = 0x21
 	http2staticTableMaxEntry         = 0x3d
 )
@@ -42,12 +40,6 @@ type http2StreamKey struct {
 	Id        uint32
 	Pad_cgo_0 [4]byte
 }
-type http2StatusCode struct {
-	Raw_buffer         [3]uint8
-	Is_huffman_encoded bool
-	Static_table_entry uint8
-	Finalized          bool
-}
 type http2InterestingValue struct {
 	Index     uint64
 	Temporary bool
@@ -56,7 +48,7 @@ type http2InterestingValue struct {
 type http2Stream struct {
 	Response_last_seen    uint64
 	Request_started       uint64
-	Status_code           http2StatusCode
+	Status_code           http2InterestingValue
 	Request_method        http2InterestingValue
 	Path                  http2InterestingValue
 	Request_end_of_stream bool

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -417,6 +417,9 @@ func (s *usmHTTP2Suite) TestHTTP2KernelTelemetry() {
 func (s *usmHTTP2Suite) TestHTTP2ManyDifferentPaths() {
 	t := s.T()
 	cfg := s.getCfg()
+	// This value controls the size of the dynamic table (usermode and eBPF), thus, we set the value to ensure that
+	// the test guarantees that the dynamic table is full and triggers evictions.
+	cfg.MaxUSMConcurrentRequests = 1024
 
 	// Start local server and register its cleanup.
 	t.Cleanup(startH2CServer(t, authority, s.isTLS))
@@ -433,41 +436,58 @@ func (s *usmHTTP2Suite) TestHTTP2ManyDifferentPaths() {
 
 	const (
 		repetitionsPerRequest = 2
-		// Should be bigger than the length of the http2_dynamic_table which is 1024
-		numberOfRequests         = 1500
-		expectedNumberOfRequests = numberOfRequests * repetitionsPerRequest
+		batchSize             = 100
+		// Should be bigger than the length of the http2_dynamic_table which is 1024 (cfg.MaxUSMConcurrentRequests)
+		batches          = 20
+		numberOfRequests = batches * batchSize
 	)
+	// Ensuring any future test won't pass "accidentally" as we miscalculated the number of requests.
+	require.Greater(t, uint32(numberOfRequests), cfg.MaxUSMConcurrentRequests)
 	clients := getHTTP2UnixClientArray(1, unixPath)
-	for i := 0; i < numberOfRequests; i++ {
-		for j := 0; j < repetitionsPerRequest; j++ {
-			req, err := clients[0].Post(fmt.Sprintf("%s/test-%d", http2SrvAddr, i+1), "application/json", bytes.NewReader([]byte("test")))
-			require.NoError(t, err, "could not make request")
-			_ = req.Body.Close()
-		}
-	}
+	for batchIdx := 0; batchIdx < batches; batchIdx++ {
+		seenRequests := map[string]int{}
 
-	matches := PrintableInt(0)
-
-	seenRequests := map[string]int{}
-	assert.Eventuallyf(t, func() bool {
-		for key, stat := range getHTTPLikeProtocolStats(monitor, protocols.HTTP2) {
-			if (key.DstPort == srvPort || key.SrcPort == srvPort) && key.Method == usmhttp.MethodPost && strings.HasPrefix(key.Path.Content.Get(), "/test") {
-				if _, ok := seenRequests[key.Path.Content.Get()]; !ok {
-					seenRequests[key.Path.Content.Get()] = 0
-				}
-				seenRequests[key.Path.Content.Get()] += stat.Data[200].Count
-				matches.Add(stat.Data[200].Count)
+		for i := 0; i < batchSize; i++ {
+			pathIndex := batchIdx*batchSize + i + 1
+			for j := 0; j < repetitionsPerRequest; j++ {
+				req, err := clients[0].Post(fmt.Sprintf("%s/test-%d", http2SrvAddr, pathIndex), "application/json", bytes.NewReader([]byte("test")))
+				require.NoError(t, err, "could not make request")
+				req.Body.Close()
 			}
 		}
 
-		// Due to a known issue in http2, we might consider an RST packet as a response to a request and therefore
-		// we might capture a request twice. This is why we are expecting to see 2*numberOfRequests instead of
-		return (expectedNumberOfRequests-1) <= matches.Load() && matches.Load() <= (expectedNumberOfRequests+1)
-	}, time.Second*10, time.Millisecond*100, "%v != %v", &matches, expectedNumberOfRequests)
+		assert.Eventually(t, func() bool {
+			for key, stat := range getHTTPLikeProtocolStats(monitor, protocols.HTTP2) {
+				if (key.DstPort == srvPort || key.SrcPort == srvPort) && key.Method == usmhttp.MethodPost && strings.HasPrefix(key.Path.Content.Get(), "/test") {
+					if _, ok := seenRequests[key.Path.Content.Get()]; !ok {
+						seenRequests[key.Path.Content.Get()] = 0
+					}
+					seenRequests[key.Path.Content.Get()] += stat.Data[200].Count
+				}
+			}
 
-	for i := 0; i < numberOfRequests; i++ {
-		if v, ok := seenRequests[fmt.Sprintf("/test-%d", i+1)]; !ok || v != repetitionsPerRequest {
-			t.Logf("path: /test-%d should have %d occurrences but instead has %d", i+1, repetitionsPerRequest, v)
+			// Due to a known issue in http2, we might consider an RST packet as a response to a request and therefore
+			// we might capture a request twice. This is why we are expecting to see 2*numberOfRequests instead of
+			fail := false
+			for i := 0; i < batchSize; i++ {
+				pathIndex := batchIdx*batchSize + i + 1
+				if v, ok := seenRequests[fmt.Sprintf("/test-%d", pathIndex)]; !ok || v < repetitionsPerRequest {
+					fail = true
+				}
+			}
+			return !fail
+		}, time.Second*10, time.Millisecond*100)
+
+		if t.Failed() {
+			// In case of a failure, we want to print the requests that were not captured as expected and then
+			// fail the test, as there is no point in continuing for the rest of the batches.
+			for i := 0; i < batchSize; i++ {
+				pathIndex := batchIdx*batchSize + i + 1
+				if v, ok := seenRequests[fmt.Sprintf("/test-%d", pathIndex)]; !ok || v < repetitionsPerRequest {
+					t.Logf("path: /test-%d should have %d occurrences but instead has %d", pathIndex, repetitionsPerRequest, v)
+				}
+			}
+			t.FailNow()
 		}
 	}
 }

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -1314,7 +1314,7 @@ func (s *usmHTTP2Suite) TestDynamicTable() {
 					Method: usmhttp.MethodPost,
 				}: 10,
 			},
-			expectedDynamicTablePathIndexes: []int{1, 7, 13, 19, 25, 31, 37, 43, 49, 55},
+			expectedDynamicTablePathIndexes: []int{63, 69, 75, 81, 87, 93, 99, 105, 111, 117},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

eBPF maps changes:

- `http2_in_flight` went down from 20 MB to 12 MB (for 65K entries)
- `http2_dynamic_table` changed from 10240 entries to 65K (`MaxUSMConcurrentRequests`) memory changed from 2.9MB to 8MB (298B per entry to 128B per entry)
- `http2_dynamic_counter_table` changed number of entries from const 10240 to `MaxUSMConcurrentRequests` (65K), memory changed from 1.2MB to 7.5MB

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
