### PR TITLE
New alerting for consecutive failures

### DIFF
--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -36,6 +36,7 @@ notify:
         else
           invoke -e notify.send-message --notification-type "merge"
         fi
+        invoke notify.check-consistent-failures
       else
         echo "This pipeline was triggered by another repository, skipping notification."
       fi

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -32,9 +32,9 @@ notify:
       # The triggering repo should already have its own notification system
       if [ "$CI_PIPELINE_SOURCE" != "pipeline" ]; then
         if [ "$DEPLOY_AGENT" = "true" ]; then
-          invoke -e pipeline.notify --notification-type "deploy"
+          invoke -e notify.send-message --notification-type "deploy"
         else
-          invoke -e pipeline.notify --notification-type "merge"
+          invoke -e notify.send-message --notification-type "merge"
         fi
       else
         echo "This pipeline was triggered by another repository, skipping notification."
@@ -53,4 +53,4 @@ send_pipeline_stats:
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_read_api_token --with-decryption --query "Parameter.Value" --out text)
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
     - !reference [.setup_python_mirror_linux]
-    - invoke -e pipeline.send-stats
+    - invoke -e notify.send-stats

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -22,6 +22,8 @@ notify:
   rules: !reference [.on_main_or_release_branch_or_deploy_always]
   dependencies: []
   tags: ["arch:amd64"]
+  resource_group: notification
+  timeout: 15 minutes # Added to prevent a stuck job blocking the resource_group defined above
   script:
     - set +x
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_read_api_token --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab/source_test/slack.yml
+++ b/.gitlab/source_test/slack.yml
@@ -8,6 +8,4 @@ slack_teams_channels_check:
   script:
     - source /root/.bashrc
     - python3 -m pip install codeowners -c tasks/libs/requirements-notifications.txt
