### PR TITLE
Adding oracle.can_query service check (DBMON-3620)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -10,6 +10,7 @@ package oracle
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -143,6 +144,7 @@ func checkIntervalExpired(lastRun *time.Time, collectionInterval int64) bool {
 
 // Run executes the check.
 func (c *Check) Run() error {
+	var allErrors error
 	if c.db == nil {
 		db, err := c.Connect()
 		if err != nil {
@@ -178,7 +180,7 @@ func (c *Check) Run() error {
 	if dbInstanceIntervalExpired {
 		err := sendDbInstanceMetadata(c)
 		if err != nil {
-			return fmt.Errorf("%s failed to send db instance metadata %w", c.logPrompt, err)
+			allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to send db instance metadata %w", c.logPrompt, err))
 		}
 	}
 
@@ -187,7 +189,7 @@ func (c *Check) Run() error {
 		if c.dbmEnabled {
 			err := c.dataGuard()
 			if err != nil {
-				return err
+				allErrors = errors.Join(allErrors, err)
 			}
 		}
 		fixTags(c)
@@ -203,7 +205,7 @@ func (c *Check) Run() error {
 				handleServiceCheck(c, nil)
 			}
 			closeDatabase(c, db)
-			return fmt.Errorf("%s failed to collect os stats %w", c.logPrompt, err)
+			allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect os stats %w", c.logPrompt, err))
 		} else { //nolint:revive // TODO(DBM) Fix revive linter
 			handleServiceCheck(c, nil)
 		}
@@ -212,25 +214,25 @@ func (c *Check) Run() error {
 			log.Debugf("%s Entered sysmetrics", c.logPrompt)
 			_, err := c.sysMetrics()
 			if err != nil {
-				return fmt.Errorf("%s failed to collect sysmetrics %w", c.logPrompt, err)
+				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect sysmetrics %w", c.logPrompt, err))
 			}
 		}
 		if c.config.Tablespaces.Enabled {
 			err := c.Tablespaces()
 			if err != nil {
-				return fmt.Errorf("%s %w", c.logPrompt, err)
+				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect tablespaces %w", c.logPrompt, err))
 			}
 		}
 		if c.config.ProcessMemory.Enabled || c.config.InactiveSessions.Enabled {
 			err := c.ProcessMemory()
 			if err != nil {
-				return fmt.Errorf("%s %w", c.logPrompt, err)
+				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect process memory %w", c.logPrompt, err))
 			}
 		}
 		if len(c.config.InstanceConfig.CustomQueries) > 0 || len(c.config.InitConfig.CustomQueries) > 0 {
 			err := c.CustomQueries()
 			if err != nil {
-				log.Errorf("%s failed to execute custom queries %s", c.logPrompt, err)
+				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to execute custom queries %w", c.logPrompt, err))
 			}
 		}
 	}
@@ -239,12 +241,12 @@ func (c *Check) Run() error {
 		if c.config.QuerySamples.Enabled {
 			err := c.SampleSession()
 			if err != nil {
-				return fmt.Errorf("%s %w", c.logPrompt, err)
+				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect session samples %w", c.logPrompt, err))
 			}
 			if c.config.QueryMetrics.Enabled {
 				_, err = c.StatementMetrics()
 				if err != nil {
-					return fmt.Errorf("%s %w", c.logPrompt, err)
+					allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect statement metrics %w", c.logPrompt, err))
 				}
 			}
 		}
@@ -252,7 +254,7 @@ func (c *Check) Run() error {
 			if c.config.SharedMemory.Enabled {
 				err := c.SharedMemory()
 				if err != nil {
-					return fmt.Errorf("%s %w", c.logPrompt, err)
+					allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect shared memory %w", c.logPrompt, err))
 				}
 			}
 		}
@@ -261,7 +263,7 @@ func (c *Check) Run() error {
 			if c.config.Asm.Enabled {
 				err := c.asmDiskgroups()
 				if err != nil {
-					return fmt.Errorf("%s %w", c.logPrompt, err)
+					allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect asm diskgroups %w", c.logPrompt, err))
 				}
 			}
 		}
@@ -270,13 +272,13 @@ func (c *Check) Run() error {
 			if c.config.ResourceManager.Enabled {
 				err := c.resourceManager()
 				if err != nil {
-					return fmt.Errorf("%s %w", c.logPrompt, err)
+					allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect resource manager %w", c.logPrompt, err))
 				}
 			}
 			if c.config.Locks.Enabled {
 				err := c.locks()
 				if err != nil {
-					return fmt.Errorf("%s %w", c.logPrompt, err)
+					allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect locks %w", c.logPrompt, err))
 				}
 			}
 		}
@@ -294,7 +296,18 @@ func (c *Check) Run() error {
 			c.db.SetMaxOpenConns(MAX_OPEN_CONNECTIONS)
 		}
 	}
-	return nil
+
+	var message string
+	var status servicecheck.ServiceCheckStatus
+	if allErrors == nil {
+		status = servicecheck.ServiceCheckOK
+	} else {
+		status = servicecheck.ServiceCheckCritical
+		message = allErrors.Error()
+	}
+	sendServiceCheck(c, "oracle.can_query", status, message)
+	commit(c)
+	return allErrors
 }
 
 func assertBool(val bool) bool {

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -55,6 +55,8 @@ const (
 	MaxSQLFullTextVSQLStats = 1000
 )
 
+const serviceCheckName = "oracle.can_query"
+
 type hostingCode string
 
 const (

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -307,7 +307,7 @@ func (c *Check) Run() error {
 		status = servicecheck.ServiceCheckCritical
 		message = allErrors.Error()
 	}
-	sendServiceCheck(c, "oracle.can_query", status, message)
+	sendServiceCheck(c, serviceCheckName, status, message)
 	commit(c)
 	return allErrors
 }

--- a/pkg/collector/corechecks/oracle-dbm/sender_util.go
+++ b/pkg/collector/corechecks/oracle-dbm/sender_util.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
@@ -75,4 +76,23 @@ func sendMetric(c *Check, method metricType, metric string, value float64, tags 
 
 func sendMetricWithDefaultTags(c *Check, method metricType, metric string, value float64) {
 	sendMetric(c, method, metric, value, c.tags)
+}
+
+func sendServiceCheck(c *Check, service string, status servicecheck.ServiceCheckStatus, message string) {
+	sender, err := c.GetSender()
+	if err != nil {
+		log.Errorf("%s failed to get metric sender %s", err)
+		return
+	}
+
+	sender.ServiceCheck("oracle.can_query", status, c.dbHostname, c.tags, message)
+}
+
+func commit(c *Check) {
+	sender, err := c.GetSender()
+	if err != nil {
+		log.Errorf("%s failed to get metric sender %s", err)
+		return
+	}
+	sender.Commit()
 }

--- a/pkg/collector/corechecks/oracle-dbm/sender_util.go
+++ b/pkg/collector/corechecks/oracle-dbm/sender_util.go
@@ -85,7 +85,7 @@ func sendServiceCheck(c *Check, service string, status servicecheck.ServiceCheck
 		return
 	}
 
-	sender.ServiceCheck("oracle.can_query", status, c.dbHostname, c.tags, message)
+	sender.ServiceCheck(service, status, c.dbHostname, c.tags, message)
 }
 
 func commit(c *Check) {

--- a/releasenotes/notes/oracle-can-query-c82d891454d06bfe.yaml
+++ b/releasenotes/notes/oracle-can-query-c82d891454d06bfe.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [oracle] Adding `oracle.can_query` service check.

--- a/releasenotes/notes/oracle-can-query-c82d891454d06bfe.yaml
+++ b/releasenotes/notes/oracle-can-query-c82d891454d06bfe.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    [oracle] Adding `oracle.can_query` service check.
+    [oracle] Adds `oracle.can_query` service check.


### PR DESCRIPTION
### What does this PR do?

Adding `oracle.can_query` service check.

### Motivation

Compatibility with the old Oracle integration written in Python.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Check on monitors if `can_query` appears.