### PR TITLE
[CONTINT-3830] Fix CollectorHTML template

### DIFF
--- a/pkg/status/collector/fixtures/status_info.html
+++ b/pkg/status/collector/fixtures/status_info.html
@@ -1,0 +1,89 @@
+
+  <div class="stat">
+    <span class="stat_title">Error initializing Python</span>
+    <span class="stat_data">
+    <span class="stat_subdata">
+        could not initialize rtloader: could not import base class: No module named &#39;datadog_checks&#39;</span>
+    
+    </span></div>
+
+<div class="stat">
+  <span class="stat_title">Running Checks</span>
+  <span class="stat_data">
+        
+        <span class="stat_subtitle">cpu</span>
+          <span class="stat_subdata">
+              Instance ID: cpu [<span class="ok">OK</span>]<br>
+              Total Runs: 1<br>
+              Metric Samples: 1, Total: 1<br>
+              Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>Average Execution Time : 1ms<br>
+              Last Execution Date : 2024-02-20 10:27:30 UTC (1708424850000)<br>
+              Last Successful Execution Date : 2024-02-20 10:27:30 UTC (1708424850000)<br></span>
+        
+        
+        <span class="stat_subtitle">file_handle</span>
+          <span class="stat_subdata">
+              Instance ID: file_handle [<span class="ok">OK</span>]<br>
+              Total Runs: 1<br>
+              Metric Samples: 2, Total: 2<br>
+              Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>Average Execution Time : 0s<br>
+              Last Execution Date : 2024-02-20 10:27:34 UTC (1708424854000)<br>
+              Last Successful Execution Date : 2024-02-20 10:27:34 UTC (1708424854000)<br></span>
+        
+        
+        <span class="stat_subtitle">ntp</span>
+          <span class="stat_subdata">
+              Instance ID: ntp:3c427a42a70bbf8 [<span class="ok">OK</span>]<br>
+              Total Runs: 1<br>
+              Metric Samples: 1, Total: 1<br>
+              Events: 0, Total: 0<br>Service Checks: 1, Total: 1<br>Average Execution Time : 579ms<br>
+              Last Execution Date : 2024-02-20 10:27:33 UTC (1708424853000)<br>
+              Last Successful Execution Date : 2024-02-20 10:27:33 UTC (1708424853000)<br></span>
+        
+        
+        <span class="stat_subtitle">telemetry</span>
+          <span class="stat_subdata">
+              Instance ID: telemetry [<span class="ok">OK</span>]<br>
+              Total Runs: 1<br>
+              Metric Samples: 2, Total: 2<br>
+              Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>Average Execution Time : 0s<br>
+              Last Execution Date : 2024-02-20 10:27:35 UTC (1708424855000)<br>
+              Last Successful Execution Date : 2024-02-20 10:27:35 UTC (1708424855000)<br></span>
+        <span/>
+</div>
+    <div class="stat">
+      <span class="stat_title">Loading Errors</span>
+      <span class="stat_data">
+          <span class="stat_subtitle">apm</span>
+          <span class="stat_subdata">
+                <b>Core Check Loader</b>: Could not configure check APM Agent: Can&#39;t access the default apm binary at /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: stat /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: no such file or directory<br>
+              
+                <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
+              
+                <b>Python Check Loader</b>: unable to import module &#39;apm&#39;: No module named &#39;apm&#39;<br></span>
+        
+          <span class="stat_subtitle">network</span>
+          <span class="stat_subdata">
+                <b>Core Check Loader</b>: Check network not found in Catalog<br>
+              
+                <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
+              
+                <b>Python Check Loader</b>: unable to import module &#39;network&#39;: No module named &#39;network&#39;<br></span>
+        
+          <span class="stat_subtitle">process_agent</span>
+          <span class="stat_subdata">
+                <b>Core Check Loader</b>: Could not configure check Process Agent: Can&#39;t access the default process-agent binary at /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/process-agent<br>
+              
+                <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
+              
+                <b>Python Check Loader</b>: unable to import module &#39;process_agent&#39;: No module named &#39;process_agent&#39;<br></span>
+        
+          <span class="stat_subtitle">winproc</span>
+          <span class="stat_subdata">
+                <b>Core Check Loader</b>: Check winproc not found in Catalog<br>
+              
+                <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
+              
+                <b>Python Check Loader</b>: unable to import module &#39;winproc&#39;: No module named &#39;winproc&#39;<br></span>
+        </span>
+    </div>

