### PR TITLE
[process-agent] explicitly invoke the tagger component to fix container tagging

### DIFF
--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -169,6 +169,8 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 			_ profiler.Component,
 			_ expvars.Component,
 			_ apiserver.Component,
+			// TODO: This is needed by the container-provider and should be updated to be handled by it
+			_ tagger.Component,
 			processAgent optional.Option[agent.Component],
 		) error {
 			if !processAgent.IsSet() {

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -51,10 +51,14 @@ type dependencies struct {
 
 	CliParams *cliParams
 
-	Config       config.Component
-	Syscfg       sysprobeconfig.Component
-	Log          log.Component
-	Hostinfo     hostinfo.Component
+	Config   config.Component
+	Syscfg   sysprobeconfig.Component
+	Log      log.Component
+	Hostinfo hostinfo.Component
+	// TODO: the tagger is used by the ContainerProvider, which is currently not a component so there is no direct
+	// dependency on it. The ContainerProvider needs to be componentized so it can be injected and have fx manage its
+	// lifecycle.
+	Tagger       tagger.Component
 	WorkloadMeta workloadmeta.Component
 	Checks       []types.CheckComponent `group:"check"`
 }


### PR DESCRIPTION
### What does this PR do?
Invokes the tagger component directly in the process-agent and the process check subcommand. The tagger was migrated to a component in https://github.com/DataDog/datadog-agent/pull/21314 This stopped initializing it explicitly. 

### Motivation
Tags were missing from container collection as the tagger is not initialized.

### Additional Notes
Future follow-ups would be to componentize the ContainerProvider and have it depend on the tagger, so it is properly invoked/started.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Test in a k8s environment

- Start the process-agent with process or container checks enabled.
- Check tags show up in Live containers and Live processes
- Run the `tagger-list` sub-command and verify containers and tags show up
    `process-agent tagger-list`
