### PR TITLE
Add ddprocmon versions handling in release.create-rc task

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -549,27 +549,10 @@ def _get_windows_release_json_info(release_json, agent_major_version, is_first_r
     """
     release_json_version_data = _get_release_json_info_for_next_rc(release_json, agent_major_version, is_first_rc)
 
-    # Step 1: DDNPM
-
-    win_ddnpm_driver = release_json_version_data['WINDOWS_DDNPM_DRIVER']
-    win_ddnpm_version = release_json_version_data['WINDOWS_DDNPM_VERSION']
-    win_ddnpm_shasum = release_json_version_data['WINDOWS_DDNPM_SHASUM']
-
-    if win_ddnpm_driver not in ['release-signed', 'attestation-signed']:
-        print(f"WARN: WINDOWS_DDNPM_DRIVER value '{win_ddnpm_driver}' is not valid")
-
-    print(f"The windows ddnpm version is {win_ddnpm_version}")
-
-    # Step 2: DDPROCMON
-
-    win_ddprocmon_driver = release_json_version_data['WINDOWS_DDPROCMON_DRIVER']
-    win_ddprocmon_version = release_json_version_data['WINDOWS_DDPROCMON_VERSION']
-    win_ddprocmon_shasum = release_json_version_data['WINDOWS_DDPROCMON_SHASUM']
-
-    if win_ddnpm_driver not in ['release-signed', 'attestation-signed']:
-        print(f"WARN: WINDOWS_DDPROCMON_DRIVER value '{win_ddprocmon_driver}' is not valid")
-
-    print(f"The windows ddprocmon version is {win_ddnpm_version}")
+    win_ddnpm_driver, win_ddnpm_version, win_ddnpm_shasum = _get_windows_driver_info(release_json_version_data, 'DDNPM')
+    win_ddprocmon_driver, win_ddprocmon_version, win_ddprocmon_shasum = _get_windows_driver_info(
+        release_json_version_data, 'DDPROCMON'
+    )
 
     return (
         win_ddnpm_driver,
@@ -579,6 +562,26 @@ def _get_windows_release_json_info(release_json, agent_major_version, is_first_r
         win_ddprocmon_version,
         win_ddprocmon_shasum,
     )
+
+
+def _get_windows_driver_info(release_json_version_data, driver_name):
+    """
+    Gets the Windows driver info from the release.json version data.
+    """
+    driver_key = f'WINDOWS_{driver_name}_DRIVER'
+    version_key = f'WINDOWS_{driver_name}_VERSION'
+    shasum_key = f'WINDOWS_{driver_name}_SHASUM'
+
+    driver_value = release_json_version_data[driver_key]
+    version_value = release_json_version_data[version_key]
+    shasum_value = release_json_version_data[shasum_key]
+
+    if driver_value not in ['release-signed', 'attestation-signed']:
+        print(f"WARN: {driver_key} value '{driver_value}' is not valid")
+
+    print(f"The windows {driver_name.lower()} version is {version_value}")
+
+    return driver_value, version_value, shasum_value
 
 
 def _get_release_json_info_for_next_rc(release_json, agent_major_version, is_first_rc=False):

--- a/tasks/unit-tests/release_tests.py
+++ b/tasks/unit-tests/release_tests.py
@@ -146,6 +146,9 @@ class TestUpdateReleaseJsonEntry(unittest.TestCase):
                     "WINDOWS_DDNPM_VERSION": "0.98.2.git.86.53d1ee4",
                     "WINDOWS_DDNPM_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                     "SECURITY_AGENT_POLICIES_VERSION": "master",
+                    "WINDOWS_DDPROCMON_DRIVER": "release-signed",
+                    "WINDOWS_DDPROCMON_VERSION": "0.98.2.git.86.53d1ee4",
+                    "WINDOWS_DDPROCMON_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                 },
                 release.nightly_entry_for(7): {
                     "INTEGRATIONS_CORE_VERSION": "master",
@@ -158,6 +161,9 @@ class TestUpdateReleaseJsonEntry(unittest.TestCase):
                     "WINDOWS_DDNPM_VERSION": "0.98.2.git.86.53d1ee4",
                     "WINDOWS_DDNPM_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                     "SECURITY_AGENT_POLICIES_VERSION": "master",
+                    "WINDOWS_DDPROCMON_DRIVER": "release-signed",
+                    "WINDOWS_DDPROCMON_VERSION": "0.98.2.git.86.53d1ee4",
+                    "WINDOWS_DDPROCMON_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                 },
                 release.release_entry_for(6): {
                     "INTEGRATIONS_CORE_VERSION": "master",
@@ -170,6 +176,9 @@ class TestUpdateReleaseJsonEntry(unittest.TestCase):
                     "WINDOWS_DDNPM_VERSION": "0.98.2.git.86.53d1ee4",
                     "WINDOWS_DDNPM_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                     "SECURITY_AGENT_POLICIES_VERSION": "master",
+                    "WINDOWS_DDPROCMON_DRIVER": "release-signed",
+                    "WINDOWS_DDPROCMON_VERSION": "0.98.2.git.86.53d1ee4",
+                    "WINDOWS_DDPROCMON_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                 },
                 release.release_entry_for(7): {
                     "INTEGRATIONS_CORE_VERSION": "master",
@@ -182,6 +191,9 @@ class TestUpdateReleaseJsonEntry(unittest.TestCase):
                     "WINDOWS_DDNPM_VERSION": "0.98.2.git.86.53d1ee4",
                     "WINDOWS_DDNPM_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                     "SECURITY_AGENT_POLICIES_VERSION": "master",
+                    "WINDOWS_DDPROCMON_DRIVER": "release-signed",
+                    "WINDOWS_DDPROCMON_VERSION": "0.98.2.git.86.53d1ee4",
+                    "WINDOWS_DDPROCMON_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                 },
             }
         )
@@ -196,6 +208,9 @@ class TestUpdateReleaseJsonEntry(unittest.TestCase):
         windows_ddnpm_driver = "release-signed"
         windows_ddnpm_version = "1.2.1"
         windows_ddnpm_shasum = "windowsddnpmshasum"
+        windows_ddprocmon_driver = "release-signed"
+        windows_ddprocmon_version = "1.2.1"
+        windows_ddprocmon_shasum = "windowsddprocmonshasum"
 
         release_json = release._update_release_json_entry(
             release_json=initial_release_json,
@@ -210,6 +225,9 @@ class TestUpdateReleaseJsonEntry(unittest.TestCase):
             windows_ddnpm_driver=windows_ddnpm_driver,
             windows_ddnpm_version=windows_ddnpm_version,
             windows_ddnpm_shasum=windows_ddnpm_shasum,
+            windows_ddprocmon_driver=windows_ddprocmon_driver,
+            windows_ddprocmon_version=windows_ddprocmon_version,
+            windows_ddprocmon_shasum=windows_ddprocmon_shasum,
         )
 
         expected_release_json = OrderedDict(
@@ -225,6 +243,9 @@ class TestUpdateReleaseJsonEntry(unittest.TestCase):
                     "WINDOWS_DDNPM_VERSION": "0.98.2.git.86.53d1ee4",
                     "WINDOWS_DDNPM_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                     "SECURITY_AGENT_POLICIES_VERSION": "master",
+                    "WINDOWS_DDPROCMON_DRIVER": "release-signed",
+                    "WINDOWS_DDPROCMON_VERSION": "0.98.2.git.86.53d1ee4",
+                    "WINDOWS_DDPROCMON_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                 },
                 release.nightly_entry_for(7): {
                     "INTEGRATIONS_CORE_VERSION": "master",
@@ -237,6 +258,9 @@ class TestUpdateReleaseJsonEntry(unittest.TestCase):
                     "WINDOWS_DDNPM_VERSION": "0.98.2.git.86.53d1ee4",
                     "WINDOWS_DDNPM_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                     "SECURITY_AGENT_POLICIES_VERSION": "master",
+                    "WINDOWS_DDPROCMON_DRIVER": "release-signed",
+                    "WINDOWS_DDPROCMON_VERSION": "0.98.2.git.86.53d1ee4",
+                    "WINDOWS_DDPROCMON_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                 },
                 release.release_entry_for(6): {
                     "INTEGRATIONS_CORE_VERSION": "master",
@@ -249,6 +273,9 @@ class TestUpdateReleaseJsonEntry(unittest.TestCase):
                     "WINDOWS_DDNPM_VERSION": "0.98.2.git.86.53d1ee4",
                     "WINDOWS_DDNPM_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                     "SECURITY_AGENT_POLICIES_VERSION": "master",
+                    "WINDOWS_DDPROCMON_DRIVER": "release-signed",
+                    "WINDOWS_DDPROCMON_VERSION": "0.98.2.git.86.53d1ee4",
+                    "WINDOWS_DDPROCMON_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
                 },
                 release.release_entry_for(7): {
                     "INTEGRATIONS_CORE_VERSION": str(integrations_version),
@@ -261,6 +288,9 @@ class TestUpdateReleaseJsonEntry(unittest.TestCase):
                     "WINDOWS_DDNPM_VERSION": str(windows_ddnpm_version),
                     "WINDOWS_DDNPM_SHASUM": str(windows_ddnpm_shasum),
                     "SECURITY_AGENT_POLICIES_VERSION": str(security_agent_policies_version),
+                    "WINDOWS_DDPROCMON_DRIVER": str(windows_ddprocmon_driver),
+                    "WINDOWS_DDPROCMON_VERSION": str(windows_ddprocmon_version),
+                    "WINDOWS_DDPROCMON_SHASUM": str(windows_ddprocmon_shasum),
                 },
             }
         )
@@ -315,37 +345,69 @@ class TestGetWindowsDDNPMReleaseJsonInfo(unittest.TestCase):
             "WINDOWS_DDNPM_DRIVER": "attestation-signed",
             "WINDOWS_DDNPM_VERSION": "nightly-ddnpm-version",
             "WINDOWS_DDNPM_SHASUM": "nightly-ddnpm-sha",
+            "WINDOWS_DDPROCMON_DRIVER": "attestation-signed",
+            "WINDOWS_DDPROCMON_VERSION": "nightly-ddprocmon-version",
+            "WINDOWS_DDPROCMON_SHASUM": "nightly-ddprocmon-sha",
         },
         release.nightly_entry_for(7): {
             "WINDOWS_DDNPM_DRIVER": "attestation-signed",
             "WINDOWS_DDNPM_VERSION": "nightly-ddnpm-version",
             "WINDOWS_DDNPM_SHASUM": "nightly-ddnpm-sha",
+            "WINDOWS_DDPROCMON_DRIVER": "attestation-signed",
+            "WINDOWS_DDPROCMON_VERSION": "nightly-ddprocmon-version",
+            "WINDOWS_DDPROCMON_SHASUM": "nightly-ddprocmon-sha",
         },
         release.release_entry_for(6): {
             "WINDOWS_DDNPM_DRIVER": "release-signed",
             "WINDOWS_DDNPM_VERSION": "rc3-ddnpm-version",
             "WINDOWS_DDNPM_SHASUM": "rc3-ddnpm-sha",
+            "WINDOWS_DDPROCMON_DRIVER": "release-signed",
+            "WINDOWS_DDPROCMON_VERSION": "rc3-ddprocmon-version",
+            "WINDOWS_DDPROCMON_SHASUM": "rc3-ddprocmon-sha",
         },
         release.release_entry_for(7): {
             "WINDOWS_DDNPM_DRIVER": "release-signed",
             "WINDOWS_DDNPM_VERSION": "rc3-ddnpm-version",
             "WINDOWS_DDNPM_SHASUM": "rc3-ddnpm-sha",
+            "WINDOWS_DDPROCMON_DRIVER": "release-signed",
+            "WINDOWS_DDPROCMON_VERSION": "rc3-ddprocmon-version",
+            "WINDOWS_DDPROCMON_SHASUM": "rc3-ddprocmon-sha",
         },
     }
 
     def test_ddnpm_info_is_taken_from_nightly_on_first_rc(self):
-        driver, version, shasum = release._get_windows_ddnpm_release_json_info(self.test_release_json, 7, True)
+        (
+            ddnpm_driver,
+            ddnpm_version,
+            ddnpm_shasum,
+            ddprocmon_driver,
+            ddprocmon_version,
+            ddprocmon_shasum,
+        ) = release._get_windows_release_json_info(self.test_release_json, 7, True)
 
-        self.assertEqual(driver, 'attestation-signed')
-        self.assertEqual(version, 'nightly-ddnpm-version')
-        self.assertEqual(shasum, 'nightly-ddnpm-sha')
+        self.assertEqual(ddnpm_driver, 'attestation-signed')
+        self.assertEqual(ddnpm_version, 'nightly-ddnpm-version')
+        self.assertEqual(ddnpm_shasum, 'nightly-ddnpm-sha')
+        self.assertEqual(ddprocmon_driver, 'attestation-signed')
+        self.assertEqual(ddprocmon_version, 'nightly-ddprocmon-version')
+        self.assertEqual(ddprocmon_shasum, 'nightly-ddprocmon-sha')
 
     def test_ddnpm_info_is_taken_from_previous_rc_on_subsequent_rcs(self):
-        driver, version, shasum = release._get_windows_ddnpm_release_json_info(self.test_release_json, 7, False)
+        (
+            ddnpm_driver,
+            ddnpm_version,
+            ddnpm_shasum,
+            ddprocmon_driver,
+            ddprocmon_version,
+            ddprocmon_shasum,
+        ) = release._get_windows_release_json_info(self.test_release_json, 7, False)
 
-        self.assertEqual(driver, 'release-signed')
-        self.assertEqual(version, 'rc3-ddnpm-version')
-        self.assertEqual(shasum, 'rc3-ddnpm-sha')
+        self.assertEqual(ddnpm_driver, 'release-signed')
+        self.assertEqual(ddnpm_version, 'rc3-ddnpm-version')
+        self.assertEqual(ddnpm_shasum, 'rc3-ddnpm-sha')
+        self.assertEqual(ddprocmon_driver, 'release-signed')
+        self.assertEqual(ddprocmon_version, 'rc3-ddprocmon-version')
+        self.assertEqual(ddprocmon_shasum, 'rc3-ddprocmon-sha')
 
 
 class TestGetReleaseJsonInfoForNextRC(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?

windows-kernel-integration team added recently new entries to the `release.json` file. They were not considered when running `in release.create-rc` task which we use to generate new RC entries and ended up being discarded. This PR adds missing functionality.

### Motivation

Automation of Agent RC build process.

### Describe how to test/QA your changes

Tested locally in mocked scenario. This needs to be properly tested when creating next real RC build.
