### PR TITLE
Only provide dummy responses to List all external metrics

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2966,6 +2966,7 @@ core,sigs.k8s.io/custom-metrics-apiserver/pkg/generated/openapi/core,Apache-2.0,
 core,sigs.k8s.io/custom-metrics-apiserver/pkg/generated/openapi/custommetrics,Apache-2.0,Copyright 2017 The Kubernetes Authors.
 core,sigs.k8s.io/custom-metrics-apiserver/pkg/generated/openapi/externalmetrics,Apache-2.0,Copyright 2017 The Kubernetes Authors.
 core,sigs.k8s.io/custom-metrics-apiserver/pkg/provider,Apache-2.0,Copyright 2017 The Kubernetes Authors.
+core,sigs.k8s.io/custom-metrics-apiserver/pkg/provider/defaults,Apache-2.0,Copyright 2017 The Kubernetes Authors.
 core,sigs.k8s.io/custom-metrics-apiserver/pkg/registry/custom_metrics,Apache-2.0,Copyright 2017 The Kubernetes Authors.
 core,sigs.k8s.io/custom-metrics-apiserver/pkg/registry/external_metrics,Apache-2.0,Copyright 2017 The Kubernetes Authors.
 core,sigs.k8s.io/json,Apache-2.0,Copyright 2017 The Kubernetes Authors.

