### PR TITLE
feat(CI): wrap the calls to aws ssm get-parameter to prevent unable to locate credential issues

### DIFF
--- a/.gitlab/.pre/cancel-prev-pipelines.yml
+++ b/.gitlab/.pre/cancel-prev-pipelines.yml
@@ -15,5 +15,6 @@ cancel-prev-pipelines:
     - when: on_success
   script:
     - source /root/.bashrc
+    - which aws
     - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - inv pipeline.auto-cancel-previous-pipelines

--- a/.gitlab/.pre/cancel-prev-pipelines.yml
+++ b/.gitlab/.pre/cancel-prev-pipelines.yml
@@ -3,18 +3,17 @@ cancel-prev-pipelines:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   rules: # this should only run on dev branches
-  - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
-    when: never
-  - if: $CI_COMMIT_TAG
-    when: never
-  - !reference [.except_main_or_release_branch]
-  - if: $CI_COMMIT_MESSAGE =~ /.*\[skip cancel\].*/
-    when: never
-  - if: $CI_COMMIT_REF_NAME =~ /.*-skip-cancel$/
-    when: never
-  - when: on_success
+    - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
+      when: never
+    - if: $CI_COMMIT_TAG
+      when: never
+    - !reference [.except_main_or_release_branch]
+    - if: $CI_COMMIT_MESSAGE =~ /.*\[skip cancel\].*/
+      when: never
+    - if: $CI_COMMIT_REF_NAME =~ /.*-skip-cancel$/
+      when: never
+    - when: on_success
   script:
     - source /root/.bashrc
-    - set +x
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - inv pipeline.auto-cancel-previous-pipelines

--- a/.gitlab/.pre/cancel-prev-pipelines.yml
+++ b/.gitlab/.pre/cancel-prev-pipelines.yml
@@ -16,5 +16,5 @@ cancel-prev-pipelines:
   script:
     - source /root/.bashrc
     - which aws
-    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - inv pipeline.auto-cancel-previous-pipelines

--- a/.gitlab/.pre/cancel-prev-pipelines.yml
+++ b/.gitlab/.pre/cancel-prev-pipelines.yml
@@ -15,6 +15,5 @@ cancel-prev-pipelines:
     - when: on_success
   script:
     - source /root/.bashrc
-    - which aws
     - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - inv pipeline.auto-cancel-previous-pipelines

--- a/.gitlab/choco_deploy/choco_deploy.yml
+++ b/.gitlab/choco_deploy/choco_deploy.yml
@@ -10,7 +10,8 @@ publish_choco_7_x64:
   variables:
     ARCH: "x64"
   before_script:
-    - $chocolateyApiKey = (& "$CI_PROJECT_DIR\tools\ci\aws_ssm_get_wrapper.ps1" ci.datadog-agent.chocolatey_api_key)
+    - $chocolateyApiKey = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.chocolatey_api_key --with-decryption --query "Parameter.Value" --out text)
+
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"

--- a/.gitlab/choco_deploy/choco_deploy.yml
+++ b/.gitlab/choco_deploy/choco_deploy.yml
@@ -10,7 +10,7 @@ publish_choco_7_x64:
   variables:
     ARCH: "x64"
   before_script:
-    - $chocolateyApiKey = (.\tools\ci\aws_ssm_get_wrapper.ps1 ci.datadog-agent.chocolatey_api_key)
+    - $chocolateyApiKey = (& "$CI_PROJECT_DIR\tools\ci\aws_ssm_get_wrapper.ps1" ci.datadog-agent.chocolatey_api_key)
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"

--- a/.gitlab/choco_deploy/choco_deploy.yml
+++ b/.gitlab/choco_deploy/choco_deploy.yml
@@ -3,15 +3,14 @@
 # Contains a job which deploys the chocolatey Agent package.
 
 publish_choco_7_x64:
-  rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
+  rules: !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
   stage: choco_deploy
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["windows_choco_online_7_x64"]
   variables:
     ARCH: "x64"
   before_script:
-    - $chocolateyApiKey = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.chocolatey_api_key --with-decryption --query "Parameter.Value" --out text)
+    - $chocolateyApiKey = (.\tools\ci\aws_ssm_get_wrapper.ps1 ci.datadog-agent.chocolatey_api_key)
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"

--- a/.gitlab/choco_deploy/choco_deploy.yml
+++ b/.gitlab/choco_deploy/choco_deploy.yml
@@ -11,7 +11,6 @@ publish_choco_7_x64:
     ARCH: "x64"
   before_script:
     - $chocolateyApiKey = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.chocolatey_api_key --with-decryption --query "Parameter.Value" --out text)
-
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"

--- a/.gitlab/common/container_publish_job_templates.yml
+++ b/.gitlab/common/container_publish_job_templates.yml
@@ -14,7 +14,7 @@
     IMG_SIGNING: ""
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
     - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"

--- a/.gitlab/common/container_publish_job_templates.yml
+++ b/.gitlab/common/container_publish_job_templates.yml
@@ -14,7 +14,7 @@
     IMG_SIGNING: ""
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
     - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"

--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -3,7 +3,7 @@
   - ARTIFACTORY_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $ARTIFACTORY_TOKEN_SSM_NAME)
 
 .get_artifactory_token_win: &get_artifactory_token_win
-  - $ARTIFACTORY_TOKEN=$(& "$env:CI_PROJECT_DIR\tools\ci\aws_ssm_get_wrapper.ps1" $ARTIFACTORY_TOKEN_SSM_NAME)
+  - $ARTIFACTORY_TOKEN=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_TOKEN_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
 
 .get_artifactory_bypass_linux: &get_artifactory_bypass_linux
   - ARTIFACTORY_BYPASS=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $ARTIFACTORY_BYPASS_SSM_NAME)

--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -1,17 +1,16 @@
 ---
-
 .get_artifactory_token_linux: &get_artifactory_token_linux
-  - ARTIFACTORY_TOKEN=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_TOKEN_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - ARTIFACTORY_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh $ARTIFACTORY_TOKEN_SSM_NAME)
 
 .get_artifactory_token_win: &get_artifactory_token_win
-  - $ARTIFACTORY_TOKEN=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_TOKEN_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - $ARTIFACTORY_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh $ARTIFACTORY_TOKEN_SSM_NAME)
 
 .get_artifactory_bypass_linux: &get_artifactory_bypass_linux
-  - ARTIFACTORY_BYPASS=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_BYPASS_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - ARTIFACTORY_BYPASS=$(./tools/ci/aws_ssm_get_wrapper.sh $ARTIFACTORY_BYPASS_SSM_NAME)
   - if [ "${ARTIFACTORY_BYPASS}" = "true" ]; then echo "Bypassing Artifactory"; fi
 
 .get_artifactory_bypass_win: &get_artifactory_bypass_win
-  - $ARTIFACTORY_BYPASS=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_BYPASS_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - $ARTIFACTORY_BYPASS=$(.\tools\ci\aws_ssm_get_wrapper.ps1 $ARTIFACTORY_BYPASS_SSM_NAME)
   - if ($Env:ARTIFACTORY_BYPASS -eq "true") { Write-Host "Bypassing Artifactory" }
 
 .setup_ruby_mirror_linux:

--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -1,16 +1,16 @@
 ---
 .get_artifactory_token_linux: &get_artifactory_token_linux
-  - ARTIFACTORY_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh $ARTIFACTORY_TOKEN_SSM_NAME)
+  - ARTIFACTORY_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $ARTIFACTORY_TOKEN_SSM_NAME)
 
 .get_artifactory_token_win: &get_artifactory_token_win
-  - $ARTIFACTORY_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh $ARTIFACTORY_TOKEN_SSM_NAME)
+  - $ARTIFACTORY_TOKEN=$(& "$env:CI_PROJECT_DIR\tools\ci\aws_ssm_get_wrapper.ps1" $ARTIFACTORY_TOKEN_SSM_NAME)
 
 .get_artifactory_bypass_linux: &get_artifactory_bypass_linux
-  - ARTIFACTORY_BYPASS=$(./tools/ci/aws_ssm_get_wrapper.sh $ARTIFACTORY_BYPASS_SSM_NAME)
+  - ARTIFACTORY_BYPASS=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $ARTIFACTORY_BYPASS_SSM_NAME)
   - if [ "${ARTIFACTORY_BYPASS}" = "true" ]; then echo "Bypassing Artifactory"; fi
 
 .get_artifactory_bypass_win: &get_artifactory_bypass_win
-  - $ARTIFACTORY_BYPASS=$(.\tools\ci\aws_ssm_get_wrapper.ps1 $ARTIFACTORY_BYPASS_SSM_NAME)
+  - $ARTIFACTORY_BYPASS=$(& "$env:CI_PROJECT_DIR\tools\ci\aws_ssm_get_wrapper.ps1" $ARTIFACTORY_BYPASS_SSM_NAME)
   - if ($Env:ARTIFACTORY_BYPASS -eq "true") { Write-Host "Bypassing Artifactory" }
 
 .setup_ruby_mirror_linux:

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -10,8 +10,8 @@
     - ECR_RELEASE_SUFFIX=${CI_COMMIT_TAG+-release}
     - TARGET_TAG=${IMAGE}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}$TAG_SUFFIX-$ARCH
     # DockerHub login for build to limit rate limit when pulling base images
-    - DOCKER_REGISTRY_LOGIN=$(./tools/ci/aws_ssm_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
-    - ./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    - DOCKER_REGISTRY_LOGIN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
+    - $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Build image
     - docker buildx build --no-cache --push --pull --platform linux/$ARCH --build-arg CIBUILD=true --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} $BUILD_ARG --file $BUILD_CONTEXT/Dockerfile --tag ${TARGET_TAG} $BUILD_CONTEXT
     # Squash image

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -10,8 +10,8 @@
     - ECR_RELEASE_SUFFIX=${CI_COMMIT_TAG+-release}
     - TARGET_TAG=${IMAGE}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}$TAG_SUFFIX-$ARCH
     # DockerHub login for build to limit rate limit when pulling base images
-    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    - DOCKER_REGISTRY_LOGIN=$(./tools/ci/aws_ssm_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
+    - ./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Build image
     - docker buildx build --no-cache --push --pull --platform linux/$ARCH --build-arg CIBUILD=true --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} $BUILD_ARG --file $BUILD_CONTEXT/Dockerfile --tag ${TARGET_TAG} $BUILD_CONTEXT
     # Squash image

--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -13,8 +13,8 @@
       docker login --username AWS --password "`${AWS_ECR_PASSWORD}" 486234852809.dkr.ecr.us-east-1.amazonaws.com
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       # DockerHub login
-      `$DOCKER_REGISTRY_LOGIN = .\tools\ci\aws_ssm_get_wrapper.ps1 ci.datadog-agent.${DOCKER_REGISTRY_LOGIN_SSM_KEY}
-      `$DOCKER_REGISTRY_PWD = .\tools\ci\aws_ssm_get_wrapper.ps1 ci.datadog-agent.${DOCKER_REGISTRY_PWD_SSM_KEY}
+      `$DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DOCKER_REGISTRY_LOGIN_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
+      `$DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DOCKER_REGISTRY_PWD_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
       docker login --username "`${DOCKER_REGISTRY_LOGIN}" --password "`${DOCKER_REGISTRY_PWD}" "${DOCKER_REGISTRY_URL}"
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | out-file ci-scripts/docker-login.ps1

--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -13,8 +13,8 @@
       docker login --username AWS --password "`${AWS_ECR_PASSWORD}" 486234852809.dkr.ecr.us-east-1.amazonaws.com
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       # DockerHub login
-      `$DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DOCKER_REGISTRY_LOGIN_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
-      `$DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DOCKER_REGISTRY_PWD_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
+      `$DOCKER_REGISTRY_LOGIN = .\tools\ci\aws_ssm_get_wrapper.ps1 ci.datadog-agent.${DOCKER_REGISTRY_LOGIN_SSM_KEY}
+      `$DOCKER_REGISTRY_PWD = .\tools\ci\aws_ssm_get_wrapper.ps1 ci.datadog-agent.${DOCKER_REGISTRY_PWD_SSM_KEY}
       docker login --username "`${DOCKER_REGISTRY_LOGIN}" --password "`${DOCKER_REGISTRY_PWD}" "${DOCKER_REGISTRY_URL}"
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | out-file ci-scripts/docker-login.ps1
@@ -68,9 +68,9 @@
 .docker_build_agent7_windows_common:
   extends:
     - .docker_build_agent_windows_common
-  rules:
-    !reference [.on_a7]
-  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
+  rules: !reference [.on_a7]
+  needs:
+    ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-7*-x86_64.zip"
     BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=nano-${VARIANT}"
@@ -78,8 +78,7 @@
 .docker_build_agent6_windows_common:
   extends:
     - .docker_build_agent_windows_common
-  rules:
-    !reference [.on_a6]
+  rules: !reference [.on_a6]
   needs: ["windows_msi_x64-a6", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-6*-x86_64.zip"

--- a/.gitlab/deploy_packages/winget.yml
+++ b/.gitlab/deploy_packages/winget.yml
@@ -10,7 +10,7 @@ publish_winget_7_x64:
   variables:
     ARCH: "x64"
   before_script:
-    - $wingetPat = (.\tools\ci\aws_ssm_get_wrapper.ps1 ci.datadog-agent.winget_pat)
+    - $wingetPat = (& "$CI_PROJECT_DIR\tools\ci\aws_ssm_get_wrapper.ps1" ci.datadog-agent.winget_pat)
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"

--- a/.gitlab/deploy_packages/winget.yml
+++ b/.gitlab/deploy_packages/winget.yml
@@ -4,14 +4,13 @@
 
 publish_winget_7_x64:
   dependencies: []
-  rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
+  rules: !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
   stage: deploy_packages
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     ARCH: "x64"
   before_script:
-    - $wingetPat = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.winget_pat --with-decryption --query "Parameter.Value" --out text)
+    - $wingetPat = (.\tools\ci\aws_ssm_get_wrapper.ps1 ci.datadog-agent.winget_pat)
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"

--- a/.gitlab/deploy_packages/winget.yml
+++ b/.gitlab/deploy_packages/winget.yml
@@ -10,7 +10,8 @@ publish_winget_7_x64:
   variables:
     ARCH: "x64"
   before_script:
-    - $wingetPat = (& "$CI_PROJECT_DIR\tools\ci\aws_ssm_get_wrapper.ps1" ci.datadog-agent.winget_pat)
+    - $wingetPat = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.winget_pat --with-decryption --query "Parameter.Value" --out text)
+
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"

--- a/.gitlab/deploy_packages/winget.yml
+++ b/.gitlab/deploy_packages/winget.yml
@@ -11,7 +11,6 @@ publish_winget_7_x64:
     ARCH: "x64"
   before_script:
     - $wingetPat = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.winget_pat --with-decryption --query "Parameter.Value" --out text)
-
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -10,16 +10,16 @@
   variables:
     LANG: C.UTF-8
   before_script:
-    - export DOCKER_REGISTRY_LOGIN=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
-    - export DOCKER_REGISTRY_PWD=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY)
-    - export DD_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key)
+    - export DOCKER_REGISTRY_LOGIN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
+    - export DOCKER_REGISTRY_PWD=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY)
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key)
 
 .k8s-e2e-cws-cspm-init:
   - set +x
   - export DATADOG_AGENT_SITE=datadoghq.com
-  - export DATADOG_AGENT_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_api_key)
-  - export DATADOG_AGENT_APP_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_app_key)
-  - export DATADOG_AGENT_RC_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_rc_key)
+  - export DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_api_key)
+  - export DATADOG_AGENT_APP_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_app_key)
+  - export DATADOG_AGENT_RC_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_rc_key)
 
 k8s-e2e-cws-dev:
   extends: .k8s_e2e_template
