### PR TITLE
Clean up check after cancel timeout

### DIFF
--- a/comp/collector/collector/collectorimpl/collector.go
+++ b/comp/collector/collector/collectorimpl/collector.go
@@ -220,10 +220,12 @@ func (c *collectorImpl) StopCheck(id checkid.ID) error {
 	if err := c.runner.StopCheck(id); err != nil {
 		// still attempt to cancel the check before returning the error
 		_ = c.cancelCheck(ch, c.cancelCheckTimeout)
+		c.delete(id)
 		return fmt.Errorf("an error occurred while stopping the check: %s", err)
 	}
 
 	if err := c.cancelCheck(ch, c.cancelCheckTimeout); err != nil {
+		c.delete(id)
 		return fmt.Errorf("an error occurred while calling check.Cancel(): %s", err)
 	}
 

--- a/comp/collector/collector/collectorimpl/collector_test.go
+++ b/comp/collector/collector/collectorimpl/collector_test.go
@@ -161,6 +161,20 @@ func (suite *CollectorTestSuite) TestCancelCheck_TimeoutIsApplied() {
 	ch.AssertNumberOfCalls(suite.T(), "Cancel", 1)
 }
 
+func (suite *CollectorTestSuite) TestCancelCheck_CheckIsCleanedUp() {
+	ch := NewCheckSlowCancel(10 * time.Second)
+
+	start := time.Now()
+	id, err := suite.c.RunCheck(ch)
+	assert.Nil(suite.T(), err)
+	assert.NotEmpty(suite.T(), suite.c.checks)
+
+	err = suite.c.StopCheck(id)
+	assert.NotNil(suite.T(), err)
+	assert.WithinDuration(suite.T(), start, time.Now(), 5*time.Second)
+	assert.Empty(suite.T(), suite.c.checks)
+}
+
 func (suite *CollectorTestSuite) TestGet() {
 	_, found := suite.c.get("bar")
 	assert.False(suite.T(), found)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Removes a check that failed to cancel from the collector's registry of checks. This allows the check to be rescheduled again and send metrics normally.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
To allow for a check to be rescheduled again after failing to cancel in time. Previously, the check was left in a zombie state which resulted in a loss of metrics.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
- Test that checks still work normally
- Test that a check that fails to cancel in time can be rescheduled properly and metrics can be sent again.
Example custom check something provided as an example below:
```
#checks.d/something.py
import time
from checks import AgentCheck
class HelloCheck(AgentCheck):
  def check(self, instance):
    for i in range(9):
      self.count('custom.check.count', 1)
      time.sleep(10)
  def cancel(self):
    time.sleep(90)
```
`conf.d/something.yaml`:
```
init_config:
instances:
  [{}]

```
1. Set `autoconf_config_files_poll: true` in `datadog.yaml`
2. Let the check get run
3. `sudo mv something.yaml backup`  . autoconf config file poll will detect that the file has changed and the check will be unscheduled + canceled. The collector cancellation will timeout but the check should now be removed from the registry.
`agent configcheck` should not have the something check listed
4. `sudo mv backup something.yaml` The scheduler should be able to schedule this check again and the check should run normally
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
