### PR TITLE
(fleet) multi-package updater

### DIFF
--- a/cmd/updater/command/command.go
+++ b/cmd/updater/command/command.go
@@ -34,9 +34,6 @@ type GlobalParams struct {
 	// LogFilePath is the path to the log file.
 	LogFilePath string
 
-	// Package is the package managed by this instance of the updater.
-	Package string
-
 	// RepositoriesDir is the path to the directory containing the repositories.
 	RepositoriesDir string
 
@@ -63,7 +60,6 @@ Datadog Updater updates your agents based on requests received from the Datadog 
 	}
 
 	agentCmd.PersistentFlags().StringVarP(&globalParams.ConfFilePath, "cfgpath", "c", "", "path to directory containing updater.yaml")
-	agentCmd.PersistentFlags().StringVarP(&globalParams.Package, "package", "P", "", "package to update")
 	agentCmd.PersistentFlags().StringVarP(&globalParams.RepositoriesDir, "repositories", "d", "/opt/datadog-packages", "path to directory containing repositories")
 	agentCmd.PersistentFlags().StringVarP(&globalParams.PIDFilePath, "pidfile", "p", "", "path to the pidfile")
 	_ = agentCmd.MarkFlagRequired("package")

--- a/cmd/updater/subcommands/bootstrap/command.go
+++ b/cmd/updater/subcommands/bootstrap/command.go
@@ -26,11 +26,13 @@ import (
 
 type cliParams struct {
 	command.GlobalParams
+	pkg string
 }
 
 // Commands returns the bootstrap command
 func Commands(global *command.GlobalParams) []*cobra.Command {
 	var timeout time.Duration
+	var pkg string
 	bootstrapCmd := &cobra.Command{
 		Use:   "bootstrap",
 		Short: "Bootstraps the package with the first version.",
@@ -42,10 +44,12 @@ func Commands(global *command.GlobalParams) []*cobra.Command {
 			defer cancel()
 			return boostrapFxWrapper(ctx, &cliParams{
 				GlobalParams: *global,
+				pkg:          pkg,
 			})
 		},
 	}
 	bootstrapCmd.Flags().DurationVarP(&timeout, "timeout", "T", 3*time.Minute, "timeout to bootstrap with")
+	bootstrapCmd.Flags().StringVarP(&pkg, "package", "P", "", "package to bootstrap")
 	return []*cobra.Command{bootstrapCmd}
 }
 
@@ -64,7 +68,7 @@ func boostrapFxWrapper(ctx context.Context, params *cliParams) error {
 }
 
 func bootstrap(ctx context.Context, params *cliParams) error {
-	err := updater.Bootstrap(ctx, params.Package)
+	err := updater.Bootstrap(ctx, params.pkg)
 	if err != nil {
 		return fmt.Errorf("could not install package: %w", err)
 	}

--- a/cmd/updater/subcommands/run/command.go
+++ b/cmd/updater/subcommands/run/command.go
@@ -71,9 +71,6 @@ func runFxWrapper(params *cliParams) error {
 			LogParams:            logimpl.ForDaemon("UPDATER", "updater.log_file", pkgconfig.DefaultUpdaterLogFile),
 		}),
 		core.Bundle(),
-		fx.Supply(updaterimpl.Parameters{
-			Package: params.Package,
-		}),
 		fx.Supply(&rcservice.Params{
 			Options: []service.Option{
 				service.WithDatabaseFileName("remote-config-updater.db"),

--- a/comp/updater/updater/updaterimpl/updater.go
+++ b/comp/updater/updater/updaterimpl/updater.go
@@ -32,11 +32,6 @@ func Module() fxutil.Module {
 	)
 }
 
-// Parameters contains the parameters for the updater.
-type Parameters struct {
-	Package string
-}
-
 // dependencies contains the dependencies to build the updater.
 type dependencies struct {
 	fx.In
@@ -44,7 +39,6 @@ type dependencies struct {
 	Log          log.Component
 	Config       config.Component
 	RemoteConfig optional.Option[rcservice.Component]
-	Parameters   Parameters
 }
 
 func newUpdaterComponent(lc fx.Lifecycle, dependencies dependencies) (updatercomp.Component, error) {
@@ -52,7 +46,7 @@ func newUpdaterComponent(lc fx.Lifecycle, dependencies dependencies) (updatercom
 	if !ok {
 		return nil, errRemoteConfigRequired
 	}
-	updater, err := updater.NewUpdater(remoteConfig, dependencies.Parameters.Package)
+	updater, err := updater.NewUpdater(remoteConfig)
 	if err != nil {
 		return nil, fmt.Errorf("could not create updater: %w", err)
 	}

--- a/comp/updater/updater/updaterimpl/updater_test.go
+++ b/comp/updater/updater/updaterimpl/updater_test.go
@@ -33,9 +33,6 @@ func TestUpdaterWithoutRemoteConfig(t *testing.T) {
 		core.MockBundle(),
 		fx.Supply(core.BundleParams{}),
 		fx.Supply(optional.NewNoneOption[rcservice.Component]()),
-		fx.Supply(Parameters{
-			Package: "test",
-		}),
 		Module(),
 	))
 	_, err := newUpdaterComponent(&mockLifecycle{}, deps.Dependencies)

--- a/pkg/updater/install_test.go
+++ b/pkg/updater/install_test.go
@@ -70,16 +70,20 @@ func fsContainsAll(a fs.FS, b fs.FS) error {
 	})
 }
 
+func newTestInstaller(t *testing.T) *installer {
+	repositories, err := repository.NewRepositories(t.TempDir(), t.TempDir())
+	assert.NoError(t, err)
+	return newInstaller(repositories)
+}
+
 func TestInstallStable(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.s.Close()
-	r := repository.Repository{
-		RootPath:  t.TempDir(),
-		LocksPath: t.TempDir(),
-	}
-	installer := newInstaller(&r)
+	installer := newTestInstaller(t)
 
-	err := installer.installStable(fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
+	err := installer.installStable(fixtureSimpleV1.pkg, fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
+	assert.NoError(t, err)
+	r, err := installer.repositories.Get(fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
 	state, err := r.GetState()
 	assert.NoError(t, err)
@@ -91,15 +95,13 @@ func TestInstallStable(t *testing.T) {
 func TestInstallExperiment(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.s.Close()
-	r := repository.Repository{
-		RootPath:  t.TempDir(),
-		LocksPath: t.TempDir(),
-	}
-	installer := newInstaller(&r)
+	installer := newTestInstaller(t)
 
-	err := installer.installStable(fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
+	err := installer.installStable(fixtureSimpleV1.pkg, fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
 	assert.NoError(t, err)
-	err = installer.installExperiment(fixtureSimpleV2.version, s.Image(fixtureSimpleV2))
+	err = installer.installExperiment(fixtureSimpleV1.pkg, fixtureSimpleV2.version, s.Image(fixtureSimpleV2))
+	assert.NoError(t, err)
+	r, err := installer.repositories.Get(fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
 	state, err := r.GetState()
 	assert.NoError(t, err)
@@ -112,17 +114,15 @@ func TestInstallExperiment(t *testing.T) {
 func TestPromoteExperiment(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.s.Close()
-	r := repository.Repository{
-		RootPath:  t.TempDir(),
-		LocksPath: t.TempDir(),
-	}
-	installer := newInstaller(&r)
+	installer := newTestInstaller(t)
 
-	err := installer.installStable(fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
+	err := installer.installStable(fixtureSimpleV1.pkg, fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
 	assert.NoError(t, err)
-	err = installer.installExperiment(fixtureSimpleV2.version, s.Image(fixtureSimpleV2))
+	err = installer.installExperiment(fixtureSimpleV1.pkg, fixtureSimpleV2.version, s.Image(fixtureSimpleV2))
 	assert.NoError(t, err)
-	err = installer.promoteExperiment()
+	err = installer.promoteExperiment(fixtureSimpleV1.pkg)
+	assert.NoError(t, err)
+	r, err := installer.repositories.Get(fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
 	state, err := r.GetState()
 	assert.NoError(t, err)
@@ -134,17 +134,15 @@ func TestPromoteExperiment(t *testing.T) {
 func TestUninstallExperiment(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.s.Close()
-	r := repository.Repository{
-		RootPath:  t.TempDir(),
-		LocksPath: t.TempDir(),
-	}
-	installer := newInstaller(&r)
+	installer := newTestInstaller(t)
 
-	err := installer.installStable(fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
+	err := installer.installStable(fixtureSimpleV1.pkg, fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
 	assert.NoError(t, err)
-	err = installer.installExperiment(fixtureSimpleV2.version, s.Image(fixtureSimpleV2))
+	err = installer.installExperiment(fixtureSimpleV1.pkg, fixtureSimpleV2.version, s.Image(fixtureSimpleV2))
 	assert.NoError(t, err)
-	err = installer.uninstallExperiment()
+	err = installer.uninstallExperiment(fixtureSimpleV1.pkg)
+	assert.NoError(t, err)
+	r, err := installer.repositories.Get(fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
 	state, err := r.GetState()
 	assert.NoError(t, err)

--- a/pkg/updater/remote_config.go
+++ b/pkg/updater/remote_config.go
@@ -63,7 +63,7 @@ func (rc *remoteConfig) Close() {
 }
 
 // SetState sets the state of the given package.
-func (rc *remoteConfig) SetState(pkg string, state *repository.State) {
+func (rc *remoteConfig) SetState(pkg string, state repository.State) {
 	if rc.client == nil {
 		return
 	}
@@ -147,6 +147,7 @@ const (
 
 type remoteAPIRequest struct {
 	ID            string          `json:"id"`
+	Package       string          `json:"package"`
 	ExpectedState expectedState   `json:"expected_state"`
 	Method        string          `json:"method"`
 	Params        json.RawMessage `json:"params"`

--- a/pkg/updater/repository/repositories.go
+++ b/pkg/updater/repository/repositories.go
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package repository
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Repositories manages multiple repositories.
+type Repositories struct {
+	rootPath     string
+	locksPath    string
+	repositories map[string]*Repository
+}
+
+// NewRepositories returns a new Repositories.
+func NewRepositories(rootPath, locksPath string) (*Repositories, error) {
+	r := &Repositories{
+		rootPath:     rootPath,
+		locksPath:    locksPath,
+		repositories: make(map[string]*Repository),
+	}
+	dir, err := os.ReadDir(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not open root directory: %w", err)
+	}
+	for _, d := range dir {
+		if !d.IsDir() {
+			continue
+		}
+		repo := &Repository{
+			rootPath:  filepath.Join(rootPath, d.Name()),
+			locksPath: filepath.Join(locksPath, d.Name()),
+		}
+		r.repositories[d.Name()] = repo
+	}
+	return r, nil
+}
+
+// Get returns the repository for the given package name.
+func (r *Repositories) Get(pkg string) (*Repository, error) {
+	repo, ok := r.repositories[pkg]
+	if !ok {
+		return nil, fmt.Errorf("repository for package %s not found", pkg)
+	}
+	return repo, nil
+}
+
+// Create creates a new repository for the given package name.
+func (r *Repositories) Create(pkg string, version string, stableSourcePath string) error {
+	repository := &Repository{
+		rootPath:  filepath.Join(r.rootPath, pkg),
+		locksPath: filepath.Join(r.locksPath, pkg),
+	}
+	err := repository.Create(version, stableSourcePath)
+	if err != nil {
+		return fmt.Errorf("could not create repository for package %s: %w", pkg, err)
+	}
+	r.repositories[pkg] = repository
+	return nil
+}
+
+// GetState returns the state of all repositories.
+func (r *Repositories) GetState() (map[string]State, error) {
+	state := make(map[string]State)
+	var err error
+	for name, repo := range r.repositories {
+		state[name], err = repo.GetState()
+		if err != nil {
+			return nil, fmt.Errorf("could not get state for repository %s: %w", name, err)
+		}
+	}
+	return state, nil
+}
+
+// GetPackageState returns the state of the given package.
+func (r *Repositories) GetPackageState(pkg string) (State, error) {
+	if repo, ok := r.repositories[pkg]; ok {
+		return repo.GetState()
+	}
+	return State{}, nil
+}
+
+// Cleanup cleans up the repositories.
+func (r *Repositories) Cleanup() error {
+	for _, repo := range r.repositories {
+		err := repo.Cleanup()
+		if err != nil {
+			return fmt.Errorf("could not clean up repository: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/updater/repository/repositories_test.go
+++ b/pkg/updater/repository/repositories_test.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestRepositories(t *testing.T) *Repositories {
+	rootPath := t.TempDir()
+	locksRootPath := t.TempDir()
+	repositories, err := NewRepositories(rootPath, locksRootPath)
+	assert.NoError(t, err)
+	return repositories
+}
+
+func TestRepositoriesEmpty(t *testing.T) {
+	repositories := newTestRepositories(t)
+
+	state, err := repositories.GetState()
+	assert.NoError(t, err)
+	assert.Empty(t, state)
+}
+
+func TestRepositories(t *testing.T) {
+	repositories := newTestRepositories(t)
+
+	err := repositories.Create("repo1", "v1", t.TempDir())
+	assert.NoError(t, err)
+	repository, err := repositories.Get("repo1")
+	assert.NoError(t, err)
+	err = repository.SetExperiment("v2", t.TempDir())
+	assert.NoError(t, err)
+	err = repositories.Create("repo2", "v1.0", t.TempDir())
+	assert.NoError(t, err)
+
+	state, err := repositories.GetState()
+	assert.NoError(t, err)
+	assert.Len(t, state, 2)
+	assert.Equal(t, state["repo1"], State{Stable: "v1", Experiment: "v2"})
+	assert.Equal(t, state["repo2"], State{Stable: "v1.0"})
+}
+
+func TestRepositoriesReopen(t *testing.T) {
+	repositories := newTestRepositories(t)
+	err := repositories.Create("repo1", "v1", t.TempDir())
+	assert.NoError(t, err)
+	err = repositories.Create("repo2", "v1", t.TempDir())
+	assert.NoError(t, err)
+
+	repositories, err = NewRepositories(repositories.rootPath, repositories.locksPath)
+	assert.NoError(t, err)
+
+	state, err := repositories.GetState()
+	assert.NoError(t, err)
+	assert.Len(t, state, 2)
+	assert.Equal(t, state["repo1"], State{Stable: "v1"})
+	assert.Equal(t, state["repo2"], State{Stable: "v1"})
+}

--- a/pkg/updater/repository/repository_test.go
+++ b/pkg/updater/repository/repository_test.go
@@ -23,8 +23,8 @@ func createTestRepository(t *testing.T, dir string, stablePackageName string) *R
 	os.MkdirAll(locksPath, 0777)
 	stablePackagePath := createTestDownloadedPackage(t, dir, stablePackageName)
 	r := Repository{
-		RootPath:  repositoryPath,
-		LocksPath: locksPath,
+		rootPath:  repositoryPath,
+		locksPath: locksPath,
 	}
 	err := r.Create(stablePackageName, stablePackagePath)
 	assert.NoError(t, err)
@@ -42,8 +42,8 @@ func TestCreateFresh(t *testing.T) {
 	dir := t.TempDir()
 	repository := createTestRepository(t, dir, "v1")
 
-	assert.DirExists(t, repository.RootPath)
-	assert.DirExists(t, path.Join(repository.RootPath, "v1"))
+	assert.DirExists(t, repository.rootPath)
+	assert.DirExists(t, path.Join(repository.rootPath, "v1"))
 }
 
 func TestCreateOverwrite(t *testing.T) {
@@ -52,23 +52,23 @@ func TestCreateOverwrite(t *testing.T) {
 
 	repository := createTestRepository(t, dir, "v1")
 
-	assert.Equal(t, oldRepository.RootPath, repository.RootPath)
-	assert.DirExists(t, repository.RootPath)
-	assert.DirExists(t, path.Join(repository.RootPath, "v1"))
-	assert.NoDirExists(t, path.Join(oldRepository.RootPath, "old"))
+	assert.Equal(t, oldRepository.rootPath, repository.rootPath)
+	assert.DirExists(t, repository.rootPath)
+	assert.DirExists(t, path.Join(repository.rootPath, "v1"))
+	assert.NoDirExists(t, path.Join(oldRepository.rootPath, "old"))
 }
 
 func TestCreateOverwriteWithLockedPackage(t *testing.T) {
 	dir := t.TempDir()
 	oldRepository := createTestRepository(t, dir, "old")
-	err := os.MkdirAll(path.Join(oldRepository.LocksPath, "garbagetocollect"), 0777)
+	err := os.MkdirAll(path.Join(oldRepository.locksPath, "garbagetocollect"), 0777)
 	assert.NoError(t, err)
 
 	// Add a running process... our own! So we're sure it's running.
-	err = os.MkdirAll(path.Join(oldRepository.LocksPath, "old"), 0777)
+	err = os.MkdirAll(path.Join(oldRepository.locksPath, "old"), 0777)
 	assert.NoError(t, err)
 	err = os.WriteFile(
-		path.Join(oldRepository.LocksPath, "old", fmt.Sprint(os.Getpid())),
+		path.Join(oldRepository.locksPath, "old", fmt.Sprint(os.Getpid())),
 		nil,
 		0644,
 	)
@@ -76,11 +76,11 @@ func TestCreateOverwriteWithLockedPackage(t *testing.T) {
 
 	repository := createTestRepository(t, dir, "v1")
 
-	assert.Equal(t, oldRepository.RootPath, repository.RootPath)
-	assert.DirExists(t, repository.RootPath)
-	assert.DirExists(t, path.Join(repository.RootPath, "v1"))
-	assert.DirExists(t, path.Join(repository.RootPath, "old"))
-	assert.NoDirExists(t, path.Join(oldRepository.LocksPath, "garbagetocollect"))
+	assert.Equal(t, oldRepository.rootPath, repository.rootPath)
+	assert.DirExists(t, repository.rootPath)
+	assert.DirExists(t, path.Join(repository.rootPath, "v1"))
+	assert.DirExists(t, path.Join(repository.rootPath, "old"))
+	assert.NoDirExists(t, path.Join(oldRepository.locksPath, "garbagetocollect"))
 }
 
 func TestSetExperiment(t *testing.T) {
@@ -90,7 +90,7 @@ func TestSetExperiment(t *testing.T) {
 
 	err := repository.SetExperiment("v2", experimentDownloadPackagePath)
 	assert.NoError(t, err)
-	assert.DirExists(t, path.Join(repository.RootPath, "v2"))
+	assert.DirExists(t, path.Join(repository.rootPath, "v2"))
 }
 
 func TestSetExperimentTwice(t *testing.T) {
@@ -103,13 +103,13 @@ func TestSetExperimentTwice(t *testing.T) {
 	assert.NoError(t, err)
 	err = repository.SetExperiment("v3", experiment2DownloadPackagePath)
 	assert.NoError(t, err)
-	assert.DirExists(t, path.Join(repository.RootPath, "v2"))
+	assert.DirExists(t, path.Join(repository.rootPath, "v2"))
 }
 
 func TestSetExperimentBeforeStable(t *testing.T) {
 	dir := t.TempDir()
 	repository := Repository{
-		RootPath: dir,
+		rootPath: dir,
 	}
 	experimentDownloadPackagePath := createTestDownloadedPackage(t, dir, "v2")
 
@@ -126,8 +126,8 @@ func TestPromoteExperiment(t *testing.T) {
 	assert.NoError(t, err)
 	err = repository.PromoteExperiment()
 	assert.NoError(t, err)
-	assert.NoDirExists(t, path.Join(repository.RootPath, "v1"))
-	assert.DirExists(t, path.Join(repository.RootPath, "v2"))
+	assert.NoDirExists(t, path.Join(repository.rootPath, "v1"))
+	assert.DirExists(t, path.Join(repository.rootPath, "v2"))
 }
 
 func TestPromoteExperimentWithoutExperiment(t *testing.T) {
@@ -147,7 +147,7 @@ func TestDeleteExperiment(t *testing.T) {
 	assert.NoError(t, err)
 	err = repository.DeleteExperiment()
 	assert.NoError(t, err)
-	assert.NoDirExists(t, path.Join(repository.RootPath, "v2"))
+	assert.NoDirExists(t, path.Join(repository.rootPath, "v2"))
 }
 
 func TestDeleteExperimentWithoutExperiment(t *testing.T) {
@@ -167,20 +167,20 @@ func TestDeleteExperimentWithLockedPackage(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Add a running process... our own! So we're sure it's running.
-	err = os.MkdirAll(path.Join(repository.LocksPath, "v2"), 0766)
+	err = os.MkdirAll(path.Join(repository.locksPath, "v2"), 0766)
 	assert.NoError(t, err)
 	err = os.WriteFile(
-		path.Join(repository.LocksPath, "v2", fmt.Sprint(os.Getpid())),
+		path.Join(repository.locksPath, "v2", fmt.Sprint(os.Getpid())),
 		nil,
 		0644,
 	)
 	assert.NoError(t, err)
 
 	// Add a running process that's not running to check its deletion
-	err = os.MkdirAll(path.Join(repository.LocksPath, "v2"), 0766)
+	err = os.MkdirAll(path.Join(repository.locksPath, "v2"), 0766)
 	assert.NoError(t, err)
 	err = os.WriteFile(
-		path.Join(repository.LocksPath, "v2", "-1"), // We're sure not to hit a running process
+		path.Join(repository.locksPath, "v2", "-1"), // We're sure not to hit a running process
 		nil,
 		0644,
 	)
@@ -188,8 +188,8 @@ func TestDeleteExperimentWithLockedPackage(t *testing.T) {
 
 	err = repository.DeleteExperiment()
 	assert.NoError(t, err)
-	assert.DirExists(t, path.Join(repository.RootPath, "v2"))
-	assert.DirExists(t, path.Join(repository.LocksPath, "v2"))
-	assert.NoFileExists(t, path.Join(repository.LocksPath, "v2", "-1"))
-	assert.FileExists(t, path.Join(repository.LocksPath, "v2", fmt.Sprint(os.Getpid())))
+	assert.DirExists(t, path.Join(repository.rootPath, "v2"))
+	assert.DirExists(t, path.Join(repository.locksPath, "v2"))
+	assert.NoFileExists(t, path.Join(repository.locksPath, "v2", "-1"))
+	assert.FileExists(t, path.Join(repository.locksPath, "v2", fmt.Sprint(os.Getpid())))
 }


### PR DESCRIPTION
Make the updater able to handle multiple packages without having to
specify them through the CLI.

This is now needed to handle datadog-agent, datadog-updater and tracers.

---

**Stack**:
- #23360
- #23358
- #23353
- #23351 ⬅
- #23349


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*