@@ -82,11 +82,11 @@ k8s-e2e-otlp-main:
   before_script:
     # Setup AWS Credentials
     - mkdir -p ~/.aws
-    - ./aws_ssm_get_wrapper.sh ci.datadog-agent.agent-qa-profile >> ~/.aws/config
+    - $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.agent-qa-profile >> ~/.aws/config
     - export AWS_PROFILE=agent-qa-ci
     # Now all `aws` commands target the agent-qa profile
-    - ./aws_ssm_get_wrapper.sh ci.datadog-agent.ssh_public_key_rsa > $E2E_PUBLIC_KEY_PATH
-    - touch $E2E_PRIVATE_KEY_PATH && chmod 600 $E2E_PRIVATE_KEY_PATH && ./aws_ssm_get_wrapper.sh ci.datadog-agent.ssh_key_rsa > $E2E_PRIVATE_KEY_PATH
+    - $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.ssh_public_key_rsa > $E2E_PUBLIC_KEY_PATH
+    - touch $E2E_PRIVATE_KEY_PATH && chmod 600 $E2E_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.ssh_key_rsa > $E2E_PRIVATE_KEY_PATH
     # Use S3 backend
     - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
   variables:

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -10,16 +10,16 @@
   variables:
     LANG: C.UTF-8
   before_script:
-    - export DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - export DOCKER_REGISTRY_PWD=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
+    - export DOCKER_REGISTRY_LOGIN=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
+    - export DOCKER_REGISTRY_PWD=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY)
+    - export DD_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key)
 
 .k8s-e2e-cws-cspm-init:
   - set +x
   - export DATADOG_AGENT_SITE=datadoghq.com
-  - export DATADOG_AGENT_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.e2e_tests_api_key --with-decryption --query "Parameter.Value" --out text)
-  - export DATADOG_AGENT_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.e2e_tests_app_key --with-decryption --query "Parameter.Value" --out text)
-  - export DATADOG_AGENT_RC_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.e2e_tests_rc_key --with-decryption --query "Parameter.Value" --out text)
+  - export DATADOG_AGENT_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_api_key)
+  - export DATADOG_AGENT_APP_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_app_key)
+  - export DATADOG_AGENT_RC_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.e2e_tests_rc_key)
 
 k8s-e2e-cws-dev:
   extends: .k8s_e2e_template
@@ -82,11 +82,11 @@ k8s-e2e-otlp-main:
   before_script:
     # Setup AWS Credentials
     - mkdir -p ~/.aws
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.agent-qa-profile --with-decryption --query "Parameter.Value" --out text >> ~/.aws/config
+    - ./aws_ssm_get_wrapper.sh ci.datadog-agent.agent-qa-profile >> ~/.aws/config
     - export AWS_PROFILE=agent-qa-ci
     # Now all `aws` commands target the agent-qa profile
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.ssh_public_key_rsa --with-decryption --query "Parameter.Value" --out text > $E2E_PUBLIC_KEY_PATH
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.ssh_key_rsa --with-decryption --query "Parameter.Value" --out text > $E2E_PRIVATE_KEY_PATH && chmod 600 $E2E_PRIVATE_KEY_PATH
+    - ./aws_ssm_get_wrapper.sh ci.datadog-agent.ssh_public_key_rsa > $E2E_PUBLIC_KEY_PATH
+    - touch $E2E_PRIVATE_KEY_PATH && chmod 600 $E2E_PRIVATE_KEY_PATH && ./aws_ssm_get_wrapper.sh ci.datadog-agent.ssh_key_rsa > $E2E_PRIVATE_KEY_PATH
     # Use S3 backend
     - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
   variables:
@@ -118,8 +118,7 @@ new-e2e-containers:
   # TODO once images are deployed to ECR for dev branches, update
   #.on_main_or_rc_and_no_skip_e2e adding on_dev_branch_manual rules
   # and move rules to template
-  rules:
-    !reference [.on_container_or_e2e_changes_or_manual]
+  rules: !reference [.on_container_or_e2e_changes_or_manual]
   needs:
     - qa_agent
     - qa_dca
@@ -137,8 +136,7 @@ new-e2e-containers:
 
 new-e2e-remote-config:
   extends: .new_e2e_template
-  rules:
-    !reference [.on_rc_or_e2e_changes_or_manual]
+  rules: !reference [.on_rc_or_e2e_changes_or_manual]
   needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/remote-config

--- a/.gitlab/e2e_test_junit_upload/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload/e2e_test_junit_upload.yml
@@ -5,9 +5,7 @@
   variables:
     DD_ENV: ci
   script:
-    - set +x
-    - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export DATADOG_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - set +e
     - for f in junit*-e2e*.tgz; do inv -e junit-upload --tgz-path "$f"; done
 
@@ -87,7 +85,7 @@ e2e_installer_test_junit_upload:
 e2e_pre_test_junit_upload:
   extends: .e2e_test_junit_template
   rules:
-  # using the same rules as the kitchen_tests_upload job
+    # using the same rules as the kitchen_tests_upload job
     - !reference [.on_e2e_changes_or_manual]
   when: always
   stage: e2e_pre_test_junit_upload

--- a/.gitlab/e2e_test_junit_upload/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload/e2e_test_junit_upload.yml
@@ -5,7 +5,7 @@
   variables:
     DD_ENV: ci
   script:
-    - export DATADOG_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - set +e
     - for f in junit*-e2e*.tgz; do inv -e junit-upload --tgz-path "$f"; done
 

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -45,12 +45,12 @@ single-machine-performance-regression_detector:
     - echo "Merge base is ${SMP_MERGE_BASE}"
     # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"
-    - SMP_ACCOUNT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-account-id)
+    - SMP_ACCOUNT_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-account-id)
     - SMP_ECR_URL=${SMP_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
-    - SMP_AGENT_TEAM_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-agent-team-id)
-    - SMP_API=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-api)
-    - aws configure set aws_access_key_id $(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key-id) --profile ${AWS_NAMED_PROFILE}
-    - aws configure set aws_secret_access_key $(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key) --profile ${AWS_NAMED_PROFILE}
+    - SMP_AGENT_TEAM_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-agent-team-id)
+    - SMP_API=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-api)
+    - aws configure set aws_access_key_id $($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key-id) --profile ${AWS_NAMED_PROFILE}
+    - aws configure set aws_secret_access_key $($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key) --profile ${AWS_NAMED_PROFILE}
     - aws configure set region us-west-2 --profile ${AWS_NAMED_PROFILE}
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -11,10 +11,10 @@ single-machine-performance-regression_detector:
   artifacts:
     expire_in: 1 weeks
     paths:
-      - submission_metadata              # for provenance, debugging
-      - ${CI_COMMIT_SHA}-baseline_sha    # for provenance, debugging
-      - outputs/report.md                # for debugging, also on S3
-      - outputs/report.html              # for debugging, also on S3
+      - submission_metadata # for provenance, debugging
+      - ${CI_COMMIT_SHA}-baseline_sha # for provenance, debugging
+      - outputs/report.md # for debugging, also on S3
+      - outputs/report.html # for debugging, also on S3
     when: always
   variables:
     SMP_VERSION: 0.12.0
@@ -34,9 +34,9 @@ single-machine-performance-regression_detector:
   allow_failure: true
   script:
     # Ensure output files exist for artifact downloads step
-    - mkdir outputs              # Also needed for smp job sync step
-    - touch outputs/report.md    # Will be emitted by smp job sync
-    - touch outputs/report.html  # Will be emitted by smp job sync
+    - mkdir outputs # Also needed for smp job sync step
+    - touch outputs/report.md # Will be emitted by smp job sync
+    - touch outputs/report.html # Will be emitted by smp job sync
     # Compute merge base of current commit and `main`
     - git fetch origin
     - SMP_BASE_BRANCH=$(inv release.get-release-json-value base_branch)
@@ -45,12 +45,12 @@ single-machine-performance-regression_detector:
     - echo "Merge base is ${SMP_MERGE_BASE}"
     # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"
-    - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
+    - SMP_ACCOUNT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-account-id)
     - SMP_ECR_URL=${SMP_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
-    - SMP_AGENT_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-agent-team-id --with-decryption --query "Parameter.Value" --out text)
-    - SMP_API=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-api --with-decryption --query "Parameter.Value" --out text)
-    - aws configure set aws_access_key_id $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key-id --with-decryption --query "Parameter.Value" --out text) --profile ${AWS_NAMED_PROFILE}
-    - aws configure set aws_secret_access_key $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key --with-decryption --query "Parameter.Value" --out text) --profile ${AWS_NAMED_PROFILE}
+    - SMP_AGENT_TEAM_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-agent-team-id)
+    - SMP_API=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-api)
+    - aws configure set aws_access_key_id $(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key-id) --profile ${AWS_NAMED_PROFILE}
+    - aws configure set aws_secret_access_key $(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key) --profile ${AWS_NAMED_PROFILE}
     - aws configure set region us-west-2 --profile ${AWS_NAMED_PROFILE}
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp
@@ -71,32 +71,32 @@ single-machine-performance-regression_detector:
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job submit
-            --lading-version ${LADING_VERSION}
-            --baseline-image ${BASELINE_IMAGE}
-            --comparison-image ${COMPARISON_IMAGE}
-            --baseline-sha ${BASELINE_SHA}
-            --comparison-sha ${CI_COMMIT_SHA}
-            --target-name datadog-agent
-            --target-command "/bin/entrypoint.sh"
-            --target-environment-variables "DD_HOSTNAME=smp-regression,DD_DD_URL=http://127.0.0.1:9092"
-            --target-config-dir test/regression/
-            --target-cpu-allotment ${CPUS}
-            --target-memory-allotment ${MEMORY}
-            --submission-metadata submission_metadata
+      job submit
+      --lading-version ${LADING_VERSION}
+      --baseline-image ${BASELINE_IMAGE}
+      --comparison-image ${COMPARISON_IMAGE}
+      --baseline-sha ${BASELINE_SHA}
+      --comparison-sha ${CI_COMMIT_SHA}
+      --target-name datadog-agent
+      --target-command "/bin/entrypoint.sh"
+      --target-environment-variables "DD_HOSTNAME=smp-regression,DD_DD_URL=http://127.0.0.1:9092"
+      --target-config-dir test/regression/
+      --target-cpu-allotment ${CPUS}
+      --target-memory-allotment ${MEMORY}
+      --submission-metadata submission_metadata
     # Wait for job to complete.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job status
-            --use-consignor welch
-            --wait
-            --wait-delay-seconds 60
-            --submission-metadata submission_metadata
+      job status
+      --use-consignor welch
+      --wait
+      --wait-delay-seconds 60
+      --submission-metadata submission_metadata
     # Now that the job is completed pull the analysis report, output it to stdout.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job sync
-            --use-consignor welch
-            --submission-metadata submission_metadata
-            --output-path outputs
+      job sync
+      --use-consignor welch
+      --submission-metadata submission_metadata
+      --output-path outputs
     # Replace empty lines in the output with lines containing various unicode
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
@@ -125,6 +125,6 @@ single-machine-performance-regression_detector:
     - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME"
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job result
-            --use-consignor welch
-            --submission-metadata submission_metadata
+      job result
+      --use-consignor welch
+      --submission-metadata submission_metadata

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -2,8 +2,7 @@ single-machine-performance-workload-checks:
   stage: functional_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker"]
-  rules:
-    !reference [.on_scheduled_main]
+  rules: !reference [.on_scheduled_main]
   needs:
     - job: single_machine_performance-nightly-amd64-a7
       artifacts: false
@@ -23,12 +22,12 @@ single-machine-performance-workload-checks:
     - git fetch origin
     # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"
-    - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
+    - SMP_ACCOUNT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-account-id)
     - SMP_ECR_URL=${SMP_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
-    - SMP_AGENT_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-agent-team-id --with-decryption --query "Parameter.Value" --out text)
-    - SMP_API=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-api --with-decryption --query "Parameter.Value" --out text)
-    - aws configure set aws_access_key_id $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key-id --with-decryption --query "Parameter.Value" --out text) --profile ${AWS_NAMED_PROFILE}
-    - aws configure set aws_secret_access_key $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key --with-decryption --query "Parameter.Value" --out text) --profile ${AWS_NAMED_PROFILE}
+    - SMP_AGENT_TEAM_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-agent-team-id)
+    - SMP_API=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-api)
+    - aws configure set aws_access_key_id $(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key-id) --profile ${AWS_NAMED_PROFILE}
+    - aws configure set aws_secret_access_key $(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key) --profile ${AWS_NAMED_PROFILE}
     - aws configure set region us-west-2 --profile ${AWS_NAMED_PROFILE}
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp
@@ -39,22 +38,22 @@ single-machine-performance-workload-checks:
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"
     - RUST_BACKTRACE=1 RUST_LOG="${RUST_LOG_DEBUG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job submit-workload
-            --lading-version ${LADING_VERSION}
-            --total-samples ${TOTAL_SAMPLES}
-            --warmup-seconds ${WARMUP_SECONDS}
-            --replicas ${REPLICAS}
-            --target-image ${TARGET_IMAGE}
-            --target-sha ${CI_COMMIT_SHA}
-            --target-config-dir test/workload-checks
-            --target-name datadog-agent
-            --target-command "/bin/entrypoint.sh"
-            --target-environment-variables "DD_HOSTNAME=smp-workload-checks,DD_DD_URL=http://127.0.0.1:9092,DD_API_KEY=00000001"
-            --tags smp_status=nightly,client_team="agent",tag_date="${CURRENT_DATE}"
-            --submission-metadata submission-metadata
+      job submit-workload
+      --lading-version ${LADING_VERSION}
+      --total-samples ${TOTAL_SAMPLES}
+      --warmup-seconds ${WARMUP_SECONDS}
+      --replicas ${REPLICAS}
+      --target-image ${TARGET_IMAGE}
+      --target-sha ${CI_COMMIT_SHA}
+      --target-config-dir test/workload-checks
+      --target-name datadog-agent
+      --target-command "/bin/entrypoint.sh"
+      --target-environment-variables "DD_HOSTNAME=smp-workload-checks,DD_DD_URL=http://127.0.0.1:9092,DD_API_KEY=00000001"
+      --tags smp_status=nightly,client_team="agent",tag_date="${CURRENT_DATE}"
+      --submission-metadata submission-metadata
     # Wait for job to complete.
     - RUST_BACKTRACE=1 RUST_LOG="${RUST_LOG_DEBUG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job status
-            --wait
-            --wait-delay-seconds 60
-            --submission-metadata submission-metadata
+      job status
+      --wait
+      --wait-delay-seconds 60
+      --submission-metadata submission-metadata

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -22,12 +22,12 @@ single-machine-performance-workload-checks:
     - git fetch origin
     # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"
-    - SMP_ACCOUNT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-account-id)
+    - SMP_ACCOUNT_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-account-id)
     - SMP_ECR_URL=${SMP_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
-    - SMP_AGENT_TEAM_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-agent-team-id)
-    - SMP_API=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-api)
-    - aws configure set aws_access_key_id $(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key-id) --profile ${AWS_NAMED_PROFILE}
-    - aws configure set aws_secret_access_key $(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key) --profile ${AWS_NAMED_PROFILE}
+    - SMP_AGENT_TEAM_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-agent-team-id)
+    - SMP_API=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-api)
+    - aws configure set aws_access_key_id $($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key-id) --profile ${AWS_NAMED_PROFILE}
+    - aws configure set aws_secret_access_key $($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.single-machine-performance-bot-access-key) --profile ${AWS_NAMED_PROFILE}
     - aws configure set region us-west-2 --profile ${AWS_NAMED_PROFILE}
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp

--- a/.gitlab/functional_test_junit_upload/functional_test_junit_upload_security-agent.yml
+++ b/.gitlab/functional_test_junit_upload/functional_test_junit_upload_security-agent.yml
@@ -14,7 +14,5 @@ functional_test_junit_upload_security_agent:
   variables:
     DD_ENV: ci
   script:
