### PR TITLE
fix(ci): Re-enable caching on parent go.mod file

### DIFF
--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -44,6 +44,7 @@ go_deps:
   cache:
     - key:
         files:
+          - go.mod
           - ./**/go.mod
         prefix: "go_deps"
       paths:


### PR DESCRIPTION
### What does this PR do?
Re-enable taking into account the parent `go.mod` in the gomodcache key computation. Previous change took into account child but dismissed the parent file.

### Motivation
Prevent cache rebuild when it's useless and possible infrastructure issues (eg [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/432855554) where a network issue causes a job to fail whereas we should not have called the network)

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes
Pushed few commits to test cache generation:
- Initial commit without `go.mod` modification: [use cache](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/442007418) 2dc4d7993d3bcba8a24031126d4eb7db8d87eb71
- Fake update on parent `go.mod`: [create new cache](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/442014827) 3b62c2b75e5c8dea5aaac078d8dc81e019027291
- Append fake update on child `go.mod`: [create new cache](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/442042660) 6e012516fa11a4767e304eb4cf789035487f7968
- Keep only modification on child: [create new cache](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/442053707) 6bcddfc4588bb394e89cb09c8895cc1ec387bcdf
- Revert to initial commit (no `go.mod` modification): [use cache](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/442690168) 2dc4d7993d3bcba8a24031126d4eb7db8d87eb71
