### PR TITLE
fix(CI): Add a need condition to force tests to start earlier

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -21,45 +21,61 @@
   - export DATADOG_AGENT_APP_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_app_key)
   - export DATADOG_AGENT_RC_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_rc_key)
 
-.k8s_e2e_template_dev:
+.k8s_e2e_template_needs_dev:
   extends: .k8s_e2e_template
   needs:
     - dev_branch_multiarch-a7
     - dca_dev_branch
+
+.k8s_e2e_template_dev:
+  extends: .k8s_e2e_template_needs_dev
+  script:
+    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=$ARGO_WORKFLOW
+
+.k8s_e2e_template_dev_with_cws_cspm_init:
+  extends: .k8s_e2e_template_needs_dev
   script:
     - !reference [.k8s-e2e-cws-cspm-init]
     - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=$ARGO_WORKFLOW
 
-.k8s_e2e_template_main:
+.k8s_e2e_template_needs_main:
   extends: .k8s_e2e_template
   needs:
     - dev_master-a7
     - dca_dev_master
+
+.k8s_e2e_template_main_with_cws_cspm_init:
+  extends: .k8s_e2e_template_needs_main
   script:
     - !reference [.k8s-e2e-cws-cspm-init]
     - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=$ARGO_WORKFLOW
 
+.k8s_e2e_template_main:
+  extends: .k8s_e2e_template_needs_main
+  script:
+    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=$ARGO_WORKFLOW
+
 k8s-e2e-cws-dev:
-  extends: .k8s_e2e_template_dev
+  extends: .k8s_e2e_template_dev_with_cws_cspm_init
   rules: !reference [.on_dev_branch_manual]
   variables:
     ARGO_WORKFLOW: cws
 
 k8s-e2e-cws-main:
-  extends: .k8s_e2e_template_main
+  extends: .k8s_e2e_template_main_with_cws_cspm_init
   rules: !reference [.on_main]
   retry: 1
   variables:
     ARGO_WORKFLOW: cws
 
 k8s-e2e-cspm-dev:
-  extends: .k8s_e2e_template_dev
+  extends: .k8s_e2e_template_dev_with_cws_cspm_init
   rules: !reference [.on_dev_branch_manual]
   variables:
     ARGO_WORKFLOW: cspm
 
 k8s-e2e-cspm-main:
-  extends: .k8s_e2e_template_main
+  extends: .k8s_e2e_template_main_with_cws_cspm_init
   rules: !reference [.on_main]
   retry: 1
   variables:

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -2,18 +2,11 @@
 # e2e stage
 # Contains jobs which runs e2e tests on our Docker images.
 
-.container_e2e_needs:
-  needs:
-    - qa_agent
-    - qa_dca
-    - qa_dogstatsd
-
 .k8s_e2e_template:
   stage: e2e
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
   dependencies: []
-  extends: .container_e2e_needs
   variables:
     LANG: C.UTF-8
   before_script:
@@ -28,85 +21,66 @@
   - export DATADOG_AGENT_APP_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_app_key)
   - export DATADOG_AGENT_RC_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_rc_key)
 
-k8s-e2e-cws-dev:
+.k8s_e2e_template_dev:
   extends: .k8s_e2e_template
-  rules: !reference [.on_dev_branch_manual]
-  needs: []
+  needs:
+    - dev_branch_multiarch-a7
+    - dca_dev_branch
   script:
     - !reference [.k8s-e2e-cws-cspm-init]
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=cws
+    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=$ARGO_WORKFLOW
+
+.k8s_e2e_template_main:
+  extends: .k8s_e2e_template
+  needs:
+    - dev_master-a7
+    - dca_dev_master
+  script:
+    - !reference [.k8s-e2e-cws-cspm-init]
+    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=$ARGO_WORKFLOW
+
+k8s-e2e-cws-dev:
+  extends: .k8s_e2e_template_dev
+  rules: !reference [.on_dev_branch_manual]
+  variables:
+    ARGO_WORKFLOW: cws
 
 k8s-e2e-cws-main:
