### PR TITLE
Prevent panic on stop of rotated tailer during agent shutdown 

### DIFF
--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -121,6 +121,7 @@ func (s *Launcher) run() {
 // cleanup all tailers
 func (s *Launcher) cleanup() {
 	stopper := startstop.NewParallelStopper()
+	s.cleanUpRotatedTailers()
 	for _, tailer := range s.rotatedTailers {
 		stopper.Add(tailer)
 	}

--- a/pkg/logs/launchers/file/launcher_test.go
+++ b/pkg/logs/launchers/file/launcher_test.go
@@ -607,6 +607,7 @@ func TestLauncherFileRotation(t *testing.T) {
 
 	launcher.scan()
 	assert.Equal(t, 2, launcher.tailers.Count())
+	assert.Equal(t, 0, len(launcher.rotatedTailers))
 	assert.True(t, launcher.tailers.Contains(path("c.log")))
 	assert.True(t, launcher.tailers.Contains(path("d.log")))
 
@@ -624,8 +625,13 @@ func TestLauncherFileRotation(t *testing.T) {
 
 	launcher.scan()
 	assert.Equal(t, launcher.tailers.Count(), 2)
+	assert.Equal(t, 1, len(launcher.rotatedTailers))
 	assert.True(t, launcher.tailers.Contains(path("c.log")))
 	assert.True(t, launcher.tailers.Contains(path("d.log")))
+
+	launcher.cleanup() // Stop all the tailers
+	assert.Equal(t, launcher.tailers.Count(), 0)
+	assert.Equal(t, len(launcher.rotatedTailers), 0)
 }
 
 func TestLauncherFileDetectionSingleScan(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

We have observed some rare `panic: send on closed channel` in the file tailer. This can happen if the following constrains are met:

- The tailer has rotated
- the rotated tailer has not yet fully stopped (reached it's timeout)
- the agent is asked to stop gracefully 
- logs are still being tailed by the rotated tailer

If all of the above occur, it is possible the tailer will write to the pipeline after the pipeline has been stoped. This is because the "dangling" rotated tailers are no longer tracked and explicitly stopped before the pipeline is shut down. 

This PR keeps track of rotated tailers and evicts the ones that stop on their own every scan interval. When the agent is explicitly stopped, these tailers will also be stopped synchronously before the pipeline is shutdown preventing the write on closed channel. 

Note: I was not able to directly reproduce this, but was able to probe the state of the tailer/launcher to find this chain of events. The unit tests now cover cleaning up the rotated tailer list. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

No Repro - so rely on unit tests and real world deployments. 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
