### PR TITLE
fix(ci): RUN_E2E_TESTS is not false, but on, auto or true

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -287,7 +287,7 @@ variables:
 # RUN_E2E_TESTS can be set to on to force all the installer tests to be run on a branch pipeline.
 # RUN_E2E_TESTS can be set to false to force installer tests to not run on main/deploy pipelines.
 .if_installer_tests: &if_installer_tests
-  if: ($CI_COMMIT_BRANCH == "main"  || $DEPLOY_AGENT == "true" || $RUN_E2E_TESTS == "true") && $RUN_E2E_TESTS != "false"
+  if: ($CI_COMMIT_BRANCH == "main"  || $DEPLOY_AGENT == "true" || $RUN_E2E_TESTS != "off") && $RUN_E2E_TESTS != "off"
 
 .if_testing_cleanup: &if_testing_cleanup
   if: $TESTING_CLEANUP == "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -857,17 +857,23 @@ workflow:
     allow_failure: true
 
 .on_kitchen_tests_a6:
+  - <<: *if_mergequeue
+    when: never
   - <<: *if_not_version_6
     when: never
   - <<: *if_installer_tests
 
 .on_kitchen_tests_a6_always:
+  - <<: *if_mergequeue
+    when: never
   - <<: *if_not_version_6
     when: never
   - <<: *if_installer_tests
     when: always
 
 .on_all_kitchen_builds_a6:
+  - <<: *if_mergequeue
+    when: never
   - <<: *if_not_version_6
     when: never
   - <<: *if_not_run_all_builds
@@ -875,11 +881,15 @@ workflow:
   - <<: *if_installer_tests
 
 .on_kitchen_tests_a7:
+  - <<: *if_mergequeue
+    when: never
   - <<: *if_not_version_7
     when: never
   - <<: *if_installer_tests
 
 .on_all_kitchen_builds_a7:
+  - <<: *if_mergequeue
+    when: never
   - <<: *if_not_version_7
     when: never
   - <<: *if_not_run_all_builds
@@ -887,6 +897,8 @@ workflow:
   - <<: *if_installer_tests
 
 .on_all_new-e2e_tests_a7:
+  - <<: *if_mergequeue
+    when: never
   - <<: *if_not_version_7
     when: never
   - <<: *if_not_run_all_builds

--- a/.gitlab/kitchen_deploy/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy/kitchen_deploy.yml
@@ -87,7 +87,7 @@ deploy_deb_testing-a6_x64:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 6 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 deploy_deb_testing-a6_arm64:
-  rules: !reference [.on_all_kitchen_builds_a6]
+  rules: !reference [.on_kitchen_tests_a6]
   extends:
     - .deploy_deb_testing-a6
   needs: ["agent_deb-arm64-a6"]
@@ -191,7 +191,7 @@ deploy_rpm_testing-a6_x64:
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/6/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-6.*x86_64.rpm
 
 deploy_rpm_testing-a6_arm64:
-  rules: !reference [.on_all_kitchen_builds_a6]
+  rules: !reference [.on_kitchen_tests_a6]
   extends:
     - .deploy_rpm_testing-a6
   needs:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Rule on RUN_E2E_TESTS is checking a `true` status whereas it should be only `on`, `auto` or `off`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fix rules condition that prevent gitlab to [generate pipelines correctly](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/29368527) with this setup:
```
Creating child pipeline with params: {'RELEASE_VERSION_6': 'nightly', 'RELEASE_VERSION_7': 'nightly-a7', 'BUCKET_BRANCH': 'dev', 'DEPLOY_AGENT': 'false', 'INTEGRATIONS_CORE_VERSION': 'bot/update-dependencies-1709518593', 'RUN_KITCHEN_TESTS': 'false', 'RUN_E2E_TESTS': 'off'} off branch: main
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
