### PR TITLE
Fix linter errors from `inv lint-go` command with golangci-lint version `v1.55.2`

### DIFF
--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -301,13 +301,13 @@ func validateArgs(args []string, local bool) error {
 		}
 	} else {
 		// Validate the wheel we try to install exists
-		if _, err := os.Stat(args[0]); err == nil {
+		var err error
+		if _, err = os.Stat(args[0]); err == nil {
 			return nil
 		} else if os.IsNotExist(err) {
 			return fmt.Errorf("local wheel %s does not exist", args[0])
-		} else {
-			return fmt.Errorf("cannot read local wheel %s: %v", args[0], err)
 		}
+		return fmt.Errorf("cannot read local wheel %s: %v", args[0], err)
 	}
 
 	return nil

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -45,17 +45,16 @@ type cliParams struct {
 func main() {
 	if len(os.Args) < 2 {
 		panic("[datadog init process] invalid argument count, did you forget to set CMD ?")
-	} else {
+	}
 
-		cliParams := &cliParams{
-			args: os.Args[1:],
-		}
+	cliParams := &cliParams{
+		args: os.Args[1:],
+	}
 
-		err := fxutil.OneShot(run, fx.Supply(cliParams))
+	err := fxutil.OneShot(run, fx.Supply(cliParams))
 
-		if err != nil {
-			logger.Error(err)
-		}
+	if err != nil {
+		logger.Error(err)
 	}
 }
 

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -206,10 +206,9 @@ func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, er
 				errorStats.setLoaderError(config.Name, fmt.Sprintf("%v", loader), err.Error())
 				checks = append(checks, c)
 				break
-			} else {
-				errorStats.setLoaderError(config.Name, fmt.Sprintf("%v", loader), err.Error())
-				errors = append(errors, fmt.Sprintf("%v: %s", loader, err))
 			}
+			errorStats.setLoaderError(config.Name, fmt.Sprintf("%v", loader), err.Error())
+			errors = append(errors, fmt.Sprintf("%v: %s", loader, err))
 		}
 
 		if len(errors) == numLoaders {

--- a/pkg/network/go/dwarfutils/locexpr/exec.go
+++ b/pkg/network/go/dwarfutils/locexpr/exec.go
@@ -102,9 +102,8 @@ func Exec(expression []byte, totalSize int64, pointerSize int) ([]LocationPiece,
 			return offset - fakeFrameBase
 		} else if offset > (fakeCFA / 2) {
 			return offset - fakeCFA
-		} else {
-			return offset
 		}
+		return offset
 	}
 
 	if len(opPieces) == 0 {

--- a/pkg/network/go/lutgen/run.go
+++ b/pkg/network/go/lutgen/run.go
@@ -305,7 +305,6 @@ func versionToString(v goversion.GoVersion) string {
 		return fmt.Sprintf("%d.%dbeta%d", v.Major, v.Minor, v.Beta)
 	} else if v.Rev > 0 {
 		return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Rev)
-	} else {
-		return fmt.Sprintf("%d.%d", v.Major, v.Minor)
 	}
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
 }

--- a/pkg/network/go/rungo/matrix/matrix.go
+++ b/pkg/network/go/rungo/matrix/matrix.go
@@ -267,7 +267,6 @@ func versionToString(v goversion.GoVersion) string {
 		return fmt.Sprintf("%d.%dbeta%d", v.Major, v.Minor, v.Beta)
 	} else if v.Rev > 0 {
 		return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Rev)
-	} else {
-		return fmt.Sprintf("%d.%d", v.Major, v.Minor)
 	}
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
 }

--- a/pkg/network/proc_net.go
+++ b/pkg/network/proc_net.go
@@ -53,39 +53,39 @@ func readProcNetWithStatus(path string, status int64) ([]uint16, error) {
 			break
 		} else if err != nil {
 			return nil, err
-		} else {
-			iter := &fieldIterator{data: b}
-			iter.nextField() // entry number
-
-			rawLocal = iter.nextField() // local_address
-
-			iter.nextField() // remote_address
-
-			rawState = iter.nextField() // st
-
-			state, err := strconv.ParseInt(string(rawState), 16, 0)
-			if err != nil {
-				log.Errorf("error parsing tcp state [%s] as hex: %s", rawState, err)
-				continue
-			}
-
-			if state != status {
-				continue
-			}
-
-			idx := bytes.IndexByte(rawLocal, ':')
-			if idx == -1 {
-				continue
-			}
-
-			port, err := strconv.ParseUint(string(rawLocal[idx+1:]), 16, 16)
-			if err != nil {
-				log.Errorf("error parsing port [%s] as hex: %s", rawLocal[idx+1:], err)
-				continue
-			}
-
-			ports = append(ports, uint16(port))
 		}
