### PR TITLE
[kubelet] Fix `display_container_name` disappearing when pod is unready

### DIFF
--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -25,6 +25,8 @@ type KubeletListener struct {
 	workloadmetaListener
 }
 
+const unreadinessTimeout = 30 * time.Second
+
 // NewKubeletListener returns a new KubeletListener.
 func NewKubeletListener(Config) (ServiceListener, error) {
 	const name = "ad-kubeletlistener"
@@ -131,6 +133,11 @@ func (l *KubeletListener) createContainerService(
 			log.Debugf("container %q not running for too long, skipping", container.ID)
 			return
 		}
+	}
+
+	if time.Since(container.LastSeenReady) > unreadinessTimeout {
+		log.Debugf("container %q last seen ready exceeds the unreadiness timeout, skipping", container.ID)
+		return
 	}
 
 	ports := make([]ContainerPort, 0, len(container.Ports))

--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -135,7 +135,7 @@ func (l *KubeletListener) createContainerService(
 		}
 	}
 
-	if time.Since(container.LastSeenReady) > unreadinessTimeout {
+	if !container.LastSeenReady.IsZero() && time.Since(container.LastSeenReady) > unreadinessTimeout {
 		log.Debugf("container %q last seen ready exceeds the unreadiness timeout, skipping", container.ID)
 		return
 	}

--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -272,6 +272,7 @@ func (c *collector) parsePodContainers(
 			containerState.StartedAt = st.StartedAt
 			containerState.FinishedAt = st.FinishedAt
 		}
+		containerState.LastSeenReady = container.LastSeenReady
 
 		podContainers = append(podContainers, podContainer)
 		events = append(events, workloadmeta.CollectorEvent{

--- a/comp/core/workloadmeta/dump_test.go
+++ b/comp/core/workloadmeta/dump_test.go
@@ -129,6 +129,7 @@ Health:
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
+Last Seen Ready: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
 Allowed env variables: DD_SERVICE:my-svc DD_ENV:prod DD_VERSION:v1 
 Hostname: 
@@ -158,6 +159,7 @@ Health:
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
+Last Seen Ready: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
 Allowed env variables: 
 Hostname: 
@@ -187,6 +189,7 @@ Health:
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
+Last Seen Ready: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
 Allowed env variables: DD_SERVICE:my-svc DD_ENV:prod DD_VERSION:v1 
 Hostname: 

--- a/comp/core/workloadmeta/types.go
+++ b/comp/core/workloadmeta/types.go
@@ -328,6 +328,7 @@ func (c ContainerState) String(verbose bool) string {
 		_, _ = fmt.Fprintln(&sb, "Created At:", c.CreatedAt)
 		_, _ = fmt.Fprintln(&sb, "Started At:", c.StartedAt)
 		_, _ = fmt.Fprintln(&sb, "Finished At:", c.FinishedAt)
+		_, _ = fmt.Fprintln(&sb, "Last Seen Ready:", c.LastSeenReady)
 		if c.ExitCode != nil {
 			_, _ = fmt.Fprintln(&sb, "Exit Code:", *c.ExitCode)
 		}

--- a/comp/core/workloadmeta/types.go
+++ b/comp/core/workloadmeta/types.go
@@ -307,13 +307,14 @@ func (c ContainerImage) String(verbose bool) string {
 
 // ContainerState is the state of a container.
 type ContainerState struct {
-	Running    bool
-	Status     ContainerStatus
-	Health     ContainerHealth
-	CreatedAt  time.Time
-	StartedAt  time.Time
-	FinishedAt time.Time
-	ExitCode   *uint32
+	Running       bool
+	Status        ContainerStatus
+	Health        ContainerHealth
+	CreatedAt     time.Time
+	StartedAt     time.Time
+	FinishedAt    time.Time
+	ExitCode      *uint32
+	LastSeenReady time.Time
 }
 
 // String returns a string representation of ContainerState.
@@ -522,6 +523,7 @@ type Container struct {
 	Owner           *EntityID
 	SecurityContext *ContainerSecurityContext
 	Resources       ContainerResources
+	LastSeenReady   time.Time
 }
 
 // GetID implements Entity#GetID.

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -18,8 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// const unreadinessTimeout = 30 * time.Second
-
 // PodWatcher regularly pools the kubelet for new/changed/removed containers.
 // It keeps an internal state to only send the updated pods.
 type PodWatcher struct {
@@ -167,14 +165,6 @@ func (w *PodWatcher) Expire() ([]string, error) {
 			expiredContainers = append(expiredContainers, id)
 		}
 	}
-	// for id, lastSeenReady := range w.lastSeenReady {
-	// 	// we keep pods gone unready for 25 seconds and then force removal
-	// 	if now.Sub(lastSeenReady) > unreadinessTimeout {
-	// 		delete(w.lastSeenReady, id)
-	// 		expiredContainers = append(expiredContainers, id)
-	// 	}
-	// }
-
 	return expiredContainers, nil
 }
 

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -86,7 +86,7 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 		updatedContainer := false
 		isPodReady := IsPodReady(pod)
 
-		for _, container := range pod.Status.GetAllContainers() {
+		for idx, container := range pod.Status.GetAllContainers() {
 			if container.IsPending() {
 				// We don't check container readiness as init
 				// containers are never ready. We check if the
@@ -112,7 +112,8 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 			w.oldReadiness[container.ID] = isPodReady
 
 			if isPodReady {
-				container.LastSeenReady = now
+				pod.UpdateLastSeenReady(idx, now)
+				updatedContainer = true
 			}
 		}
 

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -389,8 +389,7 @@ func TestPodwatcherTestSuite(t *testing.T) {
 
 func newWatcher() *PodWatcher {
 	return &PodWatcher{
-		lastSeen: make(map[string]time.Time),
-		// lastSeenReady:  make(map[string]time.Time),
+		lastSeen:       make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
 		oldPhase:       make(map[string]string),
 		oldReadiness:   make(map[string]bool),

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -192,14 +192,15 @@ type Conditions struct {
 
 // ContainerStatus contains fields for unmarshalling a Pod.Status.Containers
 type ContainerStatus struct {
-	Name         string         `json:"name"`
-	Image        string         `json:"image"`
-	ImageID      string         `json:"imageID"`
-	ID           string         `json:"containerID"`
-	Ready        bool           `json:"ready"`
-	RestartCount int            `json:"restartCount"`
-	State        ContainerState `json:"state"`
-	LastState    ContainerState `json:"lastState"`
+	Name          string         `json:"name"`
+	Image         string         `json:"image"`
+	ImageID       string         `json:"imageID"`
+	ID            string         `json:"containerID"`
+	Ready         bool           `json:"ready"`
+	RestartCount  int            `json:"restartCount"`
+	State         ContainerState `json:"state"`
+	LastState     ContainerState `json:"lastState"`
+	LastSeenReady time.Time      `json:"lastSeenReady"`
 }
 
 // IsPending returns if the container doesn't have an ID

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -200,7 +200,7 @@ type ContainerStatus struct {
 	RestartCount  int            `json:"restartCount"`
 	State         ContainerState `json:"state"`
 	LastState     ContainerState `json:"lastState"`
-	LastSeenReady time.Time      `json:"lastSeenReady"`
+	LastSeenReady time.Time
 }
 
 // IsPending returns if the container doesn't have an ID

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -185,6 +185,7 @@ func (s *Status) GetAllContainers() []ContainerStatus {
 	return s.AllContainers
 }
 
+// Update the LastSeenReady field for a container
 func (pod *Pod) UpdateLastSeenReady(idx int, lastSeenReady time.Time) {
 	pod.Status.AllContainers[idx].LastSeenReady = lastSeenReady
 	if idx < len(pod.Status.InitContainers) && pod.Status.InitContainers[idx].ID == pod.Status.AllContainers[idx].ID {

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -185,7 +185,7 @@ func (s *Status) GetAllContainers() []ContainerStatus {
 	return s.AllContainers
 }
 
-// Update the LastSeenReady field for a container
+// UpdateLastSeenReady updates the LastSeenReady field for a container
 func (pod *Pod) UpdateLastSeenReady(idx int, lastSeenReady time.Time) {
 	pod.Status.AllContainers[idx].LastSeenReady = lastSeenReady
 	if idx < len(pod.Status.InitContainers) && pod.Status.InitContainers[idx].ID == pod.Status.AllContainers[idx].ID {

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -190,7 +190,7 @@ func (pod *Pod) UpdateLastSeenReady(idx int, lastSeenReady time.Time) {
 	pod.Status.AllContainers[idx].LastSeenReady = lastSeenReady
 	if idx < len(pod.Status.InitContainers) && pod.Status.InitContainers[idx].ID == pod.Status.AllContainers[idx].ID {
 		pod.Status.InitContainers[idx].LastSeenReady = lastSeenReady
-	} else if idx < len(pod.Status.Containers) && pod.Status.Containers[idx-len(pod.Status.InitContainers)].ID == pod.Status.AllContainers[idx].ID {
+	} else if idx < len(pod.Status.AllContainers) && pod.Status.Containers[idx-len(pod.Status.InitContainers)].ID == pod.Status.AllContainers[idx].ID {
 		pod.Status.Containers[idx-len(pod.Status.InitContainers)].LastSeenReady = lastSeenReady
 	} else {
 		log.Debugf("Encountered invalid container index when trying to update LastSeenReady for pod %s", pod.Metadata.Name)

--- a/releasenotes/notes/fix-kubelet-display-container-name-na-7e1703b2f0db6847.yaml
+++ b/releasenotes/notes/fix-kubelet-display-container-name-na-7e1703b2f0db6847.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix issue with ``display_container_name`` being tagged as ``N/A`` 
+    when ``container_name`` information is available.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR moves the pod last seen ready logic out of the kubelet pod watcher and into the kubelet AD listener.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Previously, when pods go from a ready to unready state, there would be instances where the `display_container_name` would not be tagged properly. This change ensures that the container info used for `display_container_name` does not get unset.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1. Start a minikube cluster with containerd: `minikube start --container-runtime=containerd`
2. Start the agent
3. Create the following nginx deployment: `k create namespace workload-nginx && k apply -f test-deploy.yaml`
`test-deploy.yaml`:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: mynginx
  namespace: workload-nginx
  labels:
    app: mynginx
spec:
  replicas: 60
  selector:
    matchLabels:
      app: mynginx
  template:
    metadata:
      name: mynginx
      labels:
        app: mynginx
      namespace: workload-nginx
    spec:
      containers:
        - name: mynginx-minute
          image: nginx:latest
          imagePullPolicy: IfNotPresent
          args:
            - /bin/bash
            - '-c'
            - sleep 60; echo hello
        - name: mynginx-2min
          image: nginx:latest
          imagePullPolicy: IfNotPresent
          args:
            - /bin/bash
            - '-c'
            - sleep 120; echo hello
        - name: mynginx-5min
          image: nginx:latest
          imagePullPolicy: IfNotPresent
          args:
            - /bin/bash
            - '-c'
            - sleep 300; echo hello
        - name: mynginx-10min
          image: nginx:latest
          imagePullPolicy: IfNotPresent
          args:
            - /bin/bash
            - '-c'
            - sleep 600; echo hello
```
4. Verify that you do not see any metrics tagged with `display_container_name:N/A` if the `container_name` is not `N/A`; e.g.:
<img width="1350" alt="image" src="https://github.com/DataDog/datadog-agent/assets/32009013/bf69dcd5-2ad3-4e37-8656-b82196e37097">
