### PR TITLE
[SEC-10008][CWS] split model_unix types and functions

### DIFF
--- a/pkg/security/secl/model/model_helpers_unix.go
+++ b/pkg/security/secl/model/model_helpers_unix.go
@@ -1,0 +1,351 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build unix
+
+package model
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
+
+const (
+	OverlayFS = "overlay" // OverlayFS overlay filesystem
+	TmpFS     = "tmpfs"   // TmpFS tmpfs
+	UnknownFS = "unknown" // UnknownFS unknown filesystem
+
+	ErrPathMustBeAbsolute = "all the path have to be absolute"            // ErrPathMustBeAbsolute tells when a path is not absolute
+	ErrPathDepthLimit     = "path depths have to be shorter than"         // ErrPathDepthLimit tells when a path is too long
+	ErrPathSegmentLimit   = "each segment of a path must be shorter than" // ErrPathSegmentLimit tells when a patch reached the segment limit
+
+	// SizeOfCookie size of cookie
+	SizeOfCookie = 8
+)
+
+// check that all path are absolute
+func validatePath(field eval.Field, fieldValue eval.FieldValue) error {
+	// do not support regular expression on path, currently unable to support discarder for regex value
+	if fieldValue.Type == eval.RegexpValueType {
+		return fmt.Errorf("regexp not supported on path `%s`", field)
+	} else if fieldValue.Type == eval.VariableValueType {
+		return nil
+	}
+
+	if value, ok := fieldValue.Value.(string); ok {
+		errAbs := fmt.Errorf("invalid path `%s`, %s", value, ErrPathMustBeAbsolute)
+		errDepth := fmt.Errorf("invalid path `%s`, %s %d", value, ErrPathDepthLimit, MaxPathDepth)
+		errSegment := fmt.Errorf("invalid path `%s`, %s %d", value, ErrPathSegmentLimit, MaxSegmentLength)
+
+		if value == "" {
+			return nil
+		}
+
+		if value != path.Clean(value) {
+			return errAbs
+		}
+
+		if value == "*" {
+			return errAbs
+		}
+
+		if !filepath.IsAbs(value) && len(value) > 0 && value[0] != '*' {
+			return errAbs
+		}
+
+		if strings.HasPrefix(value, "~") {
+			return errAbs
+		}
+
+		// check resolution limitations
+		segments := strings.Split(value, "/")
+		if len(segments) > MaxPathDepth {
+			return errDepth
+		}
+		for _, segment := range segments {
+			if segment == ".." {
+				return errAbs
+			}
+			if len(segment) > MaxSegmentLength {
+				return errSegment
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateField validates the value of a field
+func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) error {
+	if strings.HasSuffix(field, "path") {
+		if err := validatePath(field, fieldValue); err != nil {
+			return err
+		}
+	}
+
+	switch field {
+
+	case "event.retval":
+		if value := fieldValue.Value; value != -int(syscall.EPERM) && value != -int(syscall.EACCES) {
+			return errors.New("return value can only be tested against EPERM or EACCES")
+		}
+	case "bpf.map.name", "bpf.prog.name":
+		if value, ok := fieldValue.Value.(string); ok {
+			if len(value) > MaxBpfObjName {
+				return fmt.Errorf("the name provided in %s must be at most %d characters, len(\"%s\") = %d", field, MaxBpfObjName, value, len(value))
+			}
+		}
+	}
+
+	if m.ExtraValidateFieldFnc != nil {
+		return m.ExtraValidateFieldFnc(field, fieldValue)
+	}
+
+	return nil
+}
+
+// SetPathResolutionError sets the Event.pathResolutionError
+func (ev *Event) SetPathResolutionError(fileFields *FileEvent, err error) {
+	fileFields.PathResolutionError = err
+	ev.Error = err
+}
+
+// Equals returns if both credentials are equal
+func (c *Credentials) Equals(o *Credentials) bool {
+	return c.UID == o.UID &&
+		c.GID == o.GID &&
+		c.EUID == o.EUID &&
+		c.EGID == o.EGID &&
+		c.FSUID == o.FSUID &&
+		c.FSGID == o.FSGID &&
+		c.CapEffective == o.CapEffective &&
+		c.CapPermitted == o.CapPermitted
+}
+
+// SetSpan sets the span
+func (p *Process) SetSpan(spanID uint64, traceID uint64) {
+	p.SpanID = spanID
+	p.TraceID = traceID
+}
+
+// GetPathResolutionError returns the path resolution error as a string if there is one
+func (p *Process) GetPathResolutionError() string {
+	return p.FileEvent.GetPathResolutionError()
+}
+
+// HasInterpreter returns whether the process uses an interpreter
+func (p *Process) HasInterpreter() bool {
+	return p.LinuxBinprm.FileEvent.Inode != 0
+}
+
+// IsNotKworker returns true if the process isn't a kworker
+func (p *Process) IsNotKworker() bool {
+	return !p.IsKworker
+}
+
+// GetProcessArgv returns the unscrubbed args of the event as an array. Use with caution.
+func (p *Process) GetProcessArgv() ([]string, bool) {
+	if p.ArgsEntry == nil {
+		return p.Argv, p.ArgsTruncated
+	}
+
+	argv := p.ArgsEntry.Values
+	if len(argv) > 0 {
+		argv = argv[1:]
+	}
+	p.Argv = argv
+	p.ArgsTruncated = p.ArgsTruncated || p.ArgsEntry.Truncated
+	return p.Argv, p.ArgsTruncated
+}
+
+// GetProcessArgv0 returns the first arg of the event and whether the process arguments are truncated
+func (p *Process) GetProcessArgv0() (string, bool) {
+	if p.ArgsEntry == nil {
+		return p.Argv0, p.ArgsTruncated
+	}
+
+	argv := p.ArgsEntry.Values
+	if len(argv) > 0 {
+		p.Argv0 = argv[0]
+	}
+	p.ArgsTruncated = p.ArgsTruncated || p.ArgsEntry.Truncated
+	return p.Argv0, p.ArgsTruncated
+}
+
+// Equals compares two FileFields
+func (f *FileFields) Equals(o *FileFields) bool {
+	return f.Inode == o.Inode && f.MountID == o.MountID && f.MTime == o.MTime && f.UID == o.UID && f.GID == o.GID && f.Mode == o.Mode
+}
+
+// IsFileless return whether it is a file less access
+func (f *FileFields) IsFileless() bool {
+	// TODO(safchain) fix this heuristic by add a flag in the event intead of using mount ID 0
+	return f.Inode != 0 && f.MountID == 0
+}
+
+// HasHardLinks returns whether the file has hardlink
+func (f *FileFields) HasHardLinks() bool {
+	return f.NLink > 1
+}
+
+// GetInLowerLayer returns whether a file is in a lower layer
+func (f *FileFields) GetInLowerLayer() bool {
+	return f.Flags&LowerLayer != 0
+}
+
+// GetInUpperLayer returns whether a file is in the upper layer
+func (f *FileFields) GetInUpperLayer() bool {
+	return f.Flags&UpperLayer != 0
+}
+
+// Equals compare two FileEvent
+func (e *FileEvent) Equals(o *FileEvent) bool {
+	return e.FileFields.Equals(&o.FileFields)
+}
+
+// SetPathnameStr set and mark as resolved
+func (e *FileEvent) SetPathnameStr(str string) {
+	e.PathnameStr = str
+	e.IsPathnameStrResolved = true
+}
+
+// SetBasenameStr set and mark as resolved
+func (e *FileEvent) SetBasenameStr(str string) {
+	e.BasenameStr = str
+	e.IsBasenameStrResolved = true
+}
+
+// GetPathResolutionError returns the path resolution error as a string if there is one
+func (e *FileEvent) GetPathResolutionError() string {
+	if e.PathResolutionError != nil {
+		return e.PathResolutionError.Error()
+	}
+	return ""
+}
+
+// IsOverlayFS returns whether it is an overlay fs
+func (e *FileEvent) IsOverlayFS() bool {
+	return e.Filesystem == "overlay"
+}
+
+// GetFSType returns the filesystem type of the mountpoint
+func (m *Mount) GetFSType() string {
+	return m.FSType
+}
+
+// IsOverlayFS returns whether it is an overlay fs
+func (m *Mount) IsOverlayFS() bool {
+	return m.GetFSType() == "overlay"
+}
+
+const (
+	ProcessCacheEntryFromUnknown     = iota // ProcessCacheEntryFromUnknown defines a process cache entry from unknown
+	ProcessCacheEntryFromPlaceholder        // ProcessCacheEntryFromPlaceholder defines the source of a placeholder process cache entry
+	ProcessCacheEntryFromEvent              // ProcessCacheEntryFromEvent defines a process cache entry from event
+	ProcessCacheEntryFromKernelMap          // ProcessCacheEntryFromKernelMap defines a process cache entry from kernel map
+	ProcessCacheEntryFromProcFS             // ProcessCacheEntryFromProcFS defines a process cache entry from procfs. Note that some exec parent may be missing.
+	ProcessCacheEntryFromSnapshot           // ProcessCacheEntryFromSnapshot defines a process cache entry from snapshot
+)
+
+// ProcessSources defines process sources
+var ProcessSources = [...]string{
+	"unknown",
+	"placeholder",
+	"event",
+	"map",
+	"procfs_fallback",
+	"procfs_snapshot",
+}
+
+// ProcessSourceToString returns the string corresponding to a process source
+func ProcessSourceToString(source uint64) string {
+	return ProcessSources[source]
+}
+
+// SetTimeout updates the timeout of an activity dump
+func (adlc *ActivityDumpLoadConfig) SetTimeout(duration time.Duration) {
+	adlc.Timeout = duration
+	adlc.EndTimestampRaw = adlc.StartTimestampRaw + uint64(duration)
+}
+
+// GetKey returns a key to uniquely identify a network device on the system
+func (d NetDevice) GetKey() string {
+	return fmt.Sprintf("%v_%v", d.IfIndex, d.NetNS)
+}
+
+func (p *PathKey) Write(buffer []byte) {
+	ByteOrder.PutUint64(buffer[0:8], p.Inode)
+	ByteOrder.PutUint32(buffer[8:12], p.MountID)
+	ByteOrder.PutUint32(buffer[12:16], p.PathID)
+}
+
+// IsNull returns true if a key is invalid
+func (p *PathKey) IsNull() bool {
+	return p.Inode == 0 && p.MountID == 0
+}
+
+func (p *PathKey) String() string {
+	return fmt.Sprintf("%x/%x", p.MountID, p.Inode)
+}
+
+// MarshalBinary returns the binary representation of a path key
+func (p *PathKey) MarshalBinary() ([]byte, error) {
+	if p.IsNull() {
+		return nil, &ErrInvalidKeyPath{Inode: p.Inode, MountID: p.MountID}
+	}
+
+	buff := make([]byte, 16)
+	p.Write(buff)
+
+	return buff, nil
+}
+
+// PathLeafSize defines path_leaf struct size
+const PathLeafSize = PathKeySize + MaxSegmentLength + 1 + 2 + 6 // path_key + name + len + padding
+
+// PathLeaf is the go representation of the eBPF path_leaf_t structure
+type PathLeaf struct {
+	Parent  PathKey
+	Name    [MaxSegmentLength + 1]byte
+	Len     uint16
+	Padding [6]uint8
+}
+
+// GetName returns the path value as a string
+func (pl *PathLeaf) GetName() string {
+	return NullTerminatedString(pl.Name[:])
+}
+
+// SetName sets the path name
+func (pl *PathLeaf) SetName(name string) {
+	copy(pl.Name[:], []byte(name))
+	pl.Len = uint16(len(name) + 1)
+}
+
+// MarshalBinary returns the binary representation of a path key
+func (pl *PathLeaf) MarshalBinary() ([]byte, error) {
+	buff := make([]byte, PathLeafSize)
+
+	pl.Parent.Write(buff)
+	copy(buff[16:], pl.Name[:])
+	ByteOrder.PutUint16(buff[16+len(pl.Name):], pl.Len)
+
+	return buff, nil
+}
+
+// ResolveHashes resolves the hash of the provided file
+func (dfh *DefaultFieldHandlers) ResolveHashes(_ EventType, _ *Process, _ *FileEvent) []string {
+	return nil
+}
+
+// ResolveUserSessionContext resolves and updates the provided user session context
+func (dfh *DefaultFieldHandlers) ResolveUserSessionContext(_ *UserSessionContext) {}

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -11,127 +11,10 @@
 package model
 
 import (
-	"errors"
-	"fmt"
-	"path"
-	"path/filepath"
-	"strings"
-	"syscall"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
-
-const (
-	OverlayFS = "overlay" // OverlayFS overlay filesystem
-	TmpFS     = "tmpfs"   // TmpFS tmpfs
-	UnknownFS = "unknown" // UnknownFS unknown filesystem
-
-	ErrPathMustBeAbsolute = "all the path have to be absolute"            // ErrPathMustBeAbsolute tells when a path is not absolute
-	ErrPathDepthLimit     = "path depths have to be shorter than"         // ErrPathDepthLimit tells when a path is too long
-	ErrPathSegmentLimit   = "each segment of a path must be shorter than" // ErrPathSegmentLimit tells when a patch reached the segment limit
-
-	// SizeOfCookie size of cookie
-	SizeOfCookie = 8
-)
-
-// check that all path are absolute
-func validatePath(field eval.Field, fieldValue eval.FieldValue) error {
-	// do not support regular expression on path, currently unable to support discarder for regex value
-	if fieldValue.Type == eval.RegexpValueType {
-		return fmt.Errorf("regexp not supported on path `%s`", field)
-	} else if fieldValue.Type == eval.VariableValueType {
-		return nil
-	}
-
-	if value, ok := fieldValue.Value.(string); ok {
-		errAbs := fmt.Errorf("invalid path `%s`, %s", value, ErrPathMustBeAbsolute)
-		errDepth := fmt.Errorf("invalid path `%s`, %s %d", value, ErrPathDepthLimit, MaxPathDepth)
-		errSegment := fmt.Errorf("invalid path `%s`, %s %d", value, ErrPathSegmentLimit, MaxSegmentLength)
-
-		if value == "" {
-			return nil
-		}
-
-		if value != path.Clean(value) {
-			return errAbs
-		}
-
-		if value == "*" {
-			return errAbs
-		}
-
-		if !filepath.IsAbs(value) && len(value) > 0 && value[0] != '*' {
-			return errAbs
-		}
-
-		if strings.HasPrefix(value, "~") {
-			return errAbs
-		}
-
-		// check resolution limitations
-		segments := strings.Split(value, "/")
-		if len(segments) > MaxPathDepth {
-			return errDepth
-		}
-		for _, segment := range segments {
-			if segment == ".." {
-				return errAbs
-			}
-			if len(segment) > MaxSegmentLength {
-				return errSegment
-			}
-		}
-	}
-
-	return nil
-}
-
-// ValidateField validates the value of a field
-func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) error {
-	if strings.HasSuffix(field, "path") {
-		if err := validatePath(field, fieldValue); err != nil {
-			return err
-		}
-	}
-
-	switch field {
-
-	case "event.retval":
-		if value := fieldValue.Value; value != -int(syscall.EPERM) && value != -int(syscall.EACCES) {
-			return errors.New("return value can only be tested against EPERM or EACCES")
-		}
-	case "bpf.map.name", "bpf.prog.name":
-		if value, ok := fieldValue.Value.(string); ok {
-			if len(value) > MaxBpfObjName {
-				return fmt.Errorf("the name provided in %s must be at most %d characters, len(\"%s\") = %d", field, MaxBpfObjName, value, len(value))
-			}
-		}
-	}
-
-	if m.ExtraValidateFieldFnc != nil {
-		return m.ExtraValidateFieldFnc(field, fieldValue)
-	}
-
-	return nil
-}
-
-// ChmodEvent represents a chmod event
-type ChmodEvent struct {
-	SyscallEvent
-	File FileEvent `field:"file"`
-	Mode uint32    `field:"file.destination.mode; file.destination.rights"` // SECLDoc[file.destination.mode] Definition:`New mode of the chmod-ed file` Constants:`File mode constants` SECLDoc[file.destination.rights] Definition:`New rights of the chmod-ed file` Constants:`File mode constants`
-}
-
-// ChownEvent represents a chown event
-type ChownEvent struct {
-	SyscallEvent
-	File  FileEvent `field:"file"`
-	UID   int64     `field:"file.destination.uid"`                           // SECLDoc[file.destination.uid] Definition:`New UID of the chown-ed file's owner`
-	User  string    `field:"file.destination.user,handler:ResolveChownUID"`  // SECLDoc[file.destination.user] Definition:`New user of the chown-ed file's owner`
-	GID   int64     `field:"file.destination.gid"`                           // SECLDoc[file.destination.gid] Definition:`New GID of the chown-ed file's owner`
-	Group string    `field:"file.destination.group,handler:ResolveChownGID"` // SECLDoc[file.destination.group] Definition:`New group of the chown-ed file's owner`
-}
 
 // Event represents an event sent from the kernel
 // genaccessors
@@ -199,10 +82,26 @@ type Event struct {
 	NSID uint64 `field:"-"`
 }
 
-// SetPathResolutionError sets the Event.pathResolutionError
-func (ev *Event) SetPathResolutionError(fileFields *FileEvent, err error) {
-	fileFields.PathResolutionError = err
-	ev.Error = err
+// SyscallEvent contains common fields for all the event
+type SyscallEvent struct {
+	Retval int64 `field:"retval"` // SECLDoc[retval] Definition:`Return value of the syscall` Constants:`Error constants`
+}
+
+// ChmodEvent represents a chmod event
+type ChmodEvent struct {
+	SyscallEvent
+	File FileEvent `field:"file"`
+	Mode uint32    `field:"file.destination.mode; file.destination.rights"` // SECLDoc[file.destination.mode] Definition:`New mode of the chmod-ed file` Constants:`File mode constants` SECLDoc[file.destination.rights] Definition:`New rights of the chmod-ed file` Constants:`File mode constants`
+}
+
+// ChownEvent represents a chown event
+type ChownEvent struct {
+	SyscallEvent
+	File  FileEvent `field:"file"`
+	UID   int64     `field:"file.destination.uid"`                           // SECLDoc[file.destination.uid] Definition:`New UID of the chown-ed file's owner`
+	User  string    `field:"file.destination.user,handler:ResolveChownUID"`  // SECLDoc[file.destination.user] Definition:`New user of the chown-ed file's owner`
+	GID   int64     `field:"file.destination.gid"`                           // SECLDoc[file.destination.gid] Definition:`New GID of the chown-ed file's owner`
+	Group string    `field:"file.destination.group,handler:ResolveChownGID"` // SECLDoc[file.destination.group] Definition:`New group of the chown-ed file's owner`
 }
 
 // SetuidEvent represents a setuid event
@@ -250,68 +149,6 @@ type Credentials struct {
 
 	CapEffective uint64 `field:"cap_effective"` // SECLDoc[cap_effective] Definition:`Effective capability set of the process` Constants:`Kernel Capability constants`
 	CapPermitted uint64 `field:"cap_permitted"` // SECLDoc[cap_permitted] Definition:`Permitted capability set of the process` Constants:`Kernel Capability constants`
-}
-
-// Equals returns if both credentials are equal
-func (c *Credentials) Equals(o *Credentials) bool {
-	return c.UID == o.UID &&
-		c.GID == o.GID &&
-		c.EUID == o.EUID &&
-		c.EGID == o.EGID &&
-		c.FSUID == o.FSUID &&
-		c.FSGID == o.FSGID &&
-		c.CapEffective == o.CapEffective &&
-		c.CapPermitted == o.CapPermitted
-}
-
-// SetSpan sets the span
-func (p *Process) SetSpan(spanID uint64, traceID uint64) {
-	p.SpanID = spanID
-	p.TraceID = traceID
-}
-
-// GetPathResolutionError returns the path resolution error as a string if there is one
-func (p *Process) GetPathResolutionError() string {
-	return p.FileEvent.GetPathResolutionError()
-}
-
-// HasInterpreter returns whether the process uses an interpreter
-func (p *Process) HasInterpreter() bool {
-	return p.LinuxBinprm.FileEvent.Inode != 0
-}
-
-// IsNotKworker returns true if the process isn't a kworker
-func (p *Process) IsNotKworker() bool {
-	return !p.IsKworker
-}
-
-// GetProcessArgv returns the unscrubbed args of the event as an array. Use with caution.
-func (p *Process) GetProcessArgv() ([]string, bool) {
-	if p.ArgsEntry == nil {
-		return p.Argv, p.ArgsTruncated
-	}
-
-	argv := p.ArgsEntry.Values
-	if len(argv) > 0 {
-		argv = argv[1:]
-	}
-	p.Argv = argv
-	p.ArgsTruncated = p.ArgsTruncated || p.ArgsEntry.Truncated
-	return p.Argv, p.ArgsTruncated
-}
-
-// GetProcessArgv0 returns the first arg of the event and whether the process arguments are truncated
-func (p *Process) GetProcessArgv0() (string, bool) {
-	if p.ArgsEntry == nil {
-		return p.Argv0, p.ArgsTruncated
-	}
-
-	argv := p.ArgsEntry.Values
-	if len(argv) > 0 {
-		p.Argv0 = argv[0]
-	}
-	p.ArgsTruncated = p.ArgsTruncated || p.ArgsEntry.Truncated
-	return p.Argv0, p.ArgsTruncated
 }
 
 // LinuxBinprm contains content from the linux_binprm struct, which holds the arguments used for loading binaries
@@ -411,32 +248,6 @@ type FileFields struct {
 	Flags int32  `field:"-"`
 }
 
-// Equals compares two FileFields
-func (f *FileFields) Equals(o *FileFields) bool {
-	return f.Inode == o.Inode && f.MountID == o.MountID && f.MTime == o.MTime && f.UID == o.UID && f.GID == o.GID && f.Mode == o.Mode
-}
-
-// IsFileless return whether it is a file less access
-func (f *FileFields) IsFileless() bool {
-	// TODO(safchain) fix this heuristic by add a flag in the event intead of using mount ID 0
-	return f.Inode != 0 && f.MountID == 0
-}
-
-// HasHardLinks returns whether the file has hardlink
-func (f *FileFields) HasHardLinks() bool {
-	return f.NLink > 1
-}
-
-// GetInLowerLayer returns whether a file is in a lower layer
-func (f *FileFields) GetInLowerLayer() bool {
-	return f.Flags&LowerLayer != 0
-}
-
-// GetInUpperLayer returns whether a file is in the upper layer
-func (f *FileFields) GetInUpperLayer() bool {
-	return f.Flags&UpperLayer != 0
-}
-
 // FileEvent is the common file event type
 type FileEvent struct {
 	FileFields ``
@@ -457,36 +268,6 @@ type FileEvent struct {
 	// used to mark as already resolved, can be used in case of empty path
 	IsPathnameStrResolved bool `field:"-"`
 	IsBasenameStrResolved bool `field:"-"`
-}
-
-// Equals compare two FileEvent
-func (e *FileEvent) Equals(o *FileEvent) bool {
-	return e.FileFields.Equals(&o.FileFields)
-}
-
-// SetPathnameStr set and mark as resolved
-func (e *FileEvent) SetPathnameStr(str string) {
-	e.PathnameStr = str
-	e.IsPathnameStrResolved = true
-}
-
-// SetBasenameStr set and mark as resolved
-func (e *FileEvent) SetBasenameStr(str string) {
-	e.BasenameStr = str
-	e.IsBasenameStrResolved = true
-}
-
-// GetPathResolutionError returns the path resolution error as a string if there is one
-func (e *FileEvent) GetPathResolutionError() string {
-	if e.PathResolutionError != nil {
-		return e.PathResolutionError.Error()
-	}
-	return ""
-}
-
-// IsOverlayFS returns whether it is an overlay fs
-func (e *FileEvent) IsOverlayFS() bool {
-	return e.Filesystem == "overlay"
 }
 
 // InvalidateDentryEvent defines a invalidate dentry event
@@ -551,16 +332,6 @@ type UnshareMountNSEvent struct {
 	Mount
 }
 
-// GetFSType returns the filesystem type of the mountpoint
-func (m *Mount) GetFSType() string {
-	return m.FSType
-}
-
-// IsOverlayFS returns whether it is an overlay fs
-func (m *Mount) IsOverlayFS() bool {
-	return m.GetFSType() == "overlay"
-}
-
 // ChdirEvent represents a chdir event
 type ChdirEvent struct {
 	SyscallEvent
@@ -597,30 +368,6 @@ type SELinuxEvent struct {
 	EnforceStatus   string           `field:"enforce.status"`                           // SECLDoc[enforce.status] Definition:`SELinux enforcement status (one of "enforcing", "permissive", "disabled")`
 }
 
-const (
-	ProcessCacheEntryFromUnknown     = iota // ProcessCacheEntryFromUnknown defines a process cache entry from unknown
-	ProcessCacheEntryFromPlaceholder        // ProcessCacheEntryFromPlaceholder defines the source of a placeholder process cache entry
-	ProcessCacheEntryFromEvent              // ProcessCacheEntryFromEvent defines a process cache entry from event
-	ProcessCacheEntryFromKernelMap          // ProcessCacheEntryFromKernelMap defines a process cache entry from kernel map
-	ProcessCacheEntryFromProcFS             // ProcessCacheEntryFromProcFS defines a process cache entry from procfs. Note that some exec parent may be missing.
-	ProcessCacheEntryFromSnapshot           // ProcessCacheEntryFromSnapshot defines a process cache entry from snapshot
-)
-
-// ProcessSources defines process sources
-var ProcessSources = [...]string{
-	"unknown",
-	"placeholder",
-	"event",
-	"map",
-	"procfs_fallback",
-	"procfs_snapshot",
-}
-
-// ProcessSourceToString returns the string corresponding to a process source
-func ProcessSourceToString(source uint64) string {
-	return ProcessSources[source]
-}
-
 // PIDContext holds the process context of a kernel event
 type PIDContext struct {
 	Pid       uint32 `field:"pid"` // SECLDoc[pid] Definition:`Process ID of the process (also called thread group ID)`
@@ -651,11 +398,6 @@ type SetXAttrEvent struct {
 	Name      string    `field:"file.destination.name,handler:ResolveXAttrName"`           // SECLDoc[file.destination.name] Definition:`Name of the extended attribute`
 
 	NameRaw [200]byte `field:"-"`
-}
-
-// SyscallEvent contains common fields for all the event
-type SyscallEvent struct {
-	Retval int64 `field:"retval"` // SECLDoc[retval] Definition:`Return value of the syscall` Constants:`Error constants`
 }
 
 // UnlinkEvent represents an unlink event
@@ -792,12 +534,6 @@ type ActivityDumpLoadConfig struct {
 	Paused               uint32
 }
 
-// SetTimeout updates the timeout of an activity dump
-func (adlc *ActivityDumpLoadConfig) SetTimeout(duration time.Duration) {
-	adlc.Timeout = duration
-	adlc.EndTimestampRaw = adlc.StartTimestampRaw + uint64(duration)
-}
-
 // NetworkDeviceContext represents the network device context of a network event
 type NetworkDeviceContext struct {
 	NetNS   uint32 `field:"-"`
@@ -820,11 +556,6 @@ type NetDevice struct {
 	IfIndex     uint32
 	PeerNetNS   uint32
 	PeerIfIndex uint32
-}
-
-// GetKey returns a key to uniquely identify a network device on the system
-func (d NetDevice) GetKey() string {
-	return fmt.Sprintf("%v_%v", d.IfIndex, d.NetNS)
 }
 
 // NetDeviceEvent represents a network device event
@@ -862,77 +593,9 @@ type PathKey struct {
 	PathID  uint32 `field:"-"`
 }
 
-func (p *PathKey) Write(buffer []byte) {
-	ByteOrder.PutUint64(buffer[0:8], p.Inode)
-	ByteOrder.PutUint32(buffer[8:12], p.MountID)
-	ByteOrder.PutUint32(buffer[12:16], p.PathID)
-}
-
-// IsNull returns true if a key is invalid
-func (p *PathKey) IsNull() bool {
-	return p.Inode == 0 && p.MountID == 0
-}
-
-func (p *PathKey) String() string {
-	return fmt.Sprintf("%x/%x", p.MountID, p.Inode)
-}
-
-// MarshalBinary returns the binary representation of a path key
-func (p *PathKey) MarshalBinary() ([]byte, error) {
-	if p.IsNull() {
-		return nil, &ErrInvalidKeyPath{Inode: p.Inode, MountID: p.MountID}
-	}
-
-	buff := make([]byte, 16)
-	p.Write(buff)
-
-	return buff, nil
-}
-
-// PathLeafSize defines path_leaf struct size
-const PathLeafSize = PathKeySize + MaxSegmentLength + 1 + 2 + 6 // path_key + name + len + padding
-
-// PathLeaf is the go representation of the eBPF path_leaf_t structure
-type PathLeaf struct {
-	Parent  PathKey
-	Name    [MaxSegmentLength + 1]byte
-	Len     uint16
-	Padding [6]uint8
-}
-
-// GetName returns the path value as a string
-func (pl *PathLeaf) GetName() string {
-	return NullTerminatedString(pl.Name[:])
-}
-
-// SetName sets the path name
-func (pl *PathLeaf) SetName(name string) {
-	copy(pl.Name[:], []byte(name))
-	pl.Len = uint16(len(name) + 1)
-}
-
-// MarshalBinary returns the binary representation of a path key
-func (pl *PathLeaf) MarshalBinary() ([]byte, error) {
-	buff := make([]byte, PathLeafSize)
-
-	pl.Parent.Write(buff)
-	copy(buff[16:], pl.Name[:])
-	ByteOrder.PutUint16(buff[16+len(pl.Name):], pl.Len)
-
-	return buff, nil
-}
-
 // ExtraFieldHandlers handlers not hold by any field
 type ExtraFieldHandlers interface {
 	BaseExtraFieldHandlers
 	ResolveHashes(eventType EventType, process *Process, file *FileEvent) []string
 	ResolveUserSessionContext(evtCtx *UserSessionContext)
 }
-
-// ResolveHashes resolves the hash of the provided file
-func (dfh *DefaultFieldHandlers) ResolveHashes(_ EventType, _ *Process, _ *FileEvent) []string {
-	return nil
-}
-
-// ResolveUserSessionContext resolves and updates the provided user session context
-func (dfh *DefaultFieldHandlers) ResolveUserSessionContext(_ *UserSessionContext) {}


### PR DESCRIPTION
### What does this PR do?

This PR is the first PR of the new multi-platform model support initiative. The goal here is first to split the `model_unix` into types and functions.

This will allow the new generator to generate the type file, ensuring it's generating the same exact code as the current types, allowing a transition without too much impact on other developers celerity.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
