### PR TITLE
event monitor: allow configuring socket path on windows

### DIFF
--- a/pkg/config/setup/config_nix.go
+++ b/pkg/config/setup/config_nix.go
@@ -20,6 +20,8 @@ var (
 	defaultRunPath = filepath.Join(InstallPath, "run")
 	// defaultSystemProbeAddress is the default unix socket path to be used for connecting to the system probe
 	defaultSystemProbeAddress = filepath.Join(InstallPath, "run/sysprobe.sock")
+	// defaultEventMonitorAddress is the default unix socket path to be used for connecting to the event monitor
+	defaultEventMonitorAddress = filepath.Join(InstallPath, "run/event-monitor.sock")
 	// DefaultDDAgentBin the process agent's binary
 	DefaultDDAgentBin = filepath.Join(InstallPath, "bin/agent/agent")
 )

--- a/pkg/config/setup/config_windows.go
+++ b/pkg/config/setup/config_windows.go
@@ -26,7 +26,9 @@ var (
 	DefaultProcessAgentLogFile = "C:\\ProgramData\\Datadog\\logs\\process-agent.log"
 
 	// defaultSystemProbeAddress is the default address to be used for connecting to the system probe
-	defaultSystemProbeAddress     = "localhost:3333"
+	defaultSystemProbeAddress = "localhost:3333"
+	// defaultEventMonitorAddress is the default address to be used for connecting to the event monitor
+	defaultEventMonitorAddress    = "localhost:3335"
 	defaultSystemProbeLogFilePath = "c:\\programdata\\datadog\\logs\\system-probe.log"
 	// DefaultDDAgentBin the process agent's binary
 	DefaultDDAgentBin = "c:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe"

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -339,7 +339,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.enabled"), true)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "events_stats.polling_interval"), 20)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "syscalls_monitor.enabled"), false)
-	cfg.BindEnvAndSetDefault(join(evNS, "socket"), filepath.Join(InstallPath, "run/event-monitor.sock"))
+	cfg.BindEnvAndSetDefault(join(evNS, "socket"), defaultEventMonitorAddress)
 	cfg.BindEnvAndSetDefault(join(evNS, "event_server.burst"), 40)
 
 	// process event monitoring data limits for network tracer

--- a/pkg/eventmonitor/eventmonitor_windows.go
+++ b/pkg/eventmonitor/eventmonitor_windows.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (m *EventMonitor) getListener() (net.Listener, error) {
-	return net.Listen("tcp", ":3335")
+	return net.Listen("tcp", m.Config.SocketPath)
 }
 
 func (m *EventMonitor) init() error {


### PR DESCRIPTION
### What does this PR do?

The event monitor socket path is currently hardcoded and not configurable, this PR makes it configurable.
The end goal is to give the possibility of free-ing the port 3335 if needed.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
