### PR TITLE
[EBPF-384] switch all ebpf programs to work with new ebpf manager wrapper and modifiers 

### DIFF
--- a/pkg/ebpf/ebpf.go
+++ b/pkg/ebpf/ebpf.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/ebpf/rlimit"
 
+	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
 
@@ -64,6 +65,7 @@ func registerDefaultModifiers() {
 	// more details in the Modifier documentation.
 	defaultModifiers = []Modifier{
 		&PrintkPatcherModifier{},
+		&ebpftelemetry.ErrorsTelemetryModifier{},
 	}
 }
 

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -41,7 +41,7 @@ func NewEBPFErrorsCollector() prometheus.Collector {
 		return nil
 	}
 	return &EBPFErrorsCollector{
-		T:                NewEBPFTelemetry(),
+		T:                newEBPFTelemetry(),
 		ebpfMapOpsErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfMapTelemetryNS), "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil),
 		ebpfHelperErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfHelperTelemetryNS), "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil),
 		lastValues:       make(map[string]uint64),
@@ -56,13 +56,13 @@ func (e *EBPFErrorsCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect returns the current state of all metrics of the collector
 func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
-	e.T.mtx.Lock()
-	defer e.T.mtx.Unlock()
-
 	//if internal telemetry struct failed to initialize
 	if e.T == nil {
 		return
 	}
+
+	e.T.mtx.Lock()
+	defer e.T.mtx.Unlock()
 
 	if e.T.helperErrMap != nil {
 		var hval HelperErrTelemetry

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -41,7 +41,7 @@ func NewEBPFErrorsCollector() prometheus.Collector {
 		return nil
 	}
 	return &EBPFErrorsCollector{
-		T:                newEBPFTelemetry(),
+		T:                getEBPFTelemetry(),
 		ebpfMapOpsErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfMapTelemetryNS), "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil),
 		ebpfHelperErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfHelperTelemetryNS), "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil),
 		lastValues:       make(map[string]uint64),

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -28,7 +28,7 @@ const (
 // EBPFErrorsCollector implements the prometheus Collector interface
 // for collecting statistics about errors of ebpf helpers and ebpf maps operations.
 type EBPFErrorsCollector struct {
-	*EBPFTelemetry
+	T                *EBPFTelemetry
 	ebpfMapOpsErrors *prometheus.Desc
 	ebpfHelperErrors *prometheus.Desc
 	//we can use one map for both map errors and ebpf helpers errors, as the keys are different
@@ -41,10 +41,7 @@ func NewEBPFErrorsCollector() prometheus.Collector {
 		return nil
 	}
 	return &EBPFErrorsCollector{
-		EBPFTelemetry: &EBPFTelemetry{
-			mapKeys:   make(map[string]uint64),
-			probeKeys: make(map[string]uint64),
-		},
+		T:                NewEBPFTelemetry(),
 		ebpfMapOpsErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfMapTelemetryNS), "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil),
 		ebpfHelperErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfHelperTelemetryNS), "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil),
 		lastValues:       make(map[string]uint64),
@@ -59,13 +56,18 @@ func (e *EBPFErrorsCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect returns the current state of all metrics of the collector
 func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
-	e.mtx.Lock()
-	defer e.mtx.Unlock()
+	e.T.mtx.Lock()
+	defer e.T.mtx.Unlock()
 
-	if e.helperErrMap != nil {
+	//if internal telemetry struct failed to initialize
+	if e.T == nil {
+		return
+	}
+
+	if e.T.helperErrMap != nil {
 		var hval HelperErrTelemetry
-		for probeName, k := range e.probeKeys {
-			err := e.helperErrMap.Lookup(&k, &hval)
+		for probeName, k := range e.T.probeKeys {
+			err := e.T.helperErrMap.Lookup(&k, &hval)
 			if err != nil {
 				log.Debugf("failed to get telemetry for probe:key %s:%d\n", probeName, k)
 				continue
@@ -85,10 +87,10 @@ func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 	}
 
-	if e.mapErrMap != nil {
+	if e.T.mapErrMap != nil {
 		var val MapErrTelemetry
-		for m, k := range e.mapKeys {
-			err := e.mapErrMap.Lookup(&k, &val)
+		for m, k := range e.T.mapKeys {
+			err := e.T.mapErrMap.Lookup(&k, &val)
 			if err != nil {
 				log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
 				continue

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -41,7 +41,7 @@ func NewEBPFErrorsCollector() prometheus.Collector {
 		return nil
 	}
 	return &EBPFErrorsCollector{
-		T:                getEBPFTelemetry(),
+		T:                newEBPFTelemetry(),
 		ebpfMapOpsErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfMapTelemetryNS), "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil),
 		ebpfHelperErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfHelperTelemetryNS), "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil),
 		lastValues:       make(map[string]uint64),
@@ -56,11 +56,6 @@ func (e *EBPFErrorsCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect returns the current state of all metrics of the collector
 func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
-	//if internal telemetry struct failed to initialize
-	if e.T == nil {
-		return
-	}
-
 	e.T.mtx.Lock()
 	defer e.T.mtx.Unlock()
 

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -28,7 +28,7 @@ const (
 // EBPFErrorsCollector implements the prometheus Collector interface
 // for collecting statistics about errors of ebpf helpers and ebpf maps operations.
 type EBPFErrorsCollector struct {
-	T                *EBPFTelemetry
+	T                *eBPFTelemetry
 	ebpfMapOpsErrors *prometheus.Desc
 	ebpfHelperErrors *prometheus.Desc
 	//we can use one map for both map errors and ebpf helpers errors, as the keys are different

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -53,8 +53,8 @@ type EBPFTelemetry struct {
 // A singleton instance of the ebpf telemetry struct. Used by the collector and the ebpf managers (via ErrorsTelemetryModifier).
 var errorsTelemetry *EBPFTelemetry
 
-// newEBPFTelemetry initializes a new EBPFTelemetry object
-func newEBPFTelemetry() *EBPFTelemetry {
+// getEBPFTelemetry initializes a new EBPFTelemetry object
+func getEBPFTelemetry() *EBPFTelemetry {
 	if errorsTelemetry != nil {
 		return errorsTelemetry
 	}

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -50,14 +50,36 @@ type EBPFTelemetry struct {
 	probeKeys    map[string]uint64
 }
 
+// A singleton instance of the ebpf telemetry struct. Used by the collector and the ebpf managers (via ErrorsTelemetryModifier).
+var errorsTelemetry *EBPFTelemetry
+
 // NewEBPFTelemetry initializes a new EBPFTelemetry object
 func NewEBPFTelemetry() *EBPFTelemetry {
 	if supported, _ := ebpfTelemetrySupported(); !supported {
 		return nil
 	}
-	return &EBPFTelemetry{
+	if errorsTelemetry != nil {
+		return errorsTelemetry
+	}
+	errorsTelemetry = &EBPFTelemetry{
 		mapKeys:   make(map[string]uint64),
 		probeKeys: make(map[string]uint64),
+	}
+	return errorsTelemetry
+}
+
+func (b *EBPFTelemetry) setupMapEditors(opts *manager.Options) {
+	if (b.mapErrMap != nil) || (b.helperErrMap != nil) {
+		if opts.MapEditors == nil {
+			opts.MapEditors = make(map[string]*ebpf.Map)
+		}
+	}
+	// if the maps have already been loaded, setup editors to point to them
+	if b.mapErrMap != nil {
+		opts.MapEditors[probes.MapErrTelemetryMap] = b.mapErrMap.Map()
+	}
+	if b.helperErrMap != nil {
+		opts.MapEditors[probes.HelperErrTelemetryMap] = b.helperErrMap.Map()
 	}
 }
 
@@ -82,34 +104,6 @@ func (b *EBPFTelemetry) populateMapsWithKeys(m *manager.Manager) error {
 		return err
 	}
 	return nil
-}
-
-func buildMapErrTelemetryConstants(mgr *manager.Manager) []manager.ConstantEditor {
-	var keys []manager.ConstantEditor
-	h := keyHash()
-	for _, m := range mgr.Maps {
-		keys = append(keys, manager.ConstantEditor{
-			Name:  m.Name + "_telemetry_key",
-			Value: mapKey(h, m),
-		})
-	}
-	return keys
-}
-
-func keyHash() hash.Hash64 {
-	return fnv.New64a()
-}
-
-func mapKey(h hash.Hash64, m *manager.Map) uint64 {
-	h.Reset()
-	_, _ = h.Write([]byte(m.Name))
-	return h.Sum64()
-}
-
-func probeKey(h hash.Hash64, funcName string) uint64 {
-	h.Reset()
-	_, _ = h.Write([]byte(funcName))
-	return h.Sum64()
 }
 
 func (b *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error {
@@ -149,6 +143,40 @@ func (b *EBPFTelemetry) initializeHelperErrTelemetryMap() error {
 			return fmt.Errorf("failed to initialize telemetry struct for probe %s", p)
 		}
 	}
+	return nil
+}
+
+// setupForTelemetry sets up the manager to handle eBPF telemetry.
+// It will patch the instructions of all the manager probes and `undefinedProbes` provided.
+// Constants are replaced for map error and helper error keys with their respective values.
+// This must be called before ebpf-manager.Manager.Init/InitWithOptions
+func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetry *EBPFTelemetry) error {
+	activateBPFTelemetry, err := ebpfTelemetrySupported()
+	if err != nil {
+		return err
+	}
+	m.InstructionPatchers = append(m.InstructionPatchers, func(m *manager.Manager) error {
+		return patchEBPFTelemetry(m, activateBPFTelemetry, bpfTelemetry)
+	})
+
+	if activateBPFTelemetry {
+		// add telemetry maps to list of maps, if not present
+		if !slices.ContainsFunc(m.Maps, func(x *manager.Map) bool { return x.Name == probes.MapErrTelemetryMap }) {
+			m.Maps = append(m.Maps, &manager.Map{Name: probes.MapErrTelemetryMap})
+		}
+		if !slices.ContainsFunc(m.Maps, func(x *manager.Map) bool { return x.Name == probes.HelperErrTelemetryMap }) {
+			m.Maps = append(m.Maps, &manager.Map{Name: probes.HelperErrTelemetryMap})
+		}
+
+		if bpfTelemetry != nil {
+			bpfTelemetry.setupMapEditors(options)
+		}
+
+		options.ConstantEditors = append(options.ConstantEditors, buildMapErrTelemetryConstants(m)...)
+	}
+	// we cannot exclude the telemetry maps because on some kernels, deadcode elimination hasn't removed references
+	// if telemetry not enabled: leave key constants as zero, and deadcode elimination should reduce number of instructions
+
 	return nil
 }
 
@@ -199,53 +227,32 @@ func patchEBPFTelemetry(m *manager.Manager, enable bool, bpfTelemetry *EBPFTelem
 	return nil
 }
 
-// setupForTelemetry sets up the manager to handle eBPF telemetry.
-// It will patch the instructions of all the manager probes and `undefinedProbes` provided.
-// Constants are replaced for map error and helper error keys with their respective values.
-// This must be called before ebpf-manager.Manager.Init/InitWithOptions
-func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetry *EBPFTelemetry) error {
-	activateBPFTelemetry, err := ebpfTelemetrySupported()
-	if err != nil {
-		return err
+func buildMapErrTelemetryConstants(mgr *manager.Manager) []manager.ConstantEditor {
+	var keys []manager.ConstantEditor
+	h := keyHash()
+	for _, m := range mgr.Maps {
+		keys = append(keys, manager.ConstantEditor{
+			Name:  m.Name + "_telemetry_key",
+			Value: mapKey(h, m),
+		})
 	}
-	m.InstructionPatchers = append(m.InstructionPatchers, func(m *manager.Manager) error {
-		return patchEBPFTelemetry(m, activateBPFTelemetry, bpfTelemetry)
-	})
-
-	if activateBPFTelemetry {
-		// add telemetry maps to list of maps, if not present
-		if !slices.ContainsFunc(m.Maps, func(x *manager.Map) bool { return x.Name == probes.MapErrTelemetryMap }) {
-			m.Maps = append(m.Maps, &manager.Map{Name: probes.MapErrTelemetryMap})
-		}
-		if !slices.ContainsFunc(m.Maps, func(x *manager.Map) bool { return x.Name == probes.HelperErrTelemetryMap }) {
-			m.Maps = append(m.Maps, &manager.Map{Name: probes.HelperErrTelemetryMap})
-		}
-
-		if bpfTelemetry != nil {
-			bpfTelemetry.setupMapEditors(options)
-		}
-
-		options.ConstantEditors = append(options.ConstantEditors, buildMapErrTelemetryConstants(m)...)
-	}
-	// we cannot exclude the telemetry maps because on some kernels, deadcode elimination hasn't removed references
-	// if telemetry not enabled: leave key constants as zero, and deadcode elimination should reduce number of instructions
-
-	return nil
+	return keys
 }
 
-func (b *EBPFTelemetry) setupMapEditors(opts *manager.Options) {
-	if (b.mapErrMap != nil) || (b.helperErrMap != nil) {
-		if opts.MapEditors == nil {
-			opts.MapEditors = make(map[string]*ebpf.Map)
-		}
-	}
-	// if the maps have already been loaded, setup editors to point to them
-	if b.mapErrMap != nil {
-		opts.MapEditors[probes.MapErrTelemetryMap] = b.mapErrMap.Map()
-	}
-	if b.helperErrMap != nil {
-		opts.MapEditors[probes.HelperErrTelemetryMap] = b.helperErrMap.Map()
-	}
+func keyHash() hash.Hash64 {
+	return fnv.New64a()
+}
+
+func mapKey(h hash.Hash64, m *manager.Map) uint64 {
+	h.Reset()
+	_, _ = h.Write([]byte(m.Name))
+	return h.Sum64()
+}
+
+func probeKey(h hash.Hash64, funcName string) uint64 {
+	h.Reset()
+	_, _ = h.Write([]byte(funcName))
+	return h.Sum64()
 }
 
 // ebpfTelemetrySupported returns whether eBPF telemetry is supported, which depends on the verifier in 4.14+

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -53,11 +53,8 @@ type EBPFTelemetry struct {
 // A singleton instance of the ebpf telemetry struct. Used by the collector and the ebpf managers (via ErrorsTelemetryModifier).
 var errorsTelemetry *EBPFTelemetry
 
-// NewEBPFTelemetry initializes a new EBPFTelemetry object
-func NewEBPFTelemetry() *EBPFTelemetry {
-	if supported, _ := ebpfTelemetrySupported(); !supported {
-		return nil
-	}
+// newEBPFTelemetry initializes a new EBPFTelemetry object
+func newEBPFTelemetry() *EBPFTelemetry {
 	if errorsTelemetry != nil {
 		return errorsTelemetry
 	}

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -53,11 +53,8 @@ type EBPFTelemetry struct {
 // A singleton instance of the ebpf telemetry struct. Used by the collector and the ebpf managers (via ErrorsTelemetryModifier).
 var errorsTelemetry *EBPFTelemetry
 
-// getEBPFTelemetry initializes a new EBPFTelemetry object
-func getEBPFTelemetry() *EBPFTelemetry {
-	if errorsTelemetry != nil {
-		return errorsTelemetry
-	}
+// newEBPFTelemetry initializes a new EBPFTelemetry object
+func newEBPFTelemetry() *EBPFTelemetry {
 	errorsTelemetry = &EBPFTelemetry{
 		mapKeys:   make(map[string]uint64),
 		probeKeys: make(map[string]uint64),

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -40,9 +40,9 @@ var helperNames = map[int]string{
 	perfEventOutput: "bpf_perf_event_output",
 }
 
-// EBPFTelemetry struct contains all the maps that
+// eBPFTelemetry struct contains all the maps that
 // are registered to have their telemetry collected.
-type EBPFTelemetry struct {
+type eBPFTelemetry struct {
 	mtx          sync.Mutex
 	mapErrMap    *maps.GenericMap[uint64, MapErrTelemetry]
 	helperErrMap *maps.GenericMap[uint64, HelperErrTelemetry]
@@ -51,18 +51,18 @@ type EBPFTelemetry struct {
 }
 
 // A singleton instance of the ebpf telemetry struct. Used by the collector and the ebpf managers (via ErrorsTelemetryModifier).
-var errorsTelemetry *EBPFTelemetry
+var errorsTelemetry *eBPFTelemetry
 
-// newEBPFTelemetry initializes a new EBPFTelemetry object
-func newEBPFTelemetry() *EBPFTelemetry {
-	errorsTelemetry = &EBPFTelemetry{
+// newEBPFTelemetry initializes a new eBPFTelemetry object
+func newEBPFTelemetry() *eBPFTelemetry {
+	errorsTelemetry = &eBPFTelemetry{
 		mapKeys:   make(map[string]uint64),
 		probeKeys: make(map[string]uint64),
 	}
 	return errorsTelemetry
 }
 
-func (b *EBPFTelemetry) setupMapEditors(opts *manager.Options) {
+func (b *eBPFTelemetry) setupMapEditors(opts *manager.Options) {
 	if (b.mapErrMap != nil) || (b.helperErrMap != nil) {
 		if opts.MapEditors == nil {
 			opts.MapEditors = make(map[string]*ebpf.Map)
@@ -79,7 +79,7 @@ func (b *EBPFTelemetry) setupMapEditors(opts *manager.Options) {
 
 // populateMapsWithKeys initializes the maps for holding telemetry info.
 // It must be called after the manager is initialized
-func (b *EBPFTelemetry) populateMapsWithKeys(m *manager.Manager) error {
+func (b *eBPFTelemetry) populateMapsWithKeys(m *manager.Manager) error {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 
@@ -100,7 +100,7 @@ func (b *EBPFTelemetry) populateMapsWithKeys(m *manager.Manager) error {
 	return nil
 }
 
-func (b *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error {
+func (b *eBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error {
 	if b.mapErrMap == nil {
 		return nil
 	}
@@ -124,7 +124,7 @@ func (b *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error 
 	return nil
 }
 
-func (b *EBPFTelemetry) initializeHelperErrTelemetryMap() error {
+func (b *eBPFTelemetry) initializeHelperErrTelemetryMap() error {
 	if b.helperErrMap == nil {
 		return nil
 	}
@@ -144,7 +144,7 @@ func (b *EBPFTelemetry) initializeHelperErrTelemetryMap() error {
 // It will patch the instructions of all the manager probes and `undefinedProbes` provided.
 // Constants are replaced for map error and helper error keys with their respective values.
 // This must be called before ebpf-manager.Manager.Init/InitWithOptions
-func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetry *EBPFTelemetry) error {
+func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetry *eBPFTelemetry) error {
 	activateBPFTelemetry, err := ebpfTelemetrySupported()
 	if err != nil {
 		return err
@@ -174,7 +174,7 @@ func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetr
 	return nil
 }
 
-func patchEBPFTelemetry(m *manager.Manager, enable bool, bpfTelemetry *EBPFTelemetry) error {
+func patchEBPFTelemetry(m *manager.Manager, enable bool, bpfTelemetry *eBPFTelemetry) error {
 	const symbol = "telemetry_program_id_key"
 	newIns := asm.Mov.Reg(asm.R1, asm.R1)
 	if enable {

--- a/pkg/ebpf/telemetry/errors_telemetry_testhelpers.go
+++ b/pkg/ebpf/telemetry/errors_telemetry_testhelpers.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetHelpersTelemetry returns a map of error telemetry for each ebpf program
-func (b *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
+func (b *eBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
 	helperTelemMap := make(map[string]interface{})
 	if b.helperErrMap == nil {
 		return helperTelemMap
@@ -41,7 +41,7 @@ func (b *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
 }
 
 // GetMapsTelemetry returns a map of error telemetry for each ebpf map
-func (b *EBPFTelemetry) GetMapsTelemetry() map[string]interface{} {
+func (b *eBPFTelemetry) GetMapsTelemetry() map[string]interface{} {
 	t := make(map[string]interface{})
 	if b.mapErrMap == nil {
 		return t

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -8,45 +8,8 @@
 package telemetry
 
 import (
-	"io"
-
 	manager "github.com/DataDog/ebpf-manager"
 )
-
-// Manager wraps ebpf-manager.Manager to transparently handle eBPF telemetry
-// Deprecated: The telemetry manager wrapper should no longer be used. Instead, use ebpf/manager.Manager instead with the ErrorsTelemetryModifier
-type Manager struct {
-	*manager.Manager
-	bpfTelemetry *EBPFTelemetry
-}
-
-// NewManager creates a Manager
-// Deprecated: The telemetry manager wrapper should no longer be used. Instead, use ebpf/manager.Manager instead with the ErrorsTelemetryModifier
-func NewManager(mgr *manager.Manager, bt *EBPFTelemetry) *Manager {
-	return &Manager{
-		Manager:      mgr,
-		bpfTelemetry: bt,
-	}
-}
-
-// InitWithOptions is a wrapper around ebpf-manager.Manager.InitWithOptions
-// Deprecated: The telemetry manager wrapper should no longer be used. Instead, use ebpf/manager.Manager instead with the ErrorsTelemetryModifier
-func (m *Manager) InitWithOptions(bytecode io.ReaderAt, opts manager.Options) error {
-	if err := setupForTelemetry(m.Manager, &opts, m.bpfTelemetry); err != nil {
-		return err
-	}
-
-	if err := m.Manager.InitWithOptions(bytecode, opts); err != nil {
-		return err
-	}
-
-	if m.bpfTelemetry != nil {
-		if err := m.bpfTelemetry.populateMapsWithKeys(m.Manager); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 // ErrorsTelemetryModifier is a modifier that sets up the manager to handle eBPF telemetry.
 type ErrorsTelemetryModifier struct{}

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -14,7 +14,6 @@ import (
 )
 
 // Manager wraps ebpf-manager.Manager to transparently handle eBPF telemetry
-
 // Deprecated: The telemetry manager wrapper should no longer be used. Instead, use ebpf/manager.Manager instead with the ErrorsTelemetryModifier
 type Manager struct {
 	*manager.Manager
@@ -49,8 +48,10 @@ func (m *Manager) InitWithOptions(bytecode io.ReaderAt, opts manager.Options) er
 	return nil
 }
 
+// ErrorsTelemetryModifier is a modifier that sets up the manager to handle eBPF telemetry.
 type ErrorsTelemetryModifier struct{}
 
+// String returns the name of the modifier.
 func (t *ErrorsTelemetryModifier) String() string {
 	return "ErrorsTelemetryModifier"
 }

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -44,3 +44,26 @@ func (m *Manager) InitWithOptions(bytecode io.ReaderAt, opts manager.Options) er
 	}
 	return nil
 }
+
+type ErrorsTelemetryModifier struct{}
+
+func (t *ErrorsTelemetryModifier) String() string {
+	return "ErrorsTelemetryModifier"
+}
+
+// BeforeInit sets up the manager to handle eBPF telemetry.
+// It will patch the instructions of all the manager probes and `undefinedProbes` provided.
+// Constants are replaced for map error and helper error keys with their respective values.
+func (t *ErrorsTelemetryModifier) BeforeInit(m *manager.Manager, _ *manager.Options) error {
+	return setupForTelemetry(m, &manager.Options{}, errorsTelemetry)
+}
+
+// AfterInit pre-populates the telemetry maps with entries corresponding to the ebpf program of the manager.
+func (t *ErrorsTelemetryModifier) AfterInit(m *manager.Manager, _ *manager.Options) error {
+	if errorsTelemetry != nil {
+		if err := errorsTelemetry.populateMapsWithKeys(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -14,12 +14,15 @@ import (
 )
 
 // Manager wraps ebpf-manager.Manager to transparently handle eBPF telemetry
+
+// Deprecated: The telemetry manager wrapper should no longer be used. Instead, use ebpf/manager.Manager instead with the ErrorsTelemetryModifier
 type Manager struct {
 	*manager.Manager
 	bpfTelemetry *EBPFTelemetry
 }
 
 // NewManager creates a Manager
+// Deprecated: The telemetry manager wrapper should no longer be used. Instead, use ebpf/manager.Manager instead with the ErrorsTelemetryModifier
 func NewManager(mgr *manager.Manager, bt *EBPFTelemetry) *Manager {
 	return &Manager{
 		Manager:      mgr,
@@ -28,6 +31,7 @@ func NewManager(mgr *manager.Manager, bt *EBPFTelemetry) *Manager {
 }
 
 // InitWithOptions is a wrapper around ebpf-manager.Manager.InitWithOptions
+// Deprecated: The telemetry manager wrapper should no longer be used. Instead, use ebpf/manager.Manager instead with the ErrorsTelemetryModifier
 func (m *Manager) InitWithOptions(bytecode io.ReaderAt, opts manager.Options) error {
 	if err := setupForTelemetry(m.Manager, &opts, m.bpfTelemetry); err != nil {
 		return err

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -59,8 +59,8 @@ func (t *ErrorsTelemetryModifier) String() string {
 // BeforeInit sets up the manager to handle eBPF telemetry.
 // It will patch the instructions of all the manager probes and `undefinedProbes` provided.
 // Constants are replaced for map error and helper error keys with their respective values.
-func (t *ErrorsTelemetryModifier) BeforeInit(m *manager.Manager, _ *manager.Options) error {
-	return setupForTelemetry(m, &manager.Options{}, errorsTelemetry)
+func (t *ErrorsTelemetryModifier) BeforeInit(m *manager.Manager, opts *manager.Options) error {
+	return setupForTelemetry(m, opts, errorsTelemetry)
 }
 
 // AfterInit pre-populates the telemetry maps with entries corresponding to the ebpf program of the manager.

--- a/pkg/network/tracer/connection/fentry/manager.go
+++ b/pkg/network/tracer/connection/fentry/manager.go
@@ -18,7 +18,7 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 )
 
-func initManager(mgr *ebpftelemetry.Manager, closedHandler *ebpf.PerfHandler, cfg *config.Config) {
+func initManager(mgr *ebpf.Manager, closedHandler *ebpf.PerfHandler, cfg *config.Config) {
 	mgr.Maps = []*manager.Map{
 		{Name: probes.ConnMap},
 		{Name: probes.TCPStatsMap},

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -17,7 +17,6 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
-	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
@@ -29,12 +28,12 @@ const probeUID = "net"
 var ErrorNotSupported = errors.New("fentry tracer is only supported on Fargate")
 
 // LoadTracer loads a new tracer
-func LoadTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
+func LoadTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
 	if !fargate.IsFargateInstance() {
 		return nil, nil, ErrorNotSupported
 	}
 
-	m := ebpftelemetry.NewManager(&manager.Manager{}, bpfTelemetry)
+	m := ddebpf.NewManager(&manager.Manager{})
 	err := ddebpf.LoadCOREAsset(netebpf.ModuleFileName("tracer-fentry", config.BPFDebug), func(ar bytecode.AssetReader, o manager.Options) error {
 		o.RLimit = mgrOpts.RLimit
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
@@ -83,7 +82,7 @@ func LoadTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *
 				})
 		}
 
-		return m.InitWithOptions(ar, o)
+		return m.InitWithOptions(ar, &o)
 	})
 
 	if err != nil {

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -13,6 +13,7 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
@@ -61,7 +62,7 @@ var mainProbes = []probes.ProbeFuncName{
 	probes.UDPSendPageReturn,
 }
 
-func initManager(mgr *ebpftelemetry.Manager, closedHandler *ebpf.PerfHandler, runtimeTracer bool, cfg *config.Config) error {
+func initManager(mgr *ddebpf.Manager, closedHandler *ebpf.PerfHandler, runtimeTracer bool, cfg *config.Config) error {
 	mgr.Maps = []*manager.Map{
 		{Name: probes.ConnMap},
 		{Name: probes.TCPStatsMap},

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -17,7 +17,6 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
-	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
@@ -124,7 +123,7 @@ func addBoolConst(options *manager.Options, flag bool, name string) {
 }
 
 // LoadTracer loads the co-re/prebuilt/runtime compiled network tracer, depending on config
-func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (*manager.Manager, func(), TracerType, error) {
+func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), TracerType, error) {
 	kprobeAttachMethod := manager.AttachKprobeWithPerfEventOpen
 	if cfg.AttachKprobesWithKprobeEventsABI {
 		kprobeAttachMethod = manager.AttachKprobeWithKprobeEvents
@@ -141,7 +140,7 @@ func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *dde
 		var m *manager.Manager
 		var closeFn func()
 		if err == nil {
-			m, closeFn, err = coreTracerLoader(cfg, mgrOpts, perfHandlerTCP, bpfTelemetry)
+			m, closeFn, err = coreTracerLoader(cfg, mgrOpts, perfHandlerTCP)
 			// if it is a verifier error, bail always regardless of
 			// whether a fallback is enabled in config
 			var ve *ebpf.VerifierError
@@ -162,7 +161,7 @@ func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *dde
 	}
 
 	if cfg.EnableRuntimeCompiler && (!cfg.EnableCORE || cfg.AllowRuntimeCompiledFallback) {
-		m, closeFn, err := rcTracerLoader(cfg, mgrOpts, perfHandlerTCP, bpfTelemetry)
+		m, closeFn, err := rcTracerLoader(cfg, mgrOpts, perfHandlerTCP)
 		if err == nil {
 			return m, closeFn, TracerTypeRuntimeCompiled, err
 		}
@@ -181,12 +180,12 @@ func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *dde
 
 	mgrOpts.ConstantEditors = append(mgrOpts.ConstantEditors, offsets...)
 
-	m, closeFn, err := prebuiltTracerLoader(cfg, mgrOpts, perfHandlerTCP, bpfTelemetry)
+	m, closeFn, err := prebuiltTracerLoader(cfg, mgrOpts, perfHandlerTCP)
 	return m, closeFn, TracerTypePrebuilt, err
 }
 
-func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer bool, config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
-	m := ebpftelemetry.NewManager(&manager.Manager{}, bpfTelemetry)
+func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer bool, config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
+	m := ddebpf.NewManager(&manager.Manager{})
 	if err := initManager(m, perfHandlerTCP, runtimeTracer, config); err != nil {
 		return nil, nil, fmt.Errorf("could not initialize manager: %w", err)
 	}
@@ -265,14 +264,14 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 			})
 	}
 
-	if err := m.InitWithOptions(buf, mgrOpts); err != nil {
+	if err := m.InitWithOptions(buf, &mgrOpts); err != nil {
 		return nil, nil, fmt.Errorf("failed to init ebpf manager: %w", err)
 	}
 
 	return m.Manager, closeProtocolClassifierSocketFilterFn, nil
 }
 
-func loadCORETracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
+func loadCORETracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
 	var m *manager.Manager
 	var closeFn func()
 	var err error
@@ -281,24 +280,24 @@ func loadCORETracer(config *config.Config, mgrOpts manager.Options, perfHandlerT
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
 		o.ConstantEditors = mgrOpts.ConstantEditors
 		o.DefaultKprobeAttachMethod = mgrOpts.DefaultKprobeAttachMethod
-		m, closeFn, err = loadTracerFromAsset(ar, false, true, config, o, perfHandlerTCP, bpfTelemetry)
+		m, closeFn, err = loadTracerFromAsset(ar, false, true, config, o, perfHandlerTCP)
 		return err
 	})
 
 	return m, closeFn, err
 }
 
-func loadRuntimeCompiledTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
+func loadRuntimeCompiledTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
 	buf, err := getRuntimeCompiledTracer(config)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer buf.Close()
 
-	return loadTracerFromAsset(buf, true, false, config, mgrOpts, perfHandlerTCP, bpfTelemetry)
+	return loadTracerFromAsset(buf, true, false, config, mgrOpts, perfHandlerTCP)
 }
 
-func loadPrebuiltTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
+func loadPrebuiltTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
 	buf, err := netebpf.ReadBPFModule(config.BPFDir, config.BPFDebug)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not read bpf module: %w", err)
@@ -314,7 +313,7 @@ func loadPrebuiltTracer(config *config.Config, mgrOpts manager.Options, perfHand
 		config.CollectUDPv6Conns = false
 	}
 
-	return loadTracerFromAsset(buf, false, false, config, mgrOpts, perfHandlerTCP, bpfTelemetry)
+	return loadTracerFromAsset(buf, false, false, config, mgrOpts, perfHandlerTCP)
 }
 
 func isCORETracerSupported() error {

--- a/pkg/network/tracer/connection/kprobe/tracer_test.go
+++ b/pkg/network/tracer/connection/kprobe/tracer_test.go
@@ -16,7 +16,6 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
-	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
@@ -169,8 +168,8 @@ func testTracerFallbackCOREAndRCErr(t *testing.T) {
 	runFallbackTests(t, "CORE and RC error", true, true, tests)
 }
 
-func loaderFunc(closeFn func(), err error) func(_ *config.Config, _ manager.Options, _ *ddebpf.PerfHandler, _ *ebpftelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
-	return func(_ *config.Config, _ manager.Options, _ *ddebpf.PerfHandler, _ *ebpftelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
+func loaderFunc(closeFn func(), err error) func(_ *config.Config, _ manager.Options, _ *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
+	return func(_ *config.Config, _ manager.Options, _ *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
 		return nil, closeFn, err
 	}
 }
@@ -211,7 +210,7 @@ func runFallbackTests(t *testing.T, desc string, coreErr, rcErr bool, tests []st
 			cfg.AllowPrecompiledFallback = te.allowPrebuiltFallback
 
 			prevOffsetGuessingRun := offsetGuessingRun
-			_, closeFn, tracerType, err := LoadTracer(cfg, manager.Options{}, nil, nil)
+			_, closeFn, tracerType, err := LoadTracer(cfg, manager.Options{}, nil)
 			if te.err == nil {
 				assert.NoError(t, err, "%+v", te)
 			} else {
@@ -246,12 +245,12 @@ func TestCORETracerSupported(t *testing.T) {
 	})
 
 	coreCalled := false
-	coreTracerLoader = func(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
+	coreTracerLoader = func(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
 		coreCalled = true
 		return nil, nil, nil
 	}
 	prebuiltCalled := false
-	prebuiltTracerLoader = func(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
+	prebuiltTracerLoader = func(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
 		prebuiltCalled = true
 		return nil, nil, nil
 	}
@@ -265,7 +264,7 @@ func TestCORETracerSupported(t *testing.T) {
 	cfg := config.New()
 	cfg.EnableCORE = true
 	cfg.AllowRuntimeCompiledFallback = false
-	_, _, _, err = LoadTracer(cfg, manager.Options{}, nil, nil)
+	_, _, _, err = LoadTracer(cfg, manager.Options{}, nil)
 	assert.False(t, prebuiltCalled)
 	if kv < kernel.VersionCode(4, 4, 128) && platform != "centos" && platform != "redhat" {
 		assert.False(t, coreCalled)
@@ -278,7 +277,7 @@ func TestCORETracerSupported(t *testing.T) {
 	coreCalled = false
 	prebuiltCalled = false
 	cfg.AllowRuntimeCompiledFallback = true
-	_, _, _, err = LoadTracer(cfg, manager.Options{}, nil, nil)
+	_, _, _, err = LoadTracer(cfg, manager.Options{}, nil)
 	assert.NoError(t, err)
 	if kv < kernel.VersionCode(4, 4, 128) && platform != "centos" && platform != "redhat" {
 		assert.False(t, coreCalled)

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -177,7 +177,7 @@ type tracer struct {
 }
 
 // NewTracer creates a new tracer
-func NewTracer(config *config.Config, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (Tracer, error) {
+func NewTracer(config *config.Config) (Tracer, error) {
 	mgrOptions := manager.Options{
 		// Extend RLIMIT_MEMLOCK (8) size
 		// On some systems, the default for RLIMIT_MEMLOCK may be as low as 64 bytes.
@@ -224,7 +224,7 @@ func NewTracer(config *config.Config, bpfTelemetry *ebpftelemetry.EBPFTelemetry)
 	//nolint:revive // TODO(NET) Fix revive linter
 	var tracerType TracerType = TracerTypeFentry
 	var closeTracerFn func()
-	m, closeTracerFn, err := fentry.LoadTracer(config, mgrOptions, perfHandlerTCP, bpfTelemetry)
+	m, closeTracerFn, err := fentry.LoadTracer(config, mgrOptions, perfHandlerTCP)
 	if err != nil && !errors.Is(err, fentry.ErrorNotSupported) {
 		// failed to load fentry tracer
 		return nil, err
@@ -234,7 +234,7 @@ func NewTracer(config *config.Config, bpfTelemetry *ebpftelemetry.EBPFTelemetry)
 		// load the kprobe tracer
 		log.Info("fentry tracer not supported, falling back to kprobe tracer")
 		var kprobeTracerType kprobe.TracerType
-		m, closeTracerFn, kprobeTracerType, err = kprobe.LoadTracer(config, mgrOptions, perfHandlerTCP, bpfTelemetry)
+		m, closeTracerFn, kprobeTracerType, err = kprobe.LoadTracer(config, mgrOptions, perfHandlerTCP)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/network/tracer/conntracker_test.go
+++ b/pkg/network/tracer/conntracker_test.go
@@ -92,7 +92,7 @@ func runConntrackerTest(t *testing.T, name string, createFn func(*testing.T, *co
 
 //nolint:revive // TODO(NET) Fix revive linter
 func setupEBPFConntracker(t *testing.T, cfg *config.Config) (netlink.Conntracker, error) {
-	return NewEBPFConntracker(cfg, nil)
+	return NewEBPFConntracker(cfg)
 }
 
 //nolint:revive // TODO(NET) Fix revive linter

--- a/pkg/network/tracer/ebpf_conntracker_test.go
+++ b/pkg/network/tracer/ebpf_conntracker_test.go
@@ -21,7 +21,7 @@ func TestEbpfConntrackerLoadTriggersOffsetGuessing(t *testing.T) {
 
 	cfg := testConfig()
 	cfg.EnableRuntimeCompiler = false
-	conntracker, err := NewEBPFConntracker(cfg, nil)
+	conntracker, err := NewEBPFConntracker(cfg)
 	assert.NoError(t, err)
 	require.NotNil(t, conntracker)
 	t.Cleanup(conntracker.Close)

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -168,7 +168,7 @@ func newTracer(cfg *config.Config) (_ *Tracer, reterr error) {
 		//this is a patch for now, until ebpfTelemetry is fully encapsulated in the ebpf/telemetry pkg
 		if errorsCollector, ok := eec.(*ebpftelemetry.EBPFErrorsCollector); ok {
 			tr.bpfErrorsCollector = errorsCollector
-			bpfTelemetry = tr.bpfErrorsCollector.EBPFTelemetry
+			bpfTelemetry = tr.bpfErrorsCollector.T
 		}
 	} else {
 		log.Debug("eBPF telemetry not supported")

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -158,29 +158,24 @@ func newTracer(cfg *config.Config) (_ *Tracer, reterr error) {
 		}
 	}()
 
-	// pointer to embedded ebpfTelemetry struct within the bpfErrorsCollector,
-	// to avoid possible nil pointer dereference when accessing it via the bpfErrorsCollector pointer
-	var bpfTelemetry *ebpftelemetry.EBPFTelemetry
-
 	if eec := ebpftelemetry.NewEBPFErrorsCollector(); eec != nil {
 		coretelemetry.GetCompatComponent().RegisterCollector(eec)
 
 		//this is a patch for now, until ebpfTelemetry is fully encapsulated in the ebpf/telemetry pkg
 		if errorsCollector, ok := eec.(*ebpftelemetry.EBPFErrorsCollector); ok {
 			tr.bpfErrorsCollector = errorsCollector
-			bpfTelemetry = tr.bpfErrorsCollector.T
 		}
 	} else {
 		log.Debug("eBPF telemetry not supported")
 	}
 
-	tr.ebpfTracer, err = connection.NewTracer(cfg, bpfTelemetry)
+	tr.ebpfTracer, err = connection.NewTracer(cfg)
 	if err != nil {
 		return nil, err
 	}
 	coretelemetry.GetCompatComponent().RegisterCollector(tr.ebpfTracer)
 
-	tr.conntracker, err = newConntracker(cfg, bpfTelemetry)
+	tr.conntracker, err = newConntracker(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +187,7 @@ func newTracer(cfg *config.Config) (_ *Tracer, reterr error) {
 	}
 
 	tr.reverseDNS = newReverseDNS(cfg)
-	tr.usmMonitor = newUSMMonitor(cfg, tr.ebpfTracer, bpfTelemetry)
+	tr.usmMonitor = newUSMMonitor(cfg, tr.ebpfTracer)
 
 	if cfg.EnableProcessEventMonitoring {
 		if tr.processCache, err = newProcessCache(cfg.MaxProcessesTracked, defaultFilteredEnvs); err != nil {
@@ -242,7 +237,7 @@ func (tr *Tracer) start() error {
 	return nil
 }
 
-func newConntracker(cfg *config.Config, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (netlink.Conntracker, error) {
+func newConntracker(cfg *config.Config) (netlink.Conntracker, error) {
 	if !cfg.EnableConntrack {
 		return netlink.NewNoOpConntracker(), nil
 	}
@@ -260,7 +255,7 @@ func newConntracker(cfg *config.Config, bpfTelemetry *ebpftelemetry.EBPFTelemetr
 		}
 	}
 
-	if c, err = NewEBPFConntracker(cfg, bpfTelemetry); err == nil {
+	if c, err = NewEBPFConntracker(cfg); err == nil {
 		return c, nil
 	}
 
@@ -848,11 +843,11 @@ func (t *Tracer) DebugDumpProcessCache(ctx context.Context) (interface{}, error)
 	return nil, nil
 }
 
-func newUSMMonitor(c *config.Config, tracer connection.Tracer, bpfTelemetry *ebpftelemetry.EBPFTelemetry) *usm.Monitor {
+func newUSMMonitor(c *config.Config, tracer connection.Tracer) *usm.Monitor {
 	// Shared with the USM program
 	connectionProtocolMap := tracer.GetMap(probes.ConnectionProtocolMap)
 
-	monitor, err := usm.NewMonitor(c, connectionProtocolMap, bpfTelemetry)
+	monitor, err := usm.NewMonitor(c, connectionProtocolMap)
 	if err != nil {
 		log.Errorf("usm initialization failed: %s", err)
 		return nil

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -158,24 +158,29 @@ func newTracer(cfg *config.Config) (_ *Tracer, reterr error) {
 		}
 	}()
 
+	// pointer to embedded ebpfTelemetry struct within the bpfErrorsCollector,
+	// to avoid possible nil pointer dereference when accessing it via the bpfErrorsCollector pointer
+	var bpfTelemetry *ebpftelemetry.EBPFTelemetry
+
 	if eec := ebpftelemetry.NewEBPFErrorsCollector(); eec != nil {
 		coretelemetry.GetCompatComponent().RegisterCollector(eec)
 
 		//this is a patch for now, until ebpfTelemetry is fully encapsulated in the ebpf/telemetry pkg
 		if errorsCollector, ok := eec.(*ebpftelemetry.EBPFErrorsCollector); ok {
 			tr.bpfErrorsCollector = errorsCollector
+			bpfTelemetry = tr.bpfErrorsCollector.T
 		}
 	} else {
 		log.Debug("eBPF telemetry not supported")
 	}
 
-	tr.ebpfTracer, err = connection.NewTracer(cfg)
+	tr.ebpfTracer, err = connection.NewTracer(cfg, bpfTelemetry)
 	if err != nil {
 		return nil, err
 	}
 	coretelemetry.GetCompatComponent().RegisterCollector(tr.ebpfTracer)
 
-	tr.conntracker, err = newConntracker(cfg)
+	tr.conntracker, err = newConntracker(cfg, bpfTelemetry)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +192,7 @@ func newTracer(cfg *config.Config) (_ *Tracer, reterr error) {
 	}
 
 	tr.reverseDNS = newReverseDNS(cfg)
-	tr.usmMonitor = newUSMMonitor(cfg, tr.ebpfTracer)
+	tr.usmMonitor = newUSMMonitor(cfg, tr.ebpfTracer, bpfTelemetry)
 
 	if cfg.EnableProcessEventMonitoring {
 		if tr.processCache, err = newProcessCache(cfg.MaxProcessesTracked, defaultFilteredEnvs); err != nil {
@@ -237,7 +242,7 @@ func (tr *Tracer) start() error {
 	return nil
 }
 
-func newConntracker(cfg *config.Config) (netlink.Conntracker, error) {
+func newConntracker(cfg *config.Config, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (netlink.Conntracker, error) {
 	if !cfg.EnableConntrack {
 		return netlink.NewNoOpConntracker(), nil
 	}
@@ -255,7 +260,7 @@ func newConntracker(cfg *config.Config) (netlink.Conntracker, error) {
 		}
 	}
 
-	if c, err = NewEBPFConntracker(cfg); err == nil {
+	if c, err = NewEBPFConntracker(cfg, bpfTelemetry); err == nil {
 		return c, nil
 	}
 
@@ -843,11 +848,11 @@ func (t *Tracer) DebugDumpProcessCache(ctx context.Context) (interface{}, error)
 	return nil, nil
 }
 
-func newUSMMonitor(c *config.Config, tracer connection.Tracer) *usm.Monitor {
+func newUSMMonitor(c *config.Config, tracer connection.Tracer, bpfTelemetry *ebpftelemetry.EBPFTelemetry) *usm.Monitor {
 	// Shared with the USM program
 	connectionProtocolMap := tracer.GetMap(probes.ConnectionProtocolMap)
 
-	monitor, err := usm.NewMonitor(c, connectionProtocolMap)
+	monitor, err := usm.NewMonitor(c, connectionProtocolMap, bpfTelemetry)
 	if err != nil {
 		log.Errorf("usm initialization failed: %s", err)
 		return nil

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2085,7 +2085,7 @@ func TestEbpfConntrackerFallback(t *testing.T) {
 				ebpfConntrackerRCCreator = func(cfg *config.Config) (rc.CompiledOutput, error) { return nil, assert.AnError }
 			}
 
-			conntracker, err := NewEBPFConntracker(cfg, nil)
+			conntracker, err := NewEBPFConntracker(cfg)
 			// ensure we always clean up the conntracker, regardless of behavior
 			if conntracker != nil {
 				t.Cleanup(conntracker.Close)
@@ -2108,7 +2108,7 @@ func TestConntrackerFallback(t *testing.T) {
 	cfg := testConfig()
 	cfg.EnableEbpfConntracker = false
 	cfg.AllowNetlinkConntrackerFallback = true
-	conntracker, err := newConntracker(cfg, nil)
+	conntracker, err := newConntracker(cfg)
 	// ensure we always clean up the conntracker, regardless of behavior
 	if conntracker != nil {
 		t.Cleanup(conntracker.Close)
@@ -2117,7 +2117,7 @@ func TestConntrackerFallback(t *testing.T) {
 	require.NotNil(t, conntracker)
 
 	cfg.AllowNetlinkConntrackerFallback = false
-	conntracker, err = newConntracker(cfg, nil)
+	conntracker, err = newConntracker(cfg)
 	// ensure we always clean up the conntracker, regardless of behavior
 	if conntracker != nil {
 		t.Cleanup(conntracker.Close)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1959,7 +1959,7 @@ func (s *TracerSuite) TestGetMapsTelemetry() {
 	err := exec.Command(cmd[0], cmd[1:]...).Run()
 	require.NoError(t, err)
 
-	mapsTelemetry := tr.bpfErrorsCollector.GetMapsTelemetry()
+	mapsTelemetry := tr.bpfErrorsCollector.T.GetMapsTelemetry()
 	t.Logf("EBPF Maps telemetry: %v\n", mapsTelemetry)
 
 	tcpStatsErrors, ok := mapsTelemetry[probes.TCPStatsMap].(map[string]uint64)
@@ -2013,7 +2013,7 @@ func (s *TracerSuite) TestGetHelpersTelemetry() {
 		syscall.Syscall(syscall.SYS_MUNMAP, uintptr(addr), uintptr(syscall.Getpagesize()), 0)
 	})
 
-	helperTelemetry := tr.bpfErrorsCollector.GetHelpersTelemetry()
+	helperTelemetry := tr.bpfErrorsCollector.T.GetHelpersTelemetry()
 	t.Logf("EBPF helper telemetry: %v\n", helperTelemetry)
 
 	openAtErrors, ok := helperTelemetry[expectedErrorTP].(map[string]interface{})

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -78,7 +78,7 @@ const (
 )
 
 type ebpfProgram struct {
-	*ebpftelemetry.Manager
+	*ddebpf.Manager
 	cfg                   *config.Config
 	tailCallRouter        []manager.TailCallRoute
 	connectionProtocolMap *ebpf.Map
@@ -91,7 +91,7 @@ type ebpfProgram struct {
 	buildMode  buildmode.Type
 }
 
-func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (*ebpfProgram, error) {
+func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map) (*ebpfProgram, error) {
 	mgr := &manager.Manager{
 		Maps: []*manager.Map{
 			{Name: protocols.TLSDispatcherProgramsMap},
@@ -150,12 +150,12 @@ func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map, bpfTeleme
 	}
 
 	program := &ebpfProgram{
-		Manager:               ebpftelemetry.NewManager(mgr, bpfTelemetry),
+		Manager:               ddebpf.NewManager(mgr),
 		cfg:                   c,
 		connectionProtocolMap: connectionProtocolMap,
 	}
 
-	opensslSpec.Factory = newSSLProgramProtocolFactory(mgr, bpfTelemetry)
+	opensslSpec.Factory = newSSLProgramProtocolFactory(mgr)
 	goTLSSpec.Factory = newGoTLSProgramProtocolFactory(mgr)
 
 	if err := program.initProtocols(c); err != nil {
@@ -450,7 +450,7 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 		}
 	}
 
-	err := e.InitWithOptions(buf, options)
+	err := e.InitWithOptions(buf, &options)
 	if err != nil {
 		cleanup()
 	} else {

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -26,7 +26,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck"
-	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
@@ -423,7 +422,7 @@ type sslProgram struct {
 	istioMonitor *istioMonitor
 }
 
-func newSSLProgramProtocolFactory(m *manager.Manager, bpfTelemetry *ebpftelemetry.EBPFTelemetry) protocols.ProtocolFactory {
+func newSSLProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactory {
 	return func(c *config.Config) (protocols.Protocol, error) {
 		if (!c.EnableNativeTLSMonitoring || !http.TLSSupported(c)) && !c.EnableIstioMonitoring {
 			return nil, nil
@@ -437,7 +436,7 @@ func newSSLProgramProtocolFactory(m *manager.Manager, bpfTelemetry *ebpftelemetr
 		procRoot := kernel.ProcFSRoot()
 
 		if c.EnableNativeTLSMonitoring && http.TLSSupported(c) {
-			watcher, err = sharedlibraries.NewWatcher(c, bpfTelemetry,
+			watcher, err = sharedlibraries.NewWatcher(c,
 				sharedlibraries.Rule{
 					Re:           regexp.MustCompile(`libssl.so`),
 					RegisterCB:   addHooks(m, procRoot, openSSLProbes),

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -20,7 +20,6 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck"
-	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	filterpkg "github.com/DataDog/datadog-agent/pkg/network/filter"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
@@ -60,7 +59,7 @@ type Monitor struct {
 }
 
 // NewMonitor returns a new Monitor instance
-func NewMonitor(c *config.Config, connectionProtocolMap *ebpf.Map, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (m *Monitor, err error) {
+func NewMonitor(c *config.Config, connectionProtocolMap *ebpf.Map) (m *Monitor, err error) {
 	defer func() {
 		// capture error and wrap it
 		if err != nil {
@@ -70,7 +69,7 @@ func NewMonitor(c *config.Config, connectionProtocolMap *ebpf.Map, bpfTelemetry 
 		}
 	}()
 
-	mgr, err := newEBPFProgram(c, connectionProtocolMap, bpfTelemetry)
+	mgr, err := newEBPFProgram(c, connectionProtocolMap)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up ebpf program: %w", err)
 	}

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -39,10 +39,10 @@ var traceTypes = []string{"enter", "exit"}
 type ebpfProgram struct {
 	cfg         *config.Config
 	perfHandler *ddebpf.PerfHandler
-	*ebpftelemetry.Manager
+	*ddebpf.Manager
 }
 
-func newEBPFProgram(c *config.Config, bpfTelemetry *ebpftelemetry.EBPFTelemetry) *ebpfProgram {
+func newEBPFProgram(c *config.Config) *ebpfProgram {
 	perfHandler := ddebpf.NewPerfHandler(100)
 	pm := &manager.PerfMap{
 		Map: manager.Map{
@@ -74,7 +74,7 @@ func newEBPFProgram(c *config.Config, bpfTelemetry *ebpftelemetry.EBPFTelemetry)
 
 	return &ebpfProgram{
 		cfg:         c,
-		Manager:     ebpftelemetry.NewManager(mgr, bpfTelemetry),
+		Manager:     ddebpf.NewManager(mgr),
 		perfHandler: perfHandler,
 	}
 }
@@ -133,7 +133,7 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 	}
 
 	options.VerifierOptions.Programs.LogSize = 10 * 1024 * 1024
-	return e.InitWithOptions(buf, options)
+	return e.InitWithOptions(buf, &options)
 }
 
 func (e *ebpfProgram) initCORE() error {

--- a/pkg/network/usm/sharedlibraries/watcher.go
+++ b/pkg/network/usm/sharedlibraries/watcher.go
@@ -18,7 +18,6 @@ import (
 	"unsafe"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
-	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
@@ -65,8 +64,8 @@ type Watcher struct {
 }
 
 // NewWatcher creates a new Watcher instance
-func NewWatcher(cfg *config.Config, bpfTelemetry *ebpftelemetry.EBPFTelemetry, rules ...Rule) (*Watcher, error) {
-	ebpfProgram := newEBPFProgram(cfg, bpfTelemetry)
+func NewWatcher(cfg *config.Config, rules ...Rule) (*Watcher, error) {
+	ebpfProgram := newEBPFProgram(cfg)
 	err := ebpfProgram.Init()
 	if err != nil {
 		return nil, fmt.Errorf("error initializing shared library program: %w", err)


### PR DESCRIPTION
### What does this PR do?

- added ebpf errors modifier to default modifiers list 
- removed deprecated ebpfTelemetry manager and replace references in ebpf programs to use the new manager wrapper 

### Motivation

Better code structure and encapsulation

### Additional Notes

Multiple files changed due to the fact that ebpfTelemetry parameter was being propagated to almost every function in our ebpf programs for NPM and USM.

1. I am considering creating an intermediate PR to migrate just one ebpf program to use the new manager with the modifiers and test for stability and regressions on stripe, before merging this PR

2. In the following PRs, I plan to move the errors_telemetry_collector from tracer to system_probe cmd to fully decouple the ebpf telemetry from the tracer

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
