### PR TITLE
(fleet) fix the updater StartExperiment

### DIFF
--- a/pkg/updater/download.go
+++ b/pkg/updater/download.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	agentArchiveFileName       = "agent.tar.gz"
+	archiveName                = "package.tar.gz"
 	maxArchiveSize             = 5 << 30  // 5GiB
 	maxArchiveDecompressedSize = 10 << 30 // 10GiB
 )
@@ -78,7 +78,7 @@ func (d *downloader) Download(ctx context.Context, pkg Package, destinationPath 
 		io.LimitReader(resp.Body, maxArchiveSize),
 		hashWriter,
 	)
-	archivePath := filepath.Join(tmpDir, agentArchiveFileName)
+	archivePath := filepath.Join(tmpDir, archiveName)
 	archiveFile, err := os.Create(archivePath)
 	if err != nil {
 		return fmt.Errorf("could not create archive file: %w", err)

--- a/pkg/updater/download_test.go
+++ b/pkg/updater/download_test.go
@@ -80,7 +80,8 @@ func createTestOCIArchive(t *testing.T, dir string) {
 	layerDigest := hex.EncodeToString(hasher.Sum(nil))
 	layerDigestPath := path.Join(blobPath, layerDigest)
 	// File names are digests: move file
-	os.Rename(layerPath, layerDigestPath)
+	err = os.Rename(layerPath, layerDigestPath)
+	assert.NoError(t, err)
 	layerStat, err := os.Stat(layerDigestPath)
 	assert.NoError(t, err)
 

--- a/pkg/updater/download_test.go
+++ b/pkg/updater/download_test.go
@@ -32,7 +32,7 @@ const (
 	testNestedAgentFileName  = "nested/agent2"
 	testLargeFileName        = "large"
 	testLargeFileSize        = 1024 * 1024 * 20 // 20MB
-	testAgentArchiveFileName = "agent.tar.gz"
+	testAgentArchiveFileName = "package.tar.gz"
 	testDownloadDir          = "download"
 )
 

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -169,11 +169,12 @@ func (u *updaterImpl) StartExperiment(ctx context.Context, version string) error
 		return fmt.Errorf("could not create temporary directory: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
-	err = u.downloader.Download(ctx, experimentPackage, tmpDir)
+	pkgDir := path.Join(tmpDir, "pkg")
+	err = u.downloader.Download(ctx, experimentPackage, pkgDir)
 	if err != nil {
 		return fmt.Errorf("could not download package: %w", err)
 	}
-	err = u.repository.SetExperiment(experimentPackage.Version, tmpDir)
+	err = u.repository.SetExperiment(experimentPackage.Version, pkgDir)
 	if err != nil {
 		return fmt.Errorf("could not set experiment: %w", err)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Small fix for the StartExperiment function of the updater that was using the wrong directory when writing temp results of `Download`.
