### PR TITLE
Set current_milestone to 7.53.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
     "base_branch": "main",
-    "current_milestone": "7.52.0",
+    "current_milestone": "7.53.0",
     "last_stable": {
         "6": "6.51.0",
         "7": "7.51.0"


### PR DESCRIPTION
Sets `current_milestone` field to 7.53.0 so github action witch sets PR milestone automatically can work properly with new milestone.