### PR TITLE
CI: don't wait for a downstream pipeline with manual jobs only

### DIFF
--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -28,7 +28,8 @@
       --variable RELEASE_PRODUCT
       --variable RELEASE_VERSION
       --variable TARGET_REPO
-      --variable TARGET_REPO_BRANCH'
+      --variable TARGET_REPO_BRANCH
+      $NO_FOLLOW'
   dependencies: []
 
 trigger_auto_staging_release:
@@ -46,5 +47,8 @@ trigger_manual_prod_release:
   variables:
     AUTO_RELEASE: "false"
     TARGET_REPO: prod
+    # The jobs in the downstream pipeline will all be manual, so following
+    # the created pipeline would likely cause this job to timeout
+    NO_FOLLOW: '--no-follow'
   rules:
     !reference [.on_deploy_stable_or_beta_manual_auto_on_stable]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR stops waiting for a downstream pipeline with manual jobs only, as it's extremely likely to timeout

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

7.51 final pipeline failed due to this job timing out:
Main pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/28327292
Trigger job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/434524970
release management pipeline: https://gitlab.ddbuild.io/DataDog/agent-release-management/-/pipelines/28333562

The release management pipeline was correctly created but no jobs were started, so the initial pipeline failed by timing out after 2 hours

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
