### PR TITLE
[auto-team-labels] Set up auto team label assignation as github workflow

### DIFF
--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -25,10 +25,27 @@ jobs:
           labels="${{join(github.event.pull_request.labels.*.name, ' ')}}"
           echo "Fetched labels for PR ${{github.event.number}}: $labels"
           echo "LABELS=$labels" >> "$GITHUB_OUTPUT"
-  assign-team-label:
+  team-label:
+    needs: fetch-labels
     if: github.triggering_actor != 'dd-devflow[bot]'
     runs-on: ubuntu-latest
     steps:
+      - name: Check team assignment
+        run: |
+          for label in $LABELS; do
+            if [[ "$label" =~ ^qa/ ]]; then
+              echo "A label to skip QA is set -- no need for team assignment"
+              exit 0
+            fi
+            if [[ "$label" =~ ^team/ && "$label" != team/triage ]]; then
+              echo "Team label found: $label"
+              exit 0
+            fi
+          done
+          echo "PR ${{github.event.number}} requires at least one non-triage team assignment label (label starting by 'team/')"
+          exit 1
+        env:
+          LABELS: ${{ needs.fetch-labels.outputs.LABELS}}
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -61,27 +78,6 @@ jobs:
             exit
           fi
           gh pr edit '${{ github.event.number }}' --add-label "$labelname"
-  team-label:
-    needs: fetch-labels
-    if: github.triggering_actor != 'dd-devflow[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check team assignment
-        run: |
-          for label in $LABELS; do
-            if [[ "$label" =~ ^qa/ ]]; then
-              echo "A label to skip QA is set -- no need for team assignment"
-              exit 0
-            fi
-            if [[ "$label" =~ ^team/ && "$label" != team/triage ]]; then
-              echo "Team label found: $label"
-              exit 0
-            fi
-          done
-          echo "PR ${{github.event.number}} requires at least one non-triage team assignment label (label starting by 'team/')"
-          exit 1
-        env:
-          LABELS: ${{ needs.fetch-labels.outputs.LABELS}}
   skip-qa:
     needs: fetch-labels
     if: github.triggering_actor != 'dd-devflow[bot]'

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -28,7 +28,10 @@ jobs:
         with:
           format: 'csv'
       - name: Auto assign team label
-        run: GITHUB_TOKEN="$GH_TOKEN" inv -e github.assign-team-label --pr-id='${{ github.event.pull_request.number }}' --changed-files='${{ steps.files.outputs.all }}'
+        run: inv -e github.assign-team-label --pr-id='${{ github.event.pull_request.number }}' --changed-files='${{ steps.files.outputs.all }}'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
   fetch-labels:
     needs: assign-team-label
     if: github.triggering_actor != 'dd-devflow[bot]'
@@ -42,6 +45,9 @@ jobs:
           labels="$(gh pr view --json labels --jq '[.labels[].name] | (join(" "))')"
           echo "Fetched labels for PR ${{github.event.number}}: $labels"
           echo "LABELS=$labels" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
   team-label:
     needs: fetch-labels
     if: github.triggering_actor != 'dd-devflow[bot]'

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -25,6 +25,42 @@ jobs:
           labels="${{join(github.event.pull_request.labels.*.name, ' ')}}"
           echo "Fetched labels for PR ${{github.event.number}}: $labels"
           echo "LABELS=$labels" >> "$GITHUB_OUTPUT"
+  assign-team-label:
+    if: github.triggering_actor != 'dd-devflow[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tasks/requirements.txt
+      - name: Add get-changed-files dependency
+        id: files
+        uses: jitterbit/get-changed-files@v1
+        with:
+          format: 'csv'
+      - name: Auto assign team label
+        run: |
+          command=( inv -e github.deduce-team-label )
+          mapfile -d ',' -t files < <(printf '%s,' '${{ steps.files.outputs.all }}')
+          for file in "${files[@]}"; do
+            command+=( --changed-files="$file" )
+          done
+          echo "COMMAND: ${command[@]}"
+          labelname="$("${command[@]}")"
+          exitcode="$?"
+          if [ "$exitcode" != 0 ]; then
+            echo "Cannot deduce team (got exit code $exitcode)"
+            exit
+          fi
+          gh pr edit '${{ github.event.number }}' --add-label "$labelname"
   team-label:
     needs: fetch-labels
     if: github.triggering_actor != 'dd-devflow[bot]'

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Add get-changed-files dependency
         id: files
         uses: jitterbit/get-changed-files@v1
