### PR TITLE
[CONTINT-3869] Mark the container image test as flaky

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -767,6 +767,8 @@ func (suite *k8sSuite) TestAdmissionController() {
 }
 
 func (suite *k8sSuite) TestContainerImage() {
+	// TODO: https://datadoghq.atlassian.net/browse/CONTINT-3869
+	suite.T().Skip("CONTINT-3869: ContainerImage test is flaky")
 	suite.EventuallyWithTf(func(c *assert.CollectT) {
 		images, err := suite.Fakeintake.FilterContainerImages("ghcr.io/datadog/apps-nginx-server")
 		// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged


### PR DESCRIPTION
### What does this PR do?
This PR marks the container image test as flaky on kind.

### Motivation
The test is passing on eks but not on kind. It appears to be flaky and we still need to determine the root cause. Manual QA shows that the container image check is working as expected
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
