### PR TITLE
set status as tag in pld telemetry in handler and patcher

### DIFF
--- a/cmd/cluster-agent/api/v1/languagedetection/language_detection.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/language_detection.go
@@ -25,6 +25,13 @@ import (
 
 const pldHandlerName = "language-detection-handler"
 
+var (
+	// statusSuccess is the value for the "status" tag that represents a successful operation
+	statusSuccess = "success"
+	// statusError is the value for the "status" tag that represents an error
+	statusError = "error"
+)
+
 // InstallLanguageDetectionEndpoints installs language detection endpoints
 func InstallLanguageDetectionEndpoints(r *mux.Router, wmeta workloadmeta.Component) {
 	handler := api.WithLeaderProxyHandler(
@@ -64,14 +71,14 @@ func loadOwnersLanguages(wlm workloadmeta.Component) *OwnersLanguages {
 // preHandler is called by both leader and followers and returns true if the request should be forwarded or handled by the leader
 func preHandler(w http.ResponseWriter, r *http.Request) bool {
 	if !config.Datadog.GetBool("language_detection.enabled") {
-		ErrorResponses.Inc()
+		ProcessedRequests.Inc(statusError)
 		http.Error(w, "Language detection feature is disabled on the cluster agent", http.StatusServiceUnavailable)
 		return false
 	}
 
 	// Reject if no body
 	if r.Body == nil {
-		ErrorResponses.Inc()
+		ProcessedRequests.Inc(statusError)
 		http.Error(w, "Request body is empty", http.StatusBadRequest)
 		return false
 	}
@@ -84,7 +91,7 @@ func leaderHandler(w http.ResponseWriter, r *http.Request, wlm workloadmeta.Comp
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read request body", http.StatusBadRequest)
-		ErrorResponses.Inc()
+		ProcessedRequests.Inc(statusError)
 		return
 	}
 
@@ -95,7 +102,7 @@ func leaderHandler(w http.ResponseWriter, r *http.Request, wlm workloadmeta.Comp
 	err = proto.Unmarshal(body, requestData)
 	if err != nil {
 		http.Error(w, "Failed to unmarshal request body", http.StatusBadRequest)
-		ErrorResponses.Inc()
+		ProcessedRequests.Inc(statusError)
 		return
 	}
 
@@ -105,10 +112,10 @@ func leaderHandler(w http.ResponseWriter, r *http.Request, wlm workloadmeta.Comp
 	err = ownersLanguage.mergeAndFlush(ownersLanguagesFromRequest, wlm)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to store some (or all) languages in workloadmeta store: %s", err), http.StatusInternalServerError)
-		ErrorResponses.Inc()
+		ProcessedRequests.Inc(statusError)
 		return
 	}
 
-	OkResponses.Inc()
+	ProcessedRequests.Inc(statusSuccess)
 	w.WriteHeader(http.StatusOK)
 }

--- a/cmd/cluster-agent/api/v1/languagedetection/telemetry.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/telemetry.go
@@ -16,21 +16,12 @@ var (
 )
 
 var (
-	// OkResponses tracks the number the request was processed successfully
-	OkResponses = telemetry.NewCounterWithOpts(
+	// ProcessedRequests tracks the number requests processed by the handler
+	ProcessedRequests = telemetry.NewCounterWithOpts(
 		subsystem,
-		"ok_response",
-		[]string{},
-		"Tracks the number of times request processing succeeds",
-		commonOpts,
-	)
-
-	// ErrorResponses tracks the number of times request processsing fails
-	ErrorResponses = telemetry.NewCounterWithOpts(
-		subsystem,
-		"fail_response",
-		[]string{},
-		"Tracks the number of times request processing fails",
+		"processed_requests",
+		[]string{"status"},
+		"Tracks the number of requests processed by the handler",
 		commonOpts,
 	)
 )

--- a/pkg/clusteragent/languagedetection/telemetry.go
+++ b/pkg/clusteragent/languagedetection/telemetry.go
@@ -16,39 +16,12 @@ var (
 )
 
 var (
-	// PatchRetries determines the number of times a patch request fails and is retried for a gived
-	PatchRetries = telemetry.NewCounterWithOpts(
+	// Patches is the number of patch requests sent by the patcher to the kubernetes api server
+	Patches = telemetry.NewCounterWithOpts(
 		subsystem,
-		"retries",
-		[]string{"owner_kind", "owner_name", "namespace"},
-		"Tracks the number of retries while patching deployments with language annotations",
-		commonOpts,
-	)
-
-	// SuccessPatches tracks the number of successful annotation patch operations
-	SuccessPatches = telemetry.NewCounterWithOpts(
-		subsystem,
-		"success_patch",
-		[]string{"owner_kind", "owner_name", "namespace"},
-		"Tracks the number of successful annotation patch operations",
-		commonOpts,
-	)
-
-	// FailedPatches tracks the number of failing annotation patch operations
-	FailedPatches = telemetry.NewCounterWithOpts(
-		subsystem,
-		"fail_patch",
-		[]string{"owner_kind", "owner_name", "namespace"},
-		"Tracks the number of failing annotation patch operations",
-		commonOpts,
-	)
-
-	// SkippedPatches tracks the number of times a patch was skipped because no new languages are detected
-	SkippedPatches = telemetry.NewCounterWithOpts(
-		subsystem,
-		"skipped_patch",
-		[]string{"owner_kind", "owner_name", "namespace"},
-		"Tracks the number of times a patch was skipped because no new languages are detected or old languages were expired",
+		"patches",
+		[]string{"owner_kind", "owner_name", "namespace", "status"},
+		"Tracks the number of patch requests sent by the patcher to the kubernetes api server",
 		commonOpts,
 	)
 )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Set status as tag in language detection telemetry instead of having 1 metric per status.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix bad telemetry naming pattern.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This should be fixed and merged in 7.52 because:
- not fixing it now implies that we should support these metrics for ever
- these metrics are collected by the datadog cluster agent integration, so another fix should be done there

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Enable language detection (example QA [here](https://github.com/DataDog/datadog-agent/pull/22830)) and verify the language detection metrics are correctly emitted by the agent and the cluster agent.

Example:
```
# HELP language_detection_dca_handler_processed_requests Tracks the number of requests processed by the handler
# TYPE language_detection_dca_handler_processed_requests counter
language_detection_dca_handler_processed_requests{status="success"} 3
# HELP language_detection_patcher_patches Tracks the number of patch requests sent by the patcher to the kubernetes api server
# TYPE language_detection_patcher_patches counter
language_detection_patcher_patches{namespace="default",owner_kind="Deployment",owner_name="dummy-dsd-app-java",status="error"} 1
language_detection_patcher_patches{namespace="default",owner_kind="Deployment",owner_name="dummy-dsd-app-java",status="retry"} 1
language_detection_patcher_patches{namespace="default",owner_kind="Deployment",owner_name="dummy-python-app",status="success"} 1
```
