### PR TITLE
[updater] Make bootstrap work

### DIFF
--- a/omnibus/config/projects/updater.rb
+++ b/omnibus/config/projects/updater.rb
@@ -114,6 +114,7 @@ if linux_target?
   extra_package_file "#{systemd_directory}/stop-experiment.path"
   extra_package_file '/etc/datadog-agent/'
   extra_package_file '/var/log/datadog/'
+  extra_package_file '/var/run/datadog-packages'
   extra_package_file '/opt/datadog-packages/'
 end
 

--- a/omnibus/config/projects/updater.rb
+++ b/omnibus/config/projects/updater.rb
@@ -114,7 +114,7 @@ if linux_target?
   extra_package_file "#{systemd_directory}/stop-experiment.path"
   extra_package_file '/etc/datadog-agent/'
   extra_package_file '/var/log/datadog/'
-  extra_package_file '/var/run/datadog-packages'
+  extra_package_file '/var/run/datadog-packages/'
   extra_package_file '/opt/datadog-packages/'
 end
 

--- a/omnibus/config/software/updater.rb
+++ b/omnibus/config/software/updater.rb
@@ -45,6 +45,7 @@ build do
     move "bin/agent/dist/conf.d", "#{etc_dir}/conf.d"
     move "bin/agent/dist/system-probe.yaml", "#{etc_dir}/system-probe.yaml.example"
     move "bin/agent/dist/security-agent.yaml", "#{etc_dir}/security-agent.yaml.example"
+    mkdir "/var/run/datadog-packages"
 
     # Packages
     mkdir "/opt/datadog-packages"
@@ -57,26 +58,39 @@ build do
       mkdir "/usr/lib/systemd/system/"
       systemdPath = "/usr/lib/systemd/system/"
     end
+
+    # Add systemd units
     templateToFile = {
       "datadog-agent.service.erb" => "datadog-agent.service",
-      "datadog-agent-exp.service.erb" => "datadog-agent-exp.service",
       "datadog-agent-trace.service.erb" => "datadog-agent-trace.service",
-      "datadog-agent-trace-exp.service.erb" => "datadog-agent-trace-exp.service",
       "datadog-agent-process.service.erb" => "datadog-agent-process.service",
-      "datadog-agent-process-exp.service.erb" => "datadog-agent-process-exp.service",
       "datadog-agent-security.service.erb" => "datadog-agent-security.service",
-      "datadog-agent-security-exp.service.erb" => "datadog-agent-security-exp.service",
       "datadog-agent-sysprobe.service.erb" => "datadog-agent-sysprobe.service",
-      "datadog-agent-sysprobe-exp.service.erb" => "datadog-agent-sysprobe-exp.service",
       "start-experiment.path.erb" => "start-experiment.path",
       "stop-experiment.path.erb" => "stop-experiment.path",
       "datadog-updater.service.erb" => "datadog-updater.service",
     }
     templateToFile.each do |template, file|
+      agent_dir = "/opt/datadog-packages/datadog-agent/stable"
       erb source: template,
          dest: systemdPath + file,
          mode: 0644,
-         vars: { install_dir: install_dir, etc_dir: etc_dir }
+         vars: { install_dir: install_dir, etc_dir: etc_dir, agent_dir: agent_dir }
+    end
+    # Add experiment systemd units
+    expTemplateToFile = {
+      "datadog-agent-exp.service.erb" => "datadog-agent-exp.service",
+      "datadog-agent-trace-exp.service.erb" => "datadog-agent-trace-exp.service",
+      "datadog-agent-process-exp.service.erb" => "datadog-agent-process-exp.service",
+      "datadog-agent-security-exp.service.erb" => "datadog-agent-security-exp.service",
+      "datadog-agent-sysprobe-exp.service.erb" => "datadog-agent-sysprobe-exp.service",
+    }
+    expTemplateToFile.each do |template, file|
+      agent_dir = "/opt/datadog-packages/datadog-agent/experiment"
+      erb source: template,
+         dest: systemdPath + file,
+         mode: 0644,
+         vars: { etc_dir: etc_dir, agent_dir: agent_dir }
     end
 
   end

