### PR TITLE
[ASCII-1594] Remove pkg/util/containers/metrics dependency from serverless build

### DIFF
--- a/comp/dogstatsd/listeners/uds_linux.go
+++ b/comp/dogstatsd/listeners/uds_linux.go
@@ -20,7 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/replay"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
-	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
@@ -129,7 +129,7 @@ func entityForPID(pid int32, capture bool, wmeta optional.Option[workloadmeta.Co
 		return state.ContainerIDForPID(pid)
 	}
 
-	cID, err := metrics.GetProvider(wmeta).GetMetaCollector().GetContainerIDForPID(int(pid), pidToEntityCacheDuration)
+	cID, err := provider.GetProvider(wmeta).GetMetaCollector().GetContainerIDForPID(int(pid), pidToEntityCacheDuration)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Remove `pkg/util/containers/metrics` packages from the serverless build.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Remove unused dependencies from serverless agent, in order to reduce init time duration and reduce binary size.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
There should be no functional change.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