-    - set +x
-    - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export DATADOG_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - ss=0; for f in $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz; do [[ -e "$f" ]] || continue; inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss

--- a/.gitlab/functional_test_junit_upload/functional_test_junit_upload_security-agent.yml
+++ b/.gitlab/functional_test_junit_upload/functional_test_junit_upload_security-agent.yml
@@ -14,5 +14,5 @@ functional_test_junit_upload_security_agent:
   variables:
     DD_ENV: ci
   script:
-    - export DATADOG_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - ss=0; for f in $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz; do [[ -e "$f" ]] || continue; inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss

--- a/.gitlab/functional_test_junit_upload/functional_test_junit_upload_system_probe.yml
+++ b/.gitlab/functional_test_junit_upload/functional_test_junit_upload_system_probe.yml
@@ -17,7 +17,7 @@ functional_test_junit_upload_system_probe:
   variables:
     DD_ENV: ci
   script:
-    - export DATADOG_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - ss=0; for f in $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz; do [[ -e "$f" ]] || continue; inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss
 
 .functional_test_junit_upload_system_probe_kmt:
@@ -31,8 +31,8 @@ functional_test_junit_upload_system_probe:
   variables:
     DD_ENV: ci
   script:
-    - export DATADOG_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
-    - export JIRA_TOKEN=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.jira_read_api_token)
+    - export DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export JIRA_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.jira_read_api_token)
     - ss=0; for f in $DD_AGENT_TESTING_DIR/junit-*.tar.gz; do [[ -e "$f" ]] || continue; inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss
 
 # junit upload jobs are separted because of gitlab limit on the number of jobs

--- a/.gitlab/functional_test_junit_upload/functional_test_junit_upload_system_probe.yml
+++ b/.gitlab/functional_test_junit_upload/functional_test_junit_upload_system_probe.yml
@@ -17,9 +17,7 @@ functional_test_junit_upload_system_probe:
   variables:
     DD_ENV: ci
   script:
-    - set +x
-    - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export DATADOG_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - ss=0; for f in $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz; do [[ -e "$f" ]] || continue; inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss
 
 .functional_test_junit_upload_system_probe_kmt:
@@ -33,10 +31,8 @@ functional_test_junit_upload_system_probe:
   variables:
     DD_ENV: ci
   script:
-    - set +x
-    - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
-    - export JIRA_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.jira_read_api_token --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export DATADOG_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export JIRA_TOKEN=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.jira_read_api_token)
     - ss=0; for f in $DD_AGENT_TESTING_DIR/junit-*.tar.gz; do [[ -e "$f" ]] || continue; inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss
 
 # junit upload jobs are separted because of gitlab limit on the number of jobs

--- a/.gitlab/functional_test_sysprobe/system_probe.yml
+++ b/.gitlab/functional_test_sysprobe/system_probe.yml
@@ -17,8 +17,8 @@
     - echo "CI_JOB_STAGE=${CI_JOB_STAGE}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt
     - cp $CI_PROJECT_DIR/minimized-btfs.tar.xz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/minimized-btfs.tar.xz
     - inv system-probe.test-docker-image-list > $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/docker-images.txt
-    - export DOCKER_REGISTRY_LOGIN=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
-    - export DOCKER_REGISTRY_PASSWORD=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY)
+    - export DOCKER_REGISTRY_LOGIN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
+    - export DOCKER_REGISTRY_PASSWORD=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY)
     - pushd $DD_AGENT_TESTING_DIR
     - tasks/kitchen_setup.sh
   script:

--- a/.gitlab/functional_test_sysprobe/system_probe.yml
+++ b/.gitlab/functional_test_sysprobe/system_probe.yml
@@ -17,13 +17,8 @@
     - echo "CI_JOB_STAGE=${CI_JOB_STAGE}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt
     - cp $CI_PROJECT_DIR/minimized-btfs.tar.xz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/minimized-btfs.tar.xz
     - inv system-probe.test-docker-image-list > $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/docker-images.txt
-    - |
-      get_docker_secrets() {
-        if [ -o xtrace ]; then set +x; trap 'set -x' RETURN; fi
-        export DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-        export DOCKER_REGISTRY_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-      }
-      get_docker_secrets
+    - export DOCKER_REGISTRY_LOGIN=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
+    - export DOCKER_REGISTRY_PASSWORD=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY)
     - pushd $DD_AGENT_TESTING_DIR
     - tasks/kitchen_setup.sh
   script:
@@ -50,17 +45,21 @@ kitchen_test_dummy_job_tmp:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/btf-gen$DATADOG_AGENT_BTF_GEN_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BTF_GEN_BUILDIMAGES
   needs: []
   tags: ["arch:amd64"]
-  rules:
-    !reference [ .on_system_probe_or_e2e_changes_or_manual ]
+  rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   script:
-    - 'true'
+    - "true"
 
 kitchen_test_system_probe_linux_x64_ec2:
   extends:
     - .kitchen_test_system_probe_linux
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
-  needs: [ "tests_ebpf_x64", "prepare_ebpf_functional_tests_x64", "generate_minimized_btfs_x64" ]
+  needs:
+    [
+      "tests_ebpf_x64",
+      "prepare_ebpf_functional_tests_x64",
+      "generate_minimized_btfs_x64",
+    ]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -118,7 +117,12 @@ kitchen_test_system_probe_linux_arm64:
     - .kitchen_test_system_probe_linux
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
-  needs: [ "tests_ebpf_arm64", "prepare_ebpf_functional_tests_arm64", "generate_minimized_btfs_arm64" ]
+  needs:
+    [
+      "tests_ebpf_arm64",
+      "prepare_ebpf_functional_tests_arm64",
+      "generate_minimized_btfs_arm64",
+    ]
   variables:
     ARCH: arm64
     KITCHEN_ARCH: arm64

--- a/.gitlab/install_script_testing/install_script_testing.yml
+++ b/.gitlab/install_script_testing/install_script_testing.yml
@@ -6,7 +6,7 @@ test_install_script:
   script:
     - source /root/.bashrc
     - set +x
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - export TESTING_APT_URL=$DEB_TESTING_S3_BUCKET
     - export TESTING_YUM_URL=$RPM_TESTING_S3_BUCKET
     - export TEST_PIPELINE_ID=$CI_PIPELINE_ID

--- a/.gitlab/install_script_testing/install_script_testing.yml
+++ b/.gitlab/install_script_testing/install_script_testing.yml
@@ -6,7 +6,7 @@ test_install_script:
   script:
     - source /root/.bashrc
     - set +x
-    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - export TESTING_APT_URL=$DEB_TESTING_S3_BUCKET
     - export TESTING_YUM_URL=$RPM_TESTING_S3_BUCKET
     - export TEST_PIPELINE_ID=$CI_PIPELINE_ID

--- a/.gitlab/integration_test/windows.yml
+++ b/.gitlab/integration_test/windows.yml
@@ -7,7 +7,7 @@
   needs: ["go_deps", "go_tools_deps"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   before_script:
-    - $vcpkgBlobSaSUrl = (& "$CI_PROJECT_DIR\tools\ci\aws_ssm_get_wrapper.ps1" ci.datadog-agent-buildimages.vcpkg_blob_sas_url)
+    - $vcpkgBlobSaSUrl = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.vcpkg_blob_sas_url --with-decryption --query "Parameter.Value" --out text)
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'

--- a/.gitlab/integration_test/windows.yml
+++ b/.gitlab/integration_test/windows.yml
@@ -7,7 +7,7 @@
   needs: ["go_deps", "go_tools_deps"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   before_script:
-    - $vcpkgBlobSaSUrl = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.vcpkg_blob_sas_url --with-decryption --query "Parameter.Value" --out text)
+    - $vcpkgBlobSaSUrl = (.\tools\ci\aws_ssm_get_wrapper.ps1 ci.datadog-agent-buildimages.vcpkg_blob_sas_url)
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'

