### PR TITLE
Revert "[process-agent] Use the same hostname lookup call when building the hostInfo in the core agent"

### DIFF
--- a/pkg/process/checks/host_info.go
+++ b/pkg/process/checks/host_info.go
@@ -20,9 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	ddgrpc "github.com/DataDog/datadog-agent/pkg/util/grpc"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -65,15 +63,6 @@ func resolveHostName(config config.Reader) (string, error) {
 		agentBin := config.GetString("process_config.dd_agent_bin")
 		connectionTimeout := config.GetDuration("process_config.grpc_connection_timeout_secs") * time.Second
 		var err error
-		// TODO: We should migrate to the common hostname component
-		if flavor.GetFlavor() == flavor.DefaultAgent {
-			hostName, err = hostname.Get(context.TODO())
-			if err != nil {
-				return "", fmt.Errorf("error while getting hostname: %v", err)
-			}
-			return hostName, nil
-		}
-
 		hostName, err = getHostname(context.Background(), agentBin, connectionTimeout)
 		if err != nil {
 			return "", log.Errorf("cannot get hostname: %v", err)

--- a/pkg/process/checks/host_info_test.go
+++ b/pkg/process/checks/host_info_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	pbmocks "github.com/DataDog/datadog-agent/pkg/proto/pbgo/mocks/core"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
 func TestGetHostname(t *testing.T) {
@@ -82,11 +81,6 @@ func TestGetHostnameFromCmd(t *testing.T) {
 }
 
 func TestInvalidHostname(t *testing.T) {
-	oldFlavor := flavor.GetFlavor()
-	defer flavor.SetFlavor(oldFlavor)
-
-	flavor.SetFlavor(flavor.ProcessAgent)
-
 	cfg := config.Mock(t)
 
 	// Lower the GRPC timeout, otherwise the test will time out in CI


### PR DESCRIPTION
Reverts DataDog/datadog-agent#22941