### PR TITLE
fix(serverless benchmarks): incorrect use of GH artifact names

### DIFF
--- a/.github/workflows/serverless-benchmarks.yml
+++ b/.github/workflows/serverless-benchmarks.yml
@@ -105,17 +105,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: baseline.log
-          path: baseline.log
+          path: baseline
       - name: Download current artifact
         uses: actions/download-artifact@v4
         with:
           name: current.log
-          path: current.log
+          path: current
 
       - name: Analyze results
         id: analyze
         run: |
-          benchstat -row /event baseline.log current.log | tee analyze.txt
+          benchstat -row /event baseline/benchmark.log current/benchmark.log | tee analyze.txt
           echo "analyze<<EOF" >> $GITHUB_OUTPUT
           cat analyze.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION

### What does this PR do?

Fixes a mistake in how GitHub actions artifacts are used in the Serverless Benchmarks workflow, which causes the benchmark results to not be produced correctly.