### PR TITLE
[amlii-1409] Add start hook for dogtstatsd replay component

### DIFF
--- a/comp/dogstatsd/replay/capture.go
+++ b/comp/dogstatsd/replay/capture.go
@@ -49,7 +49,7 @@ type trafficCapture struct {
 //nolint:revive // TODO(AML) Fix revive linter
 func NewServerlessTrafficCapture() Component {
 	tc := newTrafficCaptureCompat(config.Datadog)
-	tc.configure(context.TODO())
+	_ = tc.configure(context.TODO())
 	return tc
 }
 

--- a/comp/dogstatsd/replay/capture.go
+++ b/comp/dogstatsd/replay/capture.go
@@ -46,8 +46,10 @@ type trafficCapture struct {
 // TODO: (components) - remove once serverless is an FX app
 //
 //nolint:revive // TODO(AML) Fix revive linter
-func NewServerlessTrafficCapture() Component {
-	return newTrafficCaptureCompat(config.Datadog)
+func NewServerlessTrafficCapture() (Component, error) {
+	tc := newTrafficCaptureCompat(config.Datadog)
+	err := tc.start(context.TODO())
+	return tc, err
 }
 
 // TODO: (components) - merge with newTrafficCaptureCompat once NewServerlessTrafficCapture is removed

--- a/comp/dogstatsd/replay/capture.go
+++ b/comp/dogstatsd/replay/capture.go
@@ -48,7 +48,7 @@ type trafficCapture struct {
 //nolint:revive // TODO(AML) Fix revive linter
 func NewServerlessTrafficCapture() (Component, error) {
 	tc := newTrafficCaptureCompat(config.Datadog)
-	err := tc.start(context.TODO())
+	err := tc.configure(context.TODO())
 	return tc, err
 }
 
@@ -56,7 +56,7 @@ func NewServerlessTrafficCapture() (Component, error) {
 func newTrafficCapture(deps dependencies) Component {
 	tc := newTrafficCaptureCompat(deps.Config)
 	deps.Lc.Append(fx.Hook{
-		OnStart: tc.start,
+		OnStart: tc.configure,
 	})
 
 	return tc
@@ -68,7 +68,7 @@ func newTrafficCaptureCompat(cfg config.Reader) *trafficCapture {
 	}
 }
 
-func (tc *trafficCapture) start(_ context.Context) error {
+func (tc *trafficCapture) configure(_ context.Context) error {
 	writer := NewTrafficCaptureWriter(tc.config.GetInt("dogstatsd_capture_depth"))
 	if writer == nil {
 		return fmt.Errorf("unable to instantiate capture writer")

--- a/comp/dogstatsd/replay/component.go
+++ b/comp/dogstatsd/replay/component.go
@@ -11,19 +11,16 @@ package replay
 import (
 	"time"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 // team: agent-metrics-logs
 
 // Component is the component type.
 type Component interface {
-	// TODO: (components) we should remove the configure method once Dogstatsd's lifecycle is managed by FX (start/stop)
-	// Because Dogstatsd can fail at runtime, we can't yet rely on fx to configure and start up the replay feature
-	// since it has no way of knowing if dogstatsd started successfully.
-	Configure() error
 
 	// IsOngoing returns whether a capture is ongoing for this TrafficCapture instance.
 	IsOngoing() bool

--- a/comp/dogstatsd/replay/component.go
+++ b/comp/dogstatsd/replay/component.go
@@ -41,6 +41,9 @@ type Component interface {
 
 	// Enqueue enqueues a capture buffer so it's written to file.
 	Enqueue(msg *CaptureBuffer) bool
+
+	// GetStartUpError returns an error if TrafficCapture failed to start up
+	GetStartUpError() error
 }
 
 // Mock implements mock-specific methods.

--- a/comp/dogstatsd/replay/mock.go
+++ b/comp/dogstatsd/replay/mock.go
@@ -6,8 +6,11 @@
 package replay
 
 import (
+	"context"
 	"sync"
 	"time"
+
+	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
 )
@@ -17,11 +20,15 @@ type mockTrafficCapture struct {
 	sync.RWMutex
 }
 
-func newMockTrafficCapture() Component {
-	return &mockTrafficCapture{}
+func newMockTrafficCapture(deps dependencies) Component {
+	tc := &mockTrafficCapture{}
+	deps.Lc.Append(fx.Hook{
+		OnStart: tc.configure,
+	})
+	return tc
 }
 
-func (tc *mockTrafficCapture) Configure() error {
+func (tc *mockTrafficCapture) configure(_ context.Context) error {
 	return nil
 }
 

--- a/comp/dogstatsd/replay/mock.go
+++ b/comp/dogstatsd/replay/mock.go
@@ -68,3 +68,8 @@ func (tc *mockTrafficCapture) RegisterOOBPoolManager(p *packets.PoolManager) err
 func (tc *mockTrafficCapture) Enqueue(msg *CaptureBuffer) bool {
 	return true
 }
+
+//nolint:revive // TODO(AML) Fix revive linter
+func (tc *mockTrafficCapture) GetStartUpError() error {
+	return nil
+}

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -325,11 +325,6 @@ func (s *server) start(context.Context) error {
 
 	packetsChannel := make(chan packets.Packets, s.config.GetInt("dogstatsd_queue_size"))
 	tmpListeners := make([]listeners.StatsdListener, 0, 2)
-	err := s.tCapture.Configure()
-
-	if err != nil {
-		return err
-	}
 
 	// sharedPacketPool is used by the packet assembler to retrieve already allocated
 	// buffer in order to avoid allocation. The packets are pushed back by the server.

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -326,6 +326,10 @@ func (s *server) start(context.Context) error {
 	packetsChannel := make(chan packets.Packets, s.config.GetInt("dogstatsd_queue_size"))
 	tmpListeners := make([]listeners.StatsdListener, 0, 2)
 
+	if err := s.tCapture.GetStartUpError(); err != nil {
+		return err
+	}
+
 	// sharedPacketPool is used by the packet assembler to retrieve already allocated
 	// buffer in order to avoid allocation. The packets are pushed back by the server.
 	sharedPacketPool := packets.NewPool(s.config.GetInt("dogstatsd_buffer_size"))

--- a/comp/dogstatsd/server/serverless.go
+++ b/comp/dogstatsd/server/serverless.go
@@ -26,11 +26,7 @@ type ServerlessDogstatsd interface {
 
 //nolint:revive // TODO(AML) Fix revive linter
 func NewServerlessServer(demux aggregator.Demultiplexer) (ServerlessDogstatsd, error) {
-	tc := replay.NewServerlessTrafficCapture()
-	if err := tc.GetStartUpError(); err != nil {
-		return nil, err
-	}
-	s := newServerCompat(config.Datadog, logComponentImpl.NewTemporaryLoggerWithoutInit(), tc, serverdebugimpl.NewServerlessServerDebug(), true, demux)
+	s := newServerCompat(config.Datadog, logComponentImpl.NewTemporaryLoggerWithoutInit(), replay.NewServerlessTrafficCapture(), serverdebugimpl.NewServerlessServerDebug(), true, demux)
 
 	err := s.start(context.TODO())
 	if err != nil {

--- a/comp/dogstatsd/server/serverless.go
+++ b/comp/dogstatsd/server/serverless.go
@@ -26,13 +26,13 @@ type ServerlessDogstatsd interface {
 
 //nolint:revive // TODO(AML) Fix revive linter
 func NewServerlessServer(demux aggregator.Demultiplexer) (ServerlessDogstatsd, error) {
-	tc, err := replay.NewServerlessTrafficCapture()
-	if err != nil {
+	tc := replay.NewServerlessTrafficCapture()
+	if err := tc.GetStartUpError(); err != nil {
 		return nil, err
 	}
 	s := newServerCompat(config.Datadog, logComponentImpl.NewTemporaryLoggerWithoutInit(), tc, serverdebugimpl.NewServerlessServerDebug(), true, demux)
 
-	err = s.start(context.TODO())
+	err := s.start(context.TODO())
 	if err != nil {
 		return nil, err
 	}

--- a/comp/dogstatsd/server/serverless.go
+++ b/comp/dogstatsd/server/serverless.go
@@ -26,9 +26,13 @@ type ServerlessDogstatsd interface {
 
 //nolint:revive // TODO(AML) Fix revive linter
 func NewServerlessServer(demux aggregator.Demultiplexer) (ServerlessDogstatsd, error) {
-	s := newServerCompat(config.Datadog, logComponentImpl.NewTemporaryLoggerWithoutInit(), replay.NewServerlessTrafficCapture(), serverdebugimpl.NewServerlessServerDebug(), true, demux)
+	tc, err := replay.NewServerlessTrafficCapture()
+	if err != nil {
+		return nil, err
+	}
+	s := newServerCompat(config.Datadog, logComponentImpl.NewTemporaryLoggerWithoutInit(), tc, serverdebugimpl.NewServerlessServerDebug(), true, demux)
 
-	err := s.start(context.TODO())
+	err = s.start(context.TODO())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Replaces the `Configure` method on the dogstatsd/replay component with a start hook.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The dogstatsd server component has a start hook now so we can remove `Configure` for replay in favor of a start hook
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run `dogstatsd-capture`, send some metrics.
Run `dogstatsd-replay` and verify that it still works with the same metrics in the step above being sent again.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