--- a/omnibus/config/software/updater.rb
+++ b/omnibus/config/software/updater.rb
@@ -59,7 +59,7 @@ build do
       systemdPath = "/usr/lib/systemd/system/"
     end
 
-    # Add systemd units
+    # Add stable systemd units
     templateToFile = {
       "datadog-agent.service.erb" => "datadog-agent.service",
       "datadog-agent-trace.service.erb" => "datadog-agent-trace.service",

--- a/omnibus/config/templates/updater/datadog-agent-exp.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-exp.service.erb
@@ -15,7 +15,6 @@ EnvironmentFile=-<%= etc_dir %>/environment
 ExecStart=<%= agent_dir %>/bin/agent/agent run -p <%= agent_dir %>/run/agent.pid
 ExecStart=<%= agent_dir %>/bin/agent/agent run -p <%= agent_dir %>/run/agent.pid
 ExecStart=<%= agent_dir %>/bin/agent/agent run -p <%= agent_dir %>/run/agent.pid
-ExecStart=<%= agent_dir %>/agent_entrypoints/experiment_agent/agent run -p <%= agent_dir %>/run/agent.pid
 ExecStart=/bin/false
 ExecStop=/bin/false
 

--- a/omnibus/config/templates/updater/datadog-agent-exp.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-exp.service.erb
@@ -9,12 +9,13 @@ Wants=datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-
 
 [Service]
 Type=oneshot
-PIDFile=<%= install_dir %>/run/agent.pid
+PIDFile=<%= agent_dir %>/run/agent.pid
 User=dd-agent
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/agent run -p <%= install_dir %>/run/agent.pid
-ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/agent run -p <%= install_dir %>/run/agent.pid
-ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/agent run -p <%= install_dir %>/run/agent.pid
+ExecStart=<%= agent_dir %>/bin/agent/agent run -p <%= agent_dir %>/run/agent.pid
+ExecStart=<%= agent_dir %>/bin/agent/agent run -p <%= agent_dir %>/run/agent.pid
+ExecStart=<%= agent_dir %>/bin/agent/agent run -p <%= agent_dir %>/run/agent.pid
+ExecStart=<%= agent_dir %>/agent_entrypoints/experiment_agent/agent run -p <%= agent_dir %>/run/agent.pid
 ExecStart=/bin/false
 ExecStop=/bin/false
 

--- a/omnibus/config/templates/updater/datadog-agent-process-exp.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-process-exp.service.erb
@@ -5,11 +5,11 @@ BindsTo=datadog-agent-exp.service
 
 [Service]
 Type=simple
-PIDFile=<%= install_dir %>/run/process-agent.pid
+PIDFile=<%= agent_dir %>/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/embedded/bin/process-agent --cfgpath=<%= etc_dir %>/datadog.yaml --sysprobe-config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/process-agent.pid
+ExecStart=<%= agent_dir %>/embedded/bin/process-agent --cfgpath=<%= etc_dir %>/datadog.yaml --sysprobe-config=<%= etc_dir %>/system-probe.yaml --pid=<%= agent_dir %>/run/process-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10

--- a/omnibus/config/templates/updater/datadog-agent-process.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-process.service.erb
@@ -5,11 +5,11 @@ BindsTo=datadog-agent.service
 
 [Service]
 Type=simple
-PIDFile=<%= install_dir %>/run/process-agent.pid
+PIDFile=<%= agent_dir %>/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= install_dir %>/agent_entrypoints/agent/embedded/bin/process-agent --cfgpath=<%= etc_dir %>/datadog.yaml --sysprobe-config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/process-agent.pid
+ExecStart=<%= agent_dir %>/embedded/bin/process-agent --cfgpath=<%= etc_dir %>/datadog.yaml --sysprobe-config=<%= etc_dir %>/system-probe.yaml --pid=<%= agent_dir %>/run/process-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10

--- a/omnibus/config/templates/updater/datadog-agent-security-exp.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-security-exp.service.erb
@@ -6,10 +6,10 @@ ConditionPathExists=<%= etc_dir %>/security-agent.yaml
 
 [Service]
 Type=simple
-PIDFile=<%= install_dir %>/run/security-agent.pid
+PIDFile=<%= agent_dir %>/run/security-agent.pid
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/embedded/bin/security-agent -c <%= etc_dir %>/datadog.yaml --pidfile <%= install_dir %>/run/security-agent.pid
+ExecStart=<%= agent_dir %>/embedded/bin/security-agent -c <%= etc_dir %>/datadog.yaml --pidfile <%= agent_dir %>/run/security-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10

--- a/omnibus/config/templates/updater/datadog-agent-security.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-security.service.erb
@@ -6,10 +6,10 @@ ConditionPathExists=<%= etc_dir %>/security-agent.yaml
 
 [Service]
 Type=simple
-PIDFile=<%= install_dir %>/run/security-agent.pid
+PIDFile=<%= agent_dir %>/run/security-agent.pid
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= install_dir %>/agent_entrypoints/agent/embedded/bin/security-agent -c <%= etc_dir %>/datadog.yaml --pidfile <%= install_dir %>/run/security-agent.pid
+ExecStart=<%= agent_dir %>/embedded/bin/security-agent -c <%= etc_dir %>/datadog.yaml --pidfile <%= agent_dir %>/run/security-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10

--- a/omnibus/config/templates/updater/datadog-agent-sysprobe-exp.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-sysprobe-exp.service.erb
@@ -8,9 +8,9 @@ ConditionPathExists=<%= etc_dir %>/system-probe.yaml
 
 [Service]
 Type=simple
-PIDFile=<%= install_dir %>/run/system-probe.pid
+PIDFile=<%= agent_dir %>/run/system-probe.pid
 Restart=on-failure
-ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/embedded/bin/system-probe run --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid
+ExecStart=<%= agent_dir %>/embedded/bin/system-probe run --config=<%= etc_dir %>/system-probe.yaml --pid=<%= agent_dir %>/run/system-probe.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10

--- a/omnibus/config/templates/updater/datadog-agent-sysprobe.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-sysprobe.service.erb
@@ -8,9 +8,9 @@ ConditionPathExists=<%= etc_dir %>/system-probe.yaml
 
 [Service]
 Type=simple
-PIDFile=<%= install_dir %>/run/system-probe.pid
+PIDFile=<%= agent_dir %>/run/system-probe.pid
 Restart=on-failure
-ExecStart=<%= install_dir %>/agent_entrypoints/agent/embedded/bin/system-probe run --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid
+ExecStart=<%= agent_dir %>/embedded/bin/system-probe run --config=<%= etc_dir %>/system-probe.yaml --pid=<%= agent_dir %>/run/system-probe.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10

--- a/omnibus/config/templates/updater/datadog-agent-trace-exp.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-trace-exp.service.erb
@@ -4,11 +4,11 @@ BindsTo=datadog-agent-exp.service
 
 [Service]
 Type=simple
-PIDFile=<%= install_dir %>/run/trace-agent.pid
+PIDFile=<%= agent_dir %>/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= install_dir %>/agent_entrypoints/experiment_agent/embedded/bin/trace-agent --config <%= etc_dir %>/datadog.yaml --pidfile <%= install_dir %>/run/trace-agent.pid
+ExecStart=<%= agent_dir %>/embedded/bin/trace-agent --config <%= etc_dir %>/datadog.yaml --pidfile <%= agent_dir %>/run/trace-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10

--- a/omnibus/config/templates/updater/datadog-agent-trace.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent-trace.service.erb
@@ -5,11 +5,11 @@ BindsTo=datadog-agent.service
 
 [Service]
 Type=simple
-PIDFile=<%= install_dir %>/run/trace-agent.pid
+PIDFile=<%= agent_dir %>/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= install_dir %>/agent_entrypoints/agent/embedded/bin/trace-agent --config <%= etc_dir %>/datadog.yaml --pidfile <%= install_dir %>/run/trace-agent.pid
+ExecStart=<%= agent_dir %>/embedded/bin/trace-agent --config <%= etc_dir %>/datadog.yaml --pidfile <%= agent_dir %>/run/trace-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10

--- a/omnibus/config/templates/updater/datadog-agent.service.erb
+++ b/omnibus/config/templates/updater/datadog-agent.service.erb
@@ -7,11 +7,11 @@ Before=datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog
 
 [Service]
 Type=simple
-PIDFile=<%= install_dir %>/run/agent.pid
+PIDFile=<%= agent_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= install_dir %>/agent_entrypoints/agent/agent run -p <%= install_dir %>/run/agent.pid
+ExecStart=<%= agent_dir %>/bin/agent/agent run -p <%= agent_dir %>/run/agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10

--- a/omnibus/config/templates/updater/datadog-updater.service.erb
+++ b/omnibus/config/templates/updater/datadog-updater.service.erb
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 PIDFile=<%= install_dir %>/run/updater.pid
-User=dd-updater
+User=dd-agent
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
 ExecStart=<%= install_dir %>/bin/updater/updater run -p <%= install_dir %>/run/updater.pid

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -7,6 +7,7 @@
 INSTALL_DIR=/opt/datadog
 PACKAGES_DIR=/opt/datadog-packages
 LOG_DIR=/var/log/datadog
+PACKAGES_LOCK_DIR=/var/run/datadog-packages
 CONFIG_DIR=/etc/datadog-agent
 
 add_user_and_group() {
@@ -45,9 +46,7 @@ enable_stable_agents() {
 set -e
 case "$1" in
     configure)
-        add_user_and_group 'dd-agent' $INSTALL_DIR/agents
-        add_user_and_group 'dd-updater' $INSTALL_DIR
-        usermod -g dd-agent dd-updater
+        add_user_and_group 'dd-agent' $PACKAGES_DIR/datadog-agent
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;
@@ -81,11 +80,11 @@ fi
 # Set proper rights to the dd-agent user
 chown -R dd-agent:dd-agent ${CONFIG_DIR}
 chown -R dd-agent:dd-agent ${LOG_DIR}
-chown -R dd-updater:dd-updater ${INSTALL_DIR}
-chown -R dd-updater:dd-updater ${PACKAGES_DIR}
-
-chmod -R 755 ${INSTALL_DIR}
+chown -R dd-agent:dd-agent ${INSTALL_DIR}
+chown -R dd-agent:dd-agent ${PACKAGES_DIR}
+chown -R dd-agent:dd-agent ${PACKAGES_LOCK_DIR}
 chmod -R 755 ${PACKAGES_DIR}
+chown -R 666 ${PACKAGES_LOCK_DIR}
 
 # Make system-probe configs read-only
 chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true
@@ -107,9 +106,15 @@ if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
     chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
 fi
 
+echo "api_key: 00000000000000000000000000000000" > $CONFIG_DIR/datadog.yaml # todo remove this once in install script
+$INSTALL_DIR/updater/bin/updater/updater bootstrap -P datadog-agent
+# Bootstrap installs first agent with root ownership, overriding to dd-agent
+chown -R dd-agent:dd-agent ${PACKAGES_DIR}
+
 # start udpater
 SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-updater || true
 SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-updater || true
 enable_stable_agents
+SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-agent || true
 
 exit 0

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -84,6 +84,8 @@ chown -R dd-agent:dd-agent ${INSTALL_DIR}
 chown -R dd-agent:dd-agent ${PACKAGES_DIR}
 chown -R dd-agent:dd-agent ${PACKAGES_LOCK_DIR}
 chmod -R 755 ${PACKAGES_DIR}
+# Lock_dir is world writable as any application with a tracer injected
+# needs to write the PID
 chown -R 666 ${PACKAGES_LOCK_DIR}
 
 # Make system-probe configs read-only

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -106,7 +106,11 @@ if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
     chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
 fi
 
-echo "api_key: 00000000000000000000000000000000" > $CONFIG_DIR/datadog.yaml # todo remove this once in install script
+# todo remove this once in install script
+# a datadog.yaml file with an api_key is required for the agent bootstrap below
+if [ ! -f "$CONFIG_DIR/datadog.yaml" ]; then
+    echo "api_key: 00000000000000000000000000000000" > "$CONFIG_DIR/datadog.yaml"
+fi
 $INSTALL_DIR/updater/bin/updater/updater bootstrap -P datadog-agent
 # Bootstrap installs first agent with root ownership, overriding to dd-agent
 chown -R dd-agent:dd-agent ${PACKAGES_DIR}

--- a/omnibus/package-scripts/updater-deb/postrm
+++ b/omnibus/package-scripts/updater-deb/postrm
@@ -8,6 +8,7 @@ INSTALL_DIR=/opt/datadog
 PACKAGES_DIR=/opt/datadog-packages
 LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
+PACKAGES_LOCK_DIR=/var/run/datadog-packages
 
 set -e
 
@@ -15,17 +16,14 @@ case "$1" in
     purge)
         echo "Deleting dd-agent user"
         deluser dd-agent --quiet
-        echo "Deleting dd-updater user"
-        deluser dd-updater --quiet
         echo "Deleting dd-agent group"
         (getent group dd-agent >/dev/null && delgroup dd-agent --quiet) || true
-        echo "Deleting dd-updater group"
-        (getent group dd-updater >/dev/null && delgroup dd-updater --quiet) || true
         echo "Force-deleting $INSTALL_DIR"
         rm -rf $INSTALL_DIR
         rm -rf $LOG_DIR
         rm -rf $CONFIG_DIR
         rm -rf $PACKAGES_DIR
+        rm -rf $PACKAGES_LOCK_DIR
     ;;
     remove)
         rm "$CONFIG_DIR/install_info" || true

