### PR TITLE
Bump latest_stable to 7.51.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -2,8 +2,8 @@
     "base_branch": "main",
     "current_milestone": "7.52.0",
     "last_stable": {
-        "6": "6.50.1",
-        "7": "7.50.1"
+        "6": "6.51.0",
+        "7": "7.51.0"
     },
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "master",


### PR DESCRIPTION
### What does this PR do?

Set `latest_stable` fields in `release.json` to recently released 6/7.51.0

### Motivation

Keep the baseline up to date.