### PR TITLE
[EBPF-377] Change ebpf errors metrics to prometheus.Counter

### DIFF
--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -37,7 +37,7 @@ type EBPFErrorsCollector struct {
 type metricKey struct {
 	hash uint64
 	id   int
-	err  string ``
+	err  string
 }
 
 // NewEBPFErrorsCollector initializes a new Collector object for ebpf helper and map operations errors

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -21,10 +21,13 @@ const (
 	maxErrnoStr = "other"
 )
 
+// A singleton instance of the ebpf telemetry struct. Used by the collector and the ebpf managers (via ErrorsTelemetryModifier).
+var errorsTelemetry ebpfErrorsTelemetry
+
 // EBPFErrorsCollector implements the prometheus Collector interface
 // for collecting statistics about errors of ebpf helpers and ebpf maps operations.
 type EBPFErrorsCollector struct {
-	T                *EBPFTelemetry
+	T                ebpfErrorsTelemetry
 	ebpfMapOpsErrors *prometheus.Desc
 	ebpfHelperErrors *prometheus.Desc
 	lastValues       map[metricKey]uint64
@@ -58,58 +61,56 @@ func (e *EBPFErrorsCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect returns the current state of all metrics of the collector
 func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
-	e.T.mtx.Lock()
-	defer e.T.mtx.Unlock()
+	e.T.Lock()
+	defer e.T.Unlock()
 
-	if e.T.helperErrMap != nil {
-		var hval HelperErrTelemetry
-		for probeName, k := range e.T.probeKeys {
-			err := e.T.helperErrMap.Lookup(&k, &hval)
-			if err != nil {
-				log.Debugf("failed to get telemetry for probe:key %s:%d\n", probeName, k)
-				continue
-			}
-			for index, helperName := range helperNames {
-				base := maxErrno * index
-				if count := getErrCount(hval.Count[base : base+maxErrno]); len(count) > 0 {
-					for errStr, errCount := range count {
-						key := metricKey{
-							hash: k,
-							id:   index,
-							err:  errStr,
-						}
-						delta := float64(errCount - e.lastValues[key])
-						if delta > 0 {
-							ch <- prometheus.MustNewConstMetric(e.ebpfHelperErrors, prometheus.CounterValue, delta, helperName, probeName, errStr)
-						}
-						e.lastValues[key] = errCount
+	if !e.T.isInitialized() {
+		return // no telemetry to collect
+	}
+
+	for probeName, k := range e.T.getProbeKeys() {
+		val, err := e.T.getHelpersTelemetryEntry(k)
+		if err != nil {
+			log.Debugf("failed to get telemetry for probe:key %s:%d\n", probeName, k)
+			continue
+		}
+		for index, helperName := range helperNames {
+			base := maxErrno * index
+			if count := getErrCount(val.Count[base : base+maxErrno]); len(count) > 0 {
+				for errStr, errCount := range count {
+					key := metricKey{
+						hash: k,
+						id:   index,
+						err:  errStr,
 					}
+					delta := float64(errCount - e.lastValues[key])
+					if delta > 0 {
+						ch <- prometheus.MustNewConstMetric(e.ebpfHelperErrors, prometheus.CounterValue, delta, helperName, probeName, errStr)
+					}
+					e.lastValues[key] = errCount
 				}
 			}
 		}
 	}
 
-	if e.T.mapErrMap != nil {
-		var val MapErrTelemetry
-		for m, k := range e.T.mapKeys {
-			err := e.T.mapErrMap.Lookup(&k, &val)
-			if err != nil {
-				log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
-				continue
-			}
-			if count := getErrCount(val.Count[:]); len(count) > 0 {
-				for errStr, errCount := range count {
-					key := metricKey{
-						hash: k,
-						id:   mapErr,
-						err:  errStr,
-					}
-					delta := float64(errCount - e.lastValues[key])
-					if delta > 0 {
-						ch <- prometheus.MustNewConstMetric(e.ebpfMapOpsErrors, prometheus.CounterValue, delta, m, errStr)
-					}
-					e.lastValues[key] = errCount
+	for m, k := range e.T.getMapKeys() {
+		val, err := e.T.getMapsTelemetryEntry(k)
+		if err != nil {
+			log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
+			continue
+		}
+		if count := getErrCount(val.Count[:]); len(count) > 0 {
+			for errStr, errCount := range count {
+				key := metricKey{
+					hash: k,
+					id:   mapErr,
+					err:  errStr,
 				}
+				delta := float64(errCount - e.lastValues[key])
+				if delta > 0 {
+					ch <- prometheus.MustNewConstMetric(e.ebpfMapOpsErrors, prometheus.CounterValue, delta, m, errStr)
+				}
+				e.lastValues[key] = errCount
 			}
 		}
 	}

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -28,9 +28,7 @@ type EBPFErrorsCollector struct {
 	T            ebpfErrorsTelemetry
 	mapOpsErrors *prometheus.CounterVec
 	helperErrors *prometheus.CounterVec
-	//ebpfMapOpsErrors *prometheus.Desc
-	//ebpfHelperErrors *prometheus.Desc
-	lastValues map[metricKey]uint64
+	lastValues   map[metricKey]uint64
 }
 
 type metricKey struct {

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -80,7 +80,7 @@ func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
 		return // no telemetry to collect
 	}
 
-	e.T.forEachMapEntry(func(index telemetryIndex, val MapErrTelemetry) bool {
+	e.T.forEachMapEntry(func(index telemetryIndex, val mapErrTelemetry) bool {
 		if count := getErrCount(val.Count[:]); len(count) > 0 {
 			for errStr, errCount := range count {
 				key := metricKey{
@@ -98,7 +98,7 @@ func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
 		return true
 	})
 
-	e.T.forEachHelperEntry(func(index telemetryIndex, val HelperErrTelemetry) bool {
+	e.T.forEachHelperEntry(func(index telemetryIndex, val helperErrTelemetry) bool {
 		for i, helperName := range helperNames {
 			base := maxErrno * i
 			if count := getErrCount(val.Count[base : base+maxErrno]); len(count) > 0 {

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/unix"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -21,10 +19,13 @@ const (
 	maxErrnoStr = "other"
 )
 
+// A singleton instance of the ebpf telemetry struct. Used by the collector and the ebpf managers (via ErrorsTelemetryModifier).
+var errorsTelemetry ebpfErrorsTelemetry
+
 // EBPFErrorsCollector implements the prometheus Collector interface
 // for collecting statistics about errors of ebpf helpers and ebpf maps operations.
 type EBPFErrorsCollector struct {
-	T                *EBPFTelemetry
+	T                ebpfErrorsTelemetry
 	ebpfMapOpsErrors *prometheus.Desc
 	ebpfHelperErrors *prometheus.Desc
 	lastValues       map[metricKey]uint64
@@ -58,61 +59,51 @@ func (e *EBPFErrorsCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect returns the current state of all metrics of the collector
 func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
-	e.T.mtx.Lock()
-	defer e.T.mtx.Unlock()
+	e.T.Lock()
+	defer e.T.Unlock()
 
-	if e.T.helperErrMap != nil {
-		var hval HelperErrTelemetry
-		for probeName, k := range e.T.probeKeys {
-			err := e.T.helperErrMap.Lookup(&k, &hval)
-			if err != nil {
-				log.Debugf("failed to get telemetry for probe:key %s:%d\n", probeName, k)
-				continue
-			}
-			for index, helperName := range helperNames {
-				base := maxErrno * index
-				if count := getErrCount(hval.Count[base : base+maxErrno]); len(count) > 0 {
-					for errStr, errCount := range count {
-						key := metricKey{
-							hash: k,
-							id:   index,
-							err:  errStr,
-						}
-						delta := float64(errCount - e.lastValues[key])
-						if delta > 0 {
-							ch <- prometheus.MustNewConstMetric(e.ebpfHelperErrors, prometheus.CounterValue, delta, helperName, probeName, errStr)
-						}
-						e.lastValues[key] = errCount
-					}
-				}
-			}
-		}
+	if !e.T.isInitialized() {
+		return // no telemetry to collect
 	}
 
-	if e.T.mapErrMap != nil {
-		var val MapErrTelemetry
-		for m, k := range e.T.mapKeys {
-			err := e.T.mapErrMap.Lookup(&k, &val)
-			if err != nil {
-				log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
-				continue
+	e.T.forEachMapEntry(func(index telemetryIndex, val MapErrTelemetry) bool {
+		if count := getErrCount(val.Count[:]); len(count) > 0 {
+			for errStr, errCount := range count {
+				key := metricKey{
+					hash: index.key,
+					id:   mapErr,
+					err:  errStr,
+				}
+				delta := float64(errCount - e.lastValues[key])
+				if delta > 0 {
+					ch <- prometheus.MustNewConstMetric(e.ebpfMapOpsErrors, prometheus.CounterValue, delta, index.value, errStr)
+				}
+				e.lastValues[key] = errCount
 			}
-			if count := getErrCount(val.Count[:]); len(count) > 0 {
+		}
+		return true
+	})
+
+	e.T.forEachHelperEntry(func(index telemetryIndex, val HelperErrTelemetry) bool {
+		for i, helperName := range helperNames {
+			base := maxErrno * i
+			if count := getErrCount(val.Count[base : base+maxErrno]); len(count) > 0 {
 				for errStr, errCount := range count {
 					key := metricKey{
-						hash: k,
-						id:   mapErr,
+						hash: index.key,
+						id:   i,
 						err:  errStr,
 					}
 					delta := float64(errCount - e.lastValues[key])
 					if delta > 0 {
-						ch <- prometheus.MustNewConstMetric(e.ebpfMapOpsErrors, prometheus.CounterValue, delta, m, errStr)
+						ch <- prometheus.MustNewConstMetric(e.ebpfHelperErrors, prometheus.CounterValue, delta, helperName, index.value, errStr)
 					}
 					e.lastValues[key] = errCount
 				}
 			}
 		}
-	}
+		return true
+	})
 }
 
 func getErrCount(v []uint64) map[string]uint64 {

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -18,11 +18,11 @@ import (
 )
 
 const (
-	maxErrno    = 64
-	maxErrnoStr = "other"
-
-	ebpfMapTelemetryNS    = "ebpf_maps"
-	ebpfHelperTelemetryNS = "ebpf_helpers"
+	maxErrno              = 64
+	maxErrnoStr           = "other"
+	ebpfPrefix            = "ebpf"
+	ebpfMapTelemetryNS    = "maps"
+	ebpfHelperTelemetryNS = "helpers"
 )
 
 // EBPFErrorsCollector implements the prometheus Collector interface
@@ -48,8 +48,8 @@ func NewEBPFErrorsCollector() prometheus.Collector {
 
 	return &EBPFErrorsCollector{
 		T:                newEBPFTelemetry(),
-		ebpfMapOpsErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfMapTelemetryNS), "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil),
-		ebpfHelperErrors: prometheus.NewDesc(fmt.Sprintf("%s__errors", ebpfHelperTelemetryNS), "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil),
+		ebpfMapOpsErrors: prometheus.NewDesc(fmt.Sprintf("%s__%s__errors", ebpfPrefix, ebpfMapTelemetryNS), "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil),
+		ebpfHelperErrors: prometheus.NewDesc(fmt.Sprintf("%s__%s__errors", ebpfPrefix, ebpfHelperTelemetryNS), "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil),
 		lastValues:       make(map[metricKey]uint64),
 	}
 }

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -8,7 +8,6 @@
 package telemetry
 
 import (
-	"fmt"
 	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,11 +17,8 @@ import (
 )
 
 const (
-	maxErrno              = 64
-	maxErrnoStr           = "other"
-	ebpfPrefix            = "ebpf"
-	ebpfMapTelemetryNS    = "maps"
-	ebpfHelperTelemetryNS = "helpers"
+	maxErrno    = 64
+	maxErrnoStr = "other"
 )
 
 // EBPFErrorsCollector implements the prometheus Collector interface
@@ -48,8 +44,8 @@ func NewEBPFErrorsCollector() prometheus.Collector {
 
 	return &EBPFErrorsCollector{
 		T:                newEBPFTelemetry(),
-		ebpfMapOpsErrors: prometheus.NewDesc(fmt.Sprintf("%s__%s__errors", ebpfPrefix, ebpfMapTelemetryNS), "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil),
-		ebpfHelperErrors: prometheus.NewDesc(fmt.Sprintf("%s__%s__errors", ebpfPrefix, ebpfHelperTelemetryNS), "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil),
+		ebpfMapOpsErrors: prometheus.NewDesc("ebpf__maps__errors", "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil),
+		ebpfHelperErrors: prometheus.NewDesc("ebpf__helpers__errors", "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil),
 		lastValues:       make(map[metricKey]uint64),
 	}
 }

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -76,7 +76,7 @@ func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
 				}
 				delta := float64(errCount - e.lastValues[key])
 				if delta > 0 {
-					ch <- prometheus.MustNewConstMetric(e.ebpfMapOpsErrors, prometheus.CounterValue, delta, index.value, errStr)
+					ch <- prometheus.MustNewConstMetric(e.ebpfMapOpsErrors, prometheus.CounterValue, delta, index.name, errStr)
 				}
 				e.lastValues[key] = errCount
 			}
@@ -96,7 +96,7 @@ func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
 					}
 					delta := float64(errCount - e.lastValues[key])
 					if delta > 0 {
-						ch <- prometheus.MustNewConstMetric(e.ebpfHelperErrors, prometheus.CounterValue, delta, helperName, index.value, errStr)
+						ch <- prometheus.MustNewConstMetric(e.ebpfHelperErrors, prometheus.CounterValue, delta, helperName, index.name, errStr)
 					}
 					e.lastValues[key] = errCount
 				}

--- a/pkg/ebpf/telemetry/errors_collector_linux.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux.go
@@ -21,13 +21,10 @@ const (
 	maxErrnoStr = "other"
 )
 
-// A singleton instance of the ebpf telemetry struct. Used by the collector and the ebpf managers (via ErrorsTelemetryModifier).
-var errorsTelemetry ebpfErrorsTelemetry
-
 // EBPFErrorsCollector implements the prometheus Collector interface
 // for collecting statistics about errors of ebpf helpers and ebpf maps operations.
 type EBPFErrorsCollector struct {
-	T                ebpfErrorsTelemetry
+	T                *EBPFTelemetry
 	ebpfMapOpsErrors *prometheus.Desc
 	ebpfHelperErrors *prometheus.Desc
 	lastValues       map[metricKey]uint64
@@ -61,56 +58,58 @@ func (e *EBPFErrorsCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect returns the current state of all metrics of the collector
 func (e *EBPFErrorsCollector) Collect(ch chan<- prometheus.Metric) {
-	e.T.Lock()
-	defer e.T.Unlock()
+	e.T.mtx.Lock()
+	defer e.T.mtx.Unlock()
 
-	if !e.T.isInitialized() {
-		return // no telemetry to collect
-	}
-
-	for probeName, k := range e.T.getProbeKeys() {
-		val, err := e.T.getHelpersTelemetryEntry(k)
-		if err != nil {
-			log.Debugf("failed to get telemetry for probe:key %s:%d\n", probeName, k)
-			continue
-		}
-		for index, helperName := range helperNames {
-			base := maxErrno * index
-			if count := getErrCount(val.Count[base : base+maxErrno]); len(count) > 0 {
-				for errStr, errCount := range count {
-					key := metricKey{
-						hash: k,
-						id:   index,
-						err:  errStr,
+	if e.T.helperErrMap != nil {
+		var hval HelperErrTelemetry
+		for probeName, k := range e.T.probeKeys {
+			err := e.T.helperErrMap.Lookup(&k, &hval)
+			if err != nil {
+				log.Debugf("failed to get telemetry for probe:key %s:%d\n", probeName, k)
+				continue
+			}
+			for index, helperName := range helperNames {
+				base := maxErrno * index
+				if count := getErrCount(hval.Count[base : base+maxErrno]); len(count) > 0 {
+					for errStr, errCount := range count {
+						key := metricKey{
+							hash: k,
+							id:   index,
+							err:  errStr,
+						}
+						delta := float64(errCount - e.lastValues[key])
+						if delta > 0 {
+							ch <- prometheus.MustNewConstMetric(e.ebpfHelperErrors, prometheus.CounterValue, delta, helperName, probeName, errStr)
+						}
+						e.lastValues[key] = errCount
 					}
-					delta := float64(errCount - e.lastValues[key])
-					if delta > 0 {
-						ch <- prometheus.MustNewConstMetric(e.ebpfHelperErrors, prometheus.CounterValue, delta, helperName, probeName, errStr)
-					}
-					e.lastValues[key] = errCount
 				}
 			}
 		}
 	}
 
-	for m, k := range e.T.getMapKeys() {
-		val, err := e.T.getMapsTelemetryEntry(k)
-		if err != nil {
-			log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
-			continue
-		}
-		if count := getErrCount(val.Count[:]); len(count) > 0 {
-			for errStr, errCount := range count {
-				key := metricKey{
-					hash: k,
-					id:   mapErr,
-					err:  errStr,
+	if e.T.mapErrMap != nil {
+		var val MapErrTelemetry
+		for m, k := range e.T.mapKeys {
+			err := e.T.mapErrMap.Lookup(&k, &val)
+			if err != nil {
+				log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
+				continue
+			}
+			if count := getErrCount(val.Count[:]); len(count) > 0 {
+				for errStr, errCount := range count {
+					key := metricKey{
+						hash: k,
+						id:   mapErr,
+						err:  errStr,
+					}
+					delta := float64(errCount - e.lastValues[key])
+					if delta > 0 {
+						ch <- prometheus.MustNewConstMetric(e.ebpfMapOpsErrors, prometheus.CounterValue, delta, m, errStr)
+					}
+					e.lastValues[key] = errCount
 				}
-				delta := float64(errCount - e.lastValues[key])
-				if delta > 0 {
-					ch <- prometheus.MustNewConstMetric(e.ebpfMapOpsErrors, prometheus.CounterValue, delta, m, errStr)
-				}
-				e.lastValues[key] = errCount
 			}
 		}
 	}

--- a/pkg/ebpf/telemetry/errors_collector_linux_test.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux_test.go
@@ -1,0 +1,207 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf && test
+
+package telemetry
+
+import (
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	mockMapName    = "mock_map"
+	mockHelperName = "mock_helper"
+)
+
+type mockErrorsTelemetry struct {
+	ebpfErrorsTelemetry
+	mtx          sync.Mutex
+	mapErrMap    map[telemetryIndex]MapErrTelemetry
+	helperErrMap map[telemetryIndex]HelperErrTelemetry
+}
+
+func (m *mockErrorsTelemetry) Lock() {
+	m.mtx.Lock()
+}
+
+func (m *mockErrorsTelemetry) Unlock() {
+	m.mtx.Unlock()
+}
+
+func (m *mockErrorsTelemetry) isInitialized() bool {
+	return m.mapErrMap != nil && m.helperErrMap != nil
+}
+
+func (m *mockErrorsTelemetry) forEachMapEntry(yield func(telemetryIndex, MapErrTelemetry) bool) {
+	for i, telemetry := range m.mapErrMap {
+		if !yield(i, telemetry) {
+			return
+		}
+	}
+}
+
+func (m *mockErrorsTelemetry) forEachHelperEntry(yield func(telemetryIndex, HelperErrTelemetry) bool) {
+	for i, telemetry := range m.helperErrMap {
+		if !yield(i, telemetry) {
+			return
+		}
+	}
+}
+
+// creates an error collector and replaces the telemetry field with a mock
+func createTestCollector(telemetry ebpfErrorsTelemetry) prometheus.Collector {
+	collector := NewEBPFErrorsCollector().(*EBPFErrorsCollector)
+	collector.T = telemetry
+	return collector
+}
+
+func TestEBPFErrorsCollector_NotInitialized(t *testing.T) {
+	telemetry := &mockErrorsTelemetry{
+		mapErrMap:    nil,
+		helperErrMap: nil,
+	}
+	collector := createTestCollector(telemetry)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	//we shouldn't have any metrics collected, since the mock telemetry object is not initialized
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	assert.Equal(t, 0, len(metrics), "expected %d metrics, but got %d", 0, len(metrics))
+}
+
+func TestEBPFErrorsCollector_SingleCollect(t *testing.T) {
+
+	mapErrorsMockValue, helperErrorsMockValue := uint64(20), uint64(100)
+	//create mock telemetry objects (since we don't want to trigger full ebpf subsystem)
+	mapEntries := map[telemetryIndex]MapErrTelemetry{
+		{key: 1, name: mockMapName}: {Count: [64]uint64{mapErrorsMockValue}},
+	}
+	helperEntries := map[telemetryIndex]HelperErrTelemetry{
+		{key: 2, name: mockHelperName}: {Count: [320]uint64{helperErrorsMockValue}},
+	}
+
+	//check expected metrics and labels
+	expectedMetrics := []struct {
+		value  float64
+		labels []string
+	}{
+		{value: float64(mapErrorsMockValue), labels: []string{"errno 0", mockMapName}},
+		{value: float64(helperErrorsMockValue), labels: []string{"errno 0", "bpf_probe_read", mockHelperName}},
+	}
+
+	telemetry := &mockErrorsTelemetry{
+		mapErrMap:    mapEntries,
+		helperErrMap: helperEntries,
+	}
+	//use mock telemetry instead of real ebpfTelemetry to avoid triggering eBPF APIs
+	collector := createTestCollector(telemetry)
+	ch := make(chan prometheus.Metric)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	assert.Equal(t, len(expectedMetrics), len(metrics), "received unexpected number of metrics")
+
+	//parse received metrics to compare the values and labels
+	for i, promMetric := range metrics {
+		dtoMetric := dto.Metric{}
+		assert.NoError(t, promMetric.Write(&dtoMetric), "Failed to parse metric %v", promMetric.Desc())
+
+		assert.NotNilf(t, dtoMetric.GetCounter(), "expected metric %v to be of a counter type", promMetric.Desc())
+		assert.Equal(t, expectedMetrics[i].value, dtoMetric.GetCounter().GetValue(),
+			"expected metric value %v, but got %v", expectedMetrics[i].value, dtoMetric.GetCounter().GetValue())
+		for j, label := range dtoMetric.GetLabel() {
+			assert.Equal(t, expectedMetrics[i].labels[j], label.GetValue(),
+				"expected label %v, but got %v", expectedMetrics[i].labels[j], label.GetValue())
+		}
+	}
+}
+
+// TestEBPFErrorsCollector_DoubleCollect tests the case when the collector is called twice to validate the delta calculation of the Counter metric
+func TestEBPFErrorsCollector_DoubleCollect(t *testing.T) {
+
+	mapErrorsMockValue, helperErrorsMockValue := uint64(20), uint64(100)
+	deltaMapErrors, deltaHelperErrors := float64(80), float64(900)
+	mapEntries := map[telemetryIndex]MapErrTelemetry{
+		{key: 1, name: mockMapName}: {Count: [64]uint64{mapErrorsMockValue}},
+	}
+	helperEntries := map[telemetryIndex]HelperErrTelemetry{
+		{key: 2, name: mockHelperName}: {Count: [320]uint64{helperErrorsMockValue}},
+	}
+
+	//in this test we expect the values to match the delta between second and first collects
+	expectedMetrics := []struct {
+		value  float64
+		labels []string
+	}{
+		{value: deltaMapErrors, labels: []string{"errno 0", mockMapName}},
+		{value: deltaHelperErrors, labels: []string{"errno 0", "bpf_probe_read", mockHelperName}},
+	}
+
+	telemetry := &mockErrorsTelemetry{
+		mapErrMap:    mapEntries,
+		helperErrMap: helperEntries,
+	}
+	collector := createTestCollector(telemetry)
+	ch := make(chan prometheus.Metric)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	//make sure the channel is emptied and closed before we trigger the second collect
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	assert.Equal(t, len(expectedMetrics), len(metrics), "received unexpected number of metrics")
+
+	//increase the counters of the mock telemetry object before second collect
+	collector.(*EBPFErrorsCollector).T = &mockErrorsTelemetry{
+		mapErrMap: map[telemetryIndex]MapErrTelemetry{
+			{key: 1, name: mockMapName}: {Count: [64]uint64{mapErrorsMockValue + uint64(deltaMapErrors)}}},
+		helperErrMap: map[telemetryIndex]HelperErrTelemetry{
+			{key: 2, name: mockHelperName}: {Count: [320]uint64{helperErrorsMockValue + uint64(deltaHelperErrors)}}},
+	}
+
+	ch = make(chan prometheus.Metric)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	metrics = nil
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	assert.Equal(t, len(expectedMetrics), len(metrics), "received unexpected number of metrics")
+
+	for i, promMetric := range metrics {
+		dtoMetric := dto.Metric{}
+		assert.NoError(t, promMetric.Write(&dtoMetric), "Failed to parse metric %v", promMetric.Desc())
+
+		assert.NotNilf(t, dtoMetric.GetCounter(), "expected metric %v to be of a counter type", promMetric.Desc())
+		assert.Equal(t, expectedMetrics[i].value, dtoMetric.GetCounter().GetValue(),
+			"expected metric value %v, but got %v", expectedMetrics[i].value, dtoMetric.GetCounter().GetValue())
+	}
+}

--- a/pkg/ebpf/telemetry/errors_collector_linux_test.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux_test.go
@@ -155,13 +155,13 @@ func TestEBPFErrorsCollector_DoubleCollect(t *testing.T) {
 	if ok, _ := ebpfTelemetrySupported(); !ok {
 		t.SkipNow()
 	}
-	mapErrorsMockValue, helperErrorsMockValue := uint64(20), uint64(100)
-	deltaMapErrors, deltaHelperErrors := float64(80), float64(900)
+	mapErrorsMockValue1, helperErrorsMockValue1 := uint64(20), uint64(100)
+	mapErrorsMockValue2, helperErrorsMockValue2 := uint64(100), uint64(1000)
 	mapEntries := map[telemetryIndex]MapErrTelemetry{
-		{key: 1, name: mockMapName}: {Count: [64]uint64{mapErrorsMockValue}},
+		{key: 1, name: mockMapName}: {Count: [64]uint64{mapErrorsMockValue1}},
 	}
 	helperEntries := map[telemetryIndex]HelperErrTelemetry{
-		{key: 2, name: mockHelperName}: {Count: [320]uint64{helperErrorsMockValue}},
+		{key: 2, name: mockHelperName}: {Count: [320]uint64{helperErrorsMockValue1}},
 	}
 
 	//in this test we expect the values to match the delta between second and first collects
@@ -169,8 +169,8 @@ func TestEBPFErrorsCollector_DoubleCollect(t *testing.T) {
 		value  float64
 		labels []string
 	}{
-		{value: deltaMapErrors, labels: []string{"errno 0", mockMapName}},
-		{value: deltaHelperErrors, labels: []string{"errno 0", "bpf_probe_read", mockHelperName}},
+		{value: float64(mapErrorsMockValue2), labels: []string{"errno 0", mockMapName}},
+		{value: float64(helperErrorsMockValue2), labels: []string{"errno 0", "bpf_probe_read", mockHelperName}},
 	}
 
 	telemetry := &mockErrorsTelemetry{
@@ -196,9 +196,9 @@ func TestEBPFErrorsCollector_DoubleCollect(t *testing.T) {
 	//increase the counters of the mock telemetry object before second collect
 	collector.(*EBPFErrorsCollector).T = &mockErrorsTelemetry{
 		mapErrMap: map[telemetryIndex]MapErrTelemetry{
-			{key: 1, name: mockMapName}: {Count: [64]uint64{mapErrorsMockValue + uint64(deltaMapErrors)}}},
+			{key: 1, name: mockMapName}: {Count: [64]uint64{mapErrorsMockValue2}}},
 		helperErrMap: map[telemetryIndex]HelperErrTelemetry{
-			{key: 2, name: mockHelperName}: {Count: [320]uint64{helperErrorsMockValue + uint64(deltaHelperErrors)}}},
+			{key: 2, name: mockHelperName}: {Count: [320]uint64{helperErrorsMockValue2}}},
 	}
 
 	ch = make(chan prometheus.Metric)

--- a/pkg/ebpf/telemetry/errors_collector_linux_test.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux_test.go
@@ -24,8 +24,8 @@ const (
 type mockErrorsTelemetry struct {
 	ebpfErrorsTelemetry
 	mtx          sync.Mutex
-	mapErrMap    map[telemetryIndex]MapErrTelemetry
-	helperErrMap map[telemetryIndex]HelperErrTelemetry
+	mapErrMap    map[telemetryIndex]mapErrTelemetry
+	helperErrMap map[telemetryIndex]helperErrTelemetry
 }
 
 func (m *mockErrorsTelemetry) Lock() {
@@ -40,7 +40,7 @@ func (m *mockErrorsTelemetry) isInitialized() bool {
 	return m.mapErrMap != nil && m.helperErrMap != nil
 }
 
-func (m *mockErrorsTelemetry) forEachMapEntry(yield func(telemetryIndex, MapErrTelemetry) bool) {
+func (m *mockErrorsTelemetry) forEachMapEntry(yield func(telemetryIndex, mapErrTelemetry) bool) {
 	for i, telemetry := range m.mapErrMap {
 		if !yield(i, telemetry) {
 			return
@@ -48,7 +48,7 @@ func (m *mockErrorsTelemetry) forEachMapEntry(yield func(telemetryIndex, MapErrT
 	}
 }
 
-func (m *mockErrorsTelemetry) forEachHelperEntry(yield func(telemetryIndex, HelperErrTelemetry) bool) {
+func (m *mockErrorsTelemetry) forEachHelperEntry(yield func(telemetryIndex, helperErrTelemetry) bool) {
 	for i, telemetry := range m.helperErrMap {
 		if !yield(i, telemetry) {
 			return
@@ -98,10 +98,10 @@ func TestEBPFErrorsCollector_SingleCollect(t *testing.T) {
 	}
 	mapErrorsMockValue, helperErrorsMockValue := uint64(20), uint64(100)
 	//create mock telemetry objects (since we don't want to trigger full ebpf subsystem)
-	mapEntries := map[telemetryIndex]MapErrTelemetry{
+	mapEntries := map[telemetryIndex]mapErrTelemetry{
 		{key: 1, name: mockMapName}: {Count: [64]uint64{mapErrorsMockValue}},
 	}
-	helperEntries := map[telemetryIndex]HelperErrTelemetry{
+	helperEntries := map[telemetryIndex]helperErrTelemetry{
 		{key: 2, name: mockHelperName}: {Count: [320]uint64{helperErrorsMockValue}},
 	}
 
@@ -157,10 +157,10 @@ func TestEBPFErrorsCollector_DoubleCollect(t *testing.T) {
 	}
 	mapErrorsMockValue1, helperErrorsMockValue1 := uint64(20), uint64(100)
 	mapErrorsMockValue2, helperErrorsMockValue2 := uint64(100), uint64(1000)
-	mapEntries := map[telemetryIndex]MapErrTelemetry{
+	mapEntries := map[telemetryIndex]mapErrTelemetry{
 		{key: 1, name: mockMapName}: {Count: [64]uint64{mapErrorsMockValue1}},
 	}
-	helperEntries := map[telemetryIndex]HelperErrTelemetry{
+	helperEntries := map[telemetryIndex]helperErrTelemetry{
 		{key: 2, name: mockHelperName}: {Count: [320]uint64{helperErrorsMockValue1}},
 	}
 
@@ -195,9 +195,9 @@ func TestEBPFErrorsCollector_DoubleCollect(t *testing.T) {
 
 	//increase the counters of the mock telemetry object before second collect
 	collector.(*EBPFErrorsCollector).T = &mockErrorsTelemetry{
-		mapErrMap: map[telemetryIndex]MapErrTelemetry{
+		mapErrMap: map[telemetryIndex]mapErrTelemetry{
 			{key: 1, name: mockMapName}: {Count: [64]uint64{mapErrorsMockValue2}}},
-		helperErrMap: map[telemetryIndex]HelperErrTelemetry{
+		helperErrMap: map[telemetryIndex]helperErrTelemetry{
 			{key: 2, name: mockHelperName}: {Count: [320]uint64{helperErrorsMockValue2}}},
 	}
 

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -30,6 +30,7 @@ const (
 	readKernelIndx
 	skbLoadBytes
 	perfEventOutput
+	mapErr
 )
 
 var helperNames = map[int]string{

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -48,6 +48,7 @@ type telemetryIndex struct {
 	name string
 }
 
+// ebpfErrorsTelemetry interface allows easy mocking for UTs without a need to initialize the whole ebpf sub-system and execute ebpf maps APIs
 type ebpfErrorsTelemetry interface {
 	sync.Locker
 	setup(opts *manager.Options)
@@ -93,7 +94,7 @@ func (e *EBPFTelemetry) setup(opts *manager.Options) {
 	}
 }
 
-// populateMapsWithKeys initializes the maps for holding telemetry info.
+// fill initializes the maps for holding telemetry info.
 // It must be called after the manager is initialized
 func (e *EBPFTelemetry) fill(m *manager.Manager) error {
 	e.mtx.Lock()

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -45,8 +45,8 @@ var helperNames = map[int]string{
 }
 
 type telemetryIndex struct {
-	key   uint64
-	value string
+	key  uint64
+	name string
 }
 
 type ebpfErrorsTelemetry interface {

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/maps"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -43,7 +44,22 @@ var helperNames = map[int]string{
 	perfEventOutput: "bpf_perf_event_output",
 }
 
-// EBPFTelemetry struct contains all the maps that
+type telemetryIndex struct {
+	key   uint64
+	value string
+}
+
+type ebpfErrorsTelemetry interface {
+	sync.Locker
+	setup(opts *manager.Options)
+	fill(m *manager.Manager) error
+	setProbe(name string, hash uint64)
+	isInitialized() bool
+	forEachMapEntry(yield func(telemetryIndex, MapErrTelemetry) bool)
+	forEachHelperEntry(yield func(telemetryIndex, HelperErrTelemetry) bool)
+}
+
+// EBPFTelemetry struct implements ebpfErrorsTelemetry interface and contains all the maps that
 // are registered to have their telemetry collected.
 type EBPFTelemetry struct {
 	mtx          sync.Mutex
@@ -53,11 +69,90 @@ type EBPFTelemetry struct {
 	probeKeys    map[string]uint64
 }
 
-// A singleton instance of the ebpf telemetry struct. Used by the collector and the ebpf managers (via ErrorsTelemetryModifier).
-var errorsTelemetry *EBPFTelemetry
+func (e *EBPFTelemetry) Lock() {
+	e.mtx.Lock()
+}
+
+func (e *EBPFTelemetry) Unlock() {
+	e.mtx.Unlock()
+}
+
+func (e *EBPFTelemetry) setup(opts *manager.Options) {
+	if (e.mapErrMap != nil) || (e.helperErrMap != nil) {
+		if opts.MapEditors == nil {
+			opts.MapEditors = make(map[string]*ebpf.Map)
+		}
+	}
+	// if the maps have already been loaded, setup editors to point to them
+	if e.mapErrMap != nil {
+		opts.MapEditors[probes.MapErrTelemetryMap] = e.mapErrMap.Map()
+	}
+	if e.helperErrMap != nil {
+		opts.MapEditors[probes.HelperErrTelemetryMap] = e.helperErrMap.Map()
+	}
+}
+
+// populateMapsWithKeys initializes the maps for holding telemetry info.
+// It must be called after the manager is initialized
+func (e *EBPFTelemetry) fill(m *manager.Manager) error {
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
+
+	// first manager to call will populate the maps
+	if e.mapErrMap == nil {
+		e.mapErrMap, _ = maps.GetMap[uint64, MapErrTelemetry](m, probes.MapErrTelemetryMap)
+	}
+	if e.helperErrMap == nil {
+		e.helperErrMap, _ = maps.GetMap[uint64, HelperErrTelemetry](m, probes.HelperErrTelemetryMap)
+	}
+
+	if err := e.initializeMapErrTelemetryMap(m.Maps); err != nil {
+		return err
+	}
+	if err := e.initializeHelperErrTelemetryMap(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *EBPFTelemetry) setProbe(name string, hash uint64) {
+	e.probeKeys[name] = hash
+}
+
+func (e *EBPFTelemetry) isInitialized() bool {
+	return e.mapErrMap != nil && e.helperErrMap != nil
+}
+
+func (e *EBPFTelemetry) forEachMapEntry(yield func(index telemetryIndex, val MapErrTelemetry) bool) {
+	var mval MapErrTelemetry
+	for m, k := range e.mapKeys {
+		err := e.mapErrMap.Lookup(&k, &mval)
+		if err != nil {
+			log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
+			continue
+		}
+		if !yield(telemetryIndex{k, m}, mval) {
+			return
+		}
+	}
+}
+
+func (e *EBPFTelemetry) forEachHelperEntry(yield func(index telemetryIndex, val HelperErrTelemetry) bool) {
+	var hval HelperErrTelemetry
+	for probeName, k := range e.probeKeys {
+		err := e.helperErrMap.Lookup(&k, &hval)
+		if err != nil {
+			log.Debugf("failed to get telemetry for probe:key %s:%d\n", probeName, k)
+			continue
+		}
+		if !yield(telemetryIndex{k, probeName}, hval) {
+			return
+		}
+	}
+}
 
 // newEBPFTelemetry initializes a new EBPFTelemetry object
-func newEBPFTelemetry() *EBPFTelemetry {
+func newEBPFTelemetry() ebpfErrorsTelemetry {
 	errorsTelemetry = &EBPFTelemetry{
 		mapKeys:   make(map[string]uint64),
 		probeKeys: make(map[string]uint64),
@@ -65,46 +160,8 @@ func newEBPFTelemetry() *EBPFTelemetry {
 	return errorsTelemetry
 }
 
-func (b *EBPFTelemetry) setupMapEditors(opts *manager.Options) {
-	if (b.mapErrMap != nil) || (b.helperErrMap != nil) {
-		if opts.MapEditors == nil {
-			opts.MapEditors = make(map[string]*ebpf.Map)
-		}
-	}
-	// if the maps have already been loaded, setup editors to point to them
-	if b.mapErrMap != nil {
-		opts.MapEditors[probes.MapErrTelemetryMap] = b.mapErrMap.Map()
-	}
-	if b.helperErrMap != nil {
-		opts.MapEditors[probes.HelperErrTelemetryMap] = b.helperErrMap.Map()
-	}
-}
-
-// populateMapsWithKeys initializes the maps for holding telemetry info.
-// It must be called after the manager is initialized
-func (b *EBPFTelemetry) populateMapsWithKeys(m *manager.Manager) error {
-	b.mtx.Lock()
-	defer b.mtx.Unlock()
-
-	// first manager to call will populate the maps
-	if b.mapErrMap == nil {
-		b.mapErrMap, _ = maps.GetMap[uint64, MapErrTelemetry](m, probes.MapErrTelemetryMap)
-	}
-	if b.helperErrMap == nil {
-		b.helperErrMap, _ = maps.GetMap[uint64, HelperErrTelemetry](m, probes.HelperErrTelemetryMap)
-	}
-
-	if err := b.initializeMapErrTelemetryMap(m.Maps); err != nil {
-		return err
-	}
-	if err := b.initializeHelperErrTelemetryMap(); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (b *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error {
-	if b.mapErrMap == nil {
+func (e *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error {
+	if e.mapErrMap == nil {
 		return nil
 	}
 
@@ -113,29 +170,29 @@ func (b *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error 
 	for _, m := range maps {
 		// Some maps, such as the telemetry maps, are
 		// redefined in multiple programs.
-		if _, ok := b.mapKeys[m.Name]; ok {
+		if _, ok := e.mapKeys[m.Name]; ok {
 			continue
 		}
 
 		key := mapKey(h, m)
-		err := b.mapErrMap.Update(&key, z, ebpf.UpdateNoExist)
+		err := e.mapErrMap.Update(&key, z, ebpf.UpdateNoExist)
 		if err != nil && !errors.Is(err, ebpf.ErrKeyExist) {
 			return fmt.Errorf("failed to initialize telemetry struct for map %s", m.Name)
 		}
-		b.mapKeys[m.Name] = key
+		e.mapKeys[m.Name] = key
 	}
 	return nil
 }
 
-func (b *EBPFTelemetry) initializeHelperErrTelemetryMap() error {
-	if b.helperErrMap == nil {
+func (e *EBPFTelemetry) initializeHelperErrTelemetryMap() error {
+	if e.helperErrMap == nil {
 		return nil
 	}
 
 	// the `probeKeys` get added during instruction patching, so we just try to insert entries for any that don't exist
 	z := new(HelperErrTelemetry)
-	for p, key := range b.probeKeys {
-		err := b.helperErrMap.Update(&key, z, ebpf.UpdateNoExist)
+	for p, key := range e.probeKeys {
+		err := e.helperErrMap.Update(&key, z, ebpf.UpdateNoExist)
 		if err != nil && !errors.Is(err, ebpf.ErrKeyExist) {
 			return fmt.Errorf("failed to initialize telemetry struct for probe %s", p)
 		}
@@ -147,7 +204,7 @@ func (b *EBPFTelemetry) initializeHelperErrTelemetryMap() error {
 // It will patch the instructions of all the manager probes and `undefinedProbes` provided.
 // Constants are replaced for map error and helper error keys with their respective values.
 // This must be called before ebpf-manager.Manager.Init/InitWithOptions
-func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetry *EBPFTelemetry) error {
+func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetry ebpfErrorsTelemetry) error {
 	activateBPFTelemetry, err := ebpfTelemetrySupported()
 	if err != nil {
 		return err
@@ -166,7 +223,7 @@ func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetr
 		}
 
 		if bpfTelemetry != nil {
-			bpfTelemetry.setupMapEditors(options)
+			bpfTelemetry.setup(options)
 		}
 
 		options.ConstantEditors = append(options.ConstantEditors, buildMapErrTelemetryConstants(m)...)
@@ -177,7 +234,7 @@ func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetr
 	return nil
 }
 
-func patchEBPFTelemetry(m *manager.Manager, enable bool, bpfTelemetry *EBPFTelemetry) error {
+func patchEBPFTelemetry(m *manager.Manager, enable bool, bpfTelemetry ebpfErrorsTelemetry) error {
 	const symbol = "telemetry_program_id_key"
 	newIns := asm.Mov.Reg(asm.R1, asm.R1)
 	if enable {
@@ -205,7 +262,7 @@ func patchEBPFTelemetry(m *manager.Manager, enable bool, bpfTelemetry *EBPFTelem
 					}
 					key := probeKey(h, fn)
 					load.Constant = int64(key)
-					bpfTelemetry.probeKeys[fn] = key
+					bpfTelemetry.setProbe(fn, key)
 				}
 			}
 		}

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"hash"
 	"hash/fnv"
+	"io"
+	"math"
 	"slices"
 	"sync"
 
@@ -30,7 +32,7 @@ const (
 	readKernelIndx
 	skbLoadBytes
 	perfEventOutput
-	mapErr
+	mapErr = math.MaxInt
 )
 
 var helperNames = map[int]string{

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -69,10 +69,12 @@ type EBPFTelemetry struct {
 	probeKeys    map[string]uint64
 }
 
+// Lock is part of the Locker interface implementation.
 func (e *EBPFTelemetry) Lock() {
 	e.mtx.Lock()
 }
 
+// Unlock is part of the Locker interface implementation.
 func (e *EBPFTelemetry) Unlock() {
 	e.mtx.Unlock()
 }

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -43,6 +43,18 @@ var helperNames = map[int]string{
 	perfEventOutput: "bpf_perf_event_output",
 }
 
+type ebpfErrorsTelemetry interface {
+	sync.Locker
+	setup(opts *manager.Options)
+	fillMaps(m *manager.Manager) error
+	getMapKeys() map[string]uint64
+	getProbeKeys() map[string]uint64
+	setProbe(name string, hash uint64)
+	isInitialized() bool
+	getMapsTelemetryEntry(key uint64) (MapErrTelemetry, error)
+	getHelpersTelemetryEntry(key uint64) (HelperErrTelemetry, error)
+}
+
 // EBPFTelemetry struct contains all the maps that
 // are registered to have their telemetry collected.
 type EBPFTelemetry struct {
@@ -53,11 +65,52 @@ type EBPFTelemetry struct {
 	probeKeys    map[string]uint64
 }
 
-// A singleton instance of the ebpf telemetry struct. Used by the collector and the ebpf managers (via ErrorsTelemetryModifier).
-var errorsTelemetry *EBPFTelemetry
+func (e *EBPFTelemetry) Lock() {
+	e.mtx.Lock()
+}
+
+func (e *EBPFTelemetry) Unlock() {
+	e.mtx.Unlock()
+}
+
+func (e *EBPFTelemetry) setup(opts *manager.Options) {
+	e.setupMapEditors(opts)
+}
+
+func (e *EBPFTelemetry) fillMaps(m *manager.Manager) error {
+	return e.populateMapsWithKeys(m)
+}
+
+func (e *EBPFTelemetry) getMapKeys() map[string]uint64 {
+	return e.mapKeys
+}
+
+func (e *EBPFTelemetry) getProbeKeys() map[string]uint64 {
+	return e.probeKeys
+}
+
+func (e *EBPFTelemetry) setProbe(name string, hash uint64) {
+	e.probeKeys[name] = hash
+}
+
+func (e *EBPFTelemetry) isInitialized() bool {
+	return e.mapErrMap != nil && e.helperErrMap != nil
+}
+
+func (e *EBPFTelemetry) getMapsTelemetryEntry(key uint64) (MapErrTelemetry, error) {
+	var val MapErrTelemetry
+	err := e.mapErrMap.Lookup(&key, &val)
+	return val, err
+}
+
+func (e *EBPFTelemetry) getHelpersTelemetryEntry(key uint64) (HelperErrTelemetry, error) {
+	var val HelperErrTelemetry
+	err := e.helperErrMap.Lookup(&key, &val)
+	return val, err
+}
 
 // newEBPFTelemetry initializes a new EBPFTelemetry object
-func newEBPFTelemetry() *EBPFTelemetry {
+func newEBPFTelemetry() ebpfErrorsTelemetry {
 	errorsTelemetry = &EBPFTelemetry{
 		mapKeys:   make(map[string]uint64),
 		probeKeys: make(map[string]uint64),
@@ -65,46 +118,46 @@ func newEBPFTelemetry() *EBPFTelemetry {
 	return errorsTelemetry
 }
 
-func (b *EBPFTelemetry) setupMapEditors(opts *manager.Options) {
-	if (b.mapErrMap != nil) || (b.helperErrMap != nil) {
+func (e *EBPFTelemetry) setupMapEditors(opts *manager.Options) {
+	if (e.mapErrMap != nil) || (e.helperErrMap != nil) {
 		if opts.MapEditors == nil {
 			opts.MapEditors = make(map[string]*ebpf.Map)
 		}
 	}
 	// if the maps have already been loaded, setup editors to point to them
-	if b.mapErrMap != nil {
-		opts.MapEditors[probes.MapErrTelemetryMap] = b.mapErrMap.Map()
+	if e.mapErrMap != nil {
+		opts.MapEditors[probes.MapErrTelemetryMap] = e.mapErrMap.Map()
 	}
-	if b.helperErrMap != nil {
-		opts.MapEditors[probes.HelperErrTelemetryMap] = b.helperErrMap.Map()
+	if e.helperErrMap != nil {
+		opts.MapEditors[probes.HelperErrTelemetryMap] = e.helperErrMap.Map()
 	}
 }
 
 // populateMapsWithKeys initializes the maps for holding telemetry info.
 // It must be called after the manager is initialized
-func (b *EBPFTelemetry) populateMapsWithKeys(m *manager.Manager) error {
-	b.mtx.Lock()
-	defer b.mtx.Unlock()
+func (e *EBPFTelemetry) populateMapsWithKeys(m *manager.Manager) error {
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
 
 	// first manager to call will populate the maps
-	if b.mapErrMap == nil {
-		b.mapErrMap, _ = maps.GetMap[uint64, MapErrTelemetry](m, probes.MapErrTelemetryMap)
+	if e.mapErrMap == nil {
+		e.mapErrMap, _ = maps.GetMap[uint64, MapErrTelemetry](m, probes.MapErrTelemetryMap)
 	}
-	if b.helperErrMap == nil {
-		b.helperErrMap, _ = maps.GetMap[uint64, HelperErrTelemetry](m, probes.HelperErrTelemetryMap)
+	if e.helperErrMap == nil {
+		e.helperErrMap, _ = maps.GetMap[uint64, HelperErrTelemetry](m, probes.HelperErrTelemetryMap)
 	}
 
-	if err := b.initializeMapErrTelemetryMap(m.Maps); err != nil {
+	if err := e.initializeMapErrTelemetryMap(m.Maps); err != nil {
 		return err
 	}
-	if err := b.initializeHelperErrTelemetryMap(); err != nil {
+	if err := e.initializeHelperErrTelemetryMap(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (b *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error {
-	if b.mapErrMap == nil {
+func (e *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error {
+	if e.mapErrMap == nil {
 		return nil
 	}
 
@@ -113,29 +166,29 @@ func (b *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error 
 	for _, m := range maps {
 		// Some maps, such as the telemetry maps, are
 		// redefined in multiple programs.
-		if _, ok := b.mapKeys[m.Name]; ok {
+		if _, ok := e.mapKeys[m.Name]; ok {
 			continue
 		}
 
 		key := mapKey(h, m)
-		err := b.mapErrMap.Update(&key, z, ebpf.UpdateNoExist)
+		err := e.mapErrMap.Update(&key, z, ebpf.UpdateNoExist)
 		if err != nil && !errors.Is(err, ebpf.ErrKeyExist) {
 			return fmt.Errorf("failed to initialize telemetry struct for map %s", m.Name)
 		}
-		b.mapKeys[m.Name] = key
+		e.mapKeys[m.Name] = key
 	}
 	return nil
 }
 
-func (b *EBPFTelemetry) initializeHelperErrTelemetryMap() error {
-	if b.helperErrMap == nil {
+func (e *EBPFTelemetry) initializeHelperErrTelemetryMap() error {
+	if e.helperErrMap == nil {
 		return nil
 	}
 
 	// the `probeKeys` get added during instruction patching, so we just try to insert entries for any that don't exist
 	z := new(HelperErrTelemetry)
-	for p, key := range b.probeKeys {
-		err := b.helperErrMap.Update(&key, z, ebpf.UpdateNoExist)
+	for p, key := range e.probeKeys {
+		err := e.helperErrMap.Update(&key, z, ebpf.UpdateNoExist)
 		if err != nil && !errors.Is(err, ebpf.ErrKeyExist) {
 			return fmt.Errorf("failed to initialize telemetry struct for probe %s", p)
 		}
@@ -147,7 +200,7 @@ func (b *EBPFTelemetry) initializeHelperErrTelemetryMap() error {
 // It will patch the instructions of all the manager probes and `undefinedProbes` provided.
 // Constants are replaced for map error and helper error keys with their respective values.
 // This must be called before ebpf-manager.Manager.Init/InitWithOptions
-func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetry *EBPFTelemetry) error {
+func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetry ebpfErrorsTelemetry) error {
 	activateBPFTelemetry, err := ebpfTelemetrySupported()
 	if err != nil {
 		return err
@@ -166,7 +219,7 @@ func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetr
 		}
 
 		if bpfTelemetry != nil {
-			bpfTelemetry.setupMapEditors(options)
+			bpfTelemetry.setup(options)
 		}
 
 		options.ConstantEditors = append(options.ConstantEditors, buildMapErrTelemetryConstants(m)...)
@@ -177,7 +230,7 @@ func setupForTelemetry(m *manager.Manager, options *manager.Options, bpfTelemetr
 	return nil
 }
 
-func patchEBPFTelemetry(m *manager.Manager, enable bool, bpfTelemetry *EBPFTelemetry) error {
+func patchEBPFTelemetry(m *manager.Manager, enable bool, bpfTelemetry ebpfErrorsTelemetry) error {
 	const symbol = "telemetry_program_id_key"
 	newIns := asm.Mov.Reg(asm.R1, asm.R1)
 	if enable {
@@ -205,7 +258,7 @@ func patchEBPFTelemetry(m *manager.Manager, enable bool, bpfTelemetry *EBPFTelem
 					}
 					key := probeKey(h, fn)
 					load.Constant = int64(key)
-					bpfTelemetry.probeKeys[fn] = key
+					bpfTelemetry.setProbe(fn, key)
 				}
 			}
 		}

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"hash"
 	"hash/fnv"
-	"io"
 	"math"
 	"slices"
 	"sync"

--- a/pkg/ebpf/telemetry/errors_telemetry_testhelpers.go
+++ b/pkg/ebpf/telemetry/errors_telemetry_testhelpers.go
@@ -12,15 +12,15 @@ import (
 )
 
 // GetHelpersTelemetry returns a map of error telemetry for each ebpf program
-func (e *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
+func (b *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
 	helperTelemMap := make(map[string]interface{})
-	if e.helperErrMap == nil {
+	if b.helperErrMap == nil {
 		return helperTelemMap
 	}
 
 	var val HelperErrTelemetry
-	for probeName, k := range e.probeKeys {
-		err := e.helperErrMap.Lookup(&k, &val)
+	for probeName, k := range b.probeKeys {
+		err := b.helperErrMap.Lookup(&k, &val)
 		if err != nil {
 			log.Debugf("failed to get telemetry for map:key %s:%d\n", probeName, k)
 			continue
@@ -41,15 +41,15 @@ func (e *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
 }
 
 // GetMapsTelemetry returns a map of error telemetry for each ebpf map
-func (e *EBPFTelemetry) GetMapsTelemetry() map[string]interface{} {
+func (b *EBPFTelemetry) GetMapsTelemetry() map[string]interface{} {
 	t := make(map[string]interface{})
-	if e.mapErrMap == nil {
+	if b.mapErrMap == nil {
 		return t
 	}
 
 	var val MapErrTelemetry
-	for m, k := range e.mapKeys {
-		err := e.mapErrMap.Lookup(&k, &val)
+	for m, k := range b.mapKeys {
+		err := b.mapErrMap.Lookup(&k, &val)
 		if err != nil {
 			log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
 			continue

--- a/pkg/ebpf/telemetry/errors_telemetry_testhelpers.go
+++ b/pkg/ebpf/telemetry/errors_telemetry_testhelpers.go
@@ -18,7 +18,7 @@ func (e *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
 		return helperTelemMap
 	}
 
-	var val HelperErrTelemetry
+	var val helperErrTelemetry
 	for probeName, k := range e.probeKeys {
 		err := e.helperErrMap.Lookup(&k, &val)
 		if err != nil {
@@ -47,7 +47,7 @@ func (e *EBPFTelemetry) GetMapsTelemetry() map[string]interface{} {
 		return t
 	}
 
-	var val MapErrTelemetry
+	var val mapErrTelemetry
 	for m, k := range e.mapKeys {
 		err := e.mapErrMap.Lookup(&k, &val)
 		if err != nil {

--- a/pkg/ebpf/telemetry/errors_telemetry_testhelpers.go
+++ b/pkg/ebpf/telemetry/errors_telemetry_testhelpers.go
@@ -12,15 +12,15 @@ import (
 )
 
 // GetHelpersTelemetry returns a map of error telemetry for each ebpf program
-func (b *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
+func (e *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
 	helperTelemMap := make(map[string]interface{})
-	if b.helperErrMap == nil {
+	if e.helperErrMap == nil {
 		return helperTelemMap
 	}
 
 	var val HelperErrTelemetry
-	for probeName, k := range b.probeKeys {
-		err := b.helperErrMap.Lookup(&k, &val)
+	for probeName, k := range e.probeKeys {
+		err := e.helperErrMap.Lookup(&k, &val)
 		if err != nil {
 			log.Debugf("failed to get telemetry for map:key %s:%d\n", probeName, k)
 			continue
@@ -41,15 +41,15 @@ func (b *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
 }
 
 // GetMapsTelemetry returns a map of error telemetry for each ebpf map
-func (b *EBPFTelemetry) GetMapsTelemetry() map[string]interface{} {
+func (e *EBPFTelemetry) GetMapsTelemetry() map[string]interface{} {
 	t := make(map[string]interface{})
-	if b.mapErrMap == nil {
+	if e.mapErrMap == nil {
 		return t
 	}
 
 	var val MapErrTelemetry
-	for m, k := range b.mapKeys {
-		err := b.mapErrMap.Lookup(&k, &val)
+	for m, k := range e.mapKeys {
+		err := e.mapErrMap.Lookup(&k, &val)
 		if err != nil {
 			log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
 			continue

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -29,7 +29,7 @@ func (t *ErrorsTelemetryModifier) BeforeInit(m *manager.Manager, opts *manager.O
 // AfterInit pre-populates the telemetry maps with entries corresponding to the ebpf program of the manager.
 func (t *ErrorsTelemetryModifier) AfterInit(m *manager.Manager, _ *manager.Options) error {
 	if errorsTelemetry != nil {
-		if err := errorsTelemetry.fillMaps(m); err != nil {
+		if err := errorsTelemetry.populateMapsWithKeys(m); err != nil {
 			return err
 		}
 	}

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -29,7 +29,7 @@ func (t *ErrorsTelemetryModifier) BeforeInit(m *manager.Manager, opts *manager.O
 // AfterInit pre-populates the telemetry maps with entries corresponding to the ebpf program of the manager.
 func (t *ErrorsTelemetryModifier) AfterInit(m *manager.Manager, _ *manager.Options) error {
 	if errorsTelemetry != nil {
-		if err := errorsTelemetry.populateMapsWithKeys(m); err != nil {
+		if err := errorsTelemetry.fill(m); err != nil {
 			return err
 		}
 	}

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -29,7 +29,7 @@ func (t *ErrorsTelemetryModifier) BeforeInit(m *manager.Manager, opts *manager.O
 // AfterInit pre-populates the telemetry maps with entries corresponding to the ebpf program of the manager.
 func (t *ErrorsTelemetryModifier) AfterInit(m *manager.Manager, _ *manager.Options) error {
 	if errorsTelemetry != nil {
-		if err := errorsTelemetry.populateMapsWithKeys(m); err != nil {
+		if err := errorsTelemetry.fillMaps(m); err != nil {
 			return err
 		}
 	}

--- a/pkg/ebpf/telemetry/types.go
+++ b/pkg/ebpf/telemetry/types.go
@@ -12,5 +12,5 @@ package telemetry
 */
 import "C"
 
-type MapErrTelemetry C.map_err_telemetry_t
-type HelperErrTelemetry C.helper_err_telemetry_t
+type mapErrTelemetry C.map_err_telemetry_t
+type helperErrTelemetry C.helper_err_telemetry_t

--- a/pkg/ebpf/telemetry/types_linux.go
+++ b/pkg/ebpf/telemetry/types_linux.go
@@ -3,9 +3,9 @@
 
 package telemetry
 
-type MapErrTelemetry struct {
+type mapErrTelemetry struct {
 	Count [64]uint64
 }
-type HelperErrTelemetry struct {
+type helperErrTelemetry struct {
 	Count [320]uint64
 }

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1979,7 +1979,10 @@ func (s *TracerSuite) TestGetMapsTelemetry() {
 	ebpfTelemetryCollector, ok := tr.bpfErrorsCollector.(*ebpftelemetry.EBPFErrorsCollector)
 	require.True(t, ok)
 
-	mapsTelemetry := ebpfTelemetryCollector.T.GetMapsTelemetry()
+	telemetry, ok := ebpfTelemetryCollector.T.(*ebpftelemetry.EBPFTelemetry)
+	require.True(t, ok)
+	mapsTelemetry := telemetry.GetMapsTelemetry()
+
 	t.Logf("EBPF Maps telemetry: %v\n", mapsTelemetry)
 
 	tcpStatsErrors, ok := mapsTelemetry[probes.TCPStatsMap].(map[string]uint64)
@@ -2035,7 +2038,9 @@ func (s *TracerSuite) TestGetHelpersTelemetry() {
 	ebpfTelemetryCollector, ok := tr.bpfErrorsCollector.(*ebpftelemetry.EBPFErrorsCollector)
 	require.True(t, ok)
 
-	helperTelemetry := ebpfTelemetryCollector.T.GetHelpersTelemetry()
+	telemetry, ok := ebpfTelemetryCollector.T.(*ebpftelemetry.EBPFTelemetry)
+	require.True(t, ok)
+	helperTelemetry := telemetry.GetHelpersTelemetry()
 	t.Logf("EBPF helper telemetry: %v\n", helperTelemetry)
 
 	openAtErrors, ok := helperTelemetry[expectedErrorTP].(map[string]interface{})

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1979,10 +1979,7 @@ func (s *TracerSuite) TestGetMapsTelemetry() {
 	ebpfTelemetryCollector, ok := tr.bpfErrorsCollector.(*ebpftelemetry.EBPFErrorsCollector)
 	require.True(t, ok)
 
-	telemetry, ok := ebpfTelemetryCollector.T.(*ebpftelemetry.EBPFTelemetry)
-	require.True(t, ok)
-	mapsTelemetry := telemetry.GetMapsTelemetry()
-
+	mapsTelemetry := ebpfTelemetryCollector.T.GetMapsTelemetry()
 	t.Logf("EBPF Maps telemetry: %v\n", mapsTelemetry)
 
 	tcpStatsErrors, ok := mapsTelemetry[probes.TCPStatsMap].(map[string]uint64)
@@ -2038,9 +2035,7 @@ func (s *TracerSuite) TestGetHelpersTelemetry() {
 	ebpfTelemetryCollector, ok := tr.bpfErrorsCollector.(*ebpftelemetry.EBPFErrorsCollector)
 	require.True(t, ok)
 
-	telemetry, ok := ebpfTelemetryCollector.T.(*ebpftelemetry.EBPFTelemetry)
-	require.True(t, ok)
-	helperTelemetry := telemetry.GetHelpersTelemetry()
+	helperTelemetry := ebpfTelemetryCollector.T.GetHelpersTelemetry()
 	t.Logf("EBPF helper telemetry: %v\n", helperTelemetry)
 
 	openAtErrors, ok := helperTelemetry[expectedErrorTP].(map[string]interface{})

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1979,7 +1979,9 @@ func (s *TracerSuite) TestGetMapsTelemetry() {
 	ebpfTelemetryCollector, ok := tr.bpfErrorsCollector.(*ebpftelemetry.EBPFErrorsCollector)
 	require.True(t, ok)
 
-	mapsTelemetry := ebpfTelemetryCollector.T.GetMapsTelemetry()
+	telemetry, ok := ebpfTelemetryCollector.T.(*ebpftelemetry.EBPFTelemetry)
+	require.True(t, ok)
+	mapsTelemetry := telemetry.GetMapsTelemetry()
 	t.Logf("EBPF Maps telemetry: %v\n", mapsTelemetry)
 
 	tcpStatsErrors, ok := mapsTelemetry[probes.TCPStatsMap].(map[string]uint64)
@@ -2035,7 +2037,9 @@ func (s *TracerSuite) TestGetHelpersTelemetry() {
 	ebpfTelemetryCollector, ok := tr.bpfErrorsCollector.(*ebpftelemetry.EBPFErrorsCollector)
 	require.True(t, ok)
 
-	helperTelemetry := ebpfTelemetryCollector.T.GetHelpersTelemetry()
+	telemetry, ok := ebpfTelemetryCollector.T.(*ebpftelemetry.EBPFTelemetry)
+	require.True(t, ok)
+	helperTelemetry := telemetry.GetHelpersTelemetry()
 	t.Logf("EBPF helper telemetry: %v\n", helperTelemetry)
 
 	openAtErrors, ok := helperTelemetry[expectedErrorTP].(map[string]interface{})


### PR DESCRIPTION
### What does this PR do?

- Changes the ebpf errors telemetry metrics to Counter instead of Gauge (the metric count total number of errors in different ebpf helper functions) 
- Renamed the metrics to prevent type confusion on the backend 
- Introduced `ebpfErrorsTelemetry` interface to allow easy mocking in UTs

### Motivation

Monotonic counter is a more suitable type for this kind of metric, since we measure number of errors which increase over time and never decrease, hence it is more intuitive to see those metrics in our dashboards as counters

### Additional Notes

I will add additional UTs to check the delta calculation is done properly this time

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
