### PR TITLE
[Windows Testing] Add timeouts to `testsuite` tests so that they won'…

### DIFF
--- a/test/kitchen/test/integration/win-secagent-test/rspec_datadog/win-secagent-test_spec.rb
+++ b/test/kitchen/test/integration/win-secagent-test/rspec_datadog/win-secagent-test_spec.rb
@@ -33,7 +33,7 @@ Dir.glob("#{root_dir}/**/testsuite.exe").each do |f|
   describe "security-agent tests for #{f}" do
     it 'successfully runs' do
       Dir.chdir(File.dirname(f)) do
-        Open3.popen2e(f, "-test.v", "-test.count=1") do |_, output, wait_thr|
+        Open3.popen2e(f, "-test.v", "-test.timeout=10m", "-test.count=1") do |_, output, wait_thr|
           test_failures = check_output(output, wait_thr)
           expect(test_failures).to be_empty, test_failures.join("\n")
         end

--- a/test/kitchen/test/integration/win-sysprobe-test/rspec_datadog/win-sysprobe-test_spec.rb
+++ b/test/kitchen/test/integration/win-sysprobe-test/rspec_datadog/win-sysprobe-test_spec.rb
@@ -29,7 +29,7 @@ Dir.glob("#{root_dir}/**/testsuite.exe").each do |f|
   describe "security agent tests for #{pkg}" do
     it 'successfully runs' do
       Dir.chdir(File.dirname(f)) do
-        Open3.popen2e(f, "-test.v", "-test.count=1") do |_, output, wait_thr|
+        Open3.popen2e(f, "-test.v", "-test.timeout=10m", "-test.count=1") do |_, output, wait_thr|
           test_failures = check_output(output, wait_thr)
           expect(test_failures).to be_empty, test_failures.join("\n")
         end


### PR DESCRIPTION
…t run forever.

Discovered (the hard way) that go tests, when compiled into standalone binaries, don't time out by default.  Add a 10 minute timeout to set a reasonable bound on the Testing time.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
