### PR TITLE
[ASCII-1196] Fix agent status text and json output

### DIFF
--- a/comp/metadata/host/hostimpl/host_test.go
+++ b/comp/metadata/host/hostimpl/host_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
+	"golang.org/x/exp/maps"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
@@ -130,7 +131,12 @@ func TestStatusHeaderProvider(t *testing.T) {
 			stats := make(map[string]interface{})
 			headerStatusProvider.JSON(false, stats)
 
-			assert.NotEmpty(t, stats)
+			keys := maps.Keys(stats)
+
+			assert.Contains(t, keys, "hostnameStats")
+			assert.Contains(t, keys, "hostTags")
+			assert.Contains(t, keys, "hostinfo")
+			assert.Contains(t, keys, "metadata")
 		}},
 		{"Text", func(t *testing.T) {
 			b := new(bytes.Buffer)

--- a/comp/metadata/host/hostimpl/status.go
+++ b/comp/metadata/host/hostimpl/status.go
@@ -43,15 +43,13 @@ func (h *host) populateStatus(stats map[string]interface{}) {
 	json.Unmarshal(hostnameStatsJSON, &hostnameStats) //nolint:errcheck
 	stats["hostnameStats"] = hostnameStats
 
-	ctx := context.Background()
+	payload := utils.GetFromCache(context.TODO(), h.config)
+	metadataStats := make(map[string]interface{})
+	payloadBytes, _ := json.Marshal(payload)
 
-	payload := h.getPayload(ctx)
-	metaStats := make(map[string]interface{})
-	metaBytes, _ := json.Marshal(payload.Meta)
+	json.Unmarshal(payloadBytes, &metadataStats) //nolint:errcheck
 
-	json.Unmarshal(metaBytes, &metaStats) //nolint:errcheck
-
-	stats["meta"] = metaStats
+	stats["metadata"] = metadataStats
 
 	hostTags := make([]string, 0, len(payload.HostTags.System)+len(payload.HostTags.GoogleCloudPlatform))
 	hostTags = append(hostTags, payload.HostTags.System...)

--- a/comp/metadata/host/hostimpl/status_templates/host.tmpl
+++ b/comp/metadata/host/hostimpl/status_templates/host.tmpl
@@ -1,4 +1,4 @@
-{{- range $name, $value := .meta -}}
+{{- range $name, $value := .metadata.meta -}}
   {{- if and (ne $name "timezones") ($value) }}
   {{$name}}: {{$value}}
   {{- end }}

--- a/comp/metadata/host/hostimpl/status_templates/hostHTML.tmpl
+++ b/comp/metadata/host/hostimpl/status_templates/hostHTML.tmpl
@@ -21,7 +21,7 @@
 <div class="stat">
   <span class="stat_title">Hostnames</span>
   <span class="stat_data">
-    {{- range $type, $value := .meta -}}
+    {{- range $type, $value := .metadata.meta -}}
       {{- if ne $type "timezones" -}}
         {{- if $value}}
           {{formatTitle $type}}: {{$value -}}<br>

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"go.uber.org/fx"
+	"golang.org/x/exp/maps"
 
 	"github.com/stretchr/testify/assert"
 
@@ -277,7 +278,9 @@ func TestStatusHeaderProvider(t *testing.T) {
 			stats := make(map[string]interface{})
 			headerStatusProvider.JSON(false, stats)
 
-			assert.NotEmpty(t, stats)
+			keys := maps.Keys(stats)
+
+			assert.Contains(t, keys, "agent_metadata")
 		}},
 		{"Text", func(t *testing.T) {
 			b := new(bytes.Buffer)

--- a/comp/metadata/inventoryagent/inventoryagentimpl/status.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/status.go
@@ -27,19 +27,29 @@ func (ia *inventoryagent) Index() int {
 
 // JSON populates the status map
 func (ia *inventoryagent) JSON(_ bool, stats map[string]interface{}) error {
-	for k, v := range ia.Get() {
-		stats[k] = v
-	}
+	ia.populateStatus(stats)
 
 	return nil
 }
 
 // Text renders the text output
 func (ia *inventoryagent) Text(_ bool, buffer io.Writer) error {
-	return status.RenderText(templatesFS, "inventory.tmpl", buffer, ia.Get())
+	return status.RenderText(templatesFS, "inventory.tmpl", buffer, ia.getStatusInfo())
 }
 
 // HTML renders the html output
 func (ia *inventoryagent) HTML(_ bool, buffer io.Writer) error {
-	return status.RenderHTML(templatesFS, "inventoryHTML.tmpl", buffer, ia.Get())
+	return status.RenderHTML(templatesFS, "inventoryHTML.tmpl", buffer, ia.getStatusInfo())
+}
+
+func (ia *inventoryagent) populateStatus(stats map[string]interface{}) {
+	stats["agent_metadata"] = ia.Get()
+}
+
+func (ia *inventoryagent) getStatusInfo() map[string]interface{} {
+	stats := make(map[string]interface{})
+
+	ia.populateStatus(stats)
+
+	return stats
 }

--- a/comp/metadata/inventoryagent/inventoryagentimpl/status_templates/inventory.tmpl
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/status_templates/inventory.tmpl
@@ -1,3 +1,3 @@
-{{- range $key, $value := . }}
+{{- range $key, $value := .agent_metadata }}
   {{ $key }}: {{ $value }}
 {{- end }}

--- a/comp/metadata/inventoryagent/inventoryagentimpl/status_templates/inventoryHTML.tmpl
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/status_templates/inventoryHTML.tmpl
@@ -1,7 +1,7 @@
 <div class="stat">
   <span class="stat_title">Metadata</span>
   <span class="stat_data">
-  {{- range $key, $value := . }}
+  {{- range $key, $value := .agent_metadata }}
     {{ $key }}: {{ $value }}<br>
   {{- end }}
   </span>

--- a/pkg/status/httpproxy/status_templates/http.tmpl
+++ b/pkg/status/httpproxy/status_templates/http.tmpl
@@ -22,4 +22,6 @@
       {{ . }}
     {{- end }}
   {{- end }}
+{{- else }}
+  No Transport Proxy Warnings
 {{- end }}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

During the QA week we found a few irregularities on the agent status output. The original change was introduced in this PR https://github.com/DataDog/datadog-agent/pull/22115

This PR fixes the issues with the JSON output that was missing a few keys. Also, adds a `No Transport Proxy Warnings` text in the http proxy section in the case of no warnings.
![image](https://github.com/DataDog/datadog-agent/assets/4672858/1c48dd83-6120-47e8-9cd4-59ade7f102e5)


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Detail explanation on how to QA are provided on https://github.com/DataDog/datadog-agent/pull/22115 QA section.

I few notes:
- Check Runners: <int> is no longer present in the text output 
- System time: <Timestamp> is no longer present in the text output. 
- Verbose: <Bool> is no longer present in the text and JSON output. 
- complianceChecks is no longer present in the JSON output. That is only present in the security agent 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