--- a/test/new-e2e/tests/updater/linux_test.go
+++ b/test/new-e2e/tests/updater/linux_test.go
@@ -30,11 +30,11 @@ func TestUpdaterSuite(t *testing.T) {
 
 func (v *vmUpdaterSuite) TestUpdaterOwnership() {
 	// updater user exists and is a system user
-	require.Equal(v.T(), "/usr/sbin/nologin\n", v.Env().RemoteHost.MustExecute(`getent passwd dd-updater | cut -d: -f7`), "unexpected: user does not exist or is not a system user")
+	require.Equal(v.T(), "/usr/sbin/nologin\n", v.Env().RemoteHost.MustExecute(`getent passwd dd-agent | cut -d: -f7`), "unexpected: user does not exist or is not a system user")
 	// owner
-	require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(`stat -c "%U" /opt/datadog/updater`))
+	require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(`stat -c "%U" /opt/datadog/updater`))
 	// group
-	require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(`stat -c "%G" /opt/datadog/updater`))
+	require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(`stat -c "%G" /opt/datadog/updater`))
 	// permissions
 	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" /opt/datadog/updater`))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Agent bootstraps with updater installation 🎉 

Changes made
- fixes to systemd units to match new paths
- sunset dd-updater user and move all to dd-agent. File ownership with 2 non root users is foot-gunny and required to revisit file creation from the agent
- add /var/run/datadog-packages
- launch boot command in postinst
- temp hack of writing a default datadog.yaml, will remove once updater gets in install script

Install works on fresh host
```
test-infra-definitions $ invoke create-vm -i -o=ubuntu --install-updater --pipeline-id=28959642 --architecture=arm64
ubuntu@TEST_IP~$ sudo systemctl status datadog-agent
● datadog-agent.service - Datadog Agent
     Loaded: loaded (/lib/systemd/system/datadog-agent.service; enabled; vendor pre>
     Active: active (running) since Mon 2024-02-26 20:48:03 UTC; 49s ago
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
