### PR TITLE
[CWS] fix DNS payload event in ringbuffer

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/network/dns.h
+++ b/pkg/security/ebpf/c/include/hooks/network/dns.h
@@ -106,8 +106,14 @@ int classifier_dns_request_parser(struct __sk_buff *skb) {
         return ACT_OK;
     }
 
+    // really should not happen, the loop in parse_dns_request only ever
+    // reads DNS_MAX_LENGTH bytes
+    if (qname_length > DNS_MAX_LENGTH) {
+        return ACT_OK;
+    }
+
     // send DNS event
-    send_event_with_size_ptr(skb, EVENT_DNS, evt, offsetof(struct dns_event_t, name) + (qname_length & (DNS_MAX_LENGTH - 1)));
+    send_event_with_size_ptr(skb, EVENT_DNS, evt, offsetof(struct dns_event_t, name) + qname_length);
 
     if (!is_dns_request_parsing_done(skb, pkt)) {
         tail_call_to_classifier(skb, DNS_REQUEST_PARSER);


### PR DESCRIPTION
### What does this PR do?

If the payload size if 256, the current implementation would truncate the full payload and revert to a size of 0. This fixes this.

Example:
```
qname_length = 256
DNS_MAX_LENGTH = 256

(qname_length & (DNS_MAX_LENGTH - 1)) = (256 & 255) = 0
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