--- a/.gitlab/integration_test/windows.yml
+++ b/.gitlab/integration_test/windows.yml
@@ -7,7 +7,7 @@
   needs: ["go_deps", "go_tools_deps"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   before_script:
-    - $vcpkgBlobSaSUrl = (.\tools\ci\aws_ssm_get_wrapper.ps1 ci.datadog-agent-buildimages.vcpkg_blob_sas_url)
+    - $vcpkgBlobSaSUrl = (& "$CI_PROJECT_DIR\tools\ci\aws_ssm_get_wrapper.ps1" ci.datadog-agent-buildimages.vcpkg_blob_sas_url)
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'

--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -23,7 +23,7 @@ docker_trigger_internal:
     RELEASE_STAGING: "true"
   script:
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
@@ -66,7 +66,7 @@ docker_trigger_cluster_agent_internal:
     RELEASE_PROD: "true"
   script:
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
@@ -109,7 +109,7 @@ docker_trigger_cws_instrumentation_internal:
     RELEASE_PROD: "true"
   script:
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master

--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -4,8 +4,7 @@
 
 docker_trigger_internal:
   stage: internal_image_deploy
-  rules:
-    !reference [.on_deploy_a7_internal_or_manual]
+  rules: !reference [.on_deploy_a7_internal_or_manual]
   needs:
     - job: docker_build_agent7_jmx
       artifacts: false
@@ -24,7 +23,7 @@ docker_trigger_internal:
     RELEASE_STAGING: "true"
   script:
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
@@ -45,11 +44,9 @@ docker_trigger_internal:
       --variable TARGET_ENV
       --variable DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
 
-
 docker_trigger_cluster_agent_internal:
   stage: internal_image_deploy
-  rules:
-    !reference [.on_deploy_a7]
+  rules: !reference [.on_deploy_a7]
   needs:
     - job: docker_build_cluster_agent_amd64
       artifacts: false
@@ -69,7 +66,7 @@ docker_trigger_cluster_agent_internal:
     RELEASE_PROD: "true"
   script:
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
@@ -92,8 +89,7 @@ docker_trigger_cluster_agent_internal:
 
 docker_trigger_cws_instrumentation_internal:
   stage: internal_image_deploy
-  rules:
-    !reference [.on_deploy_a7]
+  rules: !reference [.on_deploy_a7]
   needs:
     - job: docker_build_cws_instrumentation_amd64
       artifacts: false
@@ -113,7 +109,7 @@ docker_trigger_cws_instrumentation_internal:
     RELEASE_PROD: "true"
   script:
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master

--- a/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -33,7 +33,7 @@ internal_kubernetes_deploy_experimental:
     BUNDLE_VERSION_OVERRIDE: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   script:
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/k8s-datadog-agent-ops --git-ref main
         --variable OPTION_AUTOMATIC_ROLLOUT
         --variable EXPLICIT_WORKFLOWS

--- a/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -8,21 +8,21 @@ include:
 internal_kubernetes_deploy_experimental:
   stage: internal_kubernetes_deploy
   rules:
-  - if: $FORCE_K8S_DEPLOYMENT == "true"
-    when: always
-  - if: $CI_COMMIT_BRANCH != "main"
-    when: never
-  - if: $DDR != "true"
-    when: never
-  - !reference [.on_deploy_a7]
+    - if: $FORCE_K8S_DEPLOYMENT == "true"
+      when: always
+    - if: $CI_COMMIT_BRANCH != "main"
+      when: never
+    - if: $DDR != "true"
+      when: never
+    - !reference [.on_deploy_a7]
   needs:
-  - job: docker_trigger_internal
-    artifacts: false
-  - job: docker_trigger_cluster_agent_internal
-    artifacts: false
-  - job: k8s-e2e-main # Currently only require container Argo workflow
-    artifacts: false
-    optional: true
+    - job: docker_trigger_internal
+      artifacts: false
+    - job: docker_trigger_cluster_agent_internal
+      artifacts: false
+    - job: k8s-e2e-main # Currently only require container Argo workflow
+      artifacts: false
+      optional: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:
@@ -33,7 +33,7 @@ internal_kubernetes_deploy_experimental:
     BUNDLE_VERSION_OVERRIDE: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   script:
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/k8s-datadog-agent-ops --git-ref main
         --variable OPTION_AUTOMATIC_ROLLOUT
         --variable EXPLICIT_WORKFLOWS
@@ -56,7 +56,7 @@ notify-slack:
       when: never
     - if: $DDR != "true"
       when: never
-    - !reference [ .on_deploy_a7 ]
+    - !reference [.on_deploy_a7]
   tags: ["arch:amd64"]
   needs: ["internal_kubernetes_deploy_experimental"]
   script:

--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -5,16 +5,16 @@
 rc_kubernetes_deploy:
   stage: internal_kubernetes_deploy
   rules:
-  - if: $RC_K8S_DEPLOYMENTS == "true"
-    when: always
+    - if: $RC_K8S_DEPLOYMENTS == "true"
+      when: always
   needs:
-  - job: docker_trigger_internal
-    artifacts: false
-  - job: docker_trigger_cluster_agent_internal
-    artifacts: false
-  - job: k8s-e2e-main # Currently only require container Argo workflow
-    artifacts: false
-    optional: true
+    - job: docker_trigger_internal
+      artifacts: false
+    - job: docker_trigger_cluster_agent_internal
+      artifacts: false
+    - job: k8s-e2e-main # Currently only require container Argo workflow
+      artifacts: false
+      optional: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:
@@ -24,8 +24,7 @@ rc_kubernetes_deploy:
     EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
   script:
     - source /root/.bashrc
-    - set +x
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/k8s-datadog-agent-ops --git-ref main
       --no-follow
       --variable OPTION_AUTOMATIC_ROLLOUT

--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -24,7 +24,7 @@ rc_kubernetes_deploy:
     EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
   script:
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/k8s-datadog-agent-ops --git-ref main
       --no-follow
       --variable OPTION_AUTOMATIC_ROLLOUT

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -2,13 +2,12 @@
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   needs: []
   tags: ["arch:amd64"]
-  rules:
-    !reference [ .on_system_probe_or_e2e_changes_or_manual ]
+  rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   stage: kernel_matrix_testing
   script:
     # DockerHub login for build to limit rate limit when pulling base images
-    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | crane auth login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    - DOCKER_REGISTRY_LOGIN=$(./tools/ci/aws_ssm_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
+    - ./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY | crane auth login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Pull base images
     - mkdir $KMT_DOCKERS
     - inv -e system-probe.save-test-dockers --use-crane --output-dir $KMT_DOCKERS --arch $ARCH
@@ -55,12 +54,10 @@ pull_test_dockers_arm64:
     sleep 10
 
 .write_ssh_key_file:
-  - set +x
-  - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.ssh_key --with-decryption --query "Parameter.Value" --out text > $AWS_EC2_SSH_KEY_FILE
-  - set -x
+  - touch $AWS_EC2_SSH_KEY_FILE && chmod 600 $AWS_EC2_SSH_KEY_FILE
+  - ./tools/ci/aws_ssm_getwrapper.sh ci.datadog-agent.ssh_key > $AWS_EC2_SSH_KEY_FILE
   # Without the newline ssh silently fails and moves on to try other auth methods
   - echo "" >> $AWS_EC2_SSH_KEY_FILE
-  - chmod 600 $AWS_EC2_SSH_KEY_FILE
 
 # needs variables: ARCH, INSTANCE_TYPE
 .get_instance_ip_by_type:
@@ -77,8 +74,7 @@ pull_test_dockers_arm64:
   stage: kernel_matrix_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   allow_failure: true
-  rules:
-    !reference [ .on_system_probe_or_e2e_changes_or_manual ]
+  rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   before_script:
     - !reference [.kernel_matrix_testing_new_profile]
     - !reference [.write_ssh_key_file]
@@ -113,8 +109,7 @@ upload_dependencies_arm64:
 .upload_system_probe_tests:
   stage: kernel_matrix_testing
   allow_failure: true
-  rules:
-    !reference [ .on_system_probe_or_e2e_changes_or_manual ]
+  rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.kernel_matrix_testing_new_profile]
@@ -205,8 +200,7 @@ upload_system_probe_tests_arm64:
   stage: kernel_matrix_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["arch:amd64"]
-  rules:
-    !reference [ .on_system_probe_or_e2e_changes_or_manual ]
+  rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   allow_failure: true
   script:
     # Build dependencies directory
@@ -254,17 +248,14 @@ upload_minimized_btfs_arm64:
 
 .kernel_matrix_testing_new_profile:
   - mkdir -p ~/.aws
-  - set +x
-  - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.agent-qa-profile --with-decryption --query "Parameter.Value" --out text >> ~/.aws/config
-  - set -x
+  - ./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.agent-qa-profile >> ~/.aws/config
   - export AWS_PROFILE=agent-qa-ci
 
 .kernel_matrix_testing_setup_env:
   extends:
     - .kitchen_ec2_location_us_east_1
   stage: kernel_matrix_testing
-  rules:
-    !reference [ .on_system_probe_or_e2e_changes_or_manual ]
+  rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   needs: ["go_deps", "go_tools_deps"]
   tags: ["arch:amd64"]
@@ -285,9 +276,7 @@ upload_minimized_btfs_arm64:
     VMCONFIG_FILE: "${CI_PROJECT_DIR}/vmconfig-${CI_PIPELINE_ID}-${ARCH}.json"
     TEST_SETS: "no_tracersuite,only_tracersuite"
   before_script:
-    - set +x
-    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export DD_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - !reference [.retrieve_linux_go_deps]
     - !reference [.kernel_matrix_testing_new_profile]
     - !reference [.write_ssh_key_file]
@@ -340,15 +329,12 @@ kernel_matrix_testing_setup_env_x64:
 .kernel_matrix_testing_run_tests:
   stage: kernel_matrix_testing
   allow_failure: true
-  rules:
-    !reference [ .on_system_probe_or_e2e_changes_or_manual ]
+  rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   variables:
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
     RETRY: 2
   before_script:
-    - set +x
-    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export DD_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - !reference [.kernel_matrix_testing_new_profile]
     - !reference [.write_ssh_key_file]
     - echo "CI_JOB_URL=${CI_JOB_URL}" >> $DD_AGENT_TESTING_DIR/job_env.txt
@@ -392,13 +378,36 @@ kernel_matrix_testing_run_tests_x64:
     - .kernel_matrix_testing_run_tests
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["kernel_matrix_testing_setup_env_x64", "upload_dependencies_x64", "upload_system_probe_tests_x64", "upload_minimized_btfs_x64"]
+  needs:
+    [
+      "kernel_matrix_testing_setup_env_x64",
+      "upload_dependencies_x64",
+      "upload_system_probe_tests_x64",
+      "upload_minimized_btfs_x64",
+    ]
   timeout: 3h
   variables:
     ARCH: "x86_64"
   parallel:
     matrix:
-      - TAG: ["ubuntu_16.04", "ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "ubuntu_23.10", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11", "debian_12", "centos_79", "centos_8"]
+      - TAG:
+          [
+            "ubuntu_16.04",
+            "ubuntu_18.04",
+            "ubuntu_20.04",
+            "ubuntu_22.04",
+            "ubuntu_23.10",
+            "amzn_4.14",
+            "amzn_5.4",
+            "amzn_5.10",
+            "fedora_37",
+            "fedora_38",
+            "debian_10",
+            "debian_11",
+            "debian_12",
+            "centos_79",
+            "centos_8",
+          ]
         TEST_SET: ["no_tracersuite", "only_tracersuite"]
 
 kernel_matrix_testing_run_tests_arm64:
@@ -406,13 +415,35 @@ kernel_matrix_testing_run_tests_arm64:
     - .kernel_matrix_testing_run_tests
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["arch:arm64"]
-  needs: ["kernel_matrix_testing_setup_env_arm64", "upload_dependencies_arm64", "upload_system_probe_tests_arm64", "upload_minimized_btfs_arm64"]
+  needs:
+    [
+      "kernel_matrix_testing_setup_env_arm64",
+      "upload_dependencies_arm64",
+      "upload_system_probe_tests_arm64",
+      "upload_minimized_btfs_arm64",
+    ]
   timeout: 3h
   variables:
     ARCH: "arm64"
   parallel:
     matrix:
-      - TAG: ["ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "ubuntu_23.10", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11", "debian_12", "centos_79", "centos_8"]
+      - TAG:
+          [
+            "ubuntu_18.04",
+            "ubuntu_20.04",
+            "ubuntu_22.04",
+            "ubuntu_23.10",
+            "amzn_4.14",
+            "amzn_5.4",
+            "amzn_5.10",
+            "fedora_37",
+            "fedora_38",
+            "debian_10",
+            "debian_11",
+            "debian_12",
+            "centos_79",
+            "centos_8",
+          ]
         TEST_SET: ["no_tracersuite", "only_tracersuite"]
 
 .kernel_matrix_testing_cleanup:
@@ -420,8 +451,7 @@ kernel_matrix_testing_run_tests_arm64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   when: always
   tags: ["arch:amd64"]
-  rules:
-    !reference [ .on_system_probe_or_e2e_changes_or_manual ]
+  rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   before_script:
     - !reference [.kernel_matrix_testing_new_profile]
   script:
@@ -437,7 +467,11 @@ kernel_matrix_testing_run_tests_arm64:
 kernel_matrix_testing_cleanup_arm64:
   extends:
     - .kernel_matrix_testing_cleanup
-  needs: ["kernel_matrix_testing_setup_env_arm64", "kernel_matrix_testing_run_tests_arm64"]
+  needs:
+    [
+      "kernel_matrix_testing_setup_env_arm64",
+      "kernel_matrix_testing_run_tests_arm64",
+    ]
   variables:
     ARCH: arm64
     INSTANCE_TYPE: "m6gd.metal"
@@ -445,7 +479,11 @@ kernel_matrix_testing_cleanup_arm64:
 kernel_matrix_testing_cleanup_x64:
   extends:
     - .kernel_matrix_testing_cleanup
-  needs: ["kernel_matrix_testing_setup_env_x64", "kernel_matrix_testing_run_tests_x64"]
+  needs:
+    [
+      "kernel_matrix_testing_setup_env_x64",
+      "kernel_matrix_testing_run_tests_x64",
+    ]
   variables:
     ARCH: x86_64
     INSTANCE_TYPE: "m5d.metal"

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -6,8 +6,8 @@
   stage: kernel_matrix_testing
   script:
     # DockerHub login for build to limit rate limit when pulling base images
-    - DOCKER_REGISTRY_LOGIN=$(./tools/ci/aws_ssm_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
-    - ./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY | crane auth login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    - DOCKER_REGISTRY_LOGIN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
+    - $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY | crane auth login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Pull base images
     - mkdir $KMT_DOCKERS
     - inv -e system-probe.save-test-dockers --use-crane --output-dir $KMT_DOCKERS --arch $ARCH
@@ -55,7 +55,7 @@ pull_test_dockers_arm64:
 
 .write_ssh_key_file:
   - touch $AWS_EC2_SSH_KEY_FILE && chmod 600 $AWS_EC2_SSH_KEY_FILE
-  - ./tools/ci/aws_ssm_getwrapper.sh ci.datadog-agent.ssh_key > $AWS_EC2_SSH_KEY_FILE
+  - $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.ssh_key > $AWS_EC2_SSH_KEY_FILE
   # Without the newline ssh silently fails and moves on to try other auth methods
   - echo "" >> $AWS_EC2_SSH_KEY_FILE
 
@@ -248,7 +248,7 @@ upload_minimized_btfs_arm64:
 
 .kernel_matrix_testing_new_profile:
   - mkdir -p ~/.aws
-  - ./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.agent-qa-profile >> ~/.aws/config
+  - $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.agent-qa-profile >> ~/.aws/config
   - export AWS_PROFILE=agent-qa-ci
 
 .kernel_matrix_testing_setup_env:
@@ -276,7 +276,7 @@ upload_minimized_btfs_arm64:
     VMCONFIG_FILE: "${CI_PROJECT_DIR}/vmconfig-${CI_PIPELINE_ID}-${ARCH}.json"
     TEST_SETS: "no_tracersuite,only_tracersuite"
   before_script:
-    - export DD_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - !reference [.retrieve_linux_go_deps]
     - !reference [.kernel_matrix_testing_new_profile]
     - !reference [.write_ssh_key_file]
@@ -334,7 +334,7 @@ kernel_matrix_testing_setup_env_x64:
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
     RETRY: 2
   before_script:
-    - export DD_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - !reference [.kernel_matrix_testing_new_profile]
     - !reference [.write_ssh_key_file]
     - echo "CI_JOB_URL=${CI_JOB_URL}" >> $DD_AGENT_TESTING_DIR/job_env.txt

--- a/.gitlab/kitchen_deploy/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy/kitchen_deploy.yml
@@ -3,21 +3,18 @@
 # Contains jobs which deploy Agent package to testing repsoitories that are used in kitchen tests.
 
 .setup_rpm_signing_key: &setup_rpm_signing_key
-  - set +x
-  - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $RPM_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
   - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-  - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
 
 .setup_apt_signing_key: &setup_apt_signing_key
-  - set +x  # make sure we don't output the creds to the build log
-
-  - APT_SIGNING_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name $DEB_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
-  - APT_SIGNING_KEY_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $DEB_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - APT_SIGNING_PRIVATE_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $DEB_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - APT_SIGNING_KEY_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $DEB_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
 
   - printf -- "$APT_SIGNING_PRIVATE_KEY" | gpg --import --batch
 
-.setup_signing_keys_package: &setup_signing_keys_package
-  # Set up prod apt repo to get the datadog-signing-keys package
+.setup_signing_keys_package:
+  &setup_signing_keys_package # Set up prod apt repo to get the datadog-signing-keys package
   - echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable 7' > /etc/apt/sources.list.d/datadog.list
   - touch /usr/share/keyrings/datadog-archive-keyring.gpg
   - chmod a+r /usr/share/keyrings/datadog-archive-keyring.gpg
@@ -69,14 +66,20 @@
     - ls $OMNIBUS_PACKAGE_DIR
 
 deploy_deb_testing-a6_x64:
-  rules:
-    !reference [.on_kitchen_tests_a6]
+  rules: !reference [.on_kitchen_tests_a6]
   extends:
     - .deploy_deb_testing-a6
-  needs: ["agent_deb-x64-a6", "agent_heroku_deb-x64-a6", "tests_deb-x64-py2", "lint_linux-x64", "tests_deb-x64-py3"]
+  needs:
+    [
+      "agent_deb-x64-a6",
+      "agent_heroku_deb-x64-a6",
+      "tests_deb-x64-py2",
+      "lint_linux-x64",
+      "tests_deb-x64-py3",
+    ]
   script:
     - *setup_apt_signing_key
-    - set +x  # make sure we don't output the creds to the build log
+    - set +x # make sure we don't output the creds to the build log
 
     - *setup_signing_keys_package
 
@@ -86,14 +89,13 @@ deploy_deb_testing-a6_x64:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 6 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 deploy_deb_testing-a6_arm64:
-  rules:
-    !reference [.on_all_kitchen_builds_a6]
+  rules: !reference [.on_all_kitchen_builds_a6]
   extends:
     - .deploy_deb_testing-a6
   needs: ["agent_deb-arm64-a6", "tests_deb-arm64-py2"]
   script:
     - *setup_apt_signing_key
-    - set +x  # make sure we don't output the creds to the build log
+    - set +x # make sure we don't output the creds to the build log
 
     - *setup_signing_keys_package
 
@@ -117,10 +119,18 @@ deploy_deb_testing-a7_x64:
     - !reference [.on_a7]
   extends:
     - .deploy_deb_testing-a7
-  needs: ["agent_deb-x64-a7", "agent_heroku_deb-x64-a7", "iot_agent_deb-x64", "dogstatsd_deb-x64", "lint_linux-x64", "tests_deb-x64-py3"]
+  needs:
+    [
+      "agent_deb-x64-a7",
+      "agent_heroku_deb-x64-a7",
+      "iot_agent_deb-x64",
+      "dogstatsd_deb-x64",
+      "lint_linux-x64",
+      "tests_deb-x64-py3",
+    ]
   script:
     - *setup_apt_signing_key
-    - set +x  # make sure we don't output the creds to the build log
+    - set +x # make sure we don't output the creds to the build log
 
     - *setup_signing_keys_package
 
@@ -130,14 +140,13 @@ deploy_deb_testing-a7_x64:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 7 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 deploy_deb_testing-a7_arm64:
-  rules:
-    !reference [.on_all_kitchen_builds_a7]
+  rules: !reference [.on_all_kitchen_builds_a7]
   extends:
     - .deploy_deb_testing-a7
   needs: ["agent_deb-arm64-a7", "lint_linux-arm64", "tests_deb-arm64-py3"]
   script:
     - *setup_apt_signing_key
-    - set +x  # make sure we don't output the creds to the build log
+    - set +x # make sure we don't output the creds to the build log
 
     - *setup_signing_keys_package
 
@@ -153,7 +162,7 @@ deploy_deb_testing-u7_arm64:
   needs: ["updater_deb-arm64", "lint_linux-arm64"]
   script:
     - *setup_apt_signing_key
-    - set +x  # make sure we don't output the creds to the build log
+    - set +x # make sure we don't output the creds to the build log
 
     - *setup_signing_keys_package
 
@@ -171,22 +180,32 @@ deploy_deb_testing-u7_arm64:
     - ls $OMNIBUS_PACKAGE_DIR
 
 deploy_rpm_testing-a6_x64:
-  rules:
-    !reference [.on_kitchen_tests_a6]
+  rules: !reference [.on_kitchen_tests_a6]
   extends:
     - .deploy_rpm_testing-a6
-  needs: ["agent_rpm-x64-a6", "tests_rpm-x64-py2", "lint_linux-x64", "tests_rpm-x64-py3"]
+  needs:
+    [
+      "agent_rpm-x64-a6",
+      "tests_rpm-x64-py2",
+      "lint_linux-x64",
+      "tests_rpm-x64-py3",
+    ]
   script:
     - *setup_rpm_signing_key
     - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/6/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-6.*x86_64.rpm
 
 deploy_rpm_testing-a6_arm64:
-  rules:
-    !reference [.on_all_kitchen_builds_a6]
+  rules: !reference [.on_all_kitchen_builds_a6]
   extends:
     - .deploy_rpm_testing-a6
-  needs: ["agent_rpm-arm64-a6", "tests_rpm-arm64-py2", "lint_linux-arm64", "tests_rpm-arm64-py3"]
+  needs:
+    [
+      "agent_rpm-arm64-a6",
+      "tests_rpm-arm64-py2",
+      "lint_linux-arm64",
+      "tests_rpm-arm64-py3",
+    ]
   script:
     - *setup_rpm_signing_key
     - set +x
@@ -208,15 +227,21 @@ deploy_rpm_testing-a7_x64:
     - !reference [.on_a7]
   extends:
     - .deploy_rpm_testing-a7
-  needs: ["agent_rpm-x64-a7", "iot_agent_rpm-x64", "dogstatsd_rpm-x64", "lint_linux-x64", "tests_rpm-x64-py3"]
+  needs:
+    [
+      "agent_rpm-x64-a7",
+      "iot_agent_rpm-x64",
+      "dogstatsd_rpm-x64",
+      "lint_linux-x64",
+      "tests_rpm-x64-py3",
+    ]
   script:
     - *setup_rpm_signing_key
     - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-7.*x86_64.rpm
 
 deploy_rpm_testing-a7_arm64:
-  rules:
-    !reference [.on_all_kitchen_builds_a7]
+  rules: !reference [.on_all_kitchen_builds_a7]
   extends:
     - .deploy_rpm_testing-a7
   needs: ["agent_rpm-arm64-a7", "lint_linux-arm64", "tests_rpm-arm64-py3"]
@@ -226,12 +251,17 @@ deploy_rpm_testing-a7_arm64:
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/7/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-7.*aarch64.rpm
 
 deploy_suse_rpm_testing_x64-a6:
-  rules:
-    !reference [.on_kitchen_tests_a6]
+  rules: !reference [.on_kitchen_tests_a6]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
-  needs: ["agent_suse-x64-a6", "tests_rpm-x64-py2", "lint_linux-x64", "tests_rpm-x64-py3"]
+  needs:
+    [
+      "agent_suse-x64-a6",
+      "tests_rpm-x64-py2",
+      "lint_linux-x64",
+      "tests_rpm-x64-py3",
+    ]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   before_script:
@@ -249,7 +279,14 @@ deploy_suse_rpm_testing_x64-a7:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
-  needs: ["agent_suse-x64-a7", "iot_agent_suse-x64", "dogstatsd_suse-x64", "lint_linux-x64", "tests_rpm-x64-py3"]
+  needs:
+    [
+      "agent_suse-x64-a7",
+      "iot_agent_suse-x64",
+      "dogstatsd_suse-x64",
+      "lint_linux-x64",
+      "tests_rpm-x64-py3",
+    ]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:
@@ -261,8 +298,7 @@ deploy_suse_rpm_testing_x64-a7:
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/testing/pipeline-$DD_PIPELINE_ID/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/datadog-*-7.*x86_64.rpm
 
 deploy_suse_rpm_testing_arm64-a7:
-  rules:
-    !reference [.on_kitchen_tests_a7]
+  rules: !reference [.on_kitchen_tests_a7]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
@@ -299,7 +335,8 @@ deploy_windows_testing-a7:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
-  needs: ["lint_windows-x64", "tests_windows-x64", "windows_msi_and_bosh_zip_x64-a7"]
+  needs:
+    ["lint_windows-x64", "tests_windows-x64", "windows_msi_and_bosh_zip_x64-a7"]
   before_script:
     - source /root/.bashrc
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/kitchen_deploy/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy/kitchen_deploy.yml
@@ -3,13 +3,13 @@
 # Contains jobs which deploy Agent package to testing repsoitories that are used in kitchen tests.
 
 .setup_rpm_signing_key: &setup_rpm_signing_key
-  - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
+  - RPM_GPG_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
   - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-  - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
+  - export RPM_SIGNING_PASSPHRASE=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
 
 .setup_apt_signing_key: &setup_apt_signing_key
-  - APT_SIGNING_PRIVATE_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $DEB_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
-  - APT_SIGNING_KEY_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $DEB_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - APT_SIGNING_PRIVATE_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $DEB_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - APT_SIGNING_KEY_PASSPHRASE=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $DEB_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
 
   - printf -- "$APT_SIGNING_PRIVATE_KEY" | gpg --import --batch
 

--- a/.gitlab/kitchen_testing/new-e2e_testing.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing.yml
@@ -38,7 +38,7 @@
       - START_MAJOR_VERSION: [5, 6]
         END_MAJOR_VERSION: [6]
   script:
-    - export DATADOG_AGENT_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.agent-linux-install-script.datadog_api_key)
+    - export DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.agent-linux-install-script.datadog_api_key)
     - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION
 
 .new-e2e_script_upgrade7:

