### PR TITLE
[NDM] Send unreachable on error, fix logs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,7 +174,7 @@
 /cmd/system-probe/modules/process*      @DataDog/processes
 /cmd/system-probe/modules/eventmonitor* @DataDog/agent-security
 /cmd/system-probe/modules/tcp_queue_tracer* @DataDog/container-integrations
-/cmd/system-probe/modules/ping*         @DataDog/network-device-monitoring
+/cmd/system-probe/modules/ping*.go         @DataDog/network-device-monitoring
 /cmd/system-probe/windows/              @DataDog/windows-kernel-integrations
 /cmd/system-probe/windows_resources/    @DataDog/windows-kernel-integrations
 /cmd/system-probe/main_windows*.go      @DataDog/windows-kernel-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,6 +174,7 @@
 /cmd/system-probe/modules/process*      @DataDog/processes
 /cmd/system-probe/modules/eventmonitor* @DataDog/agent-security
 /cmd/system-probe/modules/tcp_queue_tracer* @DataDog/container-integrations
+/cmd/system-probe/modules/ping*         @DataDog/network-device-monitoring
 /cmd/system-probe/windows/              @DataDog/windows-kernel-integrations
 /cmd/system-probe/windows_resources/    @DataDog/windows-kernel-integrations
 /cmd/system-probe/main_windows*.go      @DataDog/windows-kernel-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,7 +174,7 @@
 /cmd/system-probe/modules/process*      @DataDog/processes
 /cmd/system-probe/modules/eventmonitor* @DataDog/agent-security
 /cmd/system-probe/modules/tcp_queue_tracer* @DataDog/container-integrations
-/cmd/system-probe/modules/ping*.go         @DataDog/network-device-monitoring
+/cmd/system-probe/modules/ping*         @DataDog/network-device-monitoring
 /cmd/system-probe/windows/              @DataDog/windows-kernel-integrations
 /cmd/system-probe/windows_resources/    @DataDog/windows-kernel-integrations
 /cmd/system-probe/main_windows*.go      @DataDog/windows-kernel-integrations

