### PR TITLE
Fix agent status silent failure for EventPlatformEvents

### DIFF
--- a/pkg/status/collector/fixtures/status_info.html
+++ b/pkg/status/collector/fixtures/status_info.html
@@ -44,7 +44,9 @@
               Instance ID: telemetry [<span class="ok">OK</span>]<br>
               Total Runs: 1<br>
               Metric Samples: 2, Total: 2<br>
-              Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>Average Execution Time : 0s<br>
+              Events: 0, Total: 0<br>
+              dbm-samples: Last Run: 12, Total: 132<br>
+              unknown-type: Last Run: 34, Total: 342<br>Service Checks: 0, Total: 0<br>Average Execution Time : 0s<br>
               Last Execution Date : 2024-02-20 10:27:35 UTC (1708424855000)<br>
               Last Successful Execution Date : 2024-02-20 10:27:35 UTC (1708424855000)<br></span>
         <span/>

--- a/pkg/status/collector/fixtures/status_info.json
+++ b/pkg/status/collector/fixtures/status_info.json
@@ -239,7 +239,10 @@
           "CheckID": "telemetry",
           "CheckName": "telemetry",
           "CheckVersion": "",
-          "EventPlatformEvents": {},
+          "EventPlatformEvents": {
+            "dbm-samples":  12,
+            "unknown-type": 34
+          },
           "Events": 0,
           "ExecutionTimes": [
             0,
@@ -286,7 +289,10 @@
           "MetricSamples": 2,
           "ServiceChecks": 0,
           "TotalErrors": 0,
-          "TotalEventPlatformEvents": {},
+          "TotalEventPlatformEvents": {
+            "dbm-samples":  132,
+            "unknown-type": 342
+          },
           "TotalEvents": 0,
           "TotalHistogramBuckets": 0,
           "TotalMetricSamples": 2,

--- a/pkg/status/collector/status_templates/collector.tmpl
+++ b/pkg/status/collector/status_templates/collector.tmpl
@@ -18,8 +18,9 @@
       Total Runs: {{humanize .TotalRuns}}
       Metric Samples: Last Run: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
       Events: Last Run: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
+      {{- $instance := . }}
       {{- range $k, $v := .TotalEventPlatformEvents }}
-      {{ $k }}: Last Run: {{humanize (index .EventPlatformEvents $k) }}, Total: {{humanize $v}}
+      {{ $k }}: Last Run: {{humanize (index $instance.EventPlatformEvents $k) }}, Total: {{humanize $v}}
       {{- end }}
       Service Checks: Last Run: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
       {{- if .TotalHistogramBuckets}}

--- a/pkg/status/collector/status_templates/collectorHTML.tmpl
+++ b/pkg/status/collector/status_templates/collectorHTML.tmpl
@@ -16,8 +16,9 @@
               Total Runs: {{humanize .TotalRuns}}<br>
               Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
               Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
+              {{- $instance := . }}
               {{- range $k, $v := .TotalEventPlatformEvents }}
-              {{ $k }}: Last Run: {{humanize (index .EventPlatformEvents $k) }}, Total: {{humanize $v}}<br>
+              {{ $k }}: Last Run: {{humanize (index $instance.EventPlatformEvents $k) }}, Total: {{humanize $v}}<br>
               {{- end -}}
               Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
               {{- if .TotalHistogramBuckets}}

--- a/pkg/status/render/fixtures/check_stats.json
+++ b/pkg/status/render/fixtures/check_stats.json
@@ -396,7 +396,10 @@
           "LongRunning": false,
           "CheckName": "ntp",
           "CheckVersion": "",
-          "EventPlatformEvents": {},
+          "EventPlatformEvents": {
+            "dbm-samples":  12,
+            "unknown-type": 34
+          },
           "Events": 0,
           "ExecutionTimes": [
             143,
@@ -440,7 +443,10 @@
           "MetricSamples": 1,
           "ServiceChecks": 1,
           "TotalErrors": 0,
-          "TotalEventPlatformEvents": {},
+          "TotalEventPlatformEvents": {
+            "dbm-samples":  132,
+            "unknown-type": 342
+          },
           "TotalEvents": 0,
           "TotalHistogramBuckets": 0,
           "TotalMetricSamples": 3,

--- a/pkg/status/render/fixtures/check_stats.text
+++ b/pkg/status/render/fixtures/check_stats.text
@@ -95,6 +95,8 @@ Collector
       Total Runs: 3
       Metric Samples: Last Run: 1, Total: 3
       Events: Last Run: 0, Total: 0
+      dbm-samples: Last Run: 12, Total: 132
+      unknown-type: Last Run: 34, Total: 342
       Service Checks: Last Run: 1, Total: 3
       Average Execution Time : 172ms
       Last Execution Date : 2023-11-29 12:04:58 UTC (1701259498000)

--- a/pkg/status/render/templates/collector.tmpl
+++ b/pkg/status/render/templates/collector.tmpl
@@ -25,8 +25,9 @@ Collector
       Total Runs: {{humanize .TotalRuns}}
       Metric Samples: Last Run: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
       Events: Last Run: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
+      {{- $instance := . }}
       {{- range $k, $v := .TotalEventPlatformEvents }}
-      {{ $k }}: Last Run: {{humanize (index .EventPlatformEvents $k) }}, Total: {{humanize $v}}
+      {{ $k }}: Last Run: {{humanize (index $instance.EventPlatformEvents $k) }}, Total: {{humanize $v}}
       {{- end }}
       Service Checks: Last Run: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
       {{- if .TotalHistogramBuckets}}

--- a/pkg/status/render/templates/collectorHTML.tmpl
+++ b/pkg/status/render/templates/collectorHTML.tmpl
@@ -16,8 +16,9 @@
               Total Runs: {{humanize .TotalRuns}}<br>
               Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
               Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
+              {{- $instance := . }}
               {{- range $k, $v := .TotalEventPlatformEvents }}
-              {{ $k }}: Last Run: {{humanize (index .EventPlatformEvents $k) }}, Total: {{humanize $v}}<br>
+              {{ $k }}: Last Run: {{humanize (index $instance.EventPlatformEvents $k) }}, Total: {{humanize $v}}<br>
               {{- end -}}
               Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
               {{- if .TotalHistogramBuckets}}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR fixes the collector templates by making sure the template reads from `instance.EventPlaformEvents` rather than `.EventPlatformEvents`.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Expected:
```
snmp
    ----
      Instance ID: snmp:COMP-FV44JH22RN:172.19.0.2:ad2443c1f4727d2c [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/snmp.d/snmp.yaml
      Total Runs: 19
      Metric Samples: Last Run: 249, Total: 4,731
      Events: Last Run: 0, Total: 0
      Network Devices Metadata: Last Run: 1, Total: 19
      Service Checks: Last Run: 1, Total: 19
      Average Execution Time : 1.331s
      Last Execution Date : 2024-02-21 18:48:31 UTC (1708541311000)
      Last Successful Execution Date : 2024-02-21 18:48:31 UTC (1708541311000)
```

Had:
```
snmp
    ----
      Instance ID: snmp:COMP-FV44JH22RN:172.21.0.2:7da39c4b7f83b7d8 [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/snmp.d/snmp.yaml
      Total Runs: 15
      Metric Samples: Last Run: 249, Total: 3,731
      Events: Last Run: 0, Total: 0
      Network Devices Metadata: Last Run:                            <== seems to silently fail and truncate the status here

====================
Status render errors                                               
====================
  - template: collector.tmpl:22:44: executing "checkStats" at <.EventPlatformEvents>: can't evaluate field EventPlatformEvents in type interface {}
```
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Unit tests should cover everything but just in case:

Deploy the agent with a normal check that emits EventPlatformEvents (snmp and oracle-dbm are the only two I know) and make sure that `agent status` does not output any error and shows the events sent.
Same for `agent launch-gui` directly on mac or windows.

I didn't find out how to configure these checks so I just converted the sbom check to a normal check with a custom build and found some event platform events in the output as expected:
```
    sbom
    ----
      Instance ID: sbom [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/sbom.yaml
      Total Runs: 3
      Metric Samples: Last Run: 2, Total: 2
      Events: Last Run: 0, Total: 0
      container-sbom: Last Run: 16, Total: 107
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 2ms
      Last Execution Date : 2024-02-22 12:01:00 UTC (1708603260000)
      Last Successful Execution Date : 2024-02-22 12:01:00 UTC (1708603260000)```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