--- a/pkg/clusteragent/custommetrics/provider_test.go
+++ b/pkg/clusteragent/custommetrics/provider_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
@@ -26,81 +27,9 @@ type metricCompare struct {
 }
 
 func TestListAllExternalMetrics(t *testing.T) {
-	metricName := "m1"
-	metric2Name := "m2"
-	metric3Name := "m3"
-	tests := []struct {
-		name      string
-		res       []provider.ExternalMetricInfo
-		cached    []externalMetric
-		timestamp int64
-	}{
-		{
-			name: "no metrics stored",
-			res: []provider.ExternalMetricInfo{
-				fakeExternalMetric,
-			},
-			cached: []externalMetric{
-				{
-					info: fakeExternalMetric,
-				},
-			},
-		},
-		{
-			name: "one nano metric stored",
-			res: []provider.ExternalMetricInfo{
-				{
-					Metric: metricName,
-				},
-			},
-			cached: []externalMetric{
-				{
-					info: provider.ExternalMetricInfo{
-						Metric: metricName,
-					},
-				},
-			},
-		},
-		{
-			name: "multiple types",
-			cached: []externalMetric{
-				{
-					info: provider.ExternalMetricInfo{
-						Metric: metricName,
-					},
-				}, {
-					info: provider.ExternalMetricInfo{
-						Metric: metric2Name,
-					},
-				}, {
-					info: provider.ExternalMetricInfo{
-						Metric: metric3Name,
-					},
-				},
-			},
-			res: []provider.ExternalMetricInfo{
-				{
-					Metric: metricName,
-				},
-				{
-					Metric: metric2Name,
-				},
-				{
-					Metric: metric3Name,
-				},
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			dp := datadogProvider{
-				externalMetrics: test.cached,
-				isServing:       true,
-			}
-			output := dp.ListAllExternalMetrics()
-			require.Equal(t, len(test.cached), len(output))
-		})
-	}
+	dp := datadogProvider{}
+	metrics := dp.ListAllExternalMetrics()
+	assert.ElementsMatch(t, []provider.ExternalMetricInfo{{Metric: "externalmetrics"}}, metrics)
 }
 
 func TestGetExternalMetric(t *testing.T) {

--- a/pkg/clusteragent/externalmetrics/metrics_retriever.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever.go
@@ -62,7 +62,9 @@ func (mr *MetricsRetriever) Run(stopCh <-chan struct{}) {
 		select {
 		case <-tickerRefreshProcess.C:
 			if mr.isLeader() {
+				startTime := time.Now()
 				mr.retrieveMetricsValues()
+				retrieverElapsed.Observe(time.Since(startTime).Seconds())
 			}
 		case <-stopCh:
 			log.Infof("Stopping MetricsRetriever")

--- a/pkg/clusteragent/externalmetrics/provider_test.go
+++ b/pkg/clusteragent/externalmetrics/provider_test.go
@@ -204,69 +204,11 @@ func TestGetExternalMetrics(t *testing.T) {
 }
 
 func TestListAllExternalMetrics(t *testing.T) {
-	defaultUpdateTime := time.Now().UTC()
-
 	fixtures := []providerFixture{
 		{
-			desc:         "Test no metrics in store (send fake metric back)",
-			storeContent: []ddmWithQuery{},
-			expectedExternalMetricInfo: []provider.ExternalMetricInfo{
-				fakeExternalMetric,
-			},
-		},
-		{
-			desc: "Test with metrics in store",
-			storeContent: []ddmWithQuery{
-				{
-					ddm: model.DatadogMetricInternal{
-						ID:       "ns/metric0",
-						DataTime: defaultUpdateTime,
-						Valid:    true,
-						Error:    nil,
-						Value:    42.0,
-					},
-					query: "query-metric0",
-				},
-				{
-					ddm: model.DatadogMetricInternal{
-						ID:       "ns/metric1",
-						DataTime: defaultUpdateTime,
-						Valid:    false,
-						Error:    nil,
-						Value:    42.0,
-					},
-					query: "query-metric1",
-				},
-				{
-					ddm: model.DatadogMetricInternal{
-						ID:                 "autogen-foo",
-						DataTime:           defaultUpdateTime,
-						ExternalMetricName: "metric2",
-						Autogen:            true,
-						Valid:              false,
-						Error:              nil,
-						Value:              42.0,
-					},
-					query: "query-metric2",
-				},
-				{
-					ddm: model.DatadogMetricInternal{
-						ID:                 "autogen-bar",
-						DataTime:           defaultUpdateTime,
-						ExternalMetricName: "metric2",
-						Autogen:            true,
-						Valid:              false,
-						Error:              nil,
-						Value:              42.0,
-					},
-					query: "query-metric3",
-				},
-			},
-			expectedExternalMetricInfo: []provider.ExternalMetricInfo{
-				{Metric: "datadogmetric@ns:metric0"},
-				{Metric: "datadogmetric@ns:metric1"},
-				{Metric: "metric2"},
-			},
+			desc:                       "Test no metrics in store (send fake metric back)",
+			storeContent:               []ddmWithQuery{},
+			expectedExternalMetricInfo: []provider.ExternalMetricInfo{{Metric: "externalmetrics"}},
 		},
 	}
 

--- a/pkg/clusteragent/externalmetrics/telemetry.go
+++ b/pkg/clusteragent/externalmetrics/telemetry.go
@@ -36,8 +36,13 @@ var (
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	elapsedTelemetry = telemetry.NewHistogramWithOpts("external_metrics", "api_elapsed",
-		[]string{"namespace", "handler", "in_error"}, "Count of API Requests received",
+		[]string{"namespace", "handler", "in_error"}, "Wall time spent on API request (seconds)",
 		prometheus.DefBuckets,
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	retrieverElapsed = telemetry.NewHistogramWithOpts("external_metrics", "retriever_elapsed",
+		[]string{}, "Wall time spent to retrieve metrics (seconds)",
+		[]float64{0.5, 1, 5, 10, 20, 30, 60, 120, 300},
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 )
 
@@ -87,5 +92,5 @@ func setQueryTelemtry(handler, namespace string, startTime time.Time, err error)
 	}
 
 	requestsTelemetry.Inc(namespace, handler, inErrror)
-	elapsedTelemetry.Observe(float64(time.Since(startTime)), namespace, handler, inErrror)
+	elapsedTelemetry.Observe(time.Since(startTime).Seconds(), namespace, handler, inErrror)
 }

--- a/pkg/clusteragent/externalmetrics/utils.go
+++ b/pkg/clusteragent/externalmetrics/utils.go
@@ -47,10 +47,6 @@ func metricNameToDatadogMetricID(metricName string) (id string, parsed bool, has
 	return "", false, strings.HasPrefix(metricName, datadogMetricRefPrefix)
 }
 
-func datadogMetricIDToMetricName(datadogMetricID string) string {
-	return strings.ToLower(datadogMetricRefPrefix + strings.Replace(datadogMetricID, kubernetesNamespaceSep, datadogMetricRefSep, 1))
-}
-
 func getAutogenDatadogMetricNameFromLabels(metricName string, labels map[string]string) string {
 	return getAutogenDatadogMetricName(buildDatadogQueryForExternalMetric(metricName, labels))
 }


### PR DESCRIPTION
### What does this PR do?

As upstream recommends, only return dummy responses to list all external metrics as the `List` is not used by autoscaler controllers and wastes resources on all `Discovery` calls.

### Motivation

Optim

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Non-regression only required. Will be tested extensively internally, no need for manual QA.