### PR TITLE
Use correct pipeline ID variable for the bundle override

### DIFF
--- a/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -30,7 +30,7 @@ internal_kubernetes_deploy_experimental:
     OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging ${CI_COMMIT_REF_SLUG}-jmx-${CI_COMMIT_SHORT_SHA} ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}"
     SKIP_PLAN_CHECK: "true"
     EXPLICIT_WORKFLOWS: "//workflows:beta_builds.agents_nightly.publish"
-    BUNDLE_VERSION_OVERRIDE: "v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    BUNDLE_VERSION_OVERRIDE: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   script:
     - source /root/.bashrc
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
### What does this PR do?

Fixes the version override being set for the generated CNAB bundle

### Motivation

Follow up to https://github.com/DataDog/datadog-agent/pull/23108

The pipeline for the nightly last night was kicked off [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/28985877)

This generated the following version tag: `v-c41a6779` which can be seen in the [conductor output in slack](https://dd.slack.com/archives/C9X24HRUZ/p1709003404897329)

The commit sha at the end is correct, it matches the sha of the pipeline. But the `PARENT_PIPELINE_ID` env var is not set, that was a mistake on my part. I should have used `CI_PIPELINE_ID`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
