### PR TITLE
[Backport 7.52.x][EBPF-377] rollback (#22384) - changed back the ebpf telemetry metrics from Counter to Gauge

### DIFF
--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -31,8 +31,6 @@ type EBPFErrorsCollector struct {
 	*EBPFTelemetry
 	ebpfMapOpsErrors *prometheus.Desc
 	ebpfHelperErrors *prometheus.Desc
-	//we can use one map for both map errors and ebpf helpers errors, as the keys are different
-	lastValues map[string]uint64
 }
 
 // NewEBPFErrorsCollector initializes a new Collector object for ebpf helper and map operations errors
@@ -47,7 +45,6 @@ func NewEBPFErrorsCollector() prometheus.Collector {
 		},
 		ebpfMapOpsErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfMapTelemetryNS), "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil),
 		ebpfHelperErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfHelperTelemetryNS), "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil),
-		lastValues:       make(map[string]uint64),
 	}
 }
 
@@ -74,11 +71,7 @@ func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
 				base := maxErrno * index
 				if count := getErrCount(hval.Count[base : base+maxErrno]); len(count) > 0 {
 					for errStr, errCount := range count {
-						errorsDelta := float64(errCount - e.lastValues[errStr])
-						if errorsDelta > 0 {
-							ch <- prometheus.MustNewConstMetric(e.ebpfHelperErrors, prometheus.CounterValue, errorsDelta, helperName, probeName, errStr)
-						}
-						e.lastValues[errStr] = errCount
+						ch <- prometheus.MustNewConstMetric(e.ebpfHelperErrors, prometheus.GaugeValue, float64(errCount), helperName, probeName, errStr)
 					}
 				}
 			}
@@ -95,11 +88,7 @@ func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 			if count := getErrCount(val.Count[:]); len(count) > 0 {
 				for errStr, errCount := range count {
-					errorsDelta := float64(errCount - e.lastValues[errStr])
-					if errorsDelta > 0 {
-						ch <- prometheus.MustNewConstMetric(e.ebpfMapOpsErrors, prometheus.CounterValue, errorsDelta, m, errStr)
-					}
-					e.lastValues[errStr] = errCount
+					ch <- prometheus.MustNewConstMetric(e.ebpfMapOpsErrors, prometheus.GaugeValue, float64(errCount), m, errStr)
 				}
 			}
 		}


### PR DESCRIPTION
### What does this PR do?
https://github.com/DataDog/datadog-agent/pull/22384 introduced a bug in metrics calculation after switching to Prometheus.Counter, as the lastValues cache wasn't calculated properly making the metrics` values inaccurate

### Motivation
prevent ebpf telemetry being broken in 7.52

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
