### PR TITLE
Use one suite per installer test

### DIFF
--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -4,7 +4,7 @@
   variables:
     TARGETS: ./tests/windows/install-test
     TEAM: windows-agent
-    EXTRA_PARAMS: --run "TestMSI/Agent/$E2E_MSI_TEST$"
+    EXTRA_PARAMS: --run "$E2E_MSI_TEST$"
   extends:
     - .new_e2e_template
   before_script:

--- a/test/new-e2e/tests/windows/base_agent_installer_suite.go
+++ b/test/new-e2e/tests/windows/base_agent_installer_suite.go
@@ -7,6 +7,8 @@
 package windows
 
 import (
+	"fmt"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
@@ -56,9 +58,24 @@ func (b *BaseAgentInstallerSuite[Env]) SetupSuite() {
 	b.BaseSuite.SetupSuite()
 
 	var err error
-	b.AgentPackage, err = windowsAgent.GetPackageFromEnv()
+	b.AgentPackage, err = b.GetAgentPackage()
 	if err != nil {
-		b.T().Fatalf("failed to get MSI URL from env: %v", err)
+		b.T().Fatal(err)
 	}
 	b.T().Logf("Using Agent: %#v", b.AgentPackage)
+}
+
+// GetAgentPackage returns the Agent package to install.
+// This method is called automatically by SetupSuite, and only needs to be called explicitly
+// if you need to get the package before SetupSuite is called.
+func (b *BaseAgentInstallerSuite[Env]) GetAgentPackage() (*windowsAgent.Package, error) {
+	if b.AgentPackage == nil {
+		var err error
+		b.AgentPackage, err = windowsAgent.GetPackageFromEnv()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get MSI URL from env: %w", err)
+		}
+	}
+
+	return b.AgentPackage, nil
 }

