### PR TITLE
[EBPF-429] Increase the limit of allocations in ebpfcheck test to avoid flakes

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -308,7 +308,7 @@ func TestHashMapNumberOfEntriesNoExtraAllocations(t *testing.T) {
 					allocs := testing.AllocsPerRun(10, func() {
 						hashMapNumberOfEntriesWithBatch(m, &limitedBuffers, 1)
 					})
-					require.LessOrEqual(t, allocs, 6.0) // Multiple batches mean we need to use a map to keep track of the keys, that causes allocations for the values
+					require.LessOrEqual(t, allocs, 8.0) // Multiple batches mean we need to use a map to keep track of the keys, that causes allocations for the values
 				})
 			}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Increase the limit of allocations in the MultipleBatch mode of the entry count function in ebpfcheck.

### Motivation

The test `pkg/collector/corechecks/ebpf/probe/ebpfcheck.TestHashMapNumberOfEntriesNoExtraAllocations/10000MaxEntries/MultipleBatch` was detected as flaky. It fails very sporadically due to an extra allocation over the limit defined as acceptable. Investigating further, it seems that Go might do an extra allocation in the map that maintains the list of keys that were already seen. As we do not have any control over how Go does those allocations, I've just increased the limit to avoid the flakes.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
