### PR TITLE
[CWS] remove default field handlers

### DIFF
--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -397,8 +397,8 @@ func checkPoliciesLoaded(client secagent.SecurityModuleClientWrapper, writer io.
 	return nil
 }
 
-func newDefaultEvent() eval.Event {
-	return model.NewDefaultEvent()
+func newFakeEvent() eval.Event {
+	return model.NewFakeEvent()
 }
 
 func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
@@ -437,7 +437,7 @@ func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
 
 	loader := rules.NewPolicyLoader(provider)
 
-	ruleSet := rules.NewRuleSet(&model.Model{}, newDefaultEvent, ruleOpts, evalOpts)
+	ruleSet := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
 	evaluationSet, err := rules.NewEvaluationSet([]*rules.RuleSet{ruleSet})
 	if err != nil {
 		return err
@@ -550,7 +550,7 @@ func evalRule(_ log.Component, _ config.Component, _ secrets.Component, evalArgs
 
 	loader := rules.NewPolicyLoader(provider)
 
-	ruleSet := rules.NewRuleSet(&model.Model{}, newDefaultEvent, ruleOpts, evalOpts)
+	ruleSet := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
 	evaluationSet, err := rules.NewEvaluationSet([]*rules.RuleSet{ruleSet})
 	if err != nil {
 		return err

--- a/pkg/network/events/monitor_test.go
+++ b/pkg/network/events/monitor_test.go
@@ -40,7 +40,7 @@ func TestEventHandlerWrapperCopy(t *testing.T) {
 					},
 				},
 				ContainerContext: &model.ContainerContext{ID: "cid_exec"},
-				FieldHandlers:    &model.DefaultFieldHandlers{},
+				FieldHandlers:    &model.FakeFieldHandlers{},
 			}}
 		evHandler := &eventHandlerWrapper{}
 		_p := evHandler.Copy(ev)
@@ -76,7 +76,7 @@ func TestEventHandlerWrapperCopy(t *testing.T) {
 					},
 				},
 				ContainerContext: &model.ContainerContext{ID: "cid_fork"},
-				FieldHandlers:    &model.DefaultFieldHandlers{},
+				FieldHandlers:    &model.FakeFieldHandlers{},
 			}}
 		evHandler := &eventHandlerWrapper{}
 		_p := evHandler.Copy(ev)

--- a/pkg/security/probe/discarders_linux.go
+++ b/pkg/security/probe/discarders_linux.go
@@ -60,7 +60,7 @@ type onDiscarderHandler func(rs *rules.RuleSet, event *model.Event, probe *EBPFP
 var (
 	allDiscarderHandlers   = make(map[eval.EventType][]onDiscarderHandler)
 	dentryInvalidDiscarder = []string{""}
-	eventZeroDiscarder     = model.NewDefaultEvent()
+	eventZeroDiscarder     = model.NewFakeEvent()
 )
 
 // InvalidDiscarders exposes list of values that are not discarders

--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 )
 