+        continue-on-error: true
         with:
           format: 'csv'
       - name: Auto assign team label

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -13,7 +13,7 @@ env:
   GH_REPO: ${{ github.repository }}
 
 jobs:
-  assign-team-labels:
+  assign-team-label:
     if: github.triggering_actor != 'dd-devflow[bot]'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -48,36 +48,15 @@ jobs:
           LABELS: ${{ needs.fetch-labels.outputs.LABELS}}
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r tasks/requirements.txt
+        run: pip install -r tasks/requirements.txt
       - name: Add get-changed-files dependency
         id: files
         uses: jitterbit/get-changed-files@v1
         with:
           format: 'csv'
       - name: Auto assign team label
-        run: |
-          command=( inv -e github.deduce-team-label )
-          mapfile -d ',' -t files < <(printf '%s,' '${{ steps.files.outputs.all }}')
-          for file in "${files[@]}"; do
-            command+=( --changed-files="$file" )
-          done
-          echo "COMMAND: ${command[@]}"
-          labelname="$("${command[@]}")"
-          exitcode="$?"
-          if [ "$exitcode" != 0 ]; then
-            echo "Cannot deduce team (got exit code $exitcode)"
-            exit
-          fi
-          gh pr edit '${{ github.event.number }}' --add-label "$labelname"
+        run: inv -e github.assign-team-label '${{ github.event.number }}' '${{ steps.files.outputs.all }}'
   skip-qa:
     needs: fetch-labels
     if: github.triggering_actor != 'dd-devflow[bot]'

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -16,6 +16,7 @@ jobs:
   assign-team-labels:
     if: github.triggering_actor != 'dd-devflow[bot]'
     runs-on: ubuntu-latest
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Python dependencies

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Get PR labels
         id: pr-labels
         run: |
-          labels="$(gh pr view --json labels --jq '[.labels[].name] | (join(" "))')"
+          labels="$(GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}' GH_REPO='${{ github.repository }}' gh pr view --json labels --jq '[.labels[].name] | (join(" "))')"
           echo "Fetched labels for PR ${{github.event.number}}: $labels"
           echo "LABELS=$labels" >> "$GITHUB_OUTPUT"
         env:

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -22,14 +22,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Python dependencies
         run: pip install -r tasks/requirements.txt
-      - name: Add get-changed-files dependency
-        id: files
-        uses: jitterbit/get-changed-files@v1
-        continue-on-error: true
-        with:
-          format: 'csv'
       - name: Auto assign team label
-        run: inv -e github.assign-team-label --pr-id='${{ github.event.pull_request.number }}' --changed-files='${{ steps.files.outputs.all }}'
+        run: inv -e github.assign-team-label --pr-id='${{ github.event.pull_request.number }}'
   fetch-labels:
     needs: assign-team-label
     if: github.triggering_actor != 'dd-devflow[bot]'

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -9,10 +9,9 @@ on:
       - "[0-9]+.[0-9]+.x"
 
 env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GH_REPO: ${{ github.repository }}
-  GITHUB_REPO: ${{ github.repository }}
 
 jobs:
   assign-team-label:
@@ -44,7 +43,7 @@ jobs:
       - name: Get PR labels
         id: pr-labels
         run: |
-          labels="$(GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}' GH_REPO='${{ github.repository }}' gh pr view --json labels --jq '[.labels[].name] | (join(" "))')"
+          labels="$(GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}' GH_REPO='${{ github.repository }}' gh pr view '${{ github.event.pull_request.number }}' --json labels --jq '[.labels[].name] | (join(" "))')"
           echo "Fetched labels for PR ${{github.event.number}}: $labels"
           echo "LABELS=$labels" >> "$GITHUB_OUTPUT"
         env:

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Get PR labels
         id: pr-labels
         run: |
