### PR TITLE
[process-agent] Use the same hostname lookup call when building the hostInfo in the core agent

### DIFF
--- a/pkg/process/checks/host_info_test.go
+++ b/pkg/process/checks/host_info_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	pbmocks "github.com/DataDog/datadog-agent/pkg/proto/pbgo/mocks/core"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
 func TestGetHostname(t *testing.T) {
@@ -81,6 +82,11 @@ func TestGetHostnameFromCmd(t *testing.T) {
 }
 
 func TestInvalidHostname(t *testing.T) {
+	oldFlavor := flavor.GetFlavor()
+	defer flavor.SetFlavor(oldFlavor)
+
+	flavor.SetFlavor(flavor.ProcessAgent)
+
 	cfg := config.Mock(t)
 
 	// Lower the GRPC timeout, otherwise the test will time out in CI


### PR DESCRIPTION
### What does this PR do?
This adds a check when building the hostInfo for the process checks to determine which agent it's being run from. If it's in the core agent then use the common mechanism from the core agent.

### Motivation
The `hostInfo` component reaches out to the core agent to get host information as the process-agent runs from a stand alone agent. We've introduced a change in https://github.com/DataDog/datadog-agent/pull/22824 to allow for running these checks in the core agent. Since the checks now live in the core agent it can no longer get hostname information via gRPC nor does it make sense to as the data is available locally.

### Additional Notes

### Possible Drawbacks / Trade-offs
This uses [pkg/util/hostname](https://github.com/DataDog/datadog-agent/blob/b8e411a70f6ce96cc1384e17040c81a946d67a1c/pkg/util/hostname/providers.go) directly instead of the [hostname.Component
](https://github.com/DataDog/datadog-agent/tree/b8e411a70f6ce96cc1384e17040c81a946d67a1c/comp/core/hostname) 

This isn't ideal as we use shared components and rely on Fx to manage all external dependencies. These will be addressed in follow-ups.

### Describe how to test/QA your changes
- In the datadog.yaml **DO NOT** specify a hostname
- start the core agent
- Validate there is no delay in startup or errors such as
```
2024-02-16 20:57:29 EST | CORE | ERROR | (pkg/process/checks/host_info.go:91 in getHostname) | failed to get hostname from grpc: cannot connect to datadog agent via grpc: context deadline exceeded
```

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided. Except if the `qa/skip-qa` label, with required either `qa/done` or `qa/no-code-change` labels, are applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.