--- a/.gitlab/kitchen_testing/new-e2e_testing.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing.yml
@@ -51,5 +51,5 @@
       - START_MAJOR_VERSION: [5, 6, 7]
         END_MAJOR_VERSION: [7]
   script:
-    - export DATADOG_AGENT_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.agent-linux-install-script.datadog_api_key)
+    - export DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.agent-linux-install-script.datadog_api_key)
     - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION

--- a/.gitlab/kitchen_testing/new-e2e_testing.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing.yml
@@ -27,7 +27,7 @@
     TARGETS: ./tests/agent-platform/package-signing
     TEAM: agent-platform
     EXTRA_PARAMS: --osversion $E2E_BRANCH_OSVERS
-    
+
 .new-e2e_script_upgrade6:
   variables:
     TARGETS: ./tests/agent-platform/upgrade
@@ -35,10 +35,10 @@
     EXTRA_PARAMS: --osversion $E2E_OSVERS --platform $E2E_PLATFORM --arch $E2E_ARCH --flavor $FLAVOR
   parallel:
     matrix:
-      - START_MAJOR_VERSION: [5,6]
+      - START_MAJOR_VERSION: [5, 6]
         END_MAJOR_VERSION: [6]
   script:
-    - export DATADOG_AGENT_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.agent-linux-install-script.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
+    - export DATADOG_AGENT_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.agent-linux-install-script.datadog_api_key)
     - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION
 
 .new-e2e_script_upgrade7:
@@ -48,8 +48,8 @@
     EXTRA_PARAMS: --osversion $E2E_OSVERS --platform $E2E_PLATFORM --arch $E2E_ARCH --flavor $FLAVOR
   parallel:
     matrix:
-      - START_MAJOR_VERSION: [5,6,7]
+      - START_MAJOR_VERSION: [5, 6, 7]
         END_MAJOR_VERSION: [7]
   script:
-    - export DATADOG_AGENT_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.agent-linux-install-script.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
+    - export DATADOG_AGENT_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.agent-linux-install-script.datadog_api_key)
     - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION

--- a/.gitlab/kitchen_tests_upload/kitchen_tests_upload.yml
+++ b/.gitlab/kitchen_tests_upload/kitchen_tests_upload.yml
@@ -22,8 +22,5 @@ kitchen_tests_upload_common:
   variables:
     DD_ENV: ci
   script:
-    - set +x
-    - find . -name "kitchen-rspec-common-*.tar.gz"
-    - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export DATADOG_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - find . -maxdepth 1 -type f -name "kitchen-rspec-common-*.tar.gz" -exec inv -e junit-upload --tgz-path {} \;

--- a/.gitlab/kitchen_tests_upload/kitchen_tests_upload.yml
+++ b/.gitlab/kitchen_tests_upload/kitchen_tests_upload.yml
@@ -22,5 +22,5 @@ kitchen_tests_upload_common:
   variables:
     DD_ENV: ci
   script:
-    - export DATADOG_API_KEY=$(source tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - find . -maxdepth 1 -type f -name "kitchen-rspec-common-*.tar.gz" -exec inv -e junit-upload --tgz-path {} \;

--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -10,11 +10,10 @@ include:
 #
 revert_latest_6:
   extends: .docker_publish_job_definition
-  rules:
-    !reference [.on_main_manual]
+  rules: !reference [.on_main_manual]
   stage: maintenance_jobs
   variables:
-    NEW_LATEST_RELEASE_6: ""  # tag name of the non-jmx version, for example "6.21.0"
+    NEW_LATEST_RELEASE_6: "" # tag name of the non-jmx version, for example "6.21.0"
     IMG_REGISTRIES: public
   parallel:
     matrix:
@@ -25,11 +24,10 @@ revert_latest_6:
 
 revert_latest_7:
   extends: .docker_publish_job_definition
-  rules:
-    !reference [.on_main_manual]
+  rules: !reference [.on_main_manual]
   stage: maintenance_jobs
   variables:
-    NEW_LATEST_RELEASE_7: ""  # tag name of the non-jmx version, for example "7.21.0"
+    NEW_LATEST_RELEASE_7: "" # tag name of the non-jmx version, for example "7.21.0"
     IMG_REGISTRIES: public
   parallel:
     matrix:
@@ -52,19 +50,18 @@ revert_latest_7:
 # - Run a pipeline on main with the IMAGE and TAG env vars
 # - in the gitlab pipeline view, trigger the step (in the first column)
 delete_docker_tag:
-  rules:
-    !reference [.on_main_manual]
+  rules: !reference [.on_main_manual]
   stage: maintenance_jobs
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:v2718650-9ce6565-0.6.1-py3
   tags: ["arch:amd64"]
   dependencies: []
   variables:
-    IMAGE: ""  # image name, for example "agent"
-    TAG: ""  # tag name, for example "6.9.0"
+    IMAGE: "" # image name, for example "agent"
+    TAG: "" # tag name, for example "6.9.0"
     ORGANIZATION: "datadog"
   before_script:
-    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - PASS=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - DOCKER_REGISTRY_LOGIN=$(./tools/ci/aws_ssm_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
+    - PASS=$(./tools/ci/aws_ssm_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY)
     - !reference [.setup_python_mirror_linux]
     - python3 -m pip install -r requirements.txt
     - |

--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -60,8 +60,8 @@ delete_docker_tag:
     TAG: "" # tag name, for example "6.9.0"
     ORGANIZATION: "datadog"
   before_script:
-    - DOCKER_REGISTRY_LOGIN=$(./tools/ci/aws_ssm_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
-    - PASS=$(./tools/ci/aws_ssm_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY)
+    - DOCKER_REGISTRY_LOGIN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)
+    - PASS=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY)
     - !reference [.setup_python_mirror_linux]
     - python3 -m pip install -r requirements.txt
     - |

--- a/.gitlab/maintenance_jobs/kitchen.yml
+++ b/.gitlab/maintenance_jobs/kitchen.yml
@@ -26,10 +26,10 @@ periodic_kitchen_cleanup_azure:
   # the job to be run one at a time.
   resource_group: azure_cleanup
   script:
-    - export ARM_SUBSCRIPTION_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_subscription_id --with-decryption --query "Parameter.Value" --out text`
-    - export ARM_CLIENT_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_client_id --with-decryption --query "Parameter.Value" --out text`
-    - export ARM_CLIENT_SECRET=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_client_secret --with-decryption --query "Parameter.Value" --out text`
-    - export ARM_TENANT_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_tenant_id --with-decryption --query "Parameter.Value" --out text`
+    - export ARM_SUBSCRIPTION_ID=`./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id`
+    - export ARM_CLIENT_ID=`./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id`
+    - export ARM_CLIENT_SECRET=`./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret`
+    - export ARM_TENANT_ID=`./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id`
     # Remove kitchen resources for all existing test suite prefixes
     - RESOURCE_GROUP_PREFIX=kitchen-chef python3 /deploy_scripts/cleanup_azure.py
     - RESOURCE_GROUP_PREFIX=kitchen-install-script python3 /deploy_scripts/cleanup_azure.py

--- a/.gitlab/maintenance_jobs/kitchen.yml
+++ b/.gitlab/maintenance_jobs/kitchen.yml
@@ -26,10 +26,10 @@ periodic_kitchen_cleanup_azure:
   # the job to be run one at a time.
   resource_group: azure_cleanup
   script:
-    - export ARM_SUBSCRIPTION_ID=`./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id`
-    - export ARM_CLIENT_ID=`./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id`
-    - export ARM_CLIENT_SECRET=`./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret`
-    - export ARM_TENANT_ID=`./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id`
+    - export ARM_SUBSCRIPTION_ID=`$CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id`
+    - export ARM_CLIENT_ID=`$CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id`
+    - export ARM_CLIENT_SECRET=`$CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret`
+    - export ARM_TENANT_ID=`$CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id`
     # Remove kitchen resources for all existing test suite prefixes
     - RESOURCE_GROUP_PREFIX=kitchen-chef python3 /deploy_scripts/cleanup_azure.py
     - RESOURCE_GROUP_PREFIX=kitchen-install-script python3 /deploy_scripts/cleanup_azure.py

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -23,8 +23,7 @@ notify:
   dependencies: []
   tags: ["arch:amd64"]
   script:
-    - set +x
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_read_api_token --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_read_api_token)
     - !reference [.setup_python_mirror_linux]
     - python3 -m pip install -r tasks/libs/requirements-notifications.txt
     - |
@@ -49,8 +48,7 @@ send_pipeline_stats:
   dependencies: []
   script:
     - source /root/.bashrc
-    - set +x
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_read_api_token --with-decryption --query "Parameter.Value" --out text)
-    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_read_api_token)
+    - export DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - !reference [.setup_python_mirror_linux]
     - invoke -e pipeline.send-stats

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -23,7 +23,7 @@ notify:
   dependencies: []
   tags: ["arch:amd64"]
   script:
-    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_read_api_token)
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_read_api_token)
     - !reference [.setup_python_mirror_linux]
     - python3 -m pip install -r tasks/libs/requirements-notifications.txt
     - |
@@ -48,7 +48,7 @@ send_pipeline_stats:
   dependencies: []
   script:
     - source /root/.bashrc
-    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_read_api_token)
-    - export DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_read_api_token)
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - !reference [.setup_python_mirror_linux]
     - invoke -e pipeline.send-stats

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -1,8 +1,8 @@
 ---
 .setup_deb_signing_key: &setup_deb_signing_key
-  - DEB_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $DEB_GPG_KEY_SSM_NAME)
+  - DEB_GPG_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $DEB_GPG_KEY_SSM_NAME)
   - printf -- "${DEB_GPG_KEY}" | gpg --import --batch
-  - export DEB_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $DEB_SIGNING_PASSPHRASE_SSM_NAME)
+  - export DEB_SIGNING_PASSPHRASE=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $DEB_SIGNING_PASSPHRASE_SSM_NAME)
 
 .agent_build_common_deb:
   script:

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -1,10 +1,8 @@
 ---
 .setup_deb_signing_key: &setup_deb_signing_key
-  - set +x
-  - DEB_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $DEB_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - DEB_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $DEB_GPG_KEY_SSM_NAME)
   - printf -- "${DEB_GPG_KEY}" | gpg --import --batch
-  - export DEB_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $DEB_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
-  - set -x
+  - export DEB_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $DEB_SIGNING_PASSPHRASE_SSM_NAME)
 
 .agent_build_common_deb:
   script:
@@ -282,8 +280,7 @@ dogstatsd_deb-arm64:
 
 updater_deb-amd64:
   extends: .updater_build_common_deb
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -291,15 +288,14 @@ updater_deb-amd64:
   variables:
     AGENT_MAJOR_VERSION: 7
     PACKAGE_ARCH: amd64
-    DESTINATION_DEB: 'datadog-updater_7_amd64.deb'
-    DESTINATION_DBG_DEB: 'datadog-updater-dbg_7_amd64.deb'
+    DESTINATION_DEB: "datadog-updater_7_amd64.deb"
+    DESTINATION_DBG_DEB: "datadog-updater-dbg_7_amd64.deb"
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
 updater_deb-arm64:
   extends: .updater_build_common_deb
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
@@ -307,8 +303,8 @@ updater_deb-arm64:
   variables:
     AGENT_MAJOR_VERSION: 7
     PACKAGE_ARCH: arm64
-    DESTINATION_DEB: 'datadog-updater_7_arm64.deb'
-    DESTINATION_DBG_DEB: 'datadog-updater-dbg_7_arm64.deb'
+    DESTINATION_DEB: "datadog-updater_7_arm64.deb"
+    DESTINATION_DBG_DEB: "datadog-updater-dbg_7_arm64.deb"
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -5,9 +5,9 @@
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     - mkdir -p $OMNIBUS_PACKAGE_DIR
-    - export GITHUB_KEY_B64=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_key_b64 --with-decryption --query "Parameter.Value" --out text)
-    - export GITHUB_APP_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_app_id --with-decryption --query "Parameter.Value" --out text)
-    - export GITHUB_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_installation_id --with-decryption --query "Parameter.Value" --out text)
+    - export GITHUB_KEY_B64=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
+    - export GITHUB_APP_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
+    - export GITHUB_INSTALLATION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
     - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
     - !reference [.setup_python_mirror_linux]

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -5,9 +5,9 @@
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     - mkdir -p $OMNIBUS_PACKAGE_DIR
-    - export GITHUB_KEY_B64=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
-    - export GITHUB_APP_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
-    - export GITHUB_INSTALLATION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
+    - export GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
+    - export GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
+    - export GITHUB_INSTALLATION_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
     - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
     - !reference [.setup_python_mirror_linux]

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -9,11 +9,9 @@
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - set +x
-    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $RPM_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     - tar -xf $CI_PROJECT_DIR/sysprobe-build-outputs.tar.xz
     - mkdir -p /tmp/system-probe
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/clang-bpf
@@ -142,11 +140,9 @@ agent_rpm-arm64-a7:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - set +x
-    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $RPM_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     # Use --skip-deps since the deps are installed by `before_script`.
     - inv -e agent.omnibus-build --flavor iot --log-level debug --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR
