### PR TITLE
[CSPM] Early abort rego evaluations when context is canceled

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -280,7 +280,7 @@ func (a *Agent) Stop() {
 	log.Tracef("shutting down compliance agent")
 	a.cancel()
 	select {
-	case <-time.After(10 * time.Second):
+	case <-time.After(20 * time.Second):
 	case <-a.finish:
 	}
 	a.opts.Reporter.Stop()
@@ -317,6 +317,9 @@ func (a *Agent) runRegoBenchmarks(ctx context.Context) {
 			resolver := NewResolver(ctx, a.opts.ResolverOptions)
 			for _, rule := range benchmark.Rules {
 				inputs, err := resolver.ResolveInputs(ctx, rule)
+				if err := ctx.Err(); err != nil {
+					return
+				}
 				if err != nil {
 					a.reportCheckEvents(checkInterval, CheckEventFromError(RegoEvaluator, rule, benchmark, err))
 				} else {


### PR DESCRIPTION
### What does this PR do?

On `security-agent` shutdown, we make sure that if the context has been canceled while we were resolving check inputs, we do not try to send the results and abort early.

### Motivation

Some rare panics have been seen when on `security-agent` shutdown happening after the shutdown timeout and trying to send logs after the log reporter has been closed (causing send on nil channel).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
