### PR TITLE
Bump the test infra definition image used in the Agent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,7 +185,7 @@ variables:
   # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 6ba25fcf6a61
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: a2d0c9b70e92
   DATADOG_AGENT_BUILDERS: v22276738-b36b132
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -27,7 +27,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240207172919-6ba25fcf6a61
+	github.com/DataDog/test-infra-definitions v0.0.0-20240215161859-a2d0c9b70e92
 	github.com/aws/aws-sdk-go-v2 v1.24.0
 	github.com/aws/aws-sdk-go-v2/config v1.25.10
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1
@@ -242,5 +242,9 @@ require (
 require (
 	github.com/DataDog/datadog-agent/pkg/proto v0.50.2 // indirect
 	github.com/philhofer/fwd v1.1.2 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.23.0 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.23.0 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.23.0 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/v2 v2.23.0 // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect
 )

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -14,6 +14,8 @@ github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53y
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/test-infra-definitions v0.0.0-20240207172919-6ba25fcf6a61 h1:K5V7CA5fxxLL1UKzrqemwGDprjh1t65bppDJPgZ7I4E=
 github.com/DataDog/test-infra-definitions v0.0.0-20240207172919-6ba25fcf6a61/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
+github.com/DataDog/test-infra-definitions v0.0.0-20240215161859-a2d0c9b70e92 h1:LT6SiaToPY4XkhjeOATjvYMn5umajJs0I8KFYcQ0Nk8=
+github.com/DataDog/test-infra-definitions v0.0.0-20240215161859-a2d0c9b70e92/go.mod h1:Mcl9idboPONlGfuPsiNHycNiyXVJNQKi/Q+ZOXczzYc=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=
@@ -474,6 +476,14 @@ github.com/pulumi/pulumi-aws/sdk/v5 v5.42.0 h1:QdJvPoUklXdNL8faCOuCrv7qmMNp68jie
 github.com/pulumi/pulumi-aws/sdk/v5 v5.42.0/go.mod h1:qFeKTFSNIlMHotu9ntOWFjJBHtCiUhJeaiUB/0nVwXk=
 github.com/pulumi/pulumi-awsx/sdk v1.0.6 h1:oUan8VgA/pqEmbS2vXhh5Zbn7Lhs6yX5bPMzM03QuMI=
 github.com/pulumi/pulumi-awsx/sdk v1.0.6/go.mod h1:2H8uPHxZbfsIg9qr6yAfiIuvNnhBUqyhxw/8mXNLDFg=
+github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.23.0 h1:6HILPKKLjED8DLSa5RXnZiy3bMFI+xM9pYC9mXl5BKE=
+github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.23.0/go.mod h1:Rb+Eq9Dzqj10eh3NpC97nmn3xnlqrVH1wok16keDeRs=
+github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.23.0 h1:VIXkecdPZgTusCV84VnmLMredU4pV88RIXaJPLrZ6/8=
+github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.23.0/go.mod h1:B7tYacFRnh1//rFFAPP3cyjppprw3t++LR23oQN2EnM=
+github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.23.0 h1:VMv89v6Va6Pzs8spsIYa1aZCn40pShgHNd5bDzYVrSw=
+github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.23.0/go.mod h1:nijOr7SWCWQ7tBDxAPAmo0N1Zgzh0k5jOLG39SFUp48=
+github.com/pulumi/pulumi-azure-native-sdk/v2 v2.23.0 h1:Px9QfA9iVGQWSGC4uC83Lhj5PabtouUh8g7ovM5DY6o=
+github.com/pulumi/pulumi-azure-native-sdk/v2 v2.23.0/go.mod h1:QQ0bJDSjYrzgTyw73XakHwB9+5S9/GkNvjaUDBHQz2A=
 github.com/pulumi/pulumi-command/sdk v0.9.2 h1:2siCFR8pS2sSwXkeWiLrprGEtBL54FsHTzdyl125UuI=
 github.com/pulumi/pulumi-command/sdk v0.9.2/go.mod h1:VeUXTI/iTgKVjRChRJbLRlBVGxAH+uymscfwzBC2VqY=
 github.com/pulumi/pulumi-docker/sdk/v3 v3.6.1 h1:plWLn9O6u80Vr37LoCsckyobBfcrdTU9cERor72QjqA=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR bumps the test infra definition image used in the Datadog Agent repository.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Allow using the Pulumi `time` resource, without getting Github rate limited.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
For some reason `go get github.com/DataDog/test-infra-definitions@latest` pulled some indirect dependency on the `pulumi-azure-native-sdk`

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
