### PR TITLE
cluster-agent: Collect new Kubernetes resource NetworkPolicy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -599,7 +599,7 @@ require github.com/lorenzosaino/go-sysctl v0.3.1
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/DataDog/agent-payload/v5 v5.0.104
+	github.com/DataDog/agent-payload/v5 v5.0.105
 	github.com/DataDog/datadog-agent/cmd/agent/common/path v0.52.0-rc.3
 	github.com/DataDog/datadog-agent/comp/core/config v0.52.0-rc.3
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.52.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/CycloneDX/cyclonedx-go v0.7.2 h1:kKQ0t1dPOlugSIYVOMiMtFqeXI2wp/f5DBId
 github.com/CycloneDX/cyclonedx-go v0.7.2/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7Bxz4rpMQ4ZhjtSk=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/DataDog/agent-payload/v5 v5.0.104 h1:uxTIaLthyKB4CxBKe+2FeMgL6ca3KVxpeYxlJGNcoJg=
-github.com/DataDog/agent-payload/v5 v5.0.104/go.mod h1:COngtbYYCncpIPiE5D93QlXDH/3VAKk10jDNwGHcMRE=
+github.com/DataDog/agent-payload/v5 v5.0.105 h1:ip81v5WbfuRDBDGhYz2Qzzv3YwLhOmf1sp60WVfvIgA=
+github.com/DataDog/agent-payload/v5 v5.0.105/go.mod h1:COngtbYYCncpIPiE5D93QlXDH/3VAKk10jDNwGHcMRE=
 github.com/DataDog/appsec-internal-go v1.4.2 h1:rLOp0mSzJ7L7Nn3jAdWbgvs+1HK25H0DN4XYVDJu72s=
 github.com/DataDog/appsec-internal-go v1.4.2/go.mod h1:pEp8gjfNLtEOmz+iZqC8bXhu0h4k7NUsW/qiQb34k1U=
 github.com/DataDog/aptly v1.5.3 h1:oLsRvjuXSVM4ia0N83dU3KiQeiJ6BaszYbTZOkSfDlw=

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -167,7 +167,7 @@ func (cb *CollectorBundle) addCollectorFromConfig(collectorName string, isCRD bo
 	}
 
 	if err != nil {
-		_ = cb.check.Warnf("Unsupported collector: %s", collectorName)
+		_ = cb.check.Warnf("Unsupported collector: %s: %s", collectorName, err)
 		return
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
@@ -47,6 +47,7 @@ func NewCollectorInventory() *CollectorInventory {
 			k8sCollectors.NewUnassignedPodCollectorVersions(),
 			k8sCollectors.NewVerticalPodAutoscalerCollectorVersions(),
 			k8sCollectors.NewHorizontalPodAutoscalerCollectorVersions(),
+			k8sCollectors.NewNetworkPolicyCollectorVersions(),
 		},
 	}
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/networkpolicy.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/networkpolicy.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+
+package k8s
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator"
+
+	"k8s.io/apimachinery/pkg/labels"
+	networkingv1Informers "k8s.io/client-go/informers/networking/v1"
+	networkingv1Listers "k8s.io/client-go/listers/networking/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewNetworkPolicyCollectorVersions builds the group of collector versions.
+func NewNetworkPolicyCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewNetworkPolicyCollector(),
+	)
+}
+
+// NetworkPolicyCollector is a collector for Kubernetes NetworkPolicies.
+type NetworkPolicyCollector struct {
+	informer  networkingv1Informers.NetworkPolicyInformer
+	lister    networkingv1Listers.NetworkPolicyLister
+	metadata  *collectors.CollectorMetadata
+	processor *processors.Processor
+}
+
+// NewNetworkPolicyCollector creates a new collector for the Kubernetes
+// NetworkPolicy resource.
+func NewNetworkPolicyCollector() *NetworkPolicyCollector {
+	return &NetworkPolicyCollector{
+		metadata: &collectors.CollectorMetadata{
+			IsDefaultVersion:          true,
+			IsStable:                  false,
+			IsMetadataProducer:        true,
+			IsManifestProducer:        true,
+			SupportsManifestBuffering: true,
+			Name:                      "networkpolicies",
+			NodeType:                  orchestrator.K8sNetworkPolicy,
+			Version:                   "networking.k8s.io/v1",
+		},
+		processor: processors.NewProcessor(new(k8sProcessors.NetworkPolicyHandlers)),
+	}
+}
+
+// Informer returns the shared informer.
+func (c *NetworkPolicyCollector) Informer() cache.SharedInformer {
+	return c.informer.Informer()
+}
+
+// Init is used to initialize the collector.
+func (c *NetworkPolicyCollector) Init(rcfg *collectors.CollectorRunConfig) {
+	c.informer = rcfg.OrchestratorInformerFactory.InformerFactory.Networking().V1().NetworkPolicies()
+	c.lister = c.informer.Lister()
+}
+
+// Metadata is used to access information about the collector.
+func (c *NetworkPolicyCollector) Metadata() *collectors.CollectorMetadata {
+	return c.metadata
+}
+
+// Run triggers the collection process.
+func (c *NetworkPolicyCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
+	list, err := c.lister.List(labels.Everything())
+	if err != nil {
+		return nil, collectors.NewListingError(err)
+	}
+
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
+
+	processResult, processed := c.processor.Process(ctx, list)
+
+	if processed == -1 {
+		return nil, collectors.ErrProcessingPanic
+	}
+
+	result := &collectors.CollectorRunResult{
+		Result:             processResult,
+		ResourcesListed:    len(list),
+		ResourcesProcessed: processed,
+	}
+
+	return result, nil
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+
+package k8s
+
+import (
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	k8sTransformers "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator/redact"
+
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// NetworkPolicyHandlers implements the Handlers interface for Kubernetes NetworkPolicy.
+type NetworkPolicyHandlers struct {
+	BaseHandlers
+}
+
+// AfterMarshalling is a handler called after resource marshalling.
+//
+//nolint:revive // TODO(CAPP) Fix revive linter
+func (h *NetworkPolicyHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
+	m := resourceModel.(*model.NetworkPolicy)
+	m.Yaml = yaml
+	return
+}
+
+// BuildMessageBody is a handler called to build a message body out of a list of
+// extracted resources.
+func (h *NetworkPolicyHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resourceModels []interface{}, groupSize int) model.MessageBody {
+	models := make([]*model.NetworkPolicy, 0, len(resourceModels))
+
+	for _, m := range resourceModels {
+		models = append(models, m.(*model.NetworkPolicy))
+	}
+
+	return &model.CollectorNetworkPolicy{
+		ClusterName:     ctx.Cfg.KubeClusterName,
+		ClusterId:       ctx.ClusterID,
+		GroupId:         ctx.MsgGroupID,
+		GroupSize:       int32(groupSize),
+		NetworkPolicies: models,
+		Tags:            append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
+	}
+}
+
+// ExtractResource is a handler called to extract the resource model out of a raw resource.
+//
+//nolint:revive // TODO(CAPP) Fix revive linter
+func (h *NetworkPolicyHandlers) ExtractResource(ctx *processors.ProcessorContext, resource interface{}) (resourceModel interface{}) {
+	r := resource.(*netv1.NetworkPolicy)
+	return k8sTransformers.ExtractNetworkPolicy(r)
+}
+
+// ResourceList is a handler called to convert a list passed as a generic
+// interface to a list of generic interfaces.
+//
+//nolint:revive // TODO(CAPP) Fix revive linter
+func (h *NetworkPolicyHandlers) ResourceList(ctx *processors.ProcessorContext, list interface{}) (resources []interface{}) {
+	resourceList := list.([]*netv1.NetworkPolicy)
+	resources = make([]interface{}, 0, len(resourceList))
+
+	for _, resource := range resourceList {
+		resources = append(resources, resource)
+	}
+
+	return resources
+}
+
+// ResourceUID is a handler called to retrieve the resource UID.
+//
+//nolint:revive // TODO(CAPP) Fix revive linter
+func (h *NetworkPolicyHandlers) ResourceUID(ctx *processors.ProcessorContext, resource interface{}) types.UID {
+	return resource.(*netv1.NetworkPolicy).UID
+}
+
+// ResourceVersion is a handler called to retrieve the resource version.
+//
+//nolint:revive // TODO(CAPP) Fix revive linter
+func (h *NetworkPolicyHandlers) ResourceVersion(ctx *processors.ProcessorContext, resource, resourceModel interface{}) string {
+	return resource.(*netv1.NetworkPolicy).ResourceVersion
+}
+
+// ScrubBeforeExtraction is a handler called to redact the raw resource before
+// it is extracted as an internal resource model.
+//
+//nolint:revive // TODO(CAPP) Fix revive linter
+func (h *NetworkPolicyHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
+	r := resource.(*netv1.NetworkPolicy)
+	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
+}
+
+// ScrubBeforeMarshalling is a handler called to redact the raw resource before
+// it is marshalled to generate a manifest.
+//
+//nolint:revive // TODO(CAPP) Fix revive linter
+func (h *NetworkPolicyHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/common.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/common.go
@@ -52,6 +52,10 @@ func extractMetadata(m *metav1.ObjectMeta) *model.Metadata {
 }
 
 func extractLabelSelector(ls *metav1.LabelSelector) []*model.LabelSelectorRequirement {
+	if ls == nil {
+		return nil
+	}
+
 	labelSelectors := make([]*model.LabelSelectorRequirement, 0, len(ls.MatchLabels)+len(ls.MatchExpressions))
 	for k, v := range ls.MatchLabels {
 		s := model.LabelSelectorRequirement{

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/networkpolicy.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/networkpolicy.go
@@ -1,0 +1,163 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+
+package k8s
+
+import (
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
+
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// ExtractNetworkPolicy returns the protobuf model corresponding to a Kubernetes
+func ExtractNetworkPolicy(n *networkingv1.NetworkPolicy) *model.NetworkPolicy {
+	networkPolicy := model.NetworkPolicy{
+		Metadata: extractMetadata(&n.ObjectMeta),
+		Spec:     extractNetworkPolicySpec(&n.Spec),
+	}
+
+	networkPolicy.Tags = append(networkPolicy.Tags, transformers.RetrieveUnifiedServiceTags(n.ObjectMeta.Labels)...)
+
+	return &networkPolicy
+}
+
+func extractNetworkPolicySpec(spec *networkingv1.NetworkPolicySpec) *model.NetworkPolicySpec {
+	if spec == nil {
+		return nil
+	}
+
+	policySpec := &model.NetworkPolicySpec{}
+
+	if len(spec.PolicyTypes) > 0 {
+		policySpec.PolicyTypes = extractNetworkPolicyTypes(spec.PolicyTypes)
+	}
+
+	if spec.PodSelector.Size() > 0 {
+		policySpec.Selectors = extractLabelSelector(&spec.PodSelector)
+	}
+
+	if len(spec.Ingress) > 0 {
+		policySpec.Ingress = make([]*model.NetworkPolicyIngressRule, 0, len(spec.Ingress))
+		for _, i := range spec.Ingress {
+			policySpec.Ingress = append(policySpec.Ingress, extractNetworkPolicyIngressRule(&i))
+		}
+	}
+
+	if len(spec.Egress) > 0 {
+		policySpec.Egress = make([]*model.NetworkPolicyEgressRule, 0, len(spec.Egress))
+		for _, e := range spec.Egress {
+			policySpec.Egress = append(policySpec.Egress, extractNetworkPolicyEgressRule(&e))
+		}
+	}
+
+	return policySpec
+}
+
+func extractNetworkPolicyIngressRule(rule *networkingv1.NetworkPolicyIngressRule) *model.NetworkPolicyIngressRule {
+	if rule == nil {
+		return nil
+	}
+
+	from := make([]*model.NetworkPolicyPeer, 0, len(rule.From))
+	for _, f := range rule.From {
+		from = append(from, extractNetworkPolicyPeer(&f))
+	}
+
+	ports := make([]*model.NetworkPolicyPort, 0, len(rule.Ports))
+	for _, p := range rule.Ports {
+		ports = append(ports, extractNetworkPolicyPort(&p))
+	}
+
+	return &model.NetworkPolicyIngressRule{
+		From:  from,
+		Ports: ports,
+	}
+}
+
+func extractNetworkPolicyEgressRule(rule *networkingv1.NetworkPolicyEgressRule) *model.NetworkPolicyEgressRule {
+	if rule == nil {
+		return nil
+	}
+
+	to := make([]*model.NetworkPolicyPeer, 0, len(rule.To))
+	for _, t := range rule.To {
+		to = append(to, extractNetworkPolicyPeer(&t))
+	}
+
+	ports := make([]*model.NetworkPolicyPort, 0, len(rule.Ports))
+	for _, p := range rule.Ports {
+		ports = append(ports, extractNetworkPolicyPort(&p))
+	}
+
+	return &model.NetworkPolicyEgressRule{
+		To:    to,
+		Ports: ports,
+	}
+}
+
+func extractNetworkPolicyPeer(peer *networkingv1.NetworkPolicyPeer) *model.NetworkPolicyPeer {
+	if peer == nil {
+		return nil
+	}
+
+	ipBlock := extractNetworkPolicyIPBlock(peer.IPBlock)
+	namespaceSelector := extractLabelSelector(peer.NamespaceSelector)
+	podSelector := extractLabelSelector(peer.PodSelector)
+
+	return &model.NetworkPolicyPeer{
+		IpBlock:           ipBlock,
+		NamespaceSelector: namespaceSelector,
+		PodSelector:       podSelector,
+	}
+}
+
+func extractNetworkPolicyIPBlock(ipBlock *networkingv1.IPBlock) *model.NetworkPolicyIPBlock {
+	if ipBlock == nil {
+		return nil
+	}
+
+	return &model.NetworkPolicyIPBlock{
+		Cidr:   ipBlock.CIDR,
+		Except: ipBlock.Except,
+	}
+}
+
+func extractNetworkPolicyPort(port *networkingv1.NetworkPolicyPort) *model.NetworkPolicyPort {
+	if port == nil {
+		return nil
+	}
+
+	p := &model.NetworkPolicyPort{}
+	if port.Port != nil {
+		p.Port = port.Port.IntVal
+	}
+
+	if port.Protocol != nil {
+		p.Protocol = string(*port.Protocol)
+	}
+
+	if port.EndPort != nil {
+		p.EndPort = *port.EndPort
+	}
+
+	return p
+}
+
+func extractNetworkPolicyTypes(policyTypes []networkingv1.PolicyType) []string {
+	if len(policyTypes) == 0 {
+		return nil
+	}
+
+	types := make([]string, 0, len(policyTypes))
+	for _, t := range policyTypes {
+		types = append(types, string(t))
+	}
+
+	return types
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/networkpolicy_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/networkpolicy_test.go
@@ -1,0 +1,381 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+
+package k8s
+
+import (
+	"testing"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestExtractNetworkPolicy(t *testing.T) {
+	protocol := v1.Protocol("TCP")
+	tests := map[string]struct {
+		input    networkingv1.NetworkPolicy
+		expected *model.NetworkPolicy
+	}{
+		"standard": {
+			input: networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"annotation": "my-annotation",
+					},
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					Ingress: []networkingv1.NetworkPolicyIngressRule{
+						{
+							From: []networkingv1.NetworkPolicyPeer{
+								{
+									IPBlock: &networkingv1.IPBlock{
+										CIDR: "10.0.0.0/24",
+									},
+								},
+							},
+							Ports: []networkingv1.NetworkPolicyPort{
+								{
+									Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+									Protocol: &protocol,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &model.NetworkPolicy{
+				Metadata: &model.Metadata{
+					Annotations: []string{"annotation:my-annotation"},
+				},
+				Spec: &model.NetworkPolicySpec{
+					Ingress: []*model.NetworkPolicyIngressRule{
+						{
+							From: []*model.NetworkPolicyPeer{
+								{
+									IpBlock: &model.NetworkPolicyIPBlock{
+										Cidr: "10.0.0.0/24",
+									},
+								},
+							},
+							Ports: []*model.NetworkPolicyPort{
+								{
+									Port:     80,
+									Protocol: "TCP",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"nil-safety": {
+			input: networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       networkingv1.NetworkPolicySpec{},
+			},
+			expected: &model.NetworkPolicy{
+				Metadata: &model.Metadata{},
+				Spec:     &model.NetworkPolicySpec{},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ExtractNetworkPolicy(&tc.input))
+		})
+	}
+}
+
+func TestExtractNetworkPolicySpec(t *testing.T) {
+	protocol := v1.Protocol("TCP")
+	tests := map[string]struct {
+		input    networkingv1.NetworkPolicySpec
+		expected *model.NetworkPolicySpec
+	}{
+		"standard": {
+			input: networkingv1.NetworkPolicySpec{
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								IPBlock: &networkingv1.IPBlock{
+									CIDR: "10.0.0.0/24",
+								},
+							},
+						},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+								Protocol: &protocol,
+							},
+						},
+					},
+				},
+			},
+			expected: &model.NetworkPolicySpec{
+				Ingress: []*model.NetworkPolicyIngressRule{
+					{
+						From: []*model.NetworkPolicyPeer{
+							{
+								IpBlock: &model.NetworkPolicyIPBlock{
+									Cidr: "10.0.0.0/24",
+								},
+							},
+						},
+						Ports: []*model.NetworkPolicyPort{
+							{
+								Port:     80,
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+			},
+		},
+		"nil-safety": {
+			input: networkingv1.NetworkPolicySpec{},
+			expected: &model.NetworkPolicySpec{
+				Ingress: nil,
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractNetworkPolicySpec(&tc.input))
+		})
+	}
+}
+
+func TestExtractNetworkPolicyIngressRule(t *testing.T) {
+	protocol := v1.Protocol("TCP")
+	tests := map[string]struct {
+		input    networkingv1.NetworkPolicyIngressRule
+		expected *model.NetworkPolicyIngressRule
+	}{
+		"standard": {
+			input: networkingv1.NetworkPolicyIngressRule{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						IPBlock: &networkingv1.IPBlock{
+							CIDR: "10.0.0.0/24",
+						},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+						Protocol: &protocol,
+					},
+				},
+			},
+			expected: &model.NetworkPolicyIngressRule{
+				From: []*model.NetworkPolicyPeer{
+					{
+						IpBlock: &model.NetworkPolicyIPBlock{
+							Cidr: "10.0.0.0/24",
+						},
+					},
+				},
+				Ports: []*model.NetworkPolicyPort{
+					{
+						Port:     80,
+						Protocol: "TCP",
+					},
+				},
+			},
+		},
+		"nil-safety": {
+			input: networkingv1.NetworkPolicyIngressRule{},
+			expected: &model.NetworkPolicyIngressRule{
+				From:  []*model.NetworkPolicyPeer{},
+				Ports: []*model.NetworkPolicyPort{},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractNetworkPolicyIngressRule(&tc.input))
+		})
+	}
+}
+
+func TestExtractNetworkPolicyEgressRule(t *testing.T) {
+	protocol := v1.Protocol("TCP")
+	tests := map[string]struct {
+		input    networkingv1.NetworkPolicyEgressRule
+		expected *model.NetworkPolicyEgressRule
+	}{
+		"standard": {
+			input: networkingv1.NetworkPolicyEgressRule{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						IPBlock: &networkingv1.IPBlock{
+							CIDR: "10.0.0.0/24",
+						},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+						Protocol: &protocol,
+					},
+				},
+			},
+			expected: &model.NetworkPolicyEgressRule{
+				To: []*model.NetworkPolicyPeer{
+					{
+						IpBlock: &model.NetworkPolicyIPBlock{
+							Cidr: "10.0.0.0/24",
+						},
+					},
+				},
+				Ports: []*model.NetworkPolicyPort{
+					{
+						Port:     80,
+						Protocol: "TCP",
+					},
+				},
+			},
+		},
+		"nil-safety": {
+			input: networkingv1.NetworkPolicyEgressRule{},
+			expected: &model.NetworkPolicyEgressRule{
+				To:    []*model.NetworkPolicyPeer{},
+				Ports: []*model.NetworkPolicyPort{},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractNetworkPolicyEgressRule(&tc.input))
+		})
+	}
+}
+
+func TestExtractNetworkPolicyPeer(t *testing.T) {
+	tests := map[string]struct {
+		input    networkingv1.NetworkPolicyPeer
+		expected *model.NetworkPolicyPeer
+	}{
+		"standard": {
+			input: networkingv1.NetworkPolicyPeer{
+				IPBlock: &networkingv1.IPBlock{
+					CIDR: "10.0.0.0/24",
+				},
+			},
+			expected: &model.NetworkPolicyPeer{
+				IpBlock: &model.NetworkPolicyIPBlock{
+					Cidr: "10.0.0.0/24",
+				},
+			},
+		},
+		"nil-safety": {
+			input: networkingv1.NetworkPolicyPeer{},
+			expected: &model.NetworkPolicyPeer{
+				IpBlock:           nil,
+				NamespaceSelector: nil,
+				PodSelector:       nil,
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractNetworkPolicyPeer(&tc.input))
+		})
+	}
+}
+
+func TestExtractNetworkPolicyIPBlock(t *testing.T) {
+	tests := map[string]struct {
+		input    networkingv1.IPBlock
+		expected *model.NetworkPolicyIPBlock
+	}{
+		"standard": {
+			input: networkingv1.IPBlock{
+				CIDR: "10.0.0.0/24",
+			},
+			expected: &model.NetworkPolicyIPBlock{
+				Cidr: "10.0.0.0/24",
+			},
+		},
+		"nil-safety": {
+			input: networkingv1.IPBlock{},
+			expected: &model.NetworkPolicyIPBlock{
+				Cidr:   "",
+				Except: nil,
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractNetworkPolicyIPBlock(&tc.input))
+		})
+	}
+}
+
+func TestExtractNetworkPolicyPort(t *testing.T) {
+	protocol := v1.Protocol("TCP")
+	tests := map[string]struct {
+		input    networkingv1.NetworkPolicyPort
+		expected *model.NetworkPolicyPort
+	}{
+		"standard": {
+			input: networkingv1.NetworkPolicyPort{
+				Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+				Protocol: &protocol,
+			},
+			expected: &model.NetworkPolicyPort{
+				Port:     80,
+				Protocol: "TCP",
+			},
+		},
+		"nil-safety": {
+			input: networkingv1.NetworkPolicyPort{},
+			expected: &model.NetworkPolicyPort{
+				Port:     0,
+				Protocol: "",
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractNetworkPolicyPort(&tc.input))
+		})
+	}
+}
+
+func TestExtractNetworkPolicyTypes(t *testing.T) {
+	tests := map[string]struct {
+		input    []networkingv1.PolicyType
+		expected []string
+	}{
+		"standard": {
+			input: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+			expected: []string{
+				"Ingress",
+				"Egress",
+			},
+		},
+		"nil-safety": {
+			input:    nil,
+			expected: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractNetworkPolicyTypes(tc.input))
+		})
+	}
+}

--- a/pkg/orchestrator/aliases.go
+++ b/pkg/orchestrator/aliases.go
@@ -77,6 +77,8 @@ const (
 	K8sVerticalPodAutoscaler = pkgorchestratormodel.K8sVerticalPodAutoscaler
 	// K8sHorizontalPodAutoscaler alias for pkgorchestratormodel.K8sHorizontalPodAutoscaler
 	K8sHorizontalPodAutoscaler = pkgorchestratormodel.K8sHorizontalPodAutoscaler
+	// K8sNetworkPolicy alias for pkgorchestratormodel.K8sNetworkPolicy
+	K8sNetworkPolicy = pkgorchestratormodel.K8sNetworkPolicy
 )
 
 // SetCacheStats alias for pkgorchestratormodel.SetCacheStats

--- a/pkg/orchestrator/model/types.go
+++ b/pkg/orchestrator/model/types.go
@@ -77,6 +77,8 @@ const (
 	K8sVerticalPodAutoscaler = 22
 	// K8sHorizontalPodAutoscaler represents a Kubernetes Horizontal Pod Autoscaler
 	K8sHorizontalPodAutoscaler = 23
+	// K8sNetworkPolicy represents a Kubernetes NetworkPolicy
+	K8sNetworkPolicy = 24
 )
 
 // NodeTypes returns the current existing NodesTypes as a slice to iterate over.
@@ -105,6 +107,7 @@ func NodeTypes() []NodeType {
 		K8sCRD,
 		K8sVerticalPodAutoscaler,
 		K8sHorizontalPodAutoscaler,
+		K8sNetworkPolicy,
 	}
 }
 
@@ -156,6 +159,8 @@ func (n NodeType) String() string {
 		return "VerticalPodAutoscaler"
 	case K8sHorizontalPodAutoscaler:
 		return "HorizontalPodAutoscaler"
+	case K8sNetworkPolicy:
+		return "NetworkPolicy"
 	case K8sUnsetType:
 		return "UnsetType"
 	default:
@@ -190,6 +195,7 @@ func (n NodeType) Orchestrator() string {
 		K8sNamespace,
 		K8sVerticalPodAutoscaler,
 		K8sHorizontalPodAutoscaler,
+		K8sNetworkPolicy,
 		K8sUnsetType:
 		return "k8s"
 	default:

--- a/releasenotes/notes/cluster-agent-collect-network-policy-b053ad2b6f0e0995.yaml
+++ b/releasenotes/notes/cluster-agent-collect-network-policy-b053ad2b6f0e0995.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The cluster-agent now collects network policies from the cluster.
+


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This pull request adds the necessary code to collect the Kubernetes resource NetworkPolicy, with tests.

I tested this change using a GKE cluster on GCP and it successfully collected network policies.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The NetworkPolicy kubernetes resource needs to be collected.
