### PR TITLE
[CONTINT-3524] Wrap contimage and contlifecycle checks as long running checks

### DIFF
--- a/pkg/collector/corechecks/containerimage/check.go
+++ b/pkg/collector/corechecks/containerimage/check.go
@@ -95,12 +95,12 @@ type Check struct {
 // Factory returns a new check factory
 func Factory(store workloadmeta.Component) optional.Option[func() check.Check] {
 	return optional.NewOption(func() check.Check {
-		return &Check{
+		return core.NewLongRunningCheckWrapper(&Check{
 			CheckBase:         core.NewCheckBase(CheckName),
 			workloadmetaStore: store,
 			instance:          &Config{},
 			stopCh:            make(chan struct{}),
-		}
+		})
 	})
 }
 

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -147,11 +147,11 @@ func (c *Check) Interval() time.Duration { return 0 }
 // Factory returns a new check factory
 func Factory(store workloadmeta.Component) optional.Option[func() check.Check] {
 	return optional.NewOption(func() check.Check {
-		return &Check{
+		return core.NewLongRunningCheckWrapper(&Check{
 			CheckBase:         core.NewCheckBase(CheckName),
 			workloadmetaStore: store,
 			instance:          &Config{},
 			stopCh:            make(chan struct{}),
-		}
+		})
 	})
 }

--- a/releasenotes/notes/add-containerimage-container-lifecycle-to-agent-status-e8aee3de8c1d410f.yaml
+++ b/releasenotes/notes/add-containerimage-container-lifecycle-to-agent-status-e8aee3de8c1d410f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add the container image and container lifecycle checks to the output of the Agent status command.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR wraps the contimage and contlfiecycle checks as long running checks to retrieve their stats in `agent status` output.

As part of https://github.com/DataDog/datadog-agent/pull/22313, we introduced a long running check wrapper to collect long running checks metrics as part of the `agent status` and `agent flare` command (that runs agent status).
We successfully converted SBOM collection to a long running check. Now we would like to do the same for contimage and contlifecycle.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Make investigations easier
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
1. Health check
We can verify that the checks are still working with the new-e2e test framework (TestContainerImage). We can also check the container-images page or the output of `agent stream-event-platform --type container-image # (or container-lifecycle)`.

2. Agent status QA
Deploy the agent on Kubernetes and make sure `agent status` shows the long running checks metrics. Similar to:
```
    container_image
    ---------------
      Instance ID: container_image [OK]
      Long Running Check: true
      Configuration Source: file:/etc/datadog-agent/conf.d/container_image.yaml
      Total Metric Samples: 0
      Total Events: 0
      Total container-images: 147
      Total Service Checks: 0


    container_lifecycle
    -------------------
      Instance ID: container_lifecycle [OK]
      Long Running Check: true
      Configuration Source: file:/etc/datadog-agent/conf.d/container_lifecycle.d/conf.yaml.default
      Total Metric Samples: 0
      Total Events: 0
      Total container-lifecycle: 5
      Total Service Checks: 0
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
