### PR TITLE
Fix collection of rolling update options on Kubernetes workloads

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/daemonset.go
@@ -40,7 +40,7 @@ func ExtractDaemonSet(ds *appsv1.DaemonSet) *model.DaemonSet {
 	daemonSet.Spec.DeploymentStrategy = string(ds.Spec.UpdateStrategy.Type)
 	if ds.Spec.UpdateStrategy.Type == "RollingUpdate" && ds.Spec.UpdateStrategy.RollingUpdate != nil {
 		if ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable != nil {
-			daemonSet.Spec.MaxUnavailable = ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.StrVal
+			daemonSet.Spec.MaxUnavailable = ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String()
 		}
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/deployment.go
@@ -31,10 +31,10 @@ func ExtractDeployment(d *appsv1.Deployment) *model.Deployment {
 	deploy.DeploymentStrategy = string(d.Spec.Strategy.Type)
 	if deploy.DeploymentStrategy == "RollingUpdate" && d.Spec.Strategy.RollingUpdate != nil {
 		if d.Spec.Strategy.RollingUpdate.MaxUnavailable != nil {
-			deploy.MaxUnavailable = d.Spec.Strategy.RollingUpdate.MaxUnavailable.StrVal
+			deploy.MaxUnavailable = d.Spec.Strategy.RollingUpdate.MaxUnavailable.String()
 		}
 		if d.Spec.Strategy.RollingUpdate.MaxSurge != nil {
-			deploy.MaxSurge = d.Spec.Strategy.RollingUpdate.MaxSurge.StrVal
+			deploy.MaxSurge = d.Spec.Strategy.RollingUpdate.MaxSurge.String()
 		}
 	}
 	if d.Spec.Selector != nil {

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/deployment_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/deployment_test.go
@@ -26,8 +26,9 @@ import (
 
 func TestExtractDeployment(t *testing.T) {
 	timestamp := metav1.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)) // 1389744000
+	testIntOrStrPercent := intstr.FromString("1%")
+	testIntOrStrNumber := intstr.FromInt(1)
 	testInt32 := int32(2)
-	testIntorStr := intstr.FromString("1%")
 	tests := map[string]struct {
 		input    appsv1.Deployment
 		expected model.Deployment
@@ -60,8 +61,8 @@ func TestExtractDeployment(t *testing.T) {
 					Strategy: appsv1.DeploymentStrategy{
 						Type: appsv1.DeploymentStrategyType("RollingUpdate"),
 						RollingUpdate: &appsv1.RollingUpdateDeployment{
-							MaxSurge:       &testIntorStr,
-							MaxUnavailable: &testIntorStr,
+							MaxSurge:       &testIntOrStrPercent,
+							MaxUnavailable: &testIntOrStrPercent,
 						},
 					},
 				},
@@ -163,6 +164,26 @@ func TestExtractDeployment(t *testing.T) {
 					Namespace: "namespace",
 				},
 				DeploymentStrategy: "RollingUpdate",
+			},
+		},
+		"partial deploy with numeric rolling update options": {
+			input: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds: 600,
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.DeploymentStrategyType("RollingUpdate"),
+						RollingUpdate: &appsv1.RollingUpdateDeployment{
+							MaxSurge:       &testIntOrStrNumber,
+							MaxUnavailable: &testIntOrStrNumber,
+						},
+					},
+				},
+			}, expected: model.Deployment{
+				ReplicasDesired:    1,
+				Metadata:           &model.Metadata{},
+				DeploymentStrategy: "RollingUpdate",
+				MaxUnavailable:     "1",
+				MaxSurge:           "1",
 			},
 		},
 		"partial deploy with ust": {

--- a/releasenotes-dca/notes/bugfix-rolling-update-options-9d85bfb340ed76b2.yaml
+++ b/releasenotes-dca/notes/bugfix-rolling-update-options-9d85bfb340ed76b2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix collection of numeric rolling update options in Kubernetes deployments
+    and daemonsets.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix the collection of `maxSurge` and `maxUnavailable` fields in workload rolling update strategy when their content is an integer: they were empty in such a case.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