-    - inv -e pipeline.check-notify-teams
-
-
+    - inv -e notify.check-teams

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -24,6 +24,7 @@ from tasks import (
     modules,
     msi,
     new_e2e_tests,
+    notify,
     package,
     pipeline,
     process_agent,
@@ -135,6 +136,7 @@ ns.add_collection(msi)
 ns.add_collection(github_tasks, "github")
 ns.add_collection(package)
 ns.add_collection(pipeline)
+ns.add_collection(notify)
 ns.add_collection(selinux)
 ns.add_collection(systray)
 ns.add_collection(release)

--- a/tasks/libs/types.py
+++ b/tasks/libs/types.py
@@ -75,6 +75,14 @@ class FailedJobs:
     def all_mandatory_failures(self):
         return self.mandatory_job_failures + self.mandatory_infra_job_failures
 
+    def all_failures(self):
+        return (
+            self.mandatory_job_failures
+            + self.optional_job_failures
+            + self.mandatory_infra_job_failures
+            + self.optional_infra_job_failures
+        )
+
 
 class SlackMessage:
     JOBS_SECTION_HEADER = "Failed jobs:"

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -1,0 +1,200 @@
+import io
+import os
+import traceback
+from collections import defaultdict
+from datetime import datetime
+from typing import Dict
+
+from invoke import task
+from invoke.exceptions import Exit
+
+from tasks.libs.datadog_api import create_count, send_metrics
+from tasks.libs.pipeline_data import get_failed_jobs
+from tasks.libs.pipeline_notifications import (
+    GITHUB_SLACK_MAP,
+    base_message,
+    check_for_missing_owners_slack_and_jira,
+    find_job_owners,
+    get_failed_tests,
+    send_slack_message,
+)
+from tasks.libs.pipeline_stats import get_failed_jobs_stats
+from tasks.libs.types import FailedJobs, SlackMessage, TeamMessage
+
+UNKNOWN_OWNER_TEMPLATE = """The owner `{owner}` is not mapped to any slack channel.
+Please check for typos in the JOBOWNERS file and/or add them to the Github <-> Slack map.
+"""
+
+
+@task
+def check_teams(_):
+    if check_for_missing_owners_slack_and_jira():
+        print(
+            "Error: Some teams in CODEOWNERS don't have their slack notification channel or jira specified!\n"
+            "Please specify one in the GITHUB_SLACK_MAP or GITHUB_JIRA_MAP map in tasks/libs/pipeline_notifications.py."
+        )
+        raise Exit(code=1)
+    else:
+        print("All CODEOWNERS teams have their slack notification channel and jira project specified !!")
+
+
+@task
+def send_message(_, notification_type="merge", print_to_stdout=False):
+    """
+    Send notifications for the current pipeline. CI-only task.
+    Use the --print-to-stdout option to test this locally, without sending
+    real slack messages.
+    """
+    project_name = "DataDog/datadog-agent"
+
+    try:
+        failed_jobs = get_failed_jobs(project_name, os.getenv("CI_PIPELINE_ID"))
+        messages_to_send = generate_failure_messages(project_name, failed_jobs)
+    except Exception as e:
+        buffer = io.StringIO()
+        print(base_message("datadog-agent", "is in an unknown state"), file=buffer)
+        print("Found exception when generating notification:", file=buffer)
+        traceback.print_exc(limit=-1, file=buffer)
+        print("See the notify job log for the full exception traceback.", file=buffer)
+
+        messages_to_send = {
+            "@DataDog/agent-all": SlackMessage(base=buffer.getvalue()),
+        }
+        # Print traceback on job log
+        print(e)
+        traceback.print_exc()
+        raise Exit(code=1)
+
+    # From the job failures, set whether the pipeline succeeded or failed and craft the
+    # base message that will be sent.
+    if failed_jobs.all_mandatory_failures():  # At least one mandatory job failed
+        header_icon = ":host-red:"
+        state = "failed"
+        coda = "If there is something wrong with the notification please contact #agent-platform"
+    else:
+        header_icon = ":host-green:"
+        state = "succeeded"
+        coda = ""
+
+    header = ""
+    if notification_type == "merge":
+        header = f"{header_icon} :merged: datadog-agent merge"
+    elif notification_type == "deploy":
+        header = f"{header_icon} :rocket: datadog-agent deploy"
+    base = base_message(header, state)
+
+    # Send messages
+    for owner, message in messages_to_send.items():
+        channel = GITHUB_SLACK_MAP.get(owner.lower(), None)
+        message.base_message = base
+        if channel is None:
+            channel = "#datadog-agent-pipelines"
+            message.base_message += UNKNOWN_OWNER_TEMPLATE.format(owner=owner)
+        message.coda = coda
+        if print_to_stdout:
+            print(f"Would send to {channel}:\n{str(message)}")
+        else:
+            send_slack_message(channel, str(message))  # TODO: use channel variable
+
+
+@task
+def send_stats(_, print_to_stdout=False):
+    """
+    Send statistics to Datadog for the current pipeline. CI-only task.
+    Use the --print-to-stdout option to test this locally, without sending
+    data points to Datadog.
+    """
+    project_name = "DataDog/datadog-agent"
+
+    try:
+        global_failure_reason, job_failure_stats = get_failed_jobs_stats(project_name, os.getenv("CI_PIPELINE_ID"))
+    except Exception as e:
+        print("Found exception when generating statistics:")
+        print(e)
+        traceback.print_exc(limit=-1)
+        raise Exit(code=1)
+
+    if not (print_to_stdout or os.environ.get("DD_API_KEY")):
+        print("DD_API_KEY environment variable not set, cannot send pipeline metrics to the backend")
+        raise Exit(code=1)
+
+    timestamp = int(datetime.now().timestamp())
+    series = []
+
+    for failure_tags, count in job_failure_stats.items():
+        # This allows getting stats on the number of jobs that fail due to infrastructure
+        # issues vs. other failures, and have a per-pipeline ratio of infrastructure failures.
+        series.append(
+            create_count(
+                metric_name="datadog.ci.job_failures",
+                timestamp=timestamp,
+                value=count,
+                tags=list(failure_tags)
+                + [
+                    "repository:datadog-agent",
+                    f"git_ref:{os.getenv('CI_COMMIT_REF_NAME')}",
+                ],
+            )
+        )
+
+    if job_failure_stats:  # At least one job failed
+        pipeline_state = "failed"
+    else:
+        pipeline_state = "succeeded"
+
+    pipeline_tags = [
+        "repository:datadog-agent",
+        f"git_ref:{os.getenv('CI_COMMIT_REF_NAME')}",
+        f"status:{pipeline_state}",
+    ]
+    if global_failure_reason:  # Only set the reason if the pipeline fails
+        pipeline_tags.append(f"reason:{global_failure_reason}")
+
+    series.append(
+        create_count(
+            metric_name="datadog.ci.pipelines",
+            timestamp=timestamp,
+            value=1,
+            tags=pipeline_tags,
+        )
+    )
+
+    if not print_to_stdout:
+        response = send_metrics(series)
+        if response["errors"]:
+            print(f"Error(s) while sending pipeline metrics to the Datadog backend: {response['errors']}")
+            raise Exit(code=1)
+        print(f"Sent pipeline metrics: {series}")
+    else:
+        print(f"Would send: {series}")
+
+
+# Tasks to trigger pipeline notifications
+
+
+def generate_failure_messages(project_name: str, failed_jobs: FailedJobs) -> Dict[str, SlackMessage]:
+    all_teams = "@DataDog/agent-all"
+
+    # Generate messages for each team
+    messages_to_send = defaultdict(TeamMessage)
+    messages_to_send[all_teams] = SlackMessage(jobs=failed_jobs)
+
+    failed_job_owners = find_job_owners(failed_jobs)
+    for owner, jobs in failed_job_owners.items():
+        if owner == "@DataDog/multiple":
+            for job in jobs.all_non_infra_failures():
+                for test in get_failed_tests(project_name, job):
+                    messages_to_send[all_teams].add_test_failure(test, job)
+                    for owner in test.owners:
+                        messages_to_send[owner].add_test_failure(test, job)
+        elif owner == "@DataDog/do-not-notify":
+            # Jobs owned by @DataDog/do-not-notify do not send team messages
+            pass
+        elif owner == all_teams:
+            # Jobs owned by @DataDog/agent-all will already be in the global
+            # message, do not overwrite the failed jobs list
+            pass
+        else:
+            messages_to_send[owner].failed_jobs = jobs
+
+    return messages_to_send

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -1,12 +1,8 @@
-import io
 import os
 import pprint
 import re
 import time
-import traceback
-from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Dict
 
 import yaml
 from invoke import task
@@ -24,18 +20,7 @@ from tasks.libs.common.utils import (
     nightly_entry_for,
     release_entry_for,
 )
-from tasks.libs.datadog_api import create_count, send_metrics
-from tasks.libs.pipeline_data import get_failed_jobs
-from tasks.libs.pipeline_notifications import (
-    GITHUB_SLACK_MAP,
-    base_message,
-    check_for_missing_owners_slack_and_jira,
-    find_job_owners,
-    get_failed_tests,
-    read_owners,
-    send_slack_message,
-)
-from tasks.libs.pipeline_stats import get_failed_jobs_stats
+from tasks.libs.pipeline_notifications import read_owners, send_slack_message
 from tasks.libs.pipeline_tools import (
     FilteredOutException,
     cancel_pipelines_with_confirmation,
@@ -44,7 +29,6 @@ from tasks.libs.pipeline_tools import (
     trigger_agent_pipeline,
     wait_for_pipeline,
 )
-from tasks.libs.types import FailedJobs, SlackMessage, TeamMessage
 
 
 class GitlabReference(yaml.YAMLObject):
@@ -409,41 +393,6 @@ def wait_for_pipeline_from_ref(gitlab, ref):
         raise Exit(code=1)
 
 
-# Tasks to trigger pipeline notifications
-
-UNKNOWN_OWNER_TEMPLATE = """The owner `{owner}` is not mapped to any slack channel.
-Please check for typos in the JOBOWNERS file and/or add them to the Github <-> Slack map.
-"""
-
-
-def generate_failure_messages(project_name: str, failed_jobs: FailedJobs) -> Dict[str, SlackMessage]:
-    all_teams = "@DataDog/agent-all"
-
-    # Generate messages for each team
-    messages_to_send = defaultdict(TeamMessage)
-    messages_to_send[all_teams] = SlackMessage(jobs=failed_jobs)
-
-    failed_job_owners = find_job_owners(failed_jobs)
-    for owner, jobs in failed_job_owners.items():
-        if owner == "@DataDog/multiple":
-            for job in jobs.all_non_infra_failures():
-                for test in get_failed_tests(project_name, job):
-                    messages_to_send[all_teams].add_test_failure(test, job)
-                    for owner in test.owners:
-                        messages_to_send[owner].add_test_failure(test, job)
-        elif owner == "@DataDog/do-not-notify":
-            # Jobs owned by @DataDog/do-not-notify do not send team messages
-            pass
-        elif owner == all_teams:
-            # Jobs owned by @DataDog/agent-all will already be in the global
-            # message, do not overwrite the failed jobs list
-            pass
-        else:
-            messages_to_send[owner].failed_jobs = jobs
-
-    return messages_to_send
-
-
 @task(iterable=['variable'])
 def trigger_child_pipeline(_, git_ref, project_name, variable=None, follow=True):
     """
@@ -626,149 +575,6 @@ def changelog(ctx, new_commit_sha):
         "--type \"SecureString\" --region us-east-1 --overwrite",
         hide=True,
     )
-
-
-@task
-def check_notify_teams(_):
-    if check_for_missing_owners_slack_and_jira():
-        print(
-            "Error: Some teams in CODEOWNERS don't have their slack notification channel or jira specified!\n"
-            "Please specify one in the GITHUB_SLACK_MAP or GITHUB_JIRA_MAP map in tasks/libs/pipeline_notifications.py."
-        )
-        raise Exit(code=1)
-    else:
-        print("All CODEOWNERS teams have their slack notification channel and jira project specified !!")
-
-
-@task
-def notify(_, notification_type="merge", print_to_stdout=False):
-    """
-    Send notifications for the current pipeline. CI-only task.
-    Use the --print-to-stdout option to test this locally, without sending
-    real slack messages.
-    """
-    project_name = "DataDog/datadog-agent"
-
-    try:
-        failed_jobs = get_failed_jobs(project_name, os.getenv("CI_PIPELINE_ID"))
-        messages_to_send = generate_failure_messages(project_name, failed_jobs)
-    except Exception as e:
-        buffer = io.StringIO()
-        print(base_message("datadog-agent", "is in an unknown state"), file=buffer)
-        print("Found exception when generating notification:", file=buffer)
-        traceback.print_exc(limit=-1, file=buffer)
-        print("See the notify job log for the full exception traceback.", file=buffer)
-
-        messages_to_send = {
-            "@DataDog/agent-all": SlackMessage(base=buffer.getvalue()),
-        }
-        # Print traceback on job log
-        print(e)
-        traceback.print_exc()
-        raise Exit(code=1)
-
-    # From the job failures, set whether the pipeline succeeded or failed and craft the
-    # base message that will be sent.
-    if failed_jobs.all_mandatory_failures():  # At least one mandatory job failed
-        header_icon = ":host-red:"
-        state = "failed"
-        coda = "If there is something wrong with the notification please contact #agent-platform"
-    else:
-        header_icon = ":host-green:"
-        state = "succeeded"
-        coda = ""
-
-    header = ""
-    if notification_type == "merge":
-        header = f"{header_icon} :merged: datadog-agent merge"
-    elif notification_type == "deploy":
-        header = f"{header_icon} :rocket: datadog-agent deploy"
-    base = base_message(header, state)
-
-    # Send messages
-    for owner, message in messages_to_send.items():
-        channel = GITHUB_SLACK_MAP.get(owner.lower(), None)
-        message.base_message = base
-        if channel is None:
-            channel = "#datadog-agent-pipelines"
-            message.base_message += UNKNOWN_OWNER_TEMPLATE.format(owner=owner)
-        message.coda = coda
-        if print_to_stdout:
-            print(f"Would send to {channel}:\n{str(message)}")
-        else:
-            send_slack_message(channel, str(message))  # TODO: use channel variable
-
-
-@task
-def send_stats(_, print_to_stdout=False):
-    """
-    Send statistics to Datadog for the current pipeline. CI-only task.
-    Use the --print-to-stdout option to test this locally, without sending
-    data points to Datadog.
-    """
-    project_name = "DataDog/datadog-agent"
-
-    try:
-        global_failure_reason, job_failure_stats = get_failed_jobs_stats(project_name, os.getenv("CI_PIPELINE_ID"))
-    except Exception as e:
-        print("Found exception when generating statistics:")
-        print(e)
-        traceback.print_exc(limit=-1)
-        raise Exit(code=1)
-
-    if not (print_to_stdout or os.environ.get("DD_API_KEY")):
-        print("DD_API_KEY environment variable not set, cannot send pipeline metrics to the backend")
-        raise Exit(code=1)
-
-    timestamp = int(datetime.now().timestamp())
-    series = []
-
-    for failure_tags, count in job_failure_stats.items():
-        # This allows getting stats on the number of jobs that fail due to infrastructure
-        # issues vs. other failures, and have a per-pipeline ratio of infrastructure failures.
-        series.append(
-            create_count(
-                metric_name="datadog.ci.job_failures",
-                timestamp=timestamp,
-                value=count,
-                tags=list(failure_tags)
-                + [
-                    "repository:datadog-agent",
-                    f"git_ref:{os.getenv('CI_COMMIT_REF_NAME')}",
-                ],
-            )
-        )
-
-    if job_failure_stats:  # At least one job failed
-        pipeline_state = "failed"
-    else:
-        pipeline_state = "succeeded"
-
-    pipeline_tags = [
-        "repository:datadog-agent",
-        f"git_ref:{os.getenv('CI_COMMIT_REF_NAME')}",
-        f"status:{pipeline_state}",
-    ]
-    if global_failure_reason:  # Only set the reason if the pipeline fails
-        pipeline_tags.append(f"reason:{global_failure_reason}")
-
-    series.append(
-        create_count(
-            metric_name="datadog.ci.pipelines",
-            timestamp=timestamp,
-            value=1,
-            tags=pipeline_tags,
-        )
-    )
-
-    if not print_to_stdout:
-        response = send_metrics(series)
-        if response["errors"]:
-            print(f"Error(s) while sending pipeline metrics to the Datadog backend: {response['errors']}")
-            raise Exit(code=1)
-        print(f"Sent pipeline metrics: {series}")
-    else:
-        print(f"Would send: {series}")
 
 
 def _init_pipeline_schedule_task():

--- a/tasks/unit-tests/notify_tests.py
+++ b/tasks/unit-tests/notify_tests.py
@@ -1,0 +1,72 @@
+import pathlib
+import unittest
+from unittest.mock import MagicMock, patch
+
+from invoke import MockContext, Result
+from invoke.exceptions import UnexpectedExit
+
+from tasks import notify
+
+
+class TestRetrieveJobExecutionsCreated(unittest.TestCase):
+    job_executions = None
+
+    def setUp(self) -> None:
+        self.job_executions = notify.create_initial_job_executions()
+
+    def tearDown(self) -> None:
+        pathlib.Path(notify.JOB_FAILURES_FILE).unlink(missing_ok=True)
+
+    def test_retrieved(self):
+        ctx = MockContext(run=Result("test"))
+        j = notify.retrieve_job_executions(ctx)
+        self.assertEqual(j, self.job_executions)
+
+
+class TestRetrieveJobExecutions(unittest.TestCase):
+    def test_not_found(self):
+        ctx = MagicMock()
+        ctx.run.side_effect = UnexpectedExit(Result(stderr="This is a 404 not found"))
+        j = notify.retrieve_job_executions(ctx)
+        self.assertEqual(j, {"pipeline_id": 0, "jobs": {}})
+
+    def test_other_error(self):
+        ctx = MagicMock()
+        ctx.run.side_effect = UnexpectedExit(Result(stderr="This is another error"))
+        with self.assertRaises(UnexpectedExit):
+            notify.retrieve_job_executions(ctx)
+
+
+class TestUpdateStatistics(unittest.TestCase):
+    @patch('tasks.notify.get_failed_jobs')
+    def test_nominal(self, mock_get_failed):
+        failed_jobs = mock_get_failed.return_value
+        failed_jobs.all_failures.return_value = [{"name": "nifnif"}, {"name": "nafnaf"}]
+        j = {"jobs": {"nafnaf": {"cumulative_failures": 2}, "noufnouf": {"cumulative_failures": 2}}}
+        a, j = notify.update_statistics(j)
+        self.assertEqual(j["jobs"]["nifnif"]["cumulative_failures"], 1)
+        self.assertEqual(j["jobs"]["nafnaf"]["cumulative_failures"], 3)
+        self.assertEqual(j["jobs"]["noufnouf"]["cumulative_failures"], 0)
+        self.assertEqual(len(a), 1)
+        self.assertIn("nafnaf", a)
+        mock_get_failed.assert_called()
+
+    @patch('tasks.notify.get_failed_jobs')
+    def test_multiple_failures(self, mock_get_failed):
+        failed_jobs = mock_get_failed.return_value
+        failed_jobs.all_failures.return_value = [{"name": "poulidor"}, {"name": "virenque"}, {"name": "bardet"}]
+        j = {
+            "jobs": {
+                "poulidor": {"cumulative_failures": 8},
+                "virenque": {"cumulative_failures": 2},
+                "bardet": {"cumulative_failures": 2},
+            }
+        }
+        a, j = notify.update_statistics(j)
+        self.assertEqual(j["jobs"]["poulidor"]["cumulative_failures"], 9)
+        self.assertEqual(j["jobs"]["virenque"]["cumulative_failures"], 3)
+        self.assertEqual(j["jobs"]["bardet"]["cumulative_failures"], 3)
+        self.assertEqual(len(a), 2)
+        self.assertIn("virenque", a)
+        self.assertIn("bardet", a)
+        mock_get_failed.assert_called()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add a new invoke task for tracking of consecutive failures

### Motivation
Alerting currently work on fixed duration, so we can count a number of failures, but not a number of `consecutive` failures, which is more relevant in our context has we have many flakes in job execution (both because of test themselves and infrastructure)
This implementation saves a status of each pipeline and compare with the stored information to create a cumulative count.

### Additional Notes
We might want to upload this statistic in datadog in a second phase to have a monitor on it, rather than an ad-hoc slack notification.

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes
Added some UT
Trigger full pipelines as they activate the notification job
