### PR TITLE
[windows][cws] add specific registry types for notifications

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -291,7 +290,7 @@ func TestETWFileNotifications(t *testing.T) {
 		var once sync.Once
 		mypid := os.Getpid()
 
-		err := et.p.setupEtw(func(n interface{}, pid uint32, _ model.EventType) {
+		err := et.p.setupEtw(func(n interface{}, pid uint32) {
 			once.Do(func() {
 				close(et.etwStarted)
 			})

--- a/pkg/security/probe/probe_kernel_reg_windows.go
+++ b/pkg/security/probe/probe_kernel_reg_windows.go
@@ -55,6 +55,7 @@ type createKeyArgs struct {
 	relativeName     string
 	computedFullPath string
 }
+type openKeyArgs createKeyArgs
 
 /*
 		<template tid="task_0DeleteKeyArgs">
@@ -70,6 +71,10 @@ type deleteKeyArgs struct {
 	keyName          string
 	computedFullPath string
 }
+type flushKeyArgs deleteKeyArgs
+type closeKeyArgs deleteKeyArgs
+type querySecurityKeyArgs deleteKeyArgs
+type setSecurityKeyArgs deleteKeyArgs
 
 /*
 <template tid="task_0SetValueKeyArgs">
@@ -146,6 +151,14 @@ func (cka *createKeyArgs) translateBasePaths() {
 		}
 	}
 }
+func parseOpenRegistryKey(e *etw.DDEventRecord) (*openKeyArgs, error) {
+	cka, err := parseCreateRegistryKey(e)
+	if err != nil {
+		return nil, err
+	}
+	return (*openKeyArgs)(cka), nil
+}
+
 func (cka *createKeyArgs) computeFullPath() {
 
 	// var regPathResolver map[regObjectPointer]string
@@ -190,6 +203,10 @@ func (cka *createKeyArgs) string() string {
 	return output.String()
 }
 
+func (cka *openKeyArgs) string() string {
+	return (*createKeyArgs)(cka).string()
+}
+
 func parseDeleteRegistryKey(e *etw.DDEventRecord) (*deleteKeyArgs, error) {
 
 	dka := &deleteKeyArgs{
@@ -208,6 +225,36 @@ func parseDeleteRegistryKey(e *etw.DDEventRecord) (*deleteKeyArgs, error) {
 	return dka, nil
 }
 
+func parseFlushKey(e *etw.DDEventRecord) (*flushKeyArgs, error) {
+	dka, err := parseDeleteRegistryKey(e)
+	if err != nil {
+		return nil, err
+	}
+	return (*flushKeyArgs)(dka), nil
+}
+
+func parseCloseKeyArgs(e *etw.DDEventRecord) (*closeKeyArgs, error) {
+	dka, err := parseDeleteRegistryKey(e)
+	if err != nil {
+		return nil, err
+	}
+	return (*closeKeyArgs)(dka), nil
+}
+func parseQuerySecurityKeyArgs(e *etw.DDEventRecord) (*querySecurityKeyArgs, error) {
+	dka, err := parseDeleteRegistryKey(e)
+	if err != nil {
+		return nil, err
+	}
+	return (*querySecurityKeyArgs)(dka), nil
+}
+func parseSetSecurityKeyArgs(e *etw.DDEventRecord) (*setSecurityKeyArgs, error) {
+	dka, err := parseDeleteRegistryKey(e)
+	if err != nil {
+		return nil, err
+	}
+	return (*setSecurityKeyArgs)(dka), nil
+}
+
 func (dka *deleteKeyArgs) string() string {
 	var output strings.Builder
 
@@ -219,6 +266,23 @@ func (dka *deleteKeyArgs) string() string {
 	//output.WriteString("  CapturedSize: " + strconv.Itoa(int(sv.capturedPreviousDataSize)) + " pvssize: " + strconv.Itoa(int(sv.previousDataSize)) + " capturedpvssize " + strconv.Itoa(int(sv.capturedPreviousDataSize)) + "\n")
 	return output.String()
 
+}
+
+func (fka *flushKeyArgs) string() string {
+	return (*deleteKeyArgs)(fka).string()
+}
+func (cka *closeKeyArgs) string() string {
+	return (*deleteKeyArgs)(cka).string()
+}
+
+//nolint:unused
+func (qka *querySecurityKeyArgs) string() string {
+	return (*deleteKeyArgs)(qka).string()
+}
+
+//nolint:unused
+func (ska *setSecurityKeyArgs) string() string {
+	return (*deleteKeyArgs)(ska).string()
 }
 
 func parseSetValueKey(e *etw.DDEventRecord) (*setValueKeyArgs, error) {

--- a/pkg/security/probe/probe_kernel_reg_windows_test.go
+++ b/pkg/security/probe/probe_kernel_reg_windows_test.go
@@ -40,12 +40,16 @@ func processUntilRegOpen(t *testing.T, et *etwTester) {
 		case n := <-et.notify:
 
 			switch n.(type) {
+			case *openKeyArgs:
+				if strings.HasPrefix(n.(*openKeyArgs).computedFullPath, "HKEY_USERS\\") {
+					et.notifications = append(et.notifications, n)
+				}
+				continue
+
 			case *createKeyArgs:
 				if strings.HasPrefix(n.(*createKeyArgs).computedFullPath, "HKEY_USERS\\") {
 					et.notifications = append(et.notifications, n)
-					if len(et.notifications) >= 2 {
-						return
-					}
+					return
 				}
 				continue
 
@@ -165,7 +169,7 @@ func TestETWRegistryNotifications(t *testing.T) {
 
 	assert.Equal(t, 2, len(et.notifications), "expected 2 notifications, got %d", len(et.notifications))
 
-	if c, ok := et.notifications[0].(*createKeyArgs); ok {
+	if c, ok := et.notifications[0].(*openKeyArgs); ok {
 		assert.Equal(t, expectedBase, c.computedFullPath, "expected %s, got %s", expectedBase, c.computedFullPath)
 	} else {
 		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
@@ -173,6 +177,6 @@ func TestETWRegistryNotifications(t *testing.T) {
 	if c, ok := et.notifications[1].(*createKeyArgs); ok {
 		assert.Equal(t, expected, c.computedFullPath, "expected %s, got %s", expected, c.computedFullPath)
 	} else {
-		t.Errorf("expected createHandleArgs, got %T", et.notifications[1])
+		t.Errorf("expected createKeyArgs, got %T", et.notifications[1])
 	}
 }

--- a/pkg/security/probe/probe_kernel_reg_windows_test.go
+++ b/pkg/security/probe/probe_kernel_reg_windows_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -118,7 +117,7 @@ func TestETWRegistryNotifications(t *testing.T) {
 		var once sync.Once
 		mypid := os.Getpid()
 
-		err := et.p.setupEtw(func(n interface{}, pid uint32, _ model.EventType) {
+		err := et.p.setupEtw(func(n interface{}, pid uint32) {
 			once.Do(func() {
 				close(et.etwStarted)
 			})

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -260,7 +260,7 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 					ecb(cka, e.EventHeader.ProcessID, model.CreateRegistryKeyEventType)
 				}
 			case idRegOpenKey:
-				if cka, err := parseCreateRegistryKey(e); err == nil {
+				if cka, err := parseOpenRegistryKey(e); err == nil {
 					log.Debugf("Got idRegOpenKey %s", cka.string())
 					ecb(cka, e.EventHeader.ProcessID, model.OpenRegistryKeyEventType)
 				}
@@ -272,20 +272,20 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 
 				}
 			case idRegFlushKey:
-				if dka, err := parseDeleteRegistryKey(e); err == nil {
+				if dka, err := parseFlushKey(e); err == nil {
 					log.Tracef("Got idRegFlushKey %v", dka.string())
 				}
 			case idRegCloseKey:
-				if dka, err := parseDeleteRegistryKey(e); err == nil {
+				if dka, err := parseCloseKeyArgs(e); err == nil {
 					log.Debugf("Got idRegCloseKey %s", dka.string())
 					delete(regPathResolver, dka.keyObject)
 				}
 			case idQuerySecurityKey:
-				if dka, err := parseDeleteRegistryKey(e); err == nil {
+				if dka, err := parseQuerySecurityKeyArgs(e); err == nil {
 					log.Tracef("Got idQuerySecurityKey %v", dka.keyName)
 				}
 			case idSetSecurityKey:
-				if dka, err := parseDeleteRegistryKey(e); err == nil {
+				if dka, err := parseSetSecurityKeyArgs(e); err == nil {
 					log.Tracef("Got idSetSecurityKey %v", dka.keyName)
 				}
 			case idRegSetValueKey:

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -340,7 +340,7 @@ func (p *WindowsProbe) Start() error {
 						},
 					}
 				case model.OpenRegistryKeyEventType:
-					cka := n.(*createKeyArgs)
+					cka := n.(*openKeyArgs)
 					ev.Type = uint32(model.OpenRegistryKeyEventType)
 					ev.OpenRegistryKey = model.OpenRegistryKeyEvent{
 						Registry: model.RegistryEvent{

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -320,52 +320,47 @@ func (p *WindowsProbe) Start() error {
 				// handle incoming events here
 				// each event will come in as a different type
 				// parse it with
-				switch n.(type) {
+				switch arg := n.(type) {
 				case *createNewFileArgs:
-					cnfa := n.(*createNewFileArgs)
 					ev.Type = uint32(model.CreateNewFileEventType)
 					ev.CreateNewFile = model.CreateNewFileEvent{
 						File: model.FileEvent{
-							PathnameStr: cnfa.fileName,
-							BasenameStr: filepath.Base(cnfa.fileName),
+							PathnameStr: arg.fileName,
+							BasenameStr: filepath.Base(arg.fileName),
 						},
 					}
 				case *createKeyArgs:
-					cka := n.(*createKeyArgs)
 					ev.Type = uint32(model.CreateRegistryKeyEventType)
 					ev.CreateRegistryKey = model.CreateRegistryKeyEvent{
 						Registry: model.RegistryEvent{
-							KeyPath: cka.computedFullPath,
-							KeyName: filepath.Base(cka.computedFullPath),
+							KeyPath: arg.computedFullPath,
+							KeyName: filepath.Base(arg.computedFullPath),
 						},
 					}
 				case *openKeyArgs:
-					cka := n.(*openKeyArgs)
 					ev.Type = uint32(model.OpenRegistryKeyEventType)
 					ev.OpenRegistryKey = model.OpenRegistryKeyEvent{
 						Registry: model.RegistryEvent{
-							KeyPath: cka.computedFullPath,
-							KeyName: filepath.Base(cka.computedFullPath),
+							KeyPath: arg.computedFullPath,
+							KeyName: filepath.Base(arg.computedFullPath),
 						},
 					}
 				case *deleteKeyArgs:
-					dka := n.(*deleteKeyArgs)
 					ev.Type = uint32(model.DeleteRegistryKeyEventType)
 					ev.DeleteRegistryKey = model.DeleteRegistryKeyEvent{
 						Registry: model.RegistryEvent{
-							KeyName: filepath.Base(dka.computedFullPath),
-							KeyPath: dka.computedFullPath,
+							KeyName: filepath.Base(arg.computedFullPath),
+							KeyPath: arg.computedFullPath,
 						},
 					}
 				case *setValueKeyArgs:
-					svka := n.(*setValueKeyArgs)
 					ev.Type = uint32(model.SetRegistryKeyValueEventType)
 					ev.SetRegistryKeyValue = model.SetRegistryKeyValueEvent{
 						Registry: model.RegistryEvent{
-							KeyName: filepath.Base(svka.computedFullPath),
-							KeyPath: svka.computedFullPath,
+							KeyName: filepath.Base(arg.computedFullPath),
+							KeyPath: arg.computedFullPath,
 						},
-						ValueName: svka.valueName,
+						ValueName: arg.valueName,
 					}
 				}
 				if ev.Type != uint32(model.UnknownEventType) {


### PR DESCRIPTION
Updates previous PR.  In previous PR, each file type was given a specific go type, but didn't follow through on registry types.  This completes that operation by providing distinct types for each registry notification.

<!--

### Motivation

completeness

### Additional Notes

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

included automated (kitchen) tests validate change