-          labels="${{join(github.event.pull_request.labels.*.name, ' ')}}"
+          labels="$(gh pr view --json labels --jq '[.labels[].name] | (join(" "))')"
           echo "Fetched labels for PR ${{github.event.number}}: $labels"
           echo "LABELS=$labels" >> "$GITHUB_OUTPUT"
   team-label:

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           format: 'csv'
       - name: Auto assign team label
-        run: inv -e github.assign-team-label '${{ github.event.number }}' '${{ steps.files.outputs.all }}'
+        run: GITHUB_TOKEN="$GH_TOKEN" inv -e github.assign-team-label '${{ github.event.number }}' '${{ steps.files.outputs.all }}'
   fetch-labels:
     needs: assign-team-label
     if: github.triggering_actor != 'dd-devflow[bot]'

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           format: 'csv'
       - name: Auto assign team label
-        run: GITHUB_TOKEN="$GH_TOKEN" inv -e github.assign-team-label '${{ github.event.pull_request.number }}' '${{ steps.files.outputs.all }}'
+        run: GITHUB_TOKEN="$GH_TOKEN" inv -e github.assign-team-label --pr-id='${{ github.event.pull_request.number }}' --changed-files='${{ steps.files.outputs.all }}'
   fetch-labels:
     needs: assign-team-label
     if: github.triggering_actor != 'dd-devflow[bot]'

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -13,7 +13,22 @@ env:
   GH_REPO: ${{ github.repository }}
 
 jobs:
+  assign-team-labels:
+    if: github.triggering_actor != 'dd-devflow[bot]'
+    runs-on: ubuntu-latest
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Python dependencies
+        run: pip install -r tasks/requirements.txt
+      - name: Add get-changed-files dependency
+        id: files
+        uses: jitterbit/get-changed-files@v1
+        with:
+          format: 'csv'
+      - name: Auto assign team label
+        run: inv -e github.assign-team-label '${{ github.event.number }}' '${{ steps.files.outputs.all }}'
   fetch-labels:
+    needs: assign-team-label
     if: github.triggering_actor != 'dd-devflow[bot]'
     runs-on: ubuntu-latest
     outputs:
@@ -46,17 +61,6 @@ jobs:
           exit 1
         env:
           LABELS: ${{ needs.fetch-labels.outputs.LABELS}}
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Install Python dependencies
-        run: pip install -r tasks/requirements.txt
-      - name: Add get-changed-files dependency
-        id: files
-        uses: jitterbit/get-changed-files@v1
-        with:
-          format: 'csv'
-      - name: Auto assign team label
-        run: inv -e github.assign-team-label '${{ github.event.number }}' '${{ steps.files.outputs.all }}'
   skip-qa:
     needs: fetch-labels
     if: github.triggering_actor != 'dd-devflow[bot]'

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -10,7 +10,9 @@ on:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GH_REPO: ${{ github.repository }}
+  GITHUB_REPO: ${{ github.repository }}
 
 jobs:
   assign-team-label:

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -30,9 +30,6 @@ jobs:
           format: 'csv'
       - name: Auto assign team label
         run: inv -e github.assign-team-label --pr-id='${{ github.event.pull_request.number }}' --changed-files='${{ steps.files.outputs.all }}'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
   fetch-labels:
     needs: assign-team-label
     if: github.triggering_actor != 'dd-devflow[bot]'
@@ -43,12 +40,9 @@ jobs:
       - name: Get PR labels
         id: pr-labels
         run: |
-          labels="$(GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}' GH_REPO='${{ github.repository }}' gh pr view '${{ github.event.pull_request.number }}' --json labels --jq '[.labels[].name] | (join(" "))')"
+          labels="$(gh pr view '${{ github.event.pull_request.number }}' --json labels --jq '[.labels[].name] | (join(" "))')"
           echo "Fetched labels for PR ${{github.event.number}}: $labels"
           echo "LABELS=$labels" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
   team-label:
     needs: fetch-labels
     if: github.triggering_actor != 'dd-devflow[bot]'

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           format: 'csv'
       - name: Auto assign team label