-  extends: .k8s_e2e_template
+  extends: .k8s_e2e_template_main
   rules: !reference [.on_main]
   retry: 1
-  script:
-    - !reference [.k8s-e2e-cws-cspm-init]
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=cws
+  variables:
+    ARGO_WORKFLOW: cws
 
 k8s-e2e-cspm-dev:
-  extends: .k8s_e2e_template
+  extends: .k8s_e2e_template_dev
   rules: !reference [.on_dev_branch_manual]
-  needs: []
-  script:
-    - !reference [.k8s-e2e-cws-cspm-init]
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=cspm
+  variables:
+    ARGO_WORKFLOW: cspm
 
 k8s-e2e-cspm-main:
-  extends: .k8s_e2e_template
+  extends: .k8s_e2e_template_main
   rules: !reference [.on_main]
   retry: 1
-  script:
-    - !reference [.k8s-e2e-cws-cspm-init]
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=cspm
+  variables:
+    ARGO_WORKFLOW: cspm
 
 k8s-e2e-otlp-dev:
-  extends: .k8s_e2e_template
+  extends: .k8s_e2e_template_dev
   rules: !reference [.on_dev_branch_manual]
-  needs: [] # we can't explicitly define the dependencies because a job cannot depend on other manual jobs.
-  script:
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=otlp
+  variables:
+    ARGO_WORKFLOW: otlp
 
 k8s-e2e-otlp-main:
-  extends: .k8s_e2e_template
+  extends: .k8s_e2e_template_main
   rules: !reference [.on_main]
-  script:
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=otlp
+  variables:
+    ARGO_WORKFLOW: otlp
 
 .new_e2e_template:
   stage: e2e
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs:
-    - job: deploy_deb_testing-a6_x64
-      optional: true
-    - job: deploy_deb_testing-a6_arm64
-      optional: true
-    - job: deploy_deb_testing-a7_x64
-      optional: true
-    - job: deploy_deb_testing-a7_arm64
-      optional: true
-    - job: deploy_deb_testing-u7_arm64
-      optional: true
-    - job: deploy_rpm_testing-a6_x64
-      optional: true
-    - job: deploy_rpm_testing-a6_arm64
-      optional: true
-    - job: deploy_rpm_testing-a7_x64
-      optional: true
-    - job: deploy_rpm_testing-a7_arm64
-      optional: true
-    - job: deploy_suse_rpm_testing_x64-a6
-      optional: true
-    - job: deploy_suse_rpm_testing_x64-a7
-      optional: true
-    - job: deploy_suse_rpm_testing_arm64-a7
-      optional: true
-    - job: deploy_windows_testing-a6
-      optional: true
-    - job: deploy_windows_testing-a7
-      optional: true
-    - job: agent-qa
   before_script:
     # Setup AWS Credentials
     - mkdir -p ~/.aws
@@ -141,10 +115,48 @@ k8s-e2e-otlp-main:
     reports:
       junit: test/new-e2e/junit-*.xml
 
+.new_e2e_template_needs_kitchen_deploy:
+  extends: .new_e2e_template
+  needs:
+    - job: deploy_deb_testing-a6_x64
+      optional: true
+    - job: deploy_deb_testing-a6_arm64
+      optional: true
+    - job: deploy_deb_testing-a7_x64
+      optional: true
+    - job: deploy_deb_testing-a7_arm64
+      optional: true
+    - job: deploy_deb_testing-u7_arm64
+      optional: true
+    - job: deploy_rpm_testing-a6_x64
+      optional: true
+    - job: deploy_rpm_testing-a6_arm64
+      optional: true
+    - job: deploy_rpm_testing-a7_x64
+      optional: true
+    - job: deploy_rpm_testing-a7_arm64
+      optional: true
+    - job: deploy_suse_rpm_testing_x64-a6
+      optional: true
+    - job: deploy_suse_rpm_testing_x64-a7
+      optional: true
+    - job: deploy_suse_rpm_testing_arm64-a7
+      optional: true
+    - job: deploy_windows_testing-a6
+      optional: true
+    - job: deploy_windows_testing-a7
+      optional: true
+
+.new_e2e_template_needs_container_deploy:
+  extends: .new_e2e_template
+  needs:
+    - qa_agent
+    - qa_dca
+    - qa_dogstatsd
+
 new-e2e-containers:
   extends:
