### PR TITLE
(fleet) fix datadog-agent .path triggers

### DIFF
--- a/omnibus/config/projects/updater.rb
+++ b/omnibus/config/projects/updater.rb
@@ -110,8 +110,8 @@ if linux_target?
   extra_package_file "#{systemd_directory}/datadog-agent-security-exp.service"
   extra_package_file "#{systemd_directory}/datadog-agent-sysprobe.service"
   extra_package_file "#{systemd_directory}/datadog-agent-sysprobe-exp.service"
-  extra_package_file "#{systemd_directory}/start-experiment.path"
-  extra_package_file "#{systemd_directory}/stop-experiment.path"
+  extra_package_file "#{systemd_directory}/datadog-agent.path"
+  extra_package_file "#{systemd_directory}/datadog-agent-exp.path"
   extra_package_file '/etc/datadog-agent/'
   extra_package_file '/var/log/datadog/'
   extra_package_file '/var/run/datadog-packages/'

--- a/omnibus/config/software/updater.rb
+++ b/omnibus/config/software/updater.rb
@@ -66,8 +66,8 @@ build do
       "datadog-agent-process.service.erb" => "datadog-agent-process.service",
       "datadog-agent-security.service.erb" => "datadog-agent-security.service",
       "datadog-agent-sysprobe.service.erb" => "datadog-agent-sysprobe.service",
-      "start-experiment.path.erb" => "start-experiment.path",
-      "stop-experiment.path.erb" => "stop-experiment.path",
+      "datadog-agent-exp.path.erb" => "datadog-agent-exp.path",
+      "datadog-agent.path.erb" => "datadog-agent.path",
       "datadog-updater.service.erb" => "datadog-updater.service",
     }
     templateToFile.each do |template, file|

--- a/omnibus/config/templates/updater/datadog-agent-exp.path.erb
+++ b/omnibus/config/templates/updater/datadog-agent-exp.path.erb
@@ -1,9 +1,8 @@
 [Unit]
 Description="Monitor requests to start experiment"
 
-[PATH]
-PathModifed=<%= install_dir %>/systemd_commands/start_experiment
-Unit=datadog-agent-exp
+[Path]
+PathModified=<%= install_dir %>/systemd_commands/start_experiment
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-agent.path.erb
+++ b/omnibus/config/templates/updater/datadog-agent.path.erb
@@ -1,0 +1,8 @@
+[Unit]
+Description="Monitor requests to stop experiment"
+
+[Path]
+PathModified=<%= install_dir %>/systemd_commands/stop_experiment
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/stop-experiment.path.erb
+++ b/omnibus/config/templates/updater/stop-experiment.path.erb
@@ -1,9 +1,0 @@
-[Unit]
-Description="Monitor requests to stop experiment
-
-[PATH]
-PathModifed=<%= install_dir %>/systemd_commands/stop_experiment
-Unit=datadog-agent
-
-[Install]
-WantedBy=multi-user.target

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -119,5 +119,7 @@ SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-updater || true
 SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-updater || true
 enable_stable_agents
 SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-agent || true
+SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-agent.path || true
+SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-agent-exp.path || true
 
 exit 0

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -37,7 +37,9 @@ enable_stable_agents() {
         SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-trace || true
         SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-security || true
         SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent.path || true
         # experiment agents are not enabled as we don't systemctl enable them
+        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-exp.path || true
     fi
 
 

--- a/omnibus/package-scripts/updater-deb/prerm
+++ b/omnibus/package-scripts/updater-deb/prerm
@@ -8,19 +8,21 @@ stop_agents()
 {
     if command -v systemctl >/dev/null 2>&1; then
         # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
-        
+
         # starting with experiment agents to avoid retriggering agent
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process-exp || true
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-sysprobe-exp || true
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-trace-exp || true
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-security-exp || true
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-exp || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-exp.path || true
 
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process || true
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-sysprobe || true
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-trace || true
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-security || true
         SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent.path || true
     fi
 }
 
@@ -33,8 +35,9 @@ deregister_agents()
         SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-trace || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-security || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent || true
-        
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent.path || true
         # experiment agents are not disabled as we don't systemctl enable them
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-exp.path || true
     fi
 }
 case "$1" in


### PR DESCRIPTION
This PR fixes multiple small issues with `.path` triggers for the `datadog-agent` stable & experiment service units.

List of fixes:
- `[PATH]` => `[Path]`
- `PathModifed` => `PathModified`
- `.path` need to have the same name as their associated unit
- `.path`s were not enabled or started


Those files are temporary as we work on a setup where we can update systemd files but it's still worth fixing to have a working end to end setup.