### PR TITLE
New APM features to enable SQL obfuscation with go-sqllexer

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -123,7 +123,7 @@ func (o *ObfuscationConfig) Export(conf *AgentConfig) obfuscate.Config {
 			KeepSQLAlias:     conf.HasFeature("keep_sql_alias"),
 			DollarQuotedFunc: conf.HasFeature("dollar_quoted_func"),
 			Cache:            conf.HasFeature("sql_cache"),
-			ObfuscationMode:  initSqlObfuscationMode(conf),
+			ObfuscationMode:  initSQLObfuscationMode(conf),
 		},
 		ES:                   o.ES,
 		Mongo:                o.Mongo,
@@ -607,7 +607,7 @@ func inAzureAppServices() bool {
 	return existsLinux || existsWin
 }
 
-func initSqlObfuscationMode(conf *AgentConfig) obfuscate.ObfuscationMode {
+func initSQLObfuscationMode(conf *AgentConfig) obfuscate.ObfuscationMode {
 	var sqlObfuscationMode obfuscate.ObfuscationMode
 	// if sql obfuscation mode is set to "obfuscate_and_normalize" or "obfuscate_only"
 	// SQL statements will be obfuscated using go-sqllexer

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -123,6 +123,7 @@ func (o *ObfuscationConfig) Export(conf *AgentConfig) obfuscate.Config {
 			KeepSQLAlias:     conf.HasFeature("keep_sql_alias"),
 			DollarQuotedFunc: conf.HasFeature("dollar_quoted_func"),
 			Cache:            conf.HasFeature("sql_cache"),
+			ObfuscationMode:  initSqlObfuscationMode(conf),
 		},
 		ES:                   o.ES,
 		Mongo:                o.Mongo,
@@ -604,4 +605,18 @@ func inAzureAppServices() bool {
 	_, existsLinux := os.LookupEnv("APPSVC_RUN_ZIP")
 	_, existsWin := os.LookupEnv("WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED")
 	return existsLinux || existsWin
+}
+
+func initSqlObfuscationMode(conf *AgentConfig) obfuscate.ObfuscationMode {
+	var sqlObfuscationMode obfuscate.ObfuscationMode
+	// if sql obfuscation mode is set to "obfuscate_and_normalize" or "obfuscate_only"
+	// SQL statements will be obfuscated using go-sqllexer
+	if conf.HasFeature("sql_obfuscate_and_normalize") {
+		sqlObfuscationMode = obfuscate.ObfuscateAndNormalize
+	} else if conf.HasFeature("sql_obfuscate_only") {
+		sqlObfuscationMode = obfuscate.ObfuscateOnly
+	} else {
+		sqlObfuscationMode = ""
+	}
+	return sqlObfuscationMode
 }

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -613,8 +613,6 @@ func initSQLObfuscationMode(conf *AgentConfig) obfuscate.ObfuscationMode {
 	// SQL statements will be obfuscated using go-sqllexer
 	if conf.HasFeature("sql_obfuscate_and_normalize") {
 		sqlObfuscationMode = obfuscate.ObfuscateAndNormalize
-	} else if conf.HasFeature("sql_obfuscate_only") {
-		sqlObfuscationMode = obfuscate.ObfuscateOnly
 	} else {
 		sqlObfuscationMode = ""
 	}

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -48,13 +48,6 @@ func TestInitSQLObfuscationMode(t *testing.T) {
 			expected: obfuscate.ObfuscateAndNormalize,
 		},
 		{
-			name: "obfuscate_only",
-			conf: &AgentConfig{
-				Features: map[string]struct{}{"sql_obfuscate_only": {}},
-			},
-			expected: obfuscate.ObfuscateOnly,
-		},
-		{
 			name: "default",
 			conf: &AgentConfig{
 				Features: map[string]struct{}{},

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -34,7 +34,7 @@ func TestInAzureAppServices(t *testing.T) {
 	assert.False(t, isNotAzure)
 }
 
-func TestInitSqlObfuscationMode(t *testing.T) {
+func TestInitSQLObfuscationMode(t *testing.T) {
 	tests := []struct {
 		name     string
 		conf     *AgentConfig
@@ -64,7 +64,7 @@ func TestInitSqlObfuscationMode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sqlObfuscateMode := initSqlObfuscationMode(tt.conf)
+			sqlObfuscateMode := initSQLObfuscationMode(tt.conf)
 			assert.Equal(t, tt.expected, sqlObfuscateMode)
 		})
 	}

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,4 +32,40 @@ func TestInAzureAppServices(t *testing.T) {
 	assert.True(t, isLinuxAzure)
 	assert.True(t, isWindowsAzure)
 	assert.False(t, isNotAzure)
+}
+
+func TestInitSqlObfuscationMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		conf     *AgentConfig
+		expected obfuscate.ObfuscationMode
+	}{
+		{
+			name: "obfuscate_and_normalize",
+			conf: &AgentConfig{
+				Features: map[string]struct{}{"sql_obfuscate_and_normalize": {}},
+			},
+			expected: obfuscate.ObfuscateAndNormalize,
+		},
+		{
+			name: "obfuscate_only",
+			conf: &AgentConfig{
+				Features: map[string]struct{}{"sql_obfuscate_only": {}},
+			},
+			expected: obfuscate.ObfuscateOnly,
+		},
+		{
+			name: "default",
+			conf: &AgentConfig{
+				Features: map[string]struct{}{},
+			},
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sqlObfuscateMode := initSqlObfuscationMode(tt.conf)
+			assert.Equal(t, tt.expected, sqlObfuscateMode)
+		})
+	}
 }

--- a/releasenotes/notes/apm-sql-obfuscation-mode-5418f07bf4ce42af.yaml
+++ b/releasenotes/notes/apm-sql-obfuscation-mode-5418f07bf4ce42af.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: The SQL obfuscator now supports obfuscates with go-sqllexer package. Add two new features (``sql_obfuscate_and_normalize`` and ``sql_obfuscate_only``) to enable the new obfuscation mode.

--- a/releasenotes/notes/apm-sql-obfuscation-mode-5418f07bf4ce42af.yaml
+++ b/releasenotes/notes/apm-sql-obfuscation-mode-5418f07bf4ce42af.yaml
@@ -8,4 +8,5 @@
 ---
 features:
   - |
-    APM: The SQL obfuscator now supports obfuscation with the go-sqllexer package. Add two new features (``sql_obfuscate_and_normalize`` and ``sql_obfuscate_only``) to enable the new obfuscation mode.
+    APM: The SQL obfuscator now supports obfuscates with go-sqllexer package with new apm feature ``sql_obfuscate_and_normalize``.
+    To enable the new obfuscation mode, add ``sql_obfuscate_and_normalize`` to apm_config.features or use env var DD_APM_FEATURES="sql_obfuscate_and_normalize".

--- a/releasenotes/notes/apm-sql-obfuscation-mode-5418f07bf4ce42af.yaml
+++ b/releasenotes/notes/apm-sql-obfuscation-mode-5418f07bf4ce42af.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    APM: The SQL obfuscator now supports obfuscates with go-sqllexer package. Add two new features (``sql_obfuscate_and_normalize`` and ``sql_obfuscate_only``) to enable the new obfuscation mode.
+    APM: The SQL obfuscator now supports obfuscation with the go-sqllexer package. Add two new features (``sql_obfuscate_and_normalize`` and ``sql_obfuscate_only``) to enable the new obfuscation mode.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds a new APM feature `sql_obfuscate_and_normalize` to enable the new SQL obfuscation mode with go-sqllexer pkg. 

### Motivation

DBM has been testing with the new SQL obfuscator starting agent 7.51 with customers. We've seen reduced obfuscation errors after adopting the new obfuscator. The PR allows users to use new SQL obfuscator in APM tracer by setting `sql_obfuscate_and_normalize` in `DD_APM_FEATURES` or in datadog.yaml

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