+
+		iter := &fieldIterator{data: b}
+		iter.nextField() // entry number
+
+		rawLocal = iter.nextField() // local_address
+
+		iter.nextField() // remote_address
+
+		rawState = iter.nextField() // st
+
+		state, err := strconv.ParseInt(string(rawState), 16, 0)
+		if err != nil {
+			log.Errorf("error parsing tcp state [%s] as hex: %s", rawState, err)
+			continue
+		}
+
+		if state != status {
+			continue
+		}
+
+		idx := bytes.IndexByte(rawLocal, ':')
+		if idx == -1 {
+			continue
+		}
+
+		port, err := strconv.ParseUint(string(rawLocal[idx+1:]), 16, 16)
+		if err != nil {
+			log.Errorf("error parsing port [%s] as hex: %s", rawLocal[idx+1:], err)
+			continue
+		}
+
+		ports = append(ports, uint16(port))
 	}
 
 	return ports, nil

--- a/pkg/orchestrator/cache.go
+++ b/pkg/orchestrator/cache.go
@@ -66,10 +66,9 @@ func SkipKubernetesResource(uid types.UID, resourceVersion string, nodeType pkgo
 		incCacheMiss(nodeType)
 		KubernetesResourceCache.Set(cacheKey, resourceVersion, 0)
 		return false
-	} else {
-		incCacheHit(nodeType)
-		return true
 	}
+	incCacheHit(nodeType)
+	return true
 }
 
 func incCacheHit(nodeType pkgorchestratormodel.NodeType) {

--- a/pkg/security/secl/compiler/eval/utils.go
+++ b/pkg/security/secl/compiler/eval/utils.go
@@ -39,9 +39,8 @@ func IPToInt(ip net.IP) (*big.Int, int, error) {
 		return val, 32, nil
 	} else if len(ip) == net.IPv6len {
 		return val, 128, nil
-	} else {
-		return nil, 0, fmt.Errorf("unsupported address length %d", len(ip))
 	}
+	return nil, 0, fmt.Errorf("unsupported address length %d", len(ip))
 }
 
 // IntToIP transforms a big Int to an IP

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -776,12 +776,7 @@ func pascalCaseFieldName(fieldName string) string {
 }
 
 func getDefaultValueOfType(returnType string) string {
-	isArray := false
-
-	baseType, found := strings.CutPrefix(returnType, "[]")
-	if found {
-		isArray = true
-	}
+	baseType, isArray := strings.CutPrefix(returnType, "[]")
 
 	if baseType == "int" {
 		if isArray {
@@ -823,12 +818,10 @@ func getDefaultValueOfType(returnType string) string {
 			return "[]time.Time{}"
 		}
 		return "time.Time{}"
-	} else {
-		if isArray {
-			return "[]string{}"
-		}
-		return `""`
+	} else if isArray {
+		return "[]string{}"
 	}
+	return `""`
 }
 
 func needScrubbed(fieldName string) bool {

--- a/pkg/security/secl/compiler/generators/accessors/common/types.go
+++ b/pkg/security/secl/compiler/generators/accessors/common/types.go
@@ -113,12 +113,10 @@ func (sf *StructField) GetDefaultReturnValue() string {
 			return "&eval.CIDRValues{}"
 		}
 		return "net.IPNet{}"
-	} else {
-		if sf.Iterator != nil || sf.IsArray {
-			return "[]string{}"
-		}
-		return `""`
+	} else if sf.Iterator != nil || sf.IsArray {
+		return "[]string{}"
 	}
+	return `""`
 }
 
 // GetDefaultScalarReturnValue returns default scalar value for the given return type
@@ -129,9 +127,8 @@ func (sf *StructField) GetDefaultScalarReturnValue() string {
 		return "false"
 	} else if sf.ReturnType == "net.IPNet" {
 		return "net.IPNet{}"
-	} else {
-		return `""`
 	}
+	return `""`
 }
 
 // GetArrayPrefix returns the array prefix of this field

--- a/pkg/serverless/appsec/config/config.go
+++ b/pkg/serverless/appsec/config/config.go
@@ -49,9 +49,8 @@ func IsEnabled() (enabled bool, set bool, err error) {
 		return false, set, nil
 	} else if enabled, err = strconv.ParseBool(enabledStr); err != nil {
 		return false, set, fmt.Errorf("could not parse %s value `%s` as a boolean value", enabledEnvVar, enabledStr)
-	} else {
-		return enabled, set, nil
 	}
+	return enabled, set, nil
 }
 
 // IsStandalone returns whether appsec is used as a standalone product (without APM tracing) or not

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -22,9 +22,8 @@ func GetAWSPartitionByRegion(region string) string {
 		return "aws-us-gov"
 	} else if strings.HasPrefix(region, "cn-") {
 		return "aws-cn"
-	} else {
-		return "aws"
 	}
