### PR TITLE
Fix the cluster name injected by the admission controller in sidecar

### DIFF
--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -9,18 +9,21 @@
 package agentsidecar
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"os"
+
 	dca_ac "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	apiCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/dynamic"
 	k8s "k8s.io/client-go/kubernetes"
-	"os"
 )
 
 // InjectAgentSidecar handles mutating pod requests for the agentsidecat webhook
@@ -86,7 +89,7 @@ func getDefaultSidecarTemplate() *corev1.Container {
 			},
 			{
 				Name:  "DD_CLUSTER_NAME",
-				Value: config.Datadog.GetString("cluster_name"),
+				Value: clustername.GetClusterName(context.TODO(), ""),
 			},
 			{
 				Name: "DD_KUBERNETES_KUBELET_NODENAME",


### PR DESCRIPTION
### What does this PR do?

Fix the injection of the cluster name on agent sidecar container.

### Motivation

Current code was working if the cluster name was explicitly defined in the configuration but not if the cluster agent had been able to find it on its own.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Follow the instructions of #22535 to configure agent sidecar injection on an EKS cluster.
Take care of letting the cluster agent determine the EKS cluster name automatically via the EC2 API and do not explicitly set it through the config.
Before this PR, the `DD_CLUSTER_NAME` environment variable was injected in the agent sidecar container without any value.
With this PR, the cluster agent should properly inject the cluster name.
