### PR TITLE
[NPM] testE2E avoid flaky test, run FakeIntakeNPM_HostRequests first

### DIFF
--- a/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
@@ -109,7 +109,9 @@ func (v *ec2VMContainerizedSuite) BeforeTest(suiteName, testName string) {
 // 2 tests generate the request on the host and on docker
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
-func (v *ec2VMContainerizedSuite) TestFakeIntakeNPM_HostRequests() {
+//
+// The test start by 00 to validate the agent/system-probe is up and running
+func (v *ec2VMContainerizedSuite) Test00FakeIntakeNPM_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate a connection

--- a/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
@@ -65,7 +65,9 @@ func (v *ec2VMSELinuxSuite) SetupSuite() {
 // 2 tests generate the request on the host and on docker
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
-func (v *ec2VMSELinuxSuite) TestFakeIntakeNPM_HostRequests() {
+//
+// The test start by 00 to validate the agent/system-probe is up and running
+func (v *ec2VMSELinuxSuite) Test00FakeIntakeNPM_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate a connection

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -113,7 +113,9 @@ func (v *ec2VMSuite) BeforeTest(suiteName, testName string) {
 // 2 tests generate the request on the host and on docker
 //   - looking for 1 host to send CollectorConnections payload to the fakeintake
 //   - looking for 3 payloads and check if the last 2 have a span of 30s +/- 500ms
-func (v *ec2VMSuite) TestFakeIntakeNPM_HostRequests() {
+//
+// The test start by 00 to validate the agent/system-probe is up and running
+func (v *ec2VMSuite) Test00FakeIntakeNPM_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate a connection


### PR DESCRIPTION
### What does this PR do?

Avoid flaky test, run `FakeIntakeNPM_HostRequests` first
This would avoid slow agent start to failed on others tests that are more specific to the traffic generated.

### Motivation

CI error like [this one](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/445585617#L5818)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
