### PR TITLE
[ASCII-1184] Add IMDSv2 as host alias

### DIFF
--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -99,9 +99,21 @@ var instanceIDFetcher = cachedfetch.Fetcher{
 	},
 }
 
+var imdsv2InstanceIDFetcher = cachedfetch.Fetcher{
+	Name: "EC2 IMDSv2 InstanceID",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		return getMetadataItemWithMaxLength(ctx, imdsInstanceID, true)
+	},
+}
+
 // GetInstanceID fetches the instance id for current host from the EC2 metadata API
 func GetInstanceID(ctx context.Context) (string, error) {
 	return instanceIDFetcher.FetchString(ctx)
+}
+
+// GetIDMSv2InstanceID fetches the instance id for current host from the IMDSv2 EC2 metadata API
+func GetIDMSv2InstanceID(ctx context.Context) (string, error) {
+	return imdsv2InstanceIDFetcher.FetchString(ctx)
 }
 
 // GetHostID returns the instanceID for the current EC2 host using IMDSv2 only.
@@ -141,6 +153,16 @@ func GetHostAliases(ctx context.Context) ([]string, error) {
 		return []string{instanceID}, nil
 	}
 	log.Debugf("failed to get instance ID from DMI for Host Alias: %s", err)
+
+	// Try to use IMSDv2 if GetInstanceID didn't try it already
+	if !UseIMDSv2(false) {
+		imsdv2InstanceID, err := GetIDMSv2InstanceID(ctx)
+		if err == nil {
+			return []string{imsdv2InstanceID}, nil
+		}
+
+		log.Debugf("failed to get instance ID from IMDSV2 for Host Alias: %s", err)
+	}
 
 	return []string{}, nil
 }

--- a/pkg/util/ec2/imds_helpers.go
+++ b/pkg/util/ec2/imds_helpers.go
@@ -65,6 +65,7 @@ func getMetadataItem(ctx context.Context, endpoint string, forceIMDSv2 bool) (st
 	return doHTTPRequest(ctx, metadataURL+endpoint, forceIMDSv2)
 }
 
+// UseIMDSv2 returns true if the agent should use IMDSv2
 func UseIMDSv2(forceIMDSv2 bool) bool {
 	return config.Datadog.GetBool("ec2_prefer_imdsv2") || forceIMDSv2
 }

--- a/pkg/util/ec2/imds_helpers.go
+++ b/pkg/util/ec2/imds_helpers.go
@@ -65,10 +65,14 @@ func getMetadataItem(ctx context.Context, endpoint string, forceIMDSv2 bool) (st
 	return doHTTPRequest(ctx, metadataURL+endpoint, forceIMDSv2)
 }
 
+func UseIMDSv2(forceIMDSv2 bool) bool {
+	return config.Datadog.GetBool("ec2_prefer_imdsv2") || forceIMDSv2
+}
+
 func doHTTPRequest(ctx context.Context, url string, forceIMDSv2 bool) (string, error) {
 	source := metadataSourceIMDSv1
 	headers := map[string]string{}
-	if config.Datadog.GetBool("ec2_prefer_imdsv2") || forceIMDSv2 {
+	if UseIMDSv2(forceIMDSv2) {
 		tokenValue, err := token.Get(ctx)
 		if err != nil {
 			if forceIMDSv2 {

--- a/releasenotes/notes/add-imdsv2-as-host-alias-58f37c16e44df925.yaml
+++ b/releasenotes/notes/add-imdsv2-as-host-alias-58f37c16e44df925.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add the instance ID returned by the IMDSv2 metadata endpoint to the list of EC2 host aliases.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds IMDSv2 instance id to the EC2 host alias.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Here are the steps to QA:
- Create a EC2 instance with metadata version V2 only. It should be either a Windows instance or a non nitro instance (For example use the instance type `t2.xlarge`) 
![Screenshot 2024-02-13 at 18 07 59](https://github.com/DataDog/datadog-agent/assets/52180542/f93922e7-5f60-4f79-b27b-be0a5b485bd8)

- **Make sure that host alias is empty when running `agent status`**
```
 Hostnames
  =========
    hostname: i-008828bfa8ad51c7c
    socket-fqdn: ip-10-0-3-138.ec2.internal.
    socket-hostname: i-008828bfa8ad51c7c
    hostname provider: os
```
- Update the Agent to version `7.52.X`
- Make sure that host alias contains the instance ID when running `agent status`. Instance id starts with `i-`
```
========
Hostname
========

  host_aliases: [i-008828bfa8ad51c7c]
  hostname: i-008828bfa8ad51c7c
  socket-fqdn: ip-10-0-3-138.ec2.internal.
  socket-hostname: i-008828bfa8ad51c7c
  hostname provider: os
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
