### PR TITLE
[PROCS-3757][process] Fix flaking Windows E2E test

### DIFF
--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -132,10 +132,6 @@ func (s *windowsTestSuite) TestManualProcessDiscoveryCheck() {
 }
 
 func (s *windowsTestSuite) TestManualProcessCheckWithIO() {
-	s.T().Skip("skipping due to flakiness")
-	// MsMpEng.exe process missing IO stats
-	// Investigation & fix tracked in https://datadoghq.atlassian.net/browse/PROCS-3757
-
 	s.UpdateEnv(awshost.Provisioner(
 		awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
 		awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr)),
@@ -147,5 +143,7 @@ func (s *windowsTestSuite) TestManualProcessCheckWithIO() {
 	check := s.Env().RemoteHost.
 		MustExecute("& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent\\process-agent.exe\" check process --json")
 
-	assertManualProcessCheck(s.T(), check, true, "MsMpEng.exe")
+	// Check stats for Datadog agent process as it has IO stats more reliably populated than MsMpEng.exe
+	agentExe := "\"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe\""
+	assertManualProcessCheck(s.T(), check, true, agentExe)
 }


### PR DESCRIPTION
### What does this PR do?

Updates the `TestManualProcessCheckWithIO` Windows E2E test  to check process stats for the Datadog agent process instead of MsMpEng.exe, and re-enables the E2E test.

### Motivation

Windows E2E tests for the process agent are flaking with the following occasional test failure:

```
        	Test:       	TestWindowsTestSuite/TestManualProcessCheckWithIO
        	Messages:   	no MsMpEng.exe process had all data populated
```

Consequently, this E2E test was disabled in https://github.com/DataDog/datadog-agent/pull/22743

While the flake cannot be reliably reproduced when kicking off E2E test suite runs locally, we can review the failed test suite runs. This was done for ten commits to `main` where the `new-e2e-process` test suite was failing:
- https://github.com/DataDog/datadog-agent/commit/1739a048156d968bbe5fd8a1ace8e07c997d16d9
- https://github.com/DataDog/datadog-agent/commit/bb938051627cb9c7d454bb380a19911f8dc8dd42
- https://github.com/DataDog/datadog-agent/commit/dd5a969bb81d13fced977c35ef5e684b9a5a0338
- https://github.com/DataDog/datadog-agent/commit/2adc77c907c33e4df09587713d1c5391e2266536
- https://github.com/DataDog/datadog-agent/commit/62390bf7baa17c00414776a94fbe51588e461325
- https://github.com/DataDog/datadog-agent/commit/7f2ff2e12c0e46dbb24ab74d02405c5e07e55334
- https://github.com/DataDog/datadog-agent/commit/7d66986b2092a2bbd09bb1ceca75a1782d93a7d5
- https://github.com/DataDog/datadog-agent/commit/a728fe3940e100be78464640cc392aa7f1367ad5
- https://github.com/DataDog/datadog-agent/commit/dd23965c00f656739a9d33946e0c909d21ca3eb7
- https://github.com/DataDog/datadog-agent/commit/5582baaf0960e16aaadfe1d774e770946cbeda6e

In **every one** of these reviewed test suite runs that failed, the `MsMpEng.exe` process did not have IO stats populated, but the Datadog agent process did. This motivates the switch to retrieving stats for the Datadog agent process, instead of `MsMpEng.exe`

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Ran tests locally with `go test ./test/new-e2e/tests/process/... -timeout 900s -run TestWindowsTestSuite -v -count=1` and validated they are passing:

```
    suite_utils.go:19: Resources:
            - 23 deleted
        
        Duration: 2m18s
        
        
    suite_utils.go:19: The resources in the stack have been deleted, but the history and configuration associated with the stack are still maintained. 

--- PASS: TestWindowsTestSuite (655.13s)
    --- PASS: TestWindowsTestSuite/TestManualProcessCheck (2.12s)
    --- PASS: TestWindowsTestSuite/TestManualProcessCheckWithIO (19.77s)
    --- PASS: TestWindowsTestSuite/TestManualProcessDiscoveryCheck (12.99s)
    --- PASS: TestWindowsTestSuite/TestProcessCheck (16.91s)
    --- PASS: TestWindowsTestSuite/TestProcessCheckIO (30.02s)
    --- PASS: TestWindowsTestSuite/TestProcessDiscoveryCheck (37.90s)
PASS
ok  	github.com/DataDog/datadog-agent/test/new-e2e/tests/process	657.680s
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
