### PR TITLE
[CWS] add missing `defaultEventMonitorAddress` on darwin

### DIFF
--- a/pkg/config/setup/config_darwin.go
+++ b/pkg/config/setup/config_darwin.go
@@ -17,7 +17,9 @@ const (
 	// DefaultProcessAgentLogFile is the default process-agent log file
 	DefaultProcessAgentLogFile = "/opt/datadog-agent/logs/process-agent.log"
 	// defaultSystemProbeAddress is the default unix socket path to be used for connecting to the system probe
-	defaultSystemProbeAddress     = "/opt/datadog-agent/run/sysprobe.sock"
+	defaultSystemProbeAddress = "/opt/datadog-agent/run/sysprobe.sock"
+	// defaultEventMonitorAddress is the default unix socket path to be used for connecting to the event monitor
+	defaultEventMonitorAddress    = "/opt/datadog-agent/run/event-monitor.sock"
 	defaultSystemProbeLogFilePath = "/opt/datadog-agent/logs/system-probe.log"
 	// DefaultDDAgentBin the process agent's binary
 	DefaultDDAgentBin = "/opt/datadog-agent/bin/agent/agent"


### PR DESCRIPTION
### What does this PR do?

The default value was defined for linux and windows, but not darwin.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
