### PR TITLE
[CSPM] K8s: rely on user.Current() to fix tests checking for bad UID

### DIFF
--- a/pkg/compliance/k8sconfig/loader_test.go
+++ b/pkg/compliance/k8sconfig/loader_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"io/fs"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -736,19 +737,21 @@ func TestKubAksConfigLoader(t *testing.T) {
 		webhook := "Webhook"
 		assert.Equal(t, &webhook, conf.Components.Kubelet.AuthorizationMode)
 
-		assert.NotNil(t, conf.Components.Kubelet.ClientCaFile)
-		assert.Equal(t, "root", conf.Components.Kubelet.ClientCaFile.User)
-		assert.Equal(t, "root", conf.Components.Kubelet.ClientCaFile.Group)
+		user, err := user.Current()
+		assert.NoError(t, err)
+
+		assert.Equal(t, user.Name, conf.Components.Kubelet.ClientCaFile.User)
+		assert.Equal(t, user.Name, conf.Components.Kubelet.ClientCaFile.Group)
 		assert.Equal(t, uint32(0644), conf.Components.Kubelet.ClientCaFile.Mode)
 
 		assert.NotNil(t, conf.Components.Kubelet.TlsCertFile)
-		assert.Equal(t, "root", conf.Components.Kubelet.TlsCertFile.User)
-		assert.Equal(t, "root", conf.Components.Kubelet.TlsCertFile.Group)
+		assert.Equal(t, user.Name, conf.Components.Kubelet.TlsCertFile.User)
+		assert.Equal(t, user.Name, conf.Components.Kubelet.TlsCertFile.Group)
 		assert.Equal(t, uint32(0600), conf.Components.Kubelet.TlsCertFile.Mode)
 
 		assert.NotNil(t, conf.Components.Kubelet.TlsPrivateKeyFile)
-		assert.Equal(t, "root", conf.Components.Kubelet.TlsPrivateKeyFile.User)
-		assert.Equal(t, "root", conf.Components.Kubelet.TlsPrivateKeyFile.Group)
+		assert.Equal(t, user.Name, conf.Components.Kubelet.TlsPrivateKeyFile.User)
+		assert.Equal(t, user.Name, conf.Components.Kubelet.TlsPrivateKeyFile.Group)
 		assert.Equal(t, uint32(0600), conf.Components.Kubelet.TlsPrivateKeyFile.Mode)
 
 		assert.NotEmpty(t, conf.Components.Kubelet.TlsCipherSuites)


### PR DESCRIPTION
### What does this PR do?

Make tests of k8sconfig more robust and work properly when not running as root.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
