### PR TITLE
[corechecks/kubelet] Filter kubelet metrics with no kubernetes tags

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/common/testing/utils.go
+++ b/pkg/collector/corechecks/containers/kubelet/common/testing/utils.go
@@ -51,6 +51,25 @@ var (
 		"container_id://5f93d91c7aee0230f77fbe9ec642dd60958f5098e76de270a933285c24dfdc6f": {
 			"pod_name:demo-app-success-c485bc67b-klj45",
 		},
+		"container_id://580cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b06": {
+			"kube_container_name:prometheus-to-sd-exporter",
+			"kube_deployment:fluentd-gcp-v2.0.10",
+			"kube_namespace:default",
+		},
+		"container_id://6941ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76562": {
+			"kube_container_name:fluentd-gcp",
+			"kube_deployment:fluentd-gcp-v2.0.10",
+			"kube_namespace:default",
+		},
+		"container_id://690cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b06": {
+			"kube_container_name:prometheus-to-sd-exporter",
+			"kube_deployment:fluentd-gcp-v2.0.10",
+			"kube_namespace:default",
+		},
+		"container_id://5f93d91c7aee0230f77fbe9ec642dd60958f5098e76de270a933285c24dfdc6g": {
+			"pod_name:demo-app-success-c485bc67b-klj45",
+			"kube_namespace:default",
+		},
 		"kubernetes_pod_uid://d2e71e36-10d0-11e8-bd5a-42010af00137": {"pod_name:dd-agent-q6hpw"},
 		"kubernetes_pod_uid://260c2b1d43b094af6d6b4ccba082c2db": {
 			"pod_name:kube-proxy-gke-haissam-default-pool-be5066f1-wnvn",

--- a/pkg/collector/corechecks/containers/kubelet/common/testing/utils.go
+++ b/pkg/collector/corechecks/containers/kubelet/common/testing/utils.go
@@ -35,40 +35,41 @@ var (
 		"container_id://5741ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561": {
 			"kube_container_name:fluentd-gcp",
 			"kube_deployment:fluentd-gcp-v2.0.10",
+			"kube_namespace:default",
 		},
 		"container_id://580cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05": {
 			"kube_container_name:prometheus-to-sd-exporter",
 			"kube_deployment:fluentd-gcp-v2.0.10",
+			"kube_namespace:default",
 		},
 		"container_id://6941ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561": {
 			"kube_container_name:fluentd-gcp",
 			"kube_deployment:fluentd-gcp-v2.0.10",
+			"kube_namespace:default",
 		},
 		"container_id://690cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05": {
 			"kube_container_name:prometheus-to-sd-exporter",
 			"kube_deployment:fluentd-gcp-v2.0.10",
+			"kube_namespace:default",
 		},
 		"container_id://5f93d91c7aee0230f77fbe9ec642dd60958f5098e76de270a933285c24dfdc6f": {
 			"pod_name:demo-app-success-c485bc67b-klj45",
+			"kube_namespace:default",
 		},
 		"container_id://580cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b06": {
-			"kube_container_name:prometheus-to-sd-exporter",
+			"kube_container_name:prometheus-to-sd-exporter-no-namespace",
 			"kube_deployment:fluentd-gcp-v2.0.10",
-			"kube_namespace:default",
 		},
 		"container_id://6941ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76562": {
-			"kube_container_name:fluentd-gcp",
+			"kube_container_name:fluentd-gcp-no-namespace",
 			"kube_deployment:fluentd-gcp-v2.0.10",
-			"kube_namespace:default",
 		},
 		"container_id://690cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b06": {
-			"kube_container_name:prometheus-to-sd-exporter",
+			"kube_container_name:prometheus-to-sd-exporter-no-namespace",
 			"kube_deployment:fluentd-gcp-v2.0.10",
-			"kube_namespace:default",
 		},
 		"container_id://5f93d91c7aee0230f77fbe9ec642dd60958f5098e76de270a933285c24dfdc6g": {
-			"pod_name:demo-app-success-c485bc67b-klj45",
-			"kube_namespace:default",
+			"pod_name:demo-app-success-c485bc67b-klj45-no-namespace",
 		},
 		"kubernetes_pod_uid://d2e71e36-10d0-11e8-bd5a-42010af00137": {"pod_name:dd-agent-q6hpw"},
 		"kubernetes_pod_uid://260c2b1d43b094af6d6b4ccba082c2db": {
@@ -77,14 +78,16 @@ var (
 		"kubernetes_pod_uid://24d6daa3-10d8-11e8-bd5a-42010af00137":                       {"pod_name:demo-app-success-c485bc67b-klj45"},
 		"container_id://f69aa93ce78ee11e78e7c75dc71f535567961740a308422dafebdb4030b04903": {"pod_name:pi-kff76"},
 		"kubernetes_pod_uid://12ceeaa9-33ca-11e6-ac8f-42010af00003":                       {"pod_name:dd-agent-ntepl"},
-		"container_id://32fc50ecfe24df055f6d56037acb966337eef7282ad5c203a1be58f2dd2fe743": {"pod_name:dd-agent-ntepl"},
+		"container_id://32fc50ecfe24df055f6d56037acb966337eef7282ad5c203a1be58f2dd2fe743": {"pod_name:dd-agent-ntepl", "kube_namespace:default"},
 		"container_id://a335589109ce5506aa69ba7481fc3e6c943abd23c5277016c92dac15d0f40479": {
 			"kube_container_name:datadog-agent",
+			"kube_namespace:default",
 		},
 		"container_id://326b384481ca95204018e3e837c61e522b64a3b86c3804142a22b2d1db9dbd7b": {
 			"kube_container_name:datadog-agent",
+			"kube_namespace:default",
 		},
-		"container_id://6d8c6a05731b52195998c438fdca271b967b171f6c894f11ba59aa2f4deff10c": {"pod_name:cassandra-0"},
+		"container_id://6d8c6a05731b52195998c438fdca271b967b171f6c894f11ba59aa2f4deff10c": {"pod_name:cassandra-0", "kube_namespace:default"},
 		"kubernetes_pod_uid://639980e5-2e6c-11ea-8bb1-42010a800074": {
 			"kube_namespace:default",
 			"kube_service:nginx",

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -182,6 +182,10 @@ func (r *runningAggregator) recordContainer(p *Provider, pod *kubelet.Pod, cStat
 	if len(tags) == 0 {
 		return
 	}
+	// Skip recording containers without kubelet information in tagger
+	if !isTagKeyPresent("kube_namespace", tags) {
+		return
+	}
 	hashTags := generateTagHash(tags)
 	r.runningContainersCounter[hashTags]++
 	if _, ok := r.runningContainersTags[hashTags]; !ok {
@@ -229,4 +233,13 @@ func generateTagHash(tags []string) string {
 	copy(sortedTags, tags)
 	sort.Strings(sortedTags)
 	return strings.Join(sortedTags, ",")
+}
+
+func isTagKeyPresent(key string, tags []string) bool {
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, key+":") {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -120,6 +120,10 @@ func (p *Provider) generateContainerSpecMetrics(sender sender.Sender, pod *kubel
 	if len(tags) == 0 {
 		return
 	}
+	// Skip recording containers without kubelet information in tagger
+	if !isTagKeyPresent("kube_namespace", tags) {
+		return
+	}
 	tags = utils.ConcatenateTags(tags, p.config.Tags)
 
 	for r, value := range container.Resources.Requests {
@@ -137,6 +141,10 @@ func (p *Provider) generateContainerStatusMetrics(sender sender.Sender, pod *kub
 
 	tags, _ := tagger.Tag(containerID, collectors.OrchestratorCardinality)
 	if len(tags) == 0 {
+		return
+	}
+	// Skip recording containers without kubelet information in tagger
+	if !isTagKeyPresent("kube_namespace", tags) {
 		return
 	}
 	tags = utils.ConcatenateTags(tags, p.config.Tags)

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -41,6 +41,8 @@ var includeContainerStateReason = map[string][]string{
 	"terminated": {"oomkilled", "containercannotrun", "error"},
 }
 
+const kubeNamespaceTag = "kube_namespace"
+
 // Provider provides the metrics related to data collected from the `/pods` Kubelet endpoint
 type Provider struct {
 	filter   *containers.Filter
@@ -117,11 +119,8 @@ func (p *Provider) generateContainerSpecMetrics(sender sender.Sender, pod *kubel
 	}
 
 	tags, _ := tagger.Tag(containerID, collectors.HighCardinality)
-	if len(tags) == 0 {
-		return
-	}
-	// Skip recording containers without kubelet information in tagger
-	if !isTagKeyPresent("kube_namespace", tags) {
+	// Skip recording containers without kubelet information in tagger or if there are no tags
+	if !isTagKeyPresent(kubeNamespaceTag, tags) || len(tags) == 0 {
 		return
 	}
 	tags = utils.ConcatenateTags(tags, p.config.Tags)
@@ -140,11 +139,8 @@ func (p *Provider) generateContainerStatusMetrics(sender sender.Sender, pod *kub
 	}
 
 	tags, _ := tagger.Tag(containerID, collectors.OrchestratorCardinality)
-	if len(tags) == 0 {
-		return
-	}
-	// Skip recording containers without kubelet information in tagger
-	if !isTagKeyPresent("kube_namespace", tags) {
+	// Skip recording containers without kubelet information in tagger or if there are no tags
+	if !isTagKeyPresent(kubeNamespaceTag, tags) || len(tags) == 0 {
 		return
 	}
 	tags = utils.ConcatenateTags(tags, p.config.Tags)
@@ -187,11 +183,8 @@ func (r *runningAggregator) recordContainer(p *Provider, pod *kubelet.Pod, cStat
 	}
 	r.podHasRunningContainers[pod.Metadata.UID] = true
 	tags, _ := tagger.Tag(containerID, collectors.LowCardinality)
-	if len(tags) == 0 {
-		return
-	}
-	// Skip recording containers without kubelet information in tagger
-	if !isTagKeyPresent("kube_namespace", tags) {
+	// Skip recording containers without kubelet information in tagger or if there are no tags
+	if !isTagKeyPresent(kubeNamespaceTag, tags) || len(tags) == 0 {
 		return
 	}
 	hashTags := generateTagHash(tags)

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -278,7 +278,7 @@ func (suite *ProviderTestSuite) TestNoMetricNoKubeletData() {
 
 	err = suite.provider.Provide(suite.kubeUtil, suite.mockSender)
 	require.Nil(suite.T(), err)
-
+	// ensure that metrics are not emitted when there are no kubelet tags
 	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "kube_container_name:prometheus-to-sd-exporter-no-namespace", "kube_deployment:fluentd-gcp-v2.0.10"))
 	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45-no-namespace"))
 	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "kube_container_name:fluentd-gcp-no-namespace", "kube_deployment:fluentd-gcp-v2.0.10"))

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -168,6 +168,11 @@ func (suite *ProviderTestSuite) TestTransformRunningPods() {
 	suite.mockSender.AssertNumberOfCalls(suite.T(), "Gauge", 30)
 
 	// 1) pod running metrics
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", 2, "", append(config.Tags, "kube_container_name:prometheus-to-sd-exporter", "kube_deployment:fluentd-gcp-v2.0.10", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", 1, "", append(config.Tags, "kube_container_name:datadog-agent", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", 1, "", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", 2, "", append(config.Tags, "kube_container_name:fluentd-gcp", "kube_deployment:fluentd-gcp-v2.0.10", "kube_namespace:default"))
+
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pods.running", 1, "", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45"))
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pods.running", 1, "", append(config.Tags, "pod_name:fluentd-gcp-v2.0.10-9q9t4"))
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pods.running", 1, "", append(config.Tags, "pod_name:fluentd-gcp-v2.0.10-p13r3"))

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -165,7 +165,7 @@ func (suite *ProviderTestSuite) TestTransformRunningPods() {
 	err = suite.provider.Provide(suite.kubeUtil, suite.mockSender)
 	require.Nil(suite.T(), err)
 
-	suite.mockSender.AssertNumberOfCalls(suite.T(), "Gauge", 26)
+	suite.mockSender.AssertNumberOfCalls(suite.T(), "Gauge", 30)
 
 	// 1) pod running metrics
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pods.running", 1, "", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45"))
@@ -177,27 +177,21 @@ func (suite *ProviderTestSuite) TestTransformRunningPods() {
 
 	// make sure that non-running container/pods are not sent
 	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pods.running", append(config.Tags, "pod_name:dd-agent-q6hpw"))
-	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "pod_name:dd-agent-q6hpw"))
-
-	// make sure that containers with no kubernetes tags are not sent
-	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "kube_container_name:prometheus-to-sd-exporter", "kube_deployment:fluentd-gcp-v2.0.10"))
-	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "kube_container_name:datadog-agent"))
-	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45"))
-	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "kube_container_name:fluentd-gcp", "kube_deployment:fluentd-gcp-v2.0.10"))
+	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "pod_name:dd-agent-q6hpw", "kube_namespace:default"))
 
 	// 2) container spec metrics
 	// should be called twice
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.requests", 0.1, "", append(config.Tags, "kube_container_name:fluentd-gcp", "kube_deployment:fluentd-gcp-v2.0.10"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.requests", 0.1, "", append(config.Tags, "kube_container_name:fluentd-gcp", "kube_deployment:fluentd-gcp-v2.0.10", "kube_namespace:default"))
 	// should be called twice
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.requests", 0.1, "", append(config.Tags, "kube_container_name:datadog-agent"))
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.requests", 0.1, "", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45"))
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.limits", 0.25, "", append(config.Tags, "kube_container_name:datadog-agent"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.requests", 0.1, "", append(config.Tags, "kube_container_name:datadog-agent", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.requests", 0.1, "", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.limits", 0.25, "", append(config.Tags, "kube_container_name:datadog-agent", "kube_namespace:default"))
 	// should be called twice
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.requests", 209715200, "", append(config.Tags, "kube_container_name:fluentd-gcp", "kube_deployment:fluentd-gcp-v2.0.10"))
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.requests", 134217728, "", append(config.Tags, "kube_container_name:datadog-agent"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.requests", 209715200, "", append(config.Tags, "kube_container_name:fluentd-gcp", "kube_deployment:fluentd-gcp-v2.0.10", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.requests", 134217728, "", append(config.Tags, "kube_container_name:datadog-agent", "kube_namespace:default"))
 	// should be called twice
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.limits", 314572800, "", append(config.Tags, "kube_container_name:fluentd-gcp", "kube_deployment:fluentd-gcp-v2.0.10"))
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.limits", 536870912, "", append(config.Tags, "kube_container_name:datadog-agent"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.limits", 314572800, "", append(config.Tags, "kube_container_name:fluentd-gcp", "kube_deployment:fluentd-gcp-v2.0.10", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.limits", 536870912, "", append(config.Tags, "kube_container_name:datadog-agent", "kube_namespace:default"))
 
 	// make sure that resource metrics are not sent for non-running pods
 	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.requests", append(config.Tags, "pod_name:pi-kff76"))
@@ -208,12 +202,12 @@ func (suite *ProviderTestSuite) TestTransformRunningPods() {
 	// 3) container status metrics
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pods.expired", 1, "", config.Tags)
 	// should be called twice
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.restarts", 0, "", append(config.Tags, "kube_container_name:fluentd-gcp", "kube_deployment:fluentd-gcp-v2.0.10"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.restarts", 0, "", append(config.Tags, "kube_container_name:fluentd-gcp", "kube_deployment:fluentd-gcp-v2.0.10", "kube_namespace:default"))
 	// should be called twice
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.restarts", 0, "", append(config.Tags, "kube_container_name:prometheus-to-sd-exporter", "kube_deployment:fluentd-gcp-v2.0.10"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.restarts", 0, "", append(config.Tags, "kube_container_name:prometheus-to-sd-exporter", "kube_deployment:fluentd-gcp-v2.0.10", "kube_namespace:default"))
 	// should be called twice
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.restarts", 0, "", append(config.Tags, "kube_container_name:datadog-agent"))
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.restarts", 0, "", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.restarts", 0, "", append(config.Tags, "kube_container_name:datadog-agent", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.restarts", 0, "", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45", "kube_namespace:default"))
 }
 
 func (suite *ProviderTestSuite) TestTransformCrashedPods() {
@@ -273,14 +267,14 @@ func (suite *ProviderTestSuite) TestTransformPodsRequestsLimits() {
 }
 
 func (suite *ProviderTestSuite) TestNoMetricNoKubeletData() {
-	err := suite.dummyKubelet.loadPodList("../../testdata/pod_list_with_kube_tags.json")
+	err := suite.dummyKubelet.loadPodList("../../testdata/pod_list_with_no_kube_tags.json")
 	require.Nil(suite.T(), err)
 	config := suite.provider.config
 
 	err = suite.provider.Provide(suite.kubeUtil, suite.mockSender)
 	require.Nil(suite.T(), err)
 
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", 2, "", append(config.Tags, "kube_container_name:prometheus-to-sd-exporter", "kube_deployment:fluentd-gcp-v2.0.10", "kube_namespace:default"))
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", 1, "", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45", "kube_namespace:default"))
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", 1, "", append(config.Tags, "kube_container_name:fluentd-gcp", "kube_deployment:fluentd-gcp-v2.0.10", "kube_namespace:default"))
+	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "kube_container_name:prometheus-to-sd-exporter-no-namespace", "kube_deployment:fluentd-gcp-v2.0.10"))
+	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45-no-namespace"))
+	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "kube_container_name:fluentd-gcp-no-namespace", "kube_deployment:fluentd-gcp-v2.0.10"))
 }

