### PR TITLE
ebpf: printk patcher: Skip http2 program

### DIFF
--- a/pkg/ebpf/printk_patcher.go
+++ b/pkg/ebpf/printk_patcher.go
@@ -9,6 +9,7 @@ package ebpf
 
 import (
 	"errors"
+	"strings"
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
@@ -43,6 +44,10 @@ func patchPrintkNewline(m *manager.Manager) error {
 	var errs []error
 
 	for _, p := range progs {
+		// Temporary workaround to avoid patching http2 programs.
+		if strings.Contains(p.Name, "http2") {
+			continue
+		}
 		_, err := patchPrintkInstructions(p)
 		errs = append(errs, err)
 	}


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Skipping patching http2 programs as it generate errors while adding bpf_printk calls
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Apply the following diff:
```diff
diff --git a/pkg/network/ebpf/c/protocols/http2/decoding.h b/pkg/network/ebpf/c/protocols/http2/decoding.h
index 648beebda4..f13cb24b95 100644
--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -595,6 +595,7 @@ static __always_inline bool find_relevant_frames(struct __sk_buff *skb, skb_info
 
 SEC("socket/http2_handle_first_frame")
 int socket__http2_handle_first_frame(struct __sk_buff *skb) {
+    bpf_printk("test");
     const __u32 zero = 0;
     http2_frame_t current_frame = {};
```

enable http2 monitoring and run the agent

verify the following line does not appear

```
usm initialization failed: could not initialize USM: error initializing ebpf program: co-re load failed: Could not find stack offset instruction for bpf_trace_printk call 3 in socket__http2_handle_first_frame
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
