### PR TITLE
[windows][cws] make procmon buffers configurable.

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1929,6 +1929,19 @@ api_key:
   ## Default is 0 (disabled). Set a valid port number (example: 5558) to enable.
   #
   # health_port: 0
+{{- if (eq .OS "windows")}}
+
+  # windows:
+    
+    ## @param process_buffer_size - integer - optional - default: 16348
+    ## Sets the buffer size for collecting process information.
+    # process_buffer_size: 16348
+    
+    ## @param process_buffer_count - integer - optional - default: 50
+    ## Sets the the number of process buffers for collecting process information.
+    # process_buffer_count: 50
+
+{{ end }}
 
 {{- if .InternalProfiling -}}
   ## @param profiling - custom object - optional

--- a/pkg/config/setup/system_probe_cws_windows.go
+++ b/pkg/config/setup/system_probe_cws_windows.go
@@ -22,4 +22,8 @@ func platformCWSConfig(cfg pkgconfigmodel.Config) {
 		cfg.BindEnvAndSetDefault("runtime_security_config.policies.dir", "c:\\programdata\\datadog\\runtime-security.d")
 	}
 	cfg.BindEnvAndSetDefault("runtime_security_config.socket", "localhost:3334")
+
+	cfg.BindEnvAndSetDefault("runtime_security_config.windows.process_buffer_count", 50)
+	cfg.BindEnvAndSetDefault("runtime_security_config.windows.process_buffer_size", 16384)
+
 }

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -134,6 +134,13 @@ type Config struct {
 
 	// SyscallsMonitorEnabled defines if syscalls monitoring metrics should be collected
 	SyscallsMonitorEnabled bool
+
+	// windows-prefixed values only valid on windows
+	// WindowsProcessBufferCount is the number of buffers to use for the process monitor
+	WindowsProcessBufferCount int
+
+	// WindowsProcessBufferSize is the size of the buffers to use for the process monitor
+	WindowsProcessBufferSize int
 }
 
 // NewConfig returns a new Config object
@@ -176,6 +183,10 @@ func NewConfig() (*Config, error) {
 		RuntimeCompilationEnabled:       getBool("runtime_compilation.enabled"),
 		RuntimeCompiledConstantsEnabled: getBool("runtime_compilation.compiled_constants_enabled"),
 		RuntimeCompiledConstantsIsSet:   isSet("runtime_compilation.compiled_constants_enabled"),
+	}
+	if runtime.GOOS == "windows" {
+		c.WindowsProcessBufferCount = coreconfig.SystemProbe.GetInt(join(rsNS, "windows.process_buffer_count"))
+		c.WindowsProcessBufferSize = coreconfig.SystemProbe.GetInt(join(rsNS, "windows.process_buffer_size"))
 	}
 
 	if err := c.sanitize(); err != nil {

--- a/pkg/security/probe/probe_kernel_reg_windows_test.go
+++ b/pkg/security/probe/probe_kernel_reg_windows_test.go
@@ -165,7 +165,7 @@ func TestETWRegistryNotifications(t *testing.T) {
 	stopLoop(et, &wg)
 
 	assert.Equal(t, 2, len(et.notifications), "expected 2 notifications, got %d", len(et.notifications))
-	
+
 	if c, ok := et.notifications[0].(*createKeyArgs); ok {
 		assert.Equal(t, expectedBase, c.computedFullPath, "expected %s, got %s", expectedBase, c.computedFullPath)
 	} else {

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -75,7 +75,7 @@ type etwCallback func(n interface{}, pid uint32, eventType model.EventType)
 func (p *WindowsProbe) Init() error {
 
 	if !p.opts.disableProcmon {
-		pm, err := procmon.NewWinProcMon(p.onStart, p.onStop, p.onError, procmon.ProcmonDefaultReceiveSize, procmon.ProcmonDefaultNumBufs)
+		pm, err := procmon.NewWinProcMon(p.onStart, p.onStop, p.onError, p.config.Probe.WindowsProcessBufferSize, p.config.Probe.WindowsProcessBufferCount)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?

Increases the default procmon buffer size to 16384.
Makes procmon buffer size and number of buffers configurable.

### Motivation

During testing, was observed that some command lines wouldn't fit in the buffer, meaning that some notifications could be missed.  Enlarge the buffer to decrease the circumstances in which that happens, and make it runtime configurable to work around if further instances are found.

### Additional Notes


### Possible Drawbacks / Trade-offs

Increasing the buffer size will increase the static memory usage of system probe.  This number is hard-capped in the change.

### Describe how to test/QA your changes

Install the agent.
Enable system probe.
Set system probe logging to `debug`.
Change the included variables (documented in the template.yaml)
verify in the debug log message that correct buffer size is set.

```
2024-02-20 22:46:07 PST | SYS-PROBE | DEBUG | (D:/src/agent.cws/pkg/windowsdriver/procmon/procmon.go:96 in NewWinProcMon) | creating new WinProcmon with bufsize 20000 and numbufs 50
```