--- a/pkg/status/collector/fixtures/status_info.html
+++ b/pkg/status/collector/fixtures/status_info.html
@@ -4,13 +4,13 @@
     <span class="stat_data">
     <span class="stat_subdata">
         could not initialize rtloader: could not import base class: No module named &#39;datadog_checks&#39;</span>
-
+    
     </span></div>
 
 <div class="stat">
   <span class="stat_title">Running Checks</span>
   <span class="stat_data">
-
+        
         <span class="stat_subtitle">cpu</span>
           <span class="stat_subdata">
               Instance ID: cpu [<span class="ok">OK</span>]<br>
@@ -19,8 +19,8 @@
               Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>Average Execution Time : 1ms<br>
               Last Execution Date : 2024-02-20 10:27:30 UTC (1708424850000)<br>
               Last Successful Execution Date : 2024-02-20 10:27:30 UTC (1708424850000)<br></span>
-
-
+        
+        
         <span class="stat_subtitle">file_handle</span>
           <span class="stat_subdata">
               Instance ID: file_handle [<span class="ok">OK</span>]<br>
@@ -29,18 +29,16 @@
               Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>Average Execution Time : 0s<br>
               Last Execution Date : 2024-02-20 10:27:34 UTC (1708424854000)<br>
               Last Successful Execution Date : 2024-02-20 10:27:34 UTC (1708424854000)<br></span>
-
-
+        
+        
         <span class="stat_subtitle">ntp</span>
           <span class="stat_subdata">
               Instance ID: ntp:3c427a42a70bbf8 [<span class="ok">OK</span>]<br>
-              Total Runs: 1<br>
-              Metric Samples: 1, Total: 1<br>
-              Events: 0, Total: 0<br>Service Checks: 1, Total: 1<br>Average Execution Time : 579ms<br>
-              Last Execution Date : 2024-02-20 10:27:33 UTC (1708424853000)<br>
-              Last Successful Execution Date : 2024-02-20 10:27:33 UTC (1708424853000)<br></span>
-
-
+              Long Running Check: true<br>
+              Total Metrics Samples: 1<br>
+              Total Events: 0<br>Total Service Checks: 1<br></span>
+        
+        
         <span class="stat_subtitle">telemetry</span>
           <span class="stat_subdata">
               Instance ID: telemetry [<span class="ok">OK</span>]<br>
@@ -57,33 +55,33 @@
           <span class="stat_subtitle">apm</span>
           <span class="stat_subdata">
                 <b>Core Check Loader</b>: Could not configure check APM Agent: Can&#39;t access the default apm binary at /Users/datadog/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: stat /Users/datadog/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: no such file or directory<br>
-
+              
                 <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
-
+              
                 <b>Python Check Loader</b>: unable to import module &#39;apm&#39;: No module named &#39;apm&#39;<br></span>
-
+        
           <span class="stat_subtitle">network</span>
           <span class="stat_subdata">
                 <b>Core Check Loader</b>: Check network not found in Catalog<br>
-
+              
                 <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
-
+              
                 <b>Python Check Loader</b>: unable to import module &#39;network&#39;: No module named &#39;network&#39;<br></span>
-
+        
           <span class="stat_subtitle">process_agent</span>
           <span class="stat_subdata">
                 <b>Core Check Loader</b>: Could not configure check Process Agent: Can&#39;t access the default process-agent binary at /Users/datadog/go/src/github.com/DataDog/datadog-agent/embedded/bin/process-agent<br>
-
+              
                 <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
-
+              
                 <b>Python Check Loader</b>: unable to import module &#39;process_agent&#39;: No module named &#39;process_agent&#39;<br></span>
-
+        
           <span class="stat_subtitle">winproc</span>
           <span class="stat_subdata">
                 <b>Core Check Loader</b>: Check winproc not found in Catalog<br>
-
+              
                 <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
-
+              
                 <b>Python Check Loader</b>: unable to import module &#39;winproc&#39;: No module named &#39;winproc&#39;<br></span>
         </span>
     </div>

--- a/pkg/status/collector/fixtures/status_info.html
+++ b/pkg/status/collector/fixtures/status_info.html
@@ -4,13 +4,13 @@
     <span class="stat_data">
     <span class="stat_subdata">
         could not initialize rtloader: could not import base class: No module named &#39;datadog_checks&#39;</span>
