### PR TITLE
[clusteragent/admission/auto_instrumentation] Raise init containers CPU resources

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -90,7 +90,7 @@ const (
 	customLibAnnotationKeyCtrFormat  = "admission.datadoghq.com/%s.%s-lib.custom-image"
 
 	// defaultMilliCPURequest defines default milli cpu request number.
-	defaultMilliCPURequest int64 = 10 // 0.01 core
+	defaultMilliCPURequest int64 = 50 // 0.05 core
 	// defaultMemoryRequest defines default memory request size.
 	defaultMemoryRequest int64 = 20 * 1024 * 1024 // 20 MB
 

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic/fake"
 )
@@ -774,18 +775,18 @@ func TestInjectLibInitContainer(t *testing.T) {
 				return
 			}
 			require.Len(t, tt.pod.Spec.InitContainers, 1)
-			if tt.cpu != "" {
-				req := tt.pod.Spec.InitContainers[0].Resources.Requests[corev1.ResourceCPU]
-				lim := tt.pod.Spec.InitContainers[0].Resources.Limits[corev1.ResourceCPU]
-				require.Equal(t, tt.wantCPU, req.String())
-				require.Equal(t, tt.wantCPU, lim.String())
-			}
-			if tt.mem != "" {
-				req := tt.pod.Spec.InitContainers[0].Resources.Requests[corev1.ResourceMemory]
-				lim := tt.pod.Spec.InitContainers[0].Resources.Limits[corev1.ResourceMemory]
-				require.Equal(t, tt.wantMem, req.String())
-				require.Equal(t, tt.wantMem, lim.String())
-			}
+
+			req := tt.pod.Spec.InitContainers[0].Resources.Requests[corev1.ResourceCPU]
+			lim := tt.pod.Spec.InitContainers[0].Resources.Limits[corev1.ResourceCPU]
+			wantCPUQuantity := resource.MustParse(tt.wantCPU)
+			require.Zero(t, wantCPUQuantity.Cmp(req)) // Cmp returns 0 if equal
+			require.Zero(t, wantCPUQuantity.Cmp(lim))
+
+			req = tt.pod.Spec.InitContainers[0].Resources.Requests[corev1.ResourceMemory]
+			lim = tt.pod.Spec.InitContainers[0].Resources.Limits[corev1.ResourceMemory]
+			wantMemQuantity := resource.MustParse(tt.wantMem)
+			require.Zero(t, wantMemQuantity.Cmp(req))
+			require.Zero(t, wantMemQuantity.Cmp(lim))
 		})
 	}
 }

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -713,7 +713,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "10m",
+			wantCPU: "50m",
 			wantMem: "20Mi",
 		},
 		{
@@ -744,7 +744,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "10m",
+			wantCPU: "50m",
 			wantMem: "512Mi",
 		},
 		{
@@ -754,7 +754,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: true,
-			wantCPU: "10m",
+			wantCPU: "50m",
 			wantMem: "20Mi",
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

Set CPU request/limit for the APM init containers to 50mCPU. The current value seemed to be very low.
This PR also fixes a related test.

### Describe how to test/QA your changes

Enable APM injection and check that the CPU resource and limit for the init containers is set to 50mCPU.
