### PR TITLE
[experimental] serverless: optionally build otlp into trace-agent

### DIFF
--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -342,15 +342,15 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		return err
 	}
 
-	c.OTLPReceiver = &config.OTLP{
-		BindHost:               c.ReceiverHost,
-		GRPCPort:               grpcPort,
-		MaxRequestBytes:        c.MaxRequestBytes,
-		SpanNameRemappings:     coreconfig.Datadog.GetStringMapString("otlp_config.traces.span_name_remappings"),
-		SpanNameAsResourceName: core.GetBool("otlp_config.traces.span_name_as_resource_name"),
-		ProbabilisticSampling:  core.GetFloat64("otlp_config.traces.probabilistic_sampler.sampling_percentage"),
-		AttributesTranslator:   attributesTranslator,
-	}
+	c.OTLPReceiver = config.NewOTLP(
+		c.ReceiverHost,
+		grpcPort,
+		coreconfig.Datadog.GetStringMapString("otlp_config.traces.span_name_remappings"),
+		core.GetBool("otlp_config.traces.span_name_as_resource_name"),
+		c.MaxRequestBytes,
+		core.GetFloat64("otlp_config.traces.probabilistic_sampler.sampling_percentage"),
+		attributesTranslator,
+	)
 
 	if core.IsSet("apm_config.install_id") {
 		c.InstallSignature.Found = true

--- a/pkg/trace/api/no_otlp.go
+++ b/pkg/trace/api/no_otlp.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !otlp
+// +build !otlp
+
+package api
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+)
+
+// OTLPReceiver implements an OpenTelemetry Collector receiver which accepts incoming
+// data on two ports for both plain HTTP and gRPC.
+type OTLPReceiver struct{}
+
+// NewOTLPReceiver returns a new OTLPReceiver which sends any incoming traces down the out channel.
+func NewOTLPReceiver(_ chan<- *Payload, _ *config.AgentConfig) *OTLPReceiver {
+	return &OTLPReceiver{}
+}
+
+// Start starts the OTLPReceiver, if any of the servers were configured as active.
+func (o *OTLPReceiver) Start() {
+	// NOP
+}
+
+// Stop stops any running server.
+func (o *OTLPReceiver) Stop() {
+	// NOP
+}

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build otlp
+// +build otlp
+
 package api
 
 import (

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -15,8 +15,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
-
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
@@ -41,43 +39,6 @@ type Endpoint struct {
 
 // TelemetryEndpointPrefix specifies the prefix of the telemetry endpoint URL.
 const TelemetryEndpointPrefix = "https://instrumentation-telemetry-intake."
-
-// OTLP holds the configuration for the OpenTelemetry receiver.
-type OTLP struct {
-	// BindHost specifies the host to bind the receiver to.
-	BindHost string `mapstructure:"-"`
-
-	// GRPCPort specifies the port to use for the plain HTTP receiver.
-	// If unset (or 0), the receiver will be off.
-	GRPCPort int `mapstructure:"grpc_port"`
-
-	// SpanNameRemappings is the map of datadog span names and preferred name to map to. This can be used to
-	// automatically map Datadog Span Operation Names to an updated value. All entries should be key/value pairs.
-	SpanNameRemappings map[string]string `mapstructure:"span_name_remappings"`
-
-	// SpanNameAsResourceName specifies whether the OpenTelemetry span's name should be
-	// used as the Datadog span's operation name. By default (when this is false), the
-	// operation name is deduced from a combination between the instrumentation scope
-	// name and the span kind.
-	//
-	// For context, the OpenTelemetry 'Span Name' is equivalent to the Datadog 'resource name'.
-	// The Datadog Span's Operation Name equivalent in OpenTelemetry does not exist, but the span's
-	// kind comes close.
-	SpanNameAsResourceName bool `mapstructure:"span_name_as_resource_name"`
-
-	// MaxRequestBytes specifies the maximum number of bytes that will be read
-	// from an incoming HTTP request.
-	MaxRequestBytes int64 `mapstructure:"-"`
-
-	// ProbabilisticSampling specifies the percentage of traces to ingest. Exceptions are made for errors
-	// and rare traces (outliers) if "RareSamplerEnabled" is true. Invalid values are equivalent to 100.
-	// If spans have the "sampling.priority" attribute set, probabilistic sampling is skipped and the user's
-	// decision is followed.
-	ProbabilisticSampling float64
-
-	// AttributesTranslator specifies an OTLP to Datadog attributes translator.
-	AttributesTranslator *attributes.Translator `mapstructure:"-"`
-}
 
 // ObfuscationConfig holds the configuration for obfuscating sensitive data
 // for various span types.

--- a/pkg/trace/config/config_nootlp.go
+++ b/pkg/trace/config/config_nootlp.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !otlp
+// +build !otlp
+
+package config
+
+// OTLP holds the configuration for the OpenTelemetry receiver.
+type OTLP struct{}

--- a/pkg/trace/config/config_nootlp.go
+++ b/pkg/trace/config/config_nootlp.go
@@ -8,5 +8,12 @@
 
 package config
 
+import "github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
+
 // OTLP holds the configuration for the OpenTelemetry receiver.
 type OTLP struct{}
+
+func NewOTLP(host string, port int, spanNameRemappings map[string]string, spanNameAsResourceName bool,
+	maxReqBytes int64, sample float64, attributesTranslator *attributes.Translator) *OTLP {
+	return nil
+}

--- a/pkg/trace/config/config_otlp.go
+++ b/pkg/trace/config/config_otlp.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build otlp
+// +build otlp
+
+package config
+
+import "github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
+
+// OTLP holds the configuration for the OpenTelemetry receiver.
+type OTLP struct {
+	// BindHost specifies the host to bind the receiver to.
+	BindHost string `mapstructure:"-"`
+
+	// GRPCPort specifies the port to use for the plain HTTP receiver.
+	// If unset (or 0), the receiver will be off.
+	GRPCPort int `mapstructure:"grpc_port"`
+
+	// SpanNameRemappings is the map of datadog span names and preferred name to map to. This can be used to
+	// automatically map Datadog Span Operation Names to an updated value. All entries should be key/value pairs.
+	SpanNameRemappings map[string]string `mapstructure:"span_name_remappings"`
+
+	// SpanNameAsResourceName specifies whether the OpenTelemetry span's name should be
+	// used as the Datadog span's operation name. By default (when this is false), the
+	// operation name is deduced from a combination between the instrumentation scope
+	// name and the span kind.
+	//
+	// For context, the OpenTelemetry 'Span Name' is equivalent to the Datadog 'resource name'.
+	// The Datadog Span's Operation Name equivalent in OpenTelemetry does not exist, but the span's
+	// kind comes close.
+	SpanNameAsResourceName bool `mapstructure:"span_name_as_resource_name"`
+
+	// MaxRequestBytes specifies the maximum number of bytes that will be read
+	// from an incoming HTTP request.
+	MaxRequestBytes int64 `mapstructure:"-"`
+
+	// ProbabilisticSampling specifies the percentage of traces to ingest. Exceptions are made for errors
+	// and rare traces (outliers) if "RareSamplerEnabled" is true. Invalid values are equivalent to 100.
+	// If spans have the "sampling.priority" attribute set, probabilistic sampling is skipped and the user's
+	// decision is followed.
+	ProbabilisticSampling float64
+
+	// AttributesTranslator specifies an OTLP to Datadog attributes translator.
+	AttributesTranslator *attributes.Translator `mapstructure:"-"`
+}

--- a/pkg/trace/config/config_otlp.go
+++ b/pkg/trace/config/config_otlp.go
@@ -46,3 +46,16 @@ type OTLP struct {
 	// AttributesTranslator specifies an OTLP to Datadog attributes translator.
 	AttributesTranslator *attributes.Translator `mapstructure:"-"`
 }
+
+func NewOTLP(host string, port int, spanNameRemappings map[string]string, spanNameAsResourceName bool,
+	maxReqBytes int64, sample float64, attributesTranslator *attributes.Translator) *OTLP {
+	return &OTLP{
+		BindHost:               host,
+		GRPCPort:               port,
+		MaxRequestBytes:        maxReqBytes,
+		SpanNameRemappings:     spanNameRemappings,
+		SpanNameAsResourceName: spanNameAsResourceName,
+		ProbabilisticSampling:  sample,
+		AttributesTranslator:   attributesTranslator,
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR allows to optionally build the OTLP endpoint in the trace-agent. This allows removing it for (potentially) unnecessary environments like serverless where it may not yet been supported.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Reduce overhead.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
