### PR TITLE
Rotate the API key at runtime in the logs-agent

### DIFF
--- a/comp/logs/agent/agent_test.go
+++ b/comp/logs/agent/agent_test.go
@@ -172,7 +172,7 @@ func (suite *AgentTestSuite) TestAgentHttp() {
 }
 
 func (suite *AgentTestSuite) TestAgentStopsWithWrongBackendTcp() {
-	endpoint := config.Endpoint{Host: "fake:", Port: 0}
+	endpoint := config.NewEndpoint("", "fake:", 0, false)
 	endpoints := config.NewEndpoints(endpoint, []config.Endpoint{}, true, false)
 
 	coreConfig.SetFeatures(suite.T(), coreConfig.Docker, coreConfig.Kubernetes)

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -17,7 +17,6 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 // ContainerCollectAll is the name of the docker integration that collect logs from all containers
@@ -142,13 +141,7 @@ func IsExpectedTagsSet(coreConfig pkgconfigmodel.Reader) bool {
 
 func buildTCPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys) (*Endpoints, error) {
 	useProto := logsConfig.devModeUseProto()
-	proxyAddress := logsConfig.socks5ProxyAddress()
-	main := Endpoint{
-		APIKey:                  logsConfig.getLogsAPIKey(),
-		ProxyAddress:            proxyAddress,
-		ConnectionResetInterval: logsConfig.connectionResetInterval(),
-		UseSSL:                  pointer.Ptr(logsConfig.logsNoSSL()),
-	}
+	main := NewTCPEndpoint(logsConfig)
 
 	if logsDDURL, defined := logsConfig.logsDDURL(); defined {
 		// Proxy settings, expect 'logs_config.logs_dd_url' to respect the format '<HOST>:<PORT>'
@@ -160,11 +153,11 @@ func buildTCPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigK
 		}
 		main.Host = host
 		main.Port = port
-		*main.UseSSL = !logsConfig.logsNoSSL()
+		main.useSSL = !logsConfig.logsNoSSL()
 	} else if logsConfig.usePort443() {
 		main.Host = logsConfig.ddURL443()
 		main.Port = 443
-		*main.UseSSL = true
+		main.useSSL = true
 	} else {
 		// If no proxy is set, we default to 'logs_config.dd_url' if set, or to 'site'.
 		// if none of them is set, we default to the US agent endpoint.
@@ -174,17 +167,10 @@ func buildTCPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigK
 		} else {
 			main.Port = logsConfig.ddPort()
 		}
-		*main.UseSSL = !logsConfig.devModeNoSSL()
+		main.useSSL = !logsConfig.devModeNoSSL()
 	}
 
-	additionals := logsConfig.getAdditionalEndpoints()
-	for i := 0; i < len(additionals); i++ {
-		if additionals[i].UseSSL == nil {
-			additionals[i].UseSSL = main.UseSSL
-		}
-		additionals[i].ProxyAddress = proxyAddress
-		additionals[i].APIKey = pkgconfigutils.SanitizeAPIKey(additionals[i].APIKey)
-	}
+	additionals := loadTCPAdditionalEndpoints(main, logsConfig)
 	return NewEndpoints(main, additionals, useProto, false), nil
 }
 
@@ -203,18 +189,7 @@ func BuildHTTPEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *
 	// Provide default values for legacy settings when the configuration key does not exist
 	defaultNoSSL := logsConfig.logsNoSSL()
 
-	main := Endpoint{
-		APIKey:                  logsConfig.getLogsAPIKey(),
-		UseCompression:          logsConfig.useCompression(),
-		CompressionLevel:        logsConfig.compressionLevel(),
-		ConnectionResetInterval: logsConfig.connectionResetInterval(),
-		BackoffBase:             logsConfig.senderBackoffBase(),
-		BackoffMax:              logsConfig.senderBackoffMax(),
-		BackoffFactor:           logsConfig.senderBackoffFactor(),
-		RecoveryInterval:        logsConfig.senderRecoveryInterval(),
-		RecoveryReset:           logsConfig.senderRecoveryReset(),
-		UseSSL:                  pointer.Ptr(defaultNoSSL),
-	}
+	main := NewHTTPEndpoint(logsConfig)
 
 	if logsConfig.useV2API() && intakeTrackType != "" {
 		main.Version = EPIntakeVersion2
@@ -232,7 +207,7 @@ func BuildHTTPEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *
 		}
 		main.Host = host
 		main.Port = port
-		*main.UseSSL = useSSL
+		main.useSSL = useSSL
 	} else if logsDDURL, logsDDURLDefined := logsConfig.logsDDURL(); logsDDURLDefined {
 		host, port, useSSL, err := parseAddressWithScheme(logsDDURL, defaultNoSSL, parseAddress)
 		if err != nil {
@@ -240,7 +215,7 @@ func BuildHTTPEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *
 		}
 		main.Host = host
 		main.Port = port
-		*main.UseSSL = useSSL
+		main.useSSL = useSSL
 	} else {
 		addr := pkgconfigutils.GetMainEndpoint(coreConfig, endpointPrefix, logsConfig.getConfigKey("dd_url"))
 		host, port, useSSL, err := parseAddressWithScheme(addr, logsConfig.devModeNoSSL(), parseAddressAsHost)
@@ -250,32 +225,10 @@ func BuildHTTPEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *
 
 		main.Host = host
 		main.Port = port
-		*main.UseSSL = useSSL
+		main.useSSL = useSSL
 	}
 