-        run: GITHUB_TOKEN="$GH_TOKEN" inv -e github.assign-team-label '${{ github.event.number }}' '${{ steps.files.outputs.all }}'
+        run: GITHUB_TOKEN="$GH_TOKEN" inv -e github.assign-team-label '${{ github.event.pull_request.number }}' '${{ steps.files.outputs.all }}'
   fetch-labels:
     needs: assign-team-label
     if: github.triggering_actor != 'dd-devflow[bot]'

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -236,7 +236,7 @@ def assign_team_label(_, pr_id=-1):
 
     # Find team
     teams = _get_teams(gh.get_pr_files(pr_id))
-    teams = [team for team in teams if team.startswith('@DataDog/')]
+    team_labels = [f"team{team.removeprefix('@Datadog')}" for team in teams if team.startswith("@DataDog/")]
     if teams == []:
         print('No team found')
         return

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -219,6 +219,7 @@ def assign_team_label(_, pr_id=-1):
     be deduced from the changed files
     """
     from tasks.libs.common.github_api import GithubAPI
+    import github
 
     gh = GithubAPI('DataDog/datadog-agent')
 
@@ -243,7 +244,8 @@ def assign_team_label(_, pr_id=-1):
     # Assign label
     for team in teams:
         label_name = 'team' + team.removeprefix('@DataDog')
-        if gh.add_pr_label(pr_id, label_name):
+        try:
+            gh.add_pr_label(pr_id, label_name)
             print(label_name, 'label assigned to the pull request')
-        else:
+        except github.GithubException.GithubException:
             print('Failed to assign label')

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -220,17 +220,16 @@ def assign_team_label(_, pr_id=-1):
 
     gh = GithubAPI('DataDog/datadog-agent')
 
-    # TODO
-    # # Skip if necessary
-    # labels = set(gh.get_pr_labels(pr_id))
+    # Skip if necessary
+    labels = set(gh.get_pr_labels(pr_id))
 
-    # if 'qa/done' in labels or 'qa/no-code-change' in labels:
-    #     print('Qa done or no code change, skipping')
-    #     return
+    if 'qa/done' in labels or 'qa/no-code-change' in labels:
+        print('Qa done or no code change, skipping')
+        return
 
-    # if any(label.startswith('team/') for label in labels):
-    #     print('This PR already has a team label, skipping')
-    #     return
+    if any(label.startswith('team/') for label in labels):
+        print('This PR already has a team label, skipping')
+        return
 
     # Find team
     team = get_team(gh.get_pr_files(pr_id))

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -192,7 +192,7 @@ def get_token_from_app(_, app_id_env='GITHUB_APP_ID', pkey_env='GITHUB_KEY_B64')
 
 
 @task
-def assign_team_label(_, pr_id, changed_files):
+def assign_team_label(_, pr_id = -1, changed_files = ''):
     """
     Assigns the github team label name if a single team can
     be deduced from the changed files.

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -16,8 +16,8 @@ from tasks.libs.github_actions_tools import (
     trigger_macos_workflow,
 )
 from tasks.libs.junit_upload_core import repack_macos_junit_tar
-from tasks.release import _get_release_json_value
 from tasks.libs.pipeline_notifications import read_owners
+from tasks.release import _get_release_json_value
 
 
 @lru_cache(maxsize=None)

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -236,14 +236,13 @@ def assign_team_label(_, pr_id=-1):
 
     # Find team
     teams = _get_teams(gh.get_pr_files(pr_id))
-    team_labels = [f"team{team.removeprefix('@Datadog')}" for team in teams if team.startswith("@DataDog/")]
     if teams == []:
         print('No team found')
         return
 
     # Assign label
-    for team in teams:
-        label_name = 'team' + team.removeprefix('@DataDog')
+    team_labels = [f"team{team.removeprefix('@Datadog')}" for team in teams if team.startswith("@DataDog/")]
+    for label_name in team_labels:
         try:
             gh.add_pr_label(pr_id, label_name)
             print(label_name, 'label assigned to the pull request')

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -222,7 +222,7 @@ def assign_team_label(_, pr_id, changed_files):
     gh = GithubAPI('DataDog/datadog-agent')
 
     # Skip if necessary
