### PR TITLE
Add the oracle.process.pga_maximum_memory metric (DBMON-3621)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/processes.go
+++ b/pkg/collector/corechecks/oracle-dbm/processes.go
@@ -109,6 +109,8 @@ func (c *Check) ProcessMemory() error {
 			sendMetric(c, gauge, fmt.Sprintf("%s.process.pga_allocated_memory", common.IntegrationName), r.PGAAllocMem, tags)
 			sendMetric(c, gauge, fmt.Sprintf("%s.process.pga_freeable_memory", common.IntegrationName), r.PGAFreeableMem, tags)
 			sendMetric(c, gauge, fmt.Sprintf("%s.process.pga_max_memory", common.IntegrationName), r.PGAMaxMem, tags)
+			// we send pga_maximum_memory for backward compatibility with the old Oracle integration
+			sendMetric(c, gauge, fmt.Sprintf("%s.process.pga_maximum_memory", common.IntegrationName), r.PGAMaxMem, tags)
 		}
 
 		if c.config.InactiveSessions.Enabled && r.Status.Valid && r.Status.String == "INACTIVE" && r.LastCallEt.Valid {

--- a/releasenotes/notes/oracle-pga-maximum-894061dc4c754d75.yaml
+++ b/releasenotes/notes/oracle-pga-maximum-894061dc4c754d75.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add the ``oracle.process.pga_maximum_memory`` metric for backward compatibility.

--- a/releasenotes/notes/oracle-pga-maximum-894061dc4c754d75.yaml
+++ b/releasenotes/notes/oracle-pga-maximum-894061dc4c754d75.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    [oracle] Add the ``oracle.process.pga_maximum_memory`` metric for backward compatibility.
+    [oracle] Adds the ``oracle.process.pga_maximum_memory`` metric for backward compatibility.

--- a/releasenotes/notes/oracle-pga-maximum-894061dc4c754d75.yaml
+++ b/releasenotes/notes/oracle-pga-maximum-894061dc4c754d75.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Add the ``oracle.process.pga_maximum_memory`` metric for backward compatibility.
+    [oracle] Add the ``oracle.process.pga_maximum_memory`` metric for backward compatibility.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adding the `oracle.process.pga_maximum_memory` metric.

### Motivation

Backward compatibility with the old Oracle integration. 

### Possible Drawbacks / Trade-offs

Now the agent emits two metrics with the same value: `oracle.process.pga_maximum_memory` and `oracle.process.pga_max_memory`. This is less bad than introducing a breaking change.

### Describe how to test/QA your changes

Check if the metric `oracle.process.pga_maximum_memory` is emitted.