--- a/pkg/collector/corechecks/containers/kubelet/testdata/pod_list_with_kube_tags.json
+++ b/pkg/collector/corechecks/containers/kubelet/testdata/pod_list_with_kube_tags.json
@@ -1,0 +1,706 @@
+{
+    "items": [
+      {
+        "status": {
+          "qosClass": "Burstable",
+          "containerStatuses": [
+            {
+              "restartCount": 0,
+              "name": "fluentd-gcp",
+              "image": "asia.gcr.io/google-containers/fluentd-gcp:2.0.10",
+              "imageID": "docker-pullable://asia.gcr.io/google-containers/fluentd-gcp@sha256:a81a2c0137aee9f8a3e870898773976df9b63b27809bed2a4b9297531fb3c3c9",
+              "state": {
+                "running": {
+                  "startedAt": "2018-02-13T16:10:45Z"
+                }
+              },
+              "ready": true,
+              "lastState": {},
+              "containerID": "docker://5741ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561"
+            },
+            {
+              "restartCount": 0,
+              "name": "prometheus-to-sd-exporter",
+              "image": "asia.gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+              "imageID": "docker-pullable://asia.gcr.io/google-containers/prometheus-to-sd@sha256:5831390762c790b0375c202579fd41dd5f40c71950f7538adbe14b0c16f35d56",
+              "state": {
+                "running": {
+                  "startedAt": "2018-02-13T16:10:46Z"
+                }
+              },
+              "ready": true,
+              "lastState": {},
+              "containerID": "docker://580cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b06"
+            }
+          ],
+          "podIP": "10.8.2.4",
+          "startTime": "2018-02-13T14:57:17Z",
+          "hostIP": "10.132.0.4",
+          "phase": "Running",
+          "conditions": [
+            {
+              "status": "True",
+              "lastProbeTime": null,
+              "type": "Initialized",
+              "lastTransitionTime": "2018-02-13T14:57:17Z"
+            },
+            {
+              "status": "True",
+              "lastProbeTime": null,
+              "type": "Ready",
+              "lastTransitionTime": "2018-02-13T16:10:47Z"
+            },
+            {
+              "status": "True",
+              "lastProbeTime": null,
+              "type": "PodScheduled",
+              "lastTransitionTime": "2018-02-13T14:57:27Z"
+            }
+          ]
+        },
+        "spec": {
+          "dnsPolicy": "Default",
+          "securityContext": {},
+          "serviceAccountName": "fluentd-gcp",
+          "schedulerName": "default-scheduler",
+          "serviceAccount": "fluentd-gcp",
+          "nodeSelector": {
+            "beta.kubernetes.io/fluentd-ds-ready": "true"
+          },
+          "terminationGracePeriodSeconds": 30,
+          "restartPolicy": "Always",
+          "volumes": [
+            {
+              "hostPath": {
+                "path": "/var/log",
+                "type": ""
+              },
+              "name": "varlog"
+            },
+            {
+              "hostPath": {
+                "path": "/var/lib/docker/containers",
+                "type": ""
+              },
+              "name": "varlibdockercontainers"
+            },
+            {
+              "hostPath": {
+                "path": "/usr/lib64",
+                "type": ""
+              },
+              "name": "libsystemddir"
+            },
+            {
+              "configMap": {
+                "name": "fluentd-gcp-config-v1.2.3",
+                "defaultMode": 420
+              },
+              "name": "config-volume"
+            },
+            {
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "fluentd-gcp-token-vcd8d"
+              },
+              "name": "fluentd-gcp-token-vcd8d"
+            }
+          ],
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "node.alpha.kubernetes.io/ismaster"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoExecute"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoSchedule"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/not-ready"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unreachable"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoSchedule",
+              "key": "node.kubernetes.io/disk-pressure"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoSchedule",
+              "key": "node.kubernetes.io/memory-pressure"
+            }
+          ],
+          "containers": [
+            {
+              "livenessProbe": {
+                "timeoutSeconds": 1,
+                "exec": {
+                  "command": [
+                    "/bin/sh",
+                    "-c",
+                    "LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900}; if [ ! -e /var/log/fluentd-buffers ]; then\n  exit 1;\nfi; LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r \"s/Modify: (.*)/\\1/\"`; LAST_MODIFIED_TIMESTAMP=`date -d \"$LAST_MODIFIED_DATE\" +%s`; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ]; then\n  rm -rf /var/log/fluentd-buffers;\n  exit 1;\nfi; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ]; then\n  exit 1;\nfi;\n"
+                  ]
+                },
+                "initialDelaySeconds": 600,
+                "periodSeconds": 60,
+                "successThreshold": 1,
+                "failureThreshold": 3
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "name": "fluentd-gcp",
+              "image": "gcr.io/google-containers/fluentd-gcp:2.0.10",
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/log",
+                  "name": "varlog"
+                },
+                {
+                  "readOnly": true,
+                  "mountPath": "/var/lib/docker/containers",
+                  "name": "varlibdockercontainers"
+                },
+                {
+                  "readOnly": true,
+                  "mountPath": "/host/lib",
+                  "name": "libsystemddir"
+                },
+                {
+                  "mountPath": "/etc/fluent/config.d",
+                  "name": "config-volume"
+                },
+                {
+                  "readOnly": true,
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "fluentd-gcp-token-vcd8d"
+                }
+              ],
+              "terminationMessagePolicy": "File",
+              "env": [
+                {
+                  "name": "FLUENTD_ARGS",
+                  "value": "--no-supervisor -q"
+                }
+              ],
+              "imagePullPolicy": "IfNotPresent",
+              "resources": {
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "200Mi"
+                },
+                "limits": {
+                  "memory": "300Mi"
+                }
+              }
+            },
+            {
+              "terminationMessagePath": "/dev/termination-log",
+              "name": "prometheus-to-sd-exporter",
+              "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+              "volumeMounts": [
+                {
+                  "readOnly": true,
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "fluentd-gcp-token-vcd8d"
+                }
+              ],
+              "terminationMessagePolicy": "File",
+              "command": [
+                "/monitor",
+                "--stackdriver-prefix=container.googleapis.com/internal/addons",
+                "--api-override=https://monitoring.googleapis.com/",
+                "--source=fluentd:http://localhost:31337?whitelisted=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count",
+                "--pod-id=$(POD_NAME)",
+                "--namespace-id=$(POD_NAMESPACE)"
+              ],
+              "env": [
+                {
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.name",
+                      "apiVersion": "v1"
+                    }
+                  },
+                  "name": "POD_NAME"
+                },
+                {
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.namespace",
+                      "apiVersion": "v1"
+                    }
+                  },
+                  "name": "POD_NAMESPACE"
+                }
+              ],
+              "imagePullPolicy": "IfNotPresent",
+              "resources": {}
+            }
+          ],
+          "nodeName": "gke-haissam-default-pool-be5066f1-wnvn"
+        },
+        "metadata": {
+          "name": "fluentd-gcp-v2.0.10-9q9t4",
+          "labels": {
+            "k8s-app": "fluentd-gcp",
+            "version": "v2.0.10",
+            "pod-template-generation": "1",
+            "kubernetes.io/cluster-service": "true",
+            "controller-revision-hash": "1108666223"
+          },
+          "namespace": "kube-system",
+          "ownerReferences": [
+            {
+              "kind": "DaemonSet",
+              "name": "fluentd-gcp-v2.0.10",
+              "apiVersion": "extensions/v1beta1",
+              "controller": true,
+              "blockOwnerDeletion": true,
+              "uid": "77585c76-10cc-11e8-bd5a-42010af00137"
+            }
+          ],
+          "resourceVersion": "30704838",
+          "generateName": "fluentd-gcp-v2.0.10-",
+          "creationTimestamp": "2018-02-13T14:57:17Z",
+          "annotations": {
+            "scheduler.alpha.kubernetes.io/critical-pod": "",
+            "kubernetes.io/config.source": "api",
+            "kubernetes.io/config.seen": "2018-02-13T16:10:19.509264637Z"
+          },
+          "selfLink": "/api/v1/namespaces/kube-system/pods/fluentd-gcp-v2.0.10-9q9t4",
+          "uid": "2edfd4d9-10ce-11e8-bd5a-42010af00137"
+        }
+      },
+      {
+        "status": {
+          "qosClass": "Burstable",
+          "containerStatuses": [
+            {
+              "restartCount": 0,
+              "name": "fluentd-gcp",
+              "image": "asia.gcr.io/google-containers/fluentd-gcp:2.0.10",
+              "imageID": "docker-pullable://asia.gcr.io/google-containers/fluentd-gcp@sha256:a81a2c0137aee9f8a3e870898773976df9b63b27809bed2a4b9297531fb3c3c9",
+              "state": {
+                "running": {
+                  "startedAt": "2018-02-13T16:10:45Z"
+                }
+              },
+              "ready": true,
+              "lastState": {},
+              "containerID": "docker://6941ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76562"
+            },
+            {
+              "restartCount": 0,
+              "name": "prometheus-to-sd-exporter",
+              "image": "asia.gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+              "imageID": "docker-pullable://asia.gcr.io/google-containers/prometheus-to-sd@sha256:5831390762c790b0375c202579fd41dd5f40c71950f7538adbe14b0c16f35d56",
+              "state": {
+                "running": {
+                  "startedAt": "2018-02-13T16:10:46Z"
+                }
+              },
+              "ready": true,
+              "lastState": {},
+              "containerID": "docker://690cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b06"
+            }
+          ],
+          "podIP": "10.8.2.4",
+          "startTime": "2018-02-13T14:57:17Z",
+          "hostIP": "10.132.0.4",
+          "phase": "Running",
+          "conditions": [
+            {
+              "status": "True",
+              "lastProbeTime": null,
+              "type": "Initialized",
+              "lastTransitionTime": "2018-02-13T14:57:17Z"
+            },
+            {
+              "status": "True",
+              "lastProbeTime": null,
+              "type": "Ready",
+              "lastTransitionTime": "2018-02-13T16:10:47Z"
+            },
+            {
+              "status": "True",
+              "lastProbeTime": null,
+              "type": "PodScheduled",
+              "lastTransitionTime": "2018-02-13T14:57:27Z"
+            }
+          ]
+        },
+        "spec": {
+          "dnsPolicy": "Default",
+          "securityContext": {},
+          "serviceAccountName": "fluentd-gcp",
+          "schedulerName": "default-scheduler",
+          "serviceAccount": "fluentd-gcp",
+          "nodeSelector": {
+            "beta.kubernetes.io/fluentd-ds-ready": "true"
+          },
+          "terminationGracePeriodSeconds": 30,
+          "restartPolicy": "Always",
+          "volumes": [
+            {
+              "hostPath": {
+                "path": "/var/log",
+                "type": ""
+              },
+              "name": "varlog"
+            },
+            {
+              "hostPath": {
+                "path": "/var/lib/docker/containers",
+                "type": ""
+              },
+              "name": "varlibdockercontainers"
+            },
+            {
+              "hostPath": {
+                "path": "/usr/lib64",
+                "type": ""
+              },
+              "name": "libsystemddir"
+            },
+            {
+              "configMap": {
+                "name": "fluentd-gcp-config-v1.2.3",
+                "defaultMode": 420
+              },
+              "name": "config-volume"
+            },
+            {
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "fluentd-gcp-token-vcd8d"
+              },
+              "name": "fluentd-gcp-token-vcd8d"
+            }
+          ],
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "node.alpha.kubernetes.io/ismaster"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoExecute"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoSchedule"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/not-ready"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unreachable"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoSchedule",
+              "key": "node.kubernetes.io/disk-pressure"
+            },
+            {
+              "operator": "Exists",
+              "effect": "NoSchedule",
+              "key": "node.kubernetes.io/memory-pressure"
+            }
+          ],
+          "containers": [
+            {
+              "livenessProbe": {
+                "timeoutSeconds": 1,
+                "exec": {
+                  "command": [
+                    "/bin/sh",
+                    "-c",
+                    "LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900}; if [ ! -e /var/log/fluentd-buffers ]; then\n  exit 1;\nfi; LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r \"s/Modify: (.*)/\\1/\"`; LAST_MODIFIED_TIMESTAMP=`date -d \"$LAST_MODIFIED_DATE\" +%s`; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ]; then\n  rm -rf /var/log/fluentd-buffers;\n  exit 1;\nfi; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ]; then\n  exit 1;\nfi;\n"
+                  ]
+                },
+                "initialDelaySeconds": 600,
+                "periodSeconds": 60,
+                "successThreshold": 1,
+                "failureThreshold": 3
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "name": "fluentd-gcp",
+              "image": "gcr.io/google-containers/fluentd-gcp:2.0.10",
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/log",
+                  "name": "varlog"
+                },
+                {
+                  "readOnly": true,
+                  "mountPath": "/var/lib/docker/containers",
+                  "name": "varlibdockercontainers"
+                },
+                {
+                  "readOnly": true,
+                  "mountPath": "/host/lib",
+                  "name": "libsystemddir"
+                },
+                {
+                  "mountPath": "/etc/fluent/config.d",
+                  "name": "config-volume"
+                },
+                {
+                  "readOnly": true,
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "fluentd-gcp-token-vcd8d"
+                }
+              ],
+              "terminationMessagePolicy": "File",
+              "env": [
+                {
+                  "name": "FLUENTD_ARGS",
+                  "value": "--no-supervisor -q"
+                }
+              ],
+              "imagePullPolicy": "IfNotPresent",
+              "resources": {
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "200Mi"
+                },
+                "limits": {
+                  "memory": "300Mi"
+                }
+              }
+            },
+            {
+              "terminationMessagePath": "/dev/termination-log",
+              "name": "prometheus-to-sd-exporter",
+              "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+              "volumeMounts": [
+                {
+                  "readOnly": true,
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "fluentd-gcp-token-vcd8d"
+                }
+              ],
+              "terminationMessagePolicy": "File",
+              "command": [
+                "/monitor",
+                "--stackdriver-prefix=container.googleapis.com/internal/addons",
+                "--api-override=https://monitoring.googleapis.com/",
+                "--source=fluentd:http://localhost:31337?whitelisted=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count",
+                "--pod-id=$(POD_NAME)",
+                "--namespace-id=$(POD_NAMESPACE)"
+              ],
+              "env": [
+                {
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.name",
+                      "apiVersion": "v1"
+                    }
+                  },
+                  "name": "POD_NAME"
+                },
+                {
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.namespace",
+                      "apiVersion": "v1"
+                    }
+                  },
+                  "name": "POD_NAMESPACE"
+                }
+              ],
+              "imagePullPolicy": "IfNotPresent",
+              "resources": {}
+            }
+          ],
+          "nodeName": "gke-haissam-default-pool-be5066f1-wnvn"
+        },
+        "metadata": {
+          "name": "fluentd-gcp-v2.0.10-p13r3",
+          "labels": {
+            "k8s-app": "fluentd-gcp",
+            "version": "v2.0.10",
+            "pod-template-generation": "1",
+            "kubernetes.io/cluster-service": "true",
+            "controller-revision-hash": "1108666223"
+          },
+          "namespace": "kube-system",
+          "ownerReferences": [
+            {
+              "kind": "DaemonSet",
+              "name": "fluentd-gcp-v2.0.10",
+              "apiVersion": "extensions/v1beta1",
+              "controller": true,
+              "blockOwnerDeletion": true,
+              "uid": "77585c76-10cc-11e8-bd5a-42010af00137"
+            }
+          ],
+          "resourceVersion": "30704838",
+          "generateName": "fluentd-gcp-v2.0.10-",
+          "creationTimestamp": "2018-02-13T14:57:17Z",
+          "annotations": {
+            "scheduler.alpha.kubernetes.io/critical-pod": "",
+            "kubernetes.io/config.source": "api",
+            "kubernetes.io/config.seen": "2018-02-13T16:10:19.509264637Z"
+          },
+          "selfLink": "/api/v1/namespaces/kube-system/pods/fluentd-gcp-v2.0.10-p13r3",
+          "uid": "2fdfd4d9-10ce-11e8-bd5a-42010af00137"
+        }
+      },
+      {
+        "status": {
+          "qosClass": "Burstable",
+          "containerStatuses": [
+            {
+              "restartCount": 0,
+              "name": "demo-app",
+              "image": "hkaj/demo-app:latest",
+              "imageID": "docker-pullable://hkaj/demo-app@sha256:0b638d574b905c853c67f69801677d219ae177c38d7fab25292934ec5564642f",
+              "state": {
+                "running": {
+                  "startedAt": "2018-02-13T16:11:44Z"
+                }
+              },
+              "ready": true,
+              "lastState": {},
+              "containerID": "docker://5f93d91c7aee0230f77fbe9ec642dd60958f5098e76de270a933285c24dfdc6g"
+            }
+          ],
+          "podIP": "10.8.2.5",
+          "startTime": "2018-02-13T16:11:38Z",
+          "hostIP": "10.132.0.4",
+          "phase": "Pending",
+          "conditions": [
+            {
+              "status": "True",
+              "lastProbeTime": null,
+              "type": "Initialized",
+              "lastTransitionTime": "2018-02-13T16:11:38Z"
+            },
+            {
+              "status": "True",
+              "lastProbeTime": null,
+              "type": "Ready",
+              "lastTransitionTime": "2018-02-13T16:11:45Z"
+            },
+            {
+              "status": "True",
+              "lastProbeTime": null,
+              "type": "PodScheduled",
+              "lastTransitionTime": "2018-02-13T16:11:38Z"
+            }
+          ]
+        },
+        "spec": {
+          "dnsPolicy": "ClusterFirst",
+          "securityContext": {},
+          "serviceAccountName": "default",
+          "schedulerName": "default-scheduler",
+          "serviceAccount": "default",
+          "terminationGracePeriodSeconds": 30,
+          "restartPolicy": "Always",
+          "volumes": [
+            {
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "default-token-zkdf2"
+              },
+              "name": "default-token-zkdf2"
+            }
+          ],
+          "tolerations": [
+            {
+              "operator": "Exists",
+              "tolerationSeconds": 300,
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/not-ready"
+            },
+            {
+              "operator": "Exists",
+              "tolerationSeconds": 300,
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unreachable"
+            }
+          ],
+          "containers": [
+            {
+              "terminationMessagePath": "/dev/termination-log",
+              "name": "demo-app",
+              "image": "hkaj/demo-app:latest",
+              "volumeMounts": [
+                {
+                  "readOnly": true,
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "default-token-zkdf2"
+                }
+              ],
+              "terminationMessagePolicy": "File",
+              "imagePullPolicy": "Always",
+              "ports": [
+                {
+                  "protocol": "TCP",
+                  "containerPort": 80
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": "100m"
+                }
+              }
+            }
+          ],
+          "nodeName": "gke-haissam-default-pool-be5066f1-wnvn"
+        },
+        "metadata": {
+          "name": "demo-app-success-c485bc67b-klj45",
+          "labels": {
+            "pod-template-hash": "704167236",
+            "project": "cncf",
+            "app": "demo-app",
+            "version": "1"
+          },
+          "namespace": "default",
+          "ownerReferences": [
+            {
+              "kind": "ReplicaSet",
+              "name": "demo-app-success-c485bc67b",
+              "apiVersion": "extensions/v1beta1",
+              "controller": true,
+              "blockOwnerDeletion": true,
+              "uid": "390ee05e-0c3d-11e8-a231-42010af000a9"
+            }
+          ],
+          "resourceVersion": "30705944",
+          "generateName": "demo-app-success-c485bc67b-",
+          "creationTimestamp": "2018-02-13T16:08:35Z",
+          "annotations": {
+            "kubernetes.io/config.seen": "2018-02-13T16:11:38.235504619Z",
+            "service-discovery.datadoghq.com/demo-app.init_configs": "[{}]",
+            "service-discovery.datadoghq.com/demo-app.check_names": "[\"go_expvar\"]",
+            "kubernetes.io/config.source": "api",
+            "service-discovery.datadoghq.com/demo-app.instances": "[{\"expvar_url\": \"http://%%host%%:8080\", \"metrics\": [{\"path\": \"demo.requests.failures\", \"type\": \"counter\"}, {\"path\": \"demo.requests.success\", \"type\": \"counter\"}], \"tags\": [\"%%tags%%\"]}]",
+            "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container demo-app"
+          },
+          "selfLink": "/api/v1/namespaces/default/pods/demo-app-success-c485bc67b-klj45",
+          "uid": "24d6daa3-10d8-11e8-bd5a-42010af00137"
+        }
+      }
+    ],
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {}
+  }
+  

