### PR TITLE
move agent install script in updater (sidecar with fifo solution)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -363,7 +363,7 @@ require (
 	github.com/cavaliergopher/grab/v3 v3.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/continuity v0.4.3 // indirect
-	github.com/containerd/fifo v1.1.0 // indirect
+	github.com/containerd/fifo v1.1.0
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
 	github.com/containerd/ttrpc v1.2.2 // indirect
 	github.com/containernetworking/plugins v1.4.0 // indirect

--- a/omnibus/config/projects/updater.rb
+++ b/omnibus/config/projects/updater.rb
@@ -101,6 +101,7 @@ if linux_target?
   end
   extra_package_file "#{systemd_directory}/datadog-updater-admin.path"
   extra_package_file "#{systemd_directory}/datadog-updater-admin.service"
+  extra_package_file "#{systemd_directory}/datadog-updater-admin-exec.service"
   extra_package_file "#{systemd_directory}/datadog-updater.service"
   extra_package_file '/etc/datadog-agent/'
   extra_package_file '/var/log/datadog/'

--- a/omnibus/config/projects/updater.rb
+++ b/omnibus/config/projects/updater.rb
@@ -99,19 +99,9 @@ if linux_target?
   if debian_target?
     systemd_directory = "/lib/systemd/system"
   end
+  extra_package_file "#{systemd_directory}/datadog-updater-admin.path"
+  extra_package_file "#{systemd_directory}/datadog-updater-admin.service"
   extra_package_file "#{systemd_directory}/datadog-updater.service"
-  extra_package_file "#{systemd_directory}/datadog-agent.service"
-  extra_package_file "#{systemd_directory}/datadog-agent-exp.service"
-  extra_package_file "#{systemd_directory}/datadog-agent-trace.service"
-  extra_package_file "#{systemd_directory}/datadog-agent-trace-exp.service"
-  extra_package_file "#{systemd_directory}/datadog-agent-process.service"
-  extra_package_file "#{systemd_directory}/datadog-agent-process-exp.service"
-  extra_package_file "#{systemd_directory}/datadog-agent-security.service"
-  extra_package_file "#{systemd_directory}/datadog-agent-security-exp.service"
-  extra_package_file "#{systemd_directory}/datadog-agent-sysprobe.service"
-  extra_package_file "#{systemd_directory}/datadog-agent-sysprobe-exp.service"
-  extra_package_file "#{systemd_directory}/datadog-agent.path"
-  extra_package_file "#{systemd_directory}/datadog-agent-exp.path"
   extra_package_file '/etc/datadog-agent/'
   extra_package_file '/var/log/datadog/'
   extra_package_file '/var/run/datadog-packages/'

--- a/omnibus/config/software/updater.rb
+++ b/omnibus/config/software/updater.rb
@@ -61,10 +61,10 @@ build do
 
 
     # Add updater units
-    systemd_path = "/lib/systemd/system/"
+    systemdPath = "/lib/systemd/system/"
     if not debian_target?
       mkdir "/usr/lib/systemd/system/"
-      systemd_path = "/usr/lib/systemd/system/"
+      systemdPath = "/usr/lib/systemd/system/"
     end
     templateToFile = {
       "datadog-updater-admin.path.erb" => "datadog-updater-admin.path",
@@ -73,13 +73,13 @@ build do
     }
     templateToFile.each do |template, file|
       erb source: template,
-         dest: systemd_path + file,
+         dest: systemdPath + file,
          mode: 0644,
          vars: { install_dir: install_dir, etc_dir: etc_dir}
     end
 
 
-    systemd_path = "#{install_dir}/systemd/"
+    systemdPath = "#{install_dir}/systemd/"
     # Add stable agent units
     templateToFile = {
       "datadog-agent.service.erb" => "datadog-agent.service",
@@ -92,7 +92,7 @@ build do
     templateToFile.each do |template, file|
       agent_dir = "/opt/datadog-packages/datadog-agent/stable"
       erb source: template,
-         dest: systemd_path + file,
+         dest: systemdPath + file,
          mode: 0644,
          vars: { install_dir: install_dir, etc_dir: etc_dir, agent_dir: agent_dir }
     end
@@ -107,7 +107,7 @@ build do
     expTemplateToFile.each do |template, file|
       agent_dir = "/opt/datadog-packages/datadog-agent/experiment"
       erb source: template,
-         dest: systemd_path + file,
+         dest: systemdPath + file,
          mode: 0644,
          vars: { etc_dir: etc_dir, agent_dir: agent_dir }
     end

--- a/omnibus/config/software/updater.rb
+++ b/omnibus/config/software/updater.rb
@@ -69,6 +69,7 @@ build do
     templateToFile = {
       "datadog-updater-admin.path.erb" => "datadog-updater-admin.path",
       "datadog-updater-admin.service.erb" => "datadog-updater-admin.service",
+      "datadog-updater-admin-exec.service.erb" => "datadog-updater-admin-exec.service",
       "datadog-updater.service.erb" => "datadog-updater.service",
     }
     templateToFile.each do |template, file|

--- a/omnibus/config/templates/updater/datadog-agent-exp.path.erb
+++ b/omnibus/config/templates/updater/datadog-agent-exp.path.erb
@@ -1,9 +1,0 @@
-[Unit]
-Description="Monitor requests to start experiment"
-
-[Path]
-PathModified=<%= install_dir %>/systemd_commands/start_experiment
-
-[Install]
-WantedBy=multi-user.target
-

--- a/omnibus/config/templates/updater/datadog-agent.path.erb
+++ b/omnibus/config/templates/updater/datadog-agent.path.erb
@@ -1,8 +1,0 @@
-[Unit]
-Description="Monitor requests to stop experiment"
-
-[Path]
-PathModified=<%= install_dir %>/systemd_commands/stop_experiment
-
-[Install]
-WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-updater-admin-exec.service.erb
+++ b/omnibus/config/templates/updater/datadog-updater-admin-exec.service.erb
@@ -1,0 +1,11 @@
+[Unit]
+Description=Datadog Updater admin command executor
+
+[Service]
+Type=oneshot
+User=root
+EnvironmentFile=-<%= etc_dir %>/environment
+ExecStart=<%= install_dir %>/bin/updater-admin-exec.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-updater-admin.path.erb
+++ b/omnibus/config/templates/updater/datadog-updater-admin.path.erb
@@ -1,0 +1,8 @@
+[Unit]
+Description="Monitor requests to execute systemd commands"
+
+[Path]
+PathModified=<%= install_dir %>/run/in.fifo
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-updater-admin.path.erb
+++ b/omnibus/config/templates/updater/datadog-updater-admin.path.erb
@@ -2,7 +2,7 @@
 Description="Monitor requests to execute systemd commands"
 
 [Path]
-PathModified=<%= install_dir %>/run/in.fifo
+PathChanged=<%= install_dir %>/run/in.fifo
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-updater-admin.service.erb
+++ b/omnibus/config/templates/updater/datadog-updater-admin.service.erb
@@ -4,8 +4,9 @@ Description=Clean start of datadog admin executor
 [Service]
 Type=oneshot
 User=root
-ExecStart=systemctl kill -s SIGKILL datadog-updater-admin-exec.service || true
-ExecStart=systemctl start datadog-updater-admin-exec.service || true
+ExecStart=/bin/sh -c 'systemctl kill -s SIGKILL datadog-updater-admin-exec.service' || true
+ExecStart=test -e <%= install_dir %>/run/in.fifo
+ExecStart=systemctl start datadog-updater-admin-exec.service --no-block
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-updater-admin.service.erb
+++ b/omnibus/config/templates/updater/datadog-updater-admin.service.erb
@@ -4,8 +4,8 @@ Description=Clean start of datadog admin executor
 [Service]
 Type=oneshot
 User=root
-ExecStart=systemctl kill -s SIGKILL datadog-updater-admin-exec.service
-ExecStart=systemctl start datadog-updater-admin-exec.service
+ExecStart=systemctl kill -s SIGKILL datadog-updater-admin-exec.service || true
+ExecStart=systemctl start datadog-updater-admin-exec.service || true
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-updater-admin.service.erb
+++ b/omnibus/config/templates/updater/datadog-updater-admin.service.erb
@@ -1,0 +1,11 @@
+[Unit]
+Description=Datadog Updater admin command executor
+
+[Service]
+Type=oneshot
+User=root
+EnvironmentFile=-<%= etc_dir %>/environment
+ExecStart=<%= install_dir %>/bin/updater-admin-exec.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/datadog-updater-admin.service.erb
+++ b/omnibus/config/templates/updater/datadog-updater-admin.service.erb
@@ -4,7 +4,7 @@ Description=Clean start of datadog admin executor
 [Service]
 Type=oneshot
 User=root
-ExecStart=/bin/sh -c 'systemctl kill -s SIGKILL datadog-updater-admin-exec.service' || true
+ExecStart=-systemctl kill -s SIGKILL datadog-updater-admin-exec.service
 ExecStart=test -e <%= install_dir %>/run/in.fifo
 ExecStart=systemctl start datadog-updater-admin-exec.service --no-block
 

--- a/omnibus/config/templates/updater/datadog-updater-admin.service.erb
+++ b/omnibus/config/templates/updater/datadog-updater-admin.service.erb
@@ -1,11 +1,11 @@
 [Unit]
-Description=Datadog Updater admin command executor
+Description=Clean start of datadog admin executor
 
 [Service]
 Type=oneshot
 User=root
-EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= install_dir %>/bin/updater-admin-exec.sh
+ExecStart=systemctl kill -s SIGKILL datadog-updater-admin-exec.service
+ExecStart=systemctl start datadog-updater-admin-exec.service
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/updater/updater-admin-exec.sh.erb
+++ b/omnibus/config/templates/updater/updater-admin-exec.sh.erb
@@ -138,7 +138,7 @@ while true; do
 
     result="success"
     if [ -n "$error_message" ]; then
-       result="error: $error_message"
+       result="$error_message"
     fi
     echo "sending $result"
     echo "$result" >&3

--- a/omnibus/config/templates/updater/updater-admin-exec.sh.erb
+++ b/omnibus/config/templates/updater/updater-admin-exec.sh.erb
@@ -84,7 +84,7 @@ handle_command() {
             ;;
         "systemd-reload")
             if ! systemctl daemon-reload; then
-                error_message="failed to reload: $unit"
+                error_message="failed to reload"
                 return 1
             fi
             return 0

--- a/omnibus/config/templates/updater/updater-admin-exec.sh.erb
+++ b/omnibus/config/templates/updater/updater-admin-exec.sh.erb
@@ -36,21 +36,17 @@ assert_command() {
                 ;;
             *)
                 error_message="invalid command: $command"
-                echo "failed"
                 return 1
                 ;;
         esac
     done
-    echo "success"
     return 0
 }
 
 assert_unit() {
     unit="$1"
-    echo "asserting unit $unit"
     if [ "${unit#"datadog"}" = "$unit" ]; then
         error_message="unit name must start with 'datadog'"
-        echo "failed datadog start check"
         return 1
     fi
     return 0
@@ -100,9 +96,7 @@ handle_command() {
             fi
             unit="$2"
             assert_unit "$unit" || return 1
-            echo "added"
             cp "$unit_path/$unit" "$systemd_path/$unit"
-            echo "it passes"
             return 0
             ;;
         "remove-unit")
@@ -113,7 +107,6 @@ handle_command() {
             unit="$2"
             assert_unit "$unit" || return 1
             rm "$systemd_path/$unit"
-            echo "removed"
             return 0
             ;;
         *)
@@ -128,7 +121,7 @@ handle_command() {
 exec 3> "$out_fifo"
 exec 4< "$in_fifo"
 while true; do
-    echo "waiting"
+    echo "waiting for command"
     if ! read -r command <&4; then
         # close file descriptors
         exec 3>&-

--- a/omnibus/config/templates/updater/updater-admin-exec.sh.erb
+++ b/omnibus/config/templates/updater/updater-admin-exec.sh.erb
@@ -1,0 +1,153 @@
+#!/bin/sh
+# This script is used to allow datadog-updater
+# to execute a predefined set of root commands.
+# A datadog-root-runner.service executes those commands
+# on writes to a fifo file.
+
+error_message=""
+updater_path=<%= install_dir %>
+unit_path="$updater_path/systemd"
+in_fifo="$updater_path/run/in.fifo"
+out_fifo="$updater_path/run/out.fifo"
+
+systemd_path="/lib/systemd/system"
+if [ ! -f /etc/debian_version ]; then
+    mkdir -p "/usr/lib/systemd/system"
+    systemd_path="/usr/lib/systemd/system"
+fi
+
+assert_command() {
+    command="$1"
+    if [ "${#command}" -gt 100 ]; then
+        error_message="command longer than 100"
+        return 1
+    fi
+    tmp_str="${command}"
+    while [ -n "$tmp_str" ]; do
+        rest="${tmp_str#?}"
+        first_character="${tmp_str%"$rest"}"
+        tmp_str="$rest"
+        case "$first_character" in
+            [abcdefghijklmnopqrstuvwxyz-])
+                ;;
+            ".")
+                ;;
+            " ")
+                ;;
+            *)
+                error_message="invalid command: $command"
+                echo "failed"
+                return 1
+                ;;
+        esac
+    done
+    echo "success"
+    return 0
+}
+
+assert_unit() {
+    unit="$1"
+    echo "asserting unit $unit"
+    if [ "${unit#"datadog"}" = "$unit" ]; then
+        error_message="unit name must start with 'datadog'"
+        echo "failed datadog start check"
+        return 1
+    fi
+    return 0
+}
+
+handle_command() {
+    command="$1"
+    case "$command" in
+        "stop" | "enable" | "disable")
+            if [ "$#" -ne 2 ]; then
+                error_message="missing argument"
+                return 1
+            fi
+            unit="$2"
+            assert_unit "$unit" || return 1
+            if ! systemctl "$command" "$unit"; then
+                error_message="failed to $command unit: $unit"
+                return 1
+            fi
+            return 0
+            ;;
+        "start")
+            if [ "$#" -ne 2 ]; then
+                error_message="missing arguments"
+                return 1
+            fi
+            unit="$2"
+            assert_unit "$unit" || return 1
+            # --no-block is used to avoid blocking on oneshot executions
+            if ! systemctl "$command" "$unit" --no-block ; then
+                error_message="failed to $command unit: $unit"
+                return 1
+            fi
+            return 0
+            ;;
+        "systemd-reload")
+            if ! systemctl daemon-reload; then
+                error_message="failed to reload: $unit"
+                return 1
+            fi
+            return 0
+            ;;
+        "load-unit")
+            if [ "$#" -ne 2 ]; then
+                error_message="missing arguments"
+                return 1
+            fi
+            unit="$2"
+            assert_unit "$unit" || return 1
+            echo "added"
+            cp "$unit_path/$unit" "$systemd_path/$unit"
+            echo "it passes"
+            return 0
+            ;;
+        "remove-unit")
+            if [ "$#" -ne 2 ]; then
+                error_message="missing arguments"
+                return 1
+            fi
+            unit="$2"
+            assert_unit "$unit" || return 1
+            rm "$systemd_path/$unit"
+            echo "removed"
+            return 0
+            ;;
+        *)
+            error_message="not supported command: $command"
+            return 1
+            ;;
+    esac
+}
+# open file descriptors
+# they need to remain open for the lifetime of the script
+# for the updater to be able to communicate with it
+exec 3> "$out_fifo"
+exec 4< "$in_fifo"
+while true; do
+    echo "waiting"
+    if ! read -r command <&4; then
+        # close file descriptors
+        exec 3>&-
+        exec 4<&-
+        exit 0
+    fi
+    echo "read $command"
+
+    # verify command before expanding it in handle_command
+    if assert_command "$command"; then
+        # shellcheck disable=SC2086
+        handle_command $command
+    fi
+
+    result="success"
+    if [ -n "$error_message" ]; then
+       result="error: $error_message"
+    fi
+    echo "sending $result"
+    echo "$result" >&3
+    error_message=""
+done

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -4,7 +4,7 @@
 #
 # .deb: STEP 5 of 5
 
