### PR TITLE
feat(preinst): fix service not correctly unloaded

### DIFF
--- a/omnibus/package-scripts/agent-dmg/preinst
+++ b/omnibus/package-scripts/agent-dmg/preinst
@@ -116,11 +116,11 @@ if sudo -u "$INSTALL_USER" launchctl print "gui/$user_uid/com.datadoghq.agent" 1
   else
     # version is at least 7.52.0
     sudo -u "$INSTALL_USER" launchctl stop "com.datadoghq.gui"
-    sudo -u "$INSTALL_USER" launchctl unload "$gui_user_plist_file"
+    sudo -u "$INSTALL_USER" launchctl unload -w "$gui_user_plist_file"
   fi
 
   sudo -u "$INSTALL_USER" launchctl stop "com.datadoghq.agent"
-  sudo -u "$INSTALL_USER" launchctl unload "$user_plist_file"
+  sudo -u "$INSTALL_USER" launchctl unload -w "$user_plist_file"
 fi
 # Debriefing time
 echo "# State at the end"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Ensure to correctly unload macOS launchctl services the `-w` parameter was missing.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Installing the agent back to back on macOS followed by a restart re-activated supposedly unloaded services and launched multiple tray icon app

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
