### PR TITLE
[EBPF-442] Support subset of micro-vms for kmt.init  

### DIFF
--- a/tasks/kernel_matrix_testing/download.py
+++ b/tasks/kernel_matrix_testing/download.py
@@ -40,7 +40,7 @@ def requires_update(url_base, rootfs_dir, image):
     return False
 
 
-def download_rootfs(ctx, rootfs_dir):
+def download_rootfs(ctx, rootfs_dir, vms=None):
     with open(platforms_file) as f:
         platforms = json.load(f)
 
@@ -52,7 +52,16 @@ def download_rootfs(ctx, rootfs_dir):
     arch = arch_mapping[platform.machine()]
     to_download = list()
     file_ls = list()
+    if vms:
+        info("Initializing following micro VMs:")
+        for vm in vms:
+            info(f"{vm}, ")
+    else:
+        info("Initializing all micro VMs")
     for tag in platforms[arch]:
+        # if provided specific micro-vms, skip downloading unnecessary files
+        if vms and tag not in vms:
+            continue
         path = os.path.basename(platforms[arch][tag])
         if path.endswith(".xz"):
             path = path[: -len(".xz")]

--- a/tasks/kernel_matrix_testing/download.py
+++ b/tasks/kernel_matrix_testing/download.py
@@ -53,11 +53,11 @@ def download_rootfs(ctx, rootfs_dir, vms=None):
     to_download = list()
     file_ls = list()
     if vms:
-        info("Initializing following micro VMs:")
+        info("[+] Initializing following VMs:")
         for vm in vms:
             info(f"{vm}, ")
     else:
-        info("Initializing all micro VMs")
+        info("[+] Initializing all VMs")
     for tag in platforms[arch]:
         # if provided specific micro-vms, skip downloading unnecessary files
         if vms and tag not in vms:

--- a/tasks/kernel_matrix_testing/init_kmt.py
+++ b/tasks/kernel_matrix_testing/init_kmt.py
@@ -39,7 +39,7 @@ def gen_ssh_key(ctx, kmt_dir):
     ctx.run(f"chmod 400 {kmt_dir}/ddvm_rsa")
 
 
-def init_kernel_matrix_testing_system(ctx, lite):
+def init_kernel_matrix_testing_system(ctx, lite, vms=None):
     kmt_os = get_kmt_os()
 
     sudo = "sudo" if not is_root() else ""
@@ -63,7 +63,7 @@ def init_kernel_matrix_testing_system(ctx, lite):
 
     # download dependencies
     if not lite:
-        download_rootfs(ctx, kmt_os.rootfs_dir)
+        download_rootfs(ctx, kmt_os.rootfs_dir, vms)
         gen_ssh_key(ctx, kmt_os.kmt_dir)
 
     # build docker compile image

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -202,9 +202,9 @@ def ls(_, distro=False, custom=False):
     print(tabulate(vmconfig.get_image_list(distro, custom), headers='firstrow', tablefmt='fancy_grid'))
 
 
-@task
-def init(ctx, lite=False):
-    init_kernel_matrix_testing_system(ctx, lite)
+@task(iterable=['vms'])
+def init(ctx, lite=False, vms=None):
+    init_kernel_matrix_testing_system(ctx, lite, vms)
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

Added optional vms list parameter to allow partial initialization when calling the `kmt.init` task
### Motivation

reduce the first-time-use initialization time in scenarios where a specific vm is required.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