-INSTALL_DIR=/opt/datadog
+INSTALL_DIR=/opt/datadog/updater
 PACKAGES_DIR=/opt/datadog-packages
 LOG_DIR=/var/log/datadog
 PACKAGES_LOCK_DIR=/var/run/datadog-packages
@@ -27,22 +27,6 @@ add_user_and_group() {
         echo "Adding $NAME user to $NAME group"
         usermod -g "$NAME" "$NAME"
     fi
-}
-
-enable_stable_agents() {
-    if command -v systemctl >/dev/null 2>&1; then
-        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
-        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-process || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-sysprobe || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-trace || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-security || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent.path || true
-        # experiment agents are not enabled as we don't systemctl enable them
-        SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-agent-exp.path || true
-    fi
-
-
 }
 
 set -e
@@ -110,16 +94,15 @@ if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
     chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
 fi
 
-$INSTALL_DIR/updater/bin/updater/updater bootstrap -P datadog-agent
+SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-updater-admin.path || true
+SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-updater-admin.path || true
+
+$INSTALL_DIR/bin/updater/updater bootstrap -P datadog-agent
 # Bootstrap installs first agent with root ownership, overriding to dd-agent
 chown -R dd-agent:dd-agent ${PACKAGES_DIR}
 
-# start udpater
+# start updater
 SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-updater || true
 SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-updater || true
