### PR TITLE
Fix config isknown to properly handle uppercase keys

### DIFF
--- a/comp/otelcol/otlp/config.go
+++ b/comp/otelcol/otlp/config.go
@@ -59,7 +59,7 @@ func readConfigSection(cfg config.Reader, section string) *confmap.Conf {
 	// we check every key manually, and if it belongs to the OTLP receiver section,
 	// we set it. We need to do this to account for environment variable values.
 	prefix := section + "."
-	for _, key := range cfg.AllKeys() {
+	for _, key := range cfg.AllKeysLowercased() {
 		if strings.HasPrefix(key, prefix) && cfg.IsSet(key) {
 			mapKey := strings.ReplaceAll(key[len(prefix):], ".", confmap.KeyDelimiter)
 			// deep copy since `cfg.Get` returns a reference

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -67,6 +67,7 @@ type Reader interface {
 
 	// GetKnownKeys returns all the keys that meet at least one of these criteria:
 	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()
+	// Note that it returns the keys lowercased.
 	GetKnownKeys() map[string]interface{}
 
 	// GetEnvVars returns a list of the env vars that the config supports.

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -54,7 +54,9 @@ type Reader interface {
 	AllSettings() map[string]interface{}
 	AllSettingsWithoutDefault() map[string]interface{}
 	AllSourceSettingsWithoutDefault(source Source) map[string]interface{}
-	AllKeys() []string
+	// AllKeysLowercased returns all config keys in the config, no matter how they are set.
+	// Note that it returns the keys lowercased.
+	AllKeysLowercased() []string
 
 	IsSet(key string) bool
 	IsSetForSource(key string, source Source) bool
@@ -65,10 +67,10 @@ type Reader interface {
 	// IsKnown returns whether this key is known
 	IsKnown(key string) bool
 
-	// GetKnownKeys returns all the keys that meet at least one of these criteria:
+	// GetKnownKeysLowercased returns all the keys that meet at least one of these criteria:
 	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()
 	// Note that it returns the keys lowercased.
-	GetKnownKeys() map[string]interface{}
+	GetKnownKeysLowercased() map[string]interface{}
 
 	// GetEnvVars returns a list of the env vars that the config supports.
 	// These have had the EnvPrefix applied, as well as the EnvKeyReplacer.

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -143,20 +143,20 @@ func (c *safeConfig) SetKnown(key string) {
 
 // IsKnown returns whether a key is known
 func (c *safeConfig) IsKnown(key string) bool {
-	keys := c.GetKnownKeys()
+	keys := c.GetKnownKeysLowercased()
 	key = strings.ToLower(key)
 	_, ok := keys[key]
 	return ok
 }
 
-// GetKnownKeys returns all the keys that meet at least one of these criteria:
+// GetKnownKeysLowercased returns all the keys that meet at least one of these criteria:
 // 1) have a default, 2) have an environment variable binded or 3) have been SetKnown()
 // Note that it returns the keys lowercased.
-func (c *safeConfig) GetKnownKeys() map[string]interface{} {
+func (c *safeConfig) GetKnownKeysLowercased() map[string]interface{} {
 	c.RLock()
 	defer c.RUnlock()
 
-	// GetKnownKeys returns a fresh map, so the caller may do with it
+	// GetKnownKeysLowercased returns a fresh map, so the caller may do with it
 	// as they please without holding the lock.
 	return c.Viper.GetKnownKeys()
 }
@@ -203,7 +203,7 @@ func (c *safeConfig) IsSectionSet(section string) bool {
 	// if "section_key" is set.
 	sectionPrefix := section + "."
 
-	for _, key := range c.AllKeys() {
+	for _, key := range c.AllKeysLowercased() {
 		if strings.HasPrefix(key, sectionPrefix) && c.IsSet(key) {
 			return true
 		}
@@ -214,7 +214,7 @@ func (c *safeConfig) IsSectionSet(section string) bool {
 	return c.IsSet(section)
 }
 
-func (c *safeConfig) AllKeys() []string {
+func (c *safeConfig) AllKeysLowercased() []string {
 	c.RLock()
 	defer c.RUnlock()
 	return c.Viper.AllKeys()

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -144,12 +144,14 @@ func (c *safeConfig) SetKnown(key string) {
 // IsKnown returns whether a key is known
 func (c *safeConfig) IsKnown(key string) bool {
 	keys := c.GetKnownKeys()
+	key = strings.ToLower(key)
 	_, ok := keys[key]
 	return ok
 }
 
 // GetKnownKeys returns all the keys that meet at least one of these criteria:
 // 1) have a default, 2) have an environment variable binded or 3) have been SetKnown()
+// Note that it returns the keys lowercased.
 func (c *safeConfig) GetKnownKeys() map[string]interface{} {
 	c.RLock()
 	defer c.RUnlock()

--- a/pkg/config/model/viper_test.go
+++ b/pkg/config/model/viper_test.go
@@ -223,6 +223,57 @@ func TestIsSet(t *testing.T) {
 	assert.True(t, config.IsSetForSource("foo", SourceFile))
 }
 
+func TestIsKnown(t *testing.T) {
+	testCases := []struct {
+		setDefault bool
+		setEnv     bool
+		setKnown   bool
+		expected   bool
+	}{
+		{false, false, false, false},
+		{false, false, true, true},
+		{false, true, false, true},
+		{false, true, true, true},
+		{true, false, false, true},
+		{true, false, true, true},
+		{true, true, false, true},
+		{true, true, true, true},
+	}
+
+	configDefault := "somedefault"
+	configEnv := "SOME_ENV"
+
+	for _, tc := range testCases {
+		testName := "isknown"
+		if tc.setKnown {
+			testName += "-known"
+		}
+		if tc.setDefault {
+			testName += "-default"
+		}
+		if tc.setEnv {
+			testName += "-env"
+		}
+		t.Run(testName, func(t *testing.T) {
+			for _, configName := range []string{"foo", "BAR", "BaZ", "foo_BAR", "foo.BAR", "foo.BAR.baz"} {
+				config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+
+				if tc.setKnown {
+					config.SetKnown(configName)
+				}
+				if tc.setDefault {
+					config.SetDefault(configName, configDefault)
+				}
+				if tc.setEnv {
+					config.BindEnv(configName, configEnv)
+				}
+
+				assert.Equal(t, tc.expected, config.IsKnown(configName))
+			}
+		})
+	}
+}
+
 func TestUnsetForSource(t *testing.T) {
 	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
 	config.Set("foo", "bar", SourceFile)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1424,8 +1424,8 @@ func Merge(configPaths []string, config pkgconfigmodel.Config) error {
 
 func findUnknownKeys(config pkgconfigmodel.Config) []string {
 	var unknownKeys []string
-	knownKeys := config.GetKnownKeys()
-	loadedKeys := config.AllKeys()
+	knownKeys := config.GetKnownKeysLowercased()
+	loadedKeys := config.AllKeysLowercased()
 	for _, key := range loadedKeys {
 		if _, found := knownKeys[key]; !found {
 			// Check if any subkey terminated with a '.*' wildcard is marked as known
@@ -1472,7 +1472,7 @@ func findUnexpectedUnicode(config pkgconfigmodel.Config) []string {
 		}
 	}
 
-	allKeys := config.AllKeys()
+	allKeys := config.AllKeysLowercased()
 	for _, key := range allKeys {
 		checkAndRecordString(key, fmt.Sprintf("Configuration key string '%s'", key))
 		if unknownValue := config.Get(key); unknownValue != nil {

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -16,13 +16,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 func unsetEnvForTest(t *testing.T, env string) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Lowercase keys in `config.IsKnown`, so that it returns the correct information for uppercased keys.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
`config.IsKnown` currently returns `false` for all keys containing uppercased characters (eg. `GUI_port`).
It relies on `viper.GetKnownKeys`, which returns lowercased keys.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Added an extensive unit test around `IsKnown`.
