### PR TITLE
convert remote SFTP paths to forward slashes for Windows hosts

### DIFF
--- a/test/new-e2e/examples/vm_test.go
+++ b/test/new-e2e/examples/vm_test.go
@@ -25,7 +25,7 @@ type vmSuite struct {
 
 // TestVMSuite runs tests for the VM interface to ensure its implementation is correct.
 func TestVMSuite(t *testing.T) {
-	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault))))}
+	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault))))}
 	if *devMode {
 		suiteParams = append(suiteParams, e2e.WithDevMode())
 	}
@@ -43,7 +43,8 @@ func (v *vmSuite) TestExecute() {
 
 func (v *vmSuite) TestFileOperations() {
 	vm := v.Env().RemoteHost
-	testFilePath := "test"
+	// Use drive letter path with forward slashes to ensure Windows paths are handled correctly
+	testFilePath := "C:\\testFile"
 
 	v.T().Cleanup(func() {
 		_ = vm.Remove(testFilePath)
@@ -96,8 +97,9 @@ func (v *vmSuite) TestFileOperations() {
 
 func (v *vmSuite) TestDirectoryOperations() {
 	vm := v.Env().RemoteHost
-	testDirPath := "testDirectory"
-	testSubDirPath := "testDirectory/testSubDirectory"
+	// Use drive letter path with forward slashes to ensure Windows paths are handled correctly
+	testDirPath := "C:\\testDirectory"
+	testSubDirPath := "C:\\testDirectory\\testSubDirectory"
 
 	v.T().Cleanup(func() {
 		_ = vm.RemoveAll(testDirPath)

--- a/test/new-e2e/pkg/components/remotehost.go
+++ b/test/new-e2e/pkg/components/remotehost.go
@@ -85,58 +85,58 @@ func (h *RemoteHost) MustExecute(command string, options ...ExecuteOption) strin
 
 // CopyFile copy file to the remote host
 func (h *RemoteHost) CopyFile(src string, dst string) {
-	dst = h.convertToForwardSlash(dst)
+	dst = h.convertToForwardSlashOnWindows(dst)
 	err := clients.CopyFile(h.client, src, dst)
 	require.NoError(h.context.T(), err)
 }
 
 // CopyFolder copy a folder to the remote host
 func (h *RemoteHost) CopyFolder(srcFolder string, dstFolder string) {
-	dstFolder = h.convertToForwardSlash(dstFolder)
+	dstFolder = h.convertToForwardSlashOnWindows(dstFolder)
 	err := clients.CopyFolder(h.client, srcFolder, dstFolder)
 	require.NoError(h.context.T(), err)
 }
 
 // GetFile copy file from the remote host
 func (h *RemoteHost) GetFile(src string, dst string) error {
-	src = h.convertToForwardSlash(src)
+	src = h.convertToForwardSlashOnWindows(src)
 	return clients.GetFile(h.client, src, dst)
 }
 
 // FileExists returns true if the file exists and is a regular file and returns an error if any
 func (h *RemoteHost) FileExists(path string) (bool, error) {
-	path = h.convertToForwardSlash(path)
+	path = h.convertToForwardSlashOnWindows(path)
 	return clients.FileExists(h.client, path)
 }
 
 // ReadFile reads the content of the file, return bytes read and error if any
 func (h *RemoteHost) ReadFile(path string) ([]byte, error) {
-	path = h.convertToForwardSlash(path)
+	path = h.convertToForwardSlashOnWindows(path)
 	return clients.ReadFile(h.client, path)
 }
 
 // WriteFile write content to the file and returns the number of bytes written and error if any
 func (h *RemoteHost) WriteFile(path string, content []byte) (int64, error) {
-	path = h.convertToForwardSlash(path)
+	path = h.convertToForwardSlashOnWindows(path)
 	return clients.WriteFile(h.client, path, content)
 }
 
 // AppendFile append content to the file and returns the number of bytes written and error if any
 func (h *RemoteHost) AppendFile(os, path string, content []byte) (int64, error) {
-	path = h.convertToForwardSlash(path)
+	path = h.convertToForwardSlashOnWindows(path)
 	return clients.AppendFile(h.client, os, path, content)
 }
 
 // ReadDir returns list of directory entries in path
 func (h *RemoteHost) ReadDir(path string) ([]fs.DirEntry, error) {
-	path = h.convertToForwardSlash(path)
+	path = h.convertToForwardSlashOnWindows(path)
 	return clients.ReadDir(h.client, path)
 }
 
 // Lstat returns a FileInfo structure describing path.
 // if path is a symbolic link, the FileInfo structure describes the symbolic link.
 func (h *RemoteHost) Lstat(path string) (fs.FileInfo, error) {
-	path = h.convertToForwardSlash(path)
+	path = h.convertToForwardSlashOnWindows(path)
 	return clients.Lstat(h.client, path)
 }
 
@@ -144,21 +144,21 @@ func (h *RemoteHost) Lstat(path string) (fs.FileInfo, error) {
 // If the path is already a directory, does nothing and returns nil.
 // Otherwise returns an error if any.
 func (h *RemoteHost) MkdirAll(path string) error {
-	path = h.convertToForwardSlash(path)
+	path = h.convertToForwardSlashOnWindows(path)
 	return clients.MkdirAll(h.client, path)
 }
 
 // Remove removes the specified file or directory.
 // Returns an error if file or directory does not exist, or if the directory is not empty.
 func (h *RemoteHost) Remove(path string) error {
-	path = h.convertToForwardSlash(path)
+	path = h.convertToForwardSlashOnWindows(path)
 	return clients.Remove(h.client, path)
 }
 
 // RemoveAll recursively removes all files/folders in the specified directory.
 // Returns an error if the directory does not exist.
 func (h *RemoteHost) RemoveAll(path string) error {
-	path = h.convertToForwardSlash(path)
+	path = h.convertToForwardSlashOnWindows(path)
 	return clients.RemoveAll(h.client, path)
 }
 
@@ -234,13 +234,13 @@ func (h *RemoteHost) buildEnvVariables(command string, envVar EnvVar) string {
 	return cmd
 }
 
-// convertToForwardSlash replaces backslashes in the path with forward slashes for Windows remote hosts.
+// convertToForwardSlashOnWindows replaces backslashes in the path with forward slashes for Windows remote hosts.
 // The path is unchanged for non-Windows remote hosts.
 //
 // This is necessary for remote paths because the sftp package only supports forward slashes, regardless of the local OS.
 // The Windows SSH implementation does this conversion, too. Though we have an advantage in that we can check the OSFamily.
 // https://github.com/PowerShell/openssh-portable/blob/59aba65cf2e2f423c09d12ad825c3b32a11f408f/scp.c#L636-L650
-func (h *RemoteHost) convertToForwardSlash(path string) string {
+func (h *RemoteHost) convertToForwardSlashOnWindows(path string) string {
 	if h.OSFamily == osComp.WindowsFamily {
 		return strings.ReplaceAll(path, "\\", "/")
 	}

--- a/test/new-e2e/pkg/components/remotehost.go
+++ b/test/new-e2e/pkg/components/remotehost.go
@@ -85,49 +85,58 @@ func (h *RemoteHost) MustExecute(command string, options ...ExecuteOption) strin
 
 // CopyFile copy file to the remote host
 func (h *RemoteHost) CopyFile(src string, dst string) {
+	dst = h.convertToForwardSlash(dst)
 	err := clients.CopyFile(h.client, src, dst)
 	require.NoError(h.context.T(), err)
 }
 
 // CopyFolder copy a folder to the remote host
 func (h *RemoteHost) CopyFolder(srcFolder string, dstFolder string) {
+	dstFolder = h.convertToForwardSlash(dstFolder)
 	err := clients.CopyFolder(h.client, srcFolder, dstFolder)
 	require.NoError(h.context.T(), err)
 }
 
 // GetFile copy file from the remote host
 func (h *RemoteHost) GetFile(src string, dst string) error {
+	src = h.convertToForwardSlash(src)
 	return clients.GetFile(h.client, src, dst)
 }
 
 // FileExists returns true if the file exists and is a regular file and returns an error if any
 func (h *RemoteHost) FileExists(path string) (bool, error) {
+	path = h.convertToForwardSlash(path)
 	return clients.FileExists(h.client, path)
 }
 
 // ReadFile reads the content of the file, return bytes read and error if any
 func (h *RemoteHost) ReadFile(path string) ([]byte, error) {
+	path = h.convertToForwardSlash(path)
 	return clients.ReadFile(h.client, path)
 }
 
 // WriteFile write content to the file and returns the number of bytes written and error if any
 func (h *RemoteHost) WriteFile(path string, content []byte) (int64, error) {
+	path = h.convertToForwardSlash(path)
 	return clients.WriteFile(h.client, path, content)
 }
 
 // AppendFile append content to the file and returns the number of bytes written and error if any
 func (h *RemoteHost) AppendFile(os, path string, content []byte) (int64, error) {
+	path = h.convertToForwardSlash(path)
 	return clients.AppendFile(h.client, os, path, content)
 }
 
 // ReadDir returns list of directory entries in path
 func (h *RemoteHost) ReadDir(path string) ([]fs.DirEntry, error) {
+	path = h.convertToForwardSlash(path)
 	return clients.ReadDir(h.client, path)
 }
 
 // Lstat returns a FileInfo structure describing path.
 // if path is a symbolic link, the FileInfo structure describes the symbolic link.
 func (h *RemoteHost) Lstat(path string) (fs.FileInfo, error) {
+	path = h.convertToForwardSlash(path)
 	return clients.Lstat(h.client, path)
 }
 
@@ -135,18 +144,21 @@ func (h *RemoteHost) Lstat(path string) (fs.FileInfo, error) {
 // If the path is already a directory, does nothing and returns nil.
 // Otherwise returns an error if any.
 func (h *RemoteHost) MkdirAll(path string) error {
+	path = h.convertToForwardSlash(path)
 	return clients.MkdirAll(h.client, path)
 }
 
 // Remove removes the specified file or directory.
 // Returns an error if file or directory does not exist, or if the directory is not empty.
 func (h *RemoteHost) Remove(path string) error {
+	path = h.convertToForwardSlash(path)
 	return clients.Remove(h.client, path)
 }
 
 // RemoveAll recursively removes all files/folders in the specified directory.
 // Returns an error if the directory does not exist.
 func (h *RemoteHost) RemoveAll(path string) error {
+	path = h.convertToForwardSlash(path)
 	return clients.RemoveAll(h.client, path)
 }
 
@@ -220,4 +232,17 @@ func (h *RemoteHost) buildEnvVariables(command string, envVar EnvVar) string {
 		cmd += command
 	}
 	return cmd
+}
+
+// convertToForwardSlash replaces backslashes in the path with forward slashes for Windows remote hosts.
+// The path is unchanged for non-Windows remote hosts.
+//
+// This is necessary for remote paths because the sftp package only supports forward slashes, regardless of the local OS.
+// The Windows SSH implementation does this conversion, too. Though we have an advantage in that we can check the OSFamily.
+// https://github.com/PowerShell/openssh-portable/blob/59aba65cf2e2f423c09d12ad825c3b32a11f408f/scp.c#L636-L650
+func (h *RemoteHost) convertToForwardSlash(path string) string {
+	if h.OSFamily == osComp.WindowsFamily {
+		return strings.ReplaceAll(path, "\\", "/")
+	}
+	return path
 }

--- a/test/new-e2e/pkg/utils/clients/ssh.go
+++ b/test/new-e2e/pkg/utils/clients/ssh.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -128,6 +129,7 @@ func GetFile(client *ssh.Client, src string, dst string) error {
 	defer sftpClient.Close()
 
 	// remote
+	src = convertToForwardSlash(src)
 	fsrc, err := sftpClient.Open(src)
 	if err != nil {
 		return err
@@ -151,6 +153,7 @@ func copyFolder(sftpClient *sftp.Client, srcFolder string, dstFolder string) err
 		return err
 	}
 
+	dstFolder = convertToForwardSlash(dstFolder)
 	if err := sftpClient.MkdirAll(dstFolder); err != nil {
 		return err
 	}
@@ -178,6 +181,7 @@ func copyFile(sftpClient *sftp.Client, src string, dst string) error {
 	}
 	defer srcFile.Close()
 
+	dst = convertToForwardSlash(dst)
 	dstFile, err := sftpClient.Create(dst)
 	if err != nil {
 		return err
@@ -198,6 +202,7 @@ func FileExists(client *ssh.Client, path string) (bool, error) {
 	}
 	defer sftpClient.Close()
 
+	path = convertToForwardSlash(path)
 	info, err := sftpClient.Lstat(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -217,6 +222,7 @@ func ReadFile(client *ssh.Client, path string) ([]byte, error) {
 	}
 	defer sftpClient.Close()
 
+	path = convertToForwardSlash(path)
 	f, err := sftpClient.Open(path)
 	if err != nil {
 		return nil, err
@@ -239,6 +245,7 @@ func WriteFile(client *ssh.Client, path string, content []byte) (int64, error) {
 	}
 	defer sftpClient.Close()
 
+	path = convertToForwardSlash(path)
 	f, err := sftpClient.Create(path)
 	if err != nil {
 		return 0, err
@@ -285,6 +292,7 @@ func appendWithSftp(client *ssh.Client, path string, content []byte) (int64, err
 	defer sftpClient.Close()
 
 	// Open the file in append mode and create it if it doesn't exist
+	path = convertToForwardSlash(path)
 	f, err := sftpClient.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY)
 	if err != nil {
 		return 0, err
@@ -308,6 +316,7 @@ func ReadDir(client *ssh.Client, path string) ([]fs.DirEntry, error) {
 	}
 	defer sftpClient.Close()
 
+	path = convertToForwardSlash(path)
 	infos, err := sftpClient.ReadDir(path)
 	if err != nil {
 		return nil, err
@@ -331,6 +340,7 @@ func Lstat(client *ssh.Client, path string) (fs.FileInfo, error) {
 	}
 	defer sftpClient.Close()
 
+	path = convertToForwardSlash(path)
 	return sftpClient.Lstat(path)
 }
 
@@ -344,6 +354,7 @@ func MkdirAll(client *ssh.Client, path string) error {
 	}
 	defer sftpClient.Close()
 
+	path = convertToForwardSlash(path)
 	return sftpClient.MkdirAll(path)
 }
 
@@ -356,6 +367,7 @@ func Remove(client *ssh.Client, path string) error {
 	}
 	defer sftpClient.Close()
 
+	path = convertToForwardSlash(path)
 	return sftpClient.Remove(path)
 }
 
@@ -368,5 +380,15 @@ func RemoveAll(client *ssh.Client, path string) error {
 	}
 	defer sftpClient.Close()
 
+	path = convertToForwardSlash(path)
 	return sftpClient.RemoveAll(path)
+}
+
+// convertToForwardSlash replaces backslashes in the path with forward slashes
+//
+// This is necessary for remote paths because the sftp package only supports forward slashes.
+// This is safe for remote Windows hosts, the Windows SSH implementation does this conversion, too.
+// https://github.com/PowerShell/openssh-portable/blob/59aba65cf2e2f423c09d12ad825c3b32a11f408f/scp.c#L636-L650
+func convertToForwardSlash(path string) string {
+	return strings.ReplaceAll(path, "\\", "/")
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Convert backslashes to forward slashes in any remote paths used in Windows E2E remote hosts.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Some methods in the [go sftp package](https://pkg.go.dev/github.com/pkg/sftp) use the [go path package](https://pkg.go.dev/path) for path parsing, this causes errors with Windows paths of the form `C:\\Windows\\Temp`. The issue was first noticed with [MkdirAll](https://pkg.go.dev/github.com/pkg/sftp#Client.MkdirAll).

https://datadoghq.atlassian.net/browse/WINA-692

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
backslashes are a valid Linux filename character, so I chose to put the path conversion in `RemoteHost` rather than `ssh/client.go` so we can check the `OSFamily`. This means direct usage of `ssh/client.go` could still be impacted by this issue. At the moment only `RemoteHost` uses `ssh/client.go`.

The [go path package](https://pkg.go.dev/path) also does not support drive letter paths, so for example `IsAbs("C:\\Windows")` will return `false`. At the moment [go sftp package](https://pkg.go.dev/github.com/pkg/sftp) does not appear to use `IsAbs` or other functions that may be affected by this.

I've added the conversion to all SFTP functions, even if the go `sftp` function does not currently use a `path` function that could throw an error. The converted path will still work, and we won't have to keep our code up to date with any changes to the go `sftp` package.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
