### PR TITLE
(fleet) set the install_path in the updater

### DIFF
--- a/omnibus/config/software/updater.rb
+++ b/omnibus/config/software/updater.rb
@@ -32,7 +32,7 @@ build do
   env = with_embedded_path(env)
 
   if linux_target?
-    command "invoke updater.build --rebuild", env: env
+    command "invoke updater.build --rebuild --install-path=#{install_dir}", env: env
     mkdir "#{install_dir}/bin"
     mkdir "#{install_dir}/run/"
 

--- a/tasks/updater.py
+++ b/tasks/updater.py
@@ -23,6 +23,7 @@ def build(
     ctx,
     rebuild=False,
     race=False,
+    install_path=None,
     build_include=None,
     build_exclude=None,
     arch="x64",
@@ -32,7 +33,7 @@ def build(
     Build the updater.
     """
 
-    ldflags, gcflags, env = get_build_flags(ctx, major_version=MAJOR_VERSION)
+    ldflags, gcflags, env = get_build_flags(ctx, major_version=MAJOR_VERSION, install_path=install_path)
 
     build_include = (
         get_default_build_tags(


### PR DESCRIPTION
The updater is missing an override of its install path. This is causing
issues with the RC initialization as it uses the install path to resolve
where to store the local cache.

This PR injects in the install_path in `updater.build`.