### PR TITLE
[oracle] Default metric_prefix (DBMON-3622)

### DIFF
--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -234,7 +234,7 @@ instances:
   ## @param custom_queries - list of mappings - optional
   ## Each query must have 2 fields, and can have a third optional field:
   ##
-  ## 1. metric_prefix - Each metric starts with the chosen prefix. Default is `oracle`.
+  ## 1. metric_prefix - Each metric starts with the chosen prefix. The default is `oracle`.
   ## 2. query - The SQL to execute. It can be a simple statement or a multi-line script.
   ##            Use the pipe `|` if you require a multi-line script.
   ## 3. columns - The list representing each column, ordered sequentially from left to right.

--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -234,7 +234,7 @@ instances:
   ## @param custom_queries - list of mappings - optional
   ## Each query must have 2 fields, and can have a third optional field:
   ##
-  ## 1. metric_prefix - Each metric starts with the chosen prefix.
+  ## 1. metric_prefix - Each metric starts with the chosen prefix. Default is `oracle`.
   ## 2. query - The SQL to execute. It can be a simple statement or a multi-line script.
   ##            Use the pipe `|` if you require a multi-line script.
   ## 3. columns - The list representing each column, ordered sequentially from left to right.
@@ -256,7 +256,7 @@ instances:
   ## WARNING: Running custom queries may result in additional costs or fees assessed by Oracle.
   #
   # custom_queries:
-  #   - metric_prefix: oracle.custom_query
+  #   - metric_prefix: oracle
   #     query: SELECT 'foo', 11 FROM dual
   #     columns:
   #     - name: foo

--- a/pkg/collector/corechecks/oracle-dbm/custom_queries.go
+++ b/pkg/collector/corechecks/oracle-dbm/custom_queries.go
@@ -84,8 +84,7 @@ func (c *Check) CustomQueries() error {
 		metricPrefix := q.MetricPrefix
 
 		if metricPrefix == "" {
-			allErrors = concatenateError(allErrors, "Undefined metric_prefix for a custom query")
-			continue
+			metricPrefix = "oracle"
 		}
 		log.Debugf("%s custom query configuration %v", c.logPrompt, q)
 		var pdb string

--- a/releasenotes/notes/oracle-default-metric-prefix-b309821f0f5dddd3.yaml
+++ b/releasenotes/notes/oracle-default-metric-prefix-b309821f0f5dddd3.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    [oracle] Set default for ``metric_prefix`` in ``custom_queries`` to ``oracle``.
+    [oracle] Set the default for ``metric_prefix`` in ``custom_queries`` to ``oracle``.

--- a/releasenotes/notes/oracle-default-metric-prefix-b309821f0f5dddd3.yaml
+++ b/releasenotes/notes/oracle-default-metric-prefix-b309821f0f5dddd3.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    [oracle] Set default for ``metric_prefix`` in ``custom_queries`` to ``oracle``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Set default for `metric_prefix` in `custom_queries` to `oracle`.

### Motivation

Compatibility with the old Python integration.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Describe how to test/QA your changes

Don't set `metric_prefix` for and custom query and check if the metric is being emitted.