### PR TITLE
SLVS-3835 [serverless-init] Compute trace stats in serverless-init

### DIFF
--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -57,6 +57,7 @@ func GetBaseTagsMapWithMetadata(metadata map[string]string) map[string]string {
 	}
 
 	tagsMap["datadog_init_version"] = tags.GetExtensionVersion()
+	tagsMap[tags.ComputeStatsKey] = tags.ComputeStatsValue
 
 	return tagsMap
 }

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestGetBaseTagsArrayNoEnvNoMetadata(t *testing.T) {
-	assert.Equal(t, 1, len(GetBaseTagsArrayWithMetadataTags(make(map[string]string, 0))))
+	assert.Equal(t, 2, len(GetBaseTagsArrayWithMetadataTags(make(map[string]string, 0))))
 }
 
 func TestGetBaseTagsArrayWithMetadataTagsNoMetadata(t *testing.T) {
@@ -28,11 +28,12 @@ func TestGetBaseTagsArrayWithMetadataTagsNoMetadata(t *testing.T) {
 	t.Setenv("DD_VERSION", "123.4")
 	tags := GetBaseTagsArrayWithMetadataTags(make(map[string]string, 0))
 	sort.Strings(tags)
-	assert.Equal(t, 4, len(tags))
-	assert.Contains(t, tags[0], "datadog_init_version")
-	assert.Equal(t, "env:myenv", tags[1])
-	assert.Equal(t, "service:superservice", tags[2])
-	assert.Equal(t, "version:123.4", tags[3])
+	assert.Equal(t, 5, len(tags))
+	assert.Contains(t, tags[0], "_dd.compute_stats:1")
+	assert.Contains(t, tags[1], "datadog_init_version")
+	assert.Equal(t, "env:myenv", tags[2])
+	assert.Equal(t, "service:superservice", tags[3])
+	assert.Equal(t, "version:123.4", tags[4])
 }
 
 func TestGetTagFound(t *testing.T) {
@@ -49,7 +50,7 @@ func TestGetTagNotFound(t *testing.T) {
 }
 
 func TestGetBaseTagsMapNoEnvNoMetadata(t *testing.T) {
-	assert.Equal(t, 1, len(GetBaseTagsMapWithMetadata(make(map[string]string, 0))))
+	assert.Equal(t, 2, len(GetBaseTagsMapWithMetadata(make(map[string]string, 0))))
 }
 
 func TestGetBaseTagsMapNoMetadata(t *testing.T) {
@@ -59,7 +60,7 @@ func TestGetBaseTagsMapNoMetadata(t *testing.T) {
 	t.Setenv("DD_SERVICE", "superService")
 	t.Setenv("DD_VERSION", "123.4")
 	tags := GetBaseTagsMapWithMetadata(make(map[string]string, 0))
-	assert.Equal(t, 4, len(tags))
+	assert.Equal(t, 5, len(tags))
 	assert.Equal(t, "myenv", tags["env"])
 	assert.Equal(t, "superservice", tags["service"])
 	assert.Equal(t, "123.4", tags["version"])
@@ -71,7 +72,7 @@ func TestGetBaseTagsMapWithMetadata(t *testing.T) {
 		"location":      "mysuperlocation",
 		"othermetadata": "mysuperothermetadatavalue",
 	})
-	assert.Equal(t, 3, len(tags))
+	assert.Equal(t, 4, len(tags))
 	assert.Equal(t, "mysuperlocation", tags["location"])
 	assert.Equal(t, "mysuperothermetadatavalue", tags["othermetadata"])
 }
@@ -83,10 +84,11 @@ func TestGetBaseTagsArrayWithMetadataTags(t *testing.T) {
 		"othermetadata": "mysuperothermetadatavalue",
 	})
 	sort.Strings(tags)
-	assert.Equal(t, 3, len(tags))
-	assert.Contains(t, tags[0], "datadog_init_version")
-	assert.Equal(t, "location:mysuperlocation", tags[1])
-	assert.Equal(t, "othermetadata:mysuperothermetadatavalue", tags[2])
+	assert.Equal(t, 4, len(tags))
+	assert.Contains(t, tags[0], "_dd.compute_stats:1")
+	assert.Contains(t, tags[1], "datadog_init_version")
+	assert.Equal(t, "location:mysuperlocation", tags[2])
+	assert.Equal(t, "othermetadata:mysuperothermetadatavalue", tags[3])
 }
 
 func TestDdTags(t *testing.T) {

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -56,8 +56,10 @@ const (
 	traceOriginMetadataKey   = "_dd.origin"
 	traceOriginMetadataValue = "lambda"
 
-	computeStatsKey   = "_dd.compute_stats"
-	computeStatsValue = "1"
+	// ComputeStatsKey is the tag key indicating whether trace stats should be computed
+	ComputeStatsKey = "_dd.compute_stats"
+	// ComputeStatsValue is the tag value indicating trace stats should be computed
+	ComputeStatsValue = "1"
 
 	extensionVersionKey = "dd_extension_version"
 
@@ -97,7 +99,7 @@ func BuildTagMap(arn string, configTags []string) map[string]string {
 	tags = MergeWithOverwrite(tags, ArrayToMap(configTags))
 
 	tags = setIfNotEmpty(tags, traceOriginMetadataKey, traceOriginMetadataValue)
-	tags = setIfNotEmpty(tags, computeStatsKey, computeStatsValue)
+	tags = setIfNotEmpty(tags, ComputeStatsKey, ComputeStatsValue)
 	tags = setIfNotEmpty(tags, FunctionARNKey, arn)
 	tags = setIfNotEmpty(tags, extensionVersionKey, GetExtensionVersion())
 
@@ -156,7 +158,7 @@ func MergeWithOverwrite(tags map[string]string, overwritingTags map[string]strin
 
 // BuildTagsFromMap builds an array of tag based on map of tags
 func BuildTagsFromMap(tags map[string]string) []string {
-	tagsMap := buildTags(tags, []string{traceOriginMetadataKey, computeStatsKey})
+	tagsMap := buildTags(tags, []string{traceOriginMetadataKey, ComputeStatsKey})
 	return MapToArray(tagsMap)
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Adds the `_dd.compute_stats:1` tag so that trace metrics are created when using serverless-init. 

### Motivation
Sister PR of https://github.com/DataDog/logs-backend/pull/65802 (currently WIP), which will start to allow us to use second primary tags for AAS and Container Apps.

Example in staging where `datacenter` is the second primary tag.
![Screenshot 2024-03-04 at 10 32 52 AM](https://github.com/DataDog/datadog-agent/assets/25290232/962e02e0-5adf-4e43-88a1-5ebf411c86f3)


### Additional Notes
Unrelated to these changes, the the way serverless-init currently computes tags adds all tags like `_dd.origin` or `_dd.compute_stats` to metrics, logs and traces
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Updated unit tests
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
