### PR TITLE
pkg/trace/api: limit simultaneous otlp requests, do not drop payloads

### DIFF
--- a/comp/otelcol/otlp/map_provider_config_not_serverless.go
+++ b/comp/otelcol/otlp/map_provider_config_not_serverless.go
@@ -14,12 +14,17 @@ package otlp
 const defaultTracesConfig string = `
 receivers:
   otlp:
+    protocols:
+      grpc:
+        max_concurrent_streams: 1
 
 exporters:
   otlp:
     tls:
       insecure: true
     compression: none
+    sending_queue:
+      enabled: false
 
 service:
   telemetry:

--- a/comp/otelcol/otlp/map_provider_config_not_serverless.go
+++ b/comp/otelcol/otlp/map_provider_config_not_serverless.go
@@ -14,9 +14,6 @@ package otlp
 const defaultTracesConfig string = `
 receivers:
   otlp:
-    protocols:
-      grpc:
-        max_concurrent_streams: 1
 
 exporters:
   otlp:

--- a/comp/otelcol/otlp/map_provider_not_serverless_test.go
+++ b/comp/otelcol/otlp/map_provider_not_serverless_test.go
@@ -55,6 +55,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 				},
 				"service": map[string]interface{}{
@@ -111,6 +114,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"serializer": map[string]interface{}{
 						"metrics": map[string]interface{}{
@@ -184,6 +190,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"serializer": map[string]interface{}{
 						"metrics": map[string]interface{}{
@@ -244,6 +253,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 				},
 				"service": map[string]interface{}{
@@ -345,6 +357,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"logging": map[string]interface{}{
 						"loglevel": "info",
@@ -465,6 +480,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"serializer": map[string]interface{}{
 						"metrics": map[string]interface{}{
@@ -525,6 +543,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"logsagent": interface{}(nil),
 				},
@@ -593,6 +614,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"serializer": map[string]interface{}{
 						"metrics": map[string]interface{}{
@@ -673,6 +697,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"serializer": map[string]interface{}{
 						"metrics": map[string]interface{}{
@@ -745,6 +772,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"logsagent": interface{}(nil),
 				},
@@ -865,6 +895,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"logging": map[string]interface{}{
 						"loglevel": "info",
@@ -999,6 +1032,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"serializer": map[string]interface{}{
 						"metrics": map[string]interface{}{

--- a/comp/otelcol/otlp/map_provider_serverless_test.go
+++ b/comp/otelcol/otlp/map_provider_serverless_test.go
@@ -51,6 +51,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 				},
 				"service": map[string]interface{}{
@@ -102,6 +105,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"serializer": map[string]interface{}{
 						"metrics": map[string]interface{}{
@@ -169,6 +175,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"serializer": map[string]interface{}{
 						"metrics": map[string]interface{}{
@@ -228,6 +237,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 				},
 				"service": map[string]interface{}{
@@ -323,6 +335,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"logging": map[string]interface{}{
 						"loglevel": "info",
@@ -432,6 +447,9 @@ func TestNewMap(t *testing.T) {
 						},
 						"compression": "none",
 						"endpoint":    "localhost:5003",
+						"sending_queue": map[string]interface{}{
+							"enabled": false,
+						},
 					},
 					"serializer": map[string]interface{}{
 						"metrics": map[string]interface{}{

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -76,7 +76,10 @@ func (o *OTLPReceiver) Start() {
 		if err != nil {
 			log.Criticalf("Error starting OpenTelemetry gRPC server: %v", err)
 		} else {
-			o.grpcsrv = grpc.NewServer(grpc.MaxRecvMsgSize(10 * 1024 * 1024))
+			o.grpcsrv = grpc.NewServer(
+				grpc.MaxRecvMsgSize(10*1024*1024),
+				grpc.MaxConcurrentStreams(1), // Each payload must be sent to processing stage before we decode the next.
+			)
 			ptraceotlp.RegisterGRPCServer(o.grpcsrv, o)
 			o.wg.Add(1)
 			go func() {
@@ -307,12 +310,8 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 			tagContainersTags: payloadTags.String(),
 		}
 	}
-	select {
-	case o.out <- &p:
-		// success
-	default:
-		log.Warn("Payload in channel full. Dropped 1 payload.")
-	}
+
+	o.out <- &p
 	return src
 }
 

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -167,6 +167,18 @@ func TestOTLPMetrics(t *testing.T) {
 		},
 	}).Traces().ResourceSpans()
 
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-out:
+			case <-stop:
+				return
+			}
+		}
+	}()
+	defer close(stop)
+
 	rcv.ReceiveResourceSpans(context.Background(), rspans.At(0), http.Header{})
 	rcv.ReceiveResourceSpans(context.Background(), rspans.At(1), http.Header{})
 

--- a/releasenotes/notes/apm-otel-receiver-backpressure-40e301d75d00804d.yaml
+++ b/releasenotes/notes/apm-otel-receiver-backpressure-40e301d75d00804d.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Stop dropping incoming otel payloads when the processing channel is full
+    and eliminate OOM issues in the trace agent and collector component in high
+    load scenarios, making the OTel pipeline more reliable.

--- a/releasenotes/notes/apm-otel-receiver-backpressure-40e301d75d00804d.yaml
+++ b/releasenotes/notes/apm-otel-receiver-backpressure-40e301d75d00804d.yaml
@@ -8,6 +8,6 @@
 ---
 fixes:
   - |
-    APM: Stop dropping incoming otel payloads when the processing channel is full
+    APM: Stop dropping incoming OTel payloads when the processing channel is full
     and eliminate OOM issues in the trace agent and collector component in high
     load scenarios, making the OTel pipeline more reliable.


### PR DESCRIPTION



<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This commit causes the Trace Agent OTLP Receiver to not drop traces when the payload channel is full.

This commit also limits the number of simultaneous RPC requests, forwarding the backpressure from the pipeline to the client, and limiting our memory to O(MaxConnections * MaxStreams * MaxPayloadSize) in the receiver, with MaxStreams being 1.

Finally, it eliminates the trace buffer in the collector component exporter, preventing the core agent from buffering GiBs of traces under load.

All of these changes reduce trace drops while preventing uncontrolled memory growth.


### Motivation

Previously, the OTLP Receiver in the Trace Agent dropped traces when the processor channel was full. This means that the receiver was dropping traces unnecessarily, and a better strategy is to block on the send. This will cause backpressure up through the otlp pipeline.

By default, a gRPC server will allow practically unlimited concurrent RPC requests, spawning a goroutine for each. The routine will read and deserialize the payload before calling the handler, which is now blocking.

This means that our memory usage is not reasonably bounded, since we could be holding hundreds of payloads in memory waiting to be processed. Limiting the number of concurrent RPC requests is required.

Finally, the backpressure goes to the core agent collector component. Here we need to remove the trace buffer to prevent GiBs of trace payloads from being buffered when it feels the backpressure from the Trace Agent.

### Additional Notes


### Possible Drawbacks / Trade-offs

Eliminating the trace buffer in the collector component could in theory result in higher trace loss in certain bursty scenarios. In practice, we don't see such scenarios and so this is a fair trade-off.

### Describe how to test/QA your changes

We will use the new OTel load testing environment to exercise this change.

We should compare:

throughput (are traces being dropped)
memory usage (is memory usage better or worse)
See @knusbaum for details about more specifics regarding infrastructure.
