### PR TITLE
system-probe: allow building and loading config on darwin

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -48,11 +48,6 @@ func New(configPath string) (*types.Config, error) {
 }
 
 func newSysprobeConfig(configPath string) (*types.Config, error) {
-	// System probe is not supported on darwin, so we should fail gracefully in this case.
-	if runtime.GOOS == "darwin" {
-		return &types.Config{}, nil
-	}
-
 	aconfig.SystemProbe.SetConfigName("system-probe")
 	// set the paths where a config file is expected
 	if len(configPath) != 0 {

--- a/cmd/system-probe/config/config_darwin.go
+++ b/cmd/system-probe/config/config_darwin.go
@@ -3,21 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !unix && !windows
+//go:build darwin
 
 package config
-
-import "fmt"
-
-const (
-	defaultConfigDir          = ""
-	defaultSystemProbeAddress = ""
-)
-
-// ValidateSocketAddress validates that the sysprobe socket config option is of the correct format.
-func ValidateSocketAddress(sockPath string) error { //nolint:revive // TODO fix revive unused-parameter
-	return fmt.Errorf("system-probe unsupported")
-}
 
 // ProcessEventDataStreamSupported returns true if process event data stream is supported
 func ProcessEventDataStreamSupported() bool {

--- a/cmd/system-probe/config/config_linux.go
+++ b/cmd/system-probe/config/config_linux.go
@@ -8,27 +8,9 @@
 package config
 
 import (
-	"fmt"
-	"path/filepath"
-
 	ebpfkernel "github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-const (
-	// defaultSystemProbeAddress is the default unix socket path to be used for connecting to the system probe
-	defaultSystemProbeAddress = "/opt/datadog-agent/run/sysprobe.sock"
-
-	defaultConfigDir = "/etc/datadog-agent"
-)
-
-// ValidateSocketAddress validates that the sysprobe socket config option is of the correct format.
-func ValidateSocketAddress(sockPath string) error {
-	if !filepath.IsAbs(sockPath) {
-		return fmt.Errorf("socket path must be an absolute file path: `%s`", sockPath)
-	}
-	return nil
-}
 
 // ProcessEventDataStreamSupported returns true if process event data stream is supported
 func ProcessEventDataStreamSupported() bool {

--- a/cmd/system-probe/config/config_unix.go
+++ b/cmd/system-probe/config/config_unix.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build unix
+
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+const (
+	// defaultSystemProbeAddress is the default unix socket path to be used for connecting to the system probe
+	defaultSystemProbeAddress = "/opt/datadog-agent/run/sysprobe.sock"
+
+	defaultConfigDir = "/etc/datadog-agent"
+)
+
+// ValidateSocketAddress validates that the sysprobe socket config option is of the correct format.
+func ValidateSocketAddress(sockPath string) error {
+	if !filepath.IsAbs(sockPath) {
+		return fmt.Errorf("socket path must be an absolute file path: `%s`", sockPath)
+	}
+	return nil
+}

--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build unix
 
 // Package main is the entrypoint for system-probe process
 package main

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -8,6 +8,7 @@ package checks
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sort"
 	"time"
 
@@ -110,6 +111,11 @@ func (c *ConnectionsCheck) Init(syscfg *SysProbeConfig, hostInfo *HostInfo, _ bo
 
 // IsEnabled returns true if the check is enabled by configuration
 func (c *ConnectionsCheck) IsEnabled() bool {
+	// connection check is not supported on darwin, so we should fail gracefully in this case.
+	if runtime.GOOS == "darwin" {
+		return false
+	}
+
 	_, npmModuleEnabled := c.syscfg.EnabledModules[sysconfig.NetworkTracerModule]
 	return npmModuleEnabled && c.syscfg.Enabled
 }

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -54,6 +54,7 @@ EMBEDDED_SHARE_DIR = os.path.join("/opt", "datadog-agent", "embedded", "share", 
 EMBEDDED_SHARE_JAVA_DIR = os.path.join("/opt", "datadog-agent", "embedded", "share", "system-probe", "java")
 
 is_windows = sys.platform == "win32"
+is_macos = sys.platform == "darwin"
 
 arch_mapping = {
     "amd64": "x64",
@@ -524,15 +525,16 @@ def build(
     """
     Build the system-probe
     """
-    build_object_files(
-        ctx,
-        major_version=major_version,
-        arch=arch,
-        kernel_release=kernel_release,
-        debug=debug,
-        strip_object_files=strip_object_files,
-        with_unit_test=with_unit_test,
-    )
+    if not is_macos:
+        build_object_files(
+            ctx,
+            major_version=major_version,
+            arch=arch,
+            kernel_release=kernel_release,
+            debug=debug,
+            strip_object_files=strip_object_files,
+            with_unit_test=with_unit_test,
+        )
 
     build_sysprobe_binary(
         ctx,


### PR DESCRIPTION
### What does this PR do?

This PR allows building the system probe on macOS (it can't do much yet but it builds):
```
inv -e system-probe.build --no-bundle
```

and removes most restrictions to linux by moving what can be to unix tags (`unix` is basically equals to `linux + darwin`), and allows the config to be loaded on darwin. 


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
