### PR TITLE
usm: kafka: Removed kafka_last_tcp_seq_per_connection map

### DIFF
--- a/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
+++ b/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
@@ -141,17 +141,6 @@ static __always_inline bool kafka_allow_packet(kafka_transaction_t *kafka, struc
         return skb_info->tcp_flags&(TCPHDR_FIN|TCPHDR_RST);
     }
 
-    // Check that we didn't see this tcp segment before so we won't process
-    // the same traffic twice
-    log_debug("kafka: Current tcp sequence: %lu", skb_info->tcp_seq);
-    // Hack to make verifier happy on 4.14.
-    conn_tuple_t tup = kafka->base.tup;
-    __u32 *last_tcp_seq = bpf_map_lookup_elem(&kafka_last_tcp_seq_per_connection, &tup);
-    if (last_tcp_seq != NULL && *last_tcp_seq == skb_info->tcp_seq) {
-        log_debug("kafka: already seen this tcp sequence: %lu", *last_tcp_seq);
-        return false;
-    }
-    bpf_map_update_with_telemetry(kafka_last_tcp_seq_per_connection, &tup, &skb_info->tcp_seq, BPF_ANY);
     return true;
 }
 

--- a/pkg/network/ebpf/c/protocols/kafka/parsing-maps.h
+++ b/pkg/network/ebpf/c/protocols/kafka/parsing-maps.h
@@ -2,10 +2,5 @@
 #define __KAFKA_PARSING_MAPS_H
 
 BPF_PERCPU_ARRAY_MAP(kafka_heap, kafka_transaction_t, 1)
-/*
-    This map help us to avoid processing the same traffic twice.
-    It holds the last tcp sequence number for each connection.
-   */
-BPF_HASH_MAP(kafka_last_tcp_seq_per_connection, conn_tuple_t, __u32, 0)
 
 #endif

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -32,7 +32,6 @@ const (
 	filterTailCall                           = "socket__kafka_filter"
 	dispatcherTailCall                       = "socket__protocol_dispatcher_kafka"
 	protocolDispatcherClassificationPrograms = "dispatcher_classification_progs"
-	kafkaLastTCPSeqPerConnectionMap          = "kafka_last_tcp_seq_per_connection"
 	kafkaHeapMap                             = "kafka_heap"
 )
 
@@ -42,9 +41,6 @@ var Spec = &protocols.ProtocolSpec{
 	Maps: []*manager.Map{
 		{
 			Name: protocolDispatcherClassificationPrograms,
-		},
-		{
-			Name: kafkaLastTCPSeqPerConnectionMap,
 		},
 		{
 			Name: kafkaHeapMap,
@@ -84,17 +80,11 @@ func (p *protocol) Name() string {
 	return "Kafka"
 }
 
-// ConfigureOptions add the necessary options for the kafka monitoring to work,
-// to be used by the manager. These are:
-// - Set the `kafka_last_tcp_seq_per_connection` map size to the value of the `max_tracked_connection` configuration variable.
-//
-// We also configure the kafka event stream with the manager and its options.
+// ConfigureOptions add the necessary options for the kafka monitoring to work, to be used by the manager.
+// Configuring the kafka event stream with the manager and its options, and enabling the kafka_monitoring_enabled eBPF
+// option.
 func (p *protocol) ConfigureOptions(mgr *manager.Manager, opts *manager.Options) {
 	events.Configure(eventStreamName, mgr, opts)
-	opts.MapSpecEditors[kafkaLastTCPSeqPerConnectionMap] = manager.MapSpecEditor{
-		MaxEntries: p.cfg.MaxTrackedConnections,
-		EditorFlag: manager.EditMaxEntries,
-	}
 	utils.EnableOption(opts, "kafka_monitoring_enabled")
 }
 


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Removes `kafka_last_tcp_seq_per_connection` map from the kafka filtering program
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We used the map to ensure we're not processing the same packet twice in the socket filter program. However, that is guaranteed already by protocol_dispatcher_entrypoint.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
The change simplifies the programs, removes a map, and spare 7.5MB from USM (assuming, 65K entries in the map).
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
