### PR TITLE
[APM Onboarding] SSI bug fix for 7.52.0

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -80,7 +80,7 @@ type language string
 
 type pinnedLibraries struct {
 	libraries []libInfo
-	once      *sync.Once
+	once      sync.Once
 }
 
 const (

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -575,8 +574,7 @@ func TestExtractLibInfo(t *testing.T) {
 			}
 
 			// reset pinned libraries between test runs
-			pinnedLibs.once = new(sync.Once)
-			pinnedLibs.libraries = []libInfo{}
+			pinnedLibs = &pinnedLibraries{}
 
 			apmInstrumentation, err := newAPMInstrumentationWebhook()
 			require.NoError(t, err)
@@ -1848,8 +1846,7 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 			fakeStoreWithDeployment(t, tt.langDetectionDeployments)
 
 			// reset pinned libraries between test runs
-			pinnedLibs.once = new(sync.Once)
-			pinnedLibs.libraries = []libInfo{}
+			pinnedLibs = &pinnedLibraries{}
 
 			apmInstrumentation, err := newAPMInstrumentationWebhook()
 			require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?
Fixes the bug of NIL due to *sync.once not being initialized.

### Motivation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
1. DCA dev image https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/438235718
2. Deploy the following helm configuration on DA to the test cluster:
```
datadog:
  apiKeyExistingSecret: datadog-secret2
  clusterName: "apm-onboarding-injection"
  site: datad0g.com
  apm:
    enabled: false
    socketEnabled: true
    instrumentation:
      enabled: true
      enabledNamespaces:
        - rc-tests
clusterAgent:
  image:
    repository: datadog/cluster-agent-dev
    digest: "sha256:c7cc34bcd153f73c47a7e1ce4c0daa1b2a7a82dc7674514de658213955019521"
    pullPolicy: Always
    doNotCheckTag: true
```
3. If DA is installed from main of public helm-chart, DCA will have the following env variables installed:
```
    - name: DD_APM_INSTRUMENTATION_ENABLED
      value: "true"
    - name: DD_APM_INSTRUMENTATION_DISABLED_NAMESPACES
      value: '["default"]'
```
In https://github.com/DataDog/datadog-agent/pull/21673/files we re-defined SSI configuration options, but for those to take an effect, we also need to change helm-chart.

If DA is installed from a branch **liliya.belaus/remove-datadog-ns-blacklisting-ssi** (https://github.com/DataDog/helm-charts/pull/1318), DCA has the expected env variables installed.
```
    - name: DD_APM_INSTRUMENTATION_ENABLED
      value: "true"
    - name: DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES
      value: '["rc-tests"]'
```
4. NIL pointer exception is gone.
