### PR TITLE
[corechecks/kubelet] Remove _core suffix from kubelet core check

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/common/config.go
+++ b/pkg/collector/corechecks/containers/kubelet/common/config.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// KubeletMetricsPrefix is the prefix included in the metrics emitted by the kubernetes_core check.
-	KubeletMetricsPrefix = "kubernetes_core."
+	KubeletMetricsPrefix = "kubernetes."
 )
 
 // KubeletConfig is the config of the Kubelet.

--- a/pkg/collector/corechecks/containers/kubelet/kubelet.go
+++ b/pkg/collector/corechecks/containers/kubelet/kubelet.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// CheckName is the name of the check
-	CheckName = "kubelet_core"
+	CheckName = "kubelet"
 )
 
 // Provider provides the metrics related to a given Kubelet endpoint

--- a/pkg/collector/corechecks/containers/kubelet/provider/health/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/health/provider_test.go
@@ -49,11 +49,11 @@ func TestProvider_Provide(t *testing.T) {
 			},
 			want: want{
 				servicechecks: []checkinfo{
-					{CheckName: "kubernetes_core.kubelet.check.ping",
+					{CheckName: "kubernetes.kubelet.check.ping",
 						status: servicecheck.ServiceCheckOK},
-					{CheckName: "kubernetes_core.kubelet.check.log",
+					{CheckName: "kubernetes.kubelet.check.log",
 						status: servicecheck.ServiceCheckOK},
-					{CheckName: "kubernetes_core.kubelet.check",
+					{CheckName: "kubernetes.kubelet.check",
 						status: servicecheck.ServiceCheckOK},
 				},
 				err: nil,
@@ -68,11 +68,11 @@ func TestProvider_Provide(t *testing.T) {
 			},
 			want: want{
 				servicechecks: []checkinfo{
-					{CheckName: "kubernetes_core.kubelet.check.ping",
+					{CheckName: "kubernetes.kubelet.check.ping",
 						status: servicecheck.ServiceCheckCritical},
-					{CheckName: "kubernetes_core.kubelet.check.log",
+					{CheckName: "kubernetes.kubelet.check.log",
 						status: servicecheck.ServiceCheckOK},
-					{CheckName: "kubernetes_core.kubelet.check",
+					{CheckName: "kubernetes.kubelet.check",
 						status: servicecheck.ServiceCheckCritical,
 						msg:    "Kubelet health check failed, http response code = 200"},
 				},

--- a/releasenotes/notes/rename-kubelet-corecheck-8f28eff881fde78a.yaml
+++ b/releasenotes/notes/rename-kubelet-corecheck-8f28eff881fde78a.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Rename ``kubelet`` core check and change metrics prefix to 
+    ``kubernetes`` to allow as replacement for Python ``kubelet`` 
+    check.

--- a/releasenotes/notes/rename-kubelet-corecheck-8f28eff881fde78a.yaml
+++ b/releasenotes/notes/rename-kubelet-corecheck-8f28eff881fde78a.yaml
@@ -8,6 +8,6 @@
 ---
 enhancements:
   - |
-    Rename ``kubelet`` core check and change metrics prefix to 
-    ``kubernetes`` to allow as replacement for Python ``kubelet`` 
-    check.
+    Rename ``kubelet_core`` check to ``kubelet`` and change metrics prefix 
+    from ``kubernetes_core`` to ``kubernetes`` to allow as replacement for 
+    Python ``kubelet`` check.

--- a/releasenotes/notes/rename-kubelet-corecheck-8f28eff881fde78a.yaml
+++ b/releasenotes/notes/rename-kubelet-corecheck-8f28eff881fde78a.yaml
@@ -8,6 +8,6 @@
 ---
 enhancements:
   - |
-    Rename ``kubelet_core`` check to ``kubelet`` and change metrics prefix 
-    from ``kubernetes_core`` to ``kubernetes`` to allow as replacement for 
-    Python ``kubelet`` check.
+    Rename the ``kubelet_core`` check to ``kubelet`` and change the metrics 
+    prefix from ``kubernetes_core`` to ``kubernetes`` so that it can replace 
+    the Python ``kubelet`` check.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR removes the `_core` suffix from the kubelet core check name and metrics so it can be used in place of the Python kubelet check.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

As a part of the efforts to migrate from the Python kubelet check to the core kubelet check, we need to rename the core check to ensure the reported metrics have the same name (and the switch does not break any existing monitors/dashboards). The Python check will remain enabled by default for now, until we are confident in the core check implementation.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. Deploy the agent with the following configuration to force the use of the core loader:
```
datadog:
  ...
  confd:
    kubelet.yaml: |
      init_config:
        loader: core
      instances:
        - min_collection_interval: 20
```
2. Verify that the metrics are reported with the `kubernetes` prefix (as before) e.g. `kubernetes.containers.running`
3. Verify that it is now running the core check by checking the output of `agent check -r kubelet`; there should not be a version number listed after `kubelet`
```
kubelet
    ------------
      Instance ID: kubelet [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/kubelet.yaml
      Total Runs: 2
      Metric Samples: Last Run: 574, Total: 1,148
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 4, Total: 8
      Average Execution Time : 460ms
      Last Execution Date : 2024-02-13 20:27:59 UTC (1707856079000)
      Last Successful Execution Date : 2024-02-13 20:27:59 UTC (1707856079000)
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