--- a/test/new-e2e/tests/windows/install-test/base.go
+++ b/test/new-e2e/tests/windows/install-test/base.go
@@ -1,0 +1,152 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package installtest contains e2e tests for the Windows agent installer
+package installtest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
+	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
+	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+
+	componentos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
+	"testing"
+)
+
+type agentInstallerSuite[Env any] interface {
+	e2e.Suite[Env]
+
+	GetStackName() (string, error)
+	GetAgentMajorVersion() (string, error)
+}
+
+type baseAgentMSISuite struct {
+	windows.BaseAgentInstallerSuite[environments.Host]
+}
+
+// getStackNamePrefix returns the stack name for the test suite.
+// Set unique stack names to avoid conflicts with other tests.
+func (s *baseAgentMSISuite) GetStackName() (string, error) {
+	agentPackage, err := s.GetAgentPackage()
+	if err != nil {
+		return "", err
+	}
+	majorVersion := strings.Split(agentPackage.Version, ".")[0]
+
+	// E2E auto includes the pipeline ID in the stack name, so we don't need to do that here.
+	stackName := fmt.Sprintf("windows-msi-test-v%s-%s", majorVersion, agentPackage.Arch)
+
+	// If running in CI, append the CI job ID to the stack name to ensure uniqueness between jobs
+	ciJobID := os.Getenv("CI_JOB_ID")
+	if ciJobID != "" {
+		stackName = fmt.Sprintf("%s-%s", stackName, ciJobID)
+	}
+
+	return stackName, nil
+}
+
+func (s *baseAgentMSISuite) GetAgentMajorVersion() (string, error) {
+	agentPackage, err := s.GetAgentPackage()
+	if err != nil {
+		return "", err
+	}
+	return strings.Split(agentPackage.Version, ".")[0], nil
+}
+
+func (s *baseAgentMSISuite) prepareHost() {
+	vm := s.Env().RemoteHost
+
+	if !s.Run("prepare VM", func() {
+		s.Run("disable defender", func() {
+			err := windowsCommon.DisableDefender(vm)
+			s.Require().NoError(err, "should disable defender")
+		})
+	}) {
+		s.T().Fatal("failed to prepare VM")
+	}
+}
+
+func (s *baseAgentMSISuite) installAgentPackage(vm *components.RemoteHost, agentPackage *windowsAgent.Package, installOptions []windowsAgent.InstallAgentOption, testerOptions ...TesterOption) *Tester {
+	installOpts := []windowsAgent.InstallAgentOption{
+		windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "install.log")),
+	}
+	installOpts = append(installOpts, installOptions...)
+	testerOpts := []TesterOption{
+		WithAgentPackage(agentPackage),
+	}
+	testerOpts = append(testerOpts, testerOptions...)
+	t, err := NewTester(s.T(), vm, testerOpts...)
+	s.Require().NoError(err, "should create tester")
+
+	if !s.Run(fmt.Sprintf("install %s", t.agentPackage.AgentVersion()), func() {
+		err = t.InstallAgent(installOpts...)
+		s.Require().NoError(err, "should install agent %s", t.agentPackage.AgentVersion())
+	}) {
+		s.T().FailNow()
+	}
+
+	return t
+}
+
+// installAgent installs the agent package on the VM and returns the Tester
+func (s *baseAgentMSISuite) installAgent(vm *components.RemoteHost, options []windowsAgent.InstallAgentOption, testerOpts ...TesterOption) *Tester {
+	return s.installAgentPackage(vm, s.AgentPackage, options, testerOpts...)
+}
+
+// installLastStable installs the last stable agent package on the VM, runs tests, and returns the Tester
+func (s *baseAgentMSISuite) installLastStable(vm *components.RemoteHost, options []windowsAgent.InstallAgentOption) *Tester {
+	previousAgentPackage, err := windowsAgent.GetLastStablePackageFromEnv()
+	s.Require().NoError(err, "should get last stable agent package from env")
+	t := s.installAgentPackage(vm, previousAgentPackage, options,
+		WithPreviousVersion(),
+	)
+
+	// Ensure the agent is functioning properly to provide a proper foundation for the test
+	if !t.TestExpectations(s.T()) {
+		s.T().FailNow()
+	}
+
+	return t
+}
+
+func run[Env any, T agentInstallerSuite[Env]](t *testing.T, s T, options ...e2e.SuiteOption) {
+	s.SetT(t)
+
+	opts := []e2e.SuiteOption{e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(
+		awshost.WithEC2InstanceOptions(ec2.WithOS(componentos.WindowsDefault)),
+	))}
+
+	stackName, err := s.GetStackName()
+	if err != nil {
+		t.Fatalf("failed to get stack name: %v", err)
+	}
+	opts = append(opts, e2e.WithStackName(stackName))
+
+	// give precedence to provided options
+	opts = append(opts, options...)
+
+	// Include the agent major version in the test name so junit reports will differentiate the tests
+	majorVersion, err := s.GetAgentMajorVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	testName := fmt.Sprintf("Windows Agent v%s", majorVersion)
+
+	t.Run(testName, func(t *testing.T) {
+		e2e.Run(t, s, opts...)
+	})
+}