-    
+
     </span></div>
 
 <div class="stat">
   <span class="stat_title">Running Checks</span>
   <span class="stat_data">
-        
+
         <span class="stat_subtitle">cpu</span>
           <span class="stat_subdata">
               Instance ID: cpu [<span class="ok">OK</span>]<br>
@@ -19,8 +19,8 @@
               Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>Average Execution Time : 1ms<br>
               Last Execution Date : 2024-02-20 10:27:30 UTC (1708424850000)<br>
               Last Successful Execution Date : 2024-02-20 10:27:30 UTC (1708424850000)<br></span>
-        
-        
+
+
         <span class="stat_subtitle">file_handle</span>
           <span class="stat_subdata">
               Instance ID: file_handle [<span class="ok">OK</span>]<br>
@@ -29,8 +29,8 @@
               Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>Average Execution Time : 0s<br>
               Last Execution Date : 2024-02-20 10:27:34 UTC (1708424854000)<br>
               Last Successful Execution Date : 2024-02-20 10:27:34 UTC (1708424854000)<br></span>
-        
-        
+
+
         <span class="stat_subtitle">ntp</span>
           <span class="stat_subdata">
               Instance ID: ntp:3c427a42a70bbf8 [<span class="ok">OK</span>]<br>
@@ -39,8 +39,8 @@
               Events: 0, Total: 0<br>Service Checks: 1, Total: 1<br>Average Execution Time : 579ms<br>
               Last Execution Date : 2024-02-20 10:27:33 UTC (1708424853000)<br>
               Last Successful Execution Date : 2024-02-20 10:27:33 UTC (1708424853000)<br></span>
-        
-        
+
+
         <span class="stat_subtitle">telemetry</span>
           <span class="stat_subdata">
               Instance ID: telemetry [<span class="ok">OK</span>]<br>
@@ -56,34 +56,34 @@
       <span class="stat_data">
           <span class="stat_subtitle">apm</span>
           <span class="stat_subdata">
-                <b>Core Check Loader</b>: Could not configure check APM Agent: Can&#39;t access the default apm binary at /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: stat /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: no such file or directory<br>
-              
+                <b>Core Check Loader</b>: Could not configure check APM Agent: Can&#39;t access the default apm binary at /Users/datadog/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: stat /Users/datadog/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: no such file or directory<br>
+
                 <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
-              
+
                 <b>Python Check Loader</b>: unable to import module &#39;apm&#39;: No module named &#39;apm&#39;<br></span>
-        
+
           <span class="stat_subtitle">network</span>
           <span class="stat_subdata">
                 <b>Core Check Loader</b>: Check network not found in Catalog<br>
-              
+
                 <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
-              
+
                 <b>Python Check Loader</b>: unable to import module &#39;network&#39;: No module named &#39;network&#39;<br></span>
-        
+
           <span class="stat_subtitle">process_agent</span>
           <span class="stat_subdata">
-                <b>Core Check Loader</b>: Could not configure check Process Agent: Can&#39;t access the default process-agent binary at /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/process-agent<br>
-              
+                <b>Core Check Loader</b>: Could not configure check Process Agent: Can&#39;t access the default process-agent binary at /Users/datadog/go/src/github.com/DataDog/datadog-agent/embedded/bin/process-agent<br>
+
                 <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
-              
+
                 <b>Python Check Loader</b>: unable to import module &#39;process_agent&#39;: No module named &#39;process_agent&#39;<br></span>
-        
+
           <span class="stat_subtitle">winproc</span>
           <span class="stat_subdata">
                 <b>Core Check Loader</b>: Check winproc not found in Catalog<br>
-              
+
                 <b>JMX Check Loader</b>: check is not a jmx check, or unable to determine if it&#39;s so<br>
-              
+
                 <b>Python Check Loader</b>: unable to import module &#39;winproc&#39;: No module named &#39;winproc&#39;<br></span>
         </span>
     </div>