--- a/cmd/system-probe/modules/ping.go
+++ b/cmd/system-probe/modules/ping.go
@@ -125,7 +125,7 @@ func logPingRequests(host string, client string, count int, interval int, timeou
 	args := []interface{}{host, client, count, interval, timeout, runCount, time.Since(start)}
 	msg := "Got request on /ping/%s?client_id=%s&count=%d&interval=%d&timeout=%d (count: %d): retrieved ping in %s"
 	switch {
-	case count <= 5, count%20 == 0:
+	case runCount <= 5, runCount%20 == 0:
 		log.Infof(msg, args...)
 	default:
 		log.Debugf(msg, args...)

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -174,7 +174,10 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 		if err != nil {
 			// if the ping fails, send no metrics/metadata, log and add diagnosis
 			log.Errorf("%s: failed to ping device: %s", d.config.IPAddress, err.Error())
+			pingStatus = metadata.DeviceStatusUnreachable
 			d.diagnoses.Add("error", "SNMP_FAILED_TO_PING_DEVICE", "Agent encountered an error when pinging this network device. Check agent logs for more details.")
+			d.sender.Gauge(pingReachableMetric, common.BoolToFloat64(false), tags)
+			d.sender.Gauge(pingUnreachableMetric, common.BoolToFloat64(true), tags)
 		} else {
 			// if ping succeeds, set pingCanConnect for use in metadata and send metrics
 			log.Debugf("%s: ping returned: %+v", d.config.IPAddress, pingResult)

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -1101,6 +1101,7 @@ profiles:
 
 	// Assert Ping Metrics
 	sender.AssertMetric(t, "Gauge", pingReachableMetric, float64(1), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", pingUnreachableMetric, float64(0), "", snmpTags)
 	sender.AssertMetric(t, "Gauge", pingAvgRttMetric, 4, "", snmpTags)
 	sender.AssertMetric(t, "Gauge", pingPacketLoss, 0.57, "", snmpTags)
 }
@@ -1241,8 +1242,11 @@ profiles:
 	assert.Len(t, deviceCk.config.Metrics, 2)
 	assert.Len(t, deviceCk.config.MetricTags, 2)
 
-	// Assert Ping Metrics not sent
-	sender.AssertNotCalled(t, "Gauge", pingReachableMetric, mock.Anything, mock.Anything, mock.Anything)
+	// Assert Ping reachability metrics are sent
+	sender.AssertMetric(t, "Gauge", pingReachableMetric, float64(0), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", pingUnreachableMetric, float64(1), "", snmpTags)
+
+	// Assert Ping Loss and RTT metrics are not send
 	sender.AssertNotCalled(t, "Gauge", pingAvgRttMetric, mock.Anything, mock.Anything, mock.Anything)
 	sender.AssertNotCalled(t, "Gauge", pingPacketLoss, mock.Anything, mock.Anything, mock.Anything)
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -678,6 +678,13 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.SetKnown("snmp_listener.min_collection_interval")
 	config.SetKnown("snmp_listener.namespace")
 	config.SetKnown("snmp_listener.use_device_id_as_hostname")
+	config.SetKnown("snmp_listener.ping")
+	config.SetKnown("snmp_listener.ping.enabled")
+	config.SetKnown("snmp_listener.ping.count")
+	config.SetKnown("snmp_listener.ping.interval")
+	config.SetKnown("snmp_listener.ping.timeout")
+	config.SetKnown("snmp_listener.ping.linux")
+	config.SetKnown("snmp_listener.ping.linux.use_raw_socket")
 
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.snmp_traps.forwarder.")
 	config.BindEnvAndSetDefault("network_devices.snmp_traps.enabled", false)

--- a/pkg/networkdevice/pinger/utils.go
+++ b/pkg/networkdevice/pinger/utils.go
@@ -13,7 +13,7 @@ import (
 
 // RunPing creates a pinger for the requested host and sends the requested number of packets to it
 func RunPing(cfg *Config, host string) (*Result, error) {
-	log.Infof("Running ping for host: %s, useRawSocket: %t\n", host, cfg.UseRawSocket)
+	log.Debugf("Running ping for host: %s, useRawSocket: %t\n", host, cfg.UseRawSocket)
 	pinger, err := probing.NewPinger(host)
 	if err != nil {
 		return &Result{}, err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR fixes a few small bugs in the ping portion (new feature) of the SNMP integration.

1) In the case that calling ping errored out before an ICMP packet was sent, the status metrics and metadata were unset which could lead to confusion for customers
2) The agent logged that configuration keys for ping under the `snmp_listener` were unknown even though they were being properly read in and used
3) The system-probe was logging for every ping due to an incorrect variable being used

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fix issues that could impact the customer experience when using ping.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

See the 3 issues described above and their numbers.

1) The easiest way I've found to test for this case is in a Linux environment. You can use mimic. With `ping` configuration set `linux.use_raw_socket: true` you can simulate a failing call to ping by ensuring the ping module on the system probe is disabled.

Agent config:
```yaml
ping:
  enabled: true
  linux:
    use_raw_socket: true
```

System Probe config:
```yaml
ping:
  enabled: false
```
When you run the agent, it will attempt to ping using the system probe but the call will fail, returning an error. You can either check the output of `agent check snmp` to see that the metadata contains `ping_status` set to `2`.

```json
...
  "devices": [
    {
    ...
    "ping_status": 2
    ...
    }
  ]
...
```

And metrics for `networkdevice.ping.reachable` set to `0` and `networkdevice.ping.unreachable` set to `1`.

2) To ensure this is fixed, run the agent with a configuration for ping under `snmp_listener` like so:

```yaml
snmp_listener:
  ping:
    enabled: true
    count: 2
    interval: 20
    timeout: 3000
    linux:
      use_raw_socket: true
```
Check to see that there are no log statements like the following for any of these configurations:

```
2024-02-27 14:07:00 EST | CORE | WARN | (pkg/util/log/log.go:682 in func1) | Unknown key in config file: snmp_listener.ping.linux.use_raw_socket
2024-02-27 14:07:00 EST | CORE | WARN | (pkg/util/log/log.go:682 in func1) | Unknown key in config file: snmp_listener.ping.enabled
```

3) This can only be tested in Linux, so it's probably easiest to use mimic here as well. Ensure that the ping integration is set up to use system probe:

Agent config:
```yaml
ping:
  enabled: true
  linux:
    use_raw_socket: true
```

System Probe config:
```yaml
ping:
  enabled: true
```

Then with the agent running, see that the log statements for ping are occurring with a "count" from 1 to 5, then from count 20, every 20 after.

Specifically look for the following log statements:
```
2024-02-28 12:10:28 PST | SYS-PROBE | INFO | (cmd/system-probe/modules/ping.go:129 in logPingRequests) | Got request on /ping/10.0.0.81?client_id=pinger-agent-linux&count=2&interval=10000000&timeout=3000000000 (count: 20): retrieved ping in 21.962074ms
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
