### PR TITLE
[CWS][Windows] Add user context at the base of event's json 

### DIFF
--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -27,9 +27,9 @@ type FileSerializer struct {
 // easyjson:json
 type UserContextSerializer struct {
 	// User name
-	User string `json:"user_name,omitempty"`
+	User string `json:"name,omitempty"`
 	// Owner Sid
-	OwnerSidString string `json:"owner_sid,omitempty"`
+	OwnerSidString string `json:"sid,omitempty"`
 }
 
 // RegistrySerializer serializes a registry to JSON
@@ -93,7 +93,7 @@ func newFileSerializer(fe *model.FileEvent, e *model.Event, _ ...uint64) *FileSe
 
 func newUserContextSerializer(e *model.Event) *UserContextSerializer {
 	return &UserContextSerializer{
-		User:           e.FieldHandlers.ResolveUser(e, e.ProcessContext.Process),
+		User:           e.FieldHandlers.ResolveUser(e, &e.ProcessContext.Process),
 		OwnerSidString: e.ProcessContext.Process.OwnerSidString,
 	}
 }

--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -92,7 +92,7 @@ func newFileSerializer(fe *model.FileEvent, e *model.Event, _ ...uint64) *FileSe
 }
 
 func newUserContextSerializer(e *model.Event) *UserContextSerializer {
-	if e.ProcessContext == nil || e.ProcessContext.Process == nil {
+	if e.ProcessContext == nil || e.ProcessContext.Pid == 0 || e == nil {
 		return nil
 	}
 	return &UserContextSerializer{

--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -92,6 +92,9 @@ func newFileSerializer(fe *model.FileEvent, e *model.Event, _ ...uint64) *FileSe
 }
 
 func newUserContextSerializer(e *model.Event) *UserContextSerializer {
+	if e.ProcessContext == nil || e.ProcessContext.Process == nil {
+		return nil
+	}
 	return &UserContextSerializer{
 		User:           e.FieldHandlers.ResolveUser(e, &e.ProcessContext.Process),
 		OwnerSidString: e.ProcessContext.Process.OwnerSidString,

--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -23,6 +23,15 @@ type FileSerializer struct {
 	Name string `json:"name,omitempty"`
 }
 
+// UserContextSerializer serializes a user context to JSON
+// easyjson:json
+type UserContextSerializer struct {
+	// User name
+	User string `json:"user_name,omitempty"`
+	// Owner Sid
+	OwnerSidString string `json:"owner_sid,omitempty"`
+}
+
 // RegistrySerializer serializes a registry to JSON
 type RegistrySerializer struct {
 	// Registry key name
@@ -49,8 +58,6 @@ type ProcessSerializer struct {
 	Container *ContainerContextSerializer `json:"container,omitempty"`
 	// Command line arguments
 	CmdLine string `json:"cmdline,omitempty"`
-	// User's sid
-	OwnerSidString string `json:"user_sid,omitempty"`
 	// User name
 	User string `json:"user,omitempty"`
 	// Variables values
@@ -74,12 +81,20 @@ type NetworkDeviceSerializer struct{}
 type EventSerializer struct {
 	*BaseEventSerializer
 	*RegistryEventSerializer `json:"registry,omitempty"`
+	*UserContextSerializer   `json:"usr,omitempty"`
 }
 
 func newFileSerializer(fe *model.FileEvent, e *model.Event, _ ...uint64) *FileSerializer {
 	return &FileSerializer{
 		Path: e.FieldHandlers.ResolveFilePath(e, fe),
 		Name: e.FieldHandlers.ResolveFileBasename(e, fe),
+	}
+}
+
+func newUserContextSerializer(e *model.Event) *UserContextSerializer {
+	return &UserContextSerializer{
+		User:           e.FieldHandlers.ResolveUser(e, e.ProcessContext.Process),
+		OwnerSidString: e.ProcessContext.Process.OwnerSidString,
 	}
 }
 
@@ -96,13 +111,12 @@ func newProcessSerializer(ps *model.Process, e *model.Event, opts *eval.Opts) *P
 		ExecTime: utils.NewEasyjsonTimeIfNotZero(ps.ExecTime),
 		ExitTime: utils.NewEasyjsonTimeIfNotZero(ps.ExitTime),
 
-		Pid:            ps.Pid,
-		PPid:           getUint32Pointer(&ps.PPid),
-		Executable:     newFileSerializer(&ps.FileEvent, e),
-		CmdLine:        e.FieldHandlers.ResolveProcessCmdLineScrubbed(e, ps),
-		OwnerSidString: ps.OwnerSidString,
-		User:           e.FieldHandlers.ResolveUser(e, ps),
-		Variables:      newVariablesContext(e, opts, "process."),
+		Pid:        ps.Pid,
+		PPid:       getUint32Pointer(&ps.PPid),
+		Executable: newFileSerializer(&ps.FileEvent, e),
+		CmdLine:    e.FieldHandlers.ResolveProcessCmdLineScrubbed(e, ps),
+		User:       e.FieldHandlers.ResolveUser(e, ps),
+		Variables:  newVariablesContext(e, opts, "process."),
 	}
 
 	if len(ps.ContainerID) != 0 {
@@ -169,7 +183,8 @@ func MarshalCustomEvent(event *events.CustomEvent) ([]byte, error) {
 // NewEventSerializer creates a new event serializer based on the event type
 func NewEventSerializer(event *model.Event, opts *eval.Opts) *EventSerializer {
 	s := &EventSerializer{
-		BaseEventSerializer: NewBaseEventSerializer(event, opts),
+		BaseEventSerializer:   NewBaseEventSerializer(event, opts),
+		UserContextSerializer: newUserContextSerializer(event),
 	}
 	eventType := model.EventType(event.Type)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This PR aims to add the user field at the base of the event's json for windows to match windows events
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
