### PR TITLE
(fleet) fix the install path override

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -173,9 +173,9 @@ def get_build_flags(
 
     rtloader_lib, rtloader_headers, rtloader_common_headers = get_rtloader_paths(embedded_path, rtloader_root)
 
-    # setting the install path
+    # setting the install path, allowing the agent to be installed in a custom location
     if sys.platform.startswith('linux') and install_path:
-        ldflags += f"-X {REPO_PATH}/pkg/config.InstallPath={install_path} "
+        ldflags += f"-X {REPO_PATH}/pkg/config/setup.InstallPath={install_path} "
 
     # setting python homes in the code
     if python_home_2:


### PR DESCRIPTION
This PR fixes the override of the InstallPath variable when the agent is
built with a non-default installation dir.

This fixes running the updater on a system that has no
`/opt/datadog-agent/`

This isn't covered by tests right now because it's a bit tricky to do so
but it will naturally be covered soon as we introduce some e2e tests on
the updater.

---

**Stack**:
- #23360
- #23358
- #23353
- #23351
- #23349 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*