### PR TITLE
[ASCII-1457] Remove some grpc dependencies from `comp/trace/config` for the serverless agent

### DIFF
--- a/comp/trace/config/hostname.go
+++ b/comp/trace/config/hostname.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !serverless
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/util/grpc"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// fallbackHostnameFunc specifies the function to use for obtaining the hostname
+// when it can not be obtained by any other means. It is replaced in tests.
+var fallbackHostnameFunc = os.Hostname
+
+func hostname(c *config.AgentConfig) error {
+	// no user-set hostname, try to acquire
+	if err := acquireHostname(c); err != nil {
+		log.Infof("Could not get hostname via gRPC: %v. Falling back to other methods.", err)
+		if err := acquireHostnameFallback(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// acquireHostname attempts to acquire a hostname for the trace-agent by connecting to the core agent's
+// gRPC endpoints. If it fails, it will return an error.
+func acquireHostname(c *config.AgentConfig) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ipcAddress, err := coreconfig.GetIPCAddress()
+	if err != nil {
+		return err
+	}
+
+	client, err := grpc.GetDDAgentClient(ctx, ipcAddress, coreconfig.GetIPCPort())
+	if err != nil {
+		return err
+	}
+	reply, err := client.GetHostname(ctx, &pbgo.HostnameRequest{})
+	if err != nil {
+		return err
+	}
+	if c.HasFeature("disable_empty_hostname") && reply.Hostname == "" {
+		log.Infof("Acquired empty hostname from gRPC but it's disallowed.")
+		return errors.New("empty hostname disallowed")
+	}
+	c.Hostname = reply.Hostname
+	log.Infof("Acquired hostname from gRPC: %s", c.Hostname)
+	return nil
+}
+
+// acquireHostnameFallback attempts to acquire a hostname for this configuration. It
+// tries to shell out to the infrastructure agent for this, if DD_AGENT_BIN is
+// set, otherwise falling back to os.Hostname.
+func acquireHostnameFallback(c *config.AgentConfig) error {
+	var out bytes.Buffer
+	cmd := exec.Command(c.DDAgentBin, "hostname")
+	cmd.Env = append(os.Environ(), cmd.Env...) // needed for Windows
+	cmd.Stdout = &out
+	err := cmd.Run()
+	c.Hostname = strings.TrimSpace(out.String())
+	if emptyDisallowed := c.HasFeature("disable_empty_hostname") && c.Hostname == ""; err != nil || emptyDisallowed {
+		if emptyDisallowed {
+			log.Infof("Core agent returned empty hostname but is disallowed by disable_empty_hostname feature flag. Falling back to os.Hostname.")
+		}
+		// There was either an error retrieving the hostname from the core agent, or
+		// it was empty and its disallowed by the disable_empty_hostname feature flag.
+		host, err2 := fallbackHostnameFunc()
+		if err2 != nil {
+			return fmt.Errorf("couldn't get hostname from agent (%q), nor from OS (%q). Try specifying it by means of config or the DD_HOSTNAME env var", err, err2)
+		}
+		if emptyDisallowed && host == "" {
+			return errors.New("empty hostname disallowed")
+		}
+		c.Hostname = host
+		log.Infof("Acquired hostname from OS: %q. Core agent was unreachable at %q: %v.", c.Hostname, c.DDAgentBin, err)
+		return nil
+	}
+	log.Infof("Acquired hostname from core agent (%s): %q.", c.DDAgentBin, c.Hostname)
+	return nil
+}

--- a/comp/trace/config/hostname_serverless.go
+++ b/comp/trace/config/hostname_serverless.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build serverless
+
+package config
+
+import "github.com/DataDog/datadog-agent/pkg/trace/config"
+
+func hostname(*config.AgentConfig) error {
+	return nil
+}

--- a/comp/trace/config/remote.go
+++ b/comp/trace/config/remote.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !serverless
+
+package config
+
+import (
+	corecompcfg "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/api/security"
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	rc "github.com/DataDog/datadog-agent/pkg/config/remote/client"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+func remote(c corecompcfg.Component, ipcAddress string) (config.RemoteClient, error) {
+	return rc.NewGRPCClient(
+		ipcAddress,
+		coreconfig.GetIPCPort(),
+		func() (string, error) { return security.FetchAuthToken(c) },
+		rc.WithAgent(rcClientName, version.AgentVersion),
+		rc.WithProducts(state.ProductAPMSampling, state.ProductAgentConfig),
+		rc.WithPollInterval(rcClientPollInterval),
+		rc.WithDirectorRootOverride(c.GetString("site"), c.GetString("remote_configuration.director_root")),
+	)
+
+}

--- a/comp/trace/config/remote_serverless.go
+++ b/comp/trace/config/remote_serverless.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build serverless
+
+package config
+
+import (
+	"errors"
+
+	corecompcfg "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+)
+
+func remote(corecompcfg.Component, string) (config.RemoteClient, error) {
+	return nil, errors.New("remote configuration is not supported in serverless")
+}

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -6,15 +6,12 @@
 package config
 
 import (
-	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"html"
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -29,12 +26,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	rc "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
-	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	//nolint:revive // TODO(APM) Fix revive linter
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
-	"github.com/DataDog/datadog-agent/pkg/util/grpc"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -800,77 +797,10 @@ func validate(c *config.AgentConfig, core corecompcfg.Component) error {
 	}
 
 	if c.Hostname == "" && !core.GetBool("serverless.enabled") {
-		// no user-set hostname, try to acquire
-		if err := acquireHostname(c); err != nil {
-			log.Infof("Could not get hostname via gRPC: %v. Falling back to other methods.", err)
-			if err := acquireHostnameFallback(c); err != nil {
-				return err
-			}
+		if err := hostname(c); err != nil {
+			return err
 		}
 	}
-	return nil
-}
-
-// fallbackHostnameFunc specifies the function to use for obtaining the hostname
-// when it can not be obtained by any other means. It is replaced in tests.
-var fallbackHostnameFunc = os.Hostname
-
-// acquireHostname attempts to acquire a hostname for the trace-agent by connecting to the core agent's
-// gRPC endpoints. If it fails, it will return an error.
-func acquireHostname(c *config.AgentConfig) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	ipcAddress, err := coreconfig.GetIPCAddress()
-	if err != nil {
-		return err
-	}
-
-	client, err := grpc.GetDDAgentClient(ctx, ipcAddress, coreconfig.GetIPCPort())
-	if err != nil {
-		return err
-	}
-	reply, err := client.GetHostname(ctx, &pbgo.HostnameRequest{})
-	if err != nil {
-		return err
-	}
-	if c.HasFeature("disable_empty_hostname") && reply.Hostname == "" {
-		log.Infof("Acquired empty hostname from gRPC but it's disallowed.")
-		return errors.New("empty hostname disallowed")
-	}
-	c.Hostname = reply.Hostname
-	log.Infof("Acquired hostname from gRPC: %s", c.Hostname)
-	return nil
-}
-
-// acquireHostnameFallback attempts to acquire a hostname for this configuration. It
-// tries to shell out to the infrastructure agent for this, if DD_AGENT_BIN is
-// set, otherwise falling back to os.Hostname.
-func acquireHostnameFallback(c *config.AgentConfig) error {
-	var out bytes.Buffer
-	cmd := exec.Command(c.DDAgentBin, "hostname")
-	cmd.Env = append(os.Environ(), cmd.Env...) // needed for Windows
-	cmd.Stdout = &out
-	err := cmd.Run()
-	c.Hostname = strings.TrimSpace(out.String())
-	if emptyDisallowed := c.HasFeature("disable_empty_hostname") && c.Hostname == ""; err != nil || emptyDisallowed {
-		if emptyDisallowed {
-			log.Infof("Core agent returned empty hostname but is disallowed by disable_empty_hostname feature flag. Falling back to os.Hostname.")
-		}
-		// There was either an error retrieving the hostname from the core agent, or
-		// it was empty and its disallowed by the disable_empty_hostname feature flag.
-		host, err2 := fallbackHostnameFunc()
-		if err2 != nil {
-			return fmt.Errorf("couldn't get hostname from agent (%q), nor from OS (%q). Try specifying it by means of config or the DD_HOSTNAME env var", err, err2)
-		}
-		if emptyDisallowed && host == "" {
-			return errors.New("empty hostname disallowed")
-		}
-		c.Hostname = host
-		log.Infof("Acquired hostname from OS: %q. Core agent was unreachable at %q: %v.", c.Hostname, c.DDAgentBin, err)
-		return nil
-	}
-	log.Infof("Acquired hostname from core agent (%s): %q.", c.DDAgentBin, c.Hostname)
 	return nil
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Move some uses of `grpc` behind a `!serverless` build tag in `pkg/trace/config`.

The two uses are:
- getting the hostname (was already disabled for serverless anyway)
- initializing a `grpc` client for remote-config (not enabled for serverless)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Remove several grpc related dependencies (see https://github.com/DataDog/datadog-agent/pull/23372#issuecomment-1976550669).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
There should be no functional code change outside of serverless, and for serverless it should just disable features that wouldn't have been enabled anyway.
