### PR TITLE
Add datadog-agentless-scanner package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -155,6 +155,7 @@
 /cmd/agent/dist/conf.d/snmp.d/          @DataDog/network-device-monitoring
 /cmd/agent/install*.sh                  @DataDog/agent-build-and-releases
 /cmd/agent/gui/views/private/js/apm.js                       @DataDog/agent-apm
+/cmd/agentless-scanner/                 @DataDog/agent-cspm
 /cmd/cluster-agent/                     @DataDog/container-integrations
 /cmd/cluster-agent/commands/            @DataDog/container-integrations @DataDog/platform-integrations
 /cmd/cluster-agent-cloudfoundry/        @DataDog/platform-integrations

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,6 +124,7 @@ variables:
   DD_AGENT_TESTING_DIR: $CI_PROJECT_DIR/test/kitchen
   STATIC_BINARIES_DIR: bin/static
   DOGSTATSD_BINARIES_DIR: bin/dogstatsd
+  AGENTLESS_SCANNER_BINARIES_DIR: bin/agentless-scanner
   AGENT_BINARIES_DIR: bin/agent
   CLUSTER_AGENT_BINARIES_DIR: bin/datadog-cluster-agent
   CWS_INSTRUMENTATION_BINARIES_DIR: bin/cws-instrumentation

--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -93,3 +93,35 @@ build_iot_agent-binary_arm64:
     - source /root/.bashrc
     - inv check-go-version
     - inv -e agent.build --flavor iot --major-version 7
+
+build_agentless_scanner-binary_x64:
+  stage: binary_build
+  rules:
+    !reference [.on_a7]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["lint_linux-x64", "go_deps"]
+  before_script:
+    - source /root/.bashrc
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    - inv check-go-version
+    - inv -e agentless-scanner.build --major-version 7
+    - $S3_CP_CMD $CI_PROJECT_DIR/$AGENTLESS_SCANNER_BINARIES_DIR/agentless-scanner $S3_ARTIFACTS_URI/agentless-scanner/agentless-scanner
+
+build_agentless_scanner-binary_arm64:
+  stage: binary_build
+  rules:
+    !reference [.on_a7]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
+  tags: ["arch:arm64"]
+  needs: ["lint_linux-arm64", "go_deps"]
+  variables:
+    ARCH: arm64
+  before_script:
+    - source /root/.bashrc
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    - inv check-go-version
+    - inv -e agentless-scanner.build --major-version 7
+    - $S3_CP_CMD $CI_PROJECT_DIR/$AGENTLESS_SCANNER_BINARIES_DIR/agentless-scanner $S3_ARTIFACTS_URI/agentless-scanner/agentless-scanner.$ARCH

--- a/.gitlab/deploy_packages/nix.yml
+++ b/.gitlab/deploy_packages/nix.yml
@@ -90,6 +90,18 @@ deploy_packages_dogstatsd_deb-arm64-7:
   variables:
     PACKAGE_ARCH: arm64
 
+deploy_packages_agentless_scanner_deb-x64-7:
+  extends: .deploy_packages_deb-7
+  needs: [ agentless_scanner_deb-x64 ]
+  variables:
+    PACKAGE_ARCH: amd64
+
+deploy_packages_agentless_scanner_deb-arm64-7:
+  extends: .deploy_packages_deb-7
+  needs: [ agentless_scanner_deb-arm64 ]
+  variables:
+    PACKAGE_ARCH: arm64
+
 deploy_packages_rpm-x64-7:
   extends: .deploy_packages_rpm-7
   needs: [ agent_rpm-x64-a7 ]
@@ -126,6 +138,18 @@ deploy_packages_dogstatsd_rpm-x64-7:
   variables:
     PACKAGE_ARCH: x86_64
 
+deploy_packages_agentless_scanner_rpm-x64-7:
+  extends: .deploy_packages_rpm-7
+  needs: [ agentless_scanner_rpm-x64 ]
+  variables:
+    PACKAGE_ARCH: x86_64
+
+deploy_packages_agentless_scanner_rpm-arm64-7:
+  extends: .deploy_packages_rpm-7
+  needs: [ agentless_scanner_rpm-arm64 ]
+  variables:
+    PACKAGE_ARCH: arm64
+
 deploy_packages_suse_rpm-x64-7:
   extends: .deploy_packages_suse_rpm-7
   needs: [ agent_suse-x64-a7 ]
@@ -147,6 +171,12 @@ deploy_packages_iot_suse_rpm-x64-7:
 deploy_packages_dogstatsd_suse_rpm-x64-7:
   extends: .deploy_packages_suse_rpm-7
   needs: [ dogstatsd_suse-x64 ]