-    - .new_e2e_template
-    - .container_e2e_needs
+    - .new_e2e_template_needs_container_deploy
   # TODO once images are deployed to ECR for dev branches, update
   #.on_main_or_rc_and_no_skip_e2e adding on_dev_branch_manual rules
   # and move rules to template
@@ -165,21 +177,21 @@ new-e2e-containers:
       - EXTRA_PARAMS: --skip "Test(Kind|EKS|ECS|Docker)Suite"
 
 new-e2e-remote-config:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_rc_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/remote-config
     TEAM: remote-config
 
 new-e2e-agent-shared-components:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_asc_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/agent-shared-components
     TEAM: agent-shared-components
 
 new-e2e-agent-subcommands:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_subcommands_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/agent-subcommands
@@ -205,28 +217,28 @@ new-e2e-agent-subcommands:
       - EXTRA_PARAMS: --run TestLinuxCheckSuite
 
 new-e2e-language-detection:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_language-detection_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/language-detection
     TEAM: processes
 
 new-e2e-npm:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_npm_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/npm
     TEAM: network-performance-monitoring
 
 new-e2e-aml:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_aml_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/agent-metric-logs
     TEAM: agent-metric-logs
 
 new-e2e-cws:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_cws_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/cws
@@ -238,7 +250,7 @@ new-e2e-cws:
       - EXTRA_PARAMS: --run TestECSFargate
 
 new-e2e-process:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_process_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/process
@@ -246,12 +258,11 @@ new-e2e-process:
 
 new-e2e-orchestrator:
   extends:
-    - .new_e2e_template
-    - .container_e2e_needs
+    - .new_e2e_template_needs_container_deploy
   rules: !reference [.on_main_or_rc_and_no_skip_e2e]
   variables:
-    TARGETS: ./tests/process
-    TEAM: processes
+    TARGETS: ./tests/orchestrator
+    TEAM: container-app
 
 new-e2e-apm:
   extends: .new_e2e_template
@@ -270,7 +281,7 @@ new-e2e-apm:
       - EXTRA_PARAMS: --run TestVMFakeintakeSuiteTCP
 
 new-e2e-updater:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules:
     !reference [.on_updater_or_e2e_changes_or_manual]
   variables:

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -2,7 +2,7 @@
 # e2e stage
 # Contains jobs which runs e2e tests on our Docker images.
 
-.container_needs:
+.container_e2e_needs:
   needs:
     - qa_agent
     - qa_dca
@@ -13,7 +13,7 @@
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
   dependencies: []
-  extends: .container_needs
+  extends: .container_e2e_needs
   variables:
     LANG: C.UTF-8
   before_script:
@@ -78,10 +78,35 @@ k8s-e2e-otlp-main:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
   needs:
-    - job: "deploy_rpm_testing-a6_x64" # This deploy is the last one of all the deploys
+    - job: deploy_deb_testing-a6_x64
       optional: true
-    - job: "deploy_rpm_testing-a7_x64" # In case agent6 is not built
+    - job: deploy_deb_testing-a6_arm64
       optional: true
