### PR TITLE
Check for nil provider to avoid segfault in flare

### DIFF
--- a/comp/collector/collector/collectorimpl/collector.go
+++ b/comp/collector/collector/collectorimpl/collector.go
@@ -70,38 +70,25 @@ type collectorImpl struct {
 type provides struct {
 	fx.Out
 
-	Comp         collector.Component
-	OptionalComp optional.Option[collector.Component]
-	Provider     status.InformationProvider
+	Comp     collector.Component
+	Provider status.InformationProvider
 }
 
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
 		fx.Provide(newProvides),
-	)
-}
-
-// ModuleNoneCollector defines a module with a none collector and a status provider.
-func ModuleNoneCollector() fxutil.Module {
-	return fxutil.Component(
-		fx.Provide(newNoneCollector),
+		fx.Provide(func(c collector.Component) optional.Option[collector.Component] {
+			return optional.NewOption[collector.Component](c)
+		}),
 	)
 }
 
 func newProvides(deps dependencies) provides {
 	c := newCollector(deps)
 	return provides{
-		Comp:         c,
-		OptionalComp: optional.NewOption[collector.Component](c),
-		Provider:     status.NewInformationProvider(collectorStatus.Provider{}),
-	}
-}
-
-func newNoneCollector() provides {
-	return provides{
-		OptionalComp: optional.NewNoneOption[collector.Component](),
-		Provider:     status.NewInformationProvider(collectorStatus.Provider{}),
+		Comp:     c,
+		Provider: status.NewInformationProvider(collectorStatus.Provider{}),
 	}
 }
 

--- a/comp/collector/collector/component.go
+++ b/comp/collector/collector/component.go
@@ -9,6 +9,9 @@ package collector
 import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
+	"go.uber.org/fx"
 )
 
 // team: agent-metrics-logs
@@ -42,4 +45,16 @@ type Component interface {
 	ReloadAllCheckInstances(name string, newInstances []check.Check) ([]checkid.ID, error)
 	// AddEventReceiver adds a callback to the collector to be called each time a check is added or removed.
 	AddEventReceiver(cb EventReceiver)
+}
+
+// NoneModule return a None optional type for Component.
+//
+// This helper allows code that needs a disabled Optional type for the collector to get it. The helper is split from
+// the implementation to avoid linking with the implementation.
+func NoneModule() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(func() optional.Option[Component] {
+			return optional.NewNoneOption[Component]()
+		}),
+	)
 }

--- a/comp/core/flare/flare.go
+++ b/comp/core/flare/flare.go
@@ -132,11 +132,13 @@ func (f *flare) Create(pdata ProfileData, ipcError error) (string, error) {
 	)
 
 	for _, p := range providers {
-		err = p(fb)
-		if err != nil {
-			f.log.Errorf("error calling '%s' for flare creation: %s",
-				runtime.FuncForPC(reflect.ValueOf(p).Pointer()).Name(), // reflect p.Callback function name
-				err)
+		if p != nil {
+			err = p(fb)
+			if err != nil {
+				f.log.Errorf("error calling '%s' for flare creation: %s",
+					runtime.FuncForPC(reflect.ValueOf(p).Pointer()).Name(), // reflect p.Callback function name
+					err)
+			}
 		}
 	}
 

--- a/comp/core/flare/flare_test.go
+++ b/comp/core/flare/flare_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package flare
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager"
+	"github.com/DataDog/datadog-agent/comp/collector/collector"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/flare/types"
+	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/inventoryagentimpl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+)
+
+func TestFlareCreation(t *testing.T) {
+	realProvider := func(fb types.FlareBuilder) error { return nil }
+
+	f, _, err := newFlare(
+		fxutil.Test[dependencies](
+			t,
+			logimpl.MockModule(),
+			config.MockModule(),
+			fx.Provide(func() diagnosesendermanager.Component { return nil }),
+			inventoryagentimpl.MockModule(),
+			fx.Provide(func() Params { return Params{} }),
+			collector.NoneModule(),
+
+			// provider a nil FlareCallback
+			fx.Provide(fx.Annotate(
+				func() types.FlareCallback { return nil },
+				fx.ResultTags(`group:"flare"`),
+			)),
+			// provider a real FlareCallback
+			fx.Provide(fx.Annotate(
+				func() types.FlareCallback { return realProvider },
+				fx.ResultTags(`group:"flare"`),
+			)),
+		),
+	)
+
+	require.NoError(t, err)
+	assert.Len(t, f.(*flare).providers, 1)
+	assert.NotNil(t, f.(*flare).providers[0])
+}

--- a/comp/core/status/statusimpl/status.go
+++ b/comp/core/status/statusimpl/status.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"embed"
 	"encoding/json"
+	"fmt"
 	"io"
 	"path"
 	"sort"
@@ -290,7 +291,10 @@ func (s *statusImplementation) GetStatusBySection(section string, format string,
 			return []byte{}, nil
 		}
 	default:
-		providers := s.sortedProvidersBySection[section]
+		providers, ok := s.sortedProvidersBySection[section]
+		if !ok {
+			return nil, fmt.Errorf("unknown status section '%s'", section)
+		}
 		switch format {
 		case "json":
 			stats := make(map[string]interface{})

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -73,7 +73,6 @@ import (
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
-	collectorStatus "github.com/DataDog/datadog-agent/pkg/status/collector"
 	statuscollector "github.com/DataDog/datadog-agent/pkg/status/collector"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -170,7 +169,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				// inventorychecksimpl depends on a collector and serializer when created to send payload.
 				// Here we just want to collect metadata to be displayed, so we don't need a collector.
 				collector.NoneModule(),
-				fx.Supply(status.NewInformationProvider(collectorStatus.Provider{})),
+				fx.Supply(status.NewInformationProvider(statuscollector.Provider{})),
 				fx.Provide(func() optional.Option[logagent.Component] {
 					return optional.NewNoneOption[logagent.Component]()
 

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -32,7 +32,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl"
 	authtokenimpl "github.com/DataDog/datadog-agent/comp/api/authtoken/createandfetchimpl"
 	"github.com/DataDog/datadog-agent/comp/collector/collector"
-	"github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
@@ -74,6 +73,7 @@ import (
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	collectorStatus "github.com/DataDog/datadog-agent/pkg/status/collector"
 	statuscollector "github.com/DataDog/datadog-agent/pkg/status/collector"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -169,7 +169,8 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				inventorychecksimpl.Module(),
 				// inventorychecksimpl depends on a collector and serializer when created to send payload.
 				// Here we just want to collect metadata to be displayed, so we don't need a collector.
-				collectorimpl.ModuleNoneCollector(),
+				collector.NoneModule(),
+				fx.Supply(status.NewInformationProvider(collectorStatus.Provider{})),
 				fx.Provide(func() optional.Option[logagent.Component] {
 					return optional.NewNoneOption[logagent.Component]()
 


### PR DESCRIPTION
### What does this PR do?

We had issues where the Agent panics because a Flare Provider is `nil` and we don't check for `nil` before using the provider. This PR filters all `nil` providers in the flare component before using them.

### Motivation

Avoid panic

### Possible Drawbacks / Trade-offs

Because we're filtering `nil` component, we might miss some unexpected bugs where a provider is `nil` while it should not be. In this case, we'll be missing flare information instead of panicking.

### Describe how to test/QA your changes

Run `datadog-agent flare` and `datadog-agent flare --local` and verify that the Agent does not panic.