### PR TITLE
[EBPF-384] removed deprecated ebpftelemetry.Manager 

### DIFF
--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -8,45 +8,8 @@
 package telemetry
 
 import (
-	"io"
-
 	manager "github.com/DataDog/ebpf-manager"
 )
-
-// Manager wraps ebpf-manager.Manager to transparently handle eBPF telemetry
-// Deprecated: The telemetry manager wrapper should no longer be used. Instead, use ebpf/manager.Manager instead with the ErrorsTelemetryModifier
-type Manager struct {
-	*manager.Manager
-	bpfTelemetry *EBPFTelemetry
-}
-
-// NewManager creates a Manager
-// Deprecated: The telemetry manager wrapper should no longer be used. Instead, use ebpf/manager.Manager instead with the ErrorsTelemetryModifier
-func NewManager(mgr *manager.Manager, bt *EBPFTelemetry) *Manager {
-	return &Manager{
-		Manager:      mgr,
-		bpfTelemetry: bt,
-	}
-}
-
-// InitWithOptions is a wrapper around ebpf-manager.Manager.InitWithOptions
-// Deprecated: The telemetry manager wrapper should no longer be used. Instead, use ebpf/manager.Manager instead with the ErrorsTelemetryModifier
-func (m *Manager) InitWithOptions(bytecode io.ReaderAt, opts manager.Options) error {
-	if err := setupForTelemetry(m.Manager, &opts, m.bpfTelemetry); err != nil {
-		return err
-	}
-
-	if err := m.Manager.InitWithOptions(bytecode, opts); err != nil {
-		return err
-	}
-
-	if m.bpfTelemetry != nil {
-		if err := m.bpfTelemetry.populateMapsWithKeys(m.Manager); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 // ErrorsTelemetryModifier is a modifier that sets up the manager to handle eBPF telemetry.
 type ErrorsTelemetryModifier struct{}


### PR DESCRIPTION

### What does this PR do?

all ebpf programs migrated to the new manager with ErrorsTelemetryModifier

### Motivation

removed deprecated code

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
