### PR TITLE
[CWS] `string` -> `String` and reduce allocation linked to potential trace logs

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -169,7 +169,7 @@ func parseCreateNewFileArgs(e *etw.DDEventRecord) (*createNewFileArgs, error) {
 }
 
 // nolint: unused
-func (ca *createHandleArgs) string() string {
+func (ca *createHandleArgs) String() string {
 	var output strings.Builder
 
 	output.WriteString("  Create PID: " + strconv.Itoa(int(ca.ProcessID)) + "\n")
@@ -180,8 +180,8 @@ func (ca *createHandleArgs) string() string {
 }
 
 // nolint: unused
-func (ca *createNewFileArgs) string() string {
-	return (*createHandleArgs)(ca).string()
+func (ca *createNewFileArgs) String() string {
+	return (*createHandleArgs)(ca).String()
 }
 
 /*
@@ -245,7 +245,7 @@ func parseInformationArgs(e *etw.DDEventRecord) (*setInformationArgs, error) {
 }
 
 // nolint: unused
-func (sia *setInformationArgs) string() string {
+func (sia *setInformationArgs) String() string {
 	var output strings.Builder
 
 	output.WriteString("  SIA TID: " + strconv.Itoa(int(sia.threadID)) + "\n")
@@ -331,7 +331,7 @@ func parseFlushArgs(e *etw.DDEventRecord) (*flushArgs, error) {
 }
 
 // nolint: unused
-func (ca *cleanupArgs) string() string {
+func (ca *cleanupArgs) String() string {
 	var output strings.Builder
 
 	output.WriteString("  CLEANUP: TID: " + strconv.Itoa(int(ca.threadID)) + "\n")
@@ -342,11 +342,11 @@ func (ca *cleanupArgs) string() string {
 }
 
 // nolint: unused
-func (ca *closeArgs) string() string {
-	return (*cleanupArgs)(ca).string()
+func (ca *closeArgs) String() string {
+	return (*cleanupArgs)(ca).String()
 }
 
 // nolint: unused
-func (fa *flushArgs) string() string {
-	return (*cleanupArgs)(fa).string()
+func (fa *flushArgs) String() string {
+	return (*cleanupArgs)(fa).String()
 }

--- a/pkg/security/probe/probe_kernel_reg_windows.go
+++ b/pkg/security/probe/probe_kernel_reg_windows.go
@@ -188,7 +188,7 @@ func (cka *createKeyArgs) computeFullPath() {
 	regPathResolver[cka.keyObject] = outstr
 	cka.computedFullPath = outstr
 }
-func (cka *createKeyArgs) string() string {
+func (cka *createKeyArgs) String() string {
 
 	var output strings.Builder
 
@@ -202,8 +202,8 @@ func (cka *createKeyArgs) string() string {
 	return output.String()
 }
 
-func (cka *openKeyArgs) string() string {
-	return (*createKeyArgs)(cka).string()
+func (cka *openKeyArgs) String() string {
+	return (*createKeyArgs)(cka).String()
 }
 
 func parseDeleteRegistryKey(e *etw.DDEventRecord) (*deleteKeyArgs, error) {
@@ -254,7 +254,7 @@ func parseSetSecurityKeyArgs(e *etw.DDEventRecord) (*setSecurityKeyArgs, error) 
 	return (*setSecurityKeyArgs)(dka), nil
 }
 
-func (dka *deleteKeyArgs) string() string {
+func (dka *deleteKeyArgs) String() string {
 	var output strings.Builder
 
 	output.WriteString("  PID: " + strconv.Itoa(int(dka.ProcessID)) + "\n")
@@ -267,21 +267,21 @@ func (dka *deleteKeyArgs) string() string {
 
 }
 
-func (fka *flushKeyArgs) string() string {
-	return (*deleteKeyArgs)(fka).string()
+func (fka *flushKeyArgs) String() string {
+	return (*deleteKeyArgs)(fka).String()
 }
-func (cka *closeKeyArgs) string() string {
-	return (*deleteKeyArgs)(cka).string()
-}
-
-//nolint:unused
-func (qka *querySecurityKeyArgs) string() string {
-	return (*deleteKeyArgs)(qka).string()
+func (cka *closeKeyArgs) String() string {
+	return (*deleteKeyArgs)(cka).String()
 }
 
 //nolint:unused
-func (ska *setSecurityKeyArgs) string() string {
-	return (*deleteKeyArgs)(ska).string()
+func (qka *querySecurityKeyArgs) String() string {
+	return (*deleteKeyArgs)(qka).String()
+}
+
+//nolint:unused
+func (ska *setSecurityKeyArgs) String() string {
+	return (*deleteKeyArgs)(ska).String()
 }
 
 func parseSetValueKey(e *etw.DDEventRecord) (*setValueKeyArgs, error) {
@@ -340,7 +340,7 @@ func parseSetValueKey(e *etw.DDEventRecord) (*setValueKeyArgs, error) {
 	return sv, nil
 }
 
-func (sv *setValueKeyArgs) string() string {
+func (sv *setValueKeyArgs) String() string {
 	var output strings.Builder
 
 	output.WriteString("  PID: " + strconv.Itoa(int(sv.ProcessID)) + "\n")

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -213,7 +213,7 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 			switch e.EventHeader.EventDescriptor.ID {
 			case idCreate:
 				if ca, err := parseCreateHandleArgs(e); err == nil {
-					log.Tracef("Received idCreate event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
+					log.Tracef("Received idCreate event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
 					ecb(ca, e.EventHeader.ProcessID)
 				}
 
@@ -228,7 +228,7 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 
 			case idClose:
 				if ca, err := parseCloseArgs(e); err == nil {
-					//fmt.Printf("Received Close event %d %v\n", e.EventHeader.EventDescriptor.ID, ca.string())
+					//fmt.Printf("Received Close event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
 					ecb(ca, e.EventHeader.ProcessID)
 					if e.EventHeader.EventDescriptor.ID == idClose {
 						delete(filePathResolver, ca.fileObject)
@@ -250,7 +250,7 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 				fallthrough
 			case idRename29:
 				if sia, err := parseInformationArgs(e); err == nil {
-					log.Tracef("got id %v args %s", e.EventHeader.EventDescriptor.ID, sia.string())
+					log.Tracef("got id %v args %s", e.EventHeader.EventDescriptor.ID, sia)
 				}
 			}
 
@@ -258,28 +258,28 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 			switch e.EventHeader.EventDescriptor.ID {
 			case idRegCreateKey:
 				if cka, err := parseCreateRegistryKey(e); err == nil {
-					log.Tracef("Got idRegCreateKey %s", cka.string())
+					log.Tracef("Got idRegCreateKey %s", cka)
 					ecb(cka, e.EventHeader.ProcessID)
 				}
 			case idRegOpenKey:
 				if cka, err := parseOpenRegistryKey(e); err == nil {
-					log.Debugf("Got idRegOpenKey %s", cka.string())
+					log.Debugf("Got idRegOpenKey %s", cka)
 					ecb(cka, e.EventHeader.ProcessID)
 				}
 
 			case idRegDeleteKey:
 				if dka, err := parseDeleteRegistryKey(e); err == nil {
-					log.Tracef("Got idRegDeleteKey %v", dka.string())
+					log.Tracef("Got idRegDeleteKey %v", dka)
 					ecb(dka, e.EventHeader.ProcessID)
 
 				}
 			case idRegFlushKey:
 				if dka, err := parseFlushKey(e); err == nil {
-					log.Tracef("Got idRegFlushKey %v", dka.string())
+					log.Tracef("Got idRegFlushKey %v", dka)
 				}
 			case idRegCloseKey:
 				if dka, err := parseCloseKeyArgs(e); err == nil {
-					log.Debugf("Got idRegCloseKey %s", dka.string())
+					log.Debugf("Got idRegCloseKey %s", dka)
 					delete(regPathResolver, dka.keyObject)
 				}
 			case idQuerySecurityKey:
@@ -292,7 +292,7 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 				}
 			case idRegSetValueKey:
 				if svk, err := parseSetValueKey(e); err == nil {
-					log.Tracef("Got idRegSetValueKey %s", svk.string())
+					log.Tracef("Got idRegSetValueKey %s", svk)
 					ecb(svk, e.EventHeader.ProcessID)
 
 				}


### PR DESCRIPTION
### What does this PR do?

Since the args are passed to `log.Trace` even if the loglevel is not trace, we end up computing the `string()` value of most etw/file events.
This PR fixes this by respecting the `Stringer` interface, and passing the value directly. `String()` will be called by the trace function if actually needed.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