--- a/test/new-e2e/tests/windows/install-test/install_agent_user_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_agent_user_test.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package installtest contains e2e tests for the Windows agent installer
+package installtest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
+
+	"testing"
+)
+
+type agentUserTestCase interface {
+	TC() *staticAgentUserTestCase
+}
+
+// staticAgentUserTestCase is a test case that can be fully defined without information from the host
+type staticAgentUserTestCase struct {
+	name           string
+	username       string
+	expectedDomain string
+	expectedUser   string
+}
+
+func (tc *staticAgentUserTestCase) TC() *staticAgentUserTestCase {
+	return tc
+}
+
+// dynamicAgentUserTestCase is a test case that needs information from the host before
+// it can be fully defined.
+type dynamicAgentUserTestCase struct {
+	staticAgentUserTestCase
+	setHostname func(tc *dynamicAgentUserTestCase, hostname string)
+}
+
+func (tc *dynamicAgentUserTestCase) HostReady(host *components.RemoteHost) error {
+	hostinfo, err := windowsCommon.GetHostInfo(host)
+	if err != nil {
+		return err
+	}
+
+	domainPart := windowsCommon.NameToNetBIOSName(hostinfo.Hostname)
+	tc.setHostname(tc, domainPart)
+
+	return nil
+}
+
+// hostReadyUpdater is an interface for test cases that need to update their state when
+// the test host becomes available.
+type hostReadyUpdater interface {
+	HostReady(host *components.RemoteHost) error
+}
+
+type agentUserTestSuite struct {
+	baseAgentMSISuite
+
+	tc agentUserTestCase
+}
+
+func (s *agentUserTestSuite) GetStackName() (string, error) {
+	base, err := s.baseAgentMSISuite.GetStackName()
+	if err != nil {
+		return "", err
+	}
+
+	// if we're running in parallel, include the test case name in the stack name
+	// so each gets its own stack
+	if s.shouldRunParallel() {
+		return fmt.Sprintf("%s-%s", base, s.tc.TC().name), nil
+	}
+
+	// otherwise, just use the base stack name
+	return base, nil
+}
+
+func (s *agentUserTestSuite) shouldRunParallel() bool {
+	// run the tests in parallel in the CI
+	return os.Getenv("CI") != ""
+}
+
+// TC-INS-006
+func TestAgentUser(t *testing.T) {
+	tcs := []agentUserTestCase{
+		&dynamicAgentUserTestCase{
+			staticAgentUserTestCase{name: "user_only"},
+			func(tc *dynamicAgentUserTestCase, hostname string) {
+				tc.username = "testuser"
+				tc.expectedDomain = hostname
+				tc.expectedUser = "testuser"
+			}},
+		&dynamicAgentUserTestCase{
+			staticAgentUserTestCase{name: "dotslash_user"},
+			func(tc *dynamicAgentUserTestCase, hostname string) {
+				tc.username = ".\\testuser"
+				tc.expectedDomain = hostname
+				tc.expectedUser = "testuser"
+			}},
+		&dynamicAgentUserTestCase{
+			staticAgentUserTestCase{name: "domain_user"},
+			func(tc *dynamicAgentUserTestCase, hostname string) {
+				tc.username = fmt.Sprintf("%s\\testuser", hostname)
+				tc.expectedDomain = hostname
+				tc.expectedUser = "testuser"
+			}},
+		&staticAgentUserTestCase{"LocalSystem", "LocalSystem", "NT AUTHORITY", "SYSTEM"},
+		&staticAgentUserTestCase{"SYSTEM", "SYSTEM", "NT AUTHORITY", "SYSTEM"},
+	}
+	for _, tc := range tcs {
+		s := &agentUserTestSuite{
+			tc: tc,
+		}
+		t.Run(tc.TC().name, func(t *testing.T) {
+			if s.shouldRunParallel() {
+				t.Parallel()
+			}
+			run(t, s)
+		})
+	}
+}
+
+func (s *agentUserTestSuite) TestAgentUser() {
+	vm := s.Env().RemoteHost
+	s.prepareHost()
+
+	// provide the test case with the host if it needs it
+	if tc, ok := s.tc.(hostReadyUpdater); ok {
+		err := tc.HostReady(vm)
+		s.Require().NoError(err)
+	}
+
+	tc := s.tc.TC()
+
+	t := s.installAgent(vm, nil,
+		WithInstallUser(tc.username),
+		WithExpectedAgentUser(tc.expectedDomain, tc.expectedUser),
+	)
+
+	if !t.TestExpectations(s.T()) {
+		s.T().FailNow()
+	}
+
+	t.TestUninstall(s.T(), filepath.Join(s.OutputDir, "uninstall.log"))
+}

--- a/test/new-e2e/tests/windows/install-test/install_agent_user_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_agent_user_test.go
@@ -64,20 +64,19 @@ type agentUserTestSuite struct {
 	tc agentUserTestCase
 }
 