-    labels = gh.get_labels()
+    labels = gh.get_labels(pr_id)
 
     if 'qa/done' in labels:
         print('Qa done, skipping')

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -225,7 +225,7 @@ def assign_team_label(_, pr_id=-1, changed_files=''):
     labels = set(gh.get_labels(pr_id))
 
     if 'qa/done' in labels or 'qa/no-code-change' in labels:
-        print('Qa done, skipping')
+        print('Qa done or no code change, skipping')
         return
 
     if any(label.startswith('team/') for label in labels):

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -197,7 +197,7 @@ def assign_team_label(_, pr_id=-1):
     Assigns the github team label name if a single team can
     be deduced from the changed files
     """
-    from .libs.common.github_api import GithubAPI
+    from tasks.libs.common.github_api import GithubAPI
 
     def get_team(changed_files) -> str | None:
         codeowners = read_owners('.github/CODEOWNERS')

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -192,15 +192,14 @@ def get_token_from_app(_, app_id_env='GITHUB_APP_ID', pkey_env='GITHUB_KEY_B64')
 
 
 @task
-def assign_team_label(_, pr_id=-1, changed_files=''):
+def assign_team_label(_, pr_id=-1):
     """
     Assigns the github team label name if a single team can
-    be deduced from the changed files.
-    changed_files is a comma separated string
+    be deduced from the changed files
     """
     from .libs.common.github_api import GithubAPI
 
-    def get_team() -> str | None:
+    def get_team(changed_files) -> str | None:
         codeowners = read_owners('.github/CODEOWNERS')
 
         global_team = None
@@ -221,27 +220,27 @@ def assign_team_label(_, pr_id=-1, changed_files=''):
 
     gh = GithubAPI('DataDog/datadog-agent')
 
-    # Skip if necessary
-    labels = set(gh.get_labels(pr_id))
+    # TODO
+    # # Skip if necessary
+    # labels = set(gh.get_pr_labels(pr_id))
 
-    if 'qa/done' in labels or 'qa/no-code-change' in labels:
-        print('Qa done or no code change, skipping')
-        return
+    # if 'qa/done' in labels or 'qa/no-code-change' in labels:
+    #     print('Qa done or no code change, skipping')
+    #     return
 
-    if any(label.startswith('team/') for label in labels):
-        print('This PR already has a team label, skipping')
-        return
+    # if any(label.startswith('team/') for label in labels):
+    #     print('This PR already has a team label, skipping')
+    #     return
 
     # Find team
-    changed_files = changed_files.split(',')
-    team = get_team()
+    team = get_team(gh.get_pr_files(pr_id))
     if team is None:
         print('No team or multiple teams found')
         return
 
     # Assign label
     label_name = 'team' + team.removeprefix('@DataDog')
-    if gh.add_label(pr_id, label_name):
+    if gh.add_pr_label(pr_id, label_name):
         print(label_name, 'label assigned to the pull request')
     else:
         print('Failed to assign label')

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -236,6 +236,9 @@ def assign_team_label(_, pr_id=-1):
     if team is None:
         print('No team or multiple teams found')
         return
+    elif not team.startswith('@DataDog/'):
+        print('Invalid team name', team)
+        return
 
     # Assign label
     label_name = 'team' + team.removeprefix('@DataDog')

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -219,16 +219,28 @@ def assign_team_label(_, pr_id, changed_files):
 
         return global_team
 
+    gh = GithubAPI('DataDog/datadog-agent')
+
+    # Skip if necessary
+    labels = gh.get_labels()
+
+    if 'qa/done' in labels:
+        print('Qa done, skipping')
+        return
+
+    if any(label.startswith('team/') for label in labels):
+        print('This PR already has a team label, skipping')
+        return
+
     # Find team
     changed_files = changed_files.split(',')
     team = get_team()
     if team is None:
         print('No team or multiple teams found')
-        exit()
+        return
 
     # Assign label
     label_name = 'team' + team.removeprefix('@DataDog')
-    gh = GithubAPI('DataDog/datadog-agent')
     if gh.add_label(pr_id, label_name):
         print(label_name, 'label assigned to the pull request')
     else:

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -248,4 +248,4 @@ def assign_team_label(_, pr_id=-1):
             gh.add_pr_label(pr_id, label_name)
             print(label_name, 'label assigned to the pull request')
         except github.GithubException.GithubException:
-            print('Failed to assign label')
+            print(f'Failed to assign label {label_name}')

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -1,6 +1,7 @@
 import os
 import re
 import time
+import fnmatch
 from functools import lru_cache
 
 from invoke import Exit, task
@@ -188,3 +189,41 @@ def get_token_from_app(_, app_id_env='GITHUB_APP_ID', pkey_env='GITHUB_KEY_B64')
     from .libs.common.github_api import GithubAPI
 
     GithubAPI.get_token_from_app(app_id_env, pkey_env)
+
+
+@task
+def deduce_team_label(_, changed_files=[]):
+    """
+    Print the github team label name if a single team can
+    be deduced from the changed files
+    """
+    def get_team() -> str | None:
+        from codeowners import CodeOwners
+
+        with open('.github/CODEOWNERS') as f:
+            codeowners = CodeOwners(f.read())
+
+        global_team = None
+        for file in changed_files:
+            owners = [name for (kind, name) in codeowners.of(file) if kind == 'TEAM']
+            if len(owners) != 1:
+                # Multiple / no owners case
+                return
+            else:
+                file_team = owners[0]
+                if global_team is not None and file_team != global_team:
+                    # Multiple owners case
+                    return
+                else:
+                    global_team = file_team
+
+        return global_team
+
+    # Find team
+    team = get_team()
+    assert team is not None, 'No team or multiple teams found'
+    assert team.startswith('@DataDog/'), f'Unknown team {team}'
+
+    # Print label
+    label_name = 'team' + team.removeprefix('@DataDog')
+    print(label_name)

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -1,7 +1,6 @@
 import os
 import re
 import time
-import fnmatch
 from functools import lru_cache
 
 from invoke import Exit, task

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -222,9 +222,9 @@ def assign_team_label(_, pr_id=-1, changed_files=''):
     gh = GithubAPI('DataDog/datadog-agent')
 
     # Skip if necessary
-    labels = gh.get_labels(pr_id)
+    labels = set(gh.get_labels(pr_id))
 
-    if 'qa/done' in labels:
+    if 'qa/done' in labels or 'qa/no-code-change' in labels:
         print('Qa done, skipping')
         return
 

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -192,7 +192,7 @@ def get_token_from_app(_, app_id_env='GITHUB_APP_ID', pkey_env='GITHUB_KEY_B64')
 
 
 @task
-def assign_team_label(_, pr_id = -1, changed_files = ''):
+def assign_team_label(_, pr_id=-1, changed_files=''):
     """
     Assigns the github team label name if a single team can
     be deduced from the changed files.

