### PR TITLE
(fleet) add a simple status command to the updater

### DIFF
--- a/cmd/updater/subcommands/status/command.go
+++ b/cmd/updater/subcommands/status/command.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package status implements 'updater status'.
+package status
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"text/template"
+
+	"github.com/DataDog/datadog-agent/cmd/updater/command"
+	"github.com/DataDog/datadog-agent/comp/updater/localapiclient"
+	"github.com/DataDog/datadog-agent/comp/updater/localapiclient/localapiclientimpl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+)
+
+type cliParams struct {
+	command.GlobalParams
+}
+
+// Commands returns the status command
+func Commands(global *command.GlobalParams) []*cobra.Command {
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Print the updater status",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return statusFxWrapper(&cliParams{
+				GlobalParams: *global,
+			})
+		},
+	}
+	return []*cobra.Command{statusCmd}
+}
+
+func statusFxWrapper(params *cliParams) error {
+	return fxutil.OneShot(status,
+		fx.Supply(params),
+		localapiclientimpl.Module(),
+	)
+}
+
+//go:embed status.tmpl
+var statusTmpl []byte
+
+var functions = template.FuncMap{
+	"greenText":  color.GreenString,
+	"yellowText": color.YellowString,
+	"redText":    color.RedString,
+}
+
+func status(client localapiclient.Component) error {
+	tmpl, err := template.New("status").Funcs(functions).Parse(string(statusTmpl))
+	if err != nil {
+		return fmt.Errorf("error parsing status template: %w", err)
+	}
+	status, err := client.Status()
+	if err != nil {
+		return fmt.Errorf("error getting status: %w", err)
+	}
+	err = tmpl.Execute(os.Stdout, status)
+	if err != nil {
+		return fmt.Errorf("error executing status template: %w", err)
+	}
+	return nil
+}

--- a/cmd/updater/subcommands/status/command_test.go
+++ b/cmd/updater/subcommands/status/command_test.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package status
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/updater/command"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"status"},
+		status,
+		func() {})
+}

--- a/cmd/updater/subcommands/status/status.tmpl
+++ b/cmd/updater/subcommands/status/status.tmpl
@@ -1,0 +1,8 @@
+Datadog Updater v{{ .Version }}
+{{ range $name, $package := .Packages }}
+{{ $name }}
+  State: {{ yellowText "unknown (unimplemented)" }}
+  Installed versions:
+  {{ yellowText "●" }} stable v{{ $package.Stable }}
+  {{ yellowText "●" }} expermiment v{{ $package.Experiment }}
+{{ end -}}

--- a/cmd/updater/subcommands/subcommands.go
+++ b/cmd/updater/subcommands/subcommands.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/updater/command"
 	"github.com/DataDog/datadog-agent/cmd/updater/subcommands/bootstrap"
 	"github.com/DataDog/datadog-agent/cmd/updater/subcommands/run"
+	"github.com/DataDog/datadog-agent/cmd/updater/subcommands/status"
 )
 
 // UpdaterSubcommands returns SubcommandFactories for the subcommands
@@ -18,5 +19,6 @@ func UpdaterSubcommands() []command.SubcommandFactory {
 	return []command.SubcommandFactory{
 		run.Commands,
 		bootstrap.Commands,
+		status.Commands,
 	}
 }

--- a/comp/README.md
+++ b/comp/README.md
@@ -454,6 +454,10 @@ Package updater implements the updater component.
 
 Package localapi is the updater local api component.
 
+### [comp/updater/localapiclient](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/updater/localapiclient)
+
+Package localapiclient provides the local API client component.
+
 ### [comp/updater/updater](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/updater/updater)
 
 Package updater is the updater component.

--- a/comp/updater/localapiclient/component.go
+++ b/comp/updater/localapiclient/component.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package localapiclient provides the local API client component.
+package localapiclient
+
+import "github.com/DataDog/datadog-agent/pkg/updater"
+
+// team: fleet
+
+// Component is the component type.
+type Component interface {
+	updater.LocalAPIClient
+}

--- a/comp/updater/localapiclient/localapiclientimpl/localapiclient.go
+++ b/comp/updater/localapiclient/localapiclientimpl/localapiclient.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package localapiclientimpl provides the local API client component.
+package localapiclientimpl
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/updater/localapiclient"
+	"github.com/DataDog/datadog-agent/pkg/updater"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module is the fx module for the updater local api client.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newLocalAPIClientComponent),
+	)
+}
+
+func newLocalAPIClientComponent() localapiclient.Component {
+	return updater.NewLocalAPIClient()
+}


### PR DESCRIPTION
This PR adds a simple status command to the updater to help with
debugging. For now it only contains the list of installed packages with
their stable/experiment versions.

![image](https://github.com/DataDog/datadog-agent/assets/9051073/c1ab4969-d2ca-441e-bad1-92a103aaffcd)

---

**Stack**:
- #23360
- #23358
- #23353 ⬅
- #23351
- #23349


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*