### PR TITLE
[USMON-773] Cleanup http2_remainder during connection termination

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -948,11 +948,13 @@ int uprobe__http2_tls_termination(struct pt_regs *ctx) {
 
     terminated_http2_batch_enqueue(&args->tup);
     // Deleting the entry for the original tuple.
+    bpf_map_delete_elem(&http2_remainder, &args->tup);
     bpf_map_delete_elem(&http2_dynamic_counter_table, &args->tup);
     // In case of local host, the protocol will be deleted for both (client->server) and (server->client),
     // so we won't reach for that path again in the code, so we're deleting the opposite side as well.
     flip_tuple(&args->tup);
     bpf_map_delete_elem(&http2_dynamic_counter_table, &args->tup);
+    bpf_map_delete_elem(&http2_remainder, &args->tup);
 
     bpf_map_delete_elem(&tls_http2_iterations, &args->tup);
 

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -615,12 +615,14 @@ int socket__http2_handle_first_frame(struct __sk_buff *skb) {
     // If we detected a tcp termination we should stop processing the packet, and clear its dynamic table by deleting the counter.
     if (is_tcp_termination(&dispatcher_args_copy.skb_info)) {
         // Deleting the entry for the original tuple.
+        bpf_map_delete_elem(&http2_remainder, &dispatcher_args_copy.tup);
         bpf_map_delete_elem(&http2_dynamic_counter_table, &dispatcher_args_copy.tup);
         terminated_http2_batch_enqueue(&dispatcher_args_copy.tup);
         // In case of local host, the protocol will be deleted for both (client->server) and (server->client),
         // so we won't reach for that path again in the code, so we're deleting the opposite side as well.
         flip_tuple(&dispatcher_args_copy.tup);
         bpf_map_delete_elem(&http2_dynamic_counter_table, &dispatcher_args_copy.tup);
+        bpf_map_delete_elem(&http2_remainder, &dispatcher_args_copy.tup);
         return 0;
     }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adds cleanup for http2_reminder map when connection termination occurs. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We noticed that when we are in TCP termination, we are not cleaning the `http2_remainder` map correctly. This heavily affects our entry counts in the map because those entries are never cleaned. They are in an incomplete state, waiting for the response to occur. This issue was observed by the eBPF metrics, which showed that our `http2_remainder` map is full.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* Run HTTP/2, gRPC traffic and validate that the http2_remainder is not leaking.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
