### PR TITLE
feat(updater): Support runtime package bootstrap and runtime versioned package bootstrap

### DIFF
--- a/cmd/updater/subcommands/bootstrap/command.go
+++ b/cmd/updater/subcommands/bootstrap/command.go
@@ -26,13 +26,15 @@ import (
 
 type cliParams struct {
 	command.GlobalParams
-	pkg string
+	pkg     string
+	version string
 }
 
 // Commands returns the bootstrap command
 func Commands(global *command.GlobalParams) []*cobra.Command {
 	var timeout time.Duration
 	var pkg string
+	var version string
 	bootstrapCmd := &cobra.Command{
 		Use:   "bootstrap",
 		Short: "Bootstraps the package with the first version.",
@@ -45,11 +47,13 @@ func Commands(global *command.GlobalParams) []*cobra.Command {
 			return boostrapFxWrapper(ctx, &cliParams{
 				GlobalParams: *global,
 				pkg:          pkg,
+				version:      version,
 			})
 		},
 	}
 	bootstrapCmd.Flags().DurationVarP(&timeout, "timeout", "T", 3*time.Minute, "timeout to bootstrap with")
 	bootstrapCmd.Flags().StringVarP(&pkg, "package", "P", "", "package to bootstrap")
+	bootstrapCmd.Flags().StringVarP(&version, "version", "V", "", "optional version of the package to bootstrap")
 	return []*cobra.Command{bootstrapCmd}
 }
 
@@ -68,9 +72,16 @@ func boostrapFxWrapper(ctx context.Context, params *cliParams) error {
 }
 
 func bootstrap(ctx context.Context, params *cliParams) error {
-	err := updater.Bootstrap(ctx, params.pkg)
-	if err != nil {
-		return fmt.Errorf("could not install package: %w", err)
+	if params.version == "" {
+		err := updater.Bootstrap(ctx, params.pkg)
+		if err != nil {
+			return fmt.Errorf("could not install package: %w", err)
+		}
+	} else {
+		err := updater.BootstrapVersion(ctx, params.pkg, params.version)
+		if err != nil {
+			return fmt.Errorf("could not install package: %w", err)
+		}
 	}
 	return nil
 }

--- a/cmd/updater/subcommands/bootstrap/command.go
+++ b/cmd/updater/subcommands/bootstrap/command.go
@@ -26,15 +26,13 @@ import (
 
 type cliParams struct {
 	command.GlobalParams
-	pkg     string
-	version string
+	pkg string
 }
 
 // Commands returns the bootstrap command
 func Commands(global *command.GlobalParams) []*cobra.Command {
 	var timeout time.Duration
 	var pkg string
-	var version string
 	bootstrapCmd := &cobra.Command{
 		Use:   "bootstrap",
 		Short: "Bootstraps the package with the first version.",
@@ -47,13 +45,11 @@ func Commands(global *command.GlobalParams) []*cobra.Command {
 			return boostrapFxWrapper(ctx, &cliParams{
 				GlobalParams: *global,
 				pkg:          pkg,
-				version:      version,
 			})
 		},
 	}
 	bootstrapCmd.Flags().DurationVarP(&timeout, "timeout", "T", 3*time.Minute, "timeout to bootstrap with")
 	bootstrapCmd.Flags().StringVarP(&pkg, "package", "P", "", "package to bootstrap")
-	bootstrapCmd.Flags().StringVarP(&version, "version", "V", "", "optional version of the package to bootstrap")
 	return []*cobra.Command{bootstrapCmd}
 }
 
@@ -72,16 +68,9 @@ func boostrapFxWrapper(ctx context.Context, params *cliParams) error {
 }
 
 func bootstrap(ctx context.Context, params *cliParams) error {
-	if params.version == "" {
-		err := updater.Bootstrap(ctx, params.pkg)
-		if err != nil {
-			return fmt.Errorf("could not install package: %w", err)
-		}
-	} else {
-		err := updater.BootstrapVersion(ctx, params.pkg, params.version)
-		if err != nil {
-			return fmt.Errorf("could not install package: %w", err)
-		}
+	err := updater.Bootstrap(ctx, params.pkg)
+	if err != nil {
+		return fmt.Errorf("could not install package: %w", err)
 	}
 	return nil
 }

--- a/cmd/updater/subcommands/experiment/command.go
+++ b/cmd/updater/subcommands/experiment/command.go
@@ -64,7 +64,7 @@ func Commands(global *command.GlobalParams) []*cobra.Command {
 	}
 	bootstrapVersionCmd := &cobra.Command{
 		Use:     "bootstrap-version package version",
-		Aliases: []string{"promote"},
+		Aliases: []string{"bootstrap-version"},
 		Short:   "Bootstraps a package to the expected version",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/updater/subcommands/experiment/command.go
+++ b/cmd/updater/subcommands/experiment/command.go
@@ -62,7 +62,20 @@ func Commands(global *command.GlobalParams) []*cobra.Command {
 			})
 		},
 	}
-	return []*cobra.Command{startExperimentCmd, stopExperimentCmd, promoteExperimentCmd}
+	bootstrapVersionCmd := &cobra.Command{
+		Use:     "bootstrap-version package version",
+		Aliases: []string{"promote"},
+		Short:   "Bootstraps a package to the expected version",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return experimentFxWrapper(bootstrapVersion, &cliParams{
+				GlobalParams: *global,
+				pkg:          args[0],
+				version:      args[1],
+			})
+		},
+	}
+	return []*cobra.Command{startExperimentCmd, stopExperimentCmd, promoteExperimentCmd, bootstrapVersionCmd}
 }
 
 func experimentFxWrapper(f interface{}, params *cliParams) error {
@@ -94,6 +107,15 @@ func promote(params *cliParams, client localapiclient.Component) error {
 	err := client.PromoteExperiment(params.pkg)
 	if err != nil {
 		fmt.Println("Error promoting experiment:", err)
+		return err
+	}
+	return nil
+}
+
+func bootstrapVersion(params *cliParams, client localapiclient.Component) error {
+	err := client.BootstrapVersion(params.pkg, params.version)
+	if err != nil {
+		fmt.Println("Error bootstrapping package:", err)
 		return err
 	}
 	return nil

--- a/pkg/updater/defaults/boostrap.json
+++ b/pkg/updater/defaults/boostrap.json
@@ -1,3 +1,4 @@
 {
-  "datadog-agent": "7.53.0-devel.git.156.4681fd9.pipeline.29311299-1"
+  "datadog-agent": "7.53.0-devel.git.156.4681fd9.pipeline.29311299-1",
+  "dd-trace-java": "1.31.0"
 }

--- a/pkg/updater/defaults/catalog.json
+++ b/pkg/updater/defaults/catalog.json
@@ -1,6 +1,14 @@
 {
   "packages": [
     {
+      "name": "dd-trace-java",
+      "package": "dd-trace-java",
+      "version": "1.31.0",
+      "url": "https://storage.googleapis.com/updater-dev/dd-trace-java-1.31.0.tar",
+      "sha256": "9c0e49e671430a4a10f1dfbf64624bab34b7b190576669a37f3aaeef8fbf4a7f",
+      "size": 26594816
+    },
+    {
       "name": "datadog-agent",
       "package": "datadog-agent",
       "version": "7.53.0-devel.git.142.5f0ff76.pipeline.29207608-1",

--- a/pkg/updater/local_api.go
+++ b/pkg/updater/local_api.go
@@ -224,6 +224,7 @@ type LocalAPIClient interface {
 	StartExperiment(pkg, version string) error
 	StopExperiment(pkg string) error
 	PromoteExperiment(pkg string) error
+	BootstrapVersion(pkg, version string) error
 }
 
 // LocalAPIClient is a client to interact with the locally exposed updater API.
@@ -344,5 +345,36 @@ func (c *localAPIClientImpl) PromoteExperiment(pkg string) error {
 		return fmt.Errorf("error promoting experiment: %s", response.Error.Message)
 	}
 	defer resp.Body.Close()
+	return nil
+}
+
+// BootstrapVersion bootstraps a package to a specific version.
+func (c *localAPIClientImpl) BootstrapVersion(pkg, version string) error {
+	params := taskWithVersionParams{
+		Version: version,
+	}
+	body, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://updater/%s/bootstrap", pkg), bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var response APIResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return err
+	}
+	if response.Error != nil {
+		return fmt.Errorf("error starting experiment: %s", response.Error.Message)
+	}
 	return nil
 }

--- a/pkg/updater/local_api.go
+++ b/pkg/updater/local_api.go
@@ -201,12 +201,13 @@ func (l *localAPIImpl) bootstrap(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	taskID := uuid.New().String()
 	if request.Version != "" {
 		log.Infof("Received local request to bootstrap package %s version %s", pkg, request.Version)
-		err = l.updater.BootstrapVersion(r.Context(), pkg, request.Version)
+		err = l.updater.BootstrapVersion(r.Context(), pkg, request.Version, taskID)
 	} else {
 		log.Infof("Received local request to bootstrap package %s", pkg)
-		err = l.updater.Bootstrap(r.Context(), pkg)
+		err = l.updater.Bootstrap(r.Context(), pkg, taskID)
 
 	}
 	if err != nil {

--- a/pkg/updater/remote_config.go
+++ b/pkg/updater/remote_config.go
@@ -157,6 +157,7 @@ const (
 	methodStartExperiment   = "start_experiment"
 	methodStopExperiment    = "stop_experiment"
 	methodPromoteExperiment = "promote_experiment"
+	methodBootstrap         = "bootstrap"
 )
 
 type remoteAPIRequest struct {
@@ -172,7 +173,7 @@ type expectedState struct {
 	Experiment string `json:"experiment"`
 }
 
-type startExperimentParams struct {
+type taskWithVersionParams struct {
 	Version string `json:"version"`
 }
 

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -91,17 +91,6 @@ func Bootstrap(ctx context.Context, pkg string) error {
 	return u.Bootstrap(ctx, pkg, taskID)
 }
 
-// BootstrapVersion bootstraps the given package at the given version.
-func BootstrapVersion(ctx context.Context, pkg string, version string) error {
-	rc := newNoopRemoteConfig()
-	u, err := newUpdater(rc, defaultRepositoriesPath, defaultLocksPath)
-	if err != nil {
-		return err
-	}
-	taskID := uuid.New().String()
-	return u.BootstrapVersion(ctx, pkg, version, taskID)
-}
-
 // NewUpdater returns a new Updater.
 func NewUpdater(rcFetcher client.ConfigFetcher) (Updater, error) {
 	rc, err := newRemoteConfig(rcFetcher)

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -88,7 +88,7 @@ func TestUpdaterBootstrap(t *testing.T) {
 	rc := newTestRemoteConfigClient()
 	updater := newTestUpdater(t, s, rc, fixtureSimpleV1)
 
-	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
+	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
 	assert.NoError(t, err)
 
 	r := updater.repositories.Get(fixtureSimpleV1.pkg)
@@ -106,10 +106,10 @@ func TestUpdaterBootstrapCatalogUpdate(t *testing.T) {
 	updater := newTestUpdater(t, s, rc, fixtureSimpleV1)
 	updater.catalog = catalog{}
 
-	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
+	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
 	assert.Error(t, err)
 	rc.SubmitCatalog(s.Catalog())
-	err = updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
+	err = updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
 	assert.NoError(t, err)
 }
 
@@ -119,7 +119,7 @@ func TestUpdaterStartExperiment(t *testing.T) {
 	rc := newTestRemoteConfigClient()
 	updater := newTestUpdater(t, s, rc, fixtureSimpleV1)
 
-	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
+	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
 	assert.NoError(t, err)
 	rc.SubmitRequest(remoteAPIRequest{
 		ID:      uuid.NewString(),
@@ -146,7 +146,7 @@ func TestUpdaterPromoteExperiment(t *testing.T) {
 	rc := newTestRemoteConfigClient()
 	updater := newTestUpdater(t, s, rc, fixtureSimpleV1)
 
-	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
+	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
 	assert.NoError(t, err)
 	rc.SubmitRequest(remoteAPIRequest{
 		ID:      uuid.NewString(),
@@ -181,7 +181,7 @@ func TestUpdaterStopExperiment(t *testing.T) {
 	rc := newTestRemoteConfigClient()
 	updater := newTestUpdater(t, s, rc, fixtureSimpleV1)
 
-	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
+	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
 	assert.NoError(t, err)
 	rc.SubmitRequest(remoteAPIRequest{
 		ID:      uuid.NewString(),


### PR DESCRIPTION
### What does this PR do?
Adds support for bootstrap over RC & bootstrap with version over RC

### Motivation
Tracer upgrades

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
We don't have state yet for bootstrap (nor backend support)

### Describe how to test/QA your changes
Start the updater & call the bootstrap method with 
`curl -X POST --unix-socket /opt/datadog-packages/updater.sock -H 'Content-Type: application/json' http://updater/datadog-agent/bootstrap -d '{"version":"1.21.5"}'` (please adapt the version & package with what's available in the catalog)