### PR TITLE
Set BUNDLE_VERSION_OVERRIDE to override CNAB workflow version

### DIFF
--- a/.gitlab/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy.yml
@@ -30,6 +30,7 @@ internal_kubernetes_deploy_experimental:
     OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging ${CI_COMMIT_REF_SLUG}-jmx-${CI_COMMIT_SHORT_SHA} ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}"
     SKIP_PLAN_CHECK: "true"
     EXPLICIT_WORKFLOWS: "//workflows:beta_builds.agents_nightly.publish"
+    BUNDLE_VERSION_OVERRIDE: "v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   script:
     - source /root/.bashrc
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
@@ -42,7 +43,8 @@ internal_kubernetes_deploy_experimental:
         --variable DDR
         --variable DDR_WORKFLOW_ID
         --variable TARGET_ENV
-        --variable DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+        --variable DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS
+        --variable BUNDLE_VERSION_OVERRIDE"
 
 notify-slack:
   stage: internal_kubernetes_deploy


### PR DESCRIPTION
### What does this PR do?

This PR explicitly sets the version that should be used for the generated downstream CNAB workflow to match the version used for images within this pipeline

### Motivation

See [this PR](https://github.com/DataDog/k8s-datadog-agent-ops/pull/3087) for more details

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
