### PR TITLE
[WKINT-375][Windows][CWS] Normalize reporting of registry keys.

### DIFF
--- a/pkg/security/probe/probe_kernel_reg_windows_test.go
+++ b/pkg/security/probe/probe_kernel_reg_windows_test.go
@@ -41,7 +41,7 @@ func processUntilRegOpen(t *testing.T, et *etwTester) {
 
 			switch n.(type) {
 			case *createKeyArgs:
-				if strings.HasPrefix(n.(*createKeyArgs).computedFullPath, "\\REGISTRY\\USER\\") {
+				if strings.HasPrefix(n.(*createKeyArgs).computedFullPath, "HKEY_USERS\\") {
 					et.notifications = append(et.notifications, n)
 					if len(et.notifications) >= 2 {
 						return
@@ -145,9 +145,8 @@ func TestETWRegistryNotifications(t *testing.T) {
 	<-et.loopStarted
 
 	keyname := "Software\\Test"
-	expectedBase := "\\REGISTRY\\USER\\" + sidstr
+	expectedBase := "HKEY_USERS\\" + sidstr
 	expected := expectedBase + "\\" + keyname
-	// create the key
 	key, _, err := registry.CreateKey(windows.HKEY_CURRENT_USER, keyname, windows.KEY_READ|windows.KEY_WRITE)
 	assert.NoError(t, err)
 	if err == nil {
@@ -165,7 +164,7 @@ func TestETWRegistryNotifications(t *testing.T) {
 	stopLoop(et, &wg)
 
 	assert.Equal(t, 2, len(et.notifications), "expected 2 notifications, got %d", len(et.notifications))
-	
+
 	if c, ok := et.notifications[0].(*createKeyArgs); ok {
 		assert.Equal(t, expectedBase, c.computedFullPath, "expected %s, got %s", expectedBase, c.computedFullPath)
 	} else {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -563,7 +563,12 @@ func assertFieldEqualCaseInsensitve(tb testing.TB, e *model.Event, field string,
 	if reflect.TypeOf(fieldValue).Kind() == reflect.String {
 		fieldValue = strings.ToLower(fieldValue.(string))
 	}
-	return assert.Equal(tb, value, fieldValue, msgAndArgs...)
+	eq := assert.Equal(tb, value, fieldValue, msgAndArgs...)
+	if !eq {
+		tb.Logf("expected value %s\n", value.(string))
+		tb.Logf("actual value %s\n", fieldValue.(string))
+	}
+	return eq
 }
 
 //nolint:deadcode,unused

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -319,6 +319,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 }
 
 func (tm *testModule) Close() {
+	tm.eventMonitor.Close()
 }
 
 // NewTimeoutError returns a new timeout error with the metrics collected during the test

--- a/pkg/security/tests/registry_windows_test.go
+++ b/pkg/security/tests/registry_windows_test.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows && functionaltests
+
+// Package tests holds tests related files
+package tests
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+func TestBasicRegistryTest(t *testing.T) {
+	openDef := &rules.RuleDefinition{
+		ID:         "test_open_rule",
+		Expression: `open.registry.key_path == "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"`,
+	}
+
+	opts := testOpts{
+		enableFIM: true,
+	}
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{openDef}, withStaticOpts(opts))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	// this is kinda hokey.  ETW (which is what FIM is based on) takes an indeterminant amount of time to start up.
+	// so wait around for it to start
+	time.Sleep(5 * time.Second)
+
+	test.Run(t, "registry 1", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		/*
+			inputargs := []string{
+				"add",
+				"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run",
+				"/v",
+				"test",
+				"/t",
+				"REG_SZ",
+				"/d",
+				"c:\\windows\\system32\\calc.exe",
+			}
+		*/
+		inputargs := []string{
+			"-c",
+			"Set-ItemProperty",
+			"-Path",
+			`"HKLM:\Software\Microsoft\Windows\CurrentVersion\Run"`,
+			"-Name",
+			`"test"`,
+			"-Value",
+			`"test"`,
+		}
+		test.WaitSignal(t, func() error {
+			cmd := cmdFunc("powershell.exe", inputargs, nil)
+
+			// we will ignore any error
+			_ = cmd.Run()
+			return nil
+		}, test.validateRegistryEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+			assertFieldEqualCaseInsensitve(t, event, "open.registry.key_path", `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run`, "wrong registry key path")
+		}))
+	})
+}
+
+func (tm *testModule) validateRegistryEvent(tb *testing.T, kind wrapperType, validate func(event *model.Event, rule *rules.Rule)) func(event *model.Event, rule *rules.Rule) {
+	return func(event *model.Event, rule *rules.Rule) {
+		validate(event, rule)
+	}
+}

--- a/pkg/windowsdriver/olreader/olreader.go
+++ b/pkg/windowsdriver/olreader/olreader.go
@@ -168,7 +168,7 @@ func (olr *OverlappedReader) Stop() {
 		_ = windows.CloseHandle(olr.iocp)
 		olr.iocp = windows.Handle(0)
 	}
-	if olr.h == windows.Handle(0) {
+	if olr.h != windows.Handle(0) {
 		_ = windows.CloseHandle(olr.h)
 		olr.h = windows.Handle(0)
 	}

--- a/pkg/windowsdriver/olreader/olreader.go
+++ b/pkg/windowsdriver/olreader/olreader.go
@@ -164,8 +164,14 @@ func (olr *OverlappedReader) Read() error {
 
 //nolint:revive // TODO(WKIT) Fix revive linter
 func (olr *OverlappedReader) Stop() {
-	_ = windows.CloseHandle(olr.iocp)
-	_ = windows.CloseHandle(olr.h)
+	if olr.iocp != windows.Handle(0) {
+		_ = windows.CloseHandle(olr.iocp)
+		olr.iocp = windows.Handle(0)
+	}
+	if olr.h == windows.Handle(0) {
+		_ = windows.CloseHandle(olr.h)
+		olr.h = windows.Handle(0)
+	}
 	olr.wg.Wait()
 	olr.cleanBuffers()
 }


### PR DESCRIPTION
ETW returns the registry path in the format
\REGISTRY\MACHINE

Users are used to seeing HKEY_LOCAL_MACHINE

translate the ETW path to the expected path

This PR includes adding a new functional test for the registry notifications.

This PR also includes fixing a race condition in which the event object was shared between two goroutines, causing it to get intermittently stomped on.

### Describe how to test/QA your changes

Automated tests are provided.

Additional testing.
Create a registry rule in the policy file, such as 
```
- id: run_once_registry_opened
    description: A run_once registry was opened
    expression: open.registry.key_path == "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run"
    filters:
      - os == "windows"```
      
      Create that registry key; should see a notification