### PR TITLE
Upgrade chef cookbook to 4.19.0

### DIFF
--- a/test/kitchen/Berksfile
+++ b/test/kitchen/Berksfile
@@ -1,6 +1,6 @@
 source 'https://supermarket.chef.io'
 
-cookbook 'datadog', '~> 4.18.0'
+cookbook 'datadog', '~> 4.19.0'
 
 # We pin an old version of the apt cookbook because this cookbook triggers an "apt update" by default
 # and in newer versions this update is not allowed to fail, while in 3.X it is. For some reason


### PR DESCRIPTION
### What does this PR do?

Upgrades chef cookbook used in the legacy chef tests to 4.19.0.