-enable_stable_agents
-SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-agent || true
-SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-agent.path || true
-SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-agent-exp.path || true
 
 exit 0

--- a/omnibus/package-scripts/updater-deb/prerm
+++ b/omnibus/package-scripts/updater-deb/prerm
@@ -4,5 +4,7 @@
 # .deb: STEP 1 of 5
 
 SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
+SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater-admin.path || true
 SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-updater || true
+SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-updater-admin.path || true
 exit 0

--- a/omnibus/package-scripts/updater-deb/prerm
+++ b/omnibus/package-scripts/updater-deb/prerm
@@ -3,54 +3,6 @@
 #
 # .deb: STEP 1 of 5
 
-
-stop_agents()
-{
-    if command -v systemctl >/dev/null 2>&1; then
-        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
-
-        # starting with experiment agents to avoid retriggering agent
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process-exp || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-sysprobe-exp || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-trace-exp || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-security-exp || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-exp || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-exp.path || true
-
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-process || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-sysprobe || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-trace || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent-security || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-agent.path || true
-    fi
-}
-
-deregister_agents()
-{
-    if command -v systemctl >/dev/null 2>&1; then
-        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-process || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-sysprobe || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-trace || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-security || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent.path || true
-        # experiment agents are not disabled as we don't systemctl enable them
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-agent-exp.path || true
-    fi
-}
-case "$1" in
-    remove)
-        stop_agents
-        deregister_agents
-    ;;
-    upgrade)
-        SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-updater || true
-    ;;
-    *)
-    ;;
-esac
-
+SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
+SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-updater || true
 exit 0