--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -3,6 +3,7 @@ import os
 import platform
 import re
 import subprocess
+from typing import List
 
 try:
     from github import Auth, Github, GithubException, GithubIntegration, GithubObject
@@ -204,7 +205,7 @@ class GithubAPI:
 
         return True
 
-    def get_labels(self, pr_id: int) -> list[str]:
+    def get_labels(self, pr_id: int) -> List[str]:
         """
         Returns the labels of a pull request
         """

--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -192,7 +192,7 @@ class GithubAPI:
         """
         return self._github.rate_limiting
 
-    def add_pr_abel(self, pr_id: int, label: str) -> bool:
+    def add_pr_label(self, pr_id: int, label: str) -> bool:
         """
         Tries to add a label to the pull request
         Returns whether the label has been added

--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -192,18 +192,12 @@ class GithubAPI:
         """
         return self._github.rate_limiting
 
-    def add_pr_label(self, pr_id: int, label: str) -> bool:
+    def add_pr_label(self, pr_id: int, label: str) -> None:
         """
         Tries to add a label to the pull request
-        Returns whether the label has been added
         """
-        try:
-            pr = self._repository.get_pull(pr_id)
-            pr.add_to_labels(label)
-        except:
-            return False
-
-        return True
+        pr = self._repository.get_pull(pr_id)
+        pr.add_to_labels(label)
 
     def get_pr_labels(self, pr_id: int) -> List[str]:
         """

