### PR TITLE
Notifications: Move GITHUB_SLACK_MAP and GITHUB_JIRA_MAP into YAML files.

### DIFF
--- a/releasenotes/notes/Move-GITHUB_SLACK-and-GITHUB_JIRA-maps-into-YAML-files-9a38f31cec71ecdb.yaml
+++ b/releasenotes/notes/Move-GITHUB_SLACK-and-GITHUB_JIRA-maps-into-YAML-files-9a38f31cec71ecdb.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Move GitHub Teams to Jira Projects mapping, and GitHub Teams to
+    Slack Channel mapping out of Python files and into YAML files.

--- a/releasenotes/notes/Move-GITHUB_SLACK-and-GITHUB_JIRA-maps-into-YAML-files-9a38f31cec71ecdb.yaml
+++ b/releasenotes/notes/Move-GITHUB_SLACK-and-GITHUB_JIRA-maps-into-YAML-files-9a38f31cec71ecdb.yaml
@@ -8,5 +8,5 @@
 ---
 other:
   - |
-    Move GitHub Teams to Jira Projects mapping, and GitHub Teams to
-    Slack Channel mapping out of Python files and into YAML files.
+    Move GitHub teams to Jira projects mapping and GitHub teams to
+    Slack channel mapping out of Python files and into YAML files.

--- a/tasks/libs/github_jira_map.yaml
+++ b/tasks/libs/github_jira_map.yaml
@@ -1,0 +1,35 @@
+# This file contains a mapping of DataDog Github teams to JIRA projects.
+# The DEFAULT_JIRA_PROJECT value is interpreted as "AGNTR".
+# Note that keys must be quoted because the '@' symbol is reserved in YAML.
+'@datadog/agent-platform': APL
+'@datadog/documentation': DOCS
+'@datadog/container-integrations': CONTINT
+'@datadog/container-ecosystems': CECO
+'@datadog/platform-integrations': PLINT
+'@datadog/agent-security': SEC
+'@datadog/agent-apm': AIT
+'@datadog/network-device-monitoring': NDMII
+'@datadog/processes': PROCS
+'@datadog/agent-metrics-logs': AMLII
+'@datadog/agent-shared-components': ASCII
+'@datadog/container-app': CAP
+'@datadog/metrics-aggregation': AGGR
+'@datadog/serverless': SVLS
+'@datadog/remote-config': RC
+'@datadog/fleet': RC
+'@datadog/agent-all': DEFAULT_JIRA_PROJECT
+'@datadog/ebpf-platform': EBPF
+'@datadog/networks': NPM
+'@datadog/universal-service-monitoring': USMON
+'@datadog/windows-agent': WINA
+'@datadog/windows-kernel-integrations': WKINT
+'@datadog/opentelemetry': OTEL
+'@datadog/agent-e2e-testing': APL
+'@datadog/software-integrity-and-trust': SINT
+'@datadog/single-machine-performance': SMP
+'@datadog/agent-integrations': AI
+'@datadog/debugger': DEBUG
+'@datadog/database-monitoring': DBMON
+'@datadog/agent-cspm': SEC
+'@datadog/telemetry-and-analytics': DEFAULT_JIRA_PROJECT
+'@datadog/asm-go': APPSEC

