### PR TITLE
Fix update_build_links job in Agent RC build pipeline

### DIFF
--- a/.gitlab/rc_jobs/post_rc_tasks.yml
+++ b/.gitlab/rc_jobs/post_rc_tasks.yml
@@ -18,4 +18,4 @@ update_rc_build_links:
     - export ATLASSIAN_USERNAME=robot-jira-agentplatform@datadoghq.com
     - set -x
     - python3 -m pip install -r tasks/requirements_release_tasks.txt
-    - inv -e release.update-build-links ${CI_COMMIT_REF_SLUG}
+    - inv -e release.update-build-links ${CI_COMMIT_REF_NAME}


### PR DESCRIPTION
### What does this PR do?

Job in the gitlab pipeline which updates the QA build links page requires the version to provided like `7.52.0-rc.2` so that corresponds to `CI_COMMIT_REF_NAME` variable. By mistake there is `CI_COMMIT_REF_SLUG`. used now, which breaks the command.

### Motivation

Automation of the Agent release process.


### Describe how to test/QA your changes

This change will be tested with the next Agent RC build.
