### PR TITLE
[SLVS-4017][serverless-init] Fix incorrect `_dd.origin` tag for Azure + GCP serverless services

### DIFF
--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	revisionNameEnvVar = "K_REVISION"
-	serviceNameEnvVar  = "K_SERVICE"
+	ServiceNameEnvVar  = "K_SERVICE"
 )
 
 var metadataHelperFunc = helper.GetMetaData
@@ -26,7 +26,7 @@ func (c *CloudRun) GetTags() map[string]string {
 	tags := metadataHelperFunc(helper.GetDefaultConfig()).TagMap()
 
 	revisionName := os.Getenv(revisionNameEnvVar)
-	serviceName := os.Getenv(serviceNameEnvVar)
+	serviceName := os.Getenv(ServiceNameEnvVar)
 
 	if revisionName != "" {
 		tags["revision_name"] = revisionName
@@ -60,6 +60,6 @@ func (c *CloudRun) Init() error {
 }
 
 func isCloudRunService() bool {
-	_, exists := os.LookupEnv(serviceNameEnvVar)
+	_, exists := os.LookupEnv(ServiceNameEnvVar)
 	return exists
 }

--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -13,7 +13,8 @@ import (
 
 const (
 	revisionNameEnvVar = "K_REVISION"
-	ServiceNameEnvVar  = "K_SERVICE"
+	//nolint:revive // TODO(SERV) Fix revive linter
+	ServiceNameEnvVar = "K_SERVICE"
 )
 
 var metadataHelperFunc = helper.GetMetaData

--- a/cmd/serverless-init/cloudservice/service_test.go
+++ b/cmd/serverless-init/cloudservice/service_test.go
@@ -18,11 +18,11 @@ func TestGetCloudServiceType(t *testing.T) {
 	t.Setenv(ContainerAppNameEnvVar, "test-name")
 	assert.Equal(t, "containerapp", GetCloudServiceType().GetOrigin())
 
-	t.Setenv(serviceNameEnvVar, "test-name")
+	t.Setenv(ServiceNameEnvVar, "test-name")
 	assert.Equal(t, "cloudrun", GetCloudServiceType().GetOrigin())
 
 	os.Unsetenv(ContainerAppNameEnvVar)
-	os.Unsetenv(serviceNameEnvVar)
+	os.Unsetenv(ServiceNameEnvVar)
 	t.Setenv(RunZip, "false")
 	assert.Equal(t, "appservice", GetCloudServiceType().GetOrigin())
 }

--- a/pkg/serverless/trace/span_modifer_test.go
+++ b/pkg/serverless/trace/span_modifer_test.go
@@ -105,7 +105,7 @@ func TestSpanModifierAddsOriginToAllSpans(t *testing.T) {
 	testOriginTags := func(withModifier bool) {
 		agnt := agent.NewAgent(ctx, cfg, telemetry.NewNoopCollector(), &statsd.NoOpClient{})
 		if withModifier {
-			agnt.ModifySpan = (&spanModifier{tags: cfg.GlobalTags}).ModifySpan
+			agnt.ModifySpan = (&spanModifier{tags: cfg.GlobalTags, ddOrigin: getDDOrigin()}).ModifySpan
 		}
 		tc := testutil.RandomTraceChunk(2, 1)
 		tc.Priority = 1 // ensure trace is never sampled out

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	compcorecfg "github.com/DataDog/datadog-agent/comp/core/config"
 	comptracecfg "github.com/DataDog/datadog-agent/comp/trace/config"
 	ddConfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -101,6 +102,7 @@ func (s *ServerlessTraceAgent) Start(enabled bool, loadConfig Load, lambdaSpanCh
 			s.spanModifier = &spanModifier{
 				coldStartSpanId: coldStartSpanId,
 				lambdaSpanChan:  lambdaSpanChan,
+				ddOrigin:        getDDOrigin(),
 			}
 
 			s.ta.ModifySpan = s.spanModifier.ModifySpan
@@ -207,4 +209,13 @@ func filterSpanFromLambdaLibraryOrRuntime(span *pb.Span) bool {
 		return true
 	}
 	return false
+}
+
+// getDDOrigin returns the value for the _dd.origin tag based on the cloud service type
+func getDDOrigin() string {
+	origin := ddOriginTagValue
+	if cloudServiceOrigin := cloudservice.GetCloudServiceType().GetOrigin(); cloudServiceOrigin != "local" {
+		origin = cloudServiceOrigin
+	}
+	return origin
 }

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -9,12 +9,14 @@ package trace
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/random"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -178,4 +180,18 @@ func TestFilterServerlessSpanFromTracer(t *testing.T) {
 		Resource: invocationSpanResource,
 	}
 	assert.True(t, filterSpanFromLambdaLibraryOrRuntime(&span))
+}
+
+func TestGetDDOriginCloudServices(t *testing.T) {
+	serviceToEnvVar := map[string]string{
+		"cloudrun":     cloudservice.ServiceNameEnvVar,
+		"appservice":   cloudservice.RunZip,
+		"containerapp": cloudservice.ContainerAppNameEnvVar,
+		"lambda":       functionNameEnvVar,
+	}
+	for service, envVar := range serviceToEnvVar {
+		t.Setenv(envVar, "myService")
+		assert.Equal(t, service, getDDOrigin())
+		os.Unsetenv(envVar)
+	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Runs a check for the cloud service and sets the correct `_dd.origin` value when we call `ModifySpan`. 

Live staging example where Container App traces are marked with `_dd.origin: lambda`: [traces](https://dd.datad0g.com/apm/traces?query=%40_top_level%3A1%20%40resource_id%3A%22%2Fsubscriptions%2F8c56d827-5f07-45ce-8f2b-6c5001db5c6f%2Fresourcegroups%2Fserverless%2Fproviders%2Fmicrosoft.app%2Fcontainerapps%2Fserverless-self-monitoring-node%22%20&cols=service%2C%40duration%2C%40_duration.by_service%2C%40resource_id&fromUser=false&graphType=json&historicalData=false&messageDisplay=inline&query_translation_version=v0&refresh_mode=paused&shouldShowLegend=true&sort=time&spanType=service-entry&traceQuery=&view=spans&start=1708980647746&end=1708981547746&paused=false) (click the trace JSON tab and then open in a new tab to inspect)

Correct `_dd.origin` for Cloud Run: https://ddserverless.datadoghq.com/api/v1/trace/8871360755274513971?colorBy=service&env=dev&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=8781288428123163570&spanViewType=metadata&timeHint=1708981920802.639&view=spans

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Traces from serverless-init were always set as `_dd.origin: lambda` due to code being reused from the Lambda Extension. There was some hardcoding we did initially for AWS Lambda that was carried over.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Added a unit test and manually tested.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