--- a/pkg/status/collector/fixtures/status_info.json
+++ b/pkg/status/collector/fixtures/status_info.json
@@ -1,0 +1,330 @@
+{
+  "autoConfigStats": {
+    "ConfigErrors": {},
+    "ResolveWarnings": {}
+  },
+  "checkSchedulerStats": {
+    "LoaderErrors": {
+      "apm": {
+        "Core Check Loader": "Could not configure check APM Agent: Can't access the default apm binary at /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: stat /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: no such file or directory",
+        "JMX Check Loader": "check is not a jmx check, or unable to determine if it's so",
+        "Python Check Loader": "unable to import module 'apm': No module named 'apm'"
+      },
+      "network": {
+        "Core Check Loader": "Check network not found in Catalog",
+        "JMX Check Loader": "check is not a jmx check, or unable to determine if it's so",
+        "Python Check Loader": "unable to import module 'network': No module named 'network'"
+      },
+      "process_agent": {
+        "Core Check Loader": "Could not configure check Process Agent: Can't access the default process-agent binary at /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/process-agent",
+        "JMX Check Loader": "check is not a jmx check, or unable to determine if it's so",
+        "Python Check Loader": "unable to import module 'process_agent': No module named 'process_agent'"
+      },
+      "winproc": {
+        "Core Check Loader": "Check winproc not found in Catalog",
+        "JMX Check Loader": "check is not a jmx check, or unable to determine if it's so",
+        "Python Check Loader": "unable to import module 'winproc': No module named 'winproc'"
+      }
+    },
+    "RunErrors": {}
+  },
+  "inventories": {},
+  "pyLoaderStats": {
+    "ConfigureErrors": {},
+    "Py3Warnings": {}
+  },
+  "pythonInit": {
+    "Errors": [
+      "could not initialize rtloader: could not import base class: No module named 'datadog_checks'"
+    ]
+  },
+  "runnerStats": {
+    "Checks": {
+      "cpu": {
+        "cpu": {
+          "AverageExecutionTime": 1,
+          "CheckConfigSource": "file:/opt/datadog-agent/etc/conf.d/cpu.d/conf.yaml.default",
+          "CheckID": "cpu",
+          "CheckName": "cpu",
+          "CheckVersion": "",
+          "EventPlatformEvents": {},
+          "Events": 0,
+          "ExecutionTimes": [
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "HistogramBuckets": 0,
+          "Interval": 15000000000,
+          "LastDelay": 0,
+          "LastError": "",
+          "LastExecutionTime": 1,
+          "LastSuccessDate": 1708424850,
+          "LastWarnings": [],
+          "LongRunning": false,
+          "MetricSamples": 1,
+          "ServiceChecks": 0,
+          "TotalErrors": 0,
+          "TotalEventPlatformEvents": {},
+          "TotalEvents": 0,
+          "TotalHistogramBuckets": 0,
+          "TotalMetricSamples": 1,
+          "TotalRuns": 1,
+          "TotalServiceChecks": 0,
+          "TotalWarnings": 0,
+          "UpdateTimestamp": 1708424850
+        }
+      },
+      "file_handle": {
+        "file_handle": {
+          "AverageExecutionTime": 0,
+          "CheckConfigSource": "file:/Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/conf.d/file_handle.d/conf.yaml.default",
+          "CheckID": "file_handle",
+          "CheckName": "file_handle",
+          "CheckVersion": "",
+          "EventPlatformEvents": {},
+          "Events": 0,
+          "ExecutionTimes": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "HistogramBuckets": 0,
+          "Interval": 15000000000,
+          "LastDelay": 0,
+          "LastError": "",
+          "LastExecutionTime": 0,
+          "LastSuccessDate": 1708424854,
+          "LastWarnings": [],
+          "LongRunning": false,
+          "MetricSamples": 2,
+          "ServiceChecks": 0,
+          "TotalErrors": 0,
+          "TotalEventPlatformEvents": {},
+          "TotalEvents": 0,
+          "TotalHistogramBuckets": 0,
+          "TotalMetricSamples": 2,
+          "TotalRuns": 1,
+          "TotalServiceChecks": 0,
+          "TotalWarnings": 0,
+          "UpdateTimestamp": 1708424854
+        }
+      },
+      "ntp": {
+        "ntp:3c427a42a70bbf8": {
+          "AverageExecutionTime": 579,
+          "CheckConfigSource": "file:/opt/datadog-agent/etc/conf.d/ntp.d/conf.yaml.default",
+          "CheckID": "ntp:3c427a42a70bbf8",
+          "CheckName": "ntp",
+          "CheckVersion": "",
+          "EventPlatformEvents": {},
+          "Events": 0,
+          "ExecutionTimes": [
+            579,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "HistogramBuckets": 0,
+          "Interval": 900000000000,
+          "LastDelay": 0,
+          "LastError": "",
+          "LastExecutionTime": 579,
+          "LastSuccessDate": 1708424853,
+          "LastWarnings": [],
+          "LongRunning": false,
+          "MetricSamples": 1,
+          "ServiceChecks": 1,
+          "TotalErrors": 0,
+          "TotalEventPlatformEvents": {},
+          "TotalEvents": 0,
+          "TotalHistogramBuckets": 0,
+          "TotalMetricSamples": 1,
+          "TotalRuns": 1,
+          "TotalServiceChecks": 1,
+          "TotalWarnings": 0,
+          "UpdateTimestamp": 1708424853
+        }
+      },
+      "telemetry": {
+        "telemetry": {
+          "AverageExecutionTime": 0,
+          "CheckConfigSource": "file:/opt/datadog-agent/etc/conf.d/telemetry.d/conf.yaml.default",
+          "CheckID": "telemetry",
+          "CheckName": "telemetry",
+          "CheckVersion": "",
+          "EventPlatformEvents": {},
+          "Events": 0,
+          "ExecutionTimes": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "HistogramBuckets": 0,
+          "Interval": 15000000000,
+          "LastDelay": 0,
+          "LastError": "",
+          "LastExecutionTime": 0,
+          "LastSuccessDate": 1708424855,
+          "LastWarnings": [],
+          "LongRunning": false,
+          "MetricSamples": 2,
+          "ServiceChecks": 0,
+          "TotalErrors": 0,
+          "TotalEventPlatformEvents": {},
+          "TotalEvents": 0,
+          "TotalHistogramBuckets": 0,
+          "TotalMetricSamples": 2,
+          "TotalRuns": 1,
+          "TotalServiceChecks": 0,
+          "TotalWarnings": 0,
+          "UpdateTimestamp": 1708424855
+        }
+      }
+    },
+    "Running": {
+      "container_image": "2024-02-20T11:27:29+01:00",
+      "container_lifecycle": "2024-02-20T11:27:29+01:00"
+    },
+    "RunningChecks": 2,
+    "Runs": 4,
+    "Workers": {
+      "Count": 6,
+      "Instances": {
+        "worker_1": {
+          "Utilization": 0
+        },
+        "worker_2": {
+          "Utilization": 0
+        },
+        "worker_3": {
+          "Utilization": 0
+        },
+        "worker_4": {
+          "Utilization": 0
+        },
+        "worker_5": {
+          "Utilization": 0
+        },
+        "worker_6": {
+          "Utilization": 0
+        }
+      }
+    }
+  }
+}

--- a/pkg/status/collector/fixtures/status_info.json
+++ b/pkg/status/collector/fixtures/status_info.json
@@ -218,7 +218,7 @@
           "LastExecutionTime": 579,
           "LastSuccessDate": 1708424853,
           "LastWarnings": [],
-          "LongRunning": false,
+          "LongRunning": true,
           "MetricSamples": 1,
           "ServiceChecks": 1,
           "TotalErrors": 0,

--- a/pkg/status/collector/fixtures/status_info.json
+++ b/pkg/status/collector/fixtures/status_info.json
@@ -6,7 +6,7 @@
   "checkSchedulerStats": {
     "LoaderErrors": {
       "apm": {
-        "Core Check Loader": "Could not configure check APM Agent: Can't access the default apm binary at /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: stat /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: no such file or directory",
+        "Core Check Loader": "Could not configure check APM Agent: Can't access the default apm binary at /Users/datadog/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: stat /Users/datadog/go/src/github.com/DataDog/datadog-agent/embedded/bin/trace-agent: no such file or directory",
         "JMX Check Loader": "check is not a jmx check, or unable to determine if it's so",
         "Python Check Loader": "unable to import module 'apm': No module named 'apm'"
       },
@@ -16,7 +16,7 @@
         "Python Check Loader": "unable to import module 'network': No module named 'network'"
       },
       "process_agent": {
-        "Core Check Loader": "Could not configure check Process Agent: Can't access the default process-agent binary at /Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/embedded/bin/process-agent",
+        "Core Check Loader": "Could not configure check Process Agent: Can't access the default process-agent binary at /Users/datadog/go/src/github.com/DataDog/datadog-agent/embedded/bin/process-agent",
         "JMX Check Loader": "check is not a jmx check, or unable to determine if it's so",
         "Python Check Loader": "unable to import module 'process_agent': No module named 'process_agent'"
       },
@@ -107,7 +107,7 @@
       "file_handle": {
         "file_handle": {
           "AverageExecutionTime": 0,
-          "CheckConfigSource": "file:/Users/ali.benabdallah/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/conf.d/file_handle.d/conf.yaml.default",
+          "CheckConfigSource": "file:/Users/datadog/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/conf.d/file_handle.d/conf.yaml.default",
           "CheckID": "file_handle",
           "CheckName": "file_handle",
           "CheckVersion": "",

--- a/pkg/status/collector/status_templates/collectorHTML.tmpl
+++ b/pkg/status/collector/status_templates/collectorHTML.tmpl
@@ -17,7 +17,7 @@
               Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
               Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
               {{- range $k, $v := .TotalEventPlatformEvents }}
-              {{ $k }}: Last Run: {{humanize (index $instance.EventPlatformEvents $k) }}, Total: {{humanize $v}}<br>
+              {{ $k }}: Last Run: {{humanize (index .EventPlatformEvents $k) }}, Total: {{humanize $v}}<br>
               {{- end -}}
               Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
               {{- if .TotalHistogramBuckets}}

--- a/pkg/status/collector/status_test.go
+++ b/pkg/status/collector/status_test.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package collector
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core/status"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderHTML(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		fixtureFile string
+		resultFile  string
+	}{
+		{
+			name:        "CollectorHTML",
+			fixtureFile: "fixtures/status_info.json",
+			resultFile:  "fixtures/status_info.html",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			jsonBytes, err := os.ReadFile(test.fixtureFile)
+			require.NoError(t, err)
+			var data map[string]interface{}
+			err = json.Unmarshal(jsonBytes, &data)
+			require.NoError(t, err)
+
+			output := new(bytes.Buffer)
+			err = status.RenderHTML(templatesFS, "collectorHTML.tmpl", output, data)
+			require.NoError(t, err, "failed to render HTML")
+
+			expectedOutput, err := os.ReadFile(test.resultFile)
+			require.NoError(t, err)
+
+			// We replace windows line break by linux so the tests pass on every OS
+			result := strings.Replace(string(expectedOutput), "\r\n", "\n", -1)
+			stringOutput := strings.Replace(output.String(), "\r\n", "\n", -1)
+
+			require.Equal(t, result, stringOutput, "HTML rendering is not as expected")
+		})
+	}
+}

--- a/pkg/status/collector/status_test.go
+++ b/pkg/status/collector/status_test.go
@@ -17,14 +17,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRenderHTML(t *testing.T) {
+func TestRender(t *testing.T) {
 	for _, test := range []struct {
 		name        string
 		fixtureFile string
 		resultFile  string
 	}{
 		{
-			name:        "CollectorHTML",
+			name:        "collectorHTML.tmpl",
 			fixtureFile: "fixtures/status_info.json",
 			resultFile:  "fixtures/status_info.html",
 		},

--- a/pkg/status/render/templates/collectorHTML.tmpl
+++ b/pkg/status/render/templates/collectorHTML.tmpl
@@ -17,7 +17,7 @@
               Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
               Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
               {{- range $k, $v := .TotalEventPlatformEvents }}
-              {{ $k }}: Last Run: {{humanize (index $instance.EventPlatformEvents $k) }}, Total: {{humanize $v}}<br>
+              {{ $k }}: Last Run: {{humanize (index .EventPlatformEvents $k) }}, Total: {{humanize $v}}<br>
               {{- end -}}
               Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
               {{- if .TotalHistogramBuckets}}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Fixes the template trying to access a variable that isn't referenced.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
As part of the QA, we noticed a regression introduced by https://github.com/DataDog/datadog-agent/pull/22313 where the `collectors` page would return an error. 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Build the agent directly on mac with `inv agent.build`, run `./bin/agent/agent start` in one terminal and `./bin/agent/agent launch-gui` in the other. Go to the collector page and make sure it doesn't return an error
<img width="917" alt="Capture d’écran 2024-02-20 à 10 32 34" src="https://github.com/DataDog/datadog-agent/assets/125997632/92f01d95-7853-4a20-9a0e-397e92fa91cf">


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
