### PR TITLE
Update language detection test for local testing

### DIFF
--- a/test/new-e2e/tests/language-detection/language_detection_test.go
+++ b/test/new-e2e/tests/language-detection/language_detection_test.go
@@ -25,8 +25,6 @@ import (
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 )
 
-const versionStr = "7.48.0~rc.1-1"
-
 //go:embed etc/process_config.yaml
 var configStr string
 
@@ -39,12 +37,16 @@ func TestLanguageDetectionSuite(t *testing.T) {
 		agentparams.WithAgentConfig(configStr),
 	}
 
-	isCI, _ := strconv.ParseBool(os.Getenv("CI"))
-	if !isCI {
-		agentParams = append(agentParams, agentparams.WithVersion(versionStr))
+	options := []e2e.SuiteOption{
+		e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentParams...))),
 	}
 
-	e2e.Run(t, &languageDetectionSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentParams...))))
+	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
+	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
+		options = append(options, e2e.WithDevMode())
+	}
+
+	e2e.Run(t, &languageDetectionSuite{}, options...)
 }
 
 func (s *languageDetectionSuite) checkDetectedLanguage(command string, language string) {


### PR DESCRIPTION
### What does this PR do?
- Removes the hard coded agent version used for local testing, as we can now test using `E2E_PIPELINE_ID` to specify an CI version to test against
- Add the `E2E_DEVMODE` env var option so the test environment is not destroyed for debugging purposes.

### Motivation
Test cleanup

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

No functional changes