--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -191,6 +191,19 @@ class GithubAPI:
         """
         return self._github.rate_limiting
 
+    def add_label(self, pr_id: int, label: str) -> bool:
+        """
+        Tries to add a label to the pull request
+        Returns whether the label has been added
+        """
+        try:
+            pr = self._repository.get_pull(pr_id)
+            pr.add_to_labels(label)
+        except:
+            return False
+
+        return True
+
     def _chose_auth(self, public_repo):
         """
         Attempt to find a working authentication, in order:

--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -192,7 +192,7 @@ class GithubAPI:
         """
         return self._github.rate_limiting
 
-    def add_label(self, pr_id: int, label: str) -> bool:
+    def add_pr_abel(self, pr_id: int, label: str) -> bool:
         """
         Tries to add a label to the pull request
         Returns whether the label has been added
@@ -205,13 +205,21 @@ class GithubAPI:
 
         return True
 
-    def get_labels(self, pr_id: int) -> List[str]:
+    def get_pr_labels(self, pr_id: int) -> List[str]:
         """
         Returns the labels of a pull request
         """
         pr = self._repository.get_pull(pr_id)
 
         return [label.name for label in pr.get_labels()]
+
+    def get_pr_files(self, pr_id: int) -> List[str]:
+        """
+        Returns the files involved in the PR
+        """
+        pr = self._repository.get_pull(pr_id)
+
+        return [f.filename for f in pr.get_files()]
 
     def _chose_auth(self, public_repo):
         """

--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -204,6 +204,14 @@ class GithubAPI:
 
         return True
 
+    def get_labels(self, pr_id: int) -> list[str]:
+        """
+        Returns the labels of a pull request
+        """
+        pr = self._repository.get_pull(pr_id)
+
+        return [label.name for label in pr.get_labels()]
+
     def _chose_auth(self, public_repo):
         """
         Attempt to find a working authentication, in order:

--- a/tasks/unit-tests/github_tasks_tests.py
+++ b/tasks/unit-tests/github_tasks_tests.py
@@ -12,15 +12,15 @@ class TestAssignTeamLabel(unittest.TestCase):
 
         teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
 
-        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+        self.assertEqual(sorted(teams), sorted(expected_teams))
 
     def test_no_file(self):
-        changed_files = []
+        changed_files = ['idonotexist']
         expected_teams = []
 
         teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
 
-        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+        self.assertEqual(sorted(teams), sorted(expected_teams))
 
     def test_single_file_single_team(self):
         changed_files = ['.gitignore']
@@ -28,7 +28,7 @@ class TestAssignTeamLabel(unittest.TestCase):
 
         teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
 
-        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+        self.assertEqual(sorted(teams), sorted(expected_teams))
 
     def test_single_file_multiple_teams(self):
         changed_files = ['README.md']
@@ -36,7 +36,7 @@ class TestAssignTeamLabel(unittest.TestCase):
 
         teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
 
-        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+        self.assertEqual(sorted(teams), sorted(expected_teams))
 
     def test_multiple_files_single_team(self):
         changed_files = ['.gitignore', '.gitlab/a.py']
@@ -44,7 +44,7 @@ class TestAssignTeamLabel(unittest.TestCase):
 
         teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
 
-        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+        self.assertEqual(sorted(teams), sorted(expected_teams))
 
     def test_multiple_files_single_team_best(self):
         # agent-platform has more files than security so only one team will be assigned
@@ -53,7 +53,7 @@ class TestAssignTeamLabel(unittest.TestCase):
 
         teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
 
-        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+        self.assertEqual(sorted(teams), sorted(expected_teams))
 
     def test_multiple_files_multiple_teams(self):
         changed_files = ['.gitignore', '.gitlab/security.yml']