-func newDefaultEvent() eval.Event {
-	return model.NewDefaultEvent()
+func newFakeEvent() eval.Event {
+	return model.NewFakeEvent()
 }
 
 func TestIsParentDiscarder(t *testing.T) {
@@ -39,49 +39,49 @@ func TestIsParentDiscarder(t *testing.T) {
 		WithEventTypeEnabled(enabled).
 		WithLogger(seclog.DefaultLogger)
 
-	rs := rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/system-probe.log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.sock", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/var/log/datadog/system-probe.log"`, `unlink.file.name == "datadog"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/datadog-agent.log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.name =~ ".*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/.runc/1234", 1); is {
 		t.Error("shouldn't be able to find a parent discarder, due to partial evaluation: true && unlink.file.name =~ '.*'")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "sys.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.name == "conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf", 1); is {
@@ -89,77 +89,77 @@ func TestIsParentDiscarder(t *testing.T) {
 	}
 
 	// field that doesn't exists shouldn't return any discarders
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/conf.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/nginx/nginx.conf", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "*/conf.*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/ab*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d/ab*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/etc/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/cron.d/log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `open.file.path == "/tmp/passwd"`, `open.file.path == "/tmp/secret"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/runc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/run/secrets/kubernetes.io/serviceaccount/*/token"`, `open.file.path == "/etc/secret"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "*/token"`, `open.file.path == "/etc/secret"`)
 
 	is, err := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token", 1)
@@ -170,35 +170,35 @@ func TestIsParentDiscarder(t *testing.T) {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/no-approver-*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/a/test", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "*/conf.d/aaa"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/bbb", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/etc/**"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/etc/conf.d/dir/aaa", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `open.file.path == "/proc/${process.pid}/maps"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/proc/1/maps", 1); is {
@@ -206,14 +206,14 @@ func TestIsParentDiscarder(t *testing.T) {
 	}
 
 	// test basename conflict, a basename based rule matches the parent discarder
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/var/log/datadog/**" && open.file.name == "token"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/test1/test2", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/var/log/datadog/**" && open.file.name == "test1"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/test1/test2", 1); is {
@@ -236,105 +236,105 @@ func TestIsGrandParentDiscarder(t *testing.T) {
 		WithEventTypeEnabled(enabled).
 		WithLogger(seclog.DefaultLogger)
 
-	rs := rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/var/lib/datadog/system-probe.cache"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/tmp/test"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/var/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/pids/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/lib/datadog/system-probe.cache"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/pids/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "*/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "*/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/*/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/lib/datadog/system-probe.pid"`, `unlink.file.name =~ "run"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/*"`, `unlink.file.name =~ "run"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/a/test", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.name == "dir"`) // + variants
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp/dir/a/test", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/tmp/dir/a"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/tmp"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp/dir/a", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs = rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/tmp"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp", 2); is {
@@ -370,7 +370,7 @@ func TestIsDiscarderOverride(t *testing.T) {
 
 	var listener testEventListener
 
-	rs := rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	rs.AddListener(&listener)
 	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/var/log/httpd" && process.file.path == "/bin/touch"`)
 
@@ -415,7 +415,7 @@ func BenchmarkParentDiscarder(b *testing.B) {
 		WithEventTypeEnabled(enabled).
 		WithLogger(seclog.DefaultLogger)
 
-	rs := rules.NewRuleSet(&model.Model{}, newDefaultEvent, &opts, &evalOpts)
+	rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, &opts, &evalOpts)
 	kfilters.AddRuleExpr(b, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	b.ResetTimer()

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -22,10 +22,6 @@ import (
 
 // EBPFLessFieldHandlers defines a field handlers
 type EBPFLessFieldHandlers struct {
-	// TODO(safchain) remove this when support for multiple platform with the same build tags is available
-	// keeping it can be dangerous as it can hide non implemented handlers
-	model.DefaultFieldHandlers
-
 	config    *config.Config
 	resolvers *resolvers.EBPFLessResolvers
 }
@@ -186,3 +182,164 @@ func (fh *EBPFLessFieldHandlers) ResolveContainerTags(_ *model.Event, e *model.C
 func (fh *EBPFLessFieldHandlers) ResolveProcessCreatedAt(_ *model.Event, e *model.Process) int {
 	return int(e.ExecTime.UnixNano())
 }
+
+// ResolveAsync resolves the async flag
+func (fh *EBPFLessFieldHandlers) ResolveAsync(ev *model.Event) bool { return ev.Async }
+
+// ResolveChownGID resolves the ResolveProcessCacheEntry group id of a chown event to a username
+func (fh *EBPFLessFieldHandlers) ResolveChownGID(_ *model.Event, e *model.ChownEvent) string {
+	return e.Group
+}
+
+// ResolveChownUID resolves the ResolveProcessCacheEntry id of a chown event to a username
+func (fh *EBPFLessFieldHandlers) ResolveChownUID(_ *model.Event, e *model.ChownEvent) string {
+	return e.User
+}
+
+// ResolveEventTimestamp resolves the monolitic kernel event timestamp to an absolute time
+func (fh *EBPFLessFieldHandlers) ResolveEventTimestamp(_ *model.Event, e *model.BaseEvent) int {
+	return int(e.TimestampRaw)
+}
+
+// ResolveFileFieldsGroup resolves the group id of the file to a group name
+func (fh *EBPFLessFieldHandlers) ResolveFileFieldsGroup(_ *model.Event, e *model.FileFields) string {
+	return e.Group
+}
+
+// ResolveFileFieldsInUpperLayer resolves whether the file is in an upper layer
+func (fh *EBPFLessFieldHandlers) ResolveFileFieldsInUpperLayer(_ *model.Event, e *model.FileFields) bool {
+	return e.InUpperLayer
+}
+
+// ResolveFileFieldsUser resolves the user id of the file to a username
+func (fh *EBPFLessFieldHandlers) ResolveFileFieldsUser(_ *model.Event, e *model.FileFields) string {
+	return e.User
+}
+
+// ResolveFileFilesystem resolves the filesystem a file resides in
+func (fh *EBPFLessFieldHandlers) ResolveFileFilesystem(_ *model.Event, e *model.FileEvent) string {
+	return e.Filesystem
+}
+
+// ResolveHashesFromEvent resolves the hashes of the requested event
+func (fh *EBPFLessFieldHandlers) ResolveHashesFromEvent(_ *model.Event, e *model.FileEvent) []string {
+	return e.Hashes
+}
+
+// ResolveK8SGroups resolves the k8s groups of the event
+func (fh *EBPFLessFieldHandlers) ResolveK8SGroups(_ *model.Event, e *model.UserSessionContext) []string {
+	return e.K8SGroups
+}
+
+// ResolveK8SUID resolves the k8s UID of the event
+func (fh *EBPFLessFieldHandlers) ResolveK8SUID(_ *model.Event, e *model.UserSessionContext) string {
+	return e.K8SUID
+}
+
+// ResolveK8SUsername resolves the k8s username of the event
+func (fh *EBPFLessFieldHandlers) ResolveK8SUsername(_ *model.Event, e *model.UserSessionContext) string {
+	return e.K8SUsername
+}
+
+// ResolveModuleArgs resolves the correct args if the arguments were truncated, if not return module.Args
+func (fh *EBPFLessFieldHandlers) ResolveModuleArgs(_ *model.Event, e *model.LoadModuleEvent) string {
+	return e.Args
+}
+
+// ResolveModuleArgv resolves the unscrubbed args of the module as an array. Use with caution.
+func (fh *EBPFLessFieldHandlers) ResolveModuleArgv(_ *model.Event, e *model.LoadModuleEvent) []string {
+	return e.Argv
+}
+
+// ResolveMountPointPath resolves a mount point path
+func (fh *EBPFLessFieldHandlers) ResolveMountPointPath(_ *model.Event, e *model.MountEvent) string {
+	return e.MountPointPath
+}
+
+// ResolveMountRootPath resolves a mount root path
+func (fh *EBPFLessFieldHandlers) ResolveMountRootPath(_ *model.Event, e *model.MountEvent) string {
+	return e.MountRootPath
+}
+
+// ResolveMountSourcePath resolves a mount source path
+func (fh *EBPFLessFieldHandlers) ResolveMountSourcePath(_ *model.Event, e *model.MountEvent) string {
+	return e.MountSourcePath
+}
+
+// ResolveNetworkDeviceIfName returns the network iterface name from the network context
+func (fh *EBPFLessFieldHandlers) ResolveNetworkDeviceIfName(_ *model.Event, e *model.NetworkDeviceContext) string {
+	return e.IfName
+}
+
+// ResolvePackageName resolves the name of the package providing this file
+func (fh *EBPFLessFieldHandlers) ResolvePackageName(_ *model.Event, e *model.FileEvent) string {
+	return e.PkgName
+}
+
+// ResolvePackageSourceVersion resolves the version of the source package of the package providing this file
+func (fh *EBPFLessFieldHandlers) ResolvePackageSourceVersion(_ *model.Event, e *model.FileEvent) string {
+	return e.PkgSrcVersion
+}
+
+// ResolvePackageVersion resolves the version of the package providing this file
+func (fh *EBPFLessFieldHandlers) ResolvePackageVersion(_ *model.Event, e *model.FileEvent) string {
+	return e.PkgVersion
+}
+
+// ResolveRights resolves the rights of a file
+func (fh *EBPFLessFieldHandlers) ResolveRights(_ *model.Event, e *model.FileFields) int {
+	return int(e.Mode)
+}
+
+// ResolveSELinuxBoolName resolves the boolean name of the SELinux event
+func (fh *EBPFLessFieldHandlers) ResolveSELinuxBoolName(_ *model.Event, e *model.SELinuxEvent) string {
+	return e.BoolName
+}
+
+// ResolveSetgidEGroup resolves the effective group of the Setgid event
+func (fh *EBPFLessFieldHandlers) ResolveSetgidEGroup(_ *model.Event, e *model.SetgidEvent) string {
+	return e.EGroup
+}
+
+// ResolveSetgidFSGroup resolves the file-system group of the Setgid event
+func (fh *EBPFLessFieldHandlers) ResolveSetgidFSGroup(_ *model.Event, e *model.SetgidEvent) string {
+	return e.FSGroup
+}
+
+// ResolveSetgidGroup resolves the group of the Setgid event
+func (fh *EBPFLessFieldHandlers) ResolveSetgidGroup(_ *model.Event, e *model.SetgidEvent) string {
+	return e.Group
+}
+
+// ResolveSetuidEUser resolves the effective user of the Setuid event
+func (fh *EBPFLessFieldHandlers) ResolveSetuidEUser(_ *model.Event, e *model.SetuidEvent) string {
+	return e.EUser
+}
+
+// ResolveSetuidFSUser resolves the file-system user of the Setuid event
+func (fh *EBPFLessFieldHandlers) ResolveSetuidFSUser(_ *model.Event, e *model.SetuidEvent) string {
+	return e.FSUser
+}
+
+// ResolveSetuidUser resolves the user of the Setuid event
+func (fh *EBPFLessFieldHandlers) ResolveSetuidUser(_ *model.Event, e *model.SetuidEvent) string {
+	return e.User
+}
+
+// ResolveXAttrName returns the string representation of the extended attribute name
+func (fh *EBPFLessFieldHandlers) ResolveXAttrName(_ *model.Event, e *model.SetXAttrEvent) string {
+	return e.Name
+}
+
+// ResolveXAttrNamespace returns the string representation of the extended attribute namespace
+func (fh *EBPFLessFieldHandlers) ResolveXAttrNamespace(_ *model.Event, e *model.SetXAttrEvent) string {
+	return e.Namespace
+}
+
+// ResolveHashes resolves the hash of the provided file
+func (fh *EBPFLessFieldHandlers) ResolveHashes(_ model.EventType, _ *model.Process, _ *model.FileEvent) []string {
+	return nil
+}
+
+// ResolveUserSessionContext resolves and updates the provided user session context
+func (fh *EBPFLessFieldHandlers) ResolveUserSessionContext(_ *model.UserSessionContext) {}

--- a/pkg/security/probe/field_handlers_windows.go
+++ b/pkg/security/probe/field_handlers_windows.go
@@ -16,10 +16,6 @@ import (
 
 // FieldHandlers defines a field handlers
 type FieldHandlers struct {
-	// TODO(safchain) remove this when support for multiple platform with the same build tags is available
-	// keeping it can be dangerous as it can hide non implemented handlers
-	model.DefaultFieldHandlers
-
 	config    *config.Config
 	resolvers *resolvers.Resolvers
 }
@@ -97,4 +93,34 @@ func (fh *FieldHandlers) ResolveProcessCmdLineScrubbed(_ *model.Event, e *model.
 // ResolveUser resolves the user name
 func (fh *FieldHandlers) ResolveUser(_ *model.Event, process *model.Process) string {
 	return fh.resolvers.UserGroupResolver.GetUser(process.OwnerSidString)
+}
+
+// ResolveContainerCreatedAt resolves the container creation time of the event
+func (fh *FieldHandlers) ResolveContainerCreatedAt(_ *model.Event, e *model.ContainerContext) int {
+	return int(e.CreatedAt)
+}
+
+// ResolveContainerID resolves the container ID of the event
+func (fh *FieldHandlers) ResolveContainerID(_ *model.Event, e *model.ContainerContext) string {
+	return e.ID
+}
+
+// ResolveContainerTags resolves the container tags of the event
+func (fh *FieldHandlers) ResolveContainerTags(_ *model.Event, e *model.ContainerContext) []string {
+	return e.Tags
+}
+
+// ResolveEventTimestamp resolves the monolitic kernel event timestamp to an absolute time
+func (fh *FieldHandlers) ResolveEventTimestamp(_ *model.Event, e *model.BaseEvent) int {
+	return int(e.TimestampRaw)
+}
+
+// ResolveProcessCmdLine resolves the cmd line of the process of the event
+func (fh *FieldHandlers) ResolveProcessCmdLine(_ *model.Event, e *model.Process) string {
+	return e.CmdLine
+}
+
+// ResolveProcessCreatedAt resolves the process creation time of the event
+func (fh *FieldHandlers) ResolveProcessCreatedAt(_ *model.Event, e *model.Process) int {
+	return int(e.CreatedAt)
 }

--- a/pkg/security/probe/kfilters/approvers_test.go
+++ b/pkg/security/probe/kfilters/approvers_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
-func newDefaultEvent() eval.Event {
-	return model.NewDefaultEvent()
+func newFakeEvent() eval.Event {
+	return model.NewFakeEvent()
 }
 
 func TestApproverAncestors1(t *testing.T) {
@@ -25,7 +25,7 @@ func TestApproverAncestors1(t *testing.T) {
 
 	ruleOpts, evalOpts := rules.NewEvalOpts(enabled)
 
-	rs := rules.NewRuleSet(&model.Model{}, newDefaultEvent, ruleOpts, evalOpts)
+	rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
 	AddRuleExpr(t, rs, `open.file.path == "/etc/passwd" && process.ancestors.file.name == "vipw"`, `open.file.path == "/etc/shadow" && process.ancestors.file.name == "vipw"`)
 
 	capabilities, exists := allCapabilities["open"]
@@ -48,7 +48,7 @@ func TestApproverAncestors2(t *testing.T) {
 
 	ruleOpts, evalOpts := rules.NewEvalOpts(enabled)
 
-	rs := rules.NewRuleSet(&model.Model{}, newDefaultEvent, ruleOpts, evalOpts)
+	rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
 	AddRuleExpr(t, rs, `(open.file.path == "/etc/shadow" || open.file.path == "/etc/gshadow") && process.ancestors.file.path not in ["/usr/bin/dpkg"]`)
 	capabilities, exists := allCapabilities["open"]
 	if !exists {
@@ -68,7 +68,7 @@ func TestApproverAncestors3(t *testing.T) {
 
 	ruleOpts, evalOpts := rules.NewEvalOpts(enabled)
 
-	rs := rules.NewRuleSet(&model.Model{}, newDefaultEvent, ruleOpts, evalOpts)
+	rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
 	AddRuleExpr(t, rs, `open.file.path =~ "/var/run/secrets/eks.amazonaws.com/serviceaccount/*/token" && process.file.path not in ["/bin/kubectl"]`)
 	capabilities, exists := allCapabilities["open"]
 	if !exists {

--- a/pkg/security/probe/model_ebpf.go
+++ b/pkg/security/probe/model_ebpf.go
@@ -39,7 +39,7 @@ func NewEBPFModel(probe *EBPFProbe) *model.Model {
 
 // NewEBPFEvent returns a new event
 func NewEBPFEvent(fh *EBPFFieldHandlers) *model.Event {
-	event := model.NewDefaultEvent()
+	event := model.NewFakeEvent()
 	event.FieldHandlers = fh
 	return event
 }

--- a/pkg/security/probe/model_ebpfless.go
+++ b/pkg/security/probe/model_ebpfless.go
@@ -53,7 +53,7 @@ func NewEBPFLessModel() *model.Model {
 
 // NewEBPFLessEvent returns a new event
 func NewEBPFLessEvent(fh *EBPFLessFieldHandlers) *model.Event {
-	event := model.NewDefaultEvent()
+	event := model.NewFakeEvent()
 	event.FieldHandlers = fh
 	return event
 }

--- a/pkg/security/probe/model_windows.go
+++ b/pkg/security/probe/model_windows.go
@@ -31,7 +31,7 @@ func NewWindowsModel(_ *WindowsProbe) *model.Model {
 
 // NewWindowsEvent returns a new event
 func NewWindowsEvent(fh *FieldHandlers) *model.Event {
-	event := model.NewDefaultEvent()
+	event := model.NewFakeEvent()
 	event.FieldHandlers = fh
 	return event
 }

--- a/pkg/security/probe/probe_ebpf_test.go
+++ b/pkg/security/probe/probe_ebpf_test.go
@@ -42,7 +42,7 @@ func (MockEventHandler) Copy(incomingEvent *model.Event) any {
 // benchstat old.txt new.txt
 func BenchmarkSendSpecificEvent(b *testing.B) {
 	eventHandler := MockEventHandler{}
-	execEvent := model.NewDefaultEvent()
+	execEvent := model.NewFakeEvent()
 	execEvent.Type = uint32(model.ExecEventType)
 
 	type fields struct {

--- a/pkg/security/resolvers/hash/resolver_test.go
+++ b/pkg/security/resolvers/hash/resolver_test.go
@@ -58,7 +58,7 @@ func TestResolver_ComputeHashes(t *testing.T) {
 			args: args{
 				event: &model.Event{
 					BaseEvent: model.BaseEvent{
-						FieldHandlers: &model.DefaultFieldHandlers{},
+						FieldHandlers: &model.FakeFieldHandlers{},
 						Type:          uint32(model.ExecEventType),
 						ProcessContext: &model.ProcessContext{
 							Process: model.Process{
@@ -95,7 +95,7 @@ func TestResolver_ComputeHashes(t *testing.T) {
 			args: args{
 				event: &model.Event{
 					BaseEvent: model.BaseEvent{
-						FieldHandlers: &model.DefaultFieldHandlers{},
+						FieldHandlers: &model.FakeFieldHandlers{},
 						Type:          uint32(model.ExecEventType),
 						ProcessContext: &model.ProcessContext{
 							Process: model.Process{
@@ -128,7 +128,7 @@ func TestResolver_ComputeHashes(t *testing.T) {
 			args: args{
 				event: &model.Event{
 					BaseEvent: model.BaseEvent{
-						FieldHandlers: &model.DefaultFieldHandlers{},
+						FieldHandlers: &model.FakeFieldHandlers{},
 						Type:          uint32(model.ExecEventType),
 						ProcessContext: &model.ProcessContext{
 							Process: model.Process{
@@ -165,7 +165,7 @@ func TestResolver_ComputeHashes(t *testing.T) {
 			args: args{
 				event: &model.Event{
 					BaseEvent: model.BaseEvent{
-						FieldHandlers: &model.DefaultFieldHandlers{},
+						FieldHandlers: &model.FakeFieldHandlers{},
 						Type:          uint32(model.ExecEventType),
 						ProcessContext: &model.ProcessContext{
 							Process: model.Process{
@@ -198,7 +198,7 @@ func TestResolver_ComputeHashes(t *testing.T) {
 			args: args{
 				event: &model.Event{
 					BaseEvent: model.BaseEvent{
-						FieldHandlers: &model.DefaultFieldHandlers{},
+						FieldHandlers: &model.FakeFieldHandlers{},
 						Type:          uint32(model.ExecEventType),
 						ProcessContext: &model.ProcessContext{
 							Process: model.Process{
@@ -500,7 +500,7 @@ func BenchmarkHashFunctions(b *testing.B) {
 				for i := 0; i < caseB.N; i++ {
 					got := resolver.ComputeHashesFromEvent(&model.Event{
 						BaseEvent: model.BaseEvent{
-							FieldHandlers: &model.DefaultFieldHandlers{},
+							FieldHandlers: &model.FakeFieldHandlers{},
 							Type:          uint32(model.ExecEventType),
 							ProcessContext: &model.ProcessContext{
 								Process: model.Process{

--- a/pkg/security/secl/compiler/generators/accessors/field_handlers.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/field_handlers.tmpl
@@ -29,7 +29,7 @@ func (ev *Event) resolveFields(forADs bool) {
         {{- if $Field.GettersOnly }}
 	        {{continue}}
         {{end}}
-        
+
         {{- if and (eq $Field.Event "*") }}
             {{ $resolver := $Field | GetFieldHandler $.AllFields }}
             {{ if and (ne $resolver "") (not (hasKey $uniqueResolvers $resolver)) }}
@@ -104,9 +104,9 @@ type FieldHandlers interface {
     ExtraFieldHandlers
 }
 
-type DefaultFieldHandlers struct {}
+type FakeFieldHandlers struct {}
 
 {{$Handlers := .Fields | GetHandlers}}
 {{range $Proto, $Impl := $Handlers}}
-    func (dfh *DefaultFieldHandlers) {{$Proto}} {{$Impl}}
+    func (dfh *FakeFieldHandlers) {{$Proto}} {{$Impl}}
 {{end}}

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -1028,125 +1028,105 @@ type FieldHandlers interface {
 	// custom handlers not tied to any fields
 	ExtraFieldHandlers
 }
-type DefaultFieldHandlers struct{}
+type FakeFieldHandlers struct{}
 
-func (dfh *DefaultFieldHandlers) ResolveAsync(ev *Event) bool                     { return ev.Async }
-func (dfh *DefaultFieldHandlers) ResolveChownGID(ev *Event, e *ChownEvent) string { return e.Group }
-func (dfh *DefaultFieldHandlers) ResolveChownUID(ev *Event, e *ChownEvent) string { return e.User }
-func (dfh *DefaultFieldHandlers) ResolveContainerCreatedAt(ev *Event, e *ContainerContext) int {
+func (dfh *FakeFieldHandlers) ResolveAsync(ev *Event) bool                     { return ev.Async }
+func (dfh *FakeFieldHandlers) ResolveChownGID(ev *Event, e *ChownEvent) string { return e.Group }
+func (dfh *FakeFieldHandlers) ResolveChownUID(ev *Event, e *ChownEvent) string { return e.User }
+func (dfh *FakeFieldHandlers) ResolveContainerCreatedAt(ev *Event, e *ContainerContext) int {
 	return int(e.CreatedAt)
 }
-func (dfh *DefaultFieldHandlers) ResolveContainerID(ev *Event, e *ContainerContext) string {
-	return e.ID
-}
-func (dfh *DefaultFieldHandlers) ResolveContainerTags(ev *Event, e *ContainerContext) []string {
+func (dfh *FakeFieldHandlers) ResolveContainerID(ev *Event, e *ContainerContext) string { return e.ID }
+func (dfh *FakeFieldHandlers) ResolveContainerTags(ev *Event, e *ContainerContext) []string {
 	return e.Tags
 }
-func (dfh *DefaultFieldHandlers) ResolveEventTime(ev *Event, e *BaseEvent) time.Time {
-	return e.Timestamp
-}
-func (dfh *DefaultFieldHandlers) ResolveEventTimestamp(ev *Event, e *BaseEvent) int {
+func (dfh *FakeFieldHandlers) ResolveEventTime(ev *Event, e *BaseEvent) time.Time { return e.Timestamp }
+func (dfh *FakeFieldHandlers) ResolveEventTimestamp(ev *Event, e *BaseEvent) int {
 	return int(e.TimestampRaw)
 }
-func (dfh *DefaultFieldHandlers) ResolveFileBasename(ev *Event, e *FileEvent) string {
+func (dfh *FakeFieldHandlers) ResolveFileBasename(ev *Event, e *FileEvent) string {
 	return e.BasenameStr
 }
-func (dfh *DefaultFieldHandlers) ResolveFileFieldsGroup(ev *Event, e *FileFields) string {
-	return e.Group
-}
-func (dfh *DefaultFieldHandlers) ResolveFileFieldsInUpperLayer(ev *Event, e *FileFields) bool {
+func (dfh *FakeFieldHandlers) ResolveFileFieldsGroup(ev *Event, e *FileFields) string { return e.Group }
+func (dfh *FakeFieldHandlers) ResolveFileFieldsInUpperLayer(ev *Event, e *FileFields) bool {
 	return e.InUpperLayer
 }
-func (dfh *DefaultFieldHandlers) ResolveFileFieldsUser(ev *Event, e *FileFields) string {
-	return e.User
-}
-func (dfh *DefaultFieldHandlers) ResolveFileFilesystem(ev *Event, e *FileEvent) string {
+func (dfh *FakeFieldHandlers) ResolveFileFieldsUser(ev *Event, e *FileFields) string { return e.User }
+func (dfh *FakeFieldHandlers) ResolveFileFilesystem(ev *Event, e *FileEvent) string {
 	return e.Filesystem
 }
-func (dfh *DefaultFieldHandlers) ResolveFilePath(ev *Event, e *FileEvent) string {
-	return e.PathnameStr
-}
-func (dfh *DefaultFieldHandlers) ResolveHashesFromEvent(ev *Event, e *FileEvent) []string {
+func (dfh *FakeFieldHandlers) ResolveFilePath(ev *Event, e *FileEvent) string { return e.PathnameStr }
+func (dfh *FakeFieldHandlers) ResolveHashesFromEvent(ev *Event, e *FileEvent) []string {
 	return e.Hashes
 }
-func (dfh *DefaultFieldHandlers) ResolveK8SGroups(ev *Event, e *UserSessionContext) []string {
+func (dfh *FakeFieldHandlers) ResolveK8SGroups(ev *Event, e *UserSessionContext) []string {
 	return e.K8SGroups
 }
-func (dfh *DefaultFieldHandlers) ResolveK8SUID(ev *Event, e *UserSessionContext) string {
-	return e.K8SUID
-}
-func (dfh *DefaultFieldHandlers) ResolveK8SUsername(ev *Event, e *UserSessionContext) string {
+func (dfh *FakeFieldHandlers) ResolveK8SUID(ev *Event, e *UserSessionContext) string { return e.K8SUID }
+func (dfh *FakeFieldHandlers) ResolveK8SUsername(ev *Event, e *UserSessionContext) string {
 	return e.K8SUsername
 }
-func (dfh *DefaultFieldHandlers) ResolveModuleArgs(ev *Event, e *LoadModuleEvent) string {
-	return e.Args
-}
-func (dfh *DefaultFieldHandlers) ResolveModuleArgv(ev *Event, e *LoadModuleEvent) []string {
+func (dfh *FakeFieldHandlers) ResolveModuleArgs(ev *Event, e *LoadModuleEvent) string { return e.Args }
+func (dfh *FakeFieldHandlers) ResolveModuleArgv(ev *Event, e *LoadModuleEvent) []string {
 	return e.Argv
 }
-func (dfh *DefaultFieldHandlers) ResolveMountPointPath(ev *Event, e *MountEvent) string {
+func (dfh *FakeFieldHandlers) ResolveMountPointPath(ev *Event, e *MountEvent) string {
 	return e.MountPointPath
 }
-func (dfh *DefaultFieldHandlers) ResolveMountRootPath(ev *Event, e *MountEvent) string {
+func (dfh *FakeFieldHandlers) ResolveMountRootPath(ev *Event, e *MountEvent) string {
 	return e.MountRootPath
 }
-func (dfh *DefaultFieldHandlers) ResolveMountSourcePath(ev *Event, e *MountEvent) string {
+func (dfh *FakeFieldHandlers) ResolveMountSourcePath(ev *Event, e *MountEvent) string {
 	return e.MountSourcePath
 }
-func (dfh *DefaultFieldHandlers) ResolveNetworkDeviceIfName(ev *Event, e *NetworkDeviceContext) string {
+func (dfh *FakeFieldHandlers) ResolveNetworkDeviceIfName(ev *Event, e *NetworkDeviceContext) string {
 	return e.IfName
 }
-func (dfh *DefaultFieldHandlers) ResolvePackageName(ev *Event, e *FileEvent) string { return e.PkgName }
-func (dfh *DefaultFieldHandlers) ResolvePackageSourceVersion(ev *Event, e *FileEvent) string {
+func (dfh *FakeFieldHandlers) ResolvePackageName(ev *Event, e *FileEvent) string { return e.PkgName }
+func (dfh *FakeFieldHandlers) ResolvePackageSourceVersion(ev *Event, e *FileEvent) string {
 	return e.PkgSrcVersion
 }
-func (dfh *DefaultFieldHandlers) ResolvePackageVersion(ev *Event, e *FileEvent) string {
+func (dfh *FakeFieldHandlers) ResolvePackageVersion(ev *Event, e *FileEvent) string {
 	return e.PkgVersion
 }
-func (dfh *DefaultFieldHandlers) ResolveProcessArgs(ev *Event, e *Process) string { return e.Args }
-func (dfh *DefaultFieldHandlers) ResolveProcessArgsFlags(ev *Event, e *Process) []string {
+func (dfh *FakeFieldHandlers) ResolveProcessArgs(ev *Event, e *Process) string        { return e.Args }
+func (dfh *FakeFieldHandlers) ResolveProcessArgsFlags(ev *Event, e *Process) []string { return e.Argv }
+func (dfh *FakeFieldHandlers) ResolveProcessArgsOptions(ev *Event, e *Process) []string {
 	return e.Argv
 }
-func (dfh *DefaultFieldHandlers) ResolveProcessArgsOptions(ev *Event, e *Process) []string {
-	return e.Argv
-}
-func (dfh *DefaultFieldHandlers) ResolveProcessArgsScrubbed(ev *Event, e *Process) string {
+func (dfh *FakeFieldHandlers) ResolveProcessArgsScrubbed(ev *Event, e *Process) string {
 	return e.ArgsScrubbed
 }
-func (dfh *DefaultFieldHandlers) ResolveProcessArgsTruncated(ev *Event, e *Process) bool {
+func (dfh *FakeFieldHandlers) ResolveProcessArgsTruncated(ev *Event, e *Process) bool {
 	return e.ArgsTruncated
 }
-func (dfh *DefaultFieldHandlers) ResolveProcessArgv(ev *Event, e *Process) []string { return e.Argv }
-func (dfh *DefaultFieldHandlers) ResolveProcessArgv0(ev *Event, e *Process) string  { return e.Argv0 }
-func (dfh *DefaultFieldHandlers) ResolveProcessArgvScrubbed(ev *Event, e *Process) []string {
+func (dfh *FakeFieldHandlers) ResolveProcessArgv(ev *Event, e *Process) []string { return e.Argv }
+func (dfh *FakeFieldHandlers) ResolveProcessArgv0(ev *Event, e *Process) string  { return e.Argv0 }
+func (dfh *FakeFieldHandlers) ResolveProcessArgvScrubbed(ev *Event, e *Process) []string {
 	return e.ArgvScrubbed
 }
-func (dfh *DefaultFieldHandlers) ResolveProcessCreatedAt(ev *Event, e *Process) int {
+func (dfh *FakeFieldHandlers) ResolveProcessCreatedAt(ev *Event, e *Process) int {
 	return int(e.CreatedAt)
 }
-func (dfh *DefaultFieldHandlers) ResolveProcessEnvp(ev *Event, e *Process) []string { return e.Envp }
-func (dfh *DefaultFieldHandlers) ResolveProcessEnvs(ev *Event, e *Process) []string { return e.Envs }
-func (dfh *DefaultFieldHandlers) ResolveProcessEnvsTruncated(ev *Event, e *Process) bool {
+func (dfh *FakeFieldHandlers) ResolveProcessEnvp(ev *Event, e *Process) []string { return e.Envp }
+func (dfh *FakeFieldHandlers) ResolveProcessEnvs(ev *Event, e *Process) []string { return e.Envs }
+func (dfh *FakeFieldHandlers) ResolveProcessEnvsTruncated(ev *Event, e *Process) bool {
 	return e.EnvsTruncated
 }
-func (dfh *DefaultFieldHandlers) ResolveRights(ev *Event, e *FileFields) int { return int(e.Mode) }
-func (dfh *DefaultFieldHandlers) ResolveSELinuxBoolName(ev *Event, e *SELinuxEvent) string {
+func (dfh *FakeFieldHandlers) ResolveRights(ev *Event, e *FileFields) int { return int(e.Mode) }
+func (dfh *FakeFieldHandlers) ResolveSELinuxBoolName(ev *Event, e *SELinuxEvent) string {
 	return e.BoolName
 }
-func (dfh *DefaultFieldHandlers) ResolveService(ev *Event, e *BaseEvent) string { return e.Service }
-func (dfh *DefaultFieldHandlers) ResolveSetgidEGroup(ev *Event, e *SetgidEvent) string {
-	return e.EGroup
-}
-func (dfh *DefaultFieldHandlers) ResolveSetgidFSGroup(ev *Event, e *SetgidEvent) string {
+func (dfh *FakeFieldHandlers) ResolveService(ev *Event, e *BaseEvent) string        { return e.Service }
+func (dfh *FakeFieldHandlers) ResolveSetgidEGroup(ev *Event, e *SetgidEvent) string { return e.EGroup }
+func (dfh *FakeFieldHandlers) ResolveSetgidFSGroup(ev *Event, e *SetgidEvent) string {
 	return e.FSGroup
 }
-func (dfh *DefaultFieldHandlers) ResolveSetgidGroup(ev *Event, e *SetgidEvent) string { return e.Group }
-func (dfh *DefaultFieldHandlers) ResolveSetuidEUser(ev *Event, e *SetuidEvent) string { return e.EUser }
-func (dfh *DefaultFieldHandlers) ResolveSetuidFSUser(ev *Event, e *SetuidEvent) string {
-	return e.FSUser
-}
-func (dfh *DefaultFieldHandlers) ResolveSetuidUser(ev *Event, e *SetuidEvent) string  { return e.User }
-func (dfh *DefaultFieldHandlers) ResolveXAttrName(ev *Event, e *SetXAttrEvent) string { return e.Name }
-func (dfh *DefaultFieldHandlers) ResolveXAttrNamespace(ev *Event, e *SetXAttrEvent) string {
+func (dfh *FakeFieldHandlers) ResolveSetgidGroup(ev *Event, e *SetgidEvent) string  { return e.Group }
+func (dfh *FakeFieldHandlers) ResolveSetuidEUser(ev *Event, e *SetuidEvent) string  { return e.EUser }
+func (dfh *FakeFieldHandlers) ResolveSetuidFSUser(ev *Event, e *SetuidEvent) string { return e.FSUser }
+func (dfh *FakeFieldHandlers) ResolveSetuidUser(ev *Event, e *SetuidEvent) string   { return e.User }
+func (dfh *FakeFieldHandlers) ResolveXAttrName(ev *Event, e *SetXAttrEvent) string  { return e.Name }
+func (dfh *FakeFieldHandlers) ResolveXAttrNamespace(ev *Event, e *SetXAttrEvent) string {
 	return e.Namespace
 }

--- a/pkg/security/secl/model/field_handlers_windows.go
+++ b/pkg/security/secl/model/field_handlers_windows.go
@@ -99,39 +99,31 @@ type FieldHandlers interface {
 	// custom handlers not tied to any fields
 	ExtraFieldHandlers
 }
-type DefaultFieldHandlers struct{}
+type FakeFieldHandlers struct{}
 
-func (dfh *DefaultFieldHandlers) ResolveContainerCreatedAt(ev *Event, e *ContainerContext) int {
+func (dfh *FakeFieldHandlers) ResolveContainerCreatedAt(ev *Event, e *ContainerContext) int {
 	return int(e.CreatedAt)
 }
-func (dfh *DefaultFieldHandlers) ResolveContainerID(ev *Event, e *ContainerContext) string {
-	return e.ID
-}
-func (dfh *DefaultFieldHandlers) ResolveContainerTags(ev *Event, e *ContainerContext) []string {
+func (dfh *FakeFieldHandlers) ResolveContainerID(ev *Event, e *ContainerContext) string { return e.ID }
+func (dfh *FakeFieldHandlers) ResolveContainerTags(ev *Event, e *ContainerContext) []string {
 	return e.Tags
 }
-func (dfh *DefaultFieldHandlers) ResolveEventTime(ev *Event, e *BaseEvent) time.Time {
-	return e.Timestamp
-}
-func (dfh *DefaultFieldHandlers) ResolveEventTimestamp(ev *Event, e *BaseEvent) int {
+func (dfh *FakeFieldHandlers) ResolveEventTime(ev *Event, e *BaseEvent) time.Time { return e.Timestamp }
+func (dfh *FakeFieldHandlers) ResolveEventTimestamp(ev *Event, e *BaseEvent) int {
 	return int(e.TimestampRaw)
 }
-func (dfh *DefaultFieldHandlers) ResolveFileBasename(ev *Event, e *FileEvent) string {
+func (dfh *FakeFieldHandlers) ResolveFileBasename(ev *Event, e *FileEvent) string {
 	return e.BasenameStr
 }
-func (dfh *DefaultFieldHandlers) ResolveFilePath(ev *Event, e *FileEvent) string {
-	return e.PathnameStr
-}
-func (dfh *DefaultFieldHandlers) ResolveProcessCmdLine(ev *Event, e *Process) string {
-	return e.CmdLine
-}
-func (dfh *DefaultFieldHandlers) ResolveProcessCmdLineScrubbed(ev *Event, e *Process) string {
+func (dfh *FakeFieldHandlers) ResolveFilePath(ev *Event, e *FileEvent) string     { return e.PathnameStr }
+func (dfh *FakeFieldHandlers) ResolveProcessCmdLine(ev *Event, e *Process) string { return e.CmdLine }
+func (dfh *FakeFieldHandlers) ResolveProcessCmdLineScrubbed(ev *Event, e *Process) string {
 	return e.CmdLineScrubbed
 }
-func (dfh *DefaultFieldHandlers) ResolveProcessCreatedAt(ev *Event, e *Process) int {
+func (dfh *FakeFieldHandlers) ResolveProcessCreatedAt(ev *Event, e *Process) int {
 	return int(e.CreatedAt)
 }
-func (dfh *DefaultFieldHandlers) ResolveProcessEnvp(ev *Event, e *Process) []string { return e.Envp }
-func (dfh *DefaultFieldHandlers) ResolveProcessEnvs(ev *Event, e *Process) []string { return e.Envs }
-func (dfh *DefaultFieldHandlers) ResolveService(ev *Event, e *BaseEvent) string     { return e.Service }
-func (dfh *DefaultFieldHandlers) ResolveUser(ev *Event, e *Process) string          { return e.User }
+func (dfh *FakeFieldHandlers) ResolveProcessEnvp(ev *Event, e *Process) []string { return e.Envp }
+func (dfh *FakeFieldHandlers) ResolveProcessEnvs(ev *Event, e *Process) []string { return e.Envs }
+func (dfh *FakeFieldHandlers) ResolveService(ev *Event, e *BaseEvent) string     { return e.Service }
+func (dfh *FakeFieldHandlers) ResolveUser(ev *Event, e *Process) string          { return e.User }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -42,7 +42,7 @@ func (m *Model) NewDefaultEventWithType(kind EventType) eval.Event {
 	return &Event{
 		BaseEvent: BaseEvent{
 			Type:             uint32(kind),
-			FieldHandlers:    &DefaultFieldHandlers{},
+			FieldHandlers:    &FakeFieldHandlers{},
 			ContainerContext: &ContainerContext{},
 		},
 	}
@@ -180,11 +180,11 @@ func initMember(member reflect.Value, deja map[string]bool) {
 	}
 }
 
-// NewDefaultEvent returns a new event using the default field handlers
-func NewDefaultEvent() *Event {
+// NewFakeEvent returns a new event using the default field handlers
+func NewFakeEvent() *Event {
 	return &Event{
 		BaseEvent: BaseEvent{
-			FieldHandlers:    &DefaultFieldHandlers{},
+			FieldHandlers:    &FakeFieldHandlers{},
 			ContainerContext: &ContainerContext{},
 		},
 	}
@@ -555,11 +555,11 @@ type BaseExtraFieldHandlers interface {
 }
 
 // ResolveProcessCacheEntry stub implementation
-func (dfh *DefaultFieldHandlers) ResolveProcessCacheEntry(_ *Event) (*ProcessCacheEntry, bool) {
+func (dfh *FakeFieldHandlers) ResolveProcessCacheEntry(_ *Event) (*ProcessCacheEntry, bool) {
 	return nil, false
 }
 
 // ResolveContainerContext stub implementation
-func (dfh *DefaultFieldHandlers) ResolveContainerContext(_ *Event) (*ContainerContext, bool) {
+func (dfh *FakeFieldHandlers) ResolveContainerContext(_ *Event) (*ContainerContext, bool) {
 	return nil, false
 }

--- a/pkg/security/secl/model/model_helpers_unix.go
+++ b/pkg/security/secl/model/model_helpers_unix.go
@@ -346,12 +346,12 @@ func (pl *PathLeaf) MarshalBinary() ([]byte, error) {
 }
 
 // ResolveHashes resolves the hash of the provided file
-func (dfh *DefaultFieldHandlers) ResolveHashes(_ EventType, _ *Process, _ *FileEvent) []string {
+func (dfh *FakeFieldHandlers) ResolveHashes(_ EventType, _ *Process, _ *FileEvent) []string {
 	return nil
 }
 
 // ResolveUserSessionContext resolves and updates the provided user session context
-func (dfh *DefaultFieldHandlers) ResolveUserSessionContext(_ *UserSessionContext) {}
+func (dfh *FakeFieldHandlers) ResolveUserSessionContext(_ *UserSessionContext) {}
 
 // SELinuxEventKind represents the event kind for SELinux events
 type SELinuxEventKind uint32

--- a/pkg/security/secl/model/model_test.go
+++ b/pkg/security/secl/model/model_test.go
@@ -121,7 +121,7 @@ func TestSetFieldValue(t *testing.T) {
 	var readOnlyError *eval.ErrFieldReadOnly
 	var fieldNotSupportedError *eval.ErrNotSupported
 
-	event := NewDefaultEvent()
+	event := NewFakeEvent()
 	for _, field := range event.GetFields() {
 		kind, err := event.GetFieldType(field)
 		if err != nil {

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -67,7 +67,7 @@ func TestMacroMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	event := model.NewDefaultEvent()
+	event := model.NewFakeEvent()
 	event.SetFieldValue("open.file.path", "/tmp/test")
 	event.SetFieldValue("process.comm", "/usr/bin/vi")
 
@@ -258,7 +258,7 @@ func TestActionSetVariable(t *testing.T) {
 		t.Fatal("failed to find test_rule in ruleset")
 	}
 
-	event := model.NewDefaultEvent()
+	event := model.NewFakeEvent()
 	event.Type = uint32(model.FileOpenEventType)
 	processCacheEntry := &model.ProcessCacheEntry{}
 	processCacheEntry.Retain()

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -536,7 +536,7 @@ func (rs *RuleSet) GetEventApprovers(eventType eval.EventType, fieldCaps FieldCa
 		return nil, ErrNoEventTypeBucket{EventType: eventType}
 	}
 
-	return GetApprovers(bucket.rules, model.NewDefaultEvent(), fieldCaps)
+	return GetApprovers(bucket.rules, model.NewFakeEvent(), fieldCaps)
 }
 
 // GetFieldValues returns all the values of the given field

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -94,13 +94,13 @@ func addRuleExpr(t *testing.T, rs *RuleSet, exprs ...string) {
 	}
 }
 
-func newDefaultEvent() eval.Event {
-	return model.NewDefaultEvent()
+func newFakeEvent() eval.Event {
+	return model.NewFakeEvent()
 }
 
 func newRuleSet() *RuleSet {
 	ruleOpts, evalOpts := NewEvalOpts(map[eval.EventType]bool{"*": true})
-	return NewRuleSet(&model.Model{}, newDefaultEvent, ruleOpts, evalOpts)
+	return NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
 }
 
 func TestRuleBuckets(t *testing.T) {
@@ -144,13 +144,13 @@ func TestRuleSetDiscarders(t *testing.T) {
 
 	addRuleExpr(t, rs, exprs...)
 
-	ev1 := model.NewDefaultEvent()
+	ev1 := model.NewFakeEvent()
 	ev1.Type = uint32(model.FileOpenEventType)
 	ev1.SetFieldValue("open.file.path", "/usr/local/bin/rootkit")
 	ev1.SetFieldValue("open.flags", syscall.O_RDONLY)
 	ev1.SetFieldValue("process.uid", 0)
 
-	ev2 := model.NewDefaultEvent()
+	ev2 := model.NewFakeEvent()
 	ev2.Type = uint32(model.FileMkdirEventType)
 	ev2.SetFieldValue("mkdir.file.path", "/usr/local/bin/rootkit")
 	ev2.SetFieldValue("mkdir.mode", 0777)
@@ -584,7 +584,7 @@ func TestGetRuleEventType(t *testing.T) {
 		t.Fatalf("should get an event type: %s", err)
 	}
 
-	event := model.NewDefaultEvent()
+	event := model.NewFakeEvent()
 	fieldEventType, err := event.GetFieldEventType("open.file.name")
 	if err != nil {
 		t.Fatal("should get a field event type")

--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -52,7 +52,7 @@ func TestInsertFileEvent(t *testing.T) {
 	for _, path := range pathToInserts {
 		event := &model.Event{
 			BaseEvent: model.BaseEvent{
-				FieldHandlers: &model.DefaultFieldHandlers{},
+				FieldHandlers: &model.FakeFieldHandlers{},
 			},
 			Open: model.OpenEvent{
 				File: model.FileEvent{
@@ -156,7 +156,7 @@ func newExecTestEventWithAncestors(lineage []model.Process) *model.Event {
 	evt := &model.Event{
 		BaseEvent: model.BaseEvent{
 			Type:             uint32(model.ExecEventType),
-			FieldHandlers:    &model.DefaultFieldHandlers{},
+			FieldHandlers:    &model.FakeFieldHandlers{},
 			ContainerContext: &model.ContainerContext{},
 			ProcessContext:   &model.ProcessContext{},
 			ProcessCacheEntry: &model.ProcessCacheEntry{

--- a/pkg/security/security_profile/profile/manager_test.go
+++ b/pkg/security/security_profile/profile/manager_test.go
@@ -39,7 +39,7 @@ type testIteration struct {
 }
 
 func craftFakeEvent(t0 time.Time, ti *testIteration, defaultContainerID string) *model.Event {
-	event := model.NewDefaultEvent()
+	event := model.NewFakeEvent()
 	event.Type = uint32(ti.eventType)
 	event.ContainerContext.CreatedAt = uint64(t0.Add(ti.containerCreatedAt).UnixNano())
 	event.TimestampRaw = uint64(t0.Add(ti.eventTimestampRaw).UnixNano())

--- a/pkg/security/serializers/deserializers.go
+++ b/pkg/security/serializers/deserializers.go
@@ -103,7 +103,7 @@ func UnmarshalEvent(raw []byte) (*model.Event, error) {
 	event := model.Event{
 		BaseEvent: model.BaseEvent{
 			Type:             uint32(model.ExecEventType),
-			FieldHandlers:    &model.DefaultFieldHandlers{},
+			FieldHandlers:    &model.FakeFieldHandlers{},
 			ContainerContext: &model.ContainerContext{},
 			ProcessContext: &model.ProcessContext{
 				Process:  process,


### PR DESCRIPTION
### What does this PR do?

This PR removes the default field handlers embed, removing an error-prone footgun

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
