### PR TITLE
Add pip install in the update_rc_build_links job

### DIFF
--- a/.gitlab/rc_jobs/post_rc_tasks.yml
+++ b/.gitlab/rc_jobs/post_rc_tasks.yml
@@ -17,4 +17,5 @@ update_rc_build_links:
     - export ATLASSIAN_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.jira_read_api_token --with-decryption --query "Parameter.Value" --out text)
     - export ATLASSIAN_USERNAME=robot-jira-agentplatform@datadoghq.com
     - set -x
+    - python3 -m pip install -r tasks/requirements_release_tasks.txt
     - inv -e release.update-build-links ${CI_COMMIT_REF_SLUG}


### PR DESCRIPTION
### What does this PR do?

This PR fixes a problem with `update_rc_build_links` job in the RC build pipeline which depends on the specific python module. The original job missed prerequisite installation step.

### Motivation

Automation of the Agent Release Candidate build process.

### Describe how to test/QA your changes

Will be tested with 7.52.0-rc.2 build.
