### PR TITLE
[PROCS-3723][PROCS-3724] Use the process agent component in core agent(linux only) and process-agent 

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -403,7 +403,7 @@ func startAgent(
 	taggerComp tagger.Component,
 	rcclient rcclient.Component,
 	logsAgent optional.Option[logsAgent.Component],
-	processAgent optional.Option[processAgent.Component],
+	_ optional.Option[processAgent.Component],
 	_ defaultforwarder.Component,
 	_ serializer.MetricSerializer,
 	otelcollector otelcollector.Component,
@@ -535,11 +535,6 @@ func startAgent(
 		logsAgent.AddScheduler(adScheduler.New(common.AC))
 	}
 
-	if procAgent, ok := processAgent.Get(); ok {
-		log.Infof("Process Agent Enabled: %v", procAgent)
-	} else {
-		log.Infof("Process Agent Not Enabled: %v", procAgent)
-	}
 	// start the cloudfoundry container tagger
 	if pkgconfig.IsFeaturePresent(pkgconfig.CloudFoundry) && !pkgconfig.Datadog.GetBool("cloud_foundry_buildpack") {
 		containerTagger, err := containertagger.NewContainerTagger()

--- a/cmd/agent/subcommands/run/command_windows.go
+++ b/cmd/agent/subcommands/run/command_windows.go
@@ -61,6 +61,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/runner"
 	netflowServer "github.com/DataDog/datadog-agent/comp/netflow/server"
 	otelcollector "github.com/DataDog/datadog-agent/comp/otelcol/collector"
+	processAgent "github.com/DataDog/datadog-agent/comp/process/agent"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -95,6 +96,7 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 			rcclient rcclient.Component,
 			forwarder defaultforwarder.Component,
 			logsAgent optional.Option[logsAgent.Component],
+			processAgent optional.Option[processAgent.Component],
 			metadataRunner runner.Component,
 			sharedSerializer serializer.MetricSerializer,
 			otelcollector otelcollector.Component,
@@ -126,6 +128,7 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 				taggerComp,
 				rcclient,
 				logsAgent,
+				processAgent,
 				forwarder,
 				sharedSerializer,
 				otelcollector,

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -207,11 +207,6 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 		return err
 	}
 
-	if appInitDeps.Config.GetBool("process_config.run_in_core_agent.enabled") {
-		log.Info("Running in core agent mode, exiting...")
-		return nil
-	}
-
 	// Look to see if any checks are enabled, if not, return since the agent doesn't need to be enabled.
 	if !shouldEnableProcessAgent(appInitDeps.Checks, appInitDeps.Config) {
 		log.Infof(agent6DisabledMessage)

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -120,9 +120,6 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 
 		// Provide process agent bundle so fx knows where to find components
 		process.Bundle(),
-		// Provide workloadmeta and tagger module
-		workloadmeta.Module(),
-		tagger.Module(),
 
 		// Provide remote config client module
 		rcclient.Module(),

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -8,6 +8,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -27,11 +28,11 @@ import (
 	compstatsd "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl/utils"
 	"github.com/DataDog/datadog-agent/comp/process"
+	"github.com/DataDog/datadog-agent/comp/process/agent"
 	"github.com/DataDog/datadog-agent/comp/process/apiserver"
 	"github.com/DataDog/datadog-agent/comp/process/expvars"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/profiler"
-	"github.com/DataDog/datadog-agent/comp/process/runner"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -42,6 +43,7 @@ import (
 	ddutil "github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -54,6 +56,9 @@ process_config:
 to your datadog.yaml file.
 Exiting.`
 )
+
+// errAgentDisabled indicates that the process-agent wasn't enabled through environment variable or config.
+var errAgentDisabled = errors.New("process-agent not enabled")
 
 func runAgent(ctx context.Context, globalParams *GlobalParams) error {
 	if globalParams.PidFilePath != "" {
@@ -161,11 +166,15 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 
 		// Invoke the components that we want to start
 		fx.Invoke(func(
-			runner.Component,
-			profiler.Component,
-			expvars.Component,
-			apiserver.Component,
-		) {
+			_ profiler.Component,
+			_ expvars.Component,
+			_ apiserver.Component,
+			processAgent optional.Option[agent.Component],
+		) error {
+			if !processAgent.IsSet() {
+				return errAgentDisabled
+			}
+			return nil
 		}),
 
 		// Initialize the remote-config client to update the runtime settings
@@ -179,6 +188,12 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 	)
 
 	if err := app.Err(); err != nil {
+
+		if errors.Is(err, errAgentDisabled) {
+			log.Info("process-agent is not enabled, exiting...")
+			return nil
+		}
+
 		// At this point it is not guaranteed that the logger has been successfully initialized. We should fall back to
 		// stdout just in case.
 		if appInitDeps.Logger == nil {

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -120,6 +120,9 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 
 		// Provide process agent bundle so fx knows where to find components
 		process.Bundle(),
+		// Provide workloadmeta and tagger module
+		workloadmeta.Module(),
+		tagger.Module(),
 
 		// Provide remote config client module
 		rcclient.Module(),
@@ -202,6 +205,11 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 			appInitDeps.Logger.Critical("Failed to initialize the process agent: ", fxutil.UnwrapIfErrArgumentsFailed(err))
 		}
 		return err
+	}
+
+	if appInitDeps.Config.GetBool("process_config.run_in_core_agent.enabled") {
+		log.Info("Running in core agent mode, exiting...")
+		return nil
 	}
 
 	// Look to see if any checks are enabled, if not, return since the agent doesn't need to be enabled.

--- a/comp/process/agent/agentimpl/agent.go
+++ b/comp/process/agent/agentimpl/agent.go
@@ -92,7 +92,7 @@ func newProcessAgent(p processAgentParams) optional.Option[agent.Component] {
 }
 
 func (p processAgent) start(ctx context.Context) error {
-	p.Log.Info("process-agent starting")
+	p.Log.Debug("Starting the process-agent component")
 
 	chks := make([]string, 0, len(p.Checks))
 	for _, check := range p.Checks {
@@ -111,7 +111,7 @@ func (p processAgent) start(ctx context.Context) error {
 
 // stop stops all agent components that were started in reverse order
 func (p processAgent) stop(ctx context.Context) error {
-	p.Log.Info("process-agent stopping")
+	p.Log.Debug("Stopping the process-agent component")
 
 	// stop the check runner
 	err := p.Runner.Stop(ctx)

--- a/comp/process/agent/agentimpl/agent.go
+++ b/comp/process/agent/agentimpl/agent.go
@@ -94,7 +94,7 @@ func (p processAgent) start(ctx context.Context) error {
 	for _, check := range p.Checks {
 		chks = append(chks, check.Name())
 	}
-	p.Log.Info("process-agent checks", log.Object("checks", chks))
+	p.Log.Debug("process-agent checks", log.Object("checks", chks))
 
 	return p.Runner.Run(ctx)
 }

--- a/comp/process/agent/agentimpl/agent_linux.go
+++ b/comp/process/agent/agentimpl/agent_linux.go
@@ -39,6 +39,11 @@ func agentEnabled(p processAgentParams) bool {
 			}
 			return true
 		}
+
+		if runInCoreAgent {
+			p.Log.Info("The process checks will run in the core agent")
+		}
+
 		return !runInCoreAgent
 	case flavor.DefaultAgent:
 		if npmEnabled {

--- a/comp/process/bundle.go
+++ b/comp/process/bundle.go
@@ -12,6 +12,7 @@
 package process
 
 import (
+	"github.com/DataDog/datadog-agent/comp/process/agent/agentimpl"
 	"github.com/DataDog/datadog-agent/comp/process/apiserver"
 	"github.com/DataDog/datadog-agent/comp/process/connectionscheck/connectionscheckimpl"
 	"github.com/DataDog/datadog-agent/comp/process/containercheck/containercheckimpl"
@@ -44,6 +45,8 @@ func Bundle() fxutil.BundleOptions {
 		processeventscheckimpl.Module(),
 		rtcontainercheckimpl.Module(),
 		processdiscoverycheckimpl.Module(),
+
+		agentimpl.Module(),
 
 		hostinfoimpl.Module(),
 		expvarsimpl.Module(),

--- a/comp/process/runner/component.go
+++ b/comp/process/runner/component.go
@@ -20,4 +20,5 @@ type Component interface {
 	GetChecks() []checks.Check
 	GetProvidedChecks() []types.CheckComponent
 	Run(ctx context.Context) error
+	Stop(ctx context.Context) error
 }

--- a/comp/process/runner/runnerimpl/runner.go
+++ b/comp/process/runner/runnerimpl/runner.go
@@ -54,17 +54,10 @@ func newRunner(deps dependencies) (runner.Component, error) {
 	}
 	c.Submitter = deps.Submitter
 
-	runner := &runnerImpl{
+	return &runnerImpl{
 		checkRunner:    c,
 		providedChecks: deps.Checks,
-	}
-
-	deps.Lc.Append(fx.Hook{
-		OnStart: runner.Run,
-		OnStop:  runner.Stop,
-	})
-
-	return runner, nil
+	}, nil
 }
 
 func (r *runnerImpl) Run(context.Context) error {

--- a/comp/process/runner/runnerimpl/runner.go
+++ b/comp/process/runner/runnerimpl/runner.go
@@ -36,7 +36,6 @@ type runnerImpl struct {
 
 type dependencies struct {
 	fx.In
-	Lc fx.Lifecycle
 
 	Submitter  submitter.Component
 	RTNotifier <-chan types.RTResponse `optional:"true"`

--- a/comp/process/runner/runnerimpl/runner_test.go
+++ b/comp/process/runner/runnerimpl/runner_test.go
@@ -6,6 +6,7 @@
 package runnerimpl
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -58,7 +59,13 @@ func TestRunnerRealtime(t *testing.T) {
 			processcheckimpl.Module(),
 			hostinfoimpl.MockModule(),
 			core.MockBundle(),
-		))
+
+			// starts the check runner
+			fx.Invoke(func(r runner.Component) error {
+				return r.Run(context.Background())
+			},
+			)))
+
 		rtChan <- types.RTResponse{
 			&model.CollectorStatus{
 				ActiveClients: 1,
@@ -91,7 +98,12 @@ func TestRunnerRealtime(t *testing.T) {
 			processcheckimpl.Module(),
 			hostinfoimpl.MockModule(),
 			core.MockBundle(),
-		))
+
+			// starts the check runner
+			fx.Invoke(func(r runner.Component) error {
+				return r.Run(context.Background())
+			},
+			)))
 
 		rtChan <- types.RTResponse{
 			&model.CollectorStatus{

--- a/comp/process/submitter/submitterimpl/submitter.go
+++ b/comp/process/submitter/submitterimpl/submitter.go
@@ -8,7 +8,6 @@
 package submitterimpl
 
 import (
-	"context"
 	"time"
 
 	"go.uber.org/fx"
@@ -57,15 +56,6 @@ func newSubmitter(deps dependencies) (result, error) {
 		return result{}, err
 	}
 
-	deps.Lc.Append(fx.Hook{
-		OnStart: func(context.Context) error {
-			return s.Start()
-		},
-		OnStop: func(context.Context) error {
-			s.Stop()
-			return nil
-		},
-	})
 	return result{
 		Submitter: &submitterImpl{
 			s: s,

--- a/comp/process/submitter/submitterimpl/submitter_mock.go
+++ b/comp/process/submitter/submitterimpl/submitter_mock.go
@@ -26,6 +26,8 @@ func MockModule() fxutil.Module {
 
 func newMock(t testing.TB) submitterComp.Component {
 	s := mocks.NewSubmitter(t)
+	s.On("Start").Maybe().Return(nil)
+	s.On("Stop").Maybe()
 	s.On("Submit", mock.Anything, mock.Anything, mock.Anything).Maybe()
 	return s
 }

--- a/pkg/process/runner/submitter.go
+++ b/pkg/process/runner/submitter.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
@@ -59,6 +60,10 @@ type CheckSubmitter struct {
 	rtProcessForwarder   defaultforwarder.Component
 	connectionsForwarder defaultforwarder.Component
 	eventForwarder       defaultforwarder.Component
+
+	// Endpoints for logging purposes
+	processAPIEndpoints       []apicfg.Endpoint
+	processEventsAPIEndpoints []apicfg.Endpoint
 
 	hostname string
 
@@ -127,7 +132,6 @@ func NewSubmitter(config config.Component, log log.Component, forwarders forward
 		return nil, err
 	}
 
-	printStartMessage(log, hostname, processAPIEndpoints, processEventsAPIEndpoints)
 	return &CheckSubmitter{
 		log:                log,
 		processResults:     processResults,
@@ -139,6 +143,9 @@ func NewSubmitter(config config.Component, log log.Component, forwarders forward
 		rtProcessForwarder:   forwarders.GetRTProcessForwarder(),
 		connectionsForwarder: forwarders.GetConnectionsForwarder(),
 		eventForwarder:       forwarders.GetEventForwarder(),
+
+		processAPIEndpoints:       processAPIEndpoints,
+		processEventsAPIEndpoints: processEventsAPIEndpoints,
 
 		hostname: hostname,
 
@@ -176,6 +183,8 @@ func (s *CheckSubmitter) Submit(start time.Time, name string, messages *types.Pa
 
 //nolint:revive // TODO(PROC) Fix revive linter
 func (s *CheckSubmitter) Start() error {
+	printStartMessage(s.log, s.hostname, s.processAPIEndpoints, s.processEventsAPIEndpoints)
+
 	if err := s.processForwarder.Start(); err != nil {
 		return fmt.Errorf("error starting forwarder: %s", err)
 	}

--- a/releasenotes/notes/process-agent-run-in-core-agent-linux-c19289949eb0d602.yaml
+++ b/releasenotes/notes/process-agent-run-in-core-agent-linux-c19289949eb0d602.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Experimental: The process-agent checks(process, container, and process-discovery) can be run from the core agent in
+    Linux. This feature can be toggled on by setting the `process_config.run_in_core_agent.enabled` flag to `true` in
+    the `datadog.yaml` file. This feature is disabled by default.

--- a/releasenotes/notes/process-agent-run-in-core-agent-linux-c19289949eb0d602.yaml
+++ b/releasenotes/notes/process-agent-run-in-core-agent-linux-c19289949eb0d602.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    Experimental: The process-agent checks(process, container, and process-discovery) can be run from the core agent in
+    Experimental: The process-agent checks (process, container, and process-discovery) can be run from the Core Agent in
     Linux. This feature can be toggled on by setting the `process_config.run_in_core_agent.enabled` flag to `true` in
     the `datadog.yaml` file. This feature is disabled by default.

--- a/test/new-e2e/tests/process/config/process_check_in_core_agent.yaml
+++ b/test/new-e2e/tests/process/config/process_check_in_core_agent.yaml
@@ -1,0 +1,10 @@
+process_config:
+  process_collection:
+    enabled: true
+  container_collection:
+    enabled: false
+  process_discovery:
+    enabled: false
+
+  run_in_core_agent:
+    enabled: true

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -130,7 +130,7 @@ func (s *linuxTestSuite) TestProcessChecksInCoreAgent() {
 	assertProcessCollected(t, payloads, false, "stress")
 
 	// check that the process agent is not collected as it should not be running
-	assertProcessNotCollected(t, payloads, "process-agent")
+	requireProcessNotCollected(t, payloads, "process-agent")
 }
 
 func (s *linuxTestSuite) TestManualProcessCheck() {

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -24,7 +24,9 @@ type linuxTestSuite struct {
 }
 
 func TestLinuxTestSuite(t *testing.T) {
-	e2e.Run(t, &linuxTestSuite{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr)))))
+	e2e.Run(t, &linuxTestSuite{},
+		e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr)))),
+	)
 }
 
 func (s *linuxTestSuite) SetupSuite() {
@@ -96,6 +98,39 @@ func (s *linuxTestSuite) TestProcessCheckWithIO() {
 	}, 2*time.Minute, 10*time.Second)
 
 	assertProcessCollected(t, payloads, true, "stress")
+}
+
+func (s *linuxTestSuite) TestProcessChecksInCoreAgent() {
+	t := s.T()
+	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentConfigStr))))
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assertRunningChecks(collect, s.Env().RemoteHost, []string{}, false, "sudo datadog-agent status --json")
+	}, 1*time.Minute, 5*time.Second)
+
+	// Verify that the process agent is not running
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		status := s.Env().RemoteHost.MustExecute("/opt/datadog-agent/embedded/bin/process-agent status")
+		assert.Contains(t, status, "The Process Agent is not running")
+	}, 1*time.Minute, 5*time.Second)
+
+	// Flush fake intake to remove any payloads which may have
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+
+	var payloads []*aggregator.ProcessPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+
+		// Wait for two payloads, as processes must be detected in two check runs to be returned
+		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+	}, 2*time.Minute, 10*time.Second)
+
+	assertProcessCollected(t, payloads, false, "stress")
+
+	// check that the process agent is not collected as it should not be running
+	assertProcessNotCollected(t, payloads, "process-agent")
 }
 
 func (s *linuxTestSuite) TestManualProcessCheck() {

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -25,6 +25,9 @@ var processCheckConfigStr string
 //go:embed config/process_discovery_check.yaml
 var processDiscoveryCheckConfigStr string
 
+//go:embed config/process_check_in_core_agent.yaml
+var processCheckInCoreAgentConfigStr string
+
 //go:embed config/system_probe.yaml
 var systemProbeConfigStr string
 
@@ -71,6 +74,14 @@ func assertProcessCollected(
 
 	require.True(t, found, "%s process not found", process)
 	assert.True(t, populated, "no %s process had all data populated", process)
+}
+
+// assertProcessNotCollected asserts that the given process is NOT collected by the process check
+func assertProcessNotCollected(t *testing.T, payloads []*aggregator.ProcessPayload, process string) {
+	for _, payload := range payloads {
+		found, _ := findProcess(process, payload.Processes, false)
+		require.False(t, found, "%s process found", process)
+	}
 }
 
 // findProcess returns whether the process with the given name exists in the given list of

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -76,8 +76,8 @@ func assertProcessCollected(
 	assert.True(t, populated, "no %s process had all data populated", process)
 }
 
-// assertProcessNotCollected asserts that the given process is NOT collected by the process check
-func assertProcessNotCollected(t *testing.T, payloads []*aggregator.ProcessPayload, process string) {
+// requireProcessNotCollected asserts that the given process is NOT collected by the process check
+func requireProcessNotCollected(t *testing.T, payloads []*aggregator.ProcessPayload, process string) {
 	for _, payload := range payloads {
 		found, _ := findProcess(process, payload.Processes, false)
 		require.False(t, found, "%s process found", process)


### PR DESCRIPTION
### What does this PR do?
This integrates the process and core agent with the process-agent component created in https://github.com/DataDog/datadog-agent/pull/22450

### Motivation
This allows the process checks to be run in either the process agent or the core agent in a linux environment.

[PROCS-3723](https://datadoghq.atlassian.net/browse/PROCS-3723) and [PROCS-3724](https://datadoghq.atlassian.net/browse/PROCS-3724)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The process agent and core agent will need to be tested in the following configurations

#### Tests (Linux Only)
|Test Case | Configuration                                                                                           | Core Agent         | Process Agent      |
|------------|---------------------------------------------------------------------------------------------------------|--------------------|--------------------|
| 1 | run_in_core_agent :white_check_mark:<br>process, container, or process-discovery collection :white_check_mark:                           | :white_check_mark: | :x:                |
| 2 | run_in_core_agent :x:<br>process collection :white_check_mark:                                          | :x:                | :white_check_mark: |
| 3 | run_in_core_agent :white_check_mark:<br>process collection :white_check_mark:<br>NPM :white_check_mark: | :x:                | :white_check_mark: |

#### Test Case 1 - Running the process checks in the core agent enabled
1. Setup Config

`datadog.yaml`
```yaml
process_config:
  process_collection:
    enabled: true
  run_in_core_agent:
    enabled: true
```

`system-probe.yaml`
```yaml
network_config:
    enabled: false
```
2. Start datadog agent
3. `sudo service datadog-agent start`
4. Verify the process agent does not start and exits by checking logs under `/var/log/datadog/process-agent.log`
```
2024-02-14 10:45:23 PST | PROCESS | INFO | (comp/process/agent/agentimpl/agent_linux.go:44 in agentEnabled) | The process checks will run in the core agent
2024-02-14 10:45:23 PST | PROCESS | INFO | (command/main_common.go:193 in runApp) | process-agent is not enabled, exiting...
```
5. Verify the process agent component starts in the core agent under  `/var/log/datadog/agent.log`
```
2024-02-14 10:33:29 PST | CORE | INFO | (pkg/process/runner/runner.go:276 in Run) | Starting process-agent with enabled checks=[process rtprocess]
...
2024-02-14 10:33:29 PST | CORE | INFO | (pkg/process/runner/runner.go:233 in logCheckDuration) | Finished process check #1 in 9.37683ms
```
6. Verify process and container data are visible in Live Processes
7. Verify only the `agent` process is running and `process-agent` is not running in Live Processes

#### Test Case 2 - Running the process checks in the core agent disabled
1. Setup Config

`datadog.yaml`
```yaml
process_config:
  process_collection:
    enabled: true
  run_in_core_agent:
    enabled: false
```

`system-probe.yaml`
```yaml
network_config:
    enabled: false
```
2. Start datadog agent
3. `sudo service datadog-agent start`
4. Verify the process-agent starts  logs under `/var/log/datadog/process-agent.log`
```
2024-02-14 12:37:42 PST | PROCESS | INFO | (pkg/process/runner/runner.go:276 in Run) | Starting process-agent with enabled checks=[process rtprocess]
2024-02-14 12:37:42 PST | PROCESS | INFO | (pkg/process/runner/runner.go:233 in logCheckDuration) | Finished process check #1 in 9.249009ms
```
5. Verify the process agent component does not start in the core agent under  `/var/log/datadog/agent.log`. There should be no process checks running or starting.
6. Verify process and container data are visible in Live Processes
7. Verify the  `process-agent` is running in Live Processes

#### Test Case 3 - Running the process checks in the core agent enabled, but NPM is also enabled
This test that having NPM enabled blocks the process checks from running in the core agent and the checks will continue in the process-agent.

1. Setup Config

`datadog.yaml`
```yaml
process_config:
  process_collection:
    enabled: true
  run_in_core_agent:
    enabled: true
```

`system-probe.yaml`
```yaml
network_config:
    enabled: true
```
2. Start datadog agent
3. `sudo service datadog-agent start`
4. Verify the process-agent starts  logs under `/var/log/datadog/process-agent.log`
```
2024-02-14 13:44:38 PST | PROCESS | WARN | (comp/process/agent/agentimpl/agent_linux.go:37 in agentEnabled) | Network Performance Monitoring is not supported in the core agent. The process-agent will be enabled as a standalone agent
....
2024-02-14 12:37:42 PST | PROCESS | INFO | (pkg/process/runner/runner.go:276 in Run) | Starting process-agent with enabled checks=[process rtprocess]
2024-02-14 12:37:42 PST | PROCESS | INFO | (pkg/process/runner/runner.go:233 in logCheckDuration) | Finished process check #1 in 9.249009ms
```
5. Verify the process agent component does not start in the core agent under  `/var/log/datadog/agent.log`. 
```
2024-02-14 13:44:38 PST | CORE | ERROR | (comp/process/agent/agentimpl/agent_linux.go:51 in agentEnabled) | Network Performance Monitoring is not supported in the core agent. Please ensure the process-agent is enabled as a standalone agent to collect process, container and network performance metrics.
```
6. Verify process and container data are visible in Live Processes
7. Verify the  `process-agent` is running in Live Processes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[PROCS-3723]: https://datadoghq.atlassian.net/browse/PROCS-3723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROCS-3724]: https://datadoghq.atlassian.net/browse/PROCS-3724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