### PR TITLE
[config] Rename admission_controller.inject_auto_detected_libraries option for consistency

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -346,7 +346,7 @@ func getPinnedLibraries(registry string) []libInfo {
 // getLibrariesLanguageDetection runs process language auto-detection and returns languages to inject for APM Instrumentation.
 // The langages information is available in workloadmeta-store and attached on the pod's owner.
 func getLibrariesLanguageDetection(pod *corev1.Pod, registry string) []libInfo {
-	if config.Datadog.GetBool("admission_controller.inject_auto_detected_libraries") {
+	if config.Datadog.GetBool("admission_controller.auto_instrumentation.inject_auto_detected_libraries") {
 		// Use libraries returned by language detection for APM Instrumentation
 		return getAutoDetectedLibraries(pod, registry)
 	}

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -1769,7 +1769,7 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 			},
 			wantErr: false,
 			setupConfig: func() {
-				mockConfig.SetWithoutSource("admission_controller.inject_auto_detected_libraries", true)
+				mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.inject_auto_detected_libraries", true)
 				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
 			},
 		},
@@ -1832,7 +1832,7 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 			},
 			wantErr: false,
 			setupConfig: func() {
-				mockConfig.SetWithoutSource("admission_controller.inject_auto_detected_libraries", true)
+				mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.inject_auto_detected_libraries", true)
 				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
 				mockConfig.SetWithoutSource("apm_config.instrumentation.lib_versions", map[string]string{"ruby": "v1.2.3"})
 			},

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1060,7 +1060,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider", false)                                // to be enabled only in e2e tests
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json") // to be used only in e2e tests
-	config.BindEnvAndSetDefault("admission_controller.inject_auto_detected_libraries", true)                                                         // allows injecting libraries for languages detected by automatic language detection feature
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_auto_detected_libraries", true)                                    // allows injecting libraries for languages detected by automatic language detection feature
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu")
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.enabled", false)


### PR DESCRIPTION
### What does this PR do?

Renames the `admission_controller.inject_auto_detected_libraries` config option to `admission_controller.auto_instrumentation.inject_auto_detected_libraries`.

This is done to be consistent with the naming of the other config options about the admission controller.

It should be safe because this config option is about a feature that was not working until 7.52.0, and it was not documented.