-	additionals := logsConfig.getAdditionalEndpoints()
-	for i := 0; i < len(additionals); i++ {
-		if additionals[i].UseSSL == nil {
-			additionals[i].UseSSL = main.UseSSL
-		}
-		additionals[i].APIKey = pkgconfigutils.SanitizeAPIKey(additionals[i].APIKey)
-		additionals[i].UseCompression = main.UseCompression
-		additionals[i].CompressionLevel = main.CompressionLevel
-		additionals[i].BackoffBase = main.BackoffBase
-		additionals[i].BackoffMax = main.BackoffMax
-		additionals[i].BackoffFactor = main.BackoffFactor
-		additionals[i].RecoveryInterval = main.RecoveryInterval
-		additionals[i].RecoveryReset = main.RecoveryReset
-
-		if additionals[i].Version == 0 {
-			additionals[i].Version = main.Version
-		}
-		if additionals[i].Version == EPIntakeVersion2 {
-			additionals[i].TrackType = intakeTrackType
-			additionals[i].Protocol = intakeProtocol
-			additionals[i].Origin = intakeOrigin
-		}
-	}
+	additionals := loadHTTPAdditionalEndpoints(main, logsConfig, intakeTrackType, intakeProtocol, intakeOrigin)
 
 	// Add in the HAMR endpoint if HA is enabled.
 	if coreConfig.GetBool("ha.enabled") {
@@ -289,26 +242,21 @@ func BuildHTTPEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *
 			return nil, fmt.Errorf("could not parse %s: %v", haURL, err)
 		}
 
-		// HA endpoint is always reliable
-		additionals = append(additionals, Endpoint{
-			IsHA:             true,
-			IsReliable:       pointer.Ptr(true),
-			APIKey:           coreConfig.GetString("ha.api_key"),
-			Host:             haHost,
-			Port:             haPort,
-			UseSSL:           pointer.Ptr(haUseSSL),
-			UseCompression:   main.UseCompression,
-			CompressionLevel: main.CompressionLevel,
-			BackoffBase:      main.BackoffBase,
-			BackoffMax:       main.BackoffMax,
-			BackoffFactor:    main.BackoffFactor,
-			RecoveryInterval: main.RecoveryInterval,
-			RecoveryReset:    main.RecoveryReset,
-			Version:          main.Version,
-			TrackType:        intakeTrackType,
-			Protocol:         intakeProtocol,
-			Origin:           intakeOrigin,
-		})
+		e := NewEndpoint(coreConfig.GetString("ha.api_key"), haHost, haPort, haUseSSL)
+		e.IsHA = true
+		e.UseCompression = main.UseCompression
+		e.CompressionLevel = main.CompressionLevel
+		e.BackoffBase = main.BackoffBase
+		e.BackoffMax = main.BackoffMax
+		e.BackoffFactor = main.BackoffFactor
+		e.RecoveryInterval = main.RecoveryInterval
+		e.RecoveryReset = main.RecoveryReset
+		e.Version = main.Version
+		e.TrackType = intakeTrackType
+		e.Protocol = intakeProtocol
+		e.Origin = intakeOrigin
+
+		additionals = append(additionals, e)
 	}
 
 	batchWait := logsConfig.batchWait()

--- a/comp/logs/agent/config/config_keys_test.go
+++ b/comp/logs/agent/config/config_keys_test.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+)
+
+func getLogsConfigKeys(t *testing.T) (config.Component, *LogsConfigKeys) {
+	configMock := fxutil.Test[config.Component](
+		t,
+		config.MockModule(),
+		fx.Replace(config.MockParams{Overrides: map[string]any{
+			"api_key": "1234",
+		}}),
+	)
+
+	return configMock, defaultLogsConfigKeys(configMock)
+}
+
+func TestGetAPIKeyGetter(t *testing.T) {
+	configMock, l := getLogsConfigKeys(t)
+
+	assert.Equal(t, "1234", l.getAPIKeyGetter()())
+
+	configMock.SetWithoutSource("api_key", "abcd")
+	assert.Equal(t, "abcd", l.getAPIKeyGetter()())
+
+	configMock.SetWithoutSource("logs_config.api_key", "5678")
+	assert.Equal(t, "5678", l.getAPIKeyGetter()())
+}
+
+func TestGetAdditionalEndpoints(t *testing.T) {
+	expected := []unmarshalEndpoint{
+		{
+			APIKey:     "apiKey2",
+			IsReliable: pointer.Ptr(true),
+			UseSSL:     pointer.Ptr(true),
+			Endpoint: Endpoint{
+				Host: "http://localhost1",
+				Port: 1234,
+			},
+		},
+		{
+			APIKey:     "apiKey3",
+			IsReliable: pointer.Ptr(false),
+			Endpoint: Endpoint{
+				Host: "http://localhost2",
+				Port: 5678,
+			},
+		},
+	}
+
+	configMock, l := getLogsConfigKeys(t)
+
+	// Test with a JSON directly set
+	jsonString := `[{
+			"api_key":     "apiKey2",
+			"Host":        "http://localhost1",
+			"Port":        1234,
+			"is_reliable": true,
+			"use_ssl":     true
+		},
+		{
+			"api_key":     "apiKey3",
+			"Host":        "http://localhost2",
+			"Port":        5678,
+			"is_reliable": false
+		}]`
+	configMock.SetWithoutSource("logs_config.additional_endpoints", jsonString)
+
+	endpoints := l.getAdditionalEndpoints()
+	assert.Equal(t, expected, endpoints)
+
+	// Test with a regular setup from the configuration file
+	configMock.UnsetForSource("logs_config.additional_endpoints", model.SourceUnknown)
+	configMock.SetWithoutSource("logs_config.additional_endpoints",
+		[]map[string]interface{}{
+			{
+				"api_key":     "apiKey2",
+				"Host":        "http://localhost1",
+				"Port":        1234,
+				"is_reliable": true,
+				"use_ssl":     true,
+			},
+			{
+				"api_key":     "apiKey3",
+				"Host":        "http://localhost2",
+				"Port":        5678,
+				"is_reliable": false,
+			},
+		})
+	endpoints = l.getAdditionalEndpoints()
+	assert.Equal(t, expected, endpoints)
+}

