### PR TITLE
[CONTINT-3684] allow communication with dca for sidecar and customising sidecar container image

### DIFF
--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -10,6 +10,7 @@ package agentsidecar
 
 import (
 	"errors"
+	"fmt"
 	dca_ac "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -61,6 +62,10 @@ func getDefaultSidecarTemplate() *corev1.Container {
 		ddSite = config.DefaultSite
 	}
 
+	containerRegistry := config.Datadog.GetString("admission_controller.agent_sidecar.container_registry")
+	imageName := config.Datadog.GetString("admission_controller.agent_sidecar.image_name")
+	imageTag := config.Datadog.GetString("admission_controller.agent_sidecar.image_tag")
+
 	agentContainer := &corev1.Container{
 		Env: []corev1.EnvVar{
 			{
@@ -92,7 +97,7 @@ func getDefaultSidecarTemplate() *corev1.Container {
 				},
 			},
 		},
-		Image:           "datadog/agent",
+		Image:           fmt.Sprintf("%s/%s:%s", containerRegistry, imageName, imageTag),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Name:            agentSidecarContainerName,
 		Resources: corev1.ResourceRequirements{

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
@@ -8,7 +8,9 @@
 package agentsidecar
 
 import (
+	"fmt"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	apicommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -324,14 +326,14 @@ func TestDefaultSidecarTemplateClusterAgentEnvVars(t *testing.T) {
 						SecretKeyRef: &corev1.SecretKeySelector{
 							Key: "token",
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "datadog-agent-cluster-agent",
+								Name: "datadog-secret",
 							},
 						},
 					},
 				},
 				{
 					Name:  "DD_CLUSTER_AGENT_URL",
-					Value: "https://datadog-cluster-agent.default.svc.cluster.local:5005",
+					Value: fmt.Sprintf("https://datadog-cluster-agent.%s.svc.cluster.local:5005", apicommon.GetMyNamespace()),
 				},
 				{
 					Name:  "DD_ORCHESTRATOR_EXPLORER_ENABLED",
@@ -357,14 +359,14 @@ func TestDefaultSidecarTemplateClusterAgentEnvVars(t *testing.T) {
 						SecretKeyRef: &corev1.SecretKeySelector{
 							Key: "token",
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "datadog-agent-cluster-agent",
+								Name: "datadog-secret",
 							},
 						},
 					},
 				},
 				{
 					Name:  "DD_CLUSTER_AGENT_URL",
-					Value: "https://test-service-name.default.svc.cluster.local:12345",
+					Value: fmt.Sprintf("https://test-service-name.%s.svc.cluster.local:12345", apicommon.GetMyNamespace()),
 				},
 				{
 					Name:  "DD_ORCHESTRATOR_EXPLORER_ENABLED",

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
@@ -253,3 +253,36 @@ func TestInjectAgentSidecar(t *testing.T) {
 	}
 
 }
+
+func TestDefaultSidecarTemplateAgentImage(t *testing.T) {
+	mockConfig := config.Mock(t)
+
+	tests := []struct {
+		name          string
+		setConfig     func()
+		expectedImage string
+	}{
+		{
+			name:          "no configuration set",
+			setConfig:     func() {},
+			expectedImage: "gcr.io/datadoghq/agent:latest",
+		},
+		{
+			name: "setting custom registry, image and tag",
+			setConfig: func() {
+				mockConfig.SetWithoutSource("admission_controller.agent_sidecar.container_registry", "my-registry")
+				mockConfig.SetWithoutSource("admission_controller.agent_sidecar.image_name", "my-image")
+				mockConfig.SetWithoutSource("admission_controller.agent_sidecar.image_tag", "my-tag")
+			},
+			expectedImage: "my-registry/my-image:my-tag",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			test.setConfig()
+			sidecar := getDefaultSidecarTemplate()
+			assert.Equal(tt, test.expectedImage, sidecar.Image)
+		})
+	}
+}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1080,6 +1080,9 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.selectors", "[]")
 	// Should be able to parse it to a list of env vars and resource limits
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.profiles", "[]")
+	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.container_registry", "gcr.io/datadoghq")
+	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.image_name", "agent")
+	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.image_tag", "latest")
 
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1083,6 +1083,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.container_registry", "gcr.io/datadoghq")
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.image_name", "agent")
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.image_tag", "latest")
+	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.cluster_agent.enabled", "true")
 
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.

--- a/releasenotes-dca/notes/enable-dca-in-agent-sidecar-80a2a12b482c1a62.yaml
+++ b/releasenotes-dca/notes/enable-dca-in-agent-sidecar-80a2a12b482c1a62.yaml
@@ -1,5 +1,5 @@
 ---
 features:
   - |
-    Enable `cluster agent` in injected agent sidecar container by default.
-    Set default configuration for connection with the `cluster agent`.
+    Enable `cluster agent` in injected Agent sidecar container by default.
+    Set the default configuration for connecting with the `cluster agent`.

