### PR TITLE
AMLII-1528 Fix handling of empty datagrams

### DIFF
--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -269,7 +269,7 @@ func (l *UDSListener) handleConnection(conn *net.UnixConn, closeFunc CloseFuncti
 			} else {
 				n, _, err = conn.ReadFromUnix(packet.Buffer[n:maxPacketLength])
 			}
-			if n == 0 && oobn == 0 {
+			if n == 0 && oobn == 0 && l.transport == "unix" {
 				log.Debugf("dogstatsd-uds: %s connection closed", l.transport)
 				return nil
 			}

--- a/comp/dogstatsd/listeners/uds_common_test.go
+++ b/comp/dogstatsd/listeners/uds_common_test.go
@@ -10,11 +10,9 @@
 package listeners
 
 import (
-	"encoding/binary"
 	"net"
 	"os"
 	"testing"
-	"time"
 
 	"golang.org/x/net/nettest"
 
@@ -115,59 +113,4 @@ func testStartStopUDSListener(t *testing.T, listenerFactory udsListenerFactory, 
 
 	_, err = net.Dial(transport, socketPath)
 	assert.NotNil(t, err)
-}
-
-func testUDSReceive(t *testing.T, listenerFactory udsListenerFactory, transport string) {
-	socketPath := testSocketPath(t)
-
-	mockConfig := map[string]interface{}{}
-	mockConfig[socketPathConfKey(transport)] = socketPath
-	mockConfig["dogstatsd_origin_detection"] = false
-
-	var contents0 = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
-	var contents1 = []byte("daemon:999|g|#sometag1:somevalue1")
-
-	packetsChannel := make(chan packets.Packets)
-
-	config := fulfillDepsWithConfig(t, mockConfig)
-	s, err := listenerFactory(packetsChannel, newPacketPoolManagerUDS(config), config)
-	assert.Nil(t, err)
-	assert.NotNil(t, s)
-
-	s.Listen()
-	defer s.Stop()
-	conn, err := net.Dial(transport, socketPath)
-	assert.Nil(t, err)
-	defer conn.Close()
-
-	if transport == "unix" {
-		binary.Write(conn, binary.LittleEndian, int32(len(contents0)))
-	}
-	conn.Write(contents0)
-
-	if transport == "unix" {
-		binary.Write(conn, binary.LittleEndian, int32(len(contents1)))
-	}
-	conn.Write(contents1)
-
-	select {
-	case pkts := <-packetsChannel:
-		assert.Equal(t, 2, len(pkts))
-
-		packet := pkts[0]
-		assert.NotNil(t, packet)
-		assert.Equal(t, packet.Contents, contents0)
-		assert.Equal(t, packet.Origin, "")
-		assert.Equal(t, packet.Source, packets.UDS)
-
-		packet = pkts[1]
-		assert.NotNil(t, packet)
-		assert.Equal(t, packet.Contents, contents1)
-		assert.Equal(t, packet.Origin, "")
-		assert.Equal(t, packet.Source, packets.UDS)
-
-	case <-time.After(2 * time.Second):
-		assert.FailNow(t, "Timeout on receive channel")
-	}
-
 }

--- a/comp/dogstatsd/listeners/uds_datagram_test.go
+++ b/comp/dogstatsd/listeners/uds_datagram_test.go
@@ -55,20 +55,27 @@ func TestUDSDatagramReceive(t *testing.T) {
 	assert.Nil(t, err)
 	defer conn.Close()
 
+	conn.Write([]byte{})
 	conn.Write(contents0)
 	conn.Write(contents1)
 
 	select {
 	case pkts := <-packetsChannel:
-		assert.Equal(t, 2, len(pkts))
+		assert.Equal(t, 3, len(pkts))
 
 		packet := pkts[0]
+		assert.NotNil(t, packet)
+		assert.Equal(t, packet.Contents, []byte{})
+		assert.Equal(t, packet.Origin, "")
+		assert.Equal(t, packet.Source, packets.UDS)
+
+		packet = pkts[1]
 		assert.NotNil(t, packet)
 		assert.Equal(t, packet.Contents, contents0)
 		assert.Equal(t, packet.Origin, "")
 		assert.Equal(t, packet.Source, packets.UDS)
 
-		packet = pkts[1]
+		packet = pkts[2]
 		assert.NotNil(t, packet)
 		assert.Equal(t, packet.Contents, contents1)
 		assert.Equal(t, packet.Origin, "")

--- a/comp/dogstatsd/listeners/uds_datagram_test.go
+++ b/comp/dogstatsd/listeners/uds_datagram_test.go
@@ -10,7 +10,11 @@
 package listeners
 
 import (
+	"net"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
@@ -29,5 +33,49 @@ func TestStartStopUDSDatagramListener(t *testing.T) {
 }
 
 func TestUDSDatagramReceive(t *testing.T) {
-	testUDSReceive(t, udsDatagramListenerFactory, "unixgram")
+	socketPath := testSocketPath(t)
+
+	mockConfig := map[string]interface{}{}
+	mockConfig[socketPathConfKey("unixgram")] = socketPath
+	mockConfig["dogstatsd_origin_detection"] = false
+
+	var contents0 = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
+	var contents1 = []byte("daemon:999|g|#sometag1:somevalue1")
+
+	packetsChannel := make(chan packets.Packets)
+
+	config := fulfillDepsWithConfig(t, mockConfig)
+	s, err := udsDatagramListenerFactory(packetsChannel, newPacketPoolManagerUDS(config), config)
+	assert.Nil(t, err)
+	assert.NotNil(t, s)
+
+	s.Listen()
+	defer s.Stop()
+	conn, err := net.Dial("unixgram", socketPath)
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	conn.Write(contents0)
+	conn.Write(contents1)
+
+	select {
+	case pkts := <-packetsChannel:
+		assert.Equal(t, 2, len(pkts))
+
+		packet := pkts[0]
+		assert.NotNil(t, packet)
+		assert.Equal(t, packet.Contents, contents0)
+		assert.Equal(t, packet.Origin, "")
+		assert.Equal(t, packet.Source, packets.UDS)
+
+		packet = pkts[1]
+		assert.NotNil(t, packet)
+		assert.Equal(t, packet.Contents, contents1)
+		assert.Equal(t, packet.Origin, "")
+		assert.Equal(t, packet.Source, packets.UDS)
+
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "Timeout on receive channel")
+	}
+
 }

--- a/comp/dogstatsd/listeners/uds_stream_test.go
+++ b/comp/dogstatsd/listeners/uds_stream_test.go
@@ -10,7 +10,12 @@
 package listeners
 
 import (
+	"encoding/binary"
+	"net"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
@@ -29,5 +34,52 @@ func TestStartStopUDSStreamListener(t *testing.T) {
 }
 
 func TestUDSStreamReceive(t *testing.T) {
-	testUDSReceive(t, udsStreamListenerFactory, "unix")
+	socketPath := testSocketPath(t)
+
+	mockConfig := map[string]interface{}{}
+	mockConfig[socketPathConfKey("unix")] = socketPath
+	mockConfig["dogstatsd_origin_detection"] = false
+
+	var contents0 = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
+	var contents1 = []byte("daemon:999|g|#sometag1:somevalue1")
+
+	packetsChannel := make(chan packets.Packets)
+
+	config := fulfillDepsWithConfig(t, mockConfig)
+	s, err := udsStreamListenerFactory(packetsChannel, newPacketPoolManagerUDS(config), config)
+	assert.Nil(t, err)
+	assert.NotNil(t, s)
+
+	s.Listen()
+	defer s.Stop()
+	conn, err := net.Dial("unix", socketPath)
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	binary.Write(conn, binary.LittleEndian, int32(len(contents0)))
+	conn.Write(contents0)
+
+	binary.Write(conn, binary.LittleEndian, int32(len(contents1)))
+	conn.Write(contents1)
+
+	select {
+	case pkts := <-packetsChannel:
+		assert.Equal(t, 2, len(pkts))
+
+		packet := pkts[0]
+		assert.NotNil(t, packet)
+		assert.Equal(t, packet.Contents, contents0)
+		assert.Equal(t, packet.Origin, "")
+		assert.Equal(t, packet.Source, packets.UDS)
+
+		packet = pkts[1]
+		assert.NotNil(t, packet)
+		assert.Equal(t, packet.Contents, contents1)
+		assert.Equal(t, packet.Origin, "")
+		assert.Equal(t, packet.Source, packets.UDS)
+
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "Timeout on receive channel")
+	}
+
 }

--- a/releasenotes/notes/uds-empty-payload-1e0b5dcce2d7898a.yaml
+++ b/releasenotes/notes/uds-empty-payload-1e0b5dcce2d7898a.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - Empty uds payloads no longer cause dogstatsd server to close the socket.

--- a/releasenotes/notes/uds-empty-payload-1e0b5dcce2d7898a.yaml
+++ b/releasenotes/notes/uds-empty-payload-1e0b5dcce2d7898a.yaml
@@ -1,2 +1,2 @@
 fixes:
-  - Empty uds payloads no longer cause dogstatsd server to close the socket.
+  - Empty UDS payloads no longer cause the DogStatsD server to close the socket.


### PR DESCRIPTION

### What does this PR do?

Fix handling of empty dogstatsd datagrams.

### Motivation

Sending empty datagram to the dogstatsd server caused it to treat it as an end of file condition and stop processing payloads, leading to metrics loss.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