@@ -202,7 +198,6 @@ dogstatsd_rpm-x64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_mod_tidy_check", "build_dogstatsd-binary_x64", "go_deps"]
-  variables:
   before_script:
     - source /root/.bashrc
     - !reference [.retrieve_linux_go_deps]
@@ -213,11 +208,9 @@ dogstatsd_rpm-x64:
     # Artifacts and cache must live within project directory but we run omnibus
     # from the GOPATH (see above). We then call `invoke` passing --base-dir,
     # pointing to a gitlab-friendly location.
-    - set +x
-    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $RPM_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     # Use --skip-deps since the deps are installed by `before_script`.
     - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -9,9 +9,9 @@
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
+    - RPM_GPG_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
+    - export RPM_SIGNING_PASSPHRASE=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     - tar -xf $CI_PROJECT_DIR/sysprobe-build-outputs.tar.xz
     - mkdir -p /tmp/system-probe
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/clang-bpf
@@ -140,9 +140,9 @@ agent_rpm-arm64-a7:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
+    - RPM_GPG_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
+    - export RPM_SIGNING_PASSPHRASE=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     # Use --skip-deps since the deps are installed by `before_script`.
     - inv -e agent.omnibus-build --flavor iot --log-level debug --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR
@@ -208,9 +208,9 @@ dogstatsd_rpm-x64:
     # Artifacts and cache must live within project directory but we run omnibus
     # from the GOPATH (see above). We then call `invoke` passing --base-dir,
     # pointing to a gitlab-friendly location.
-    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
+    - RPM_GPG_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
+    - export RPM_SIGNING_PASSPHRASE=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     # Use --skip-deps since the deps are installed by `before_script`.
     - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -9,11 +9,9 @@
     - rm -rf $OMNIBUS_PACKAGE_DIR_SUSE/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - set +x
-    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $RPM_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     - tar -xf $CI_PROJECT_DIR/sysprobe-build-outputs.tar.xz
     - mkdir -p /tmp/system-probe
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/clang-bpf
@@ -129,11 +127,9 @@ iot_agent_suse-x64:
     - rm -rf $OMNIBUS_PACKAGE_DIR_SUSE/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - set +x
-    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $RPM_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     # Use --skip-deps since the deps are installed by `before_script`.
     - inv -e agent.omnibus-build --flavor iot --log-level debug --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR
@@ -163,11 +159,9 @@ dogstatsd_suse-x64:
     # Artifacts and cache must live within project directory but we run omnibus
     # from the GOPATH (see above). We then call `invoke` passing --base-dir,
     # pointing to a gitlab-friendly location.
-    - set +x
-    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $RPM_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     # Use --skip-deps since the deps are installed by `before_script`.
     - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -9,9 +9,9 @@
     - rm -rf $OMNIBUS_PACKAGE_DIR_SUSE/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
+    - RPM_GPG_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
+    - export RPM_SIGNING_PASSPHRASE=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     - tar -xf $CI_PROJECT_DIR/sysprobe-build-outputs.tar.xz
     - mkdir -p /tmp/system-probe
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/clang-bpf
@@ -127,9 +127,9 @@ iot_agent_suse-x64:
     - rm -rf $OMNIBUS_PACKAGE_DIR_SUSE/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
+    - RPM_GPG_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
+    - export RPM_SIGNING_PASSPHRASE=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     # Use --skip-deps since the deps are installed by `before_script`.
     - inv -e agent.omnibus-build --flavor iot --log-level debug --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR
@@ -159,9 +159,9 @@ dogstatsd_suse-x64:
     # Artifacts and cache must live within project directory but we run omnibus
     # from the GOPATH (see above). We then call `invoke` passing --base-dir,
     # pointing to a gitlab-friendly location.
-    - RPM_GPG_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
+    - RPM_GPG_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_GPG_KEY_SSM_NAME)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(./tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
+    - export RPM_SIGNING_PASSPHRASE=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $RPM_SIGNING_PASSPHRASE_SSM_NAME)
     # Use --skip-deps since the deps are installed by `before_script`.
     - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/pkg_metrics/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics/pkg_metrics.yml
@@ -28,7 +28,7 @@
 .send_metrics:
   script:
     # Send the metrics accumulated by add_metric
-    - DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key)
+    - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key)
     - 'curl --fail -X POST -H "Content-type: application/json" -d "$post_body" "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"'
 
 send_pkg_size-a6:
@@ -76,7 +76,7 @@ send_pkg_size-a6:
     - AMD64_SUSE_AGENT_SIZE=$(du -sB1 /tmp/suse/amd64-agent | sed 's/\([0-9]\+\).\+/\1/')
 
     - currenttime=$(date +%s)
-    - DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key)
+    - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key)
     - |
       curl --fail -X POST -H "Content-type: application/json" \
       -d "{\"series\":[

--- a/.gitlab/pkg_metrics/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics/pkg_metrics.yml
@@ -10,32 +10,30 @@
     - 'post_body="{\"series\": []}"'
     - currenttime=$(date +%s)
     - |
-        add_metric() {
-            local metric="${1}"
-            shift
-            local value="${1}"
-            shift
+      add_metric() {
+          local metric="${1}"
+          shift
+          local value="${1}"
+          shift
 
-            local tags=[]
-            while [ -n "${1}" ]; do
-                tags=$(echo $tags | jq -c ". += [\"${1}\"]")
-                shift
-            done
+          local tags=[]
+          while [ -n "${1}" ]; do
+              tags=$(echo $tags | jq -c ". += [\"${1}\"]")
+              shift
+          done
 
-            post_body=$(echo $post_body | jq -c ".series += [{\"metric\":\"$metric\", \"points\":[[$currenttime, $value]],\"tags\":$tags}]")
-        }
+          post_body=$(echo $post_body | jq -c ".series += [{\"metric\":\"$metric\", \"points\":[[$currenttime, $value]],\"tags\":$tags}]")
+      }
 
 .send_metrics:
   script:
     # Send the metrics accumulated by add_metric
-    - DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
+    - DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key)
     - 'curl --fail -X POST -H "Content-type: application/json" -d "$post_body" "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"'
-
 
 send_pkg_size-a6:
   allow_failure: true
-  rules:
-    !reference [.on_deploy_a6]
+  rules: !reference [.on_deploy_a6]
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -78,7 +76,7 @@ send_pkg_size-a6:
     - AMD64_SUSE_AGENT_SIZE=$(du -sB1 /tmp/suse/amd64-agent | sed 's/\([0-9]\+\).\+/\1/')
 
     - currenttime=$(date +%s)
-    - DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
+    - DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key)
     - |
       curl --fail -X POST -H "Content-type: application/json" \
       -d "{\"series\":[
@@ -92,8 +90,7 @@ send_pkg_size-a6:
 
 send_pkg_size-a7:
   allow_failure: true
-  rules:
-    !reference [.on_deploy_a7]
+  rules: !reference [.on_deploy_a7]
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -130,29 +127,29 @@ send_pkg_size-a7:
     - mkdir -p /tmp/amd64-suse/agent /tmp/amd64-suse/dogstatsd /tmp/amd64-suse/iot-agent
 
     - |
-        add_metrics() {
-            local base="${1}"
-            local os="${2}"
-            local arch="${3}"
+      add_metrics() {
+          local base="${1}"
+          local os="${2}"
+          local arch="${3}"
 
-            # record the total uncompressed size of each package
-            for package in agent dogstatsd iot-agent heroku-agent; do
-                if [ ! -d "${base}/${package}" ]; then continue; fi
-                add_metric datadog.agent.package.size $(du -sB1 "${base}/${package}" | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:${package} agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-            done
+          # record the total uncompressed size of each package
+          for package in agent dogstatsd iot-agent heroku-agent; do
+              if [ ! -d "${base}/${package}" ]; then continue; fi
+              add_metric datadog.agent.package.size $(du -sB1 "${base}/${package}" | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:${package} agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+          done
 
-            # record the size of each of the important binaries in each package
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/trace-agent | sed 's/\([0-9]\+\).\+/\1/') bin:trace-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/security-agent | sed 's/\([0-9]\+\).\+/\1/') bin:security-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/process-agent | sed 's/\([0-9]\+\).\+/\1/') bin:process-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/system-probe | sed 's/\([0-9]\+\).\+/\1/') bin:system-probe os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-            if [[ "$arch" == "amd64" || "$os" == "debian" ]]; then add_metric datadog.agent.binary.size $(du -sB1 ${base}/dogstatsd/opt/datadog-dogstatsd/bin/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') bin:dogstatsd os:${os} package:dogstatsd agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}; fi
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/iot-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:iot-agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-            if [ -f "${base}/heroku-agent/opt/datadog-agent/bin/agent/agent" ]; then
-                add_metric datadog.agent.binary.size $(du -sB1 ${base}/heroku-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:heroku-agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch};
-            fi
-        }
+          # record the size of each of the important binaries in each package
+          add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+          add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/trace-agent | sed 's/\([0-9]\+\).\+/\1/') bin:trace-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+          add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/security-agent | sed 's/\([0-9]\+\).\+/\1/') bin:security-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+          add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/process-agent | sed 's/\([0-9]\+\).\+/\1/') bin:process-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+          add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/system-probe | sed 's/\([0-9]\+\).\+/\1/') bin:system-probe os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+          if [[ "$arch" == "amd64" || "$os" == "debian" ]]; then add_metric datadog.agent.binary.size $(du -sB1 ${base}/dogstatsd/opt/datadog-dogstatsd/bin/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') bin:dogstatsd os:${os} package:dogstatsd agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}; fi
+          add_metric datadog.agent.binary.size $(du -sB1 ${base}/iot-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:iot-agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+          if [ -f "${base}/heroku-agent/opt/datadog-agent/bin/agent/agent" ]; then
+              add_metric datadog.agent.binary.size $(du -sB1 ${base}/heroku-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:heroku-agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch};
+          fi
+      }
 
     # We silence dpkg and cpio output so we don't exceed gitlab log limit
 
@@ -208,40 +205,40 @@ send_pkg_size-a7:
     # We want to run all package size comparisons before failing, so we set +e while doing the comparisons
     # to get the error codes without exiting the shell.
     - |
-        if [[ "${ARCH}" == "amd64" ]]; then ARCH_RPM_EXT="x86_64"; else ARCH_RPM_EXT="aarch64"; fi
-        for flavor in ${FLAVORS}; do
+      if [[ "${ARCH}" == "amd64" ]]; then ARCH_RPM_EXT="x86_64"; else ARCH_RPM_EXT="aarch64"; fi
+      for flavor in ${FLAVORS}; do
 
-            if [[ "${ARCH}" == "amd64" && "$flavor" != "datadog-heroku-agent" ]]; then
-              mkdir -p "/tmp/stable/${flavor}/suse"
-              curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/suse/stable/${MAJOR_VERSION}/${ARCH_RPM_EXT}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm" -o "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
-              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR_SUSE}/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm | cut -f -1) os:suse package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:${ARCH}
-              set +e
-              inv package.compare-size --package-type "${flavor} suse rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR_SUSE/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm" --stable-package "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
-              failures=$((${failures}+$?))
-              set -e
-            fi
-
-            mkdir -p "/tmp/stable/${flavor}"
-
-            curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_${ARCH}.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_${ARCH}.deb"
-
-            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_${ARCH}.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:${ARCH}
-
+          if [[ "${ARCH}" == "amd64" && "$flavor" != "datadog-heroku-agent" ]]; then
+            mkdir -p "/tmp/stable/${flavor}/suse"
+            curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/suse/stable/${MAJOR_VERSION}/${ARCH_RPM_EXT}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm" -o "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
+            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR_SUSE}/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm | cut -f -1) os:suse package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:${ARCH}
             set +e
-            inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_${ARCH}.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_${ARCH}.deb"
+            inv package.compare-size --package-type "${flavor} suse rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR_SUSE/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm" --stable-package "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
             failures=$((${failures}+$?))
             set -e
+          fi
 
-            if [[ "$flavor" != "datadog-heroku-agent" && ( "${ARCH}" == "amd64" || "$flavor" != "datadog-dogstatsd") ]]; then
-              # We don't build RPM packages for the heroku flavor
-              curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/${ARCH_RPM_EXT}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
-              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:${ARCH}
-              set +e
-              inv package.compare-size --package-type "${flavor} rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm" --stable-package "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
-              failures=$((${failures}+$?))
-              set -e
-            fi
-        done
+          mkdir -p "/tmp/stable/${flavor}"
+
+          curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_${ARCH}.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_${ARCH}.deb"
+
+          add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_${ARCH}.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:${ARCH}
+
+          set +e
+          inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_${ARCH}.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_${ARCH}.deb"
+          failures=$((${failures}+$?))
+          set -e
+
+          if [[ "$flavor" != "datadog-heroku-agent" && ( "${ARCH}" == "amd64" || "$flavor" != "datadog-dogstatsd") ]]; then
+            # We don't build RPM packages for the heroku flavor
+            curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/${ARCH_RPM_EXT}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
+            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:${ARCH}
+            set +e
+            inv package.compare-size --package-type "${flavor} rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm" --stable-package "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
+            failures=$((${failures}+$?))
+            set -e
+          fi
+      done
 
     # Send package size metrics
     - !reference [.send_metrics, script]
@@ -251,8 +248,7 @@ send_pkg_size-a7:
 
 check_pkg_size-amd64-a6:
   extends: .check_pkg_size
-  rules:
-    !reference [.on_a6]
+  rules: !reference [.on_a6]
   needs:
     - agent_deb-x64-a6
     - agent_rpm-x64-a6
@@ -265,14 +261,13 @@ check_pkg_size-amd64-a6:
     # FIXME: ["datadog-agent"]="70000000" should be replaced by "50000000"
     # "70000000" is needed as of now because of multiple large additions in 7.45
     - |
-        declare -Ar max_sizes=(
-            ["datadog-agent"]="70000000"
-        )
+      declare -Ar max_sizes=(
+          ["datadog-agent"]="70000000"
+      )
 
 check_pkg_size-arm64-a6:
   extends: .check_pkg_size
-  rules:
-    !reference [.on_all_builds_a6]
+  rules: !reference [.on_all_builds_a6]
   needs:
     - agent_deb-arm64-a6
     - agent_rpm-arm64-a6
@@ -284,14 +279,13 @@ check_pkg_size-arm64-a6:
     # FIXME: ["datadog-agent"]="70000000" should be replaced by "50000000"
     # "70000000" is needed as of now because of multiple large additions in 7.45
     - |
-        declare -Ar max_sizes=(
-            ["datadog-agent"]="70000000"
-        )
+      declare -Ar max_sizes=(
+          ["datadog-agent"]="70000000"
+      )
 
 check_pkg_size-amd64-a7:
   extends: .check_pkg_size
-  rules:
-    !reference [.on_a7]
+  rules: !reference [.on_a7]
   needs:
     - agent_deb-x64-a7
     - iot_agent_deb-x64
@@ -312,17 +306,16 @@ check_pkg_size-amd64-a7:
     # be replaced by "50000000"
     # "70000000" is needed as of now because of multiple large additions in 7.45
     - |