-func (s *agentUserTestSuite) GetStackName() (string, error) {
-	base, err := s.baseAgentMSISuite.GetStackName()
-	if err != nil {
-		return "", err
+func (s *agentUserTestSuite) GetStackNamePart() (string, error) {
+	if s.mustUseNewStack() {
+		// include the subtest name to differentiate the stacks
+		return s.tc.TC().name, nil
 	}
 
-	// if we're running in parallel, include the test case name in the stack name
-	// so each gets its own stack
-	if s.shouldRunParallel() {
-		return fmt.Sprintf("%s-%s", base, s.tc.TC().name), nil
-	}
+	// otherwise, keep the stack name the same so the same resource is used
+	return "", nil
+}
 
-	// otherwise, just use the base stack name
-	return base, nil
+func (s *agentUserTestSuite) mustUseNewStack() bool {
+	// if we're running in parallel, each test case must use its own stack
+	return !s.shouldRunParallel()
 }
 
 func (s *agentUserTestSuite) shouldRunParallel() bool {

--- a/test/new-e2e/tests/windows/install-test/install_agent_user_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_agent_user_test.go
@@ -64,19 +64,10 @@ type agentUserTestSuite struct {
 	tc agentUserTestCase
 }
 
-func (s *agentUserTestSuite) GetStackNamePart() (string, error) {
-	if s.mustUseNewStack() {
-		// include the subtest name to differentiate the stacks
-		return s.tc.TC().name, nil
-	}
-
-	// otherwise, keep the stack name the same so the same resource is used
-	return "", nil
-}
-
-func (s *agentUserTestSuite) mustUseNewStack() bool {
+// UseUniqueStackName returns true when running tests in parallel
+func (s *agentUserTestSuite) UseUniqueStackName() (bool, error) {
 	// if we're running in parallel, each test case must use its own stack
-	return s.shouldRunParallel()
+	return s.shouldRunParallel(), nil
 }
 
 func (s *agentUserTestSuite) shouldRunParallel() bool {

--- a/test/new-e2e/tests/windows/install-test/install_agent_user_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_agent_user_test.go
@@ -76,7 +76,7 @@ func (s *agentUserTestSuite) GetStackNamePart() (string, error) {
 
 func (s *agentUserTestSuite) mustUseNewStack() bool {
 	// if we're running in parallel, each test case must use its own stack
-	return !s.shouldRunParallel()
+	return s.shouldRunParallel()
 }
 
 func (s *agentUserTestSuite) shouldRunParallel() bool {

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -1,273 +1,151 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 // Package installtest contains e2e tests for the Windows agent installer
 package installtest
 
 import (
-	"flag"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
-	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
-
-	componentos "github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 
 	"testing"
 )
 
-var devMode = flag.Bool("devmode", false, "enable devmode")
-
-type agentMSISuite struct {
-	windows.BaseAgentInstallerSuite[environments.Host]
+type installTestSuite struct {
+	baseAgentMSISuite
 }
 
-func TestMSI(t *testing.T) {
-	opts := []e2e.SuiteOption{e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(
-		awshost.WithEC2InstanceOptions(ec2.WithOS(componentos.WindowsDefault)),
-	))}
-	if *devMode {
-		opts = append(opts, e2e.WithDevMode())
-	}
-
-	agentPackage, err := windowsAgent.GetPackageFromEnv()
-	if err != nil {
-		t.Fatalf("failed to get MSI URL from env: %v", err)
-	}
-	t.Logf("Using Agent: %#v", agentPackage)
-
-	majorVersion := strings.Split(agentPackage.Version, ".")[0]
-
-	// Set stack name to avoid conflicts with other tests
-	// Include channel if we're not running in a CI pipeline.
-	// E2E auto includes the pipeline ID in the stack name, so we don't need to do that here.
-	stackNameChannelPart := ""
-	if agentPackage.PipelineID == "" && agentPackage.Channel != "" {
-		stackNameChannelPart = fmt.Sprintf("-%s", agentPackage.Channel)
-	}
-	stackNameCIJobPart := ""
-	ciJobID := os.Getenv("CI_JOB_ID")
-	if ciJobID != "" {
-		stackNameCIJobPart = fmt.Sprintf("-%s", os.Getenv("CI_JOB_ID"))
-	}
-	opts = append(opts, e2e.WithStackName(fmt.Sprintf("windows-msi-test-v%s-%s%s%s", majorVersion, agentPackage.Arch, stackNameChannelPart, stackNameCIJobPart)))
-
-	s := &agentMSISuite{}
-
-	// Include the agent major version in the test name so junit reports will differentiate the tests
-	t.Run(fmt.Sprintf("Agent v%s", majorVersion), func(t *testing.T) {
-		e2e.Run(t, s, opts...)
-	})
+func TestInstall(t *testing.T) {
+	s := &installTestSuite{}
+	run(t, s)
 }
 
-func (is *agentMSISuite) prepareHost() {
-	vm := is.Env().RemoteHost
+func (s *installTestSuite) TestInstall() {
+	vm := s.Env().RemoteHost
+	s.prepareHost()
 
-	if !is.Run("prepare VM", func() {
-		is.Run("disable defender", func() {
-			err := windowsCommon.DisableDefender(vm)
-			is.Require().NoError(err, "should disable defender")
-		})
-	}) {
-		is.T().Fatal("failed to prepare VM")
-	}
-}
+	t := s.installAgent(vm, nil)
 
-func (is *agentMSISuite) TestInstall() {
-	vm := is.Env().RemoteHost
-	is.prepareHost()
-
-	t := is.installAgent(vm, nil)
-
-	if !t.TestExpectations(is.T()) {
-		is.T().FailNow()
+	if !t.TestExpectations(s.T()) {
+		s.T().FailNow()
 	}
 
-	t.TestUninstall(is.T(), filepath.Join(is.OutputDir, "uninstall.log"))
+	t.TestUninstall(s.T(), filepath.Join(s.OutputDir, "uninstall.log"))
 }
 
-func (is *agentMSISuite) TestUpgrade() {
-	vm := is.Env().RemoteHost
-	is.prepareHost()
+type upgradeTestSuite struct {
+	baseAgentMSISuite
+}
 
-	_ = is.installLastStable(vm, nil)
+func TestUpgrade(t *testing.T) {
+	s := &upgradeTestSuite{}
+	run(t, s)
+}
 
-	t, err := NewTester(is.T(), vm,
-		WithAgentPackage(is.AgentPackage),
+func (s *upgradeTestSuite) TestUpgrade() {
+	vm := s.Env().RemoteHost
+	s.prepareHost()
+
+	_ = s.installLastStable(vm, nil)
+
+	t, err := NewTester(s.T(), vm,
+		WithAgentPackage(s.AgentPackage),
 	)
-	is.Require().NoError(err, "should create tester")
+	s.Require().NoError(err, "should create tester")
 
-	if !is.Run(fmt.Sprintf("upgrade to %s", t.agentPackage.AgentVersion()), func() {
-		err = t.InstallAgent(windowsAgent.WithInstallLogFile(filepath.Join(is.OutputDir, "upgrade.log")))
-		is.Require().NoError(err, "should upgrade to agent %s", t.agentPackage.AgentVersion())
+	if !s.Run(fmt.Sprintf("upgrade to %s", t.agentPackage.AgentVersion()), func() {
+		err = t.InstallAgent(windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")))
+		s.Require().NoError(err, "should upgrade to agent %s", t.agentPackage.AgentVersion())
 	}) {
-		is.T().FailNow()
+		s.T().FailNow()
 	}
 
-	if !t.TestExpectations(is.T()) {
-		is.T().FailNow()
+	if !t.TestExpectations(s.T()) {
+		s.T().FailNow()
 	}
 
-	t.TestUninstall(is.T(), filepath.Join(is.OutputDir, "uninstall.log"))
+	t.TestUninstall(s.T(), filepath.Join(s.OutputDir, "uninstall.log"))
+}
+
+type upgradeRollbackTestSuite struct {
+	baseAgentMSISuite
+}
+
+func TestUpgradeRollback(t *testing.T) {
+	s := &upgradeRollbackTestSuite{}
+	run(t, s)
 }
 
 // TC-INS-002
-func (is *agentMSISuite) TestUpgradeRollback() {
-	vm := is.Env().RemoteHost
-	is.prepareHost()
+func (s *upgradeRollbackTestSuite) TestUpgradeRollback() {
+	vm := s.Env().RemoteHost
+	s.prepareHost()
 
-	previousTester := is.installLastStable(vm, nil)
+	previousTester := s.installLastStable(vm, nil)
 
-	if !is.Run(fmt.Sprintf("upgrade to %s with rollback", is.AgentPackage.AgentVersion()), func() {
+	if !s.Run(fmt.Sprintf("upgrade to %s with rollback", s.AgentPackage.AgentVersion()), func() {
 		_, err := windowsAgent.InstallAgent(vm,
-			windowsAgent.WithPackage(is.AgentPackage),
+			windowsAgent.WithPackage(s.AgentPackage),
 			windowsAgent.WithWixFailWhenDeferred(),
-			windowsAgent.WithInstallLogFile(filepath.Join(is.OutputDir, "upgrade.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
 		)
-		is.Require().Error(err, "should fail to install agent %s", is.AgentPackage.AgentVersion())
+		s.Require().Error(err, "should fail to install agent %s", s.AgentPackage.AgentVersion())
 	}) {
-		is.T().FailNow()
+		s.T().FailNow()
 	}
 
 	// TODO: we shouldn't have to start the agent manually after rollback
 	//       but the kitchen tests did too.
 	err := windowsCommon.StartService(vm, "DatadogAgent")
-	is.Require().NoError(err, "agent service should start after rollback")
+	s.Require().NoError(err, "agent service should start after rollback")
 
-	if !previousTester.TestExpectations(is.T()) {
-		is.T().FailNow()
+	if !previousTester.TestExpectations(s.T()) {
+		s.T().FailNow()
 	}
 
-	previousTester.TestUninstall(is.T(), filepath.Join(is.OutputDir, "uninstall.log"))
+	previousTester.TestUninstall(s.T(), filepath.Join(s.OutputDir, "uninstall.log"))
+}
+
+type repairTestSuite struct {
+	baseAgentMSISuite
+}
+
+func TestRepair(t *testing.T) {
+	s := &repairTestSuite{}
+	run(t, s)
 }
 
 // TC-INS-001
-func (is *agentMSISuite) TestRepair() {
-	vm := is.Env().RemoteHost
-	is.prepareHost()
+func (s *repairTestSuite) TestRepair() {
+	vm := s.Env().RemoteHost
+	s.prepareHost()
 
-	t := is.installAgent(vm, nil)
+	t := s.installAgent(vm, nil)
 
 	err := windowsCommon.StopService(t.host, "DatadogAgent")
-	is.Require().NoError(err)
+	s.Require().NoError(err)
 
 	// Corrupt the install
 	err = t.host.Remove("C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe")
-	is.Require().NoError(err)
+	s.Require().NoError(err)
 	err = t.host.RemoveAll("C:\\Program Files\\Datadog\\Datadog Agent\\embedded3")
-	is.Require().NoError(err)
+	s.Require().NoError(err)
 
-	if !is.Run("repair install", func() {
-		err = windowsAgent.RepairAllAgent(t.host, "", filepath.Join(is.OutputDir, "repair.log"))
-		is.Require().NoError(err)
+	if !s.Run("repair install", func() {
+		err = windowsAgent.RepairAllAgent(t.host, "", filepath.Join(s.OutputDir, "repair.log"))
+		s.Require().NoError(err)
 	}) {
-		is.T().FailNow()
+		s.T().FailNow()
 	}
 
-	if !t.TestExpectations(is.T()) {
-		is.T().FailNow()
+	if !t.TestExpectations(s.T()) {
+		s.T().FailNow()
 	}
 
-	t.TestUninstall(is.T(), filepath.Join(is.OutputDir, "uninstall.log"))
-}
-
-// TC-INS-006
-func (is *agentMSISuite) TestAgentUser() {
-	vm := is.Env().RemoteHost
-	is.prepareHost()
-
-	hostinfo, err := windowsCommon.GetHostInfo(vm)
-	is.Require().NoError(err)
-
-	domainPart := windowsCommon.NameToNetBIOSName(hostinfo.Hostname)
-
-	tcs := []struct {
-		testname       string
-		builtinaccount bool
-		username       string
-		expectedDomain string
-		expectedUser   string
-	}{
-		{"user_only", false, "testuser", domainPart, "testuser"},
-		{"dotslash_user", false, ".\\testuser", domainPart, "testuser"},
-		{"domain_user", false, fmt.Sprintf("%s\\testuser", domainPart), domainPart, "testuser"},
-		{"LocalSystem", true, "LocalSystem", "NT AUTHORITY", "SYSTEM"},
-		{"SYSTEM", true, "SYSTEM", "NT AUTHORITY", "SYSTEM"},
-	}
-	for _, tc := range tcs {
-		if !is.Run(tc.testname, func() {
-			// subtest needs a new output dir
-			is.OutputDir, err = runner.GetTestOutputDir(runner.GetProfile(), is.T())
-			is.Require().NoError(err, "should get output dir")
-
-			t := is.installAgent(vm, nil,
-				WithInstallUser(tc.username),
-				WithExpectedAgentUser(tc.expectedDomain, tc.expectedUser),
-			)
-
-			if !t.TestExpectations(is.T()) {
-				is.T().FailNow()
-			}
-
-			t.TestUninstall(is.T(), filepath.Join(is.OutputDir, "uninstall.log"))
-		}) {
-			is.T().FailNow()
-		}
-	}
-}
-
-func (is *agentMSISuite) installAgentPackage(vm *components.RemoteHost, agentPackage *windowsAgent.Package, installOptions []windowsAgent.InstallAgentOption, testerOptions ...TesterOption) *Tester {
-	installOpts := []windowsAgent.InstallAgentOption{
-		windowsAgent.WithInstallLogFile(filepath.Join(is.OutputDir, "install.log")),
-	}
-	installOpts = append(installOpts, installOptions...)
-	testerOpts := []TesterOption{
-		WithAgentPackage(agentPackage),
-	}
-	testerOpts = append(testerOpts, testerOptions...)
-	t, err := NewTester(is.T(), vm, testerOpts...)
-	is.Require().NoError(err, "should create tester")
-
-	if !is.Run(fmt.Sprintf("install %s", t.agentPackage.AgentVersion()), func() {
-		err = t.InstallAgent(installOpts...)
-		is.Require().NoError(err, "should install agent %s", t.agentPackage.AgentVersion())
-	}) {
-		is.T().FailNow()
-	}
-
-	return t
-}
-
-// installAgent installs the agent package on the VM and returns the Tester
-func (is *agentMSISuite) installAgent(vm *components.RemoteHost, options []windowsAgent.InstallAgentOption, testerOpts ...TesterOption) *Tester {
-	return is.installAgentPackage(vm, is.AgentPackage, options, testerOpts...)
-}
-
-// installLastStable installs the last stable agent package on the VM, runs tests, and returns the Tester
-func (is *agentMSISuite) installLastStable(vm *components.RemoteHost, options []windowsAgent.InstallAgentOption) *Tester {
-	previousAgentPackage, err := windowsAgent.GetLastStablePackageFromEnv()
-	is.Require().NoError(err, "should get last stable agent package from env")
-	t := is.installAgentPackage(vm, previousAgentPackage, options,
-		WithPreviousVersion(),
-	)
-
-	// Ensure the agent is functioning properly to provide a proper foundation for the test
-	if !t.TestExpectations(is.T()) {
-		is.T().FailNow()
-	}
-
-	return t
+	t.TestUninstall(s.T(), filepath.Join(s.OutputDir, "uninstall.log"))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Refactors the Windows installer E2E tests so that instead of using a single suite with suite `Test` methods for each test, each test now has its own suite type and top-level `Test` function.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
suite `Test` methods cannot be run in parallel.
This configuration gives us more flexibility in how the individual installer tests are run, same vs new stack, sequential vs parallel, etc.

https://datadoghq.atlassian.net/browse/WINA-676

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
