### PR TITLE
(fleet) make `repositories` stateless

### DIFF
--- a/pkg/updater/install.go
+++ b/pkg/updater/install.go
@@ -59,10 +59,7 @@ func (i *installer) installExperiment(pkg string, version string, image oci.Imag
 	if err != nil {
 		return fmt.Errorf("could not extract package layers: %w", err)
 	}
-	repository, err := i.repositories.Get(pkg)
-	if err != nil {
-		return fmt.Errorf("could not get repository: %w", err)
-	}
+	repository := i.repositories.Get(pkg)
 	err = repository.SetExperiment(version, tmpDir)
 	if err != nil {
 		return fmt.Errorf("could not set experiment: %w", err)
@@ -71,11 +68,8 @@ func (i *installer) installExperiment(pkg string, version string, image oci.Imag
 }
 
 func (i *installer) promoteExperiment(pkg string) error {
-	repository, err := i.repositories.Get(pkg)
-	if err != nil {
-		return fmt.Errorf("could not get repository: %w", err)
-	}
-	err = repository.PromoteExperiment()
+	repository := i.repositories.Get(pkg)
+	err := repository.PromoteExperiment()
 	if err != nil {
 		return fmt.Errorf("could not promote experiment: %w", err)
 	}
@@ -83,11 +77,8 @@ func (i *installer) promoteExperiment(pkg string) error {
 }
 
 func (i *installer) uninstallExperiment(pkg string) error {
-	repository, err := i.repositories.Get(pkg)
-	if err != nil {
-		return fmt.Errorf("could not get repository: %w", err)
-	}
-	err = repository.DeleteExperiment()
+	repository := i.repositories.Get(pkg)
+	err := repository.DeleteExperiment()
 	if err != nil {
 		return fmt.Errorf("could not delete experiment: %w", err)
 	}

--- a/pkg/updater/install_test.go
+++ b/pkg/updater/install_test.go
@@ -71,8 +71,7 @@ func fsContainsAll(a fs.FS, b fs.FS) error {
 }
 
 func newTestInstaller(t *testing.T) *installer {
-	repositories, err := repository.NewRepositories(t.TempDir(), t.TempDir())
-	assert.NoError(t, err)
+	repositories := repository.NewRepositories(t.TempDir(), t.TempDir())
 	return newInstaller(repositories)
 }
 
@@ -83,8 +82,7 @@ func TestInstallStable(t *testing.T) {
 
 	err := installer.installStable(fixtureSimpleV1.pkg, fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
 	assert.NoError(t, err)
-	r, err := installer.repositories.Get(fixtureSimpleV1.pkg)
-	assert.NoError(t, err)
+	r := installer.repositories.Get(fixtureSimpleV1.pkg)
 	state, err := r.GetState()
 	assert.NoError(t, err)
 	assert.Equal(t, fixtureSimpleV1.version, state.Stable)
@@ -101,8 +99,7 @@ func TestInstallExperiment(t *testing.T) {
 	assert.NoError(t, err)
 	err = installer.installExperiment(fixtureSimpleV1.pkg, fixtureSimpleV2.version, s.Image(fixtureSimpleV2))
 	assert.NoError(t, err)
-	r, err := installer.repositories.Get(fixtureSimpleV1.pkg)
-	assert.NoError(t, err)
+	r := installer.repositories.Get(fixtureSimpleV1.pkg)
 	state, err := r.GetState()
 	assert.NoError(t, err)
 	assert.Equal(t, fixtureSimpleV1.version, state.Stable)
@@ -122,8 +119,7 @@ func TestPromoteExperiment(t *testing.T) {
 	assert.NoError(t, err)
 	err = installer.promoteExperiment(fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
-	r, err := installer.repositories.Get(fixtureSimpleV1.pkg)
-	assert.NoError(t, err)
+	r := installer.repositories.Get(fixtureSimpleV1.pkg)
 	state, err := r.GetState()
 	assert.NoError(t, err)
 	assert.Equal(t, fixtureSimpleV2.version, state.Stable)
@@ -142,8 +138,7 @@ func TestUninstallExperiment(t *testing.T) {
 	assert.NoError(t, err)
 	err = installer.uninstallExperiment(fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
-	r, err := installer.repositories.Get(fixtureSimpleV1.pkg)
-	assert.NoError(t, err)
+	r := installer.repositories.Get(fixtureSimpleV1.pkg)
 	state, err := r.GetState()
 	assert.NoError(t, err)
 	assert.Equal(t, fixtureSimpleV1.version, state.Stable)

--- a/pkg/updater/repository/repositories_test.go
+++ b/pkg/updater/repository/repositories_test.go
@@ -16,8 +16,7 @@ import (
 func newTestRepositories(t *testing.T) *Repositories {
 	rootPath := t.TempDir()
 	locksRootPath := t.TempDir()
-	repositories, err := NewRepositories(rootPath, locksRootPath)
-	assert.NoError(t, err)
+	repositories := NewRepositories(rootPath, locksRootPath)
 	return repositories
 }
 
@@ -34,8 +33,7 @@ func TestRepositories(t *testing.T) {
 
 	err := repositories.Create("repo1", "v1", t.TempDir())
 	assert.NoError(t, err)
-	repository, err := repositories.Get("repo1")
-	assert.NoError(t, err)
+	repository := repositories.Get("repo1")
 	err = repository.SetExperiment("v2", t.TempDir())
 	assert.NoError(t, err)
 	err = repositories.Create("repo2", "v1.0", t.TempDir())
@@ -55,8 +53,7 @@ func TestRepositoriesReopen(t *testing.T) {
 	err = repositories.Create("repo2", "v1", t.TempDir())
 	assert.NoError(t, err)
 
-	repositories, err = NewRepositories(repositories.rootPath, repositories.locksPath)
-	assert.NoError(t, err)
+	repositories = NewRepositories(repositories.rootPath, repositories.locksPath)
 
 	state, err := repositories.GetState()
 	assert.NoError(t, err)

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -90,10 +90,7 @@ func NewUpdater(rcFetcher client.ConfigFetcher) (Updater, error) {
 }
 
 func newUpdater(rc *remoteConfig, repositoriesPath string, locksPath string) (*updaterImpl, error) {
-	repositories, err := repository.NewRepositories(repositoriesPath, locksPath)
-	if err != nil {
-		return nil, err
-	}
+	repositories := repository.NewRepositories(repositoriesPath, locksPath)
 	u := &updaterImpl{
 		rc:                rc,
 		repositories:      repositories,

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -91,8 +91,7 @@ func TestUpdaterBootstrap(t *testing.T) {
 	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
 
-	r, err := updater.repositories.Get(fixtureSimpleV1.pkg)
-	assert.NoError(t, err)
+	r := updater.repositories.Get(fixtureSimpleV1.pkg)
 	state, err := r.GetState()
 	assert.NoError(t, err)
 	assert.Equal(t, fixtureSimpleV1.version, state.Stable)
@@ -132,8 +131,7 @@ func TestUpdaterStartExperiment(t *testing.T) {
 		Params: json.RawMessage(`{"version":"` + fixtureSimpleV2.version + `"}`),
 	})
 
-	r, err := updater.repositories.Get(fixtureSimpleV1.pkg)
-	assert.NoError(t, err)
+	r := updater.repositories.Get(fixtureSimpleV1.pkg)
 	state, err := r.GetState()
 	assert.NoError(t, err)
 	assert.Equal(t, fixtureSimpleV1.version, state.Stable)
@@ -169,8 +167,7 @@ func TestUpdaterPromoteExperiment(t *testing.T) {
 		Method: methodPromoteExperiment,
 	})
 
-	r, err := updater.repositories.Get(fixtureSimpleV1.pkg)
-	assert.NoError(t, err)
+	r := updater.repositories.Get(fixtureSimpleV1.pkg)
 	state, err := r.GetState()
 	assert.NoError(t, err)
 	assert.Equal(t, fixtureSimpleV2.version, state.Stable)
@@ -195,8 +192,7 @@ func TestUpdaterStopExperiment(t *testing.T) {
 		Method: methodStartExperiment,
 		Params: json.RawMessage(`{"version":"` + fixtureSimpleV2.version + `"}`),
 	})
-	r, err := updater.repositories.Get(fixtureSimpleV1.pkg)
-	assert.NoError(t, err)
+	r := updater.repositories.Get(fixtureSimpleV1.pkg)
 	state, err := r.GetState()
 	assert.NoError(t, err)
 	assert.True(t, state.HasExperiment())


### PR DESCRIPTION
This PR makes the `repositories` struct stateless, following the pattern set in `repository`. This ensures we always load the underlying state on disk, making sure we can't get de-synced with it.