### PR TITLE
[oracle] Skip godror test option (DBMON-3727)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/common/constants.go
+++ b/pkg/collector/corechecks/oracle-dbm/common/constants.go
@@ -5,7 +5,7 @@
 
 //go:build oracle
 
-//nolint:revive // TODO(DBM) Fix revive linter
+// common package contains common constant definitions.
 package common
 
 // IntegrationName is the name of the integration.
@@ -17,8 +17,8 @@ const IntegrationName = "oracle"
  */
 const IntegrationNameScheduler = "oracle-dbm"
 
-//nolint:revive // TODO(DBM) Fix revive linter
+// Godror is the name of the godror driver which relies on an external Oracle client.
 const Godror = "godror"
 
-//nolint:revive // TODO(DBM) Fix revive linter
+// GoOra is the name of the go-ora driver which is a pure Go implementation.
 const GoOra = "oracle"

--- a/pkg/collector/corechecks/oracle-dbm/common/constants.go
+++ b/pkg/collector/corechecks/oracle-dbm/common/constants.go
@@ -5,16 +5,16 @@
 
 //go:build oracle
 
-// common package contains common constant definitions.
+// Package common contains common constant definitions.
 package common
 
 // IntegrationName is the name of the integration.
 const IntegrationName = "oracle"
 
-/* We are temporarily using the name `oracle-dbm` to avoid scheduling clashes with the existing Oracle integration
- * functionality written in Python. We will change this back to `oracle` once we migrated this functionality
- * here.
- */
+// IntegrationNameScheduler is the name of the integration for the scheduler.
+// We are temporarily using the name `oracle-dbm` to avoid scheduling clashes with the existing Oracle integration
+// functionality written in Python. We will change this back to `oracle` once we migrated this functionality
+// here.
 const IntegrationNameScheduler = "oracle-dbm"
 
 // Godror is the name of the godror driver which relies on an external Oracle client.

--- a/pkg/collector/corechecks/oracle-dbm/oracle_dictionary_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_dictionary_test.go
@@ -30,6 +30,9 @@ func TestGetFullSqlText(t *testing.T) {
 		} else {
 			driver = common.Godror
 		}
+		if driver == common.Godror && skipGodror() {
+			continue
+		}
 		err := chk.Run()
 		assert.NoError(t, err, "check run")
 

--- a/pkg/collector/corechecks/oracle-dbm/statements_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements_test.go
@@ -118,6 +118,9 @@ func TestUInt64Binding(t *testing.T) {
 		} else {
 			driver = common.Godror
 		}
+		if driver == common.Godror && skipGodror() {
+			continue
+		}
 
 		err := chk.Run()
 		assert.NoError(t, err, "check run with %s driver", driver)

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestSysmetrics(t *testing.T) {
+	chk, _ := newRealCheck(t, "dbm: true")
+	chk.Run()
+	assert.True(t, chk.dbmEnabled, "dbm should be enabled")
 	n, err := chk.sysMetrics()
 	assert.NoError(t, err, "failed to run sys metrics")
 	assert.Equal(t, int64(92), n)

--- a/pkg/collector/corechecks/oracle-dbm/testutil.go
+++ b/pkg/collector/corechecks/oracle-dbm/testutil.go
@@ -9,11 +9,13 @@ package oracle
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	oracle_common "github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,4 +73,16 @@ service_name: %s
 	assert.Contains(t, c.configTags, dbmsTag, "c.configTags doesn't contain static tags")
 
 	return c, sender
+}
+
+func skipGodror() bool {
+	return os.Getenv("SKIP_GODROR_TESTS") == "1"
+}
+
+func getDrivers() []string {
+	drivers := []string{oracle_common.GoOra}
+	if !skipGodror() {
+		drivers = append(drivers, oracle_common.Godror)
+	}
+	return drivers
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Option for skipping tests with the `godror` driver.

### Motivation

At some point, the dynamic runtime linking became impossible on MacOS. Since `godror` depends on an external Oracle client, we have to skip `godror` tests on MacOS.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Set `export SKIP_GODROR_TESTS=1` and check that the tests aren't failing on MacOS.