### PR TITLE
Always filter nil value from FX groups

### DIFF
--- a/comp/core/flare/flare.go
+++ b/comp/core/flare/flare.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	pkgFlare "github.com/DataDog/datadog-agent/pkg/flare"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
@@ -56,17 +57,10 @@ func newFlare(deps dependencies) (Component, rcclient.TaskListenerProvider, erro
 		log:                   deps.Log,
 		config:                deps.Config,
 		params:                deps.Params,
+		providers:             fxutil.GetAndFilterGroup(deps.Providers),
 		diagnosesendermanager: deps.Diagnosesendermanager,
 		invAgent:              deps.InvAgent,
 		collector:             deps.Collector,
-	}
-
-	// We filder nil elements from the providers list. FX doesn't filter nil elements from groups and some
-	// components register a provider conditionally.
-	for _, p := range deps.Providers {
-		if p != nil {
-			f.providers = append(f.providers, p)
-		}
 	}
 
 	rcListener := rcclient.TaskListenerProvider{

--- a/comp/core/flare/types/types.go
+++ b/comp/core/flare/types/types.go
@@ -153,10 +153,3 @@ func NewProvider(callback FlareCallback) Provider {
 		Provider: callback,
 	}
 }
-
-// NewEmptyProvider returns a new Provider with an empty callback
-func NewEmptyProvider() Provider {
-	return Provider{
-		Provider: func(fb FlareBuilder) error { return nil },
-	}
-}

--- a/comp/core/status/component.go
+++ b/comp/core/status/component.go
@@ -67,64 +67,6 @@ type HeaderInformationProvider struct {
 	Provider HeaderProvider `group:"header_status"`
 }
 