+    - job: deploy_deb_testing-a7_x64
+      optional: true
+    - job: deploy_deb_testing-a7_arm64
+      optional: true
+    - job: deploy_deb_testing-u7_arm64
+      optional: true
+    - job: deploy_rpm_testing-a6_x64
+      optional: true
+    - job: deploy_rpm_testing-a6_arm64
+      optional: true
+    - job: deploy_rpm_testing-a7_x64
+      optional: true
+    - job: deploy_rpm_testing-a7_arm64
+      optional: true
+    - job: deploy_suse_rpm_testing_x64-a6
+      optional: true
+    - job: deploy_suse_rpm_testing_x64-a7
+      optional: true
+    - job: deploy_suse_rpm_testing_arm64-a7
+      optional: true
+    - job: deploy_windows_testing-a6
+      optional: true
+    - job: deploy_windows_testing-a7
+      optional: true
+    - job: agent-qa
   before_script:
     # Setup AWS Credentials
     - mkdir -p ~/.aws
@@ -119,7 +144,7 @@ k8s-e2e-otlp-main:
 new-e2e-containers:
   extends:
     - .new_e2e_template
-    - .container_needs
+    - .container_e2e_needs
   # TODO once images are deployed to ECR for dev branches, update
   #.on_main_or_rc_and_no_skip_e2e adding on_dev_branch_manual rules
   # and move rules to template
@@ -220,22 +245,13 @@ new-e2e-process:
     TEAM: processes
 
 new-e2e-orchestrator:
-  extends: .new_e2e_template
+  extends:
+    - .new_e2e_template
+    - .container_e2e_needs
   rules: !reference [.on_main_or_rc_and_no_skip_e2e]
   variables:
     TARGETS: ./tests/process
     TEAM: processes
-
-new-e2e-orchestrator-dev:
-  extends:
-    - .new_e2e_template
-    - .container_needs
-  rules:
-    - !reference [.if_run_e2e_tests]
-    - !reference [.on_dev_branch_manual]
-  variables:
-    TARGETS: ./tests/orchestrator
-    TEAM: container-app
 
 new-e2e-apm:
   extends: .new_e2e_template

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -2,11 +2,18 @@
 # e2e stage
 # Contains jobs which runs e2e tests on our Docker images.
 
+.container_needs:
+  needs:
+    - qa_agent
+    - qa_dca
+    - qa_dogstatsd
+
 .k8s_e2e_template:
   stage: e2e
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
   dependencies: []
+  extends: .container_needs
   variables:
     LANG: C.UTF-8
   before_script:
@@ -32,9 +39,6 @@ k8s-e2e-cws-dev:
 k8s-e2e-cws-main:
   extends: .k8s_e2e_template
   rules: !reference [.on_main]
-  # needs:
-  #   - dev_master-a6
-  #   - dev_master-a7
   retry: 1
   script:
     - !reference [.k8s-e2e-cws-cspm-init]
@@ -51,9 +55,6 @@ k8s-e2e-cspm-dev:
 k8s-e2e-cspm-main:
   extends: .k8s_e2e_template
   rules: !reference [.on_main]
-  # needs:
-  #   - dev_master-a6
-  #   - dev_master-a7
   retry: 1
   script:
     - !reference [.k8s-e2e-cws-cspm-init]
@@ -69,9 +70,6 @@ k8s-e2e-otlp-dev:
 k8s-e2e-otlp-main:
   extends: .k8s_e2e_template
   rules: !reference [.on_main]
-  # needs:
-  #   - dev_master-a6
-  #   - dev_master-a7
   script:
     - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=otlp
 
@@ -79,6 +77,11 @@ k8s-e2e-otlp-main:
   stage: e2e
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
+  needs:
+    - job: "deploy_rpm_testing-a6_x64" # This deploy is the last one of all the deploys
+      optional: true
+    - job: "deploy_rpm_testing-a7_x64" # In case agent6 is not built
+      optional: true
   before_script:
     # Setup AWS Credentials
     - mkdir -p ~/.aws
@@ -114,7 +117,9 @@ k8s-e2e-otlp-main:
       junit: test/new-e2e/junit-*.xml
 
 new-e2e-containers:
-  extends: .new_e2e_template
+  extends:
+    - .new_e2e_template
+    - .container_needs
   # TODO once images are deployed to ECR for dev branches, update
   #.on_main_or_rc_and_no_skip_e2e adding on_dev_branch_manual rules
   # and move rules to template
@@ -137,7 +142,6 @@ new-e2e-containers:
 new-e2e-remote-config:
   extends: .new_e2e_template
   rules: !reference [.on_rc_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/remote-config
     TEAM: remote-config
@@ -145,7 +149,6 @@ new-e2e-remote-config:
 new-e2e-agent-shared-components:
   extends: .new_e2e_template
   rules: !reference [.on_asc_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/agent-shared-components
     TEAM: agent-shared-components
@@ -153,7 +156,6 @@ new-e2e-agent-shared-components:
 new-e2e-agent-subcommands:
   extends: .new_e2e_template
   rules: !reference [.on_subcommands_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/agent-subcommands
     TEAM: agent-shared-components
@@ -180,7 +182,6 @@ new-e2e-agent-subcommands:
 new-e2e-language-detection:
   extends: .new_e2e_template
   rules: !reference [.on_language-detection_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/language-detection
     TEAM: processes
@@ -188,7 +189,6 @@ new-e2e-language-detection:
 new-e2e-npm:
   extends: .new_e2e_template
   rules: !reference [.on_npm_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7", "qa_agent"]
   variables:
     TARGETS: ./tests/npm
     TEAM: network-performance-monitoring
@@ -196,7 +196,6 @@ new-e2e-npm:
 new-e2e-aml:
   extends: .new_e2e_template
   rules: !reference [.on_aml_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/agent-metric-logs
     TEAM: agent-metric-logs
@@ -204,7 +203,6 @@ new-e2e-aml:
 new-e2e-cws:
   extends: .new_e2e_template
   rules: !reference [.on_cws_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7", "qa_agent", "qa_cws_instrumentation"]
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
@@ -217,26 +215,31 @@ new-e2e-cws:
 new-e2e-process:
   extends: .new_e2e_template
   rules: !reference [.on_process_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/process
     TEAM: processes
 
 new-e2e-orchestrator:
   extends: .new_e2e_template
-  rules: !reference [.on_orchestrator_or_e2e_changes_or_manual]
-  needs:
-    - qa_agent
-    - qa_dca
-    - qa_dogstatsd
+  rules: !reference [.on_main_or_rc_and_no_skip_e2e]
+  variables:
+    TARGETS: ./tests/process
+    TEAM: processes
+
+new-e2e-orchestrator-dev:
+  extends:
+    - .new_e2e_template
+    - .container_needs
+  rules:
+    - !reference [.if_run_e2e_tests]
+    - !reference [.on_dev_branch_manual]
   variables:
     TARGETS: ./tests/orchestrator
     TEAM: container-app
 
 new-e2e-apm:
   extends: .new_e2e_template
-  rules:
-    !reference [.on_apm_or_e2e_changes_or_manual]
+  rules: !reference [.on_apm_or_e2e_changes_or_manual]
   needs:
     - qa_agent
     - deploy_deb_testing-a7_x64
@@ -254,7 +257,6 @@ new-e2e-updater:
   extends: .new_e2e_template
   rules:
     !reference [.on_updater_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-u7_arm64"]
   variables:
     TARGETS: ./tests/updater
     TEAM: fleet


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Add a `needs` condition to save time in the overall CI process. Without definition, jobs will wait for completion of all the previous stages, whereas they could nearly all start together.
<img width="773" alt="image" src="https://github.com/DataDog/datadog-agent/assets/24426034/e189d94a-1cac-4f24-8e26-88b0b480f5d4">


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Improve overall CI duration

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
I've forced the default `new-e2e` template with `deploy_rpm_testing-a6_x64` and `deploy_rpm_testing-a7_x64` as they appear as the last jobs from the `kitchen_deploy` stage. This is maybe fragile, we might want to put all the jobs of the stage to be sure

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
