### PR TITLE
upgrade(FA): Check available disk space before downloading & extracting packages

### DIFF
--- a/pkg/updater/tools/check_size.go
+++ b/pkg/updater/tools/check_size.go
@@ -11,7 +11,13 @@ import (
 )
 
 // CheckAvailableDiskSpace checks if the given path has enough free space to store the required bytes
-// This will check the underlying partition of the given path.
+// This will check the underlying partition of the given path. Note that the path must be an existing dir.
+//
+// s.Free is used to check the available disk space
+// On Unix, it is computed using `statfs` and is the number of free blocks available to an unprivileged used * block size
+// See https://man7.org/linux/man-pages/man2/statfs.2.html for more details
+// On Windows, it is computed using `GetDiskFreeSpaceExW` and is the number of bytes available
+// See https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdiskfreespaceexw for more details
 func CheckAvailableDiskSpace(path string, requiredBytes uint64) (bool, error) {
 	s, err := disk.Usage(path)
 	if err != nil {

--- a/pkg/updater/tools/check_size.go
+++ b/pkg/updater/tools/check_size.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package tools contains tooling required by the updater.
+package tools
+
+import (
+	"github.com/shirou/gopsutil/v3/disk"
+)
+
+// CheckAvailableDiskSpace checks if the given path has enough free space to store the required bytes
+// This will check the underlying partition of the given path.
+func CheckAvailableDiskSpace(path string, requiredBytes uint64) (bool, error) {
+	s, err := disk.Usage(path)
+	if err != nil {
+		return false, err
+	}
+	return s.Free >= requiredBytes, nil
+}

--- a/pkg/updater/tools/check_size_test.go
+++ b/pkg/updater/tools/check_size_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package tools contains tooling required by the updater.
+package tools
+
+import (
+	"testing"
+
+	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckAvailableDiskSpace(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Get the tmpDir partition size
+	s, err := disk.Usage(tmpDir)
+	assert.NoError(t, err)
+
+	// Check if the tmpDir partition has enough space to store 0 bytes
+	enough, err := CheckAvailableDiskSpace(tmpDir, 0)
+	assert.NoError(t, err)
+	assert.True(t, enough)
+
+	// Check if the tmpDir partition has enough space to store 1 byte
+	enough, err = CheckAvailableDiskSpace(tmpDir, 1)
+	assert.NoError(t, err)
+	assert.True(t, enough)
+
+	// Check if the tmpDir partition has enough space to store the entire partition
+	enough, err = CheckAvailableDiskSpace(tmpDir, s.Free)
+	assert.NoError(t, err)
+	assert.True(t, enough)
+
+	// Check if the tmpDir partition has enough space to store the entire partition + 1 byte
+	enough, err = CheckAvailableDiskSpace(tmpDir, s.Free+1)
+	assert.NoError(t, err)
+	assert.False(t, enough)
+
+	// Check that a non existing dir can't be tested
+	enough, err = CheckAvailableDiskSpace("/non-existing-dir", 1)
+	assert.Error(t, err)
+	assert.False(t, enough)
+}


### PR DESCRIPTION
### What does this PR do?
Checks available disk space on the partition before downloading & extracting packages.
While we implement the check in a few places this will likely be removed & replaced as we are changing the way we store OCI images. The only thing that will remain and that should be checked is the `tools/check_size.go` file.

### Motivation
Updater

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
We are using the maximum decompressed size as the minimum disk space allowed, this is an arbitrary number that may be footgun-y, but if we manage to auto-update the updater we should be fine.

### Describe how to test/QA your changes
Running the tests should be enough

