### PR TITLE
[bugfix] fix namespace filtering for apm instrumentation

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -192,15 +192,15 @@ func apmSSINamespaceFilter() (*containers.Filter, error) {
 	apmDisabledNamespacesWithPrefix := make([]string, len(apmDisabledNamespaces))
 
 	for i := range apmEnabledNamespaces {
-		apmEnabledNamespacesWithPrefix[i] = prefix + apmEnabledNamespaces[i]
+		apmEnabledNamespacesWithPrefix[i] = prefix + fmt.Sprintf("^%s$", apmEnabledNamespaces[i])
 	}
 	for i := range apmDisabledNamespaces {
-		apmDisabledNamespacesWithPrefix[i] = prefix + apmDisabledNamespaces[i]
+		apmDisabledNamespacesWithPrefix[i] = prefix + fmt.Sprintf("^%s$", apmDisabledNamespaces[i])
 	}
 
 	disabledByDefault := []string{
-		prefix + "kube-system",
-		prefix + apiServerCommon.GetResourcesNamespace(),
+		prefix + "^kube-system$",
+		prefix + fmt.Sprintf("^%s$", apiServerCommon.GetResourcesNamespace()),
 	}
 
 	var filterExcludeList []string

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -1944,10 +1944,10 @@ func TestShouldInject(t *testing.T) {
 		},
 		{
 			name: "instrumentation on with disabled namespace, no label",
-			pod:  fakePodWithNamespaceAndLabel("ns", "", ""),
+			pod:  fakePodWithNamespaceAndLabel("ns2", "", ""),
 			setupConfig: func() {
 				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
-				mockConfig.SetWithoutSource("apm_config.instrumentation.disabled_namespaces", []string{"ns2"})
+				mockConfig.SetWithoutSource("apm_config.instrumentation.disabled_namespaces", []string{"ns"})
 			},
 			want: true,
 		},
@@ -2019,10 +2019,10 @@ func TestShouldInject(t *testing.T) {
 		},
 		{
 			name: "instrumentation on with enabled other namespace, no label",
-			pod:  fakePodWithNamespaceAndLabel("ns", "", ""),
+			pod:  fakePodWithNamespaceAndLabel("ns2", "", ""),
 			setupConfig: func() {
 				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
-				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled_namespaces", []string{"n2s"})
+				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled_namespaces", []string{"ns"})
 			},
 			want: false,
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fix bug in namespace filtering for APM auto instrumentation.



### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`containers.Filter` is used in order to filter by namespace based on included/excluded namespace lists.

However, the generated regex are matching for substrings instead for exact match. 
For example, if `ns` is in the excluded namespaces list, any namespace of which `ns` is a substring is also excluded.

In order to fix this, we should aim to match with `^ns$` instead of matching with `ns`. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- I slightly modified the unit tests to ensure that we are filtering using exact match.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Same QA as [here](https://github.com/DataDog/datadog-agent/pull/22694), but make sure that exclude/include logic is filtering based on exact match, not on substring matching.