### PR TITLE
remove v1.History from serverless build

### DIFF
--- a/comp/core/workloadmeta/types.go
+++ b/comp/core/workloadmeta/types.go
@@ -7,7 +7,6 @@ package workloadmeta
 
 import (
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/mohae/deepcopy"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -865,13 +863,11 @@ type ContainerImageMetadata struct {
 	SBOM         *SBOM
 }
 
-// ContainerImageLayer represents a layer of a container image
-type ContainerImageLayer struct {
-	MediaType string
-	Digest    string
-	SizeBytes int64
-	URLs      []string
-	History   *v1.History
+type v1History interface {
+	Created() string
+	CreatedBy() string
+	Comment() string
+	EmptyLayer() string
 }
 
 // SBOM represents the Software Bill Of Materials (SBOM) of a container
@@ -956,19 +952,6 @@ func (layer ContainerImageLayer) String() string {
 	printHistory(&sb, layer.History)
 
 	return sb.String()
-}
-
-func printHistory(out io.Writer, history *v1.History) {
-	if history == nil {
-		_, _ = fmt.Fprintln(out, "History is nil")
-		return
-	}
-
-	_, _ = fmt.Fprintln(out, "History:")
-	_, _ = fmt.Fprintln(out, "- createdAt:", history.Created)
-	_, _ = fmt.Fprintln(out, "- createdBy:", history.CreatedBy)
-	_, _ = fmt.Fprintln(out, "- comment:", history.Comment)
-	_, _ = fmt.Fprintln(out, "- emptyLayer:", history.EmptyLayer)
 }
 
 var _ Entity = &ContainerImageMetadata{}

--- a/comp/core/workloadmeta/types_non_serverless.go
+++ b/comp/core/workloadmeta/types_non_serverless.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !serverless
+
+package workloadmeta
+
+import (
+	"fmt"
+	"io"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ContainerImageLayer represents a layer of a container image
+type ContainerImageLayer struct {
+	MediaType string
+	Digest    string
+	SizeBytes int64
+	URLs      []string
+	History   v1.History
+}
+
+func printHistory(out io.Writer, history v1History) {
+	if history == nil {
+		_, _ = fmt.Fprintln(out, "History is nil")
+		return
+	}
+
+	_, _ = fmt.Fprintln(out, "History:")
+	_, _ = fmt.Fprintln(out, "- createdAt:", history.Created())
+	_, _ = fmt.Fprintln(out, "- createdBy:", history.CreatedBy())
+	_, _ = fmt.Fprintln(out, "- comment:", history.Comment())
+	_, _ = fmt.Fprintln(out, "- emptyLayer:", history.EmptyLayer())
+}

--- a/comp/core/workloadmeta/types_serverless.go
+++ b/comp/core/workloadmeta/types_serverless.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build serverless
+
+package workloadmeta
+
+import (
+	"io"
+)
+
+// ContainerImageLayer represents a layer of a container image
+type ContainerImageLayer struct {
+	MediaType string
+	Digest    string
+	SizeBytes int64
+	URLs      []string
+	History   noOpV1History
+}
+
+type noOpV1History struct{}
+
+func (noOpV1History) Created() string {
+	return ""
+}
+
+func (noOpV1History) CreatedBy() string {
+	return ""
+}
+
+func (noOpV1History) Comment() string {
+	return ""
+}
+
+func (noOpV1History) EmptyLayer() string {
+	return ""
+}
+
+func printHistory(out io.Writer, history v1History) {
+	// nothing to do here
+}


### PR DESCRIPTION
### What does this PR do?

remove `github.com/opencontainers/image-spec/specs-go/v1` from the serverless build
(causing 3ms INIT time duration overhead)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