--- a/comp/logs/agent/config/endpoints_test.go
+++ b/comp/logs/agent/config/endpoints_test.go
@@ -77,10 +77,10 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	endpoint = endpoints.Main
-	suite.Equal("azerty", endpoint.APIKey)
+	suite.Equal("azerty", endpoint.GetAPIKey())
 	suite.Equal("agent-intake.logs.datadoghq.com", endpoint.Host)
 	suite.Equal(10516, endpoint.Port)
-	suite.True(endpoint.GetUseSSL())
+	suite.True(endpoint.UseSSL())
 	suite.Equal("boz:1234", endpoint.ProxyAddress)
 	suite.Equal(1, len(endpoints.Endpoints))
 
@@ -88,10 +88,10 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	endpoint = endpoints.Main
-	suite.Equal("azerty", endpoint.APIKey)
+	suite.Equal("azerty", endpoint.GetAPIKey())
 	suite.Equal("agent-443-intake.logs.datadoghq.com", endpoint.Host)
 	suite.Equal(443, endpoint.Port)
-	suite.True(endpoint.GetUseSSL())
+	suite.True(endpoint.UseSSL())
 	suite.Equal("boz:1234", endpoint.ProxyAddress)
 	suite.Equal(1, len(endpoints.Endpoints))
 
@@ -100,10 +100,10 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	endpoint = endpoints.Main
-	suite.Equal("azerty", endpoint.APIKey)
+	suite.Equal("azerty", endpoint.GetAPIKey())
 	suite.Equal("host", endpoint.Host)
 	suite.Equal(1234, endpoint.Port)
-	suite.False(endpoint.GetUseSSL())
+	suite.False(endpoint.UseSSL())
 	suite.Equal("boz:1234", endpoint.ProxyAddress)
 	suite.Equal(1, len(endpoints.Endpoints))
 
@@ -112,10 +112,10 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	endpoint = endpoints.Main
-	suite.Equal("azerty", endpoint.APIKey)
+	suite.Equal("azerty", endpoint.GetAPIKey())
 	suite.Equal("", endpoint.Host)
 	suite.Equal(1234, endpoint.Port)
-	suite.True(endpoint.GetUseSSL())
+	suite.True(endpoint.UseSSL())
 	suite.Equal("boz:1234", endpoint.ProxyAddress)
 	suite.Equal(1, len(endpoints.Endpoints))
 }
@@ -133,7 +133,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	suite.Equal(endpoints.BatchWait, 5*time.Second)
 
 	endpoint = endpoints.Main
-	suite.True(endpoint.GetUseSSL())
+	suite.True(endpoint.UseSSL())
 	suite.Equal("agent-http-intake.logs.datadoghq.com", endpoint.Host)
 }
 
@@ -187,7 +187,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	suite.Equal(endpoints.BatchWait, 9*time.Second)
 
 	endpoint = endpoints.Main
-	suite.True(endpoint.GetUseSSL())
+	suite.True(endpoint.UseSSL())
 	suite.Equal("foo", endpoint.Host)
 }
 
@@ -204,7 +204,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidProxyCo
 	suite.True(endpoints.UseHTTP)
 
 	endpoint = endpoints.Main
-	suite.True(endpoint.GetUseSSL())
+	suite.True(endpoint.UseSSL())
 	suite.Equal("foo", endpoint.Host)
 	suite.Equal(1234, endpoint.Port)
 }
