### PR TITLE
ci: refactor new-e2e-apm jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1083,6 +1083,25 @@ workflow:
     when: manual
     allow_failure: true
 
+.on_apm_or_e2e_changes_or_manual:
+  - <<: *if_disable_e2e
+    when: never
+  - <<: *if_main_branch
+    when: on_success
+  - <<: *if_mergequeue
+    when: never
+  - changes:
+      paths:
+        - pkg/trace/**/*
+        - cmd/trace-agent/**/*
+        - comp/trace/**/*
+        - test/new-e2e/tests/apm/**/*
+        - test/new-e2e/go.mod
+      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+    when: on_success
+  - when: manual
+    allow_failure: true
+
 .on_trace_agent_changes_or_manual:
   - changes:
       - pkg/trace/**/*

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -317,28 +317,12 @@ new-e2e-orchestrator-main:
 
   allow_failure: true #TODO: Remove when https://github.com/DataDog/datadog-agent/pull/22113 is merged
 
-new-e2e-apm-dev:
+new-e2e-apm:
   extends: .new_e2e_template
   rules:
-    - !reference [.if_run_e2e_tests]
-    - !reference [.on_dev_branch_manual]
+    !reference [.on_apm_or_e2e_changes_or_manual]
   needs:
     - qa_agent
-    - qa_dca
-    - qa_dogstatsd
-  variables:
-    TARGETS: ./tests/apm
-    TEAM: apm-agent
-  parallel:
-    matrix:
-      - EXTRA_PARAMS: --run TestDockerFakeintakeSuiteUDS
-      - EXTRA_PARAMS: --run TestDockerFakeintakeSuiteTCP
-      - EXTRA_PARAMS: --run TestVMFakeintakeSuiteUDS
-      - EXTRA_PARAMS: --run TestVMFakeintakeSuiteTCP
-
-new-e2e-apm-main:
-  extends: .new_e2e_template
-  rules: !reference [.on_main_or_rc_and_no_skip_e2e]
   variables:
     TARGETS: ./tests/apm
     TEAM: apm-agent

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -120,5 +120,5 @@ e2e_test_junit_upload:
     - new-e2e-process-main
     - new-e2e-cws-main
     - new-e2e-orchestrator-main
-    - new-e2e-apm-main
+    - new-e2e-apm
     - new-e2e-remote-config


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

AIT-9823

- Consolidate new-e2e jobs for APM in a single job definition
- Split `qa_agent` into `qa_agent_linux` and `qa_agent_windows`: the goal is to make it faster to run the tests that do not require windows containers
- Make apm tests depend only on `qa_agent_linux`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Cleaner job definition and faster execution for new-e2e-apm

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

All new-e2e jobs pass (or at least the ones that aren't expected to fail)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