-        declare -Ar max_sizes=(
-            ["datadog-agent"]="70000000"
-            ["datadog-iot-agent"]="10000000"
-            ["datadog-dogstatsd"]="10000000"
-            ["datadog-heroku-agent"]="70000000"
-        )
+      declare -Ar max_sizes=(
+          ["datadog-agent"]="70000000"
+          ["datadog-iot-agent"]="10000000"
+          ["datadog-dogstatsd"]="10000000"
+          ["datadog-heroku-agent"]="70000000"
+      )
 
 check_pkg_size-arm64-a7:
   extends: .check_pkg_size
-  rules:
-    !reference [.on_all_builds_a7]
+  rules: !reference [.on_all_builds_a7]
   needs:
     - agent_deb-arm64-a7
     - iot_agent_deb-arm64
@@ -337,8 +330,8 @@ check_pkg_size-arm64-a7:
     # FIXME: ["datadog-agent"]="70000000" should be replaced by "70000000"
     # "70000000" is needed as of now because of multiple large additions in 7.45
     - |
-        declare -Ar max_sizes=(
-            ["datadog-agent"]="70000000"
-            ["datadog-iot-agent"]="10000000"
-            ["datadog-dogstatsd"]="10000000"
-        )
+      declare -Ar max_sizes=(
+          ["datadog-agent"]="70000000"
+          ["datadog-iot-agent"]="10000000"
+          ["datadog-dogstatsd"]="10000000"
+      )

--- a/.gitlab/post_rc_build/post_rc_tasks.yml
+++ b/.gitlab/post_rc_build/post_rc_tasks.yml
@@ -13,7 +13,7 @@ update_rc_build_links:
   tags: ["arch:amd64"]
   script:
     - source /root/.bashrc
-    - export ATLASSIAN_PASSWORD=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.jira_read_api_token)
+    - export ATLASSIAN_PASSWORD=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.jira_read_api_token)
     - export ATLASSIAN_USERNAME=robot-jira-agentplatform@datadoghq.com
     - python3 -m pip install -r tasks/requirements_release_tasks.txt
     - inv -e release.update-build-links ${CI_COMMIT_REF_NAME}

--- a/.gitlab/post_rc_build/post_rc_tasks.yml
+++ b/.gitlab/post_rc_build/post_rc_tasks.yml
@@ -4,18 +4,16 @@
 update_rc_build_links:
   stage: post_rc_build
   rules:
-  - if: $RC_BUILD == "true"
-    when: always
+    - if: $RC_BUILD == "true"
+      when: always
   needs:
-  - job: docker_trigger_internal
-    artifacts: false
+    - job: docker_trigger_internal
+      artifacts: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   script:
     - source /root/.bashrc
-    - set +x
-    - export ATLASSIAN_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.jira_read_api_token --with-decryption --query "Parameter.Value" --out text)
+    - export ATLASSIAN_PASSWORD=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.jira_read_api_token)
     - export ATLASSIAN_USERNAME=robot-jira-agentplatform@datadoghq.com
-    - set -x
     - python3 -m pip install -r tasks/requirements_release_tasks.txt
     - inv -e release.update-build-links ${CI_COMMIT_REF_NAME}

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -17,9 +17,9 @@ github_rate_limit_info:
     - source /root/.bashrc
     - python3 -m pip install -r tasks/libs/requirements-github.txt
     - python3 -m pip install datadog_api_client
-    - export GITHUB_KEY_B64=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
-    - export GITHUB_APP_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
-    - export GITHUB_INSTALLATION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
-    - export DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
+    - export GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
+    - export GITHUB_INSTALLATION_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - inv github.send-rate-limit-info-datadog --pipeline-id $CI_PIPELINE_ID
   allow_failure: true

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -15,12 +15,11 @@ github_rate_limit_info:
   tags: ["arch:amd64"]
   script:
     - source /root/.bashrc
-    - set +x
     - python3 -m pip install -r tasks/libs/requirements-github.txt
     - python3 -m pip install datadog_api_client
-    - export GITHUB_KEY_B64=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_key_b64 --with-decryption --query "Parameter.Value" --out text)
-    - export GITHUB_APP_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_app_id --with-decryption --query "Parameter.Value" --out text)
-    - export GITHUB_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_installation_id --with-decryption --query "Parameter.Value" --out text)
-    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
+    - export GITHUB_KEY_B64=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
+    - export GITHUB_APP_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
+    - export GITHUB_INSTALLATION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
+    - export DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - inv github.send-rate-limit-info-datadog --pipeline-id $CI_PIPELINE_ID
   allow_failure: true

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -1,17 +1,15 @@
-
 tests_macos:
   stage: source_test
-  rules:
-    !reference [.on_a6]
+  rules: !reference [.on_a6]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:
-    PYTHON_RUNTIMES: '3'
+    PYTHON_RUNTIMES: "3"
   script:
     - source /root/.bashrc
-    - export GITHUB_KEY_B64=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_key_b64 --with-decryption --query "Parameter.Value" --out text)
-    - export GITHUB_APP_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_app_id --with-decryption --query "Parameter.Value" --out text)
-    - export GITHUB_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_installation_id --with-decryption --query "Parameter.Value" --out text)
+    - export GITHUB_KEY_B64=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
+    - export GITHUB_APP_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
+    - export GITHUB_INSTALLATION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
     - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
     - !reference [.setup_python_mirror_linux]
@@ -29,18 +27,17 @@ tests_macos:
 
 lint_macos:
   stage: source_test
-  rules:
-    !reference [.on_a6]
+  rules: !reference [.on_a6]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:
-    PYTHON_RUNTIMES: '3'
+    PYTHON_RUNTIMES: "3"
   timeout: 6h
   script:
     - source /root/.bashrc
-    - export GITHUB_KEY_B64=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_key_b64 --with-decryption --query "Parameter.Value" --out text)
-    - export GITHUB_APP_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_app_id --with-decryption --query "Parameter.Value" --out text)
-    - export GITHUB_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_installation_id --with-decryption --query "Parameter.Value" --out text)
+    - export GITHUB_KEY_B64=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
+    - export GITHUB_APP_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
+    - export GITHUB_INSTALLATION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
     - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
     - !reference [.setup_python_mirror_linux]

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -7,9 +7,9 @@ tests_macos:
     PYTHON_RUNTIMES: "3"
   script:
     - source /root/.bashrc
-    - export GITHUB_KEY_B64=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
-    - export GITHUB_APP_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
-    - export GITHUB_INSTALLATION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
+    - export GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
+    - export GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
+    - export GITHUB_INSTALLATION_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
     - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
     - !reference [.setup_python_mirror_linux]
@@ -35,9 +35,9 @@ lint_macos:
   timeout: 6h
   script:
     - source /root/.bashrc
-    - export GITHUB_KEY_B64=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
-    - export GITHUB_APP_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
-    - export GITHUB_INSTALLATION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
+    - export GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_key_b64)
+    - export GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_app_id)
+    - export GITHUB_INSTALLATION_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.macos_github_installation_id)
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
     - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
     - !reference [.setup_python_mirror_linux]

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -89,11 +89,10 @@ lint_windows-x64:
     PYTHON_RUNTIMES: 3
     ARCH: "x64"
 
-
 .tests_windows_sysprobe:
   stage: source_test
   needs: ["go_deps"]
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
@@ -120,7 +119,7 @@ lint_windows-x64:
 .tests_windows_secagent:
   stage: source_test
   needs: ["go_deps"]
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'

--- a/.gitlab/source_test_junit_upload/source_test_junit_upload.yml
+++ b/.gitlab/source_test_junit_upload/source_test_junit_upload.yml
@@ -10,5 +10,5 @@ source_test_junit_upload:
   variables:
     DD_ENV: ci
   script:
-    - export DATADOG_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - for f in junit-*.tgz; do inv -e junit-upload --tgz-path $f; done

--- a/.gitlab/source_test_junit_upload/source_test_junit_upload.yml
+++ b/.gitlab/source_test_junit_upload/source_test_junit_upload.yml
@@ -10,7 +10,5 @@ source_test_junit_upload:
   variables:
     DD_ENV: ci
   script:
-    - set +x
-    - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
-    - set -x
+    - export DATADOG_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - for f in junit-*.tgz; do inv -e junit-upload --tgz-path $f; done

--- a/.gitlab/source_test_stats/linux.yml
+++ b/.gitlab/source_test_stats/linux.yml
@@ -7,6 +7,5 @@ stats-fast-tests-deb-x64-py3:
     - !reference [.except_mergequeue]
     - when: always
   script:
-    - set +x
-    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
+    - export DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - inv -e send-unit-tests-stats --job-name tests_deb-x64-py3 --extra-tag version:v2

--- a/.gitlab/source_test_stats/linux.yml
+++ b/.gitlab/source_test_stats/linux.yml
@@ -7,5 +7,5 @@ stats-fast-tests-deb-x64-py3:
     - !reference [.except_mergequeue]
     - when: always
   script:
-    - export DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - inv -e send-unit-tests-stats --job-name tests_deb-x64-py3 --extra-tag version:v2

--- a/.gitlab/source_test_stats/windows.yml
+++ b/.gitlab/source_test_stats/windows.yml
@@ -7,5 +7,5 @@ stats-fast-tests-windows-x64:
     - !reference [.except_mergequeue]
     - when: always
   script:
-    - export DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - inv -e send-unit-tests-stats --job-name tests_windows-x64 --extra-tag version:v2

--- a/.gitlab/source_test_stats/windows.yml
+++ b/.gitlab/source_test_stats/windows.yml
@@ -7,6 +7,5 @@ stats-fast-tests-windows-x64:
     - !reference [.except_mergequeue]
     - when: always
   script:
-    - set +x
-    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
+    - export DD_API_KEY=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
     - inv -e send-unit-tests-stats --job-name tests_windows-x64 --extra-tag version:v2

--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -20,7 +20,7 @@
     # when triggered with major version 7
     - source /root/.bashrc
     - export RELEASE_VERSION=$(inv agent.version --major-version 7 --url-safe --omnibus-format)-1
-    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - 'inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "main"
       --variable ACTION
       --variable AUTO_RELEASE

--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -20,7 +20,7 @@
     # when triggered with major version 7
     - source /root/.bashrc
     - export RELEASE_VERSION=$(inv agent.version --major-version 7 --url-safe --omnibus-format)-1
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - 'inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "main"
       --variable ACTION
       --variable AUTO_RELEASE
@@ -49,6 +49,5 @@ trigger_manual_prod_release:
     TARGET_REPO: prod
     # The jobs in the downstream pipeline will all be manual, so following
     # the created pipeline would likely cause this job to timeout
-    NO_FOLLOW: '--no-follow'
-  rules:
-    !reference [.on_deploy_stable_or_beta_manual_auto_on_stable]
+    NO_FOLLOW: "--no-follow"
+  rules: !reference [.on_deploy_stable_or_beta_manual_auto_on_stable]

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -554,8 +554,13 @@ EMAIL_SLACK_ID_MAP = {"guy20495@gmail.com": "U03LJSCAPK2", "safchain@gmail.com":
 
 @task
 def changelog(ctx, new_commit_sha):
+    # Environment variable to deal with both local and CI environments
+    if "CI_PROJECT_DIR" in os.environ:
+        os.environ["PARENT_DIR"] = os.environ["CI_PROJECT_DIR"]
+    else:
+        os.environ["PARENT_DIR"] = os.getcwd()
     old_commit_sha = ctx.run(
-        "$CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_changelog_commit_sha",
+        "$PARENT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_changelog_commit_sha",
         hide=True,
     ).stdout.strip()
     if not new_commit_sha:

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -555,9 +555,7 @@ EMAIL_SLACK_ID_MAP = {"guy20495@gmail.com": "U03LJSCAPK2", "safchain@gmail.com":
 @task
 def changelog(ctx, new_commit_sha):
     old_commit_sha = ctx.run(
-        "aws ssm get-parameter --region us-east-1 --name "
-        "ci.datadog-agent.gitlab_changelog_commit_sha --with-decryption --query "
-        "\"Parameter.Value\" --out text",
+        "./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_changelog_commit_sha",
         hide=True,
     ).stdout.strip()
     if not new_commit_sha:

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -555,7 +555,7 @@ EMAIL_SLACK_ID_MAP = {"guy20495@gmail.com": "U03LJSCAPK2", "safchain@gmail.com":
 @task
 def changelog(ctx, new_commit_sha):
     old_commit_sha = ctx.run(
-        "./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_changelog_commit_sha",
+        "$CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_changelog_commit_sha",
         hide=True,
     ).stdout.strip()
     if not new_commit_sha:

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -556,11 +556,11 @@ EMAIL_SLACK_ID_MAP = {"guy20495@gmail.com": "U03LJSCAPK2", "safchain@gmail.com":
 def changelog(ctx, new_commit_sha):
     # Environment variable to deal with both local and CI environments
     if "CI_PROJECT_DIR" in os.environ:
-        os.environ["PARENT_DIR"] = os.environ["CI_PROJECT_DIR"]
+        parent_dir = os.environ["CI_PROJECT_DIR"]
     else:
-        os.environ["PARENT_DIR"] = os.getcwd()
+        parent_dir = os.getcwd()
     old_commit_sha = ctx.run(
-        "$PARENT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_changelog_commit_sha",
+        f"{parent_dir}/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_changelog_commit_sha",
         hide=True,
     ).stdout.strip()
     if not new_commit_sha:

--- a/test/kitchen/tasks/clean.sh
+++ b/test/kitchen/tasks/clean.sh
@@ -8,19 +8,19 @@ set -euxo pipefail
 
 # These should not be printed out
 if [ -z ${AZURE_CLIENT_ID+x} ]; then
-  AZURE_CLIENT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id)
+  AZURE_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id)
   export AZURE_CLIENT_ID
 fi
 if [ -z ${AZURE_CLIENT_SECRET+x} ]; then
-  AZURE_CLIENT_SECRET=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret)
+  AZURE_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret)
   export AZURE_CLIENT_SECRET
 fi
 if [ -z ${AZURE_TENANT_ID+x} ]; then
-  AZURE_TENANT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id)
+  AZURE_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id)
   export AZURE_TENANT_ID
 fi
 if [ -z ${AZURE_SUBSCRIPTION_ID+x} ]; then
-  AZURE_SUBSCRIPTION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id)
+  AZURE_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id)
   export AZURE_SUBSCRIPTION_ID
 fi
 if [ -z ${DD_PIPELINE_ID+x} ]; then

--- a/test/kitchen/tasks/clean.sh
+++ b/test/kitchen/tasks/clean.sh
@@ -7,21 +7,20 @@ IFS=$'\n\t'
 set -euxo pipefail
 
 # These should not be printed out
-set +x
 if [ -z ${AZURE_CLIENT_ID+x} ]; then
-  AZURE_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_client_id --with-decryption --query "Parameter.Value" --out text)
+  AZURE_CLIENT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id)
   export AZURE_CLIENT_ID
 fi
 if [ -z ${AZURE_CLIENT_SECRET+x} ]; then
-  AZURE_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_client_secret --with-decryption --query "Parameter.Value" --out text)
+  AZURE_CLIENT_SECRET=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret)
   export AZURE_CLIENT_SECRET
 fi
 if [ -z ${AZURE_TENANT_ID+x} ]; then
-  AZURE_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_tenant_id --with-decryption --query "Parameter.Value" --out text)
+  AZURE_TENANT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id)
   export AZURE_TENANT_ID
 fi
 if [ -z ${AZURE_SUBSCRIPTION_ID+x} ]; then
-  AZURE_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_subscription_id --with-decryption --query "Parameter.Value" --out text)
+  AZURE_SUBSCRIPTION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id)
   export AZURE_SUBSCRIPTION_ID
 fi
 if [ -z ${DD_PIPELINE_ID+x} ]; then

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -46,25 +46,25 @@ if [ "$KITCHEN_PROVIDER" == "azure" ]; then
   # These should not be printed out
   set +x
   if [ -z ${AZURE_CLIENT_ID+x} ]; then