--- a/releasenotes-dca/notes/enable-dca-in-agent-sidecar-80a2a12b482c1a62.yaml
+++ b/releasenotes-dca/notes/enable-dca-in-agent-sidecar-80a2a12b482c1a62.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Enable `cluster agent` in injected agent sidecar container by default.
+    Set default configuration for connection with the `cluster agent`.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR allows adding users have more fine-grained customisation on he sidecar injection feature by allowing:
- disabling/enabling communication between injected sidecar and the cluster-agent (enabled and configured by default)
- setting custom container_registry, image_name or image_tag to set a specific image for the agent sidecar

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Allow users to further customise injected sidecar.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Same QA as this PR, but:
- set image configs for sidecar image by setting the following env vars on the cluster agent and make sure the sidecar image is constructed based on these env vars:
   - DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_CONTAINER_REGISTRY
   - DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
   - DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
- ensure agent sidecar can communicate with the cluster agent
- ensure you can disable communication with the cluster agent

You can make use of the following setup:

- helm installation:
```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false

agents:
  enabled: false

clusterAgent:
  enabled: true
  admissionController:
    enabled: true
  env:
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_ENABLED
      value: "true"
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_PROVIDER
      value: "fargate"
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_CONTAINER_REGISTRY
      value: "my-registry"
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
      value: "my-image"
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
      value: "my-tag"

    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_SELECTORS
      value: '[{"ObjectSelector": {"MatchLabels": {"injectSidecarPodLabel": "true"}}, "NamespaceSelector": {"MatchLabels": {"injectSidecarNs": "true"}}}]'
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_PROFILES
      value: |
        [{
        "env": [
            {"name": "ENV_VAR_1", "value": "value1"}
        ],
        "resources": {
            "limits": {
                "cpu": "1",
                "memory": "512Mi"
            },
            "requests": {
                "cpu": "0.5",
                "memory": "256Mi"
            }
        }}]
```

- Create a namespace that matches the selector:
```
apiVersion: v1
kind: Namespace
metadata:
  name: ns-for-qa
  labels:
    injectSidecarNs: "true"
```

Create the following service account, clusterrole and clusterrolebinding:
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: datadog-agent
rules:
  - apiGroups:
      - ""
    resources:
      - nodes
      - namespaces
      - endpoints
    verbs:
      - get
      - list
  - apiGroups:
      - ""
    resources:
      - nodes/metrics
      - nodes/spec
      - nodes/stats
      - nodes/proxy
      - nodes/pods
      - nodes/healthz
    verbs:
      - get
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: datadog-agent
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: datadog-agent
subjects:
  - kind: ServiceAccount
    name: datadog-agent
    namespace: default
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: datadog-agent
  namespace: default
```
Add the generated cluster agent authentication token to the `datadog-secret` secret:
- Get the token first:
```
kubectl get secret datadog-agent-cluster-agent -o yaml 

....
apiVersion: v1
data:
  token: TlhCVVNEdUpOaDlSM3FQQ2d0cnBpVWowYVBDZXM4NEQ=
kind: Secret
....
```

- Add it in datadog-secret:
```
kubectl edit secret datadog-secret

# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
apiVersion: v1
data:
  api-key: ****
  token: ****
  app-key: ****
```

Copy the datadog secret from the default namespace to the `ns-for-qa` namespace:

```
kubectl get secret datadog-secret -n default -o yaml | sed -e 's/namespace: default/namespace:  ns-for-qa/' | kubectl apply -f -
```

Create a pod matching the selectors:
```
apiVersion: v1
kind: Pod
metadata:
  name: sample-pod
  namespace: ns-for-qa
  labels:
    admission.datadoghq.com/enabled: "false"
    injectSidecarPodLabel: "true"
spec:
  containers:
    - name: nginx
      image: nginx:1.14.2
      ports:
        - containerPort: 80
```

- Ensure the agent sidecar is injected with the correct image and cluster agent env vars:
```
kubectl get pod sample-pod -n ns-for-qa -o yaml

....
- env:
    - name: DD_API_KEY
      valueFrom:
        secretKeyRef:
          key: api-key
          name: datadog-secret
    - name: DD_SITE
      value: datadoghq.com
    - name: DD_CLUSTER_NAME
    - name: DD_KUBERNETES_KUBELET_NODENAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: spec.nodeName
    - name: DD_CLUSTER_AGENT_ENABLED
      value: "true"
    - name: DD_CLUSTER_AGENT_AUTH_TOKEN
      valueFrom:
        secretKeyRef:
          key: token
          name: datadog-agent-cluster-agent
    - name: DD_CLUSTER_AGENT_URL
      value: https://datadog-agent-cluster-agent.default.svc.cluster.local:5005
    - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
      value: "true"
    - name: DD_EKS_FARGATE
      value: "true"
    - name: ENV_VAR_1
      value: value1
    image: datadog/agent:latest
    imagePullPolicy: IfNotPresent
    name: datadog-agent-injected
    resources:
      limits:
        cpu: "1"
        memory: 512Mi
      requests:
        cpu: 500m
        memory: 256Mi
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-84c9r
      readOnly: true
....
```

Finally ensure the agent sidecar can connect successfully to the cluster agent:
```
kubectl exec sample-pod -c datadog-agent-injected -n ns-for-qa -- agent status

....
=====================
Datadog Cluster Agent
=====================

  - Datadog Cluster Agent endpoint detected: https://datadog-agent-cluster-agent.default.svc.cluster.local:5005/
  Successfully connected to the Datadog Cluster Agent.
  - Running: 7.52.0-devel+git.648.ff59345.commit.ff59345856
....
```