@@ -61,4 +61,4 @@ class TestAssignTeamLabel(unittest.TestCase):
 
         teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
 
-        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+        self.assertEqual(sorted(teams), sorted(expected_teams))

--- a/tasks/unit-tests/github_tasks_tests.py
+++ b/tasks/unit-tests/github_tasks_tests.py
@@ -1,0 +1,47 @@
+import unittest
+
+from tasks.github_tasks import _get_teams
+
+
+class TestAssignTeamLabel(unittest.TestCase):
+    CODEOWNERS_FILE = './tasks/unit-tests/testdata/codeowners.txt'
+
+    def test_no_match(self):
+        changed_files = ['idonotexist']
+        expected_teams = []
+
+        teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
+
+        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+
+    def test_single_file_single_team(self):
+        changed_files = ['.gitignore']
+        expected_teams = ['@DataDog/agent-platform']
+
+        teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
+
+        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+
+    def test_single_file_multiple_teams(self):
+        changed_files = ['README.md']
+        expected_teams = ['@DataDog/agent-platform', '@DataDog/documentation']
+
+        teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
+
+        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+
+    def test_multiple_files_single_team(self):
+        changed_files = ['.gitignore', '.gitlab/a.py']
+        expected_teams = ['@DataDog/agent-platform']
+
+        teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
+
+        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+
+    def test_multiple_files_multiple_teams(self):
+        changed_files = ['.gitignore', '.gitlab/security.yml']
+        expected_teams = ['@DataDog/agent-platform', '@DataDog/agent-security']
+
+        teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
+
+        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))

--- a/tasks/unit-tests/github_tasks_tests.py
+++ b/tasks/unit-tests/github_tasks_tests.py
@@ -38,6 +38,15 @@ class TestAssignTeamLabel(unittest.TestCase):
 
         self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
 
+    def test_multiple_files_single_team_best(self):
+        # agent-platform has more files than security so only one team will be assigned
+        changed_files = ['.gitignore', '.gitlab-ci.yml', '.gitlab/security.yml']
+        expected_teams = ['@DataDog/agent-platform']
+
+        teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
+
+        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+
     def test_multiple_files_multiple_teams(self):
         changed_files = ['.gitignore', '.gitlab/security.yml']
         expected_teams = ['@DataDog/agent-platform', '@DataDog/agent-security']

--- a/tasks/unit-tests/github_tasks_tests.py
+++ b/tasks/unit-tests/github_tasks_tests.py
@@ -14,6 +14,14 @@ class TestAssignTeamLabel(unittest.TestCase):
 
         self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
 
+    def test_no_file(self):
+        changed_files = []
+        expected_teams = []
+
+        teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)
+
+        self.assertEqual(list(sorted(teams)), list(sorted(expected_teams)))
+
     def test_single_file_single_team(self):
         changed_files = ['.gitignore']
         expected_teams = ['@DataDog/agent-platform']

--- a/tasks/unit-tests/github_tasks_tests.py
+++ b/tasks/unit-tests/github_tasks_tests.py
@@ -15,7 +15,7 @@ class TestAssignTeamLabel(unittest.TestCase):
         self.assertEqual(sorted(teams), sorted(expected_teams))
 
     def test_no_file(self):
-        changed_files = ['idonotexist']
+        changed_files = []
         expected_teams = []
 
         teams = _get_teams(changed_files, TestAssignTeamLabel.CODEOWNERS_FILE)

--- a/tasks/unit-tests/testdata/codeowners.txt
+++ b/tasks/unit-tests/testdata/codeowners.txt
@@ -1,0 +1,4 @@
+/.*                                     @DataDog/agent-platform
+/*.md                                   @DataDog/agent-platform @DataDog/documentation
+/.gitlab/                               @DataDog/agent-platform
+/.gitlab/security.yml                   @DataDog/agent-security


### PR DESCRIPTION
### What does this PR do?

Adds a Github workflow to set automatically the team label if it can be deduced by changed files (using CODEOWNERS).

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

- Tested using a fork of this repo