### PR TITLE
[gitlab] Make install_script testing require SUSE packages deployed

### DIFF
--- a/.gitlab/install_script_testing/install_script_testing.yml
+++ b/.gitlab/install_script_testing/install_script_testing.yml
@@ -14,6 +14,6 @@ test_install_script:
       --variable TESTING_APT_URL
       --variable TESTING_YUM_URL
       --variable TEST_PIPELINE_ID"
-  needs: ["deploy_deb_testing-a6_x64", "deploy_rpm_testing-a6_x64", "deploy_deb_testing-a7_x64", "deploy_rpm_testing-a7_x64"]
+  needs: ["deploy_deb_testing-a6_x64", "deploy_rpm_testing-a6_x64", "deploy_suse_rpm_testing_x64-a6", "deploy_deb_testing-a7_x64", "deploy_rpm_testing-a7_x64", "deploy_suse_rpm_testing_x64-a7"]
   rules:
     !reference [.on_deploy]


### PR DESCRIPTION
### What does this PR do?

Makes the install_script test require SUSE packages deployed - some tests ran in install_script CI require SUSE packages to execute, so we need this dependency.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
