### PR TITLE
[USM] Fix verifier issue in kernel 6.5

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -13,10 +13,10 @@
 #define HTTP2_MAX_FRAMES_FOR_EOS_PARSER (HTTP2_MAX_FRAMES_FOR_EOS_PARSER_PER_TAIL_CALL * HTTP2_MAX_TAIL_CALLS_FOR_EOS_PARSER)
 
 // Represents the maximum number of frames we'll process in a single tail call in `handle_headers_frames` program.
-#define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL 19
+#define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL 18
 // Represents the maximum number of tail calls to process headers frames.
-// Currently we have up to 240 frames in a packet, thus 13 (13*19 = 247) tail calls is enough.
-#define HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER 13
+// Currently we have up to 240 frames in a packet, thus 14 (14*18 = 252) tail calls is enough.
+#define HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER 14
 #define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER (HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL * HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER)
 // Maximum number of frames to be processed in a single tail call.
 #define HTTP2_MAX_FRAMES_ITERATIONS 240

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -370,3 +370,19 @@ func testHTTPSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, s
 		})
 	}
 }
+
+func TestFullMonitorWithTracer(t *testing.T) {
+	cfg := config.New()
+	cfg.EnableHTTPMonitoring = true
+	cfg.EnableHTTP2Monitoring = true
+	cfg.EnableKafkaMonitoring = true
+	cfg.EnableNativeTLSMonitoring = true
+	cfg.EnableIstioMonitoring = true
+	cfg.EnableGoTLSSupport = true
+
+	tr, err := NewTracer(cfg)
+	require.NoError(t, err)
+	t.Cleanup(tr.Stop)
+
+	initTracerState(t, tr)
+}

--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -4,6 +4,7 @@
         "ubuntu_16.04": "master/ubuntu-16-x86_64.qcow2.xz",
         "ubuntu_18.04": "master/ubuntu-18-x86_64.qcow2.xz",
         "ubuntu_20.04": "master/ubuntu-20-x86_64.qcow2.xz",
+        "ubuntu_22.04": "master/ubuntu-22-x86_64.qcow2.xz",
         "ubuntu_23.10": "master/ubuntu-23-x86_64.qcow2.xz",
         "amzn_4.14":    "master/amzn2-kvm-2.0-x86_64-4.14.qcow2.xz",
         "amzn_5.4":     "master/amzn2-kvm-2.0-x86_64-5.4.qcow2.xz",
@@ -19,6 +20,7 @@
     "arm64": {
         "ubuntu_18.04": "master/ubuntu-18-arm64.qcow2.xz",
         "ubuntu_20.04": "master/ubuntu-20-arm64.qcow2.xz",
+        "ubuntu_22.04": "master/ubuntu-22-arm64.qcow2.xz",
         "ubuntu_23.10": "master/ubuntu-23-arm64.qcow2.xz",
         "amzn_4.14":    "master/amzn2-kvm-2.0-arm64-4.14.qcow2.xz",
         "amzn_5.4":     "master/amzn2-kvm-2.0-arm64-5.4.qcow2.xz",

--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -4,7 +4,7 @@
         "ubuntu_16.04": "master/ubuntu-16-x86_64.qcow2.xz",
         "ubuntu_18.04": "master/ubuntu-18-x86_64.qcow2.xz",
         "ubuntu_20.04": "master/ubuntu-20-x86_64.qcow2.xz",
-        "ubuntu_22.04": "master/ubuntu-22-x86_64.qcow2.xz",
+        "ubuntu_22.04": "usama.saqib/ubuntu22-with-6.5/ubuntu-22-x86_64.qcow2.xz",
         "ubuntu_23.10": "master/ubuntu-23-x86_64.qcow2.xz",
         "amzn_4.14":    "master/amzn2-kvm-2.0-x86_64-4.14.qcow2.xz",
         "amzn_5.4":     "master/amzn2-kvm-2.0-x86_64-5.4.qcow2.xz",
@@ -20,7 +20,7 @@
     "arm64": {
         "ubuntu_18.04": "master/ubuntu-18-arm64.qcow2.xz",
         "ubuntu_20.04": "master/ubuntu-20-arm64.qcow2.xz",
-        "ubuntu_22.04": "master/ubuntu-22-arm64.qcow2.xz",
+        "ubuntu_22.04": "usama.saqib/ubuntu22-with-6.5/ubuntu-22-arm64.qcow2.xz",
         "ubuntu_23.10": "master/ubuntu-23-arm64.qcow2.xz",
         "amzn_4.14":    "master/amzn2-kvm-2.0-arm64-4.14.qcow2.xz",
         "amzn_5.4":     "master/amzn2-kvm-2.0-arm64-5.4.qcow2.xz",

--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -4,7 +4,6 @@
         "ubuntu_16.04": "master/ubuntu-16-x86_64.qcow2.xz",
         "ubuntu_18.04": "master/ubuntu-18-x86_64.qcow2.xz",
         "ubuntu_20.04": "master/ubuntu-20-x86_64.qcow2.xz",
-        "ubuntu_22.04": "usama.saqib/ubuntu22-with-6.5/ubuntu-22-x86_64.qcow2.xz",
         "ubuntu_23.10": "master/ubuntu-23-x86_64.qcow2.xz",
         "amzn_4.14":    "master/amzn2-kvm-2.0-x86_64-4.14.qcow2.xz",
         "amzn_5.4":     "master/amzn2-kvm-2.0-x86_64-5.4.qcow2.xz",
@@ -20,7 +19,6 @@
     "arm64": {
         "ubuntu_18.04": "master/ubuntu-18-arm64.qcow2.xz",
         "ubuntu_20.04": "master/ubuntu-20-arm64.qcow2.xz",
-        "ubuntu_22.04": "usama.saqib/ubuntu22-with-6.5/ubuntu-22-arm64.qcow2.xz",
         "ubuntu_23.10": "master/ubuntu-23-arm64.qcow2.xz",
         "amzn_4.14":    "master/amzn2-kvm-2.0-arm64-4.14.qcow2.xz",
         "amzn_5.4":     "master/amzn2-kvm-2.0-arm64-5.4.qcow2.xz",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fixes verifier issue with kernel 6.5 for HTTP/2 decoding.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We have identified a verifier issue caused by the maximum `HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL` in kernel version 6.5. This PR fixes the issue on those kernel versions.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
