### PR TITLE
[macos] Wait more during workflow retrieval step

### DIFF
--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -82,7 +82,7 @@ def trigger_macos_workflow(
     # Thus the following hack: Send an id as input when creating a workflow on Github. The worklow will use the id and put it in the name of one of its jobs.
     # We then fetch workflows and check if it contains the id in its job name.
 
-    MAX_RETRIES = 10  # Retry up to 10 times
+    MAX_RETRIES = 30  # Retry for up to 5 minutes
     for i in range(MAX_RETRIES):
         print(f"Fetching triggered workflow (try {i + 1}/{MAX_RETRIES})")
         recent_runs = gh.workflow_run_for_ref_after_date(workflow_name, github_action_ref, now)
@@ -94,8 +94,8 @@ def trigger_macos_workflow(
                         return recent_run
             else:
                 print("waiting for jobs to popup...")
-                sleep(3)
-        sleep(5)
+                sleep(5)
+        sleep(10)
 
     # Something went wrong :(
     print("Couldn't fetch workflow run that was triggered.")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->

### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Increases the number of retries in the macOS GitHub Actions workflow retrieval step, to retry up to 5 minutes. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Prevent flakiness in macOS jobs.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a
