### PR TITLE
[CONTINT-3896] fix panic on shutdown in long running checks

### DIFF
--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -138,8 +138,8 @@ func (c *Check) Run() error {
 	}
 }
 
-// Stop stops the container_lifecycle check
-func (c *Check) Stop() { close(c.stopCh) }
+// Cancel stops the container_lifecycle check
+func (c *Check) Cancel() { close(c.stopCh) }
 
 // Interval returns 0, it makes container_lifecycle a long-running check
 func (c *Check) Interval() time.Duration { return 0 }

--- a/pkg/collector/corechecks/longrunning_test.go
+++ b/pkg/collector/corechecks/longrunning_test.go
@@ -9,15 +9,16 @@ package corechecks
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
-	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
-	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/stats"
+	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -26,7 +27,8 @@ import (
 type mockLongRunningCheck struct {
 	mock.Mock
 
-	stopCh chan struct{}
+	stopCh    chan struct{}
+	runningCh chan struct{}
 }
 
 func (m *mockLongRunningCheck) Stop() {
@@ -99,19 +101,28 @@ func (m *mockLongRunningCheck) GetSender() (sender.Sender, error) {
 
 func newMockLongRunningCheck() *mockLongRunningCheck {
 	return &mockLongRunningCheck{
-		stopCh: make(chan struct{}),
+		stopCh:    make(chan struct{}),
+		runningCh: make(chan struct{}, 1),
 	}
 }
 
 func (m *mockLongRunningCheck) Run() error {
 	args := m.Called()
+	m.runningCh <- struct{}{}
 	<-m.stopCh
 	return args.Error(0)
 }
 
 func (m *mockLongRunningCheck) Cancel() {
 	m.Called()
-	m.stopCh <- struct{}{}
+	select {
+	case m.stopCh <- struct{}{}:
+	default:
+	}
+}
+
+func (m *mockLongRunningCheck) waitUntilRun() {
+	<-m.runningCh
 }
 
 // TestLongRunningCheckWrapperRun tests the Run function for different scenarios.
@@ -123,8 +134,9 @@ func TestLongRunningCheckWrapperRun(t *testing.T) {
 
 		wrapper := NewLongRunningCheckWrapper(mockCheck)
 		err := wrapper.Run()
-
 		assert.Nil(t, err)
+		mockCheck.waitUntilRun()
+
 		mockCheck.Cancel()
 		mockCheck.AssertExpectations(t)
 	})
@@ -158,6 +170,39 @@ func TestLongRunningCheckWrapperRun(t *testing.T) {
 
 		assert.EqualError(t, err, "error getting sender: failed to get sender")
 		mockCheck.AssertExpectations(t)
+	})
+
+	t.Run("Make sure innerCheck.Cancel is called only once", func(t *testing.T) {
+		mockCheck := newMockLongRunningCheck()
+		mockCheck.On("Run").Return(nil)
+		mockCheck.On("Cancel").Return()
+
+		wrapper := NewLongRunningCheckWrapper(mockCheck)
+		err := wrapper.Run()
+		mockCheck.waitUntilRun()
+
+		assert.Nil(t, err)
+		wrapper.Cancel()
+		wrapper.Cancel()
+		mockCheck.AssertNumberOfCalls(t, "Cancel", 1)
+	})
+
+	t.Run("Make sure innerCheck.Run can't be called after a cancel", func(t *testing.T) {
+		mockCheck := newMockLongRunningCheck()
+		mockCheck.On("Run").Return(nil)
+		mockCheck.On("Cancel").Return()
+
+		wrapper := NewLongRunningCheckWrapper(mockCheck)
+		err := wrapper.Run()
+		assert.Nil(t, err)
+
+		wrapper.Cancel()
+		err = wrapper.Run()
+		assert.Error(t, err)
+		mockCheck.waitUntilRun()
+
+		mockCheck.AssertExpectations(t)
+		mockCheck.AssertNumberOfCalls(t, "Run", 1)
 	})
 }
 

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -209,12 +209,15 @@ func (c *Check) Run() error {
 				return nil
 			}
 			c.processor.processContainerImagesEvents(eventBundle)
+		case scanResult, ok := <-hostSbomChan:
+			if !ok {
+				return nil
+			}
+			c.processor.processHostScanResult(scanResult)
 		case <-containerPeriodicRefreshTicker.C:
 			c.processor.processContainerImagesRefresh(c.workloadmetaStore.ListImages())
 		case <-hostPeriodicRefreshTicker.C:
 			c.processor.triggerHostScan()
-		case scanResult := <-hostSbomChan:
-			c.processor.processHostScanResult(scanResult)
 		case <-metricTicker.C:
 			c.sendUsageMetrics()
 		case <-c.stopCh:
@@ -233,8 +236,8 @@ func (c *Check) sendUsageMetrics() {
 	c.sender.Commit()
 }
 
-// Stop stops the sbom check
-func (c *Check) Stop() {
+// Cancel stops the sbom check
+func (c *Check) Cancel() {
 	close(c.stopCh)
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR fixes panics on shutdown in long running checks.

SBOM channels can be closed so we need to check for `nil` entries.
We also would like to stop the checks on `Cancel` rather than stop `Stop` because it is always called:
```
	// Stop stops the check if it's running
	Stop()
	// Cancel cancels the check. Cancel is called when the check is unscheduled:
	// - unlike Stop, it is called even if the check is not running when it's unscheduled
	// - if the check is running, Cancel is called after Stop and may be called before the call to Stop completes
	Cancel()
```
Finally we would like `Cancel` to be called only once.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Make sure that container image and sbom checks are still working.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