--- a/tasks/libs/github_slack_map.yaml
+++ b/tasks/libs/github_slack_map.yaml
@@ -1,0 +1,37 @@
+# This file contains a mapping of DataDog Github teams to slack channels.
+# The DEFAULT_SLACK_CHANNEL value is interpreted as '#agent-platform'.
+# Note that the values must be quoted if they contain a '#' symbol, because
+# YAML interprets that as the beginning of a comment. Keys must also be quoted
+# because the '@' symbol is reserved in YAML.
+'@datadog/agent-platform': DEFAULT_SLACK_CHANNEL
+'@datadog/documentation': DEFAULT_SLACK_CHANNEL
+'@datadog/container-integrations': '#container-integrations'
+'@datadog/container-ecosystems': '#container-ecosystems'
+'@datadog/platform-integrations': '#platform-integrations-ops'
+'@datadog/agent-security': '#security-and-compliance-agent-ops'
+'@datadog/agent-apm': '#apm-agent'
+'@datadog/network-device-monitoring': '#network-device-monitoring'
+'@datadog/processes': '#process-agent-ops'
+'@datadog/agent-metrics-logs': '#agent-metrics-logs'
+'@datadog/agent-shared-components': '#agent-shared-components'
+'@datadog/container-app': '#container-app'
+'@datadog/metrics-aggregation': '#metrics-aggregation'
+'@datadog/serverless': '#serverless-agent'
+'@datadog/remote-config': '#remote-config-monitoring'
+'@datadog/fleet': '#fleet-automation'
+'@datadog/agent-all': '#datadog-agent-pipelines'
+'@datadog/ebpf-platform': '#ebpf-platform-ops'
+'@datadog/networks': '#network-performance-monitoring'
+'@datadog/universal-service-monitoring': '#universal-service-monitoring'
+'@datadog/windows-agent': '#windows-agent-ops'
+'@datadog/windows-kernel-integrations': '#windows-kernel-integrations-ops'
+'@datadog/opentelemetry': '#opentelemetry-ops'
+'@datadog/agent-e2e-testing': '#agent-testing-and-qa'
+'@datadog/software-integrity-and-trust': '#sit'
+'@datadog/single-machine-performance': '#single-machine-performance'
+'@datadog/agent-integrations': '#agent-integrations'
+'@datadog/debugger': '#debugger-ops-prod'
+'@datadog/database-monitoring': '#database-monitoring'
+'@datadog/agent-cspm': '#k9-cspm-ops'
+'@datadog/telemetry-and-analytics': '#instrumentation-telemetry'
+'@datadog/asm-go': '#k9-asm-library-go'

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -1,86 +1,35 @@
 import json
 import os
+import pathlib
 import re
 import subprocess
 from collections import defaultdict
 from typing import Dict
 
+import yaml
+
 from tasks.libs.common.gitlab import Gitlab, get_gitlab_token
 from tasks.libs.types import FailedJobs, Test
 
+
+def load_and_validate(file_name: str, default_placeholder: str, default_value: str) -> Dict[str, str]:
+    p = pathlib.Path(os.path.realpath(__file__)).parent.joinpath(file_name)
+
+    result: Dict[str, str] = {}
+    with p.open(encoding='utf-8') as file_stream:
+        for key, value in yaml.safe_load(file_stream).items():
+            if not (type(key) is str and type(value) is str):
+                raise ValueError(f"File {file_name} contains a non-string key or value. Key: {key}, Value: {value}")
+            result[key] = default_value if value == default_placeholder else value
+    return result
+
+
+DATADOG_AGENT_GITHUB_ORG_URL = "https://github.com/DataDog"
 DEFAULT_SLACK_CHANNEL = "#agent-platform"
 DEFAULT_JIRA_PROJECT = "AGNTR"
-DATADOG_AGENT_GITHUB_ORG_URL = "https://github.com/DataDog"
 # Map keys in lowercase
