### PR TITLE
Removing pkg/util/compression from orchestratorinterface

### DIFF
--- a/comp/forwarder/orchestrator/orchestratorinterface/go.mod
+++ b/comp/forwarder/orchestrator/orchestratorinterface/go.mod
@@ -28,7 +28,6 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/backoff => ../../../../pkg/util/backoff
 	github.com/DataDog/datadog-agent/pkg/util/buf => ../../../../pkg/util/buf
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
-	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression/
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable
 	github.com/DataDog/datadog-agent/pkg/util/filesystem => ../../../../pkg/util/filesystem
 	github.com/DataDog/datadog-agent/pkg/util/fxutil => ../../../../pkg/util/fxutil


### PR DESCRIPTION
### What does this PR do?

Removes `pkg/util/compression` from `comp/forwarder/orchestrator/orchestratorinterface/go.mod`.

### Motivation

We want to deprecate  `pkg/util/compression` so we can improve the way we configure compression in the Agent.

### Additional Notes

None.

### Possible Drawbacks / Trade-offs

None.

### Describe how to test/QA your changes

No real code change so as long as CI passes there should be no issues.