+	return "aws"
 }
 
 // ExtractAPIGatewayEventARN returns an ARN from an APIGatewayProxyRequest

--- a/pkg/tagset/hash_generator.go
+++ b/pkg/tagset/hash_generator.go
@@ -102,12 +102,11 @@ func (g *HashGenerator) Hash(tb *HashingTagsAccumulator) uint64 {
 					hashes[i] = hashes[ntags-1]
 					ntags--
 					break
-				} else {
-					// move 'right' in the hashset because there is already a value,
-					// in this bucket, which is not the one we're dealing with right now,
-					// we may have already seen this tag
-					j = (j + 1) & mask
 				}
+				// move 'right' in the hashset because there is already a value,
+				// in this bucket, which is not the one we're dealing with right now,
+				// we may have already seen this tag
+				j = (j + 1) & mask
 			}
 		}
 		tb.Truncate(ntags)


### PR DESCRIPTION
### What does this PR do?

Fix linter errors from `inv lint-go` command with golangci-lint version `v1.55.2`.

linter output:
```
Linters for module /home/maxime/dev/go/src/github.com/DataDog/datadog-agent failed (base flavor)
Linter failures:
pkg/serverless/trigger/extractor.go:25:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
	} else {
		return "aws"
	}
pkg/network/proc_net.go:56:10: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
		} else {
			iter := &fieldIterator{data: b}
			iter.nextField() // entry number

			rawLocal = iter.nextField() // local_address

			iter.nextField() // remote_address

			rawState = iter.nextField() // st

			state, err := strconv.ParseInt(string(rawState), 16, 0)
			if err != nil {
				log.Errorf("error parsing tcp state [%s] as hex: %s", rawState, err)
				continue
			}

			if state != status {
				continue
			}

			idx := bytes.IndexByte(rawLocal, ':')
			if idx == -1 {
				continue
			}

			port, err := strconv.ParseUint(string(rawLocal[idx+1:]), 16, 16)
			if err != nil {
				log.Errorf("error parsing port [%s] as hex: %s", rawLocal[idx+1:], err)
				continue
			}

			ports = append(ports, uint16(port))
		}
pkg/orchestrator/cache.go:69:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
	} else {
		incCacheHit(nodeType)
		return true
	}
pkg/serverless/appsec/config/config.go:52:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
	} else {
		return enabled, set, nil
	}
pkg/network/go/dwarfutils/locexpr/exec.go:105:10: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
		} else {
			return offset
		}
pkg/network/go/rungo/matrix/matrix.go:270:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
	} else {
		return fmt.Sprintf("%d.%d", v.Major, v.Minor)
	}
pkg/network/go/lutgen/run.go:308:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
	} else {
		return fmt.Sprintf("%d.%d", v.Major, v.Minor)
	}
pkg/collector/scheduler.go:209:11: superfluous-else: if block ends with a break statement, so drop this else and outdent its block (revive)
			} else {
				errorStats.setLoaderError(config.Name, fmt.Sprintf("%v", loader), err.Error())
				errors = append(errors, fmt.Sprintf("%v: %s", loader, err))
			}

cmd/serverless-init/main.go:48:9: superfluous-else: if block ends with call to panic function, so drop this else and outdent its block (revive)
	} else {

		cliParams := &cliParams{
			args: os.Args[1:],
		}

		err := fxutil.OneShot(run, fx.Supply(cliParams))

		if err != nil {
			logger.Error(err)
		}
	}
cmd/agent/subcommands/integrations/command.go:308:10: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
		} else {
			return fmt.Errorf("cannot read local wheel %s: %v", args[0], err)
		}


Linters for module /home/maxime/dev/go/src/github.com/DataDog/datadog-agent/pkg/tagset failed (base flavor)
Linter failures:
pkg/tagset/hash_generator.go:105:12: superfluous-else: if block ends with a break statement, so drop this else and outdent its block (revive)
				} else {
					// move 'right' in the hashset because there is already a value,
					// in this bucket, which is not the one we're dealing with right now,
					// we may have already seen this tag
					j = (j + 1) & mask
				}


Linters for module /home/maxime/dev/go/src/github.com/DataDog/datadog-agent/pkg/security/secl failed (base flavor)
Linter failures:
pkg/security/secl/compiler/generators/accessors/common/types.go:116:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
	} else {
		if sf.Iterator != nil || sf.IsArray {
			return "[]string{}"
		}
		return `""`
	}
pkg/security/secl/compiler/generators/accessors/common/types.go:132:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
	} else {
		return `""`
	}
pkg/security/secl/compiler/generators/accessors/accessors.go:826:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
	} else {
		if isArray {
			return "[]string{}"
		}
		return `""`
	}
pkg/security/secl/compiler/eval/utils.go:42:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
	} else {
		return nil, 0, fmt.Errorf("unsupported address length %d", len(ip))
	}
```