### PR TITLE
add opensuse-leap as valid btf platform

### DIFF
--- a/pkg/ebpf/btf.go
+++ b/pkg/ebpf/btf.go
@@ -34,14 +34,15 @@ const btfFlushDelay = 1 * time.Minute
 type btfPlatform string
 
 const (
-	platformAmazon btfPlatform = "amzn"
-	platformCentOS btfPlatform = "centos"
-	platformDebian btfPlatform = "debian"
-	platformFedora btfPlatform = "fedora"
-	platformOracle btfPlatform = "ol"
-	platformRedhat btfPlatform = "rhel"
-	platformSUSE   btfPlatform = "sles"
-	platformUbuntu btfPlatform = "ubuntu"
+	platformAmazon       btfPlatform = "amzn"
+	platformCentOS       btfPlatform = "centos"
+	platformDebian       btfPlatform = "debian"
+	platformFedora       btfPlatform = "fedora"
+	platformOpenSUSELeap btfPlatform = "opensuse-leap"
+	platformOracle       btfPlatform = "ol"
+	platformRedhat       btfPlatform = "rhel"
+	platformSUSE         btfPlatform = "sles"
+	platformUbuntu       btfPlatform = "ubuntu"
 )
 
 func (p btfPlatform) String() string {
@@ -52,8 +53,10 @@ func btfPlatformFromString(platform string) (btfPlatform, error) {
 	switch platform {
 	case "amzn", "amazon":
 		return platformAmazon, nil
-	case "suse", "sles": //opensuse treated differently on purpose
+	case "suse", "sles":
 		return platformSUSE, nil
+	case "opensuse", "opensuse-leap":
+		return platformOpenSUSELeap, nil
 	case "redhat", "rhel":
 		return platformRedhat, nil
 	case "oracle", "ol":
@@ -222,6 +225,8 @@ var kernelVersionPatterns = []struct {
 	{regexp.MustCompile(`\.el[7-8]uek\.`), []btfPlatform{platformOracle}},
 	{regexp.MustCompile(`\.deb10\.`), []btfPlatform{platformDebian}},
 	{regexp.MustCompile(`\.fc\d{2}\.`), []btfPlatform{platformFedora}},
+	{regexp.MustCompile(`-lp15\d\.`), []btfPlatform{platformOpenSUSELeap}},
+	{regexp.MustCompile(`-150300\.`), []btfPlatform{platformOpenSUSELeap}},
 }
 
 var errIncorrectOSReleaseMount = errors.New("please mount the /etc/os-release file as /host/etc/os-release in the system-probe container to resolve this")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add `opensuse-leap` as valid BTF platform

### Motivation

Make use of new additions to BTFHub for openSUSE.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
