### PR TITLE
(fleet) add start/stop/promote experiment commands

### DIFF
--- a/cmd/updater/subcommands/experiment/command.go
+++ b/cmd/updater/subcommands/experiment/command.go
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package experiment implements 'updater {start, stop, promote}-experiment' subcommands.
+package experiment
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/cmd/updater/command"
+	"github.com/DataDog/datadog-agent/comp/updater/localapiclient"
+	"github.com/DataDog/datadog-agent/comp/updater/localapiclient/localapiclientimpl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+)
+
+type cliParams struct {
+	command.GlobalParams
+	pkg     string
+	version string
+}
+
+// Commands returns the experiment commands
+func Commands(global *command.GlobalParams) []*cobra.Command {
+	startExperimentCmd := &cobra.Command{
+		Use:     "start-experiment package version",
+		Aliases: []string{"start"},
+		Short:   "Starts an experiment",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return experimentFxWrapper(start, &cliParams{
+				GlobalParams: *global,
+				pkg:          args[0],
+				version:      args[1],
+			})
+		},
+	}
+	stopExperimentCmd := &cobra.Command{
+		Use:     "stop-experiment package",
+		Aliases: []string{"stop"},
+		Short:   "Stops an experiment",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return experimentFxWrapper(stop, &cliParams{
+				GlobalParams: *global,
+				pkg:          args[0],
+			})
+		},
+	}
+	promoteExperimentCmd := &cobra.Command{
+		Use:     "promote-experiment package",
+		Aliases: []string{"promote"},
+		Short:   "Promotes an experiment",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return experimentFxWrapper(promote, &cliParams{
+				GlobalParams: *global,
+				pkg:          args[0],
+			})
+		},
+	}
+	return []*cobra.Command{startExperimentCmd, stopExperimentCmd, promoteExperimentCmd}
+}
+
+func experimentFxWrapper(f interface{}, params *cliParams) error {
+	return fxutil.OneShot(f,
+		fx.Supply(params),
+		localapiclientimpl.Module(),
+	)
+}
+
+func start(params *cliParams, client localapiclient.Component) error {
+	err := client.StartExperiment(params.pkg, params.version)
+	if err != nil {
+		fmt.Println("Error starting experiment:", err)
+		return err
+	}
+	return nil
+}
+
+func stop(params *cliParams, client localapiclient.Component) error {
+	err := client.StopExperiment(params.pkg)
+	if err != nil {
+		fmt.Println("Error stopping experiment:", err)
+		return err
+	}
+	return nil
+}
+
+func promote(params *cliParams, client localapiclient.Component) error {
+	err := client.PromoteExperiment(params.pkg)
+	if err != nil {
+		fmt.Println("Error promoting experiment:", err)
+		return err
+	}
+	return nil
+}

--- a/cmd/updater/subcommands/experiment/command_test.go
+++ b/cmd/updater/subcommands/experiment/command_test.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package experiment
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/updater/command"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestStartCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"start-experiment", "datadog-agent", "7.31.0"},
+		start,
+		func() {})
+}
+
+func TestStopCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"stop-experiment", "datadog-agent"},
+		stop,
+		func() {})
+}
+
+func TestPromoteCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"promote-experiment", "datadog-agent"},
+		promote,
+		func() {})
+}

--- a/cmd/updater/subcommands/subcommands.go
+++ b/cmd/updater/subcommands/subcommands.go
@@ -9,6 +9,7 @@ package subcommands
 import (
 	"github.com/DataDog/datadog-agent/cmd/updater/command"
 	"github.com/DataDog/datadog-agent/cmd/updater/subcommands/bootstrap"
+	"github.com/DataDog/datadog-agent/cmd/updater/subcommands/experiment"
 	"github.com/DataDog/datadog-agent/cmd/updater/subcommands/run"
 	"github.com/DataDog/datadog-agent/cmd/updater/subcommands/status"
 )
@@ -20,5 +21,6 @@ func UpdaterSubcommands() []command.SubcommandFactory {
 		run.Commands,
 		bootstrap.Commands,
 		status.Commands,
+		experiment.Commands,
 	}
 }


### PR DESCRIPTION
This PR adds start/stop/promote experiment commands to help with
debugging.

Example use:

```
updater start-experiment datadog-agent 7.51.0
updater stop-experiment datadog-agent
updater start-experiment datadog-updater 7.52.0
updater promote-experiment datadog-updater
```

---

**Stack**:
- #23360
- #23358 ⬅
- #23353
- #23351
- #23349


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*