### PR TITLE
backport removal of agent_deb-x64-a7-auto

### DIFF
--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -84,30 +84,6 @@ agent_deb-x64-a7:
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
-agent_deb-x64-a7-auto:
-  extends: .agent_build_common_deb
-  rules:
-    - !reference [.on_a7]
-  stage: package_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
-  variables:
-    AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
-    PACKAGE_ARCH: amd64
-    DESTINATION_DEB: "datadog-agent_7_auto_amd64.deb"
-    DESTINATION_DBG_DEB: "datadog-agent-dbg_7_auto_amd64.deb"
-  before_script:
-    - export RELEASE_VERSION=$RELEASE_VERSION_7
-    - export INSTALL_DIR=/opt/datadog/agents/$RELEASE_VERSION_7
-
 agent_deb-arm64-a6:
   extends: .agent_build_common_deb
   rules:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Backport the removal of the `agent_deb-x64-a7-auto` job .

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The `7.51.0` docker images mistakenly included the agents built from the above job increasing their size. It appears those `.deb`s were installed because of the following glob:
https://github.com/DataDog/datadog-agent/blob/d5e1a52e0155241e9dbeb9278bfd18a00515559e/.gitlab/container_build/docker_linux.yml#L114