### PR TITLE
Adding release note for the Fleet Automation fixes

### DIFF
--- a/releasenotes/notes/fix-fleet-automation-filters-9be4a6d4196a7c89.yaml
+++ b/releasenotes/notes/fix-fleet-automation-filters-9be4a6d4196a7c89.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fleet Automation filters in the DataDog website now accurately reflect which products are enabled when deployed with the official DataDog Helm Chart on Kubernetes.

--- a/releasenotes/notes/fix-fleet-automation-filters-9be4a6d4196a7c89.yaml
+++ b/releasenotes/notes/fix-fleet-automation-filters-9be4a6d4196a7c89.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fleet Automation filters in the DataDog website now accurately reflect which products are enabled when deployed with the official DataDog Helm Chart on Kubernetes.
+    Fleet Automation filters in the Datadog UI now accurately reflect which products are enabled when deployed with the official DataDog Helm chart on Kubernetes.


### PR DESCRIPTION
### What does this PR do?

Adding release note for the Fleet Automation fixes

This covers the following PRs:
- #22773
- #22651
- #22411
- #22442
- #22132

### Describe how to test/QA your changes

QA for ASC:
- Deploy the agent on a normal host and check that the metadata payload correctly reflect the configuration (use: `datadog-agent diagnose show-metadata inventory-agent`)
- Then deploy it on k8s with our official helm chart, while enabling all product, and check the metadata is correct.

Feel free to sync with other teams involved in the QA of the PRs listed above on how to enable each product.