### PR TITLE
[WKINT-386][Windows][CWS]  Additional tests for FRIM

### DIFF
--- a/pkg/security/tests/registry_windows_test.go
+++ b/pkg/security/tests/registry_windows_test.go
@@ -48,6 +48,7 @@ func TestBasicRegistryTest(t *testing.T) {
 		inputargs := []string{
 			"add",
 			"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run",
+			"/f",
 			"/v",
 			"test",
 			"/t",
@@ -62,6 +63,8 @@ func TestBasicRegistryTest(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, test.validateRegistryEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+			s := test.debugEvent(event)
+			t.Logf("event: %s", s)
 			assertFieldEqualCaseInsensitve(t, event, "create.registry.key_path", `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run`, "wrong registry key path")
 		}))
 	})
@@ -83,6 +86,7 @@ func TestBasicRegistryTest(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, test.validateRegistryEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+			t.Logf("event: %v", event)
 			assertFieldEqualCaseInsensitve(t, event, "open.registry.key_path", `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run`, "wrong registry key path")
 		}))
 	})
@@ -95,6 +99,7 @@ func TestBasicRegistryTest(t *testing.T) {
 			return nil
 
 		}, test.validateRegistryEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+			t.Logf("event: %v", event)
 			assertFieldEqualCaseInsensitve(t, event, "create.registry.key_path", `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run`, "wrong registry key path")
 		}))
 	})


### PR DESCRIPTION
This PR adds an additional test for FRIM/registry testing. It's primary purpose is to illuminate a potential usability issue.

This PR has no agent code.  It is entirely a test.
