### PR TITLE
[gitlab] Fix e2e_container_test_junit_upload not running on failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1031,6 +1031,39 @@ workflow:
   - when: manual
     allow_failure: true
 
+.always_on_container_or_e2e_changes_or_manual:
+  - <<: *if_disable_e2e
+    when: never
+  - <<: *if_main_branch
+    when: always
+  - <<: *if_mergequeue
+    when: never
+  - changes:
+      paths:
+        - comp/core/tagger/**/*
+        - comp/core/workloadmeta/**/*
+        - pkg/autodiscovery/listeners/**/*
+        - pkg/autodiscovery/providers/**/*
+        - pkg/collector/corechecks/cluster/**/*
+        - pkg/collector/corechecks/containers/**/*
+        - pkg/collector/corechecks/containerimage/**/*
+        - pkg/collector/corechecks/containerlifecycle/**/*
+        - pkg/collector/corechecks/kubernetes/**/*
+        - pkg/collector/corechecks/sbom/**/*
+        - pkg/util/clusteragent/**/*
+        - pkg/util/containerd/**/*
+        - pkg/util/containers/**/*
+        - pkg/util/docker/**/*
+        - pkg/util/ecs/**/*
+        - pkg/util/kubernetes/**/*
+        - pkg/util/cgroups/**/*
+        - test/new-e2e/tests/containers/**/*
+        - test/new-e2e/go.mod
+      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+    when: always
+  - when: manual
+    allow_failure: true
+
 .on_container_or_e2e_changes_or_manual:
   - <<: *if_disable_e2e
     when: never

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -96,8 +96,7 @@ e2e_pre_test_junit_upload:
 e2e_container_test_junit_upload:
   extends: .e2e_test_junit_template
   rules:
-    - !reference [.on_container_or_e2e_changes_or_manual]
-  when: always
+    - !reference [.always_on_container_or_e2e_changes_or_manual]
   stage: e2e_test_junit_upload
   dependencies:
     # We need to exhaustively list all the `new-e2e-…` jobs that produce junit reports here


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the `e2e_container_test_junit_upload` to run even when the pipeline fails.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix reporting of `new-e2e-containers` tests. They are currently always skipped if any job before them fails ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/28365852)).

The reason for this is that the top-level `when: always` gets discarded when rules with a different `when` are defined.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Verify that `e2e_container_test_junit_upload` now runs on failing pipelines.
