### PR TITLE
use conductor to drive our nightly pipelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@
 /setup.cfg                              @DataDog/agent-platform
 /repository.datadog.yml                 @DataDog/agent-platform
 /generate_tools.go                      @DataDog/agent-platform
+/service.datadog.yaml                   @DataDog/agent-platform
 
 /.circleci/                             @DataDog/agent-platform
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,7 +34,7 @@
 /setup.cfg                              @DataDog/agent-platform
 /repository.datadog.yml                 @DataDog/agent-platform
 /generate_tools.go                      @DataDog/agent-platform
-/service.datadog.yaml                   @DataDog/agent-platform
+/service.datadog.yaml                   @DataDog/agent-build-and-releases
 
 /.circleci/                             @DataDog/agent-platform
 

--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -1,0 +1,15 @@
+---
+schema-version: v2
+dd-service: datadog-agent-nightly
+
+extensions:
+  datadoghq.com/sdp:
+    workday_team: "Agent Platform"
+    conductor:
+      slack: "datadog-agent-pipelines"
+      schedule: "0 3 3 * * 1-5"
+      parameterized_deployment:
+        workflow_generator: ""
+      env:
+        - name: "staging"
+          branch: "chouquette/conductor"

--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -7,7 +7,7 @@ extensions:
     workday_team: "Agent Platform"
     conductor:
       slack: "datadog-agent-pipelines"
-      schedule: "0 3 3 * * 1-5"
+      schedule: "0 3 * * 1-5"
       parameterized_deployment:
         workflow_generator: ""
       env:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR introduces a configuration for conductor, in order to drive our nightly pipelines through that tool.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We currently have 2 nightly pipelines that essentially do the same thing,
One is ran from the `k8s-datadog-agent-ops` repo, the other one from `datadog-agent`.

The k8s deployment now need to run through conductor, which is why the duplicated job was introduced initially.
If the datadog-agent nightly pipelines start though conductor, the k8s pipeline will no longer be needed.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
