### PR TITLE
[COMM-1853] Do not install msodbcsql18 for Heroku

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
@@ -21,7 +21,9 @@ if linux_target?
   # add nfsiostat script
   dependency 'unixodbc'
   dependency 'freetds'  # needed for SQL Server integration
-  dependency 'msodbcsql18' # needed for SQL Server integration
+  unless heroku_target?
+    dependency 'msodbcsql18' # needed for SQL Server integration
+  end
   dependency 'nfsiostat'
   # add libkrb5 for all integrations supporting kerberos auth with `requests-kerberos`
   dependency 'libkrb5'


### PR DESCRIPTION
### What does this PR do?

Avoid installing the msodbcsql18 driver in Heroku, as this is not used there.

### Motivation

A new dependency for DB monitoring (https://github.com/DataDog/datadog-agent/pull/20825) created a broken symlink in Heroku.

We don't need this dependency in Heroku, so we shouldn't install it in the first place.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Create a Heroku build and confirm the msodbcsql18 is not installed there.
