### PR TITLE
usm: map cleaner: Batch deletion fallback

### DIFF
--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -8,10 +8,11 @@
 package ebpf
 
 import (
+	"errors"
 	"sync"
 	"time"
 
-	cebpf "github.com/cilium/ebpf"
+	"github.com/cilium/ebpf"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/maps"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -31,7 +32,7 @@ type MapCleaner[K any, V any] struct {
 }
 
 // NewMapCleaner instantiates a new MapCleaner
-func NewMapCleaner[K any, V any](emap *cebpf.Map, defaultBatchSize uint32) (*MapCleaner[K, V], error) {
+func NewMapCleaner[K any, V any](emap *ebpf.Map, defaultBatchSize uint32) (*MapCleaner[K, V], error) {
 	batchSize := defaultBatchSize
 	if defaultBatchSize > emap.MaxEntries() {
 		batchSize = emap.MaxEntries()
@@ -137,6 +138,14 @@ func (mc *MapCleaner[K, V]) cleanWithBatches(nowTS int64, shouldClean func(nowTS
 	var deletionError error
 	if len(keysToDelete) > 0 {
 		deletedCount, deletionError = mc.emap.BatchDelete(keysToDelete)
+		if errors.Is(deletionError, ebpf.ErrKeyNotExist) {
+			deletionError = nil
+			for _, k := range keysToDelete {
+				if err := mc.emap.Delete(&k); err == nil {
+					deletedCount++
+				}
+			}
+		}
 	}
 
 	elapsed := time.Since(now)

--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -138,6 +138,9 @@ func (mc *MapCleaner[K, V]) cleanWithBatches(nowTS int64, shouldClean func(nowTS
 	var deletionError error
 	if len(keysToDelete) > 0 {
 		deletedCount, deletionError = mc.emap.BatchDelete(keysToDelete)
+		// We might have a partial deletion (as a key might be missing due to other cleaning mechanism), so we want
+		// to have a best-effort method to delete all keys. We cannot know which keys were deleted, so we have to try
+		// and delete all of them one by one.
 		if errors.Is(deletionError, ebpf.ErrKeyNotExist) {
 			deletionError = nil
 			for _, k := range keysToDelete {

--- a/pkg/ebpf/map_cleaner_test.go
+++ b/pkg/ebpf/map_cleaner_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/cihub/seelog"
-	cebpf "github.com/cilium/ebpf"
+	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,105 +30,84 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestMapCleanerWithMissingKey(t *testing.T) {
-	const numMapEntries = 10
-
-	var (
-		key = new(int64)
-		val = new(int64)
-	)
-
-	err := rlimit.RemoveMemlock()
-	require.NoError(t, err)
-
-	m, err := cebpf.NewMap(&cebpf.MapSpec{
-		Type:       cebpf.Hash,
-		KeySize:    8,
-		ValueSize:  8,
-		MaxEntries: numMapEntries,
-	})
-	require.NoError(t, err)
-
-	cleaner, err := NewMapCleaner[int64, int64](m, 5)
-	require.NoError(t, err)
-	for i := 0; i < numMapEntries; i++ {
-		*key = int64(i)
-		err := m.Put(key, val)
-		assert.Nilf(t, err, "can't put key=%d: %s", i, err)
-	}
-
-	// Clean all the even entries
-	cleaner.Clean(100*time.Millisecond, nil, nil, func(now int64, k int64, v int64) bool {
-		// Delete a random key.
-		if k == 4 {
-			m.Delete(&k)
-		}
-		return k%2 == 0
-	})
-
-	time.Sleep(1 * time.Second)
-	cleaner.Stop()
-
-	for i := 0; i < numMapEntries; i++ {
-		*key = int64(i)
-		err := m.Lookup(key, val)
-
-		// If the entry is even, it should have been deleted
-		// otherwise it should be present
-		if i%2 == 0 {
-			assert.NotNilf(t, err, "entry key=%d should not be present", i)
-		} else {
-			assert.Nil(t, err)
-		}
-	}
-}
+type cleanerSignature func(now int64, k int64, v int64) bool
 
 func TestMapCleaner(t *testing.T) {
-	const numMapEntries = 100
-
-	var (
-		key = new(int64)
-		val = new(int64)
-	)
-
-	err := rlimit.RemoveMemlock()
-	require.NoError(t, err)
-
-	m, err := cebpf.NewMap(&cebpf.MapSpec{
-		Type:       cebpf.Hash,
-		KeySize:    8,
-		ValueSize:  8,
-		MaxEntries: numMapEntries,
-	})
-	require.NoError(t, err)
-
-	cleaner, err := NewMapCleaner[int64, int64](m, 10)
-	require.NoError(t, err)
-	for i := 0; i < numMapEntries; i++ {
-		*key = int64(i)
-		err := m.Put(key, val)
-		assert.Nilf(t, err, "can't put key=%d: %s", i, err)
+	tests := []struct {
+		name           string
+		cleanerFactory func(*ebpf.Map) cleanerSignature
+	}{
+		{
+			name: "sanity",
+			cleanerFactory: func(*ebpf.Map) cleanerSignature {
+				return func(now int64, k int64, v int64) bool {
+					return k%2 == 0
+				}
+			},
+		},
+		{
+			name: "key is missing",
+			cleanerFactory: func(e *ebpf.Map) cleanerSignature {
+				return func(now int64, k int64, v int64) bool {
+					// Delete a random key.
+					if k == 4 {
+						e.Delete(&k)
+					}
+					return k%2 == 0
+				}
+			},
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const numMapEntries = 100
+			const cleanerInterval = 100 * time.Millisecond
 
-	// Clean all the even entries
-	cleaner.Clean(100*time.Millisecond, nil, nil, func(now int64, k int64, v int64) bool {
-		return k%2 == 0
-	})
+			var (
+				key = new(int64)
+				val = new(int64)
+			)
 
-	time.Sleep(1 * time.Second)
-	cleaner.Stop()
+			require.NoError(t, rlimit.RemoveMemlock())
 
-	for i := 0; i < numMapEntries; i++ {
-		*key = int64(i)
-		err := m.Lookup(key, val)
+			m, err := ebpf.NewMap(&ebpf.MapSpec{
+				Type:       ebpf.Hash,
+				KeySize:    8,
+				ValueSize:  8,
+				MaxEntries: numMapEntries,
+			})
+			require.NoError(t, err)
 
-		// If the entry is even, it should have been deleted
-		// otherwise it should be present
-		if i%2 == 0 {
-			assert.NotNilf(t, err, "entry key=%d should not be present", i)
-		} else {
-			assert.Nil(t, err)
-		}
+			cleaner, err := NewMapCleaner[int64, int64](m, 10)
+			require.NoError(t, err)
+			for i := 0; i < numMapEntries; i++ {
+				*key = int64(i)
+				err := m.Put(key, val)
+				assert.Nilf(t, err, "can't put key=%d: %s", i, err)
+			}
+
+			// Clean all the even entries
+			cleaner.Clean(cleanerInterval, nil, nil, func(now int64, k int64, v int64) bool {
+				return k%2 == 0
+			})
+
+			// Giving some time to the cleaner to do its job.
+			time.Sleep(3 * cleanerInterval)
+			cleaner.Stop()
+
+			for i := 0; i < numMapEntries; i++ {
+				*key = int64(i)
+				err := m.Lookup(key, val)
+
+				// If the entry is even, it should have been deleted
+				// otherwise it should be present
+				if i%2 == 0 {
+					assert.NotNilf(t, err, "entry key=%d should not be present", i)
+				} else {
+					assert.Nil(t, err)
+				}
+			}
+		})
 	}
 }
 
@@ -141,8 +120,8 @@ func benchmarkBatchCleaner(b *testing.B, numMapEntries, batchSize uint32) {
 	err := rlimit.RemoveMemlock()
 	require.NoError(b, err)
 
-	m, err := cebpf.NewMap(&cebpf.MapSpec{
-		Type:       cebpf.Hash,
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Hash,
 		KeySize:    8,
 		ValueSize:  8,
 		MaxEntries: numMapEntries,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Added a fallback mechanism to a element by element deletion if the BatchDelete fails with KeyDoesNotExist error.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
If a single key does not exist in the map, and we try to delete it using BatchDelete, the operation will fail with error KeyDoesNotExist, and we might partially delete the entries in the map.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