-GITHUB_SLACK_MAP = {
-    "@datadog/agent-platform": DEFAULT_SLACK_CHANNEL,
-    "@datadog/documentation": DEFAULT_SLACK_CHANNEL,
-    "@datadog/container-integrations": "#container-integrations",
-    "@datadog/container-ecosystems": "#container-ecosystems",
-    "@datadog/platform-integrations": "#platform-integrations-ops",
-    "@datadog/agent-security": "#security-and-compliance-agent-ops",
-    "@datadog/agent-apm": "#apm-agent",
-    "@datadog/network-device-monitoring": "#network-device-monitoring",
-    "@datadog/processes": "#process-agent-ops",
-    "@datadog/agent-metrics-logs": "#agent-metrics-logs",
-    "@datadog/agent-shared-components": "#agent-shared-components",
-    "@datadog/container-app": "#container-app",
-    "@datadog/metrics-aggregation": "#metrics-aggregation",
-    "@datadog/serverless": "#serverless-agent",
-    "@datadog/remote-config": "#remote-config-monitoring",
-    "@datadog/fleet": "#fleet-automation",
-    "@datadog/agent-all": "#datadog-agent-pipelines",
-    "@datadog/ebpf-platform": "#ebpf-platform-ops",
-    "@datadog/networks": "#network-performance-monitoring",
-    "@datadog/universal-service-monitoring": "#universal-service-monitoring",
-    "@datadog/windows-agent": "#windows-agent-ops",
-    "@datadog/windows-kernel-integrations": "#windows-kernel-integrations-ops",
-    "@datadog/opentelemetry": "#opentelemetry-ops",
-    "@datadog/agent-e2e-testing": "#agent-testing-and-qa",
-    "@datadog/software-integrity-and-trust": "#sit",
-    "@datadog/single-machine-performance": "#single-machine-performance",
-    "@datadog/agent-integrations": "#agent-integrations",
-    "@datadog/debugger": "#debugger-ops-prod",
-    "@datadog/database-monitoring": "#database-monitoring",
-    "@datadog/agent-cspm": "#k9-cspm-ops",
-    "@datadog/telemetry-and-analytics": "#instrumentation-telemetry",
-    "@datadog/asm-go": "#k9-asm-library-go",
-}
-
-GITHUB_JIRA_MAP = {
-    "@datadog/agent-platform": "APL",
-    "@datadog/documentation": "DOCS",
-    "@datadog/container-integrations": "CONTINT",
-    "@datadog/container-ecosystems": "CECO",
-    "@datadog/platform-integrations": "PLINT",
-    "@datadog/agent-security": "SEC",
-    "@datadog/agent-apm": "AIT",
-    "@datadog/network-device-monitoring": "NDMII",
-    "@datadog/processes": "PROCS",
-    "@datadog/agent-metrics-logs": "AMLII",
-    "@datadog/agent-shared-components": "ASCII",
-    "@datadog/container-app": "CAP",
-    "@datadog/metrics-aggregation": "AGGR",
-    "@datadog/serverless": "SVLS",
-    "@datadog/remote-config": "RC",
-    "@datadog/fleet": "RC",
-    "@datadog/agent-all": DEFAULT_JIRA_PROJECT,
-    "@datadog/ebpf-platform": "EBPF",
-    "@datadog/networks": "NPM",
-    "@datadog/universal-service-monitoring": "USMON",
-    "@datadog/windows-agent": "WINA",
-    "@datadog/windows-kernel-integrations": "WKINT",
-    "@datadog/opentelemetry": "OTEL",
-    "@datadog/agent-e2e-testing": "APL",
-    "@datadog/software-integrity-and-trust": "SINT",
-    "@datadog/single-machine-performance": "SMP",
-    "@datadog/agent-integrations": "AI",
-    "@datadog/debugger": "DEBUG",
-    "@datadog/database-monitoring": "DBMON",
-    "@datadog/agent-cspm": "SEC",
-    "@datadog/telemetry-and-analytics": DEFAULT_JIRA_PROJECT,
-    "@datadog/asm-go": "APPSEC",
-}
+GITHUB_SLACK_MAP = load_and_validate("github_slack_map.yaml", "DEFAULT_SLACK_CHANNEL", DEFAULT_SLACK_CHANNEL)
+GITHUB_JIRA_MAP = load_and_validate("github_jira_map.yaml", "DEFAULT_JIRA_PROJECT", DEFAULT_JIRA_PROJECT)
 
 
 def read_owners(owners_file):

--- a/tasks/unit-tests/pipeline_lib_tests.py
+++ b/tasks/unit-tests/pipeline_lib_tests.py
@@ -1,0 +1,14 @@
+import unittest
+
+from tasks.libs import pipeline_notifications
+
+
+class TestLoadAndValidate(unittest.TestCase):
+    def test_files_loaded_correctly(self):
+        # Assert that a couple of expected entries are there, including one that uses DEFAULT_JIRA_PROJECT
+        self.assertEqual(pipeline_notifications.GITHUB_JIRA_MAP['@datadog/agent-all'], "AGNTR")
+        self.assertEqual(pipeline_notifications.GITHUB_JIRA_MAP['@datadog/agent-platform'], "APL")
+
+        # Assert that a couple of expected entries are there, including one that uses DEFAULT_SLACK_PROJECT
+        self.assertEqual(pipeline_notifications.GITHUB_SLACK_MAP['@datadog/agent-all'], "#datadog-agent-pipelines")
+        self.assertEqual(pipeline_notifications.GITHUB_SLACK_MAP['@datadog/agent-platform'], "#agent-platform")


### PR DESCRIPTION
This commit moves the data for the GITHUB_SLACK_MAP and GITHUB_JIRA_MAP out of python files and into YAML files. This is being done so that the data is accessible to non-python code.

### What does this PR do?

Moves configuration containing a mapping of DataDog GitHub teams to JIRA projects out of python code into YAML files. For consistency, the same is done with the mapping of DataDog GitHub teams to Slack channels.

### Motivation

In the near future, go code (outside of the datadog/agent repo) will be using this data for automatic ticket assignment. YAML is a better universal format than Python code.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

It's possible for a future commit to put invalid data (i.e. badly structured) in the YAML file. This PR adds a test that will catch that.

### Describe how to test/QA your changes

Execute the unit test suite... specifically the test added in tasks/unit-tests/pipeline_lib_tests.py.