@@ -358,19 +358,19 @@ func (suite *EndpointsTestSuite) TestIsSetAndNotEmpty() {
 
 func (suite *EndpointsTestSuite) TestDefaultApiKey() {
 	suite.config.SetWithoutSource("api_key", "wassupkey")
-	suite.Equal("wassupkey", defaultLogsConfigKeys(suite.config).getLogsAPIKey())
+	suite.Equal("wassupkey", defaultLogsConfigKeys(suite.config).getAPIKeyGetter()())
 	endpoints, err := BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
-	suite.Equal("wassupkey", endpoints.Main.APIKey)
+	suite.Equal("wassupkey", endpoints.Main.GetAPIKey())
 }
 
 func (suite *EndpointsTestSuite) TestOverrideApiKey() {
 	suite.config.SetWithoutSource("api_key", "wassupkey")
 	suite.config.SetWithoutSource("logs_config.api_key", "wassuplogskey")
-	suite.Equal("wassuplogskey", defaultLogsConfigKeys(suite.config).getLogsAPIKey())
+	suite.Equal("wassuplogskey", defaultLogsConfigKeys(suite.config).getAPIKeyGetter()())
 	endpoints, err := BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
-	suite.Equal("wassuplogskey", endpoints.Main.APIKey)
+	suite.Equal("wassuplogskey", endpoints.Main.GetAPIKey())
 }
 
 func (suite *EndpointsTestSuite) TestAdditionalEndpoints() {
@@ -395,8 +395,8 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpoints() {
 
 	endpoint = endpoints.Endpoints[1]
 	suite.Equal("foo", endpoint.Host)
-	suite.Equal("1234", endpoint.APIKey)
-	suite.True(endpoint.GetUseSSL())
+	suite.Equal("1234", endpoint.GetAPIKey())
+	suite.True(endpoint.UseSSL())
 
 	suite.config.SetWithoutSource("logs_config.use_http", true)
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
@@ -405,13 +405,13 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpoints() {
 
 	endpoint = endpoints.Endpoints[1]
 	suite.Equal("foo", endpoint.Host)
-	suite.Equal("1234", endpoint.APIKey)
+	suite.Equal("1234", endpoint.GetAPIKey())
 
 	// Main should override the compression settings
 	suite.True(endpoint.UseCompression)
 	suite.Equal(6, endpoint.CompressionLevel)
 
-	suite.True(endpoint.GetUseSSL())
+	suite.True(endpoint.UseSSL())
 }
 
 func (suite *EndpointsTestSuite) TestAdditionalEndpointsMappedCorrectly() {
@@ -447,15 +447,15 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpointsMappedCorrectly() {
 
 	endpoint = endpoints.GetUnReliableEndpoints()[0]
 	suite.Equal("a", endpoint.Host)
-	suite.Equal("1", endpoint.APIKey)
+	suite.Equal("1", endpoint.GetAPIKey())
 
 	endpoint = endpoints.GetUnReliableEndpoints()[1]
 	suite.Equal("c", endpoint.Host)
-	suite.Equal("3", endpoint.APIKey)
+	suite.Equal("3", endpoint.GetAPIKey())
 
 	endpoint = endpoints.GetReliableEndpoints()[1]
 	suite.Equal("b", endpoint.Host)
-	suite.Equal("2", endpoint.APIKey)
+	suite.Equal("2", endpoint.GetAPIKey())
 }
 
 func (suite *EndpointsTestSuite) TestIsReliableDefaultTrue() {
@@ -482,9 +482,10 @@ func (suite *EndpointsTestSuite) TestIsReliableDefaultTrue() {
 	})
 
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Len(endpoints.Endpoints, 4)
 	suite.Len(endpoints.GetUnReliableEndpoints(), 1)
+	suite.Equal("c", endpoints.GetUnReliableEndpoints()[0].Host)
 	suite.Len(endpoints.GetReliableEndpoints(), 3)
 }
 
@@ -517,9 +518,9 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpointsUseSSLTCPMainEndpointTru
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Len(endpoints.Endpoints, 4)
-	suite.False(endpoints.Endpoints[1].GetUseSSL())
-	suite.True(endpoints.Endpoints[2].GetUseSSL())
-	suite.False(endpoints.Endpoints[3].GetUseSSL())
+	suite.False(endpoints.Endpoints[1].UseSSL())
+	suite.True(endpoints.Endpoints[2].UseSSL())
+	suite.False(endpoints.Endpoints[3].UseSSL())
 }
 
 func (suite *EndpointsTestSuite) TestAdditionalEndpointsUseSSLTCPMainEndpointFalse() {
@@ -551,9 +552,9 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpointsUseSSLTCPMainEndpointFal
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Len(endpoints.Endpoints, 4)
-	suite.True(endpoints.Endpoints[1].GetUseSSL())
-	suite.True(endpoints.Endpoints[2].GetUseSSL())
-	suite.False(endpoints.Endpoints[3].GetUseSSL())
+	suite.True(endpoints.Endpoints[1].UseSSL())
+	suite.True(endpoints.Endpoints[2].UseSSL())
+	suite.False(endpoints.Endpoints[3].UseSSL())
 }
 
 func (suite *EndpointsTestSuite) TestAdditionalEndpointsUseSSLHTTPMainEndpointTrue() {
@@ -586,9 +587,9 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpointsUseSSLHTTPMainEndpointTr
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivitySuccess, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Len(endpoints.Endpoints, 4)
-	suite.False(endpoints.Endpoints[1].GetUseSSL())
-	suite.True(endpoints.Endpoints[2].GetUseSSL())
-	suite.False(endpoints.Endpoints[3].GetUseSSL())
+	suite.False(endpoints.Endpoints[1].UseSSL())
+	suite.True(endpoints.Endpoints[2].UseSSL())
+	suite.False(endpoints.Endpoints[3].UseSSL())
 }
 
 func (suite *EndpointsTestSuite) TestAdditionalEndpointsUseSSLHTTPMainEndpointFalse() {
@@ -621,9 +622,152 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpointsUseSSLHTTPMainEndpointFa
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivitySuccess, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Len(endpoints.Endpoints, 4)
-	suite.False(endpoints.Endpoints[1].GetUseSSL())
-	suite.True(endpoints.Endpoints[2].GetUseSSL())
-	suite.False(endpoints.Endpoints[3].GetUseSSL())
+	suite.False(endpoints.Endpoints[1].UseSSL())
+	suite.True(endpoints.Endpoints[2].UseSSL())
+	suite.False(endpoints.Endpoints[3].UseSSL())
+}
+
+func (suite *EndpointsTestSuite) TestMainApiKeyRotation() {
+	suite.config.SetWithoutSource("api_key", "1234")
+	logsConfig := defaultLogsConfigKeys(suite.config)
+
+	tcp := NewTCPEndpoint(logsConfig)
+	http := NewHTTPEndpoint(logsConfig)
+
+	suite.Equal("1234", tcp.GetAPIKey())
+	suite.Equal("1234", http.GetAPIKey())
+
+	// change API key at runtime
+	suite.config.SetWithoutSource("api_key", "5678")
+	suite.Equal("5678", tcp.GetAPIKey())
+	suite.Equal("5678", http.GetAPIKey())
+}
+
+func (suite *EndpointsTestSuite) TestLogsConfigApiKeyRotation() {
+	suite.config.SetWithoutSource("api_key", "abcd")
+	suite.config.SetWithoutSource("logs_config.api_key", "1234")
+	logsConfig := defaultLogsConfigKeys(suite.config)
+
+	tcp := NewTCPEndpoint(logsConfig)
+	http := NewHTTPEndpoint(logsConfig)
+
+	suite.Equal("1234", tcp.GetAPIKey())
+	suite.Equal("1234", http.GetAPIKey())
+
+	// change API key at runtime
+	suite.config.SetWithoutSource("api_key", "5678")
+	suite.Equal("1234", tcp.GetAPIKey())
+	suite.Equal("1234", http.GetAPIKey())
+
+	// change API key at runtime
+	suite.config.SetWithoutSource("logs_config.api_key", "5678")
+	suite.Equal("5678", tcp.GetAPIKey())
+	suite.Equal("5678", http.GetAPIKey())
+}
+
+func (suite *EndpointsTestSuite) TestloadTCPAdditionalEndpoints() {
+	jsonString := `[{
+			"api_key":           "apiKey2",
+			"Host":              "localhost1",
+			"Port":              1234,
+			"is_reliable":       true,
+			"use_compression":   true,
+			"compression_level": 12
+		},
+		{
+			"api_key":     "apiKey3",
+			"Host":        "localhost2",
+			"Port":        5678,
+			"use_ssl":     false,
+			"is_reliable": false
+		}]`
+	suite.config.SetWithoutSource("logs_config.additional_endpoints", jsonString)
+
+	expected1 := Endpoint{
+		apiKeyGetter:     func() string { return "apiKey2" },
+		isReliable:       true,
+		useSSL:           true,
+		Host:             "localhost1",
+		Port:             1234,
+		UseCompression:   true,
+		CompressionLevel: 12,
+	}
+	expected2 := Endpoint{
+		apiKeyGetter: func() string { return "apiKey3" },
+		isReliable:   false,
+		Host:         "localhost2",
+		Port:         5678,
+	}
+
+	main := Endpoint{useSSL: true}
+	logsConfig := defaultLogsConfigKeys(suite.config)
+	endpoints := loadTCPAdditionalEndpoints(main, logsConfig)
+
+	suite.Suite.Require().Len(endpoints, 2)
+	compareEndpoint(suite.T(), expected1, endpoints[0])
+	compareEndpoint(suite.T(), expected2, endpoints[1])
+}
+
+func (suite *EndpointsTestSuite) TestloadHTTPAdditionalEndpoints() {
+	jsonString := `[{
+			"api_key":           "apiKey2",
+			"Host":              "localhost1",
+			"Port":              1234,
+			"is_reliable":       true,
+			"version":           123
+		},
+		{
+			"api_key":     "apiKey3",
+			"Host":        "localhost2",
+			"Port":        5678,
+			"use_ssl":     false,
+			"is_reliable": false
+		}]`
+	suite.config.SetWithoutSource("logs_config.additional_endpoints", jsonString)
+
+	expected1 := Endpoint{
+		apiKeyGetter:     func() string { return "apiKey2" },
+		isReliable:       true,
+		useSSL:           true,
+		Host:             "localhost1",
+		Port:             1234,
+		UseCompression:   true, // compression from main overwrite the config
+		CompressionLevel: 123,
+		Version:          123,
+	}
+	expected2 := Endpoint{
+		apiKeyGetter:     func() string { return "apiKey3" },
+		isReliable:       false,
+		Host:             "localhost2",
+		Port:             5678,
+		UseCompression:   true,
+		CompressionLevel: 123,
+		Version:          EPIntakeVersion2,
+		// Those are enforce when EPIntakeVersion2 is used
+		TrackType: "some track type",
+		Protocol:  "some intake protocol",
+		Origin:    "some intake origin",
+	}
+
+	main := Endpoint{
+		useSSL:           true,
+		UseCompression:   true,
+		CompressionLevel: 123,
+		Version:          EPIntakeVersion2,
+	}
+
+	logsConfig := defaultLogsConfigKeys(suite.config)
+	endpoints := loadHTTPAdditionalEndpoints(
+		main,
+		logsConfig,
+		"some track type",
+		"some intake protocol",
+		"some intake origin",
+	)
+
+	suite.Suite.Require().Len(endpoints, 2)
+	compareEndpoint(suite.T(), expected1, endpoints[0])
+	compareEndpoint(suite.T(), expected2, endpoints[1])
 }
 
 func TestEndpointsTestSuite(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -805,13 +805,13 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.21.0 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20231121144256-b99613f794b6 // indirect
-	golang.org/x/exp/typeparams v0.0.0-20220613132600-b0d781184e0d // indirect
+	golang.org/x/exp/typeparams v0.0.0-20230307190834-24139beb5833 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.3.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240123012728-ef4313101c80 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	honnef.co/go/tools v0.3.2 // indirect
+	honnef.co/go/tools v0.4.5 // indirect
 	k8s.io/kms v0.29.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2077,8 +2077,8 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 h1:LfspQV/FYTatPTr/3HzIcmiUFH7PGP+OQ6mgDYo3yuQ=
 golang.org/x/exp v0.0.0-20240222234643-814bf88cf225/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
-golang.org/x/exp/typeparams v0.0.0-20220613132600-b0d781184e0d h1:+W8Qf4iJtMGKkyAygcKohjxTk4JPsL9DpzApJ22m5Ic=
-golang.org/x/exp/typeparams v0.0.0-20220613132600-b0d781184e0d/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
+golang.org/x/exp/typeparams v0.0.0-20230307190834-24139beb5833 h1:jWGQJV4niP+CCmFW9ekjA9Zx8vYORzOUH2/Nl5WPuLQ=
+golang.org/x/exp/typeparams v0.0.0-20230307190834-24139beb5833/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -2761,8 +2761,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.3.2 h1:ytYb4rOqyp1TSa2EPvNVwtPQJctSELKaMyLfqNP4+34=
-honnef.co/go/tools v0.3.2/go.mod h1:jzwdWgg7Jdq75wlfblQxO4neNaFFSvgc1tD5Wv8U0Yw=
+honnef.co/go/tools v0.4.5 h1:YGD4H+SuIOOqsyoLOpZDWcieM28W47/zRO7f+9V3nvo=
+honnef.co/go/tools v0.4.5/go.mod h1:GUV+uIBCLpdf0/v6UhHHG/yzI/z6qPskBeQCjcNB96k=
 k8s.io/api v0.28.6 h1:yy6u9CuIhmg55YvF/BavPBBXB+5QicB64njJXxVnzLo=
 k8s.io/api v0.28.6/go.mod h1:AM6Ys6g9MY3dl/XNaNfg/GePI0FT7WBGu8efU/lirAo=
 k8s.io/apiextensions-apiserver v0.28.6 h1:myB3iG/3v3jqCg28JDbOefu4sH2/erNEXgytRzJKBOo=

--- a/pkg/logs/client/go.mod
+++ b/pkg/logs/client/go.mod
@@ -49,7 +49,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.52.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/http v0.52.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/log v0.52.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/util/pointer v0.52.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/version v0.52.0-rc.3
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/net v0.21.0
@@ -68,6 +67,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.52.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.52.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/optional v0.52.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/pointer v0.52.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.52.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/statstracker v0.52.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system v0.52.0-rc.3 // indirect

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -59,7 +59,7 @@ var emptyJsonPayload = message.Payload{Messages: []*message.Message{}, Encoded: 
 type Destination struct {
 	// Config
 	url                 string
-	apiKey              string
+	endpoint            config.Endpoint
 	contentType         string
 	host                string
 	client              *httputils.ResetClient
@@ -136,7 +136,7 @@ func newDestination(endpoint config.Endpoint,
 	return &Destination{
 		host:                endpoint.Host,
 		url:                 buildURL(endpoint),
-		apiKey:              endpoint.APIKey,
+		endpoint:            endpoint,
 		contentType:         contentType,
 		client:              httputils.NewResetClient(endpoint.ConnectionResetInterval, httpClientFactory(timeout, cfg)),
 		destinationsContext: destinationsContext,
@@ -280,7 +280,7 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 		// this can happen when the method or the url are valid.
 		return err
 	}
-	req.Header.Set("DD-API-KEY", d.apiKey)
+	req.Header.Set("DD-API-KEY", d.endpoint.GetAPIKey())
 	req.Header.Set("Content-Type", d.contentType)
 	if payload.Encoding != "" {
 		req.Header.Set("Content-Encoding", payload.Encoding)
@@ -378,7 +378,7 @@ func httpClientFactory(timeout time.Duration, cfg pkgconfigmodel.Reader) func() 
 // buildURL buils a url from a config endpoint.
 func buildURL(endpoint config.Endpoint) string {
 	var scheme string
-	if endpoint.GetUseSSL() {
+	if endpoint.UseSSL() {
 		scheme = "https"
 	} else {
 		scheme = "http"

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 func getNewConfig() pkgconfigmodel.ReaderWriter {
@@ -27,41 +26,25 @@ func getNewConfig() pkgconfigmodel.ReaderWriter {
 }
 
 func TestBuildURLShouldReturnHTTPSWithUseSSL(t *testing.T) {
-	url := buildURL(config.Endpoint{
-		APIKey: "bar",
-		Host:   "foo",
-		UseSSL: pointer.Ptr(true),
-	})
+	url := buildURL(config.NewEndpoint("bar", "foo", 0, true))
 	assert.Equal(t, "https://foo/v1/input", url)
 }
 
 func TestBuildURLShouldReturnHTTPWithoutUseSSL(t *testing.T) {
-	url := buildURL(config.Endpoint{
-		APIKey: "bar",
-		Host:   "foo",
-		UseSSL: pointer.Ptr(false),
-	})
+	url := buildURL(config.NewEndpoint("bar", "foo", 0, false))
 	assert.Equal(t, "http://foo/v1/input", url)
 }
 
 func TestBuildURLShouldReturnAddressWithPortWhenDefined(t *testing.T) {
-	url := buildURL(config.Endpoint{
-		APIKey: "bar",
-		Host:   "foo",
-		Port:   1234,
-		UseSSL: pointer.Ptr(false),
-	})
+	url := buildURL(config.NewEndpoint("bar", "foo", 1234, false))
 	assert.Equal(t, "http://foo:1234/v1/input", url)
 }
 
 func TestBuildURLShouldReturnAddressForVersion2(t *testing.T) {
-	url := buildURL(config.Endpoint{
-		APIKey:    "bar",
-		Host:      "foo",
-		UseSSL:    pointer.Ptr(false),
-		Version:   config.EPIntakeVersion2,
-		TrackType: "test-track",
-	})
+	e := config.NewEndpoint("bar", "foo", 0, false)
+	e.Version = config.EPIntakeVersion2
+	e.TrackType = "test-track"
+	url := buildURL(e)
 	assert.Equal(t, "http://foo/api/v2/test-track", url)
 }
 

--- a/pkg/logs/client/http/test_utils.go
+++ b/pkg/logs/client/http/test_utils.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
-	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 // StatusCodeContainer is a lock around the status code to return
@@ -73,16 +72,13 @@ func NewTestServerWithOptions(statusCode int, senders int, retryDestination bool
 	port, _ := strconv.Atoi(url[2])
 	destCtx := client.NewDestinationsContext()
 	destCtx.Start()
-	endpoint := config.Endpoint{
-		APIKey:           "test",
-		Host:             strings.Replace(url[1], "/", "", -1),
-		Port:             port,
-		UseSSL:           pointer.Ptr(false),
-		BackoffFactor:    1,
-		BackoffBase:      1,
-		BackoffMax:       10,
-		RecoveryInterval: 1,
-	}
+
+	endpoint := config.NewEndpoint("test", strings.Replace(url[1], "/", "", -1), port, false)
+	endpoint.BackoffFactor = 1
+	endpoint.BackoffBase = 1
+	endpoint.BackoffMax = 10
+	endpoint.RecoveryInterval = 1
+
 	dest := NewDestination(endpoint, JSONContentType, destCtx, senders, retryDestination, "test", cfg)
 	return &TestServer{
 		httpServer:          ts,

--- a/pkg/logs/client/tcp/connection_manager.go
+++ b/pkg/logs/client/tcp/connection_manager.go
@@ -61,9 +61,9 @@ func (cm *ConnectionManager) NewConnection(ctx context.Context) (net.Conn, error
 
 	cm.firstConn.Do(func() {
 		if cm.endpoint.ProxyAddress != "" {
-			log.Infof("Connecting to the backend: %v, via socks5: %v, with SSL: %v", cm.address(), cm.endpoint.ProxyAddress, cm.endpoint.UseSSL)
+			log.Infof("Connecting to the backend: %v, via socks5: %v, with SSL: %v", cm.address(), cm.endpoint.ProxyAddress, cm.endpoint.UseSSL())
 		} else {
-			log.Infof("Connecting to the backend: %v, with SSL: %v", cm.address(), cm.endpoint.UseSSL)
+			log.Infof("Connecting to the backend: %v, with SSL: %v", cm.address(), cm.endpoint.UseSSL())
 		}
 	})
 
@@ -110,7 +110,7 @@ func (cm *ConnectionManager) NewConnection(ctx context.Context) (net.Conn, error
 		}
 		log.Debugf("connected to %v", cm.address())
 
-		if cm.endpoint.GetUseSSL() {
+		if cm.endpoint.UseSSL() {
 			sslConn := tls.Client(conn, &tls.Config{
 				ServerName: cm.endpoint.Host,
 			})

--- a/pkg/logs/client/tcp/connection_manager_test.go
+++ b/pkg/logs/client/tcp/connection_manager_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface"
 	"github.com/DataDog/datadog-agent/pkg/logs/util/testutils"
-	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 func newConnectionManagerForAddr(addr net.Addr) *ConnectionManager {
@@ -28,7 +27,7 @@ func newConnectionManagerForAddr(addr net.Addr) *ConnectionManager {
 }
 
 func newConnectionManagerForHostPort(host string, port int) *ConnectionManager {
-	endpoint := config.Endpoint{Host: host, Port: port, UseSSL: pointer.Ptr(false)}
+	endpoint := config.NewEndpoint("", host, port, false)
 	return NewConnectionManager(endpoint, statusinterface.NewStatusProviderMock())
 }
 

--- a/pkg/logs/client/tcp/destination.go
+++ b/pkg/logs/client/tcp/destination.go
@@ -35,10 +35,9 @@ type Destination struct {
 
 // NewDestination returns a new destination.
 func NewDestination(endpoint config.Endpoint, useProto bool, destinationsContext *client.DestinationsContext, shouldRetry bool, status statusinterface.Status) *Destination {
-	prefix := endpoint.APIKey + string(' ')
 	metrics.DestinationLogsDropped.Set(endpoint.Host, &expvar.Int{})
 	return &Destination{
-		prefixer:            newPrefixer(prefix),
+		prefixer:            newPrefixer(endpoint.GetAPIKey),
 		delimiter:           NewDelimiter(useProto),
 		connManager:         NewConnectionManager(endpoint, status),
 		destinationsContext: destinationsContext,

--- a/pkg/logs/client/tcp/prefixer.go
+++ b/pkg/logs/client/tcp/prefixer.go
@@ -9,21 +9,22 @@ import "bytes"
 
 // prefixer prepends a prefix to a message.
 type prefixer struct {
-	prefix string
+	get    func() string
 	buffer bytes.Buffer
 }
 
-// newPrefixer returns a prefixer that prepends the given prefix to a message.
-func newPrefixer(prefix string) *prefixer {
+// newPrefixer returns a prefixer that will fetch the prefix and prepends it a given message each time apply is called.
+func newPrefixer(getter func() string) *prefixer {
 	return &prefixer{
-		prefix: prefix,
+		get: getter,
 	}
 }
 
-// apply prepends the prefix to the message.
+// apply prepends the prefix and a space to the message.
 func (p *prefixer) apply(content []byte) []byte {
 	p.buffer.Reset()
-	p.buffer.WriteString(p.prefix)
+	p.buffer.WriteString(p.get())
+	p.buffer.WriteByte(' ')
 	p.buffer.Write(content)
 	return p.buffer.Bytes()
 }

--- a/pkg/logs/client/tcp/prefixer_test.go
+++ b/pkg/logs/client/tcp/prefixer_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestPrefixer(t *testing.T) {
-
-	prefixer := newPrefixer("foo ")
+	prefixer := newPrefixer(func() string { return "foo" })
 	assert.Equal(t, []byte("foo bar"), prefixer.apply([]byte("bar")))
-
 }

--- a/pkg/logs/client/tcp/test_utils.go
+++ b/pkg/logs/client/tcp/test_utils.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface"
-	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 // AddrToHostPort converts a net.Addr to a (string, int).
@@ -28,7 +27,7 @@ func AddrToHostPort(remoteAddr net.Addr) (string, int) {
 // AddrToEndPoint creates an EndPoint from an Addr.
 func AddrToEndPoint(addr net.Addr) config.Endpoint {
 	host, port := AddrToHostPort(addr)
-	return config.Endpoint{Host: host, Port: port, UseSSL: pointer.Ptr(false)}
+	return config.NewEndpoint("", host, port, false)
 }
 
 // AddrToDestination creates a Destination from an Addr

--- a/pkg/security/security_profile/dump/remote_storage.go
+++ b/pkg/security/security_profile/dump/remote_storage.go
@@ -69,7 +69,9 @@ func NewActivityDumpRemoteStorage() (ActivityDumpStorage, error) {
 	}
 	for _, endpoint := range endpoints.GetReliableEndpoints() {
 		storage.urls = append(storage.urls, utils.GetEndpointURL(endpoint, "api/v2/secdump"))
-		storage.apiKeys = append(storage.apiKeys, endpoint.APIKey)
+		// TODO - runtime API key refresh: Storing the API key like this will no longer be valid once the
+		// security agent support API key refresh at runtime.
+		storage.apiKeys = append(storage.apiKeys, endpoint.GetAPIKey())
 	}
 
 	return storage, nil

--- a/pkg/security/utils/endpoint.go
+++ b/pkg/security/utils/endpoint.go
@@ -16,7 +16,7 @@ import (
 func GetEndpointURL(endpoint logsconfig.Endpoint, uri string) string {
 	port := endpoint.Port
 	var protocol string
-	if endpoint.GetUseSSL() {
+	if endpoint.UseSSL() {
 		protocol = "https"
 		if port == 0 {
 			port = 443 // use default port


### PR DESCRIPTION
### What does this PR do?

The logs-agent now pull the API key from the configuration every time it uses it. This makes rotating the API key at runtime possible.

### Describe how to test/QA your changes

* Test that the logs agent still works like before (this includes TCP/HTTP + additional_endpoints)
* Rotate the API key for HTTP and TCP destination (API key rotation is only supported for the main setting `api_key` in the configuration). But rotating the API key should not impact other destination.

Setting up API key rotation:
- Use [Secret management solution](https://docs.datadoghq.com/agent/configuration/secrets-management/?tab=linux) to set the API key (ex: `api_key: ENC[my API key]`).
- Create a binary that returned a different value each time it's called
- Use the new CLI to trigger secret rotation: `datadog-agent secrets refresh`
