### PR TITLE
usm: http2: Enable terminated_http2_monitoring_flag

### DIFF
--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -227,6 +227,7 @@ func (p *Protocol) ConfigureOptions(mgr *manager.Manager, opts *manager.Options)
 	}
 
 	utils.EnableOption(opts, "http2_monitoring_enabled")
+	utils.EnableOption(opts, "terminated_http2_monitoring_enabled")
 	// Configure event stream
 	events.Configure(eventStream, mgr, opts)
 	p.dynamicTable.configureOptions(mgr, opts)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Enables the const `terminated_http2_monitoring_enabled` so `terminated_http2_batch_flush` will be enabled

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The flag controlled the flush batches for the terminated_http2 connection map but it was disabled, thus we didn't flush anything

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
