### PR TITLE
[WKINT-388][Windows][CWS] Add ddprocmon to crash list

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -150,7 +150,7 @@ func load() (*types.Config, error) {
 		c.EnabledModules[WindowsCrashDetectModule] = struct{}{}
 	}
 	if runtime.GOOS == "windows" {
-		if c.ModuleIsEnabled(NetworkTracerModule) {
+		if c.ModuleIsEnabled(NetworkTracerModule) || c.ModuleIsEnabled(EventMonitorModule) {
 			// enable the windows crash detection module if the network tracer
 			// module is enabled, to allow the core agent to detect our own crash
 			c.EnabledModules[WindowsCrashDetectModule] = struct{}{}

--- a/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
+++ b/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
@@ -43,14 +43,16 @@ const (
 var (
 	// crashdriver included for testing purposes
 	ddDrivers = map[string]struct{}{
-		"ddnpm":       {},
-		"crashdriver": {},
+		"ddnpm":       {}, // NPM/USM driver, used for network monitoring
+		"ddprocmon":   {}, // process monitoring driver, used for CWS
+		"crashdriver": {}, // this entry exists only for testing purposes.  
 	}
 	// system probe enabled flags indicating we should be enabled
 	enabledflags = []string{
 		"windows_crash_detection.enabled",
 		"network_config.enabled",
 		"service_monitoring_config.enabled",
+		"runtime_security_config.enabled",
 	}
 	// these are vars and not consts so that they can be overridden in
 	// the unit tests.

--- a/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
+++ b/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
@@ -45,7 +45,7 @@ var (
 	ddDrivers = map[string]struct{}{
 		"ddnpm":       {}, // NPM/USM driver, used for network monitoring
 		"ddprocmon":   {}, // process monitoring driver, used for CWS
-		"crashdriver": {}, // this entry exists only for testing purposes.  
+		"crashdriver": {}, // this entry exists only for testing purposes.
 	}
 	// system probe enabled flags indicating we should be enabled
 	enabledflags = []string{


### PR DESCRIPTION
This change adds ddprocmon to the list of processes that are monitored for crashes by the agent crash detection module; which notifies us if one of our drivers crashes.

Testing Instructions
- Install agent
- Enable _only_ CWS
  - do not enable NPM or USM, because that will invalidate the test
- start the agent
- check the log for the agent crash detection module.  You should see
```
2024-02-22 15:51:08 PST | CORE | DEBUG | (pkg/collector/worker/check_logger.go:44 in CheckStarted) | check:agentcrashdetect | Running check...
2024-02-22 15:51:08 PST | CORE | DEBUG | (pkg/collector/worker/check_logger.go:61 in CheckFinished) | check:agentcrashdetect | Done running check
```
you should NOT see
```
2024-02-22 17:09:41 PST | CORE | INFO | (comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go:128 in Configure) | Agent Crash Detection module will not run; no required components running
```

For additional testing.  install and load the crash driver (location here). It will crash.  Upon reboot, a crash detection should be generated.  If your host is in `us-1`, then a slack notification should appear in #windows-kernel-intergrations-ops

<!--
