### PR TITLE
workloadmeta performance tuning

### DIFF
--- a/comp/core/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/workloadmeta.go
@@ -7,12 +7,14 @@ package workloadmeta
 
 import (
 	"context"
-	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"sync"
 	"time"
 
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"go.uber.org/fx"
@@ -87,7 +89,7 @@ func newWorkloadMeta(deps dependencies) provider {
 		store:        make(map[Kind]map[string]*cachedEntity),
 		candidates:   candidates,
 		collectors:   make(map[string]Collector),
-		eventCh:      make(chan []CollectorEvent, eventChBufferSize),
+		eventCh:      make(chan []CollectorEvent, pkgconfig.Datadog.GetInt("workloadmeta.collector_event_chan_buffer")),
 		ongoingPulls: make(map[string]time.Time),
 	}
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1132,6 +1132,8 @@ func InitConfig(config pkgconfigmodel.Config) {
 	// Remote process collector
 	config.BindEnvAndSetDefault("workloadmeta.local_process_collector.collection_interval", DefaultLocalProcessCollectorInterval)
 
+	config.BindEnvAndSetDefault("workloadmeta.collector_event_chan_buffer", 50)
+
 	// SBOM configuration
 	config.BindEnvAndSetDefault("sbom.enabled", false)
 	bindEnvAndSetLogsConfigKeys(config, "sbom.")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- Make `(*workloadmeta).Notify()` non-blocking. 
- Make `(*workloadmeta).handleEvents()` run in parallel.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

See CONS-6149

"workloadmeta-store" and "ad-kubeletlistener" become unhealthy status frequently in a cluster where many CronJob that spawns short-lieved container exists.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
