### PR TITLE
[CWS] optimization to regex evaluation part of string matches

### DIFF
--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -129,11 +129,23 @@ type StringMatcher interface {
 
 // RegexpStringMatcher defines a regular expression pattern matcher
 type RegexpStringMatcher struct {
+	stringOptionsOpt []string
+
 	re *regexp.Regexp
 }
 
+var stringBigOrRe = regexp.MustCompile(`^\.\*\(([a-zA-Z_|]+)\)\.\*$`)
+
 // Compile a regular expression based pattern
 func (r *RegexpStringMatcher) Compile(pattern string, caseInsensitive bool) error {
+	if !caseInsensitive {
+		if groups := stringBigOrRe.FindStringSubmatch(pattern); groups != nil {
+			r.stringOptionsOpt = strings.Split(groups[1], "|")
+			r.re = nil
+			return nil
+		}
+	}
+
 	if caseInsensitive {
 		pattern = "(?i)" + pattern
 	}
@@ -142,6 +154,7 @@ func (r *RegexpStringMatcher) Compile(pattern string, caseInsensitive bool) erro
 	if err != nil {
 		return err
 	}
+	r.stringOptionsOpt = nil
 	r.re = re
 
 	return nil
@@ -149,6 +162,15 @@ func (r *RegexpStringMatcher) Compile(pattern string, caseInsensitive bool) erro
 
 // Matches returns whether the value matches
 func (r *RegexpStringMatcher) Matches(value string) bool {
+	if r.stringOptionsOpt != nil {
+		for _, search := range r.stringOptionsOpt {
+			if strings.Contains(value, search) {
+				return true
+			}
+		}
+		return false
+	}
+
 	return r.re.MatchString(value)
 }
 

--- a/pkg/security/secl/compiler/eval/strings_test.go
+++ b/pkg/security/secl/compiler/eval/strings_test.go
@@ -234,6 +234,30 @@ func TestRegexp(t *testing.T) {
 			t.Error("should match")
 		}
 	})
+
+	t.Run("multiple-string-options", func(t *testing.T) {
+		matcher, err := NewStringMatcher(RegexpValueType, ".*(restore|recovery|readme|instruction|how_to|ransom).*", StringCmpOpts{})
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !matcher.Matches("123readme456") {
+			t.Error("should match")
+		}
+
+		if matcher.Matches("TEST123") {
+			t.Error("should not match")
+		}
+
+		reMatcher, ok := matcher.(*RegexpStringMatcher)
+		if !ok {
+			t.Error("should be a regex matcher")
+		}
+
+		if !slices.Equal([]string{"restore", "recovery", "readme", "instruction", "how_to", "ransom"}, reMatcher.stringOptionsOpt) {
+			t.Error("should be an optimized string option re matcher")
+		}
+	})
 }
 
 func BenchmarkRegexpEvaluator(b *testing.B) {

--- a/pkg/security/secl/compiler/eval/strings_test.go
+++ b/pkg/security/secl/compiler/eval/strings_test.go
@@ -235,3 +235,19 @@ func TestRegexp(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkRegexpEvaluator(b *testing.B) {
+	pattern := ".*(restore|recovery|readme|instruction|how_to|ransom).*"
+
+	var matcher RegexpStringMatcher
+	if err := matcher.Compile(pattern, false); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !matcher.Matches("123ransom456.txt") {
+			b.Fatal("unexpected result")
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

The main goal of this PR is to optimize patterns that look like
```
.*(word1|word2|...|wordN).*
```
to a for loop of `strings.Contains`.

Benchmark:
```
# Before:
BenchmarkRegexpEvaluator-10    	 1457696	       817.0 ns/op	       0 B/op	       0 allocs/op
# After:
BenchmarkRegexpEvaluator-10    	26507254	        44.97 ns/op	       0 B/op	       0 allocs/op
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
