### PR TITLE
Prevent job failure when github workflows are cancelled

### DIFF
--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -12,7 +12,7 @@
     - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
     - !reference [.setup_python_mirror_linux]
     - python3 -m pip install -r tasks/libs/requirements-github.txt
-    - inv -e github.trigger-macos-build --datadog-agent-ref "$CI_COMMIT_SHA" --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --destination "$OMNIBUS_PACKAGE_DIR" --version-cache "$VERSION_CACHE_CONTENT"
+    - inv -e github.trigger-macos --workflow-type "build" --datadog-agent-ref "$CI_COMMIT_SHA" --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --destination "$OMNIBUS_PACKAGE_DIR" --version-cache "$VERSION_CACHE_CONTENT"
     - !reference [.upload_sbom_artifacts]
   timeout: 3h # MacOS builds can take 1h~2h, increase the timeout to avoid timeout flakes
   artifacts:

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -17,7 +17,6 @@ tests_macos:
     - !reference [.setup_python_mirror_linux]
     - python3 -m pip install -r tasks/libs/requirements-github.txt
     - inv -e github.trigger-macos-test --datadog-agent-ref "$CI_COMMIT_SHA" --python-runtimes "$PYTHON_RUNTIMES" --version-cache "$VERSION_CACHE_CONTENT"
-  after_script:
     - inv -e junit-macos-repack --infile junit-tests_macos.tgz --outfile junit-tests_macos-repacked.tgz
   timeout: 6h
   artifacts:

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -16,8 +16,7 @@ tests_macos:
     - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
     - !reference [.setup_python_mirror_linux]
     - python3 -m pip install -r tasks/libs/requirements-github.txt
-    - inv -e github.trigger-macos-test --datadog-agent-ref "$CI_COMMIT_SHA" --python-runtimes "$PYTHON_RUNTIMES" --version-cache "$VERSION_CACHE_CONTENT"
-    - inv -e junit-macos-repack --infile junit-tests_macos.tgz --outfile junit-tests_macos-repacked.tgz
+    - inv -e github.trigger-macos --workflow-type "test" --datadog-agent-ref "$CI_COMMIT_SHA" --python-runtimes "$PYTHON_RUNTIMES" --version-cache "$VERSION_CACHE_CONTENT"
   timeout: 6h
   artifacts:
     expire_in: 2 weeks
@@ -46,4 +45,4 @@ lint_macos:
     - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
     - !reference [.setup_python_mirror_linux]
     - python3 -m pip install -r tasks/libs/requirements-github.txt
-    - inv -e github.trigger-macos-lint --datadog-agent-ref "$CI_COMMIT_SHA" --python-runtimes "$PYTHON_RUNTIMES" --version-cache "$VERSION_CACHE_CONTENT"
+    - inv -e github.trigger-macos --workflow-type "lint" --datadog-agent-ref "$CI_COMMIT_SHA" --python-runtimes "$PYTHON_RUNTIMES" --version-cache "$VERSION_CACHE_CONTENT"

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -64,7 +64,7 @@ from tasks.go_test import (
     test,
 )
 from tasks.install_tasks import download_tools, install_shellcheck, install_tools
-from tasks.junit_tasks import junit_macos_repack, junit_upload
+from tasks.junit_tasks import junit_upload
 from tasks.libs.go_workspaces import handle_go_work
 from tasks.linter_tasks import lint_copyrights, lint_filenames, lint_go, lint_python
 from tasks.pr_checks import lint_releasenote
@@ -109,7 +109,6 @@ ns.add_task(tidy_all)
 ns.add_task(internal_deps_checker)
 ns.add_task(check_go_version)
 ns.add_task(junit_upload)
-ns.add_task(junit_macos_repack)
 ns.add_task(fuzz)
 ns.add_task(go_fix)
 ns.add_task(build_messagetable)

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -39,6 +39,8 @@ def _trigger_macos_workflow(release, destination=None, retry_download=0, retry_i
     )
 
     workflow_conclusion, workflow_url = follow_workflow_run(run)
+    # Save conclusion to decide if we should fail the junit-macos-repack task
+    os.environ["GITHUB_WORKFLOW_CONCLUSION"] = workflow_conclusion
 
     if workflow_conclusion == "failure":
         print_failed_jobs_logs(run)
@@ -48,7 +50,7 @@ def _trigger_macos_workflow(release, destination=None, retry_download=0, retry_i
     if destination:
         download_with_retry(download_artifacts, run, destination, retry_download, retry_interval)
 
-    if workflow_conclusion != "success":
+    if workflow_conclusion == "failure":  # we allow workflow to be in "cancelled" state
         raise Exit(code=1)
 
 

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -105,8 +105,8 @@ def trigger_macos(
             python_runtimes=python_runtimes,
             version_cache_file_content=version_cache,
         )
-    if conclusion == "failure":
-        raise Exit(message=f"macos {workflow_type} workflow failed", code=1)
+    if conclusion != "success":
+        raise Exit(message=f"Macos {workflow_type} workflow {conclusion}", code=1)
 
 
 @task

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -15,6 +15,7 @@ from tasks.libs.github_actions_tools import (
     print_workflow_conclusion,
     trigger_macos_workflow,
 )
+from tasks.libs.junit_upload_core import repack_macos_junit_tar
 from tasks.release import _get_release_json_value
 
 
@@ -39,8 +40,6 @@ def _trigger_macos_workflow(release, destination=None, retry_download=0, retry_i
     )
 
     workflow_conclusion, workflow_url = follow_workflow_run(run)
-    # Save conclusion to decide if we should fail the junit-macos-repack task
-    os.environ["GITHUB_WORKFLOW_CONCLUSION"] = workflow_conclusion
 
     if workflow_conclusion == "failure":
         print_failed_jobs_logs(run)
@@ -50,13 +49,13 @@ def _trigger_macos_workflow(release, destination=None, retry_download=0, retry_i
     if destination:
         download_with_retry(download_artifacts, run, destination, retry_download, retry_interval)
 
-    if workflow_conclusion == "failure":  # we allow workflow to be in "cancelled" state
-        raise Exit(code=1)
+    return workflow_conclusion
 
 
 @task
-def trigger_macos_build(
+def trigger_macos(
     _,
+    workflow_type="build",
     datadog_agent_ref=DEFAULT_BRANCH,
     release_version="nightly-a7",
     major_version="7",
@@ -66,65 +65,48 @@ def trigger_macos_build(
     retry_download=3,
     retry_interval=10,
 ):
-    _trigger_macos_workflow(
-        # Provide the release version to be able to fetch the associated
-        # macos-build branch from release.json for all workflows...
-        release_version,
-        destination,
-        retry_download,
-        retry_interval,
-        workflow_name="macos.yaml",
-        datadog_agent_ref=datadog_agent_ref,
-        # ... And provide the release version as a workflow input when needed
-        release_version=release_version,
-        major_version=major_version,
-        python_runtimes=python_runtimes,
-        # Send pipeline id and bucket branch so that the package version
-        # can be constructed properly for nightlies.
-        gitlab_pipeline_id=os.environ.get("CI_PIPELINE_ID", None),
-        bucket_branch=os.environ.get("BUCKET_BRANCH", None),
-        version_cache_file_content=version_cache,
-    )
-
-
-@task
-def trigger_macos_test(
-    _,
-    datadog_agent_ref=DEFAULT_BRANCH,
-    release_version="nightly-a7",
-    python_runtimes="3",
-    destination=".",
-    version_cache=None,
-    retry_download=3,
-    retry_interval=10,
-):
-    _trigger_macos_workflow(
-        release_version,
-        destination,
-        retry_download,
-        retry_interval,
-        workflow_name="test.yaml",
-        datadog_agent_ref=datadog_agent_ref,
-        python_runtimes=python_runtimes,
-        version_cache_file_content=version_cache,
-    )
-
-
-@task
-def trigger_macos_lint(
-    _,
-    datadog_agent_ref=DEFAULT_BRANCH,
-    release_version="nightly-a7",
-    python_runtimes="3",
-    version_cache=None,
-):
-    _trigger_macos_workflow(
-        release_version,
-        workflow_name="lint.yaml",
-        datadog_agent_ref=datadog_agent_ref,
-        python_runtimes=python_runtimes,
-        version_cache_file_content=version_cache,
-    )
+    if workflow_type == "build":
+        conclusion = _trigger_macos_workflow(
+            # Provide the release version to be able to fetch the associated
+            # macos-build branch from release.json for all workflows...
+            release_version,
+            destination,
+            retry_download,
+            retry_interval,
+            workflow_name="macos.yaml",
+            datadog_agent_ref=datadog_agent_ref,
+            # ... And provide the release version as a workflow input when needed
+            release_version=release_version,
+            major_version=major_version,
+            python_runtimes=python_runtimes,
+            # Send pipeline id and bucket branch so that the package version
+            # can be constructed properly for nightlies.
+            gitlab_pipeline_id=os.environ.get("CI_PIPELINE_ID", None),
+            bucket_branch=os.environ.get("BUCKET_BRANCH", None),
+            version_cache_file_content=version_cache,
+        )
+    elif workflow_type == "test":
+        conclusion = _trigger_macos_workflow(
+            release_version,
+            destination,
+            retry_download,
+            retry_interval,
+            workflow_name="test.yaml",
+            datadog_agent_ref=datadog_agent_ref,
+            python_runtimes=python_runtimes,
+            version_cache_file_content=version_cache,
+        )
+        repack_macos_junit_tar(conclusion, "junit-tests_macos.tgz", "junit-tests_macos-repacked.tgz")
+    elif workflow_type == "lint":
+        conclusion = _trigger_macos_workflow(
+            release_version,
+            workflow_name="lint.yaml",
+            datadog_agent_ref=datadog_agent_ref,
+            python_runtimes=python_runtimes,
+            version_cache_file_content=version_cache,
+        )
+    if conclusion == "failure":
+        raise Exit(message=f"macos {workflow_type} workflow failed", code=1)
 
 
 @task

--- a/tasks/junit_tasks.py
+++ b/tasks/junit_tasks.py
@@ -1,6 +1,6 @@
 from invoke import task
 
-from tasks.libs.junit_upload_core import junit_upload_from_tgz, repack_macos_junit_tar
+from tasks.libs.junit_upload_core import junit_upload_from_tgz
 
 
 @task()
@@ -10,12 +10,3 @@ def junit_upload(_, tgz_path):
     """
 
     junit_upload_from_tgz(tgz_path)
-
-
-@task
-def junit_macos_repack(_, infile, outfile):
-    """
-    Repacks JUnit tgz file from macOS Github Action run, so it would
-    contain correct job name and job URL.
-    """
-    repack_macos_junit_tar(infile, outfile)

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -145,8 +145,7 @@ def print_workflow_conclusion(conclusion, workflow_uri):
     if conclusion == "success":
         print(color_message("Workflow run succeeded", "green"))
     else:
-        color = "orange" if conclusion == "cancelled" else "red"
-        print(color_message(f"Workflow run ended with state: {conclusion}", color))
+        print(color_message(f"Workflow run ended with state: {conclusion}", "red"))
         print(f"Failed workflow URI {workflow_uri}")
 
 

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -145,7 +145,8 @@ def print_workflow_conclusion(conclusion, workflow_uri):
     if conclusion == "success":
         print(color_message("Workflow run succeeded", "green"))
     else:
-        print(color_message(f"Workflow run ended with state: {conclusion}", "red"))
+        color = "orange" if conclusion == "cancelled" else "red"
+        print(color_message(f"Workflow run ended with state: {conclusion}", color))
         print(f"Failed workflow URI {workflow_uri}")
 
 

--- a/tasks/libs/junit_upload_core.py
+++ b/tasks/libs/junit_upload_core.py
@@ -245,9 +245,12 @@ def produce_junit_tar(files, result_path):
         tgz.addfile(job_url_info, job_url_file)
 
 
-def repack_macos_junit_tar(infile, outfile):
-    workflow_conclusion = os.environ.get("GITHUB_WORKFLOW_CONCLUSION", "failure")
-    if workflow_conclusion != "success":
+def repack_macos_junit_tar(workflow_conclusion, infile, outfile):
+    """
+    Repacks JUnit tgz file from macOS Github Action run, so it would
+    contain correct job name and job URL.
+    """
+    if workflow_conclusion == "cancelled" and not os.path.exists(infile):
         print(f"Skipping repacking of JUnit tarball due to {workflow_conclusion} workflow")
         return
 

--- a/tasks/libs/junit_upload_core.py
+++ b/tasks/libs/junit_upload_core.py
@@ -246,6 +246,11 @@ def produce_junit_tar(files, result_path):
 
 
 def repack_macos_junit_tar(infile, outfile):
+    workflow_conclusion = os.environ.get("GITHUB_WORKFLOW_CONCLUSION", "failure")
+    if workflow_conclusion != "success":
+        print(f"Skipping repacking of JUnit tarball due to {workflow_conclusion} workflow")
+        return
+
     with tarfile.open(infile) as infp, tarfile.open(outfile, "w:gz") as outfp, tempfile.TemporaryDirectory() as tempd:
         infp.extractall(tempd)
 


### PR DESCRIPTION
### What does this PR do?
Handle the possible `cancelled` state raising from github as we will allow workflow cancellation to remove pressure on builds.
- Merge the repack task with the test trigger: we must repack when a tarball is generated but bypass when we have no tarball in case of anticipated cancellation. To pass the information between workflow triggering and tarball generation it's easier to do this in a single task. Besides this task is purely ci-related (no need to launch it manually)
- factorize the different `trigger_macos_xxx` task to handle the Exit code once for all. And `Exit(1)` only on `failures`

### Motivation
We want to enable github workflow cancellation. As such we must handle situations where tarball is not generated during the test workflow. And allow cancelled jobs for build or linting.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