-// NoopProvider implements the InformationProvider interface
-// This provides is ignored by the status component
-type NoopProvider struct{}
-
-// Name returns the name
-func (p NoopProvider) Name() string {
-	return ""
-}
-
-// Section return the section
-func (p NoopProvider) Section() string {
-	return ""
-}
-
-// JSON populates the status map
-func (p NoopProvider) JSON(_ bool, _ map[string]interface{}) error {
-	return nil
-}
-
-// Text renders the text output
-func (p NoopProvider) Text(_ bool, _ io.Writer) error {
-	return nil
-}
-
-// HTML renders the html output
-func (p NoopProvider) HTML(_ bool, _ io.Writer) error {
-	return nil
-}
-
-// NoopHeaderProvider implements the HeaderProvider interface
-// This provides is ignored by the status component
-type NoopHeaderProvider struct{}
-
-// Name returns the name
-func (p NoopHeaderProvider) Name() string {
-	return ""
-}
-
-// Index return index
-func (p NoopHeaderProvider) Index() int {
-	return 0
-}
-
-// JSON populates the status map
-func (p NoopHeaderProvider) JSON(_ bool, _ map[string]interface{}) error {
-	return nil
-}
-
-// Text renders the text output
-func (p NoopHeaderProvider) Text(_ bool, _ io.Writer) error {
-	return nil
-}
-
-// HTML renders the html output
-func (p NoopHeaderProvider) HTML(_ bool, _ io.Writer) error {
-	return nil
-}
-
 // NewInformationProvider returns a InformationProvider to be called when generating the agent status
 func NewInformationProvider(provider Provider) InformationProvider {
 	return InformationProvider{
@@ -132,23 +74,9 @@ func NewInformationProvider(provider Provider) InformationProvider {
 	}
 }
 
-// NoopInformationProvider returns a Noop InformationProvider
-func NoopInformationProvider() InformationProvider {
-	return InformationProvider{
-		Provider: NoopProvider{},
-	}
-}
-
 // NewHeaderInformationProvider returns a new HeaderInformationProvider to be called when generating the agent status
 func NewHeaderInformationProvider(provider HeaderProvider) HeaderInformationProvider {
 	return HeaderInformationProvider{
 		Provider: provider,
-	}
-}
-
-// NoopHeaderInformationProvider returns a Noop HeaderInformationProvider
-func NoopHeaderInformationProvider() HeaderInformationProvider {
-	return HeaderInformationProvider{
-		Provider: NoopHeaderProvider{},
 	}
 }

--- a/comp/core/status/statusimpl/status.go
+++ b/comp/core/status/statusimpl/status.go
@@ -66,7 +66,9 @@ func newStatus(deps dependencies) (status.Component, error) {
 	sortedSectionNames := []string{}
 	collectorSectionPresent := false
 
-	for _, provider := range deps.Providers {
+	providers := fxutil.GetAndFilterGroup(deps.Providers)
+
+	for _, provider := range providers {
 		if provider.Section() == status.CollectorSection && !collectorSectionPresent {
 			collectorSectionPresent = true
 		}
@@ -84,7 +86,7 @@ func newStatus(deps dependencies) (status.Component, error) {
 
 	// Providers of each section are sort alphabetically by name
 	sortedProvidersBySection := map[string][]status.Provider{}
-	for _, provider := range deps.Providers {
+	for _, provider := range providers {
 		providers := sortedProvidersBySection[provider.Section()]
 		sortedProvidersBySection[provider.Section()] = append(providers, provider)
 	}
@@ -95,7 +97,7 @@ func newStatus(deps dependencies) (status.Component, error) {
 	// Header providers are sorted by index
 	// We manually insert the common header provider in the first place after sorting is done
 	sortedHeaderProviders := []status.HeaderProvider{}
-	sortedHeaderProviders = append(sortedHeaderProviders, deps.HeaderProviders...)
+	sortedHeaderProviders = append(sortedHeaderProviders, fxutil.GetAndFilterGroup(deps.HeaderProviders)...)
 
 	sort.SliceStable(sortedHeaderProviders, func(i, j int) bool {
 		return sortedHeaderProviders[i].Index() < sortedHeaderProviders[j].Index()

--- a/comp/core/status/statusimpl/status_test.go
+++ b/comp/core/status/statusimpl/status_test.go
@@ -218,8 +218,6 @@ func TestGetStatus(t *testing.T) {
 `,
 				index: 2,
 			}),
-			status.NoopInformationProvider(),
-			status.NoopHeaderInformationProvider(),
 		),
 	))
 

--- a/comp/core/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/workloadmeta.go
@@ -7,15 +7,17 @@ package workloadmeta
 
 import (
 	"context"
-	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"sync"
 	"time"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
-	"go.uber.org/fx"
 )
 
 // store is a central storage of metadata about workloads. A workload is any
@@ -74,7 +76,7 @@ type optionalProvider struct {
 
 func newWorkloadMeta(deps dependencies) provider {
 	candidates := make(map[string]Collector)
-	for _, c := range deps.Catalog {
+	for _, c := range fxutil.GetAndFilterGroup(deps.Catalog) {
 		if (c.GetTargetCatalog() & deps.Params.AgentType) > 0 {
 			candidates[c.GetID()] = c
 		}

--- a/comp/forwarder/defaultforwarder/forwarder.go
+++ b/comp/forwarder/defaultforwarder/forwarder.go
@@ -37,8 +37,7 @@ func newForwarder(dep dependencies) provides {
 func NewForwarder(config config.Component, log log.Component, params Params) provides {
 	if params.UseNoopForwarder {
 		return provides{
-			Comp:           NoopForwarder{},
-			StatusProvider: status.NoopInformationProvider(),
+			Comp: NoopForwarder{},
 		}
 	}
 	return provides{
@@ -49,7 +48,6 @@ func NewForwarder(config config.Component, log log.Component, params Params) pro
 
 func newMockForwarder(config config.Component, log log.Component) provides {
 	return provides{
-		Comp:           NewDefaultForwarder(config, log, NewOptions(config, log, nil)),
-		StatusProvider: status.NoopInformationProvider(),
+		Comp: NewDefaultForwarder(config, log, NewOptions(config, log, nil)),
 	}
 }

--- a/comp/logs/agent/agent.go
+++ b/comp/logs/agent/agent.go
@@ -131,7 +131,6 @@ func newLogsAgent(deps dependencies) provides {
 	return provides{
 		Comp:           optional.NewNoneOption[Component](),
 		StatusProvider: statusComponent.NewInformationProvider(NewStatusProvider()),
-		FlareProvider:  flaretypes.NewEmptyProvider(),
 	}
 }
 

--- a/comp/logs/agent/agent_test.go
+++ b/comp/logs/agent/agent_test.go
@@ -308,7 +308,7 @@ func (suite *AgentTestSuite) TestFlareProvider() {
 		{
 			"logs disabled",
 			false,
-			flaretypes.NewEmptyProvider(),
+			flaretypes.Provider{},
 		},
 	}
 
@@ -325,7 +325,11 @@ func (suite *AgentTestSuite) TestFlareProvider() {
 			provides := newLogsAgent(deps)
 
 			assert.IsType(suite.T(), test.expected, provides.FlareProvider)
-			assert.NotNil(suite.T(), provides.FlareProvider.Provider)
+			if test.enabled {
+				assert.NotNil(suite.T(), provides.FlareProvider.Provider)
+			} else {
+				assert.Nil(suite.T(), provides.FlareProvider.Provider)
+			}
 		})
 	}
 }

--- a/comp/metadata/packagesigning/packagesigningimpl/packagesigning.go
+++ b/comp/metadata/packagesigning/packagesigningimpl/packagesigning.go
@@ -110,7 +110,7 @@ func newPackageSigningProvider(deps dependencies) provides {
 	is.InventoryPayload.MaxInterval = defaultCollectInterval
 	is.InventoryPayload.MinInterval = defaultCollectInterval
 	is.InventoryPayload.Enabled = isPackageSigningEnabled(deps.Config, is.log)
-	provider := runnerimpl.NewEmptyProvider()
+	var provider runnerimpl.Provider
 	if runtime.GOOS == "linux" {
 		if getPkgManager() != "" {
 			// Package signing telemetry is only valid on Linux and DEB/RPM based distros (including SUSE)

--- a/comp/metadata/resources/resourcesimpl/resources.go
+++ b/comp/metadata/resources/resourcesimpl/resources.go
@@ -86,8 +86,7 @@ func newResourcesProvider(deps dependencies) provides {
 		serializer:      deps.Serializer,
 	}
 	res := provides{
-		Comp:     &r,
-		Provider: runnerimpl.NewEmptyProvider(),
+		Comp: &r,
 	}
 
 	if deps.Params != nil && deps.Params.Disabled {

--- a/comp/metadata/runner/runnerimpl/runner.go
+++ b/comp/metadata/runner/runnerimpl/runner.go
@@ -55,6 +55,13 @@ type Provider struct {
 	Callback optional.Option[MetadataProvider] `group:"metadata_provider"`
 }
 
+// NewProvider registers a new metadata provider by adding a callback to the runner.
+func NewProvider(callback MetadataProvider) Provider {
+	return Provider{
+		Callback: optional.NewOption[MetadataProvider](callback),
+	}
+}
+
 // NewEmptyProvider returns a empty provider which is not going to register anything. This is useful for providers that
 // can be enabled/disabled through configuration.
 func NewEmptyProvider() Provider {
@@ -63,19 +70,12 @@ func NewEmptyProvider() Provider {
 	}
 }
 
-// NewProvider registers a new metadata provider by adding a callback to the runner.
-func NewProvider(callback MetadataProvider) Provider {
-	return Provider{
-		Callback: optional.NewOption[MetadataProvider](callback),
-	}
-}
-
 // createRunner instantiates a runner object
 func createRunner(deps dependencies) *runnerImpl {
 	return &runnerImpl{
 		log:       deps.Log,
 		config:    deps.Config,
-		providers: deps.Providers,
+		providers: fxutil.GetAndFilterGroup(deps.Providers),
 		stopChan:  make(chan struct{}),
 	}
 }

--- a/comp/netflow/server/server.go
+++ b/comp/netflow/server/server.go
@@ -88,8 +88,6 @@ func newServer(lc fx.Lifecycle, deps dependencies) (provides, error) {
 
 	var statusProvider status.Provider
 
-	statusProvider = status.NoopProvider{}
-
 	if conf.Enabled {
 		statusProvider = Provider{}
 

--- a/comp/process/agent/agentimpl/agent.go
+++ b/comp/process/agent/agentimpl/agent.go
@@ -60,7 +60,7 @@ func newProcessAgent(p processAgentParams) optional.Option[agent.Component] {
 	}
 
 	enabledChecks := make([]checks.Check, 0, len(p.Checks))
-	for _, c := range p.Checks {
+	for _, c := range fxutil.GetAndFilterGroup(p.Checks) {
 		check := c.Object()
 		if check.IsEnabled() {
 			enabledChecks = append(enabledChecks, check)

--- a/comp/process/runner/runnerimpl/runner.go
+++ b/comp/process/runner/runnerimpl/runner.go
@@ -48,7 +48,8 @@ type dependencies struct {
 }
 
 func newRunner(deps dependencies) (runner.Component, error) {
-	c, err := processRunner.NewRunner(deps.Config, deps.SysCfg.SysProbeObject(), deps.HostInfo.Object(), filterEnabledChecks(deps.Checks), deps.RTNotifier)
+	checks := fxutil.GetAndFilterGroup(deps.Checks)
+	c, err := processRunner.NewRunner(deps.Config, deps.SysCfg.SysProbeObject(), deps.HostInfo.Object(), filterEnabledChecks(checks), deps.RTNotifier)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +57,7 @@ func newRunner(deps dependencies) (runner.Component, error) {
 
 	runner := &runnerImpl{
 		checkRunner:    c,
-		providedChecks: deps.Checks,
+		providedChecks: checks,
 	}
 
 	deps.Lc.Append(fx.Hook{

--- a/comp/remote-config/rcclient/rcclient.go
+++ b/comp/remote-config/rcclient/rcclient.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -102,8 +103,8 @@ func newRemoteConfigClient(deps dependencies) (provides, error) {
 	}
 
 	rc := rcClient{
-		listeners:     deps.Listeners,
-		taskListeners: deps.TaskListeners,
+		listeners:     fxutil.GetAndFilterGroup(deps.Listeners),
+		taskListeners: fxutil.GetAndFilterGroup(deps.TaskListeners),
 		m:             &sync.Mutex{},
 		client:        c,
 		clientHA:      clientHA,

--- a/comp/snmptraps/server/serverimpl/server.go
+++ b/comp/snmptraps/server/serverimpl/server.go
@@ -87,8 +87,7 @@ func (w *TrapsServer) Error() error {
 func newServer(lc fx.Lifecycle, deps dependencies) provides {
 	if !trapsconfig.IsEnabled(deps.Conf) {
 		return provides{
-			Comp:           &TrapsServer{running: false},
-			StatusProvider: coreStatus.NoopInformationProvider(),
+			Comp: &TrapsServer{running: false},
 		}
 	}
 	stat := statusimpl.New()
@@ -117,8 +116,7 @@ func newServer(lc fx.Lifecycle, deps dependencies) provides {
 		deps.Logger.Errorf("Failed to initialize snmp-traps server: %s", err)
 		server.stat.SetStartError(err)
 		return provides{
-			Comp:           server,
-			StatusProvider: coreStatus.NoopInformationProvider(),
+			Comp: server,
 		}
 	}
 

--- a/pkg/status/autodiscovery/status.go
+++ b/pkg/status/autodiscovery/status.go
@@ -31,13 +31,13 @@ var templatesFS embed.FS
 // Provider provides the functionality to populate the status output
 type Provider struct{}
 
-// GetProvider if agent is running in a container environment returns status.Provider otherwise returns NoopProvider
+// GetProvider if agent is running in a container environment returns status.Provider otherwise returns nil
 func GetProvider() status.Provider {
 	if config.IsContainerized() {
 		return Provider{}
 	}
 
-	return status.NoopProvider{}
+	return nil
 }
 
 func (p Provider) getStatusInfo() map[string]interface{} {

--- a/pkg/status/clusteragent/status_apiserver.go
+++ b/pkg/status/clusteragent/status_apiserver.go
@@ -59,13 +59,13 @@ func GetDCAStatus(stats map[string]interface{}) {
 // Provider provides the functionality to populate the status output
 type Provider struct{}
 
-// GetProvider if cluster agent is enabled returns status.Provider otherwise returns NoopProvider
+// GetProvider if cluster agent is enabled returns status.Provider otherwise returns nil
 func GetProvider(conf config.Component) status.Provider {
 	if conf.GetBool("cluster_agent.enabled") || conf.GetBool("cluster_checks.enabled") {
 		return Provider{}
 	}
 
-	return status.NoopProvider{}
+	return nil
 }
 
 //go:embed status_templates

--- a/pkg/status/clusteragent/status_no_apiserver.go
+++ b/pkg/status/clusteragent/status_no_apiserver.go
@@ -23,10 +23,7 @@ func GetDCAStatus(_ map[string]interface{}) {
 	log.Info("Not implemented")
 }
 
-// GetProvider returns NoopProvider
+// GetProvider returns nil
 func GetProvider(_ config.Component) status.Provider {
-	return status.NoopProvider{}
+	return nil
 }
-
-// Provider provides the functionality to populate the status output
-type Provider status.NoopProvider

--- a/pkg/status/httpproxy/status.go
+++ b/pkg/status/httpproxy/status.go
@@ -21,13 +21,13 @@ var templatesFS embed.FS
 // Provider provides the functionality to populate the status output
 type Provider struct{}
 
-// GetProvider if no_proxy_nonexact_match is disabled returns status.Provider otherwise returns NoopProvider
+// GetProvider if no_proxy_nonexact_match is disabled returns status.Provider otherwise returns nil
 func GetProvider(conf config.Component) status.Provider {
 	if !conf.GetBool("no_proxy_nonexact_match") {
 		return Provider{}
 	}
 
-	return status.NoopProvider{}
+	return nil
 }
 
 func (p Provider) getStatusInfo() map[string]interface{} {

--- a/pkg/status/systemprobe/status.go
+++ b/pkg/status/systemprobe/status.go
@@ -44,7 +44,7 @@ type Provider struct {
 	SocketPath string
 }
 
-// GetProvider if system probe is enabled returns status.Provider otherwise returns NoopProvider
+// GetProvider if system probe is enabled returns status.Provider otherwise returns nil
 func GetProvider(conf config.Component) status.Provider {
 	if conf.GetBool("system_probe_config.enabled") {
 		return Provider{
@@ -52,7 +52,7 @@ func GetProvider(conf config.Component) status.Provider {
 		}
 	}
 
-	return status.NoopProvider{}
+	return nil
 }
 
 //go:embed status_templates

--- a/pkg/status/systemprobe/status_unsupported.go
+++ b/pkg/status/systemprobe/status_unsupported.go
@@ -20,10 +20,7 @@ func GetStatus(stats map[string]interface{}, _ string) {
 	}
 }
 
-// GetProvider returns NoopProvider
+// GetProvider returns nil
 func GetProvider(_ config.Component) status.Provider {
-	return status.NoopProvider{}
+	return nil
 }
-
-// Provider provides the functionality to populate the status output
-type Provider status.NoopProvider

--- a/pkg/util/fxutil/group.go
+++ b/pkg/util/fxutil/group.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package fxutil
+
+import (
+	"reflect"
+	"slices"
+)
+
+// GetAndFilterGroup filters 'zero' values from an FX group.
+//
+// A 'zero' value, nil in most cases, can be injected into a group whem a component declares returning a element for
+// that group but don't actually creates the element. This is common pattern with component that can be disabled or
+// partially enabled.
+//
+// This should be called in every component's constructor that requires an FX group as a dependency.
+func GetAndFilterGroup[S ~[]E, E any](group S) S {
+	return slices.DeleteFunc(group, func(item E) bool {
+		// if item is an untyped nil, aka interface{}(nil), we filter them directly
+		t := reflect.TypeOf(item)
+		if t == nil {
+			return true
+		}
+
+		switch t.Kind() {
+		case reflect.Pointer, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice, reflect.Func, reflect.Interface:
+			return reflect.ValueOf(item).IsNil()
+		}
+		return false
+	})
+}

--- a/pkg/util/fxutil/group_test.go
+++ b/pkg/util/fxutil/group_test.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package fxutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type dummyFunc func()
+
+type dummyInterface interface {
+	test()
+}
+
+type dummy1 struct{}
+
+func (d *dummy1) test() {}
+
+type dummy2 struct{}
+
+func (d *dummy2) test() {}
+
+type dummy3 struct{}
+
+func (d dummy3) test() {}
+
+func TestGetAndFilterGroup(t *testing.T) {
+	// We don't want to filter "zero" version of basic types
+	assert.Equal(t, []int{0, 1, 2, 3, 0}, GetAndFilterGroup([]int{0, 1, 2, 3, 0}))
+	assert.Equal(t, []string{"", "a", "", "b", "c"}, GetAndFilterGroup([]string{"", "a", "", "b", "c"}))
+	assert.Len(t, GetAndFilterGroup([]dummy1{{}, {}}), 2)
+
+	// filter interface{}
+	assert.Equal(t, []interface{}{"abc"}, GetAndFilterGroup([]interface{}{nil, "abc", nil}))
+
+	// filter pointers
+	d1 := &dummy1{}
+	pointerList := []*dummy1{nil, d1, nil}
+
+	require.Len(t, GetAndFilterGroup(pointerList), 1)
+	assert.Equal(t, d1, GetAndFilterGroup(pointerList)[0])
+
+	// filter map
+	mapList := []map[string]int{{"1": 1}, nil}
+
+	require.Len(t, GetAndFilterGroup(mapList), 1)
+	assert.NotNil(t, GetAndFilterGroup(mapList)[0])
+
+	// filter slice
+	arrayList := [][]int{{1, 2, 3, 4}, nil}
+
+	require.Len(t, GetAndFilterGroup(arrayList), 1)
+	assert.NotNil(t, GetAndFilterGroup(arrayList)[0])
+
+	// filter chan
+	chanList := []chan int{make(chan int), nil}
+
+	require.Len(t, GetAndFilterGroup(chanList), 1)
+	assert.NotNil(t, GetAndFilterGroup(chanList)[0])
+
+	// filter func
+	funcList := []dummyFunc{func() {}, nil}
+
+	require.Len(t, GetAndFilterGroup(funcList), 1)
+	assert.NotNil(t, GetAndFilterGroup(funcList)[0])
+
+	// filter interface
+	d2 := &dummy2{}
+	d3 := dummy3{}
+	interfaceList := []dummyInterface{nil, d1, d2, d3, nil}
+	filtered := GetAndFilterGroup(interfaceList)
+
+	require.Len(t, filtered, 3)
+	assert.Equal(t, d1, filtered[0])
+	assert.Equal(t, d2, filtered[1])
+	assert.Equal(t, d3, filtered[2])
+}


### PR DESCRIPTION
### What does this PR do?

Nil value can be inserted in FX groups when a component declare returning a group element in the return types from its constructor but leave the element to nil. This can happen with component that can be disabled or partially enabled.

Filtering the FX group in the constructor or component using them prevent panics down the line.

### Describe how to test/QA your changes

This PR should change nothing to the behavior of any component. Each team should still QA for regression in their component.