--- a/pkg/collector/corechecks/containers/kubelet/testdata/pod_list_with_no_kube_tags.json
+++ b/pkg/collector/corechecks/containers/kubelet/testdata/pod_list_with_no_kube_tags.json
@@ -703,4 +703,3 @@
     "apiVersion": "v1",
     "metadata": {}
   }
-  


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds logic to filter out metrics with no kubernetes tags.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Previously, the count of metrics was getting inflated due to metrics being reported with `kube_namespace:N/A` on restarts. This change ensures that only metrics with the appropriate kubernetes tags are sent.
previously:
<img width="641" alt="image" src="https://github.com/DataDog/datadog-agent/assets/32009013/366065b0-fbcd-438f-ab8f-35609d0fdf84">

now:
<img width="643" alt="image" src="https://github.com/DataDog/datadog-agent/assets/32009013/f6d0a790-9b3d-4e87-82ae-dd2e3765b374">


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
By filtering out these metrics, there is a slight gap in data, whereas before, the metric would still be reported but without all the tags. 

### Describe how to test/QA your changes
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1. Deploy the kubelet core check by using something like:
2. Deploy the agent/cluster agent with a configuration like:
```
datadog:
  logLevel: DEBUG
  clusterName: jenn-kubelet-core-check
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  collectEvents: true
  logs:
    enabled: true
    containerCollectAll: true
    containerCollectUsingFiles: true
  kubelet:
    tlsVerify: false
  confd:
    kubelet_core.yaml: |
      init_config:
        loader: core
      instances:
        - min_collection_interval: 20
...
clusterAgent:
  enabled: true
clusterChecksRunner:
  enabled: true
  replicas: 5
```
3. Restart the pods multiple times and verify that no metrics are tagged with `kube_namespace:N/A`