+  variables:
+    PACKAGE_ARCH: x86_64
+
+deploy_packages_agentless_scanner_suse_rpm-x64-7:
+  extends: .deploy_packages_suse_rpm-7
+  needs: [ agentless_scanner_suse-x64 ]
   variables:
     PACKAGE_ARCH: x86_64
 

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -308,6 +308,61 @@ updater_deb-arm64:
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
+agentless_scanner_deb-x64:
+  rules:
+    !reference [.on_a7]
+  stage: package_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["go_mod_tidy_check", "build_agentless_scanner-binary_x64", "go_deps"]
+  variables:
+  before_script:
+    - source /root/.bashrc
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    # remove artifacts from previous pipelines that may come from the cache
+    - rm -rf $OMNIBUS_PACKAGE_DIR/*
+    - !reference [.setup_ruby_mirror_linux]
+    # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
+    # Thus, we move the artifacts at the end in a gitlab-friendly dir.
+    - *setup_deb_signing_key
+    # Use --skip-deps since the deps are installed by `before_script`.
+    - inv -e agentless-scanner.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
+    - ls -la $OMNIBUS_PACKAGE_DIR
+    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agentless-scanner*_amd64.deb $S3_ARTIFACTS_URI/datadog-agentless-scanner_amd64.deb
+    - !reference [.upload_sbom_artifacts]
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - $OMNIBUS_PACKAGE_DIR
+
+agentless_scanner_deb-arm64:
+  rules:
+    !reference [.on_all_builds_a7]
+  stage: package_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
+  tags: ["arch:arm64"]
+  needs: ["go_mod_tidy_check", "build_agentless_scanner-binary_arm64", "go_deps"]
+  before_script:
+    - source /root/.bashrc
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    # remove artifacts from previous pipelines that may come from the cache
+    - rm -rf $OMNIBUS_PACKAGE_DIR/*
+    - !reference [.setup_ruby_mirror_linux]
+    # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
+    # Thus, we move the artifacts at the end in a gitlab-friendly dir.
+    - *setup_deb_signing_key
+    # Use --skip-deps since the deps are installed by `before_script`.
+    - inv -e agentless-scanner.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
+    - ls -la $OMNIBUS_PACKAGE_DIR
+    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agentless-scanner*_arm64.deb $S3_ARTIFACTS_URI/datadog-agentless-scanner_arm64.deb
+    - !reference [.upload_sbom_artifacts]
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - $OMNIBUS_PACKAGE_DIR
+
 agent_heroku_deb-x64-a6:
   extends: agent_deb-x64-a6
   variables:

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -219,3 +219,67 @@ dogstatsd_rpm-x64:
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
+
+agentless_scanner_rpm-x64:
+  rules:
+    !reference [.on_a7]
+  stage: package_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["go_mod_tidy_check", "build_agentless_scanner-binary_x64", "go_deps"]
+  variables:
+  before_script:
+    - source /root/.bashrc
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    # remove artifacts from previous pipelines that may come from the cache
+    - rm -rf $OMNIBUS_PACKAGE_DIR/*
+    - !reference [.setup_ruby_mirror_linux]
+    # Artifacts and cache must live within project directory but we run omnibus
+    # from the GOPATH (see above). We then call `invoke` passing --base-dir,
+    # pointing to a gitlab-friendly location.
+    - set +x
+    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $RPM_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - printf -- "$RPM_GPG_KEY" | gpg --import --batch
+    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - set -x
+    # Use --skip-deps since the deps are installed by `before_script`.
+    - inv -e agentless-scanner.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
+    - ls -la $OMNIBUS_PACKAGE_DIR
+    - !reference [.upload_sbom_artifacts]
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - $OMNIBUS_PACKAGE_DIR
+
+agentless_scanner_rpm-arm64:
+  rules:
+    !reference [.on_a7]
+  stage: package_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:arm64"]
+  needs: ["go_mod_tidy_check", "build_agentless_scanner-binary_arm64", "go_deps"]
+  variables:
+  before_script:
+    - source /root/.bashrc
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    # remove artifacts from previous pipelines that may come from the cache
+    - rm -rf $OMNIBUS_PACKAGE_DIR/*
+    - !reference [.setup_ruby_mirror_linux]
+    # Artifacts and cache must live within project directory but we run omnibus
+    # from the GOPATH (see above). We then call `invoke` passing --base-dir,
+    # pointing to a gitlab-friendly location.
+    - set +x
+    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $RPM_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - printf -- "$RPM_GPG_KEY" | gpg --import --batch
+    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - set -x
+    # Use --skip-deps since the deps are installed by `before_script`.
+    - inv -e agentless-scanner.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
+    - ls -la $OMNIBUS_PACKAGE_DIR
+    - !reference [.upload_sbom_artifacts]
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -172,3 +172,37 @@ dogstatsd_suse-x64:
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR_SUSE
+
+agentless_scanner_suse-x64:
+  rules:
+    !reference [.on_a7]
+  stage: package_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["go_mod_tidy_check", "build_agentless_scanner-binary_x64", "go_deps"]
+  variables:
+  before_script:
+    - source /root/.bashrc
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    # remove artifacts from previous pipelines that may come from the cache
+    - rm -rf $OMNIBUS_PACKAGE_DIR_SUSE/*
+    - !reference [.setup_ruby_mirror_linux]
+    # Artifacts and cache must live within project directory but we run omnibus
+    # from the GOPATH (see above). We then call `invoke` passing --base-dir,
+    # pointing to a gitlab-friendly location.
+    - set +x
+    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $RPM_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - printf -- "$RPM_GPG_KEY" | gpg --import --batch
+    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+    - set -x
+    # Use --skip-deps since the deps are installed by `before_script`.
+    - inv -e agentless-scanner.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
+    - ls -la $OMNIBUS_PACKAGE_DIR
+    # Copy to a different directory to avoid collisions if a job downloads both the RPM and SUSE RPM artifacts
+    - mkdir -p $OMNIBUS_PACKAGE_DIR_SUSE && cp $OMNIBUS_PACKAGE_DIR/* $OMNIBUS_PACKAGE_DIR_SUSE
+    - !reference [.upload_sbom_artifacts]
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - $OMNIBUS_PACKAGE_DIR_SUSE

--- a/.gitlab/pkg_metrics/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics/pkg_metrics.yml
@@ -297,6 +297,9 @@ check_pkg_size-amd64-a7:
     - agent_suse-x64-a7
     - dogstatsd_suse-x64
     - iot_agent_suse-x64
+    - agentless_scanner_deb-x64
+    - agentless_scanner_rpm-x64
+    - agentless_scanner_suse-x64
   variables:
     MAJOR_VERSION: 7
     FLAVORS: "datadog-agent datadog-iot-agent datadog-dogstatsd datadog-heroku-agent"
@@ -311,6 +314,7 @@ check_pkg_size-amd64-a7:
           ["datadog-iot-agent"]="10000000"
           ["datadog-dogstatsd"]="10000000"
           ["datadog-heroku-agent"]="70000000"
+          ["datadog-agentless-scanner"]="10000000"
       )
 
 check_pkg_size-arm64-a7:
@@ -322,6 +326,8 @@ check_pkg_size-arm64-a7:
     - dogstatsd_deb-arm64
     - agent_rpm-arm64-a7
     - iot_agent_rpm-arm64
+    - agentless_scanner_deb-arm64
+    - agentless_scanner_rpm-arm64
   variables:
     MAJOR_VERSION: 7
     FLAVORS: "datadog-agent datadog-iot-agent datadog-dogstatsd"
@@ -334,4 +340,5 @@ check_pkg_size-arm64-a7:
           ["datadog-agent"]="70000000"
           ["datadog-iot-agent"]="10000000"
           ["datadog-dogstatsd"]="10000000"
+          ["datadog-agentless-scanner"]="10000000"
       )

--- a/cmd/agentless-scanner/main.go
+++ b/cmd/agentless-scanner/main.go
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package main implements the agentless-scanner command.
+package main
+
+func main() {
+}

--- a/omnibus/config/projects/agentless-scanner.rb
+++ b/omnibus/config/projects/agentless-scanner.rb
@@ -1,0 +1,146 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https:#www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+require "./lib/ostools.rb"
+
+name 'agentless-scanner'
+package_name 'datadog-agentless-scanner'
+homepage 'http://www.datadoghq.com'
+license "Apache-2.0"
+license_file "../LICENSE"
+
+if ENV.has_key?("OMNIBUS_WORKERS_OVERRIDE")
+  COMPRESSION_THREADS = ENV["OMNIBUS_WORKERS_OVERRIDE"].to_i
+else
+  COMPRESSION_THREADS = 1
+end
+if ENV.has_key?("DEPLOY_AGENT") && ENV["DEPLOY_AGENT"] == "true"
+  COMPRESSION_LEVEL = 9
+else
+  COMPRESSION_LEVEL = 5
+end
+
+install_dir '/opt/datadog/agentless-scanner'
+if redhat_target? || suse_target?
+  maintainer 'Datadog, Inc <package@datadoghq.com>'
+
+  # NOTE: with script dependencies, we only care about preinst/postinst/posttrans,
+  # because these would be used in a kickstart during package installation phase.
+  # All of the packages that we depend on in prerm/postrm scripts always have to be
+  # installed on all distros that we support, so we don't have to depend on them
+  # explicitly.
+
+  # postinst and posttrans scripts use a subset of preinst script deps, so we don't
+  # have to list them, because they'll already be there because of preinst
+  runtime_script_dependency :pre, "coreutils"
+  runtime_script_dependency :pre, "grep"
+  if redhat_target?
+    runtime_script_dependency :pre, "glibc-common"
+    runtime_script_dependency :pre, "shadow-utils"
+  else
+    runtime_script_dependency :pre, "glibc"
+    runtime_script_dependency :pre, "shadow"
+  end
+else
+  maintainer 'Datadog Packages <package@datadoghq.com>'
+end
+
+if debian_target?
+  runtime_recommended_dependency 'datadog-signing-keys (>= 1:1.3.1)'
+end
+
+# build_version is computed by an invoke command/function.
+# We can't call it directly from there, we pass it through the environment instead.
+build_version ENV['PACKAGE_VERSION']
+
+build_iteration 1
+
+description 'Datadog Agentless Scanner
+ The Datadog Agentless Scanner scans your cloud environment for vulnerabilities, compliance and security issues.
+ .
+ This package installs and runs the Agentless Scanner.
+ .
+ See http://www.datadoghq.com/ for more information
+'
+
+# ------------------------------------
+# Generic package information
+# ------------------------------------
+
+# .deb specific flags
+package :deb do
+  vendor 'Datadog <package@datadoghq.com>'
+  epoch 1
+  license 'Apache License Version 2.0'
+  section 'utils'
+  priority 'extra'
+  compression_threads COMPRESSION_THREADS
+  compression_level COMPRESSION_LEVEL
+  compression_algo "xz"
+  if ENV.has_key?('DEB_SIGNING_PASSPHRASE') and not ENV['DEB_SIGNING_PASSPHRASE'].empty?
+    signing_passphrase "#{ENV['DEB_SIGNING_PASSPHRASE']}"
+    if ENV.has_key?('DEB_GPG_KEY_NAME') and not ENV['DEB_GPG_KEY_NAME'].empty?
+      gpg_key_name "#{ENV['DEB_GPG_KEY_NAME']}"
+    end
+  end
+end
+
+# .rpm specific flags
+package :rpm do
+  vendor 'Datadog <package@datadoghq.com>'
+  epoch 1
+  dist_tag ''
+  license 'Apache License Version 2.0'
+  category 'System Environment/Daemons'
+  priority 'extra'
+  compression_threads COMPRESSION_THREADS
+  compression_level COMPRESSION_LEVEL
+  compression_algo "xz"
+  if ENV.has_key?('RPM_SIGNING_PASSPHRASE') and not ENV['RPM_SIGNING_PASSPHRASE'].empty?
+    signing_passphrase "#{ENV['RPM_SIGNING_PASSPHRASE']}"
+    if ENV.has_key?('RPM_GPG_KEY_NAME') and not ENV['RPM_GPG_KEY_NAME'].empty?
+      gpg_key_name "#{ENV['RPM_GPG_KEY_NAME']}"
+    end
+  end
+end
+
+# ------------------------------------
+# Dependencies
+# ------------------------------------
+
+# creates required build directories
+dependency 'datadog-agent-prepare'
+
+# version manifest file
+dependency 'version-manifest'
+
+# Agentless-scanner
+dependency 'datadog-agentless-scanner'
+
+# this dependency puts few files out of the omnibus install dir and move them
+# in the final destination. This way such files will be listed in the packages
+# manifest and owned by the package manager. This is the only point in the build
+# process where we operate outside the omnibus install dir, thus the need of
+# the `extra_package_file` directive.
+# This must be the last dependency in the project.
+
+dependency 'datadog-agentless-scanner-finalize'
+
+# package scripts
+if linux_target?
+  if debian_target?
+    package_scripts_path "#{Omnibus::Config.project_root}/package-scripts/agentless-scanner-deb"
+  else
+    package_scripts_path "#{Omnibus::Config.project_root}/package-scripts/agentless-scanner-rpm"
+  end
+end
+
+if linux_target?
+  extra_package_file '/lib/systemd/system/datadog-agentless-scanner.service'
+  extra_package_file '/var/log/datadog/'
+end
+
+exclude '\.git*'
+exclude 'bundler\/git'

--- a/omnibus/config/software/datadog-agentless-scanner-finalize.rb
+++ b/omnibus/config/software/datadog-agentless-scanner-finalize.rb
@@ -1,0 +1,27 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https:#www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+# This software definition doesn"t build anything, it"s the place where we create
+# files outside the omnibus installation directory, so that we can add them to
+# the package manifest using `extra_package_file` in the project definition.
+require './lib/ostools.rb'
+
+name "datadog-agentless-scanner-finalize"
+description "steps required to finalize the build"
+default_version "1.0.0"
+
+skip_transitive_dependency_licensing true
+
+build do
+    license :project_license
+
+    # Move system service files
+    mkdir "/lib/systemd/system"
+    move "#{install_dir}/scripts/datadog-agentless-scanner.service", "/lib/systemd/system"
+    mkdir "/var/log/datadog"
+
+    # cleanup clutter
+    delete "#{install_dir}/etc"
+end

--- a/omnibus/config/software/datadog-agentless-scanner.rb
+++ b/omnibus/config/software/datadog-agentless-scanner.rb
@@ -1,0 +1,66 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https:#www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+require 'pathname'
+
+name 'datadog-agentless-scanner'
+
+skip_transitive_dependency_licensing true
+
+source path: '..'
+relative_path 'src/github.com/DataDog/datadog-agent'
+
+build do
+  license :project_license
+
+  # set GOPATH on the omnibus source dir for this software
+  gopath = Pathname.new(project_dir) + '../../../..'
+  etc_dir = "/etc/datadog-agent"
+  env = {
+    'GOPATH' => gopath.to_path,
+    'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
+  }
+
+  unless ENV["OMNIBUS_GOMODCACHE"].nil? || ENV["OMNIBUS_GOMODCACHE"].empty?
+    gomodcache = Pathname.new(ENV["OMNIBUS_GOMODCACHE"])
+    env["GOMODCACHE"] = gomodcache.to_path
+  end
+
+  # we assume the go deps are already installed before running omnibus
+  command "invoke agentless-scanner.build --rebuild --major-version $MAJOR_VERSION", env: env
+
+  mkdir "#{install_dir}/etc/datadog-agent"
+  mkdir "#{install_dir}/run/"
+  mkdir "#{install_dir}/scripts/"
+
+  # move around bin and config files
+  copy 'bin/agentless-scanner/agentless-scanner', "#{install_dir}/bin"
+
+  if debian_target?
+    erb source: "upstart_debian.conf.erb",
+        dest: "#{install_dir}/scripts/datadog-agentless-scanner.conf",
+        mode: 0644,
+        vars: { install_dir: install_dir, etc_dir: etc_dir }
+    erb source: "sysvinit_debian.agentless-scanner.erb",
+        dest: "#{install_dir}/scripts/datadog-agentless-scanner",
+        mode: 0755,
+        vars: { install_dir: install_dir, etc_dir: etc_dir }
+  elsif redhat_target? || suse_target?
+    # Ship a different upstart job definition on RHEL to accommodate the old
+    # version of upstart (0.6.5) that RHEL 6 provides.
+    erb source: "upstart_redhat.conf.erb",
+        dest: "#{install_dir}/scripts/datadog-agentless-scanner.conf",
+        mode: 0644,
+        vars: { install_dir: install_dir, etc_dir: etc_dir }
+  end
+  erb source: "systemd.service.erb",
+      dest: "#{install_dir}/scripts/datadog-agentless-scanner.service",
+      mode: 0644,
+      vars: { install_dir: install_dir, etc_dir: etc_dir }
+
+  # The file below is touched by software builds that don't put anything in the installation
+  # directory (libgcc right now) so that the git_cache gets updated let's remove it from the
+  # final package
+  delete "#{install_dir}/uselessfile"
+end

--- a/omnibus/config/templates/datadog-agentless-scanner/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agentless-scanner/systemd.service.erb
@@ -1,0 +1,17 @@
+[Unit]
+Description=Datadog Agentless Scanner
+After=network.target datadog-agent.service
+BindsTo=datadog-agent.service
+ConditionPathExists=<%= etc_dir %>/datadog.yaml
+StartLimitInterval=10
+StartLimitBurst=5
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/agentless-scanner.pid
+Restart=on-failure
+ExecStart=<%= install_dir %>/bin/agentless-scanner run -c <%= etc_dir %>/datadog.yaml -p <%= install_dir %>/run/agentless-scanner.pid
+TimeoutStopSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-agentless-scanner/sysvinit_debian.agentless-scanner.erb
+++ b/omnibus/config/templates/datadog-agentless-scanner/sysvinit_debian.agentless-scanner.erb
@@ -1,0 +1,163 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides: datadog-agentless-scanner
+# Short-Description: Start and stop datadog agentless scanner
+# Description: Datadog Agentless Scanner
+# Required-Start: $remote_fs
+# Required-Stop: $remote_fs
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+ETC_DIR="<%= etc_dir %>"
+INSTALL_DIR="<%= install_dir %>"
+AGENTPATH="$INSTALL_DIR/bin/agentless-scanner"
+PIDFILE="$INSTALL_DIR/run/agentless-scanner.pid"
+AGENT_ARGS="--config=$ETC_DIR/datadog.yaml --pidfile=$PIDFILE"
+AGENT_USER="root"
+NAME="datadog-agentless-scanner"
+DESC="Datadog Agentless Scanner"
+
+
+
+if [ ! -x $AGENTPATH ]; then
+	echo "$AGENTPATH not found. Exiting $NAME"
+	exit 0
+fi
+
+if [ -r "/etc/default/${NAME}" ]; then
+	. "/etc/default/${NAME}"
+fi
+
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --start --test --quiet --pidfile $PIDFILE --user $AGENT_USER --startas $AGENTPATH > /dev/null \
+		|| return 1
+	start-stop-daemon --start --background --chuid $AGENT_USER --quiet --pidfile $PIDFILE --user $AGENT_USER --startas $AGENTPATH -- \
+		$AGENT_ARGS \
+		|| return 2
+	# Add code here, if necessary, that waits for the process to be ready
+	# to handle requests from services started subsequently which depend
+	# on this one.  As a last resort, sleep for some time.
+}
+
+
+#
+# Start the agent and wait for it to be up
+#
+start_and_wait()
+{
+	log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		1) log_end_msg 0 ;;
+		2) log_end_msg 1 ;;
+		*)
+			# check if the agent is running once per second for 5 seconds
+			retries=5
+			while [ $retries -gt 1 ]; do
+				start-stop-daemon --start --test --quiet --pidfile $PIDFILE --user $AGENT_USER --startas $AGENTPATH
+				if [ "$?" -eq "1" ]; then
+					# We've started up successfully. Exit cleanly
+					log_end_msg 0
+					return 0
+				else
+					retries=$(($retries - 1))
+					sleep 1
+				fi
+			done
+			# After 5 tries the agent didn't start. Report an error
+			log_end_msg 1
+
+		;;
+	esac
+}
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=30 --pidfile $PIDFILE --user $AGENT_USER --startas $AGENTPATH
+	RETVAL="$?"
+	rm -f $PIDFILE
+	return $RETVAL
+}
+
+#
+# Stop the agent and wait for it to be down
+#
+stop_and_wait()
+{
+	log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) log_end_msg 0 ;;
+		*) log_end_msg 1 ;; # Failed to stop
+	esac
+}
+
+# Action to take
+case "$1" in
+	start)
+		if init_is_upstart; then
+			exit 1
+		fi
+		if [ "$DATADOG_ENABLED" = "no" ]; then
+			echo "Disabled via /etc/default/$NAME. Exiting."
+			exit 0
+		fi
+
+		start_and_wait
+
+			;;
+
+	stop)
+		if init_is_upstart; then
+			exit 0
+		fi
+
+		stop_and_wait
+
+		;;
+
+	status)
+		status_of_proc -p $PIDFILE $AGENTPATH $NAME && exit 0 || exit $?
+		;;
+
+	restart|force-reload)
+		if init_is_upstart; then
+			exit 1
+		fi
+
+		echo "Restarting $DESC"
+
+		stop_and_wait
+		start_and_wait
+
+		;;
+
+	*)
+		N=/etc/init.d/$NAME
+		echo "Usage: $N {start|stop|restart|status}"
+		exit 1
+		;;
+esac
+
+exit $?

--- a/omnibus/config/templates/datadog-agentless-scanner/upstart_debian.conf.erb
+++ b/omnibus/config/templates/datadog-agentless-scanner/upstart_debian.conf.erb
@@ -1,0 +1,17 @@
+description "Datadog Agentless Scanner"
+
+start on started networking or started network
+stop on runlevel [!2345]
+
+respawn
+respawn limit 4 25
+normal exit 0
+
+console log # redirect daemon's outputs to `/var/log/upstart/agentless-scanner.log`
+env DD_LOG_TO_CONSOLE=false
+
+script
+  # setuid is not available in versions of upstart before 1.4. CentOS/RHEL6 use an earlier version of upstart.
+  # This is the best way to set the user in the absence of setuid.
+  exec su -s /bin/sh -c 'exec "$0" "$@"' dd-agent -- <%= install_dir %>/bin/agentless-scanner run -c <%= etc_dir %>/datadog.yaml -p <%= install_dir %>/run/agentless-scanner.pid
+end script

--- a/omnibus/config/templates/datadog-agentless-scanner/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-agentless-scanner/upstart_redhat.conf.erb
@@ -1,0 +1,18 @@
+description "Datadog Agentless Scanner"
+
+start on started networking or started network
+stop on runlevel [!2345]
+
+respawn
+respawn limit 4 25
+normal exit 0
+
+# console log is not available before upstart 1.4. CentOS/RHEL6 use an earlier version of upstart.
+console output
+env DD_LOG_TO_CONSOLE=false
+
+script
+  # setuid is not available in versions of upstart before 1.4. CentOS/RHEL6 use an earlier version of upstart.
+  # This is the best way to set the user in the absence of setuid.
+  exec su -s /bin/sh -c 'exec "$0" "$@"' dd-agent -- <%= install_dir %>/bin/agentless-scanner run -c <%= etc_dir %>/datadog.yaml -p <%= install_dir %>/run/agentless-scanner.pid
+end script

--- a/omnibus/package-scripts/agentless-scanner-deb/postinst
+++ b/omnibus/package-scripts/agentless-scanner-deb/postinst
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+# Perform necessary datadog-agentless-scanner setup steps after package is installed.
+#
+# .deb: STEP 5 of 5
+
+INSTALL_DIR=/opt/datadog/agentless-scanner
+CONFIG_DIR=/etc/datadog-agent
+SERVICE_NAME=datadog-agentless-scanner
+
+# If we are inside the Docker container, do nothing
+if [ -n "$DOCKER_DD_AGENT" ]; then
+    echo "Installation from docker-dd-agent, nothing to do in postinst"
+    exit 0
+fi
+
+set -e
+case "$1" in
+    configure)
+        # Create a symlink to the agent's binary
+        ln -sf $INSTALL_DIR/bin/agentless-scanner /usr/bin/datadog-agentless-scanner
+    ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+    ;;
+esac
+
+# Enable and restart the agentless-scanner service here on Debian platforms
+# On RHEL, this is done in the posttrans script
+# supports systemd, upstart and sysvinit
+echo "Enabling service $SERVICE_NAME"
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
+elif command -v initctl >/dev/null 2>&1; then
+    # Nothing to do, this is defined directly in the upstart job file
+    :
+elif command -v update-rc.d >/dev/null 2>&1; then
+    update-rc.d $SERVICE_NAME defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with update-rc.d"
+else
+    echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agentless-scanner package only provides service files for systemd, upstart and sysvinit."
+fi
+
+# TODO: Use a configcheck command on the agent to determine if it's safe to restart,
+# and avoid restarting when a check conf is invalid
+if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
+    echo "(Re)starting $SERVICE_NAME now..."
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl restart $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
+    elif command -v service >/dev/null 2>&1; then
+        service $SERVICE_NAME restart || true
+    else
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agentless-scanner package only provides service files for systemd and upstart."
+    fi
+else
+    # No datadog.yaml file is present. This is probably a clean install made with the
+    # step-by-step instructions/an automation tool, and the config file will be added next.
+    echo "No datadog.yaml file detected, not starting the agentless-scanner"
+fi
+
+exit 0

--- a/omnibus/package-scripts/agentless-scanner-deb/postrm
+++ b/omnibus/package-scripts/agentless-scanner-deb/postrm
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Perform necessary datadog-agentless-scanner removal steps after package is uninstalled.
+#
+# .deb: STEP 3 of 5
+
+INSTALL_DIR=/opt/datadog/agentless-scanner
+
+# Remove the symlink to the binary.
+rm -f "/usr/bin/datadog-agentless-scanner"
+
+set -e
+
+case "$1" in
+    purge)
+        echo "Force-deleting $INSTALL_DIR"
+        rm -rf $INSTALL_DIR
+    ;;
+    *)
+    ;;
+esac
+
+exit 0

--- a/omnibus/package-scripts/agentless-scanner-deb/preinst
+++ b/omnibus/package-scripts/agentless-scanner-deb/preinst
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Perform necessary datadog-agentless-scanner setup steps before package is installed.
+#
+# .deb: STEP 2 of 5
+
+SERVICE_NAME=datadog-agentless-scanner
+
+set -e
+if [ -f "/lib/systemd/system/$SERVICE_NAME.service" ] || [ -f "/usr/lib/systemd/system/$SERVICE_NAME.service" ]; then
+    # Stop an already running agent
+    # supports systemd, upstart and sysvinit
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl stop $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        initctl stop $SERVICE_NAME || true
+    elif command -v service >/dev/null 2>&1; then
+        service $SERVICE_NAME stop || true
+    else
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agentless-scanner package only provides service files for systemd, upstart and sysvinit."
+    fi
+fi
+
+exit 0

--- a/omnibus/package-scripts/agentless-scanner-deb/prerm
+++ b/omnibus/package-scripts/agentless-scanner-deb/prerm
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# Perform necessary datadog-agentless-scanner setup steps prior to remove the old package.
+#
+# .deb: STEP 1 of 5
+
+SERVICE_NAME=datadog-agentless-scanner
+
+stop_agent()
+{
+    # Stop an already running agentless-scanner
+    # supports systemd, upstart and sysvinit
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl stop $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        initctl stop $SERVICE_NAME || true
+    elif command -v service >/dev/null 2>&1; then
+        service $SERVICE_NAME stop || true
+    else
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agentless-scanner package only provides service files for systemd and upstart."
+    fi
+}
+
+deregister_agent()
+{
+    # Disable agentless-scanner start on system boot
+    # supports systemd, upstart and sysvinit
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl disable $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        # Nothing to do, this is defined directly in the upstart job file
+        :
+    elif command -v update-rc.d >/dev/null 2>&1; then
+        update-rc.d -f $SERVICE_NAME remove || true
+    else
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agentless-scanner package only provides service files for systemd, upstart and sysvinit."
+    fi
+}
+
+stop_agent
+deregister_agent
+
+exit 0

--- a/omnibus/package-scripts/agentless-scanner-rpm/postinst
+++ b/omnibus/package-scripts/agentless-scanner-rpm/postinst
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Perform necessary datadog-agentless-scanner setup steps after package is installed.
+# NOTE: part of the setup is done in the posttrans (rpm-only) script
+#
+# .rpm: STEP 3 of 6
+
+INSTALL_DIR=/opt/datadog/agentless-scanner
+LOG_DIR=/var/log/datadog
+CONFIG_DIR=/etc/datadog-agent
+
+# Set proper rights to the dd-agent user
+chown -R dd-agent:dd-agent ${CONFIG_DIR}
+chown -R dd-agent:dd-agent ${LOG_DIR}
+chown -R dd-agent:dd-agent ${INSTALL_DIR}
+
+exit 0

--- a/omnibus/package-scripts/agentless-scanner-rpm/postrm
+++ b/omnibus/package-scripts/agentless-scanner-rpm/postrm
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Perform necessary datadog-agentless-scanner removal steps after package is uninstalled.
+#
+# .rpm: STEP 5 of 6
+
+# Remove the symlink to the binary.
+rm -f "/usr/bin/datadog-agentless-scanner"
+
+case "$*" in
+    0)
+        # We're uninstalling.
+        # We don't delete the dd-agent user/group (see https://fedoraproject.org/wiki/Packaging:UsersAndGroups#Allocation_Strategies)
+    ;;
+    1)
+        # We're upgrading.
+    ;;
+    *)
+    ;;
+esac
+
+exit 0

--- a/omnibus/package-scripts/agentless-scanner-rpm/posttrans
+++ b/omnibus/package-scripts/agentless-scanner-rpm/posttrans
@@ -1,0 +1,43 @@
+#! /bin/sh
+#
+# This script is RPM-specific
+# It is run at the very end of an install/upgrade of the package
+# It is NOT run on removal of the package
+#
+# .rpm: STEP 6 of 6
+
+INSTALL_DIR=/opt/datadog/agentless-scanner
+CONFIG_DIR=/etc/datadog-agent
+SERVICE_NAME=datadog-agentless-scanner
+
+# Create a symlink to the agent's binary
+ln -sf $INSTALL_DIR/bin/agentless-scanner /usr/bin/datadog-agentless-scanner
+
+echo "Enabling service $SERVICE_NAME"
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
+elif command -v initctl >/dev/null 2>&1; then
+    # start/stop policy is already defined in the upstart job file
+    :
+else
+    echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agentless-scanner package only provides service files for systemd and upstart."
+fi
+
+# TODO: Use a configcheck command on the agent to determine if it's safe to restart,
+# and avoid restarting when a check conf is invalid
+if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
+    echo "(Re)starting $SERVICE_NAME now..."
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl restart $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
+    else
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agentless-scanner package only provides service files for systemd and upstart."
+    fi
+else
+    # No datadog.yaml file is present. This is probably a clean install made with the
+    # step-by-step instructions/an automation tool, and the config file will be added next.
+    echo "No datadog.yaml file detected, not starting the agent"
+fi
+
+exit 0

--- a/omnibus/package-scripts/agentless-scanner-rpm/preinst
+++ b/omnibus/package-scripts/agentless-scanner-rpm/preinst
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Perform necessary datadog-agentless-scanner setup steps before package is installed.
+#
+# .rpm: STEP 2 of 6
+
+SERVICE_NAME=datadog-agentless-scanner
+
+# Linux installation
+set -e
+if [ -f "/lib/systemd/system/$SERVICE_NAME.service" ] || [ -f "/usr/lib/systemd/system/$SERVICE_NAME.service" ]; then
+    # Stop an already running agent
+    # Only supports systemd and upstart
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl stop $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        initctl stop $SERVICE_NAME || true
+    else
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agentless-scanner package only provides service files for systemd and upstart."
+    fi
+fi
+
+exit 0

--- a/omnibus/package-scripts/agentless-scanner-rpm/prerm
+++ b/omnibus/package-scripts/agentless-scanner-rpm/prerm
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# Perform necessary datadog-agentless-scanner setup steps prior to remove the old package.
+#
+# .rpm: STEP 4 of 6
+
+SERVICE_NAME=datadog-agentless-scanner
+
+stop_agent()
+{
+    # Stop an already running agentless-scanner
+    # Only supports systemd and upstart
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl stop $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        initctl stop $SERVICE_NAME || true
+    else
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agentless-scanner package only provides service files for systemd and upstart."
+    fi
+}
+
+deregister_agent()
+{
+    # Disable agentless-scanner start on system boot
+    # Only supports systemd and upstart
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl disable $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        # Nothing to do, this is defined directly in the upstart job file
+        :
+    else
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agentless-scanner package only provides service files for systemd and upstart."
+    fi
+}
+
+stop_agent
+deregister_agent
+
+exit 0

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -6,6 +6,7 @@ from invoke import Collection
 
 from tasks import (
     agent,
+    agentless_scanner,
     bench,
     buildimages,
     cluster_agent,
@@ -122,6 +123,7 @@ ns.add_task(send_unit_tests_stats)
 
 # add namespaced tasks to the root
 ns.add_collection(agent)
+ns.add_collection(agentless_scanner)
 ns.add_collection(buildimages)
 ns.add_collection(cluster_agent)
 ns.add_collection(cluster_agent_cloudfoundry)

--- a/tasks/agentless_scanner.py
+++ b/tasks/agentless_scanner.py
@@ -1,0 +1,170 @@
+"""
+Agentless-scanner tasks
+"""
+
+
+import os
+import sys
+
+from invoke import task
+from invoke.exceptions import Exit
+
+from tasks.agent import bundle_install_omnibus
+from tasks.build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
+from tasks.flavor import AgentFlavor
+from tasks.go import deps
+from tasks.libs.common.utils import REPO_PATH, bin_name, get_build_flags, get_version, load_release_versions
+
+# constants
+AGENTLESS_SCANNER_BIN_PATH = os.path.join(".", "bin", "agentless-scanner")
+STATIC_BIN_PATH = os.path.join(".", "bin", "static")
+
+
+@task
+def build(
+    ctx,
+    rebuild=False,
+    race=False,
+    static=False,
+    build_include=None,
+    build_exclude=None,
+    major_version='7',
+    arch="x64",
+    go_mod="mod",
+):
+    """
+    Build Agentless-scanner
+    """
+    build_include = (
+        get_default_build_tags(build="agentless-scanner", arch=arch, flavor=AgentFlavor.agentless_scanner)
+        if build_include is None
+        else filter_incompatible_tags(build_include.split(","), arch=arch)
+    )
+    build_exclude = [] if build_exclude is None else build_exclude.split(",")
+    build_tags = get_build_tags(build_include, build_exclude)
+    ldflags, gcflags, env = get_build_flags(ctx, static=static, major_version=major_version)
+    bin_path = AGENTLESS_SCANNER_BIN_PATH
+
+    if static:
+        bin_path = STATIC_BIN_PATH
+
+    # NOTE: consider stripping symbols to reduce binary size
+    cmd = "go build -mod={go_mod} {race_opt} {build_type} -tags \"{build_tags}\" -o {bin_name} "
+    cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/agentless-scanner"
+    args = {
+        "go_mod": go_mod,
+        "race_opt": "-race" if race else "",
+        "build_type": "-a" if rebuild else "",
+        "build_tags": " ".join(build_tags),
+        "bin_name": os.path.join(bin_path, bin_name("agentless-scanner")),
+        "gcflags": gcflags,
+        "ldflags": ldflags,
+        "REPO_PATH": REPO_PATH,
+    }
+    ctx.run(cmd.format(**args), env=env)
+
+    # Render the configuration file template
+    #
+    # We need to remove cross compiling bits if any because go generate must
+    # build and execute in the native platform
+    env = {
+        "GOOS": "",
+        "GOARCH": "",
+    }
+    cmd = "go generate -mod={} {}/cmd/agentless-scanner"
+    ctx.run(cmd.format(go_mod, REPO_PATH), env=env)
+
+    if static and sys.platform.startswith("linux"):
+        cmd = "file {bin_name} "
+        args = {
+            "bin_name": os.path.join(bin_path, bin_name("agentless-scanner")),
+        }
+        result = ctx.run(cmd.format(**args))
+        if "statically linked" not in result.stdout:
+            print("agentless-scanner binary is not static, exiting...")
+            raise Exit(code=1)
+
+
+@task
+def omnibus_build(
+    ctx,
+    log_level="info",
+    base_dir=None,
+    gem_path=None,
+    skip_deps=False,
+    release_version="nightly",
+    major_version='7',
+    omnibus_s3_cache=False,
+    go_mod_cache=None,
+    host_distribution=None,
+):
+    """
+    Build the Agentless-scanner packages with Omnibus Installer.
+    """
+    if not skip_deps:
+        deps(ctx)
+
+    # omnibus config overrides
+    overrides = []
+
+    # base dir (can be overridden through env vars, command line takes precedence)
+    base_dir = base_dir or os.environ.get("ALS_OMNIBUS_BASE_DIR")
+    if base_dir:
+        overrides.append(f"base_dir:{base_dir}")
+    if host_distribution:
+        overrides.append(f'host_distribution:{host_distribution}')
+
+    overrides_cmd = ""
+    if overrides:
+        overrides_cmd = "--override=" + " ".join(overrides)
+
+    env = load_release_versions(ctx, release_version)
+
+    env['PACKAGE_VERSION'] = get_version(
+        ctx,
+        include_git=True,
+        url_safe=True,
+        git_sha_length=7,
+        major_version=major_version,
+        include_pipeline_id=True,
+    )
+
+    bundle_install_omnibus(ctx, gem_path=gem_path, env=env)
+
+    with ctx.cd("omnibus"):
+        omnibus = "bundle exec omnibus.bat" if sys.platform == 'win32' else "bundle exec omnibus"
+        cmd = "{omnibus} build agentless-scanner --log-level={log_level} {populate_s3_cache} {overrides}"
+        args = {"omnibus": omnibus, "log_level": log_level, "overrides": overrides_cmd, "populate_s3_cache": ""}
+
+        if omnibus_s3_cache:
+            args['populate_s3_cache'] = " --populate-s3-cache "
+
+        env['MAJOR_VERSION'] = major_version
+
+        integrations_core_version = os.environ.get('INTEGRATIONS_CORE_VERSION')
+        # Only overrides the env var if the value is a non-empty string.
+        if integrations_core_version:
+            env['INTEGRATIONS_CORE_VERSION'] = integrations_core_version
+
+        # If the host has a GOMODCACHE set, try to reuse it
+        if not go_mod_cache and os.environ.get('GOMODCACHE'):
+            go_mod_cache = os.environ.get('GOMODCACHE')
+
+        if go_mod_cache:
+            env['OMNIBUS_GOMODCACHE'] = go_mod_cache
+
+        ctx.run(cmd.format(**args), env=env)
+
+
+@task
+def clean(ctx):
+    """
+    Remove temporary objects and binary artifacts
+    """
+    # go clean
+    print("Executing go clean")
+    ctx.run("go clean")
+
+    # remove the bin/agentless-scanner folder
+    print("Remove agentless-scanner binary folder")
+    ctx.run("rm -rf ./bin/agentless-scanner")

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -93,6 +93,9 @@ AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
     }
 )
 
+# AGENTLESS_SCANNER_TAGS lists the tags needed when building the agentless-scanner
+AGENTLESS_SCANNER_TAGS = {""}
+
 # CLUSTER_AGENT_TAGS lists the tags needed when building the cluster-agent
 CLUSTER_AGENT_TAGS = {"clusterchecks", "kubeapiserver", "orchestrator", "zlib", "ec2", "gce"}
 
@@ -193,6 +196,12 @@ build_tags = {
         "system-tests": AGENT_TAGS,
         "lint": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS),
         "unit-tests": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS),
+    },
+    AgentFlavor.agentless_scanner: {
+        "dogstatsd": AGENTLESS_SCANNER_TAGS,
+        "system-tests": AGENT_TAGS,
+        "lint": AGENTLESS_SCANNER_TAGS.union(UNIT_TEST_TAGS),
+        "unit-tests": AGENTLESS_SCANNER_TAGS.union(UNIT_TEST_TAGS),
     },
 }
 

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -432,6 +432,10 @@ def lint_fxutil_oneshot_test(_):
             if str(file).endswith("_test.go"):
                 continue
 
+            excluded_cmds = ["agentless-scanner"]
+            if file.parts[0] == "cmd" and file.parts[1] in excluded_cmds:
+                continue
+
             one_shot_count = file.read_text().count("fxutil.OneShot(")
             run_count = file.read_text().count("fxutil.Run(")
 

--- a/tasks/flavor.py
+++ b/tasks/flavor.py
@@ -7,6 +7,7 @@ class AgentFlavor(enum.Enum):
     iot = 2
     heroku = 3
     dogstatsd = 4
+    agentless_scanner = 5
 
     def is_iot(self):
         return self == type(self).iot

--- a/tasks/unit-tests/testdata/fake_gitlab-ci.yml
+++ b/tasks/unit-tests/testdata/fake_gitlab-ci.yml
@@ -113,6 +113,7 @@ variables:
   STATIC_BINARIES_DIR: bin/static
   DOGSTATSD_BINARIES_DIR: bin/dogstatsd
   AGENT_BINARIES_DIR: bin/agent
+  AGENTLESS_SCANNER_BINARIES_DIR: bin/agentless-scanner
   CLUSTER_AGENT_BINARIES_DIR: bin/datadog-cluster-agent
   CWS_INSTRUMENTATION_BINARIES_DIR: bin/cws-instrumentation
   CLUSTER_AGENT_CLOUDFOUNDRY_BINARIES_DIR: bin/datadog-cluster-agent-cloudfoundry


### PR DESCRIPTION
### What does this PR do?

This change adds the `datadog-agentless-scanner` package.

This package depends on the `datadog-agent` package
and only contains the `agentless-scanner` software and init scripts.

This package installs files into the `/opt/datadog/agentless-scanner` directory.

This package targets the following platforms:

- Debian / Ubuntu amd64
- Debian / Ubuntu arm64
- RHEL / Fedora amd64
- RHEL / Fedora arm64
- SLES / openSUSE amd64

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