--- a/pkg/updater/install.go
+++ b/pkg/updater/install.go
@@ -41,7 +41,14 @@ func (i *installer) installStable(pkg string, version string, image oci.Image) e
 	if err != nil {
 		return fmt.Errorf("could not extract package layers: %w", err)
 	}
-	return i.repositories.Create(pkg, version, tmpDir)
+	err = i.repositories.Create(pkg, version, tmpDir)
+	if err != nil {
+		return fmt.Errorf("could not create repository: %w", err)
+	}
+	if pkg == "datadog-agent" {
+		return service.SetupAgentUnits()
+	}
+	return nil
 }
 
 func (i *installer) installExperiment(pkg string, version string, image oci.Image) error {

--- a/pkg/updater/install.go
+++ b/pkg/updater/install.go
@@ -8,22 +8,17 @@ package updater
 import (
 	"fmt"
 	"os"
-	"strconv"
-	"time"
 
 	oci "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 
 	"github.com/DataDog/datadog-agent/pkg/updater/repository"
+	"github.com/DataDog/datadog-agent/pkg/updater/service"
 )
 
 const (
 	datadogPackageLayerMediaType types.MediaType = "application/vnd.datadog.package.layer.v1.tar+zstd"
 	datadogPackageMaxSize                        = 3 << 30 // 3GiB
-
-	updaterSystemdCommandsPath                = "/opt/datadog/updater/systemd_commands"
-	updaterSystemdCommandsStartExperimentPath = updaterSystemdCommandsPath + "/start_experiment"
-	updaterSystemdCommandsStopExperimentPath  = updaterSystemdCommandsPath + "/stop_experiment"
 )
 
 type installer struct {
@@ -90,12 +85,7 @@ func (i *installer) startExperiment(pkg string) error {
 	if pkg != "datadog-agent" {
 		return nil
 	}
-	err := os.MkdirAll(updaterSystemdCommandsPath, 0755)
-	if err != nil {
-		return fmt.Errorf("could not create systemd commands directory: %w", err)
-	}
-	content := []byte(strconv.FormatInt(time.Now().UTC().UnixNano(), 10))
-	return os.WriteFile(updaterSystemdCommandsStartExperimentPath, content, 0644)
+	return service.StartAgentExperiment()
 }
 
 func (i *installer) stopExperiment(pkg string) error {
@@ -103,12 +93,7 @@ func (i *installer) stopExperiment(pkg string) error {
 	if pkg != "datadog-agent" {
 		return nil
 	}
-	err := os.MkdirAll(updaterSystemdCommandsPath, 0755)
-	if err != nil {
-		return fmt.Errorf("could not create systemd commands directory: %w", err)
-	}
-	content := []byte(strconv.FormatInt(time.Now().UTC().UnixNano(), 10))
-	return os.WriteFile(updaterSystemdCommandsStopExperimentPath, content, 0644)
+	return service.StopAgentExperiment()
 }
 
 func extractPackageLayers(image oci.Image, dir string) error {

--- a/pkg/updater/service/datadog_agent.go
+++ b/pkg/updater/service/datadog_agent.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build !windows
-// +build !windows
 
 // Package service provides a way to interact with os services
 package service

--- a/pkg/updater/service/datadog_agent.go
+++ b/pkg/updater/service/datadog_agent.go
@@ -1,0 +1,137 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+// +build !windows
+
+// Package service provides a way to interact with os services
+package service
+
+const (
+	agentUnit         = "datadog-agent.service"
+	traceAgentUnit    = "datadog-agent-trace.service"
+	processAgentUnit  = "datadog-agent-process.service"
+	systemProbeUnit   = "datadog-agent-sysprobe.service"
+	securityAgentUnit = "datadog-agent-security.service"
+	agentExp          = "datadog-agent-exp.service"
+	traceAgentExp     = "datadog-agent-trace-exp.service"
+	processAgentExp   = "datadog-agent-process-exp.service"
+	systemProbeExp    = "datadog-agent-sysprobe-exp.service"
+	securityAgentExp  = "datadog-agent-security-exp.service"
+)
+
+var (
+	stableUnits = []string{
+		agentUnit,
+		traceAgentUnit,
+		processAgentUnit,
+		systemProbeUnit,
+		securityAgentUnit,
+	}
+	experimentalUnits = []string{
+		agentExp,
+		traceAgentExp,
+		processAgentExp,
+		systemProbeExp,
+		securityAgentExp,
+	}
+)
+
+// SetupAgentUnits installs and starts the agent units
+func SetupAgentUnits() error {
+	runner, err := newScriptRunner()
+	if err != nil {
+		return err
+	}
+	defer runner.close()
+	for _, unit := range stableUnits {
+		if err := runner.loadUnit(unit); err != nil {
+			return err
+		}
+	}
+	for _, unit := range experimentalUnits {
+		if err := runner.loadUnit(unit); err != nil {
+			return err
+		}
+	}
+
+	if err = runner.systemdReload(); err != nil {
+		return err
+	}
+
+	for _, unit := range stableUnits {
+		if err := runner.enableUnit(unit); err != nil {
+			return err
+		}
+	}
+	for _, unit := range stableUnits {
+		if err := runner.startUnit(unit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveAgentUnits stops and removes the agent units
+func RemoveAgentUnits() error {
+	runner, err := newScriptRunner()
+	if err != nil {
+		return err
+	}
+	defer runner.close()
+	// stop experiments, they can restart stable agent
+	for _, unit := range experimentalUnits {
+		if err := runner.stopUnit(unit); err != nil {
+			return err
+		}
+	}
+	// stop stable agents
+	for _, unit := range stableUnits {
+		if err := runner.stopUnit(unit); err != nil {
+			return err
+		}
+	}
+	// purge experimental units
+	for _, unit := range experimentalUnits {
+		if err := runner.disableUnit(unit); err != nil {
+			return err
+		}
+		if err := runner.removeUnit(unit); err != nil {
+			return err
+		}
+	}
+	// purge stable units
+	for _, unit := range stableUnits {
+		if err := runner.disableUnit(unit); err != nil {
+			return err
+		}
+		if err := runner.removeUnit(unit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// StartAgentExperiment starts the agent experiment
+func StartAgentExperiment() error {
+	runner, err := newScriptRunner()
+	if err != nil {
+		return err
+	}
+	defer runner.close()
+
+	return runner.startUnit(agentExp)
+}
+
+// StopAgentExperiment stops the agent experiment
+func StopAgentExperiment() error {
+	runner, err := newScriptRunner()
+	if err != nil {
+		return err
+	}
+	defer runner.close()
+
+	return runner.startUnit(agentUnit)
+}

--- a/pkg/updater/service/datadog_agent_windows.go
+++ b/pkg/updater/service/datadog_agent_windows.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
+// Package service provides a way to interact with os services
+package service
+
+// SetupAgentUnits noop
+func SetupAgentUnits() error {
+	return nil
+}
+
+// StartAgentExperiment noop
+func StartAgentExperiment() error {
+	return nil
+}
+
+// StopAgentExperiment noop
+func StopAgentExperiment() error {
+	return nil
+}
+
+// RemoveAgentUnits noop
+func RemoveAgentUnits() error {
+	return nil
+}

--- a/pkg/updater/service/datadog_agent_windows.go
+++ b/pkg/updater/service/datadog_agent_windows.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build windows
-// +build windows
 
 // Package service provides a way to interact with os services
 package service

--- a/pkg/updater/service/systemd.go
+++ b/pkg/updater/service/systemd.go
@@ -1,0 +1,148 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+// +build !windows
+
+// Package service provides a way to interact with os services
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/containerd/fifo"
+)
+
+type unitCommand string
+
+const (
+	startUnit     = unitCommand("start")
+	stopUnit      = unitCommand("stop")
+	enableUnit    = unitCommand("enable")
+	disableUnit   = unitCommand("disable")
+	loadUnit      = unitCommand("load-unit")
+	removeUnit    = unitCommand("remove-systemd")
+	systemdReload = "systemd-reload"
+	adminExecutor = "datadog-updater-admin.service"
+)
+
+var (
+	inFifoPath  = filepath.Join(setup.InstallPath, "run", "in.fifo")
+	outFifoPath = filepath.Join(setup.InstallPath, "run", "out.fifo")
+)
+
+type scriptRunner struct {
+	inFifo  io.ReadWriteCloser
+	outFifo io.ReadWriteCloser
+	timeout time.Duration
+}
+
+func newScriptRunner() (*scriptRunner, error) {
+	_ = os.Remove(inFifoPath)
+	_ = os.Remove(outFifoPath)
+	// start with outFifo creation first as inFifo triggers admin exec systemd path listner
+	outFifo, err := fifo.OpenFifo(context.Background(), outFifoPath, syscall.O_CREAT|syscall.O_RDONLY|syscall.O_NONBLOCK, 0660)
+	if err != nil {
+		return nil, fmt.Errorf("error opening out.fifo: %s", err)
+	}
+	inFifo, err := fifo.OpenFifo(context.Background(), inFifoPath, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_NONBLOCK, 0660)
+	if err != nil {
+		outFifo.Close()
+		return nil, fmt.Errorf("error opening in.fifo: %s", err)
+	}
+	return &scriptRunner{
+		inFifo:  inFifo,
+		outFifo: outFifo,
+		timeout: 10 * time.Second,
+	}, nil
+}
+
+func (s *scriptRunner) stopUnit(unit string) error {
+	return s.executeCommand(wrapUnitCommand(stopUnit, unit))
+}
+
+func (s *scriptRunner) startUnit(unit string) error {
+	return s.executeCommand(wrapUnitCommand(startUnit, unit))
+}
+
+func (s *scriptRunner) enableUnit(unit string) error {
+	return s.executeCommand(wrapUnitCommand(enableUnit, unit))
+}
+
+func (s *scriptRunner) disableUnit(unit string) error {
+	return s.executeCommand(wrapUnitCommand(disableUnit, unit))
+}
+
+func (s *scriptRunner) loadUnit(unit string) error {
+	return s.executeCommand(wrapUnitCommand(loadUnit, unit))
+}
+
+func (s *scriptRunner) removeUnit(unit string) error {
+	return s.executeCommand(wrapUnitCommand(removeUnit, unit))
+}
+
+func (s *scriptRunner) systemdReload() error {
+	return s.executeCommand(string(systemdReload))
+}
+
+func (s *scriptRunner) executeCommand(command string) error {
+	err := wrapWithTimeout(func() error {
+		_, err := s.inFifo.Write([]byte(command + "\n"))
+		return err
+	},
+		s.timeout,
+	)
+	if err != nil {
+		return fmt.Errorf("error executing command %s while writing to fifo: %s", command, err)
+	}
+	res := make([]byte, 1<<6)
+	err = wrapWithTimeout(func() error {
+		n, err := s.outFifo.Read(res)
+		res = res[:n]
+		return err
+	},
+		s.timeout,
+	)
+	if err != nil {
+		return fmt.Errorf("error executing command %s while reading from fifo: %s", command, err)
+	}
+	result := strings.TrimRight(string(res), "\n")
+	if result != "success" {
+		return fmt.Errorf("error executing command %s: %s", command, result)
+	}
+	return nil
+}
+
+func (s *scriptRunner) close() {
+	s.inFifo.Close()
+	_ = os.Remove(inFifoPath)
+	s.outFifo.Close()
+	_ = os.Remove(outFifoPath)
+}
+
+func wrapUnitCommand(command unitCommand, unit string) string {
+	return string(command) + " " + unit
+}
+
+func wrapWithTimeout(fn func() error, timeout time.Duration) error {
+	err := make(chan error, 1)
+	go func() {
+		err <- fn()
+	}()
+	select {
+	case <-time.After(timeout):
+		return fmt.Errorf("timeout")
+	case e := <-err:
+		return e
+	}
+}

--- a/pkg/updater/service/systemd.go
+++ b/pkg/updater/service/systemd.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build !windows
-// +build !windows
 
 // Package service provides a way to interact with os services
 package service
@@ -92,7 +91,7 @@ func (s *scriptRunner) removeUnit(unit string) error {
 }
 
 func (s *scriptRunner) systemdReload() error {
-	return s.executeCommand(string(systemdReload))
+	return s.executeCommand(systemdReload)
 }
 
 func (s *scriptRunner) executeCommand(command string) error {

--- a/pkg/updater/service/systemd_test.go
+++ b/pkg/updater/service/systemd_test.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+// +build !windows
+
+package service
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setTestFifoPaths(testName string) {
+	updaterTestID := time.Now().UnixNano()
+	inFifoPath = fmt.Sprintf("/tmp/updater_%s_%v_in.fifo", testName, updaterTestID)
+	outFifoPath = fmt.Sprintf("/tmp/updater_%s_%v_out.fifo", testName, updaterTestID)
+}
+
+func TestScriptRunnerBootAndCleanup(t *testing.T) {
+	setTestFifoPaths("boot_clean")
+
+	// installing fake fifo files to assert cleanup at newScriptRunner
+	f, err := os.Create(inFifoPath)
+	assert.Nil(t, err)
+	assert.Nil(t, f.Close())
+	f, err = os.Create(outFifoPath)
+	assert.Nil(t, err)
+	assert.Nil(t, f.Close())
+
+	s, err := newScriptRunner()
+	assert.Nil(t, err)
+	require.NotNil(t, s)
+	defer s.close()
+
+	fileInfo, err := os.Stat(inFifoPath)
+	assert.Equal(t, fileInfo.Mode()&os.ModeNamedPipe, os.ModeNamedPipe)
+	assert.Nil(t, err)
+
+	fileInfo, err = os.Stat(outFifoPath)
+	assert.Equal(t, fileInfo.Mode()&os.ModeNamedPipe, os.ModeNamedPipe)
+	assert.Nil(t, err)
+
+	s.close()
+	_, err = os.Stat(inFifoPath)
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(outFifoPath)
+	assert.True(t, os.IsNotExist(err))
+}

--- a/pkg/updater/service/systemd_test.go
+++ b/pkg/updater/service/systemd_test.go
@@ -23,7 +23,7 @@ import (
 
 const updaterTestPath = "/tmp/updater_tests"
 
-func setTestFifoPaths() {
+func init() {
 	inFifoPath = updaterTestPath + "/run/in.fifo"
 	outFifoPath = updaterTestPath + "/run/out.fifo"
 }
@@ -45,7 +45,6 @@ func runAdmin(t *testing.T) <-chan int {
 }
 
 func TestScriptRunnerBootAndCleanup(t *testing.T) {
-	setTestFifoPaths()
 
 	// installing fake fifo files to assert cleanup at newScriptRunner
 	f, err := os.Create(inFifoPath)
@@ -75,8 +74,7 @@ func TestScriptRunnerBootAndCleanup(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
-func TestCommands(t *testing.T) {
-	setTestFifoPaths()
+func TestInvalidCommands(t *testing.T) {
 	s, err := newScriptRunner()
 	assert.Nil(t, err)
 	require.NotNil(t, s)

--- a/pkg/updater/service/systemd_test.go
+++ b/pkg/updater/service/systemd_test.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build !windows
-// +build !windows
 
 package service
 

--- a/pkg/updater/service/systemd_test.go
+++ b/pkg/updater/service/systemd_test.go
@@ -9,7 +9,6 @@ package service
 
 import (
 	_ "embed"
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -33,7 +32,6 @@ func runAdmin(t *testing.T, updaterTestPath string) <-chan int {
 	assert.Nil(t, err)
 	runScript := strings.Replace(string(template), "<%= install_dir %>", updaterTestPath, -1)
 
-	fmt.Println(inFifoPath)
 	done := make(chan int)
 	go func() {
 		cmd := exec.Command("/bin/sh", "-c", string(runScript))
@@ -58,7 +56,6 @@ func TestScriptRunnerBootAndCleanup(t *testing.T) {
 	s, err := newScriptRunner()
 	assert.Nil(t, err)
 	require.NotNil(t, s)
-	defer s.close()
 
 	fileInfo, err := os.Stat(inFifoPath)
 	assert.Equal(t, fileInfo.Mode()&os.ModeNamedPipe, os.ModeNamedPipe)
@@ -80,7 +77,6 @@ func TestInvalidCommands(t *testing.T) {
 	s, err := newScriptRunner()
 	assert.Nil(t, err)
 	require.NotNil(t, s)
-	defer s.close()
 
 	done := runAdmin(t, updaterPath)
 

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -21,7 +21,6 @@ import (
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	updaterErrors "github.com/DataDog/datadog-agent/pkg/updater/errors"
 	"github.com/DataDog/datadog-agent/pkg/updater/repository"
-	"github.com/DataDog/datadog-agent/pkg/updater/service"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/google/uuid"
@@ -215,10 +214,6 @@ func (u *updaterImpl) boostrapPackage(ctx context.Context, stablePackage Package
 	err = u.installer.installStable(stablePackage.Name, stablePackage.Version, image)
 	if err != nil {
 		return fmt.Errorf("could not install: %w", err)
-	}
-	err = service.SetupAgentUnits()
-	if err != nil {
-		return fmt.Errorf("could not setup agent units: %w", err)
 	}
 	log.Infof("Updater: Successfully installed default version %s of package %s", stablePackage.Version, stablePackage.Name)
 	return nil

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -21,6 +21,7 @@ import (
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	updaterErrors "github.com/DataDog/datadog-agent/pkg/updater/errors"
 	"github.com/DataDog/datadog-agent/pkg/updater/repository"
+	"github.com/DataDog/datadog-agent/pkg/updater/service"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/google/uuid"
@@ -209,11 +210,15 @@ func (u *updaterImpl) boostrapPackage(ctx context.Context, stablePackage Package
 	defer os.RemoveAll(tmpDir)
 	image, err := u.downloader.Download(ctx, tmpDir, stablePackage)
 	if err != nil {
-		return fmt.Errorf("could not download experiment: %w", err)
+		return fmt.Errorf("could not download: %w", err)
 	}
 	err = u.installer.installStable(stablePackage.Name, stablePackage.Version, image)
 	if err != nil {
-		return fmt.Errorf("could not install experiment: %w", err)
+		return fmt.Errorf("could not install: %w", err)
+	}
+	_ = service.SetupAgentUnits()
+	if err != nil {
+		return fmt.Errorf("could not setup agent units: %w", err)
 	}
 	log.Infof("Updater: Successfully installed default version %s of package %s", stablePackage.Version, stablePackage.Name)
 	return nil

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -216,7 +216,7 @@ func (u *updaterImpl) boostrapPackage(ctx context.Context, stablePackage Package
 	if err != nil {
 		return fmt.Errorf("could not install: %w", err)
 	}
-	_ = service.SetupAgentUnits()
+	err = service.SetupAgentUnits()
 	if err != nil {
 		return fmt.Errorf("could not setup agent units: %w", err)
 	}

--- a/test/new-e2e/tests/updater/linux_test.go
+++ b/test/new-e2e/tests/updater/linux_test.go
@@ -41,7 +41,6 @@ func (v *vmUpdaterSuite) TestUpdaterOwnership() {
 }
 
 func (v *vmUpdaterSuite) TestUpdaterAdmin() {
-	adminUnit := "datadog-updater-admin.service"
 	adminPathUnit := "datadog-updater-admin.path"
 	inFifoPath := "/opt/datadog/updater/run/in.fifo"
 	outFifoPath := "/opt/datadog/updater/run/out.fifo"

--- a/test/new-e2e/tests/updater/linux_test.go
+++ b/test/new-e2e/tests/updater/linux_test.go
@@ -6,6 +6,7 @@
 package updater
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -37,4 +38,60 @@ func (v *vmUpdaterSuite) TestUpdaterOwnership() {
 	require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(`stat -c "%G" /opt/datadog/updater`))
 	// permissions
 	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" /opt/datadog/updater`))
+}
+
+func (v *vmUpdaterSuite) TestUpdaterAdmin() {
+	adminUnit := "datadog-updater-admin.service"
+	adminPathUnit := "datadog-updater-admin.path"
+	require.Equal(v.T(), "enabled\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`systemctl is-enabled %s`, adminPathUnit)))
+	require.Equal(v.T(), "active\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`systemctl is-active %s`, adminPathUnit)))
+
+	/*
+		temporary while fixing locally, review can start without
+			// admin should activate on fifo creation
+			v.Env().RemoteHost.MustExecute("sudo mkfifo /opt/datadog/updater/run/out.fifo && sudo mkfifo /opt/datadog/updater/run/in.fifo")
+			v.Env().RemoteHost.MustExecute("sudo chmod 0666 /opt/datadog/updater/run/out.fifo && sudo chmod 0666 /opt/datadog/updater/run/in.fifo")
+
+			// assert failures
+			expectedResults := map[string]string{
+				"&":                                      "invalid command: &",
+				";":                                      "invalid command: ;",
+				"start datadog agent /":                  "invalid command: start datadog agent /",
+				"start datadog agent *":                  "invalid command: start datadog agent *",
+				string(make([]byte, 101)):                "command longer than 100 characters",
+				"not-supported":                          "not supported command: not-supported",
+				"start":                                  "missing argument",
+				"enable":                                 "missing argument",
+				"disable":                                "missing argument",
+				"stop":                                   "missing argument",
+				"load-unit":                              "missing argument",
+				"remove-unit":                            "missing argument",
+				"start non-datadog-unit.service *":       "unit name must start with 'datadog'",
+				"enable non-datadog-unit.service *":      "unit name must start with 'datadog'",
+				"disable non-datadog-unit.service *":     "unit name must start with 'datadog'",
+				"stop non-datadog-unit.service *":        "unit name must start with 'datadog'",
+				"load-unit non-datadog-unit.service *":   "unit name must start with 'datadog'",
+				"remove-unit non-datadog-unit.service *": "unit name must start with 'datadog'",
+			}
+			for cmd, expected := range expectedResults {
+				v.Env().RemoteHost.MustExecute(fmt.Sprintf(`echo %s > /opt/datadog/updater/run/in.fifo`, cmd))
+				require.Equal(v.T(), v.Env().RemoteHost.MustExecute(`< /opt/datadog/updater/run/out.fifo`), expected)
+			}
+
+			v.Env().RemoteHost.MustExecute("rm /opt/datadog/updater/run/in.fifo")
+			time.Sleep(5 * time.Second)
+	*/
+}
+
+func (v *vmUpdaterSuite) TestAgentUnitsLoaded() {
+	stableUnits := []string{
+		"datadog-agent.service",
+		"datadog-agent-trace.service",
+		"datadog-agent-process.service",
+		"datadog-agent-sysprobe.service",
+		"datadog-agent-security.service",
+	}
+	for _, unit := range stableUnits {
+		require.Equal(v.T(), "enabled\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`systemctl is-enabled %s`, unit)))
+	}
 }

--- a/test/new-e2e/tests/updater/linux_test.go
+++ b/test/new-e2e/tests/updater/linux_test.go
@@ -41,7 +41,6 @@ func (v *vmUpdaterSuite) TestUpdaterOwnership() {
 }
 
 func (v *vmUpdaterSuite) TestUpdaterAdmin() {
-	adminUnit := "datadog-updater-admin.service"
 	adminPathUnit := "datadog-updater-admin.path"
 	require.Equal(v.T(), "enabled\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`systemctl is-enabled %s`, adminPathUnit)))
 	require.Equal(v.T(), "active\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`systemctl is-active %s`, adminPathUnit)))

--- a/test/new-e2e/tests/updater/linux_test.go
+++ b/test/new-e2e/tests/updater/linux_test.go
@@ -56,7 +56,7 @@ func (v *vmUpdaterSuite) TestUpdaterAdmin() {
 
 	// assert failures
 	expectedResults := map[string]string{
-		"&": "error: invalid command: &",
+		"&": "invalid command: &",
 	}
 	for cmd, expected := range expectedResults {
 		go func() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Allows the updater to install a first package (datadog-agent) without relying on apt install script. Root commands such as loading systemd units, enabling them or starting are needed.
For that a new root service `datadog-updater-admin.service.erb` triggered on writes to a fifo executes restricted commands synchronously for the updater.

To avoid deadlocks between both processes, the updater starts a fresh exec_admin by deleting previous fifos, trigger sigkill on exec_admin, create new fifos, wait for an exec_admin to connect and answer for 10s.

```
     +----------------+      +-----------------------+      +---------------------+
     |                |      |                       |      |                     |
     |  Updater Boot  |      |   Writes Command to   |      |  Path Listener      |
     |  New Package   +----->+       in.fifo         +----->+  Starts Exec_Admin  |
     |                |      |                       |      |  (Root User)        |
     +-------+--------+      +-----------+-----------+      +----------+----------+
             ^                          |                           |
             |                          |                           |
             |                          |                           |
             |                          |                           |
             |                          |                           |
          out.fifo                   in.fifo                        |
             |                          |                           |
             |                          |                           |
             |                +---------v---------+                 |
             |                |                   |                 |
             +-----------------  Exec_Admin       <-----------------+
                              |   Executes and    |
                              |   Responds in     |
                              |   out.fifo        |
                              |                   |
                              +-------------------+

```




### Follow-ups

1. Purge command added + called in updater uninstall script
2. Updater installs and updates itself with this pattern
3. move back to dd-updater user to restrict usage of the admin exec

