### PR TITLE
[corechecks/containerd] Simplify events tests

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/events_test.go
+++ b/pkg/collector/corechecks/containers/containerd/events_test.go
@@ -39,8 +39,7 @@ type mockEvt struct {
 	mockSubscribe func(ctx context.Context, filter ...string) (ch <-chan *events.Envelope, errs <-chan error)
 }
 
-//nolint:revive // TODO(CINT) Fix revive linter
-func (m *mockEvt) Subscribe(ctx context.Context, filters ...string) (ch <-chan *events.Envelope, errs <-chan error) {
+func (m *mockEvt) Subscribe(ctx context.Context, _ ...string) (ch <-chan *events.Envelope, errs <-chan error) {
 	return m.mockSubscribe(ctx)
 }
 

--- a/pkg/collector/corechecks/containers/containerd/events_test.go
+++ b/pkg/collector/corechecks/containers/containerd/events_test.go
@@ -30,6 +30,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
+const testTimeout = 2 * time.Second
+const testTicker = 5 * time.Millisecond
+
 type mockEvt struct {
 	events.Publisher
 	events.Forwarder
@@ -89,43 +92,14 @@ func TestCheckEvents(t *testing.T) {
 	}
 	cha <- &en
 
-	timeout := time.NewTimer(2 * time.Second)
-	ticker := time.NewTicker(5 * time.Millisecond)
-	condition := false
-	for {
-		select {
-		case <-ticker.C:
-			if !sub.isRunning() {
-				continue
-			}
-			condition = true
-		case <-timeout.C:
-			require.FailNow(t, "Timeout waiting event listener to be healthy")
-		}
-		if condition {
-			break
-		}
-	}
+	require.Eventually(t, sub.isRunning, testTimeout, testTicker)
 
 	ev := sub.Flush(time.Now().Unix())
 	assert.Len(t, ev, 1)
 	assert.Equal(t, ev[0].Topic, "/tasks/paused")
 	errorsCh <- fmt.Errorf("chan breaker")
-	condition = false
-	for {
-		select {
-		case <-ticker.C:
-			if sub.isRunning() {
-				continue
-			}
-			condition = true
-		case <-timeout.C:
-			require.FailNow(t, "Timeout waiting for error")
-		}
-		if condition {
-			break
-		}
-	}
+
+	require.Eventually(t, func() bool { return !sub.isRunning() }, testTimeout, testTicker)
 
 	// Test the multiple events one unsupported
 	sub = createEventSubscriber("subscriberTest2", containerdutil.ContainerdItf(itf), nil)
@@ -158,21 +132,8 @@ func TestCheckEvents(t *testing.T) {
 	cha <- &ek
 	cha <- &evnd
 
-	condition = false
-	for {
-		select {
-		case <-ticker.C:
-			if !sub.isRunning() {
-				continue
-			}
-			condition = true
-		case <-timeout.C:
-			require.FailNow(t, "Timeout waiting event listener to be healthy")
-		}
-		if condition {
-			break
-		}
-	}
+	require.Eventually(t, sub.isRunning, testTimeout, testTicker)
+
 	ev2 := sub.Flush(time.Now().Unix())
 	fmt.Printf("\n\n 2/ Flush %v\n\n", ev2)
 	assert.Len(t, ev2, 1)
@@ -184,9 +145,6 @@ func TestCheckEvents_PauseContainers(t *testing.T) {
 	existingPauseContainerID := "existing_pause"
 	existingNonPauseContainerID := "existing_non_pause"
 	newPauseContainerID := "new_container"
-
-	testTimeout := 1 * time.Second
-	testTicker := 5 * time.Millisecond
 
 	cha := make(chan *events.Envelope)
 	errorsCh := make(chan error)


### PR DESCRIPTION

### What does this PR do?

It's a cleanup PR. It simplifies some tests in `pkg/collector/corechecks/containers/containerd/events_test.go` by using `require.Eventually`.

### Describe how to test/QA your changes

Skip.
