### PR TITLE
[EBPF-384] migrate conntracker to use the new ebpfManager wrapper

### DIFF
--- a/pkg/network/tracer/conntracker_test.go
+++ b/pkg/network/tracer/conntracker_test.go
@@ -92,7 +92,7 @@ func runConntrackerTest(t *testing.T, name string, createFn func(*testing.T, *co
 
 //nolint:revive // TODO(NET) Fix revive linter
 func setupEBPFConntracker(t *testing.T, cfg *config.Config) (netlink.Conntracker, error) {
-	return NewEBPFConntracker(cfg, nil)
+	return NewEBPFConntracker(cfg)
 }
 
 //nolint:revive // TODO(NET) Fix revive linter

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 	"time"
 
+	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
+
 	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/features"
@@ -391,7 +393,7 @@ func (e *ebpfConntracker) Collect(ch chan<- prometheus.Metric) {
 }
 
 func getManager(cfg *config.Config, buf io.ReaderAt, constants []manager.ConstantEditor) (*manager.Manager, error) {
-	mgr := ddebpf.NewManager(&manager.Manager{
+	mgr := ddebpf.NewManagerWithDefault(&manager.Manager{
 		Maps: []*manager.Map{
 			{Name: probes.ConntrackMap},
 			{Name: probes.ConntrackTelemetryMap},
@@ -412,7 +414,7 @@ func getManager(cfg *config.Config, buf io.ReaderAt, constants []manager.Constan
 				MatchFuncName: "^ctnetlink_fill_info(\\.constprop\\.0)?$",
 			},
 		},
-	})
+	}, &ebpftelemetry.ErrorsTelemetryModifier{})
 
 	kprobeAttachMethod := manager.AttachKprobeWithPerfEventOpen
 	if cfg.AttachKprobesWithKprobeEventsABI {

--- a/pkg/network/tracer/ebpf_conntracker_test.go
+++ b/pkg/network/tracer/ebpf_conntracker_test.go
@@ -21,7 +21,7 @@ func TestEbpfConntrackerLoadTriggersOffsetGuessing(t *testing.T) {
 
 	cfg := testConfig()
 	cfg.EnableRuntimeCompiler = false
-	conntracker, err := NewEBPFConntracker(cfg, nil)
+	conntracker, err := NewEBPFConntracker(cfg)
 	assert.NoError(t, err)
 	require.NotNil(t, conntracker)
 	t.Cleanup(conntracker.Close)

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -180,7 +180,7 @@ func newTracer(cfg *config.Config) (_ *Tracer, reterr error) {
 	}
 	coretelemetry.GetCompatComponent().RegisterCollector(tr.ebpfTracer)
 
-	tr.conntracker, err = newConntracker(cfg, bpfTelemetry)
+	tr.conntracker, err = newConntracker(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (tr *Tracer) start() error {
 	return nil
 }
 
-func newConntracker(cfg *config.Config, bpfTelemetry *ebpftelemetry.EBPFTelemetry) (netlink.Conntracker, error) {
+func newConntracker(cfg *config.Config) (netlink.Conntracker, error) {
 	if !cfg.EnableConntrack {
 		return netlink.NewNoOpConntracker(), nil
 	}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -260,7 +260,7 @@ func newConntracker(cfg *config.Config, bpfTelemetry *ebpftelemetry.EBPFTelemetr
 		}
 	}
 
-	if c, err = NewEBPFConntracker(cfg, bpfTelemetry); err == nil {
+	if c, err = NewEBPFConntracker(cfg); err == nil {
 		return c, nil
 	}
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2108,7 +2108,7 @@ func TestConntrackerFallback(t *testing.T) {
 	cfg := testConfig()
 	cfg.EnableEbpfConntracker = false
 	cfg.AllowNetlinkConntrackerFallback = true
-	conntracker, err := newConntracker(cfg, nil)
+	conntracker, err := newConntracker(cfg)
 	// ensure we always clean up the conntracker, regardless of behavior
 	if conntracker != nil {
 		t.Cleanup(conntracker.Close)
@@ -2117,7 +2117,7 @@ func TestConntrackerFallback(t *testing.T) {
 	require.NotNil(t, conntracker)
 
 	cfg.AllowNetlinkConntrackerFallback = false
-	conntracker, err = newConntracker(cfg, nil)
+	conntracker, err = newConntracker(cfg)
 	// ensure we always clean up the conntracker, regardless of behavior
 	if conntracker != nil {
 		t.Cleanup(conntracker.Close)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2085,7 +2085,7 @@ func TestEbpfConntrackerFallback(t *testing.T) {
 				ebpfConntrackerRCCreator = func(cfg *config.Config) (rc.CompiledOutput, error) { return nil, assert.AnError }
 			}
 
-			conntracker, err := NewEBPFConntracker(cfg, nil)
+			conntracker, err := NewEBPFConntracker(cfg)
 			// ensure we always clean up the conntracker, regardless of behavior
 			if conntracker != nil {
 				t.Cleanup(conntracker.Close)


### PR DESCRIPTION

### What does this PR do?

Migrates conntracker to use the new Manager wrapper with ErrorsTelemetryModifier instead of now deprecated ebpftelemetry.Manager

### Motivation

better code structure

### Additional Notes

another PR in a series to migrate all our ebpfPrograms to use the new telemetry pkg

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
