### PR TITLE
[CWS] add rule_id pprof labels on evaluation function

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -126,7 +126,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.block_profile_rate"), 0)
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enable_goroutine_stacktraces"), false)
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.delta_profiles"), true)
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.custom_attributes"), []string{"module"})
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.custom_attributes"), []string{"module", "rule_id"})
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.unix_socket"), "")
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.extra_tags"), []string{})
 

--- a/pkg/security/secl/compiler/eval/rule.go
+++ b/pkg/security/secl/compiler/eval/rule.go
@@ -22,11 +22,12 @@ type RuleSetTagValue = string
 
 // Rule - Rule object identified by an `ID` containing a SECL `Expression`
 type Rule struct {
-	ID         RuleID
-	Expression string
-	Tags       []string
-	Model      Model
-	Opts       *Opts
+	ID          RuleID
+	Expression  string
+	Tags        []string
+	Model       Model
+	Opts        *Opts
+	pprofLabels map[string]string
 
 	evaluator *RuleEvaluator
 	ast       *ast.Rule
@@ -53,10 +54,11 @@ func NewRule(id string, expression string, opts *Opts, tags ...string) *Rule {
 	}
 
 	return &Rule{
-		ID:         id,
-		Expression: expression,
-		Opts:       opts,
-		Tags:       tags,
+		ID:          id,
+		Expression:  expression,
+		Opts:        opts,
+		Tags:        tags,
+		pprofLabels: map[string]string{"rule_id": id},
 	}
 }
 
@@ -131,6 +133,11 @@ func (r *Rule) GetFields() []Field {
 	}
 
 	return fields
+}
+
+// GetPprofLabels returns the pprof labels
+func (r *Rule) GetPprofLabels() map[string]string {
+	return r.pprofLabels
 }
 
 // GetEvaluator - Returns the RuleEvaluator of the Rule corresponding to the SECL `Expression`

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -644,8 +644,7 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	result := false
 
 	for _, rule := range bucket.rules {
-		labels := map[string]string{"rule_id": rule.ID}
-		utils.PprofDoWithoutContext(labels, func() {
+		utils.PprofDoWithoutContext(rule.GetPprofLabels(), func() {
 			if rule.GetEvaluator().Eval(ctx) {
 
 				if rs.logger.IsTracing() {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -7,11 +7,9 @@
 package rules
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"reflect"
-	"runtime/pprof"
 	"sync"
 	"time"
 
@@ -23,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/log"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/utils"
 )
 
 // MacroID represents the ID of a macro
@@ -643,11 +642,10 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	}
 
 	result := false
-	pprofCtx := context.TODO()
 
 	for _, rule := range bucket.rules {
-		labels := pprof.Labels("rule_id", rule.ID)
-		pprof.Do(pprofCtx, labels, func(pprofCtx context.Context) {
+		labels := map[string]string{"rule_id": rule.ID}
+		utils.PprofDoWithoutContext(labels, func() {
 			if rule.GetEvaluator().Eval(ctx) {
 
 				if rs.logger.IsTracing() {

--- a/pkg/security/secl/utils/pprof.go
+++ b/pkg/security/secl/utils/pprof.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package utils groups multiple utils function that can be used by the secl package
+package utils
+
+import (
+	"unsafe"
+)
+
+type labelMap map[string]string
+
+//go:linkname runtimeSetProfLabel runtime/pprof.runtime_setProfLabel
+func runtimeSetProfLabel(labels unsafe.Pointer)
+
+//go:linkname runtimeGetProfLabel runtime/pprof.runtime_getProfLabel
+func runtimeGetProfLabel() unsafe.Pointer
+
+func setGoroutineLabels(labels *labelMap) {
+	runtimeSetProfLabel(unsafe.Pointer(labels))
+}
+
+func getGoroutineLabels() *labelMap {
+	return (*labelMap)(runtimeGetProfLabel())
+}
+
+// PprofDoWithoutContext does the same thing as https://pkg.go.dev/runtime/pprof#Do, but without the allocation resulting
+// from the usage of context values. This function also directly takes a map of labels, instead of incuring allocations
+// when converting from one format (LabelSet) to the other (map).
+func PprofDoWithoutContext(labels map[string]string, f func()) {
+	previousLabels := getGoroutineLabels()
+	defer setGoroutineLabels(previousLabels)
+
+	labels2 := (labelMap)(labels)
+
+	setGoroutineLabels(&labels2)
+	f()
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds a new pprof label around rule evaluation allowing to measure and compare the CPU impact of each rule
<img width="528" alt="image" src="https://github.com/DataDog/datadog-agent/assets/2822037/d8b99802-512b-40a2-ad92-0bd4906019e7">

The implementation is a bit ugly, but required to not use more CPU allocating labels and labelset and labelmaps and context value than actually evaluating the rule..

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
