### PR TITLE
[CSPM] Cross-container scanning by detecting container root mountpoint

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -11,15 +11,12 @@ package compliance
 import (
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"expvar"
 	"fmt"
 	"hash/fnv"
-	"io"
 	"math/rand"
 	"net/http"
-	"net/url"
-	"strconv"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -29,11 +26,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/dbconfig"
 	"github.com/DataDog/datadog-agent/pkg/compliance/k8sconfig"
 	"github.com/DataDog/datadog-agent/pkg/compliance/metrics"
+	"github.com/DataDog/datadog-agent/pkg/compliance/utils"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	secl "github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/shirou/gopsutil/v3/process"
 )
 
 const containersCountMetricName = "datadog.security_agent.compliance.containers_running"
@@ -447,20 +446,16 @@ func (a *Agent) runDBConfigurationsExport(ctx context.Context) {
 		if sleepRandomJitter(ctx, checkInterval, runCount, a.opts.Hostname, "db-configuration") {
 			return
 		}
-		pids := dbconfig.ListProcesses(ctx)
-		for containerID, pid := range pids {
-			// if the process does not run in any form of container, containerID
-			// is the empty string "" and it can be run locally
-			if containerID == "" {
-				resource, ok := dbconfig.LoadDBResourceFromPID(ctx, pid)
-				if ok {
-					a.reportResourceLog(defaultCheckIntervalLowPriority, NewResourceLog(a.opts.Hostname, resource.Type, resource.Config))
-				}
-			} else {
-				err := a.reportDBConfigurationFromSystemProbe(ctx, pid)
-				if err != nil {
-					log.Infof("error evaluating cross-container benchmark from system-probe: %v", err)
-				}
+		procs, err := process.ProcessesWithContext(ctx)
+		if err != nil {
+			continue
+		}
+		groups := groupProcesses(procs, dbconfig.GetProcResourceType)
+		for keyGroup, proc := range groups {
+			rootPath := filepath.Join(a.opts.HostRoot, keyGroup.rootPath)
+			resource, ok := dbconfig.LoadDBResource(ctx, rootPath, proc, keyGroup.containerID)
+			if ok {
+				a.reportResourceLog(defaultCheckIntervalLowPriority, NewResourceLog(a.opts.Hostname, resource.Type, resource.Config))
 			}
 		}
 		if sleepAborted(ctx, runTicker.C) {
@@ -469,52 +464,43 @@ func (a *Agent) runDBConfigurationsExport(ctx context.Context) {
 	}
 }
 
-func (a *Agent) reportDBConfigurationFromSystemProbe(ctx context.Context, pid int32) error {
-	if a.opts.SysProbeClient == nil {
-		return fmt.Errorf("system-probe socket client was not created")
-	}
+type procGroup struct {
+	key         string
+	containerID utils.ContainerID
+	rootPath    string
+}
 
-	qs := make(url.Values)
-	qs.Add("pid", strconv.FormatInt(int64(pid), 10))
-	sysProbeComplianceModuleURL := &url.URL{
-		Scheme:   "http",
-		Host:     "unix",
-		Path:     "/compliance/dbconfig",
-		RawQuery: qs.Encode(),
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sysProbeComplianceModuleURL.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := a.opts.SysProbeClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("error running cross-container benchmark: %s", resp.Status)
-	}
-
-	var resource *dbconfig.DBResource
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(body, &resource); err != nil {
-		return err
-	}
-	if resource != nil {
-		dbResourceLog := NewResourceLog(a.opts.Hostname, resource.Type, resource.Config)
-		if cID := resource.ContainerID; cID != "" {
-			dbResourceLog.Container = &CheckContainerMeta{
-				ContainerID: cID,
-			}
+func groupProcesses(procs []*process.Process, getKey func(*process.Process) (string, bool)) map[procGroup]*process.Process {
+	groups := make(map[procGroup]*process.Process)
+	for _, proc := range procs {
+		key, ok := getKey(proc)
+		if !ok {
+			continue
 		}
-		a.reportResourceLog(defaultCheckIntervalLowPriority, dbResourceLog)
+		// if the process does not run in any form of container, containerID
+		// is the empty string "" and it can be run locally
+		containerID, _ := utils.GetProcessContainerID(proc.Pid)
+		var rootPath string
+		if containerID != "" {
+			p, err := utils.GetContainerOverlayPath(proc.Pid)
+			if err != nil {
+				continue
+			}
+			rootPath = p
+		} else {
+			rootPath = "/"
+		}
+		// We dedupe our scans based on the resource type and the container
+		// ID, assuming that we will scan the same configuration for each
+		// containers running the process.
+		groupKey := procGroup{
+			key:         key,
+			containerID: containerID,
+			rootPath:    rootPath,
+		}
+		groups[groupKey] = proc
 	}
-	return nil
+	return groups
 }
 
 func (a *Agent) reportResourceLog(resourceTTL time.Duration, resourceLog *ResourceLog) {

--- a/pkg/compliance/dbconfig/loader.go
+++ b/pkg/compliance/dbconfig/loader.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance/utils"
+
 	"github.com/shirou/gopsutil/v3/process"
 	yaml "gopkg.in/yaml.v3"
 )
@@ -59,7 +60,9 @@ func readFileLimit(name string) ([]byte, error) {
 	return b, nil
 }
 
-func getProcResourceType(proc *process.Process) (string, bool) {
+// GetProcResourceType returns the type of database resource associated with
+// the given process.
+func GetProcResourceType(proc *process.Process) (string, bool) {
 	name, _ := proc.Name()
 	switch name {
 	case "postgres":
@@ -75,32 +78,32 @@ func getProcResourceType(proc *process.Process) (string, bool) {
 	return "", false
 }
 
-// ListProcesses returns a map of database application processes that we are
-// able to scan, indexed by their associated container ID.
-func ListProcesses(ctx context.Context) map[utils.ContainerID]int32 {
-	pids := make(map[utils.ContainerID]int32)
-	procs, err := process.ProcessesWithContext(ctx)
-	if err != nil {
-		return nil
+// LoadDBResource loads and returns an optional DBResource associated with the
+// given process PID.
+func LoadDBResource(ctx context.Context, rootPath string, proc *process.Process, containerID utils.ContainerID) (*DBResource, bool) {
+	resourceType, ok := GetProcResourceType(proc)
+	if !ok {
+		return nil, false
 	}
-	dedupeMap := make(map[string]struct{})
-	for _, proc := range procs {
-		resourceType, ok := getProcResourceType(proc)
-		if !ok {
-			continue
-		}
-		containerID, _ := utils.GetProcessContainerID(proc.Pid)
-		// We dedupe our scans based on the resource type and the container
-		// ID, assuming that we will scan the same configuration for each
-		// containers running the process.
-		dedupeKey := resourceType + string(containerID)
-		if _, ok := dedupeMap[dedupeKey]; ok {
-			continue
-		}
-		dedupeMap[dedupeKey] = struct{}{}
-		pids[containerID] = proc.Pid
+	var conf *DBConfig
+	switch resourceType {
+	case postgresqlResourceType:
+		conf, ok = LoadPostgreSQLConfig(ctx, rootPath, proc)
+	case mongoDBResourceType:
+		conf, ok = LoadMongoDBConfig(ctx, rootPath, proc)
+	case cassandraResourceType:
+		conf, ok = LoadCassandraConfig(ctx, rootPath, proc)
+	default:
+		ok = false
 	}
-	return pids
+	if !ok || conf == nil {
+		return nil, false
+	}
+	return &DBResource{
+		Type:        resourceType,
+		ContainerID: string(containerID),
+		Config:      *conf,
+	}, true
 }
 
 // LoadDBResourceFromPID loads and returns an optional DBResource associated
@@ -111,10 +114,11 @@ func LoadDBResourceFromPID(ctx context.Context, pid int32) (*DBResource, bool) {
 		return nil, false
 	}
 
-	resourceType, ok := getProcResourceType(proc)
+	resourceType, ok := GetProcResourceType(proc)
 	if !ok {
 		return nil, false
 	}
+
 	containerID, _ := utils.GetProcessContainerID(pid)
 	hostroot, ok := utils.GetProcessRootPath(pid)
 	if !ok {

--- a/pkg/compliance/dbconfig/loader_test.go
+++ b/pkg/compliance/dbconfig/loader_test.go
@@ -60,7 +60,7 @@ func TestDBConfLoader(t *testing.T) {
 
 		proc2, err := process.NewProcessWithContext(ctx, int32(proc.Pid))
 		assert.NoError(t, err)
-		resourceType, ok := getProcResourceType(proc2)
+		resourceType, ok := GetProcResourceType(proc2)
 		assert.True(t, ok)
 		assert.Equal(t, postgresqlResourceType, resourceType)
 

--- a/pkg/compliance/utils/processes_nolinux.go
+++ b/pkg/compliance/utils/processes_nolinux.go
@@ -7,16 +7,24 @@
 
 package utils
 
+import "fmt"
+
 // ContainerID wraps a string representing a container identifier.
 type ContainerID string
 
 // GetProcessContainerID returns the container ID associated with the given
 // process ID. Returns an empty string if no container found.
-func GetProcessContainerID(pid int32) (ContainerID, bool) { //nolint:revive // TODO fix revive unused-parameter
+func GetProcessContainerID(_ int32) (ContainerID, bool) { //nolint:revive // TODO fix revive unused-parameter
 	return "", false
 }
 
 // GetProcessRootPath returns the process root path of the given PID.
-func GetProcessRootPath(pid int32) (string, bool) { //nolint:revive // TODO fix revive unused-parameter
+func GetProcessRootPath(_ int32) (string, bool) { //nolint:revive // TODO fix revive unused-parameter
 	return "", false
+}
+
+// GetContainerOverlayPath tries to extract the directory mounted as root
+// mountpoint of the given process.
+func GetContainerOverlayPath(_ int32) (string, error) {
+	return "", fmt.Errorf("not implemented")
 }


### PR DESCRIPTION
### What does this PR do?

Executes cross-container scanning by detecting the root mountpoint of a namespaced process. To do so it find the mountpoint of the interested namespaced process by matching its overlay options with the mount entry in `/proc/1/mountinfo`.

### Motivation

We could get rid of our `system-probe` module that executes our cross-container checks today. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
