### PR TITLE
[windows] convert IPC to named pipes.

### DIFF
--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -253,7 +253,7 @@ func newSystemProbe(path string) *RemoteSysProbeUtil {
 				MaxIdleConns:    2,
 				IdleConnTimeout: 30 * time.Second,
 				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial(netType, path)
+					return dialFunc(path)
 				},
 				TLSHandshakeTimeout:   1 * time.Second,
 				ResponseHeaderTimeout: 5 * time.Second,

--- a/pkg/process/net/common_linux.go
+++ b/pkg/process/net/common_linux.go
@@ -36,3 +36,7 @@ func CheckPath(path string) error {
 	}
 	return nil
 }
+
+func dialFunc(path string) (net.Conn, error) {
+	return net.Dial(netType, path)
+}

--- a/pkg/process/net/common_unsupported.go
+++ b/pkg/process/net/common_unsupported.go
@@ -63,3 +63,9 @@ func (r *RemoteSysProbeUtil) Register(clientID string) error {
 func (r *RemoteSysProbeUtil) DetectLanguage([]int32) ([]languagemodels.Language, error) {
 	return nil, ErrNotImplemented
 }
+
+
+
+func dialFunc(path string) (net.Conn, error) {
+	nil, ErrNotImplemented
+}

--- a/pkg/process/net/common_windows.go
+++ b/pkg/process/net/common_windows.go
@@ -9,8 +9,10 @@ package net
 
 import (
 	"fmt"
+	"net"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/Microsoft/go-winio"
 )
 
 const (
@@ -32,4 +34,8 @@ func CheckPath(path string) error {
 		return fmt.Errorf("socket path is empty")
 	}
 	return nil
+}
+
+func dialFunc(_ string) (net.Conn, error) {
+	return winio.DialPipe(`\\.\pipe\datadog-system-probe`, nil)
 }

--- a/pkg/process/net/windows_pipe.go
+++ b/pkg/process/net/windows_pipe.go
@@ -9,6 +9,8 @@ package net
 
 import (
 	"net"
+
+	"github.com/Microsoft/go-winio"
 )
 
 // WindowsPipeListener for communicating with Probe
@@ -17,9 +19,15 @@ type WindowsPipeListener struct {
 	pipePath string
 }
 
+const maxGRPCServerMessage = 100 * 1024 * 1024
+
 // NewListener sets up a TCP listener for now, will eventually be a named pipe
-func NewListener(socketAddr string) (*WindowsPipeListener, error) {
-	l, err := net.Listen("tcp", socketAddr)
+func NewListener(_ string) (*WindowsPipeListener, error) {
+	pc := winio.PipeConfig{
+		InputBufferSize:  int32(maxGRPCServerMessage),
+		OutputBufferSize: int32(maxGRPCServerMessage),
+	}
+	l, err := winio.ListenPipe(`\\.\pipe\datadog-system-probe`, &pc)
 	return &WindowsPipeListener{l, "path"}, err
 }
 

--- a/pkg/security/probe/probe_kernel_reg_windows_test.go
+++ b/pkg/security/probe/probe_kernel_reg_windows_test.go
@@ -165,7 +165,7 @@ func TestETWRegistryNotifications(t *testing.T) {
 	stopLoop(et, &wg)
 
 	assert.Equal(t, 2, len(et.notifications), "expected 2 notifications, got %d", len(et.notifications))
-	
+
 	if c, ok := et.notifications[0].(*createKeyArgs); ok {
 		assert.Equal(t, expectedBase, c.computedFullPath, "expected %s, got %s", expectedBase, c.computedFullPath)
 	} else {


### PR DESCRIPTION
First commit: change process agent <-> system probe communication to use named pipes.


### Motivation

Change ipc transport to named pipes instead of localhost tcp connections.
Prevents port collisions.

### Additional Notes


### Possible Drawbacks / Trade-offs

Due to switch to named pipes, can no longer use curl/wget/iwr to connect to system probe endpoint for debugging.

### Describe how to test/QA your changes

- install build, enable npm and/or usm
- ensure process agent can still communicate with system probe
  - no errors in logs indicating problem at startup
  - logs indicate successful retrieval of connection informatoin.