### PR TITLE
[EBPF-339] - changed default modifiers initialization for agent's ebpf manager wrapper

### DIFF
--- a/pkg/ebpf/ebpf.go
+++ b/pkg/ebpf/ebpf.go
@@ -23,10 +23,8 @@ var core struct {
 }
 
 // Setup initializes CO-RE and BTF loaders with the provided config.
-// It also configures the default manager modifiers.
 // [Reset] must be called first if you want a different config to take effect
 func Setup(cfg *Config) error {
-	registerDefaultModifiers()
 	_, err := coreLoader(cfg)
 	return err
 }
@@ -58,15 +56,6 @@ func coreLoader(cfg *Config) (*coreAssetLoader, error) {
 	return core.loader, nil
 }
 
-func registerDefaultModifiers() {
-	// Important: managers that use the default modifiers will all share the same instance of each modifier.
-	// Take this into account if your modifier has internal state that should be specific to each manager, see
-	// more details in the Modifier documentation.
-	defaultModifiers = []Modifier{
-		&PrintkPatcherModifier{},
-	}
-}
-
 // Reset resets CO-RE and BTF loaders and manager modifiers back to uninitialized state
 func Reset() {
 	core.Lock()
@@ -74,6 +63,4 @@ func Reset() {
 
 	core.loader.btfLoader.Flush()
 	core.loader = nil
-
-	defaultModifiers = nil
 }

--- a/pkg/ebpf/manager.go
+++ b/pkg/ebpf/manager.go
@@ -12,8 +12,6 @@ import (
 	"io"
 	"sync"
 
-	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
-
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -46,7 +44,7 @@ func NewManager(mgr *manager.Manager, modifiers ...Modifier) *Manager {
 // NewManagerWithDefault creates a manager wrapper with default modifiers.
 func NewManagerWithDefault(mgr *manager.Manager, modifiers ...Modifier) *Manager {
 	modifiersSync.Do(func() {
-		defaultModifiers = []Modifier{&PrintkPatcherModifier{}, &ebpftelemetry.ErrorsTelemetryModifier{}}
+		defaultModifiers = []Modifier{&PrintkPatcherModifier{}}
 	})
 	return NewManager(mgr, append(defaultModifiers, modifiers...)...)
 }

--- a/pkg/ebpf/manager_test.go
+++ b/pkg/ebpf/manager_test.go
@@ -1,0 +1,60 @@
+package ebpf
+
+import (
+	"testing"
+
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/stretchr/testify/assert"
+)
+
+// PrintkPatcherModifier adds an InstructionPatcher to the manager that removes the newline character from log_debug calls if needed
+type dummyModifier struct {
+}
+
+const dummyModifierName = "DummyModifier"
+
+func (t *dummyModifier) String() string {
+	return dummyModifierName
+}
+
+// BeforeInit adds the patchPrintkNewline function to the manager
+func (t *dummyModifier) BeforeInit(_ *manager.Manager, _ *manager.Options) error { return nil }
+
+// AfterInit is a no-op for this modifier
+func (t *dummyModifier) AfterInit(_ *manager.Manager, _ *manager.Options) error {
+	return nil
+}
+
+func TestNewManagerWithDefault(t *testing.T) {
+	type args struct {
+		mgr       *manager.Manager
+		modifiers []Modifier
+	}
+	tests := []struct {
+		name                  string
+		args                  args
+		expectedModifierCount int
+	}{
+		{
+			name:                  "with one custom modifier",
+			args:                  args{mgr: nil, modifiers: []Modifier{&dummyModifier{}}},
+			expectedModifierCount: len(defaultModifiers) + 1,
+		},
+		{
+			name:                  "with empty modifiers list",
+			args:                  args{mgr: nil, modifiers: []Modifier{}},
+			expectedModifierCount: len(defaultModifiers),
+		},
+		{
+			name:                  "passing nil as modifiers list",
+			args:                  args{mgr: nil, modifiers: nil},
+			expectedModifierCount: len(defaultModifiers),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := NewManagerWithDefault(tt.args.mgr, tt.args.modifiers...)
+			assert.Equalf(t, tt.expectedModifierCount, len(target.EnabledModifiers), "Expected to have %v enabled modifiers ", tt.expectedModifierCount)
+		})
+	}
+}

--- a/pkg/ebpf/manager_test.go
+++ b/pkg/ebpf/manager_test.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+//go:build linux_bpf
+
 package ebpf
 
 import (

--- a/pkg/ebpf/manager_test.go
+++ b/pkg/ebpf/manager_test.go
@@ -36,6 +36,8 @@ func TestNewManagerWithDefault(t *testing.T) {
 		mgr       *manager.Manager
 		modifiers []Modifier
 	}
+	// ensuring the lazy init of the defaultModifiers list
+	_ = NewManagerWithDefault(nil, nil)
 	tests := []struct {
 		name                  string
 		args                  args


### PR DESCRIPTION
### What does this PR do?

- changed defaultModifiers to lazy initialized list on first manager's init.
- added a new overload to ebpf.Manager NewManagerWithDefault to allow creating a manager with default modifiers. 

### Motivation

once we migrate ebpf programs to the new ebpf.Manager, our UTs will fail ([failed job example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/444612032)) since the code-path of `ebpf.Setup` (which in turn was calling `registerDefaultModifiers`) is not called in the UTs context.

Also it seems the `ebpf.go` is a loader for CO-RE and not a general loader for all build modes, so i figured it would be a wrong place to initialize global structure such as `defaultModifiersList`.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

added UTs for the new ctor overload