-    AZURE_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_client_id --with-decryption --query "Parameter.Value" --out text)
+    AZURE_CLIENT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id)
     # make sure whitespace is removed
     AZURE_CLIENT_ID="$(echo -e "${AZURE_CLIENT_ID}" | tr -d '[:space:]')"
     export AZURE_CLIENT_ID
   fi
   if [ -z ${AZURE_CLIENT_SECRET+x} ]; then
-    AZURE_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_client_secret --with-decryption --query "Parameter.Value" --out text)
+    AZURE_CLIENT_SECRET=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret)
     # make sure whitespace is removed
     AZURE_CLIENT_SECRET="$(echo -e "${AZURE_CLIENT_SECRET}" | tr -d '[:space:]')"
     export AZURE_CLIENT_SECRET
   fi
   if [ -z ${AZURE_TENANT_ID+x} ]; then
-    AZURE_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_tenant_id --with-decryption --query "Parameter.Value" --out text)
+    AZURE_TENANT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id)
     # make sure whitespace is removed
     AZURE_TENANT_ID="$(echo -e "${AZURE_TENANT_ID}" | tr -d '[:space:]')"
     export AZURE_TENANT_ID
   fi
   if [ -z ${AZURE_SUBSCRIPTION_ID+x} ]; then
-    AZURE_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_subscription_id --with-decryption --query "Parameter.Value" --out text)
+    AZURE_SUBSCRIPTION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id)
     # make sure whitespace is removed
     AZURE_SUBSCRIPTION_ID="$(echo -e "${AZURE_SUBSCRIPTION_ID}" | tr -d '[:space:]')"
     export AZURE_SUBSCRIPTION_ID
@@ -91,11 +91,10 @@ elif [ "$KITCHEN_PROVIDER" == "ec2" ]; then
   # These should not be printed out
   set +x
   if [ -z ${KITCHEN_EC2_SSH_KEY_ID+x} ]; then
-    KITCHEN_EC2_SSH_KEY_ID="datadog-agent-kitchen"
-    export KITCHEN_EC2_SSH_KEY_ID
-    KITCHEN_EC2_SSH_KEY_PATH="$(pwd)/aws-ssh-key"
-    export KITCHEN_EC2_SSH_KEY_PATH
-    aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.aws_ec2_kitchen_ssh_key --with-decryption --query "Parameter.Value" --out text > $KITCHEN_EC2_SSH_KEY_PATH
+    export KITCHEN_EC2_SSH_KEY_ID="datadog-agent-kitchen"
+    export KITCHEN_EC2_SSH_KEY_PATH="$(pwd)/aws-ssh-key"
+    touch $KITCHEN_EC2_SSH_KEY_PATH && chmod 600 $KITCHEN_EC2_SSH_KEY_PATH
+    ./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.aws_ec2_kitchen_ssh_key > $KITCHEN_EC2_SSH_KEY_PATH
   fi
   set -x
 fi

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -13,6 +13,14 @@ fi
 if [ -f "$(pwd)/ssh-key.pub" ]; then
   rm ssh-key.pub
 fi
+# Set a PARENT_DIR variable to call the aws_ssm wrapper in both local and CI contexts
+pushd ../..
+if [ -n "$CI_PROJECT_DIR" ]; then
+  PARENT_DIR="$CI_PROJECT_DIR"
+else
+  PARENT_DIR="$(pwd)"
+fi
+popd
 
 # in docker we cannot interact to do this so we must disable it
 mkdir -p ~/.ssh
@@ -46,25 +54,25 @@ if [ "$KITCHEN_PROVIDER" == "azure" ]; then
   # These should not be printed out
   set +x
   if [ -z ${AZURE_CLIENT_ID+x} ]; then
-    AZURE_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id)
+    AZURE_CLIENT_ID=$($PARENT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id)
     # make sure whitespace is removed
     AZURE_CLIENT_ID="$(echo -e "${AZURE_CLIENT_ID}" | tr -d '[:space:]')"
     export AZURE_CLIENT_ID
   fi
   if [ -z ${AZURE_CLIENT_SECRET+x} ]; then
-    AZURE_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret)
+    AZURE_CLIENT_SECRET=$($PARENT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret)
     # make sure whitespace is removed
     AZURE_CLIENT_SECRET="$(echo -e "${AZURE_CLIENT_SECRET}" | tr -d '[:space:]')"
     export AZURE_CLIENT_SECRET
   fi
   if [ -z ${AZURE_TENANT_ID+x} ]; then
-    AZURE_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id)
+    AZURE_TENANT_ID=$($PARENT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id)
     # make sure whitespace is removed
     AZURE_TENANT_ID="$(echo -e "${AZURE_TENANT_ID}" | tr -d '[:space:]')"
     export AZURE_TENANT_ID
   fi
   if [ -z ${AZURE_SUBSCRIPTION_ID+x} ]; then
-    AZURE_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id)
+    AZURE_SUBSCRIPTION_ID=$($PARENT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id)
     # make sure whitespace is removed
     AZURE_SUBSCRIPTION_ID="$(echo -e "${AZURE_SUBSCRIPTION_ID}" | tr -d '[:space:]')"
     export AZURE_SUBSCRIPTION_ID
@@ -94,7 +102,7 @@ elif [ "$KITCHEN_PROVIDER" == "ec2" ]; then
     export KITCHEN_EC2_SSH_KEY_ID="datadog-agent-kitchen"
     export KITCHEN_EC2_SSH_KEY_PATH="$(pwd)/aws-ssh-key"
     touch $KITCHEN_EC2_SSH_KEY_PATH && chmod 600 $KITCHEN_EC2_SSH_KEY_PATH
-    $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.aws_ec2_kitchen_ssh_key > $KITCHEN_EC2_SSH_KEY_PATH
+    $PARENT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.aws_ec2_kitchen_ssh_key > $KITCHEN_EC2_SSH_KEY_PATH
   fi
   set -x
 fi

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -46,25 +46,25 @@ if [ "$KITCHEN_PROVIDER" == "azure" ]; then
   # These should not be printed out
   set +x
   if [ -z ${AZURE_CLIENT_ID+x} ]; then
-    AZURE_CLIENT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id)
+    AZURE_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id)
     # make sure whitespace is removed
     AZURE_CLIENT_ID="$(echo -e "${AZURE_CLIENT_ID}" | tr -d '[:space:]')"
     export AZURE_CLIENT_ID
   fi
   if [ -z ${AZURE_CLIENT_SECRET+x} ]; then
-    AZURE_CLIENT_SECRET=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret)
+    AZURE_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret)
     # make sure whitespace is removed
     AZURE_CLIENT_SECRET="$(echo -e "${AZURE_CLIENT_SECRET}" | tr -d '[:space:]')"
     export AZURE_CLIENT_SECRET
   fi
   if [ -z ${AZURE_TENANT_ID+x} ]; then
-    AZURE_TENANT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id)
+    AZURE_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id)
     # make sure whitespace is removed
     AZURE_TENANT_ID="$(echo -e "${AZURE_TENANT_ID}" | tr -d '[:space:]')"
     export AZURE_TENANT_ID
   fi
   if [ -z ${AZURE_SUBSCRIPTION_ID+x} ]; then
-    AZURE_SUBSCRIPTION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id)
+    AZURE_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id)
     # make sure whitespace is removed
     AZURE_SUBSCRIPTION_ID="$(echo -e "${AZURE_SUBSCRIPTION_ID}" | tr -d '[:space:]')"
     export AZURE_SUBSCRIPTION_ID
@@ -94,7 +94,7 @@ elif [ "$KITCHEN_PROVIDER" == "ec2" ]; then
     export KITCHEN_EC2_SSH_KEY_ID="datadog-agent-kitchen"
     export KITCHEN_EC2_SSH_KEY_PATH="$(pwd)/aws-ssh-key"
     touch $KITCHEN_EC2_SSH_KEY_PATH && chmod 600 $KITCHEN_EC2_SSH_KEY_PATH
-    ./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.aws_ec2_kitchen_ssh_key > $KITCHEN_EC2_SSH_KEY_PATH
+    $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.aws_ec2_kitchen_ssh_key > $KITCHEN_EC2_SSH_KEY_PATH
   fi
   set -x
 fi

--- a/test/kitchen/tasks/show-strays.sh
+++ b/test/kitchen/tasks/show-strays.sh
@@ -10,19 +10,19 @@ set -euxo pipefail
 # These should not be printed out
 set +x
 if [ -z ${AZURE_CLIENT_ID+x} ]; then
-  AZURE_CLIENT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id)
+  AZURE_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id)
   export AZURE_CLIENT_ID
 fi
 if [ -z ${AZURE_CLIENT_SECRET+x} ]; then
-  AZURE_CLIENT_SECRET=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret)
+  AZURE_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret)
   export AZURE_CLIENT_SECRET
 fi
 if [ -z ${AZURE_TENANT_ID+x} ]; then
-  AZURE_TENANT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id)
+  AZURE_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id)
   export AZURE_TENANT_ID
 fi
 if [ -z ${AZURE_SUBSCRIPTION_ID+x} ]; then
-  AZURE_SUBSCRIPTION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id)
+  AZURE_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id)
   export AZURE_SUBSCRIPTION_ID
 fi
 if [ -z ${DD_PIPELINE_ID+x} ]; then

--- a/test/kitchen/tasks/show-strays.sh
+++ b/test/kitchen/tasks/show-strays.sh
@@ -10,19 +10,19 @@ set -euxo pipefail
 # These should not be printed out
 set +x
 if [ -z ${AZURE_CLIENT_ID+x} ]; then
-  AZURE_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_client_id --with-decryption --query "Parameter.Value" --out text)
+  AZURE_CLIENT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_id)
   export AZURE_CLIENT_ID
 fi
 if [ -z ${AZURE_CLIENT_SECRET+x} ]; then
-  AZURE_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_client_secret --with-decryption --query "Parameter.Value" --out text)
+  AZURE_CLIENT_SECRET=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_client_secret)
   export AZURE_CLIENT_SECRET
 fi
 if [ -z ${AZURE_TENANT_ID+x} ]; then
-  AZURE_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_tenant_id --with-decryption --query "Parameter.Value" --out text)
+  AZURE_TENANT_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_tenant_id)
   export AZURE_TENANT_ID
 fi
 if [ -z ${AZURE_SUBSCRIPTION_ID+x} ]; then
-  AZURE_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_kitchen_subscription_id --with-decryption --query "Parameter.Value" --out text)
+  AZURE_SUBSCRIPTION_ID=$(./tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.azure_kitchen_subscription_id)
   export AZURE_SUBSCRIPTION_ID
 fi
 if [ -z ${DD_PIPELINE_ID+x} ]; then

--- a/tools/ci/aws_ssm_get_wrapper.ps1
+++ b/tools/ci/aws_ssm_get_wrapper.ps1
@@ -5,13 +5,6 @@ param (
 $retryCount = 0
 $maxRetries = 5
 
-if ($env:TraceLevel -eq '1') {
-    $script:originalDebugPreference = $DebugPreference
-    $DebugPreference = 'SilentlyContinue'
-    $script:enableDebug = { $DebugPreference = 'Continue' }
-    Register-EngineEvent PowerShell.Exiting -Action $enableDebug -SupportEvent
-}
-
 while ($retryCount -lt $maxRetries) {
     $result = (aws ssm get-parameter --region us-east-1 --name $parameterName --with-decryption --query "Parameter.Value" --output text)
 

--- a/tools/ci/aws_ssm_get_wrapper.ps1
+++ b/tools/ci/aws_ssm_get_wrapper.ps1
@@ -13,7 +13,7 @@ if ($env:TraceLevel -eq '1') {
 }
 
 while ($retryCount -lt $maxRetries) {
-    $result = aws ssm get-parameter --region us-east-1 --name $parameterName --with-description --query "Parameter.Value" --output text
+    $result = aws ssm get-parameter --region us-east-1 --name $parameterName --with-decryption --query "Parameter.Value" --output text
 
     if ($result) {
         Write-Host $result

--- a/tools/ci/aws_ssm_get_wrapper.ps1
+++ b/tools/ci/aws_ssm_get_wrapper.ps1
@@ -1,0 +1,28 @@
+param (
+    [string]$parameterName
+)
+
+$retryCount = 0
+$maxRetries = 5
+
+if ($env:TraceLevel -eq '1') {
+    $script:originalDebugPreference = $DebugPreference
+    $DebugPreference = 'SilentlyContinue'
+    $script:enableDebug = { $DebugPreference = 'Continue' }
+    Register-EngineEvent PowerShell.Exiting -Action $enableDebug -SupportEvent
+}
+
+while ($retryCount -lt $maxRetries) {
+    $result = aws ssm get-parameter --region us-east-1 --name $parameterName --with-description --query "Parameter.Value" --output text
+
+    if ($result) {
+        Write-Host $result
+        exit 0
+    }
+
+    $retryCount++
+    Start-Sleep -Seconds ([math]::Pow(2, $retryCount))
+}
+
+Write-Host "Failed to retrieve parameter after $maxRetries retries"
+exit 1

--- a/tools/ci/aws_ssm_get_wrapper.ps1
+++ b/tools/ci/aws_ssm_get_wrapper.ps1
@@ -13,16 +13,13 @@ if ($env:TraceLevel -eq '1') {
 }
 
 while ($retryCount -lt $maxRetries) {
-    $result = aws ssm get-parameter --region us-east-1 --name $parameterName --with-decryption --query "Parameter.Value" --output text
+    $result = (aws ssm get-parameter --region us-east-1 --name $parameterName --with-decryption --query "Parameter.Value" --output text)
 
     if ($result) {
-        Write-Host $result
-        exit 0
+        $result
+        break
     }
 
     $retryCount++
     Start-Sleep -Seconds ([math]::Pow(2, $retryCount))
 }
-
-Write-Host "Failed to retrieve parameter after $maxRetries retries"
-exit 1

--- a/tools/ci/aws_ssm_get_wrapper.sh
+++ b/tools/ci/aws_ssm_get_wrapper.sh
@@ -12,7 +12,7 @@ if [[ -o xtrace ]]; then
 fi
 
 while [[ $retry_count -lt $max_retries ]]; do
-    result=$(aws ssm get-parameter --region us-east-1 --name $parameter_name --with-decryption --query \"Parameter.Value\" --output text)
+    result=$(aws ssm get-parameter --region us-east-1 --name $parameter_name --with-decryption --query "Parameter.Value" --output text)
     if [ -n "$result" ]; then
         echo "$result"
         exit 0

--- a/tools/ci/aws_ssm_get_wrapper.sh
+++ b/tools/ci/aws_ssm_get_wrapper.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+retry_count=0
+max_retries=5
+parameter_name="$1"
+
+source /root/.bashrc > /dev/null 2>&1
+
+if [[ -o xtrace ]]; then
+    set +x
+    trap 'set -x' EXIT
+fi
+
+while [[ $retry_count -lt $max_retries ]]; do
+    result=$(aws ssm get-parameter --region us-east-1 --name $parameter_name --with-decryption --query \"Parameter.Value\" --output text)
+    if [ -n "$result" ]; then
+        echo "$result"
+        exit 0
+    fi
+    retry_count=$((retry_count+1))
+    sleep $((2**retry_count))
+done
+
+echo "Failed to retrieve parameter after $max_retries retries"
+exit 1


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Add a wrapper around `aws ssm get-parameter` calls:
- enable a uniform way to call it with improved security about secret disclosure
- add a retry mechanism to prevent any issue regarding secret access `unable to locate credentials`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Improve CI stability

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Sorry in advance, this PR embeds file formatting.
Only get the non secret parameters in windows context pending a real review on the ps1 script added.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
