### PR TITLE
usm: kafka: Remove redundant use case to for runtime compilation in kernels before 4.7

### DIFF
--- a/pkg/network/ebpf/c/protocols/kafka/maps.h
+++ b/pkg/network/ebpf/c/protocols/kafka/maps.h
@@ -6,29 +6,7 @@
 #include "protocols/kafka/defs.h"
 #include "protocols/kafka/types.h"
 
-// LINUX_VERSION_CODE doesn't work with co-re and is relevant to runtime compilation only
-#ifdef COMPILE_RUNTIME
-    // Kernels before 4.7 do not know about per-cpu array maps.
-    #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
-        // A per-cpu buffer used to read requests fragments during protocol
-        // classification and avoid allocating a buffer on the stack. Some protocols
-        // requires us to read at offset that are not aligned. Such reads are forbidden
-        // if done on the stack and will make the verifier complain about it, but they
-        // are allowed on map elements, hence the need for this map.
-        BPF_PERCPU_ARRAY_MAP(kafka_client_id, char [CLIENT_ID_SIZE_TO_VALIDATE], 1)
-        BPF_PERCPU_ARRAY_MAP(kafka_topic_name, char [TOPIC_NAME_MAX_STRING_SIZE_TO_VALIDATE], 1)
-    #else
-        // Kernels < 4.7.0 do not know about the per-cpu array map used
-        // in classification, preventing the program to load even though
-        // we won't use it. We change the type to a simple array map to
-        // circumvent that.
-        BPF_ARRAY_MAP(kafka_client_id, __u32, 1)
-        BPF_ARRAY_MAP(kafka_topic_name, __u32, 1)
-    #endif
-
-#else
-    BPF_PERCPU_ARRAY_MAP(kafka_client_id, char [CLIENT_ID_SIZE_TO_VALIDATE], 1)
-    BPF_PERCPU_ARRAY_MAP(kafka_topic_name, char [TOPIC_NAME_MAX_STRING_SIZE_TO_VALIDATE], 1)
-#endif
+BPF_PERCPU_ARRAY_MAP(kafka_client_id, char [CLIENT_ID_SIZE_TO_VALIDATE], 1)
+BPF_PERCPU_ARRAY_MAP(kafka_topic_name, char [TOPIC_NAME_MAX_STRING_SIZE_TO_VALIDATE], 1)
 
 #endif


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

In runtime compilation on kernels older than 4.7, we declared different type of maps for kafka_client_id and kafka_topic_name, as percpu array did not exsit. 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
USM cannot run on kernels before 4.14, we don't need that define
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
