### PR TITLE
Migrate documentation for the component framework

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -199,6 +199,11 @@
 /docs/dev/checks/                       @DataDog/documentation @DataDog/agent-metrics-logs
 /docs/cloud-workload-security/          @DataDog/documentation @DataDog/agent-security
 
+/docs/public/                                                @DataDog/agent-platform
+/docs/public/architecture/components/                        @DataDog/agent-shared-components
+/docs/public/guidelines/components/                          @DataDog/agent-shared-components
+/docs/public/how-to/components/                              @DataDog/agent-shared-components
+
 /google-marketplace/                    @DataDog/container-ecosystems
 
 # These files are owned by all teams, but assigning them to @DataDog/agent-all causes a lot of spam

--- a/docs/public/.snippets/links.txt
+++ b/docs/public/.snippets/links.txt
@@ -1,1 +1,2 @@
+[agent-components-listing]: https://github.com/DataDog/datadog-agent/blob/main/comp/README.md
 [agent-troubleshooting]: https://docs.datadoghq.com/agent/troubleshooting/

--- a/docs/public/architecture/components/fx.md
+++ b/docs/public/architecture/components/fx.md
@@ -1,0 +1,194 @@
+# Overview of Fx
+
+The Agent uses [Fx](https://uber-go.github.io/fx) as its application framework. While the linked Fx documentation is thorough, it can be a bit difficult to get started with. This document describes how Fx is used within the Agent in a more approachable style.
+
+## What Is It?
+
+Fx's core functionality is to create instances of required types "automatically," also known as [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection). Within the agent, these instances are components, so Fx connects components to one another. Fx creates a single instance of each component, on demand.
+
+This means that each component declares a few things about itself to Fx, including the other components it depends on. An "app" then declares the components it contains to Fx, and instructs Fx to start up the whole assembly.
+
+## Providing and Requiring
+
+Fx connects components using types. Within the Agent, these are typically interfaces named `Component`. For example, `scrubber.Component` might be an interface defining functionality for scrubbing passwords from data structures:
+
+=== ":octicons-file-code-16: scrubber/component.go"
+    ```go
+    type Component interface {
+        ScrubString(string) string
+    }
+    ```
+
+Fx needs to know how to *provide* an instance of this type when needed, and there are a few ways:
+
+* [`fx.Provide(NewScrubber)`](https://pkg.go.dev/go.uber.org/fx#Provide) where `NewScrubber` is a constructor that returns a `scrubber.Component`. This indicates that if and when a `scrubber.Component` is required, Fx should call `NewScrubber`. It will call `NewScrubber` only once, using the same value everywhere it is required.
+* [`fx.Supply(scrubber)`](https://pkg.go.dev/go.uber.org/fx#Supply) where `scrubber` implements the `scrubber.Component` interface. When another component requires a `scrubber.Component`, this is the instance it will get.
+
+The first form is much more common, as most components have constructors that do interesting things at runtime. A constructor can return multiple arguments, in which case the constructor is called if _any_ of those argument types are required. Constructors can also return `error` as the final return type. Fx will treat an error as fatal to app startup.
+
+Fx also needs to know when an instance is *required*, and this is where the magic happens. In specific circumstances, it uses reflection to examine the argument list of functions, and creates instances of each argument's type. Those circumstances are:
+
+* Constructors used with `fx.Provide`. Imagine `NewScrubber` depends on the config module to configure secret matchers:
+      ```go
+      func NewScrubber(config config.Component) Component {
+          return &scrubber{
+              matchers: makeMatchersFromConfig(config),
+          }
+      }
+      ```
+* Functions passed to [`fx.Invoke`](https://pkg.go.dev/go.uber.org/fx#Invoke):
+    ```go
+    fx.Invoke(func(sc scrubber.Component) {
+        fmt.Printf("scrubbed: %s", sc.ScrubString(somevalue))
+    })
+    ```
+    Like constructors, Invoked functions can take multiple arguments, and can optionally return an error. Invoked functions are called automatically when an app is created.
+* Pointers passed to [`fx.Populate`](https://pkg.go.dev/go.uber.org/fx#Populate).
+   ```go
+   var sc scrubber.Component
+   // ...
+   fx.Populate(&sc)
+   ```
+   Populate is useful in tests to fill an existing variable with a provided value. It's equivalent to `fx.Invoke(func(tmp scrubber.Component) { *sc = tmp })`.
+
+    Functions can take multple arguments of different types, requiring all of them.
+
+## Apps and Options
+
+You may have noticed that all of the `fx` methods defined so far return an `fx.Option`. They don't actually do anything on their own. Instead, Fx uses the [functional options pattern](https://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html) from Rob Pike. The idea is that a function takes a variable number of options, each of which has a different effect on the result.
+
+In Fx's case, the function taking the options is [`fx.New`](https://pkg.go.dev/go.uber.org/fx#New), which creates a new [`fx.App`](https://pkg.go.dev/go.uber.org/fx#New). It's within the context of an app that requirements are met, constructors are called, and so on.
+
+Tying the example above together, a very simple app might look like this:
+
+```go
+someValue = "my password is hunter2"
+app := fx.New(
+    fx.Provide(scrubber.NewScrubber),
+    fx.Invoke(func(sc scrubber.Component) {
+        fmt.Printf("scrubbed: %s", sc.ScrubString(somevalue))
+    }))
+app.Run()
+// Output: scrubbed: my password is *******
+```
+
+For anything more complex, it's not practical to call `fx.Provide` for every component in a single source file. Fx has two abstraction mechanisms that allow combining lots of options into one app:
+
+* [`fx.Options`](https://pkg.go.dev/go.uber.org/fx#Options) simply bundles several Option values into a single Option that can be placed in a variable. As the example in the Fx documentation shows, this is useful to gather the options related to a single Go package, which might include un-exported items, into a single value typically named `Module`.
+* [`fx.Module`](https://pkg.go.dev/go.uber.org/fx#Module) is very similar, with two additional features. First, it requires a module name which is used in some Fx logging and can help with debugging. Second, it creates a scope for the effects of [`fx.Decorate`](https://pkg.go.dev/go.uber.org/fx#Decorate) and [`fx.Replace`](https://pkg.go.dev/go.uber.org/fx#Replace). The second feature is not used in the Agent.
+
+So a slightly more complex version of the example might be:
+
+=== ":octicons-file-code-16: scrubber/component.go"
+    ```go
+    func Module() fxutil.Module {
+        return fx.Module("scrubber",
+        fx.Provide(newScrubber))    // now newScrubber need not be exported
+    }
+    ```
+
+=== ":octicons-file-code-16: main.go"
+    ```go
+    someValue = "my password is hunter2"
+    app := fx.New(
+        scrubber.Module(),
+        fx.Invoke(func(sc scrubber.Component) {
+            fmt.Printf("scrubbed: %s", sc.ScrubString(somevalue))
+        }))
+    app.Run()
+    // Output: scrubbed: my password is *******
+    ```
+
+## Lifecycle
+
+Fx provides an [`fx.Lifecycle`](https://pkg.go.dev/go.uber.org/fx#Lifecycle) component that allows hooking into application start-up and shut-down. Use it in your component's constructor like this:
+
+```go
+func newScrubber(lc fx.Lifecycle) Component {
+    sc := &scrubber{..}
+    lc.Append(fx.Hook{OnStart: sc.start, OnStop: sc.stop})
+    return sc
+}
+
+func (sc *scrubber) start(ctx context.Context) error { .. }
+func (sc *scrubber) stop(ctx context.Context) error { .. }
+```
+
+This separates the application's lifecycle into a few distinct phases:
+
+* Initialization - calling constructors to satisfy requirements, and calling invoked functions that require them.
+* Startup - calling components' OnStart hooks (in the same order the components were initialized)
+* Runtime - steady state
+* Shutdown - calling components' OnStop hooks (reverse of the startup order)
+
+## Ins and Outs
+
+Fx provides some convenience types to help build constructors that require or provide lots of types: [`fx.In`](https://pkg.go.dev/go.uber.org/fx#In) and [`fx.Out`](https://pkg.go.dev/go.uber.org/fx#Out). Both types are embedded in structs, which can then be used as argument and return types for constructors, respectively. By convention, these are named `dependencies` and `provides` in Agent code:
+
+```go
+type dependencies struct {
+    fx.In
+
+    Config config.Component
+    Log log.Component
+    Status status.Component
+)
+
+type provides struct {
+    fx.Out
+
+    Component
+    // ... (we'll see why this is useful below)
+}
+
+func newScrubber(deps dependencies) (provides, error) { // can return an fx.Out struct and other types, such as error
+    // ..
+    return provides {
+        Component: scrubber,
+        // ..
+    }, nil
+}
+```
+
+In and Out provide a nice way to summarize and document requirements and provided types, and also allow annotations via Go struct tags. Note that annotations are also possible with [`fx.Annotate`](https://pkg.go.dev/go.uber.org/fx#Annotate), but it is much less readable and its use is discouraged.
+
+### Value Groups
+
+[Value groups](https://pkg.go.dev/go.uber.org/fx#hdr-Value_Groups) make it easier to produce and consume many values of the same type. A component can add any type into groups which can be consumed by other components.
+
+For example:
+
+Here, two components add a `server.Endpoint` type to the `server` group (note the `group` label in the `fx.Out` struct).
+
+=== ":octicons-file-code-16: todolist/todolist.go"
+    ```go
+    type provides struct {
+        fx.Out
+        Component
+        Endpoint server.Endpoint `group:"server"`
+    }
+    ```
+
+=== ":octicons-file-code-16: users/users.go"
+    ```go
+    type provides struct {
+        fx.Out
+        Component
+        Endpoint server.Endpoint `group:"server"`
+    }
+    ```
+
+Here, a component requests all the types added to the `server` group. This takes the form of a slice received at
+instantiation (note once again the `group` label but in `fx.In` struct).
+
+=== ":octicons-file-code-16: server/server.go"
+    ```go
+    type dependencies struct {
+        fx.In
+        Endpoints []Endpoint `group:"server"`
+    }
+    ```
+
+# Day-to-Day Usage
+
+Day-to-day, the Agent's use of Fx is fairly formulaic. Following the [component guidelines](../../guidelines/components/purpose.md), or just copying from other components, should be enough to make things work without a deep understanding of Fx's functionality.

--- a/docs/public/architecture/components/overview.md
+++ b/docs/public/architecture/components/overview.md
@@ -1,0 +1,50 @@
+# Overview of Components
+
+The Agent is structured as a collection of components working together. Depending on how the binary is built, and how it is invoked, different components may be instantiated. The behavior of the components depends on the Agent configuration.
+
+Components are structured in a dependency graph. For example, the `comp/logs/agent` component depends on the `comp/core/config` component to access Agent configuration. At startup, a few top-level components are requested, and [Fx](fx.md) automatically instantiates all of the required components.
+
+## What is a Component?
+
+Any well-defined portion of the codebase, with a clearly documented API surface, _can_ be a component. As an aid to thinking about this question, consider four "levels" where it might apply:
+
+1. Meta: large-scale parts of the Agent that use many other components. Example: DogStatsD or Logs-Agent.
+2. Service: something that can be used at several locations (for example by different applications). Example: Forwarder.
+3. Internal: something that is used to implement a service or meta component, but doesn't make sense outside the component. Examples: DogStatsD's TimeSampler, or a workloadmeta Listener.
+4. Implementation: a type that is used to implement internal components. Example: Forwarder's DiskUsageLimit.
+
+In general, meta and service-level functionality should always be implemented as components. Implementation-level functionality should not. Internal functionality is left to the descretion of the implementing team: it's fine for a meta or service component to be implemented as one large, complex component, if that makes the most sense for the team.
+
+## Bundles
+
+There is a large and growing number of components, and listing those components out repeatedly could grow tiresome and cause bugs. Component bundles provide a way to manipulate multiple components, usually at the meta or service level, as a single unit. For example, while Logs-Agent is internally composed of many components, those can be addressed as a unit with `comp/logs.Bundle`.
+
+Bundles also provide a way to provide parameters to components at instantiation. Parameters can control the behavior of components within a bundle at a coarse scale, such as whether the logs-agent should start or not.
+
+## Apps and Binaries
+
+The build infrastructure builds several agent binaries from the agent source. Some are purpose-specific, such as the serverless agent or dogstatsd, while others such as the core agent support many kinds of functionality. Each build is made from a subset of the same universe of components. For example, the components comprising the DogStatsD build are precisely the same components implementing the DogStatsD functionality in the core agent.
+
+Most binaries support subcommands, such as `agent run` or `agent status`. Each of these also uses a subset of the components available in the binary, and perhaps some different bundle parameters. For example, `agent status` does not need the logs-agent bundle (`comp/logs.Bundle`), and does not need to start core-bundle services like component health monitoring.
+
+These subcommands are implemented as Fx _apps_. An app specifies, the set of components that can be instantiated, their parameters, and the top-level components that should be requested.
+
+There are utility functions available in `pkg/util/fxutil` to eliminate some common boilerplate in creating and running apps.
+
+### Build-Time and Runtime Dependencies
+
+Let's consider sets and subsets of components. Each of the following sets is a subset of the previous set:
+
+1. All implemented components (everything in [this document][agent-components-listing])
+1. All components in a binary (everything directly or indirectly referenced by a binary's `main()`) -- the _build-time dependencies_
+1. All components available in an app (everything provided by a bundle in the app's `fx.New` call)
+1. All components instantiated in an app (all explicitly required components and their transitive dependencies) -- the _runtime dependencies_
+1. All components started in an app (all instantiated components, except those disabled by their parameters)
+
+The build-time dependencies determine the binary size. For example, omitting container-related components from a binary dramatically reduces binary size by not requiring kubernetes and docker API libraries.
+
+The runtime dependencies determine, in part, the process memory consumption. This is a small effect because many components will use only a few Kb if they are not actually doing any work. For example, if the trace-agent's trace-writer component is instantiated, but writes no traces, the peformance impact is trivial.
+
+The started components determine CPU usage and consumption of other resources. A component polling a data source unnecessarily is wasteful of CPU resources. But perhaps more critically for correct behavior, a component started when it is not needed may open network ports or engage other resources unnecessarily. For example, `agent status` should not open a listening port for DogStatsD traffic.
+
+It's important to note that the size of the third set in the list above, "all components available", has no performance effect. As long as the components would be included in the binary anyway, it does no harm to make them available in the app.

--- a/docs/public/guidelines/components/defining-apps.md
+++ b/docs/public/guidelines/components/defining-apps.md
@@ -1,0 +1,194 @@
+# Defining Apps and Binaries
+
+## Binaries
+
+Each binary is defined as a `main` package in the `cmd/` directory, such as `cmd/iot-agent`. This top-level package contains _only_ a simple `main` function (or often, one for Windows and one for *nix) which performs any platform-specific initialization and then creates and executes a Cobra command.
+
+### Binary Size
+
+Consider carefully the tree of Go imports that begins with the `main` package. While the Go linker does some removal of unused symbols, the safest means to ensure a particular package isn't occuping space in the resulting binary is to not include it.
+
+### Simple Binaries
+
+A "simple binary" here is one that does not have subcommands.
+
+The Cobra configuration for the binary is contained in the `command` subpackage of the main package (`cmd/<binary>/command`). The `main` function calls this package to create the command, and then executes it:
+
+=== ":octicons-file-code-16: cmd/&lt;binary&gt;/main.go"
+    ```go
+    func main() {
+        if err := command.MakeCommand().Execute(); err != nil {
+            os.Exit(-1)
+        }
+    }
+    ```
+
+The `command.MakeCommand` function creates the `*cobra.Command` for the binary, with a `RunE` field that defines an app, as described below.
+
+### Binaries With Subcommands
+
+Many binaries have a collection of subcommands, along with some command-line flags defined at the binary level. For example, the `agent` binary has subcommands like `agent flare` or `agent diagnose` and accepts global `--cfgfile` and `--no-color` arguments.
+
+As with simple binaries, the top-level Cobra command is defined by a `MakeCommand` function in `cmd/<binary>/command`. This `command` package should also define a `GlobalParams` struct and a `SubcommandFactory` type:
+
+=== ":octicons-file-code-16: cmd/&lt;binary&gt;/command/command.go"
+    ```go
+    // GlobalParams contains the values of agent-global Cobra flags.
+    //
+    // A pointer to this type is passed to SubcommandFactory's, but its contents
+    // are not valid until Cobra calls the subcommand's Run or RunE function.
+    type GlobalParams struct {
+        // ConfFilePath holds the path to the folder containing the configuration
+        // file, to allow overrides from the command line
+        ConfFilePath string
+
+        // ...
+    }
+
+    // SubcommandFactory is a callable that will return a slice of subcommands.
+    type SubcommandFactory func(globalParams *GlobalParams) []*cobra.Command
+    ```
+
+Each subcommand is implemented in a subpackage of `cmd/<binary>/subcommands`, such as `cmd/<binary>/subcommands/version`. Each such subpackage contains a `command.go` defining a `Commands` function that defines the subcommands for that package:
+
+=== ":octicons-file-code-16: cmd/&lt;binary&gt;/subcommands/&lt;command&gt;/command.go"
+    ```go
+    func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+        cmd := &cobra.Command { .. }
+        return []*cobra.Command{cmd}
+    }
+    ```
+
+While `Commands` typically returns only one command, it may make sense to return multiple commands when the implementations share substantial amounts of code, such as starting, stopping and restarting a service.
+
+The `main` function supplies a slice of subcommand factories to `command.MakeCommand`, which calls each one and adds the resulting subcommands to the root command.
+
+=== ":octicons-file-code-16: cmd/&lt;binary&gt;/main.go"
+    ```go
+    subcommandFactories := []command.SubcommandFactory{
+        frobnicate.Commands,
+        ...,
+    }
+    if err := command.MakeCommand(subcommandFactories).Execute(); err != nil {
+        os.Exit(-1)
+    }
+    ```
+
+The `GlobalParams` type supports Cobra arguments that are global to all subcommands. It is passed to each subcommand factory so that the defined `RunE` callbacks can access these arguments. If the binary has no global command-line arguments, it's OK to omit this type.
+
+```go
+func MakeCommand(subcommandFactories []SubcommandFactory) *cobra.Command {
+	globalParams := GlobalParams{}
+
+	cmd := &cobra.Command{ ... }
+	cmd.PersistentFlags().StringVarP(
+        &globalParams.ConfFilePath, "cfgpath", "c", "",
+        "path to directory containing datadog.yaml")
+
+	for _, sf := range subcommandFactories {
+		subcommands := sf(&globalParams)
+		for _, cmd := range subcommands {
+			agentCmd.AddCommand(cmd)
+		}
+	}
+
+	return cmd
+}
+```
+
+If the available subcommands depend on build flags, move the creation of the subcommand factories to the
+`subcommands/<command>` package and create the slice there using source files with `//go:build` directives. Your
+factory can return `nil` if your command is not compatible with the current build flag. In all cases, the subcommands
+build logic should be constrained to its package. See `cmd/agent/subcommands/jmx/command_nojmx.go` for an example.
+
+## Apps
+
+Apps map directly to `fx.App` instances, and as such they define a set of provided components and instantiate some of them.
+
+The `fx.App` is always created _after_ Cobra has parsed the command-line, within a [`cobra.Command#RunE` function](https://pkg.go.dev/github.com/spf13/cobra#Command). This means that the components supplied to an app, and any BundleParams values, are specific to the invoked command or subcommand.
+
+### One-Shot Apps
+
+A one-shot app is one which performs some task and exits, such as `agent status`. The `pkg/util/fxutil.OneShot` helper function provides a convenient shorthand to run a function only after all components have started. Use it like this:
+
+```go
+cmd := cobra.Command{
+    Use: "foo", ...,
+    RunE: func(cmd *cobra.Command, args []string) error {
+        return fxutil.OneShot(run,
+            fx.Supply(core.BundleParams{}),
+            core.Bundle(),
+            ..., // any other bundles needed for this app
+        )
+    },
+}
+
+func run(log log.Component) error {
+    log.Debug("foo invoked!")
+    ...
+}
+```
+
+The `run` function typically also needs some command-line values. To support this, create a (sub)command-specific `cliParams` type containing the required values, and embedding a pointer to GlobalParams:
+
+```go
+type cliParams struct {
+    *command.GlobalParams
+    useTLS bool
+    args []string
+}
+```
+
+Populate this type within `Commands`, supply it as an Fx value, and require that value in the `run` function:
+
+```go
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+    cliParams := &cliParams{
+        GlobalParams: globalParams,
+    }
+    var useTLS bool
+    cmd := cobra.Command{
+        Use: "foo", ...,
+        RunE: func(cmd *cobra.Command, args []string) error {
+            cliParams.args = args
+            return fxutil.OneShot(run,
+                fx.Supply(cliParams),
+                fx.Supply(core.CreateaBundleParams()),
+                core.Bundle(),
+                ..., // any other bundles needed for this app
+            )
+        },
+    }
+	cmd.PersistentFlags().BoolVarP(&cliParams.useTLS, "usetls", "", "", "force TLS use")
+
+    return []*cobra.Command{cmd}
+}
+
+func run(cliParams *cliParams, log log.Component) error {
+    if (cliParams.Verbose) {
+        log.Info("executing foo")
+    }
+    ...
+}
+```
+
+This example includes cli params drawn from GlobalParams (`Verbose`), from subcommand-specific args (`useTLS`), and from Cobra (`args`).
+
+### Daemon Apps
+
+A daemon app is one that runs "forever", such as `agent run`. Use the `fxutil.Run` helper function for this variety of app:
+
+```go
+cmd := cobra.Command{
+    Use: "foo", ...,
+    RunE: func(cmd *cobra.Command, args []string) error {
+        return fxutil.Run(
+            fx.Supply(core.BundleParams{}),
+            core.Bundle(),
+            ..., // any other bundles needed for this app
+            fx.Supply(foo.BundleParams{}),
+            foo.Bundle(), // the bundle implementing this app
+        )
+    },
+}
+```

--- a/docs/public/guidelines/components/defining-bundles.md
+++ b/docs/public/guidelines/components/defining-bundles.md
@@ -1,0 +1,61 @@
+# Defining Component Bundles
+
+A bundle is defined in a dedicated package named `comp/<bundleName>`. The package must have the following defined in `bundle.go`:
+
+* Extensive package-level documentation. This should define:
+    * The purpose of the bundle
+    * What components are and are not included in the bundle. Components might be omitted in the interest of binary size, as discussed in the [component overview](../../architecture/components/overview.md).
+    * Which components are automatically instantiated.
+    * Which other _bundles_ this bundle depends on. Bundle dependencies are always expressed at a bundle level.
+* A team-name comment of the form `// team: <teamname>`. This is used to generate CODEOWNERS information.
+* An optional `BundleParams` -- the type of the bundle's parameters (see below). This item should have a formulaic doc string like `// BundleParams defines the parameters for this bundle.`
+* `Bundle` -- an `fx.Option` that can be included in an `fx.App` to make this bundle's components available. To assist with debugging, use `fxutil.Bundle(options...)`. Use `fx.Invoke(func(componentpkg.Component) {})` to instantiate components automatically. This item should have a formulaic doc string like `// Module defines the fx options for this component.`
+
+Typically, a bundle will automatically instantiate the top-level components that represent the bundle's purpose. For example, the trace-agent bundle `comp/trace` might automatically instantiate `comp/trace/agent`.
+
+You can use the invoke task `inv components.new-bundle comp/<bundleName>` to generate a pre-filled `bundle.go` file for the given bundle.
+
+## Bundle Parameters
+
+Apps can provide some intialization-time parameters to bundles. These parameters are limited to two kinds:
+
+* Parameters specific to the app, such as whether to start a network server; and
+* Parameters from the environment, such as command-line options.
+
+Anything else is runtime configuration and should be handled vi `comp/core/config` or another mechanism.
+
+Bundle parameters must stored only `Params` types for sub components. The reason is that each sub component
+must be usable without `BundleParams`.
+
+=== ":octicons-file-code-16: comp/&lt;bundleName&gt;/bundle.go"
+    ```go
+    import ".../comp/<bundleName>/foo"
+    import ".../comp/<bundleName>/bar"
+    // ...
+
+    // BundleParams defines the parameters for this bundle.
+    type BundleParams struct {
+        Foo foo.Params
+        Bar bar.Params
+    }
+
+    var Bundle = fxutil.Bundle(
+        // You must tell to fx how to get foo.Params from BundleParams.
+        fx.Provide(func(params BundleParams) foo.Params { return params.Foo }),
+        foo.Module(),
+        // You must tell to fx how to get bar.Params from BundleParams.
+        fx.Provide(func(params BundleParams) bar.Params { return params.Bar }),
+        bar.Module(),
+    )
+    ```
+
+## Testing
+
+A bundle should have a test file, `bundle_test.go`, to verify the documentation's claim about its dependencies. This simply uses `fxutil.TestBundle` to check that all dependencies are satisfied when given the full set of required bundles.
+
+=== ":octicons-file-code-16: bundle_test.go"
+    ```go
+    func TestBundleDependencies(t *testing.T) {
+        fxutil.TestBundle(t, Bundle, EXTERNAL_DEPENDENCIES)
+    }
+    ```

--- a/docs/public/guidelines/components/defining-components.md
+++ b/docs/public/guidelines/components/defining-components.md
@@ -1,0 +1,136 @@
+# Defining Components
+
+You can use the [invoke](../../setup.md#invoke) task `inv components.new-component comp/<bundleName>/<component>` to generate a scaffold for your new component.
+
+Below is a description of the different folders and files of your component.
+
+Every public variable, function, struct, and interface of your component **must** be documented. Please refer to the [Documentation](#documentation) section below for details.
+
+A component is defined in a dedicated package named `comp/<bundleName>/<component>`, where `<bundleName>` names the bundle that contains the component. The package must have the following defined in:
+
+* `comp/<bundleName>/<component>/component.go`
+    * A team-name comment of the form `// team: <teamname>`. This is used to generate CODEOWNERS information.
+
+    * `Component` -- The component interface. This is the interface that other components can reference when declaring the component as a dependency via `fx`. It can be an empty interface, if there is no need for any methods.
+
+* `comp/<bundleName>/<component>/<component>impl/<component>.go`
+    * `Module` -- an `fx.Option` that can be included in the bundle's `Module` or an `fx.App` to make this component available. The `Module` is defined in a separate package from the component, allowing a package to import the interface without having to import the entire implementation. To assist with debugging, declare your Module using `fxutil.Component(options...)`.
+
+!!! warning
+    Components should not be nested; that is, no component's Go path should be a prefix of another component's Go path.
+
+## Implementation
+
+The Component interface and the `Module` definition are implemented in the file `comp/<bundleName>/<component>/<component>impl/<component>.go`.
+
+!!! warning "Important"
+    The Module definition function **must** be private.
+
+=== ":octicons-file-code-16: comp/&lt;bundleName&gt;/&lt;component&gt;/&lt;component&gt;impl/&lt;component&gt;.go"
+    ```go
+    package config
+
+    // Module defines the fx options for this component.
+    func Module() fxutil.Module {
+        return fxutil.Component(
+            fx.Provide(newFoo),
+        )
+    }
+
+    type foo struct {
+        foos []string
+    }
+
+    type dependencies struct {
+        fx.In
+
+        Log log.Component
+        Config config.Component
+        // ...
+    }
+
+    func newFoo(deps dependencies) Component { ...  }
+
+    // foo implements Component#Foo.
+    func (f *foo) Foo(key string) string { ... }
+    ```
+
+The constructor `newFoo` is an `fx` constructor. It can refer to other dependencies and expect them to be automatically supplied via `fx`.
+
+See [Using Components](using-components.md) for more details.
+
+The constructor can return either a `Component`, if it is infallible, or `(Component, error)`, if it could fail. In the second form, a non-nil error will crash the agent at startup with a message containing the error. It is possible, and often necessary, to return multiple values. If the list of return values grows unwieldy, `fx.Out` can be used to create an output struct.
+
+The constructor may call methods on other components, as long as the called method's documentation indicates it is OK.
+
+## Testing Support
+
+To support testing, components can optionally provide a mock implementation, with the following in:
+
+* `comp/<bundleName>/<component>/component_mock.go`
+    * `Mock` -- the type implemented by the mock version of the component. This should embed `pkg.Component`, and provide additional exported methods for manipulating the mock for use by other packages.
+* `comp/<bundleName>/<component>/<component>impl/<component>_mock.go`
+    * `MockModule` -- an `fx.Option` that can be included in a test `App` to get the component's mock implementation.
+
+=== ":octicons-file-code-16: comp/&lt;bundleName&gt;/&lt;component&gt;/&lt;component_mock.go"
+    ```go
+    //go:build test
+
+    package foo
+
+    // Mock implements mock-specific methods.
+    type Mock interface {
+        // Component methods are included in Mock.
+        Component
+
+        // AddedFoos returns the foos added by AddFoo calls on the mock implementation.
+        AddedFoos() []Foo
+    }
+    ```
+
+===! ":octicons-file-code-16: comp/&lt;bundleName&gt;/&lt;component&gt;/&lt;component&gt;impl/&lt;component&gt;_mock.go"
+    ```go
+    //go:build test
+
+    package foo
+
+    // MockModule defines the fx options for the mock component.
+    func MockModule() fxutil.Module {
+        return fxutil.Component(
+            fx.Provide(newMock),
+        )
+    }
+    ```
+
+    ```go
+    type mock struct { ... }
+
+    // Foo implements Component#Foo.
+    func (m *mock) Foo(key string) string { ... }
+
+    // AddedFoos implements Mock#AddedFoos.
+    func (m *mock) AddedFoos() []Foo { ... }
+
+    func newMock(deps dependencies) Component {
+        return &mock{ ... }
+    }
+    ```
+
+Users of the mock module can cast the `Component` to a `Mock` to access the mock methods, as described in [Using Components](using-components.md).
+
+## Documentation
+
+The documentation (both package-level and method-level) should include everything a user of the component needs to know. In particular, any assumptions that might lead to panics if violated by the user should be documented.
+
+Detailed documentation of how to avoid bugs in using a component is an indicator of excessive complexity and should be treated as a bug. Simplifying the usage will improve the robustness of the Agent.
+
+Documentation should include:
+
+* Precise information on when each method may be called. Can methods be called concurrently? Are some methods invalid before the component has started? Such assumptions are difficult to verify. Where possible, try to make every method callable concurrently, at all times.
+* Precise information about data ownership of passed values and returned values. Users can assume that any mutable value returned by a component will not be modified by the user or the component after it is returned. Similarly, any mutable value passed to a component will not be later modified either by the component or the caller. Any deviation from these defaults should be documented.
+
+    !!! note
+        It can be surprisingly hard to avoid mutating data -- for example, `append(..)` surprisingly mutates its first argument. It is also hard to detect these bugs, as they are often intermittent, cause silent data corruption, or introduce rare data races. Where performance is not an issue, prefer to copy mutable input and outputs to avoid any potential bugs.
+
+* Precise information about goroutines and blocking. Users can assume that methods do not block indefinitely, so blocking methods should be documented as such. Methods that invoke callbacks should be clear about how the callback is invoked, and what it might do. For example, document whether the callback can block, and whether it might be called concurrently with other code.
+* Precise information about channels. Is the channel buffered? What happens if the channel is not read from quickly enough, or if reading stops? Can the channel be closed by the sender, and if so, what does that mean?

--- a/docs/public/guidelines/components/purpose.md
+++ b/docs/public/guidelines/components/purpose.md
@@ -1,0 +1,5 @@
+# Purpose of component guidelines
+
+This section describes the mechanics of implementing [apps](defining-apps.md), [components](defining-components.md), and [bundles](defining-bundles.md).
+
+The guidelines are quite prescriptive, with the intent of making all components "look the same". This reduces cognitive load when using components -- no need to remember one component's peculiarities. It also allows Agent-wide changes, where we make the same formulaic change to each component. If a situation arises that contradicts the guidelines, then we can update the guidelines (and change all affected components).

--- a/docs/public/guidelines/components/registrations.md
+++ b/docs/public/guidelines/components/registrations.md
@@ -1,0 +1,74 @@
+# Component Registrations
+
+Components generally need to talk to one another! In simple cases, that occurs by method calls. But in many cases, a single component needs to communicate with a number of other components that all share some characteristics. For example, the `comp/core/health` component monitors the health of many other components, and `comp/workloadmeta/scheduler` provides workload events to an arbitrary number of subscribers.
+
+The convention in the Agent codebase is to use [value groups](../../architecture/components/fx.md#value-groups) to accomplish this. The _collecting_ component requires a slice of some _collected type_, and the _providing_ components provide values of that type. Consider an example case of an HTTP server component to which endpoints can be attached. The server is the collecting component, requiring a slice of type `[]*endpoint`, where `*endpoint` is the collected type. Providing components provide values of type `*endpoint`.
+
+The convention is to "wrap" the collected type in a `Registration` struct type which embeds `fx.Out` and has tag `group:"pkgname"`, where `pkgname` is the short package name (Fx requires a group name, and this is as good as any). This helps providing components avoid the common mistake of omitting the tag. Because it is wrapped in an exported `Registration` type, the collected type can be an unexported type, as in the example below.
+
+The collecting component should define the registration type and a constructor for it:
+
+=== ":octicons-file-code-16: comp/server/component.go"
+    ```go
+    // ...
+    // Server endpoints are provided by other components, by providing a server.Registration
+    // instance.
+    // ...
+    package server
+
+    type endpoint struct {  // (the collected type)
+        ...
+    }
+
+    type Registration struct {
+        fx.Out
+
+        Endpoint endpoint `group:"server"`
+    }
+
+    // NewRegistration creates a new Registration instance for the given endpoint.
+    func NewRegistration(route string, handler func()) Registration { ... }
+    ```
+
+Its implementation then requires a slice of the collected type (`endpoint`), again using `group:"server"`:
+
+=== ":octicons-file-code-16: comp/server/server.go"
+    ```go
+    // endpoint defines an endpoint on this server.
+    type endpoint struct { ... }
+
+    type dependencies struct {
+        fx.In
+
+        Registrations []endpoint `group:"server"`
+    }
+
+    func newServer(deps dependencies) Component {
+        // ...
+        for _, e := range deps.Registrations {
+            if e.handler == nil {
+                continue
+            }
+            // ...
+        }
+        // ...
+    }
+    ```
+
+It's good practice to ignore zero values, as that allows providing components to skip the registration if desired.
+
+Finally, the providing component (in this case, `foo`) includes a registration in its output as an additional provided type, beyond its `Component` type:
+
+=== ":octicons-file-code-16: comp/foo/foo.go"
+    ```go
+    func newFoo(deps dependencies) (Component, server.Registration) {
+        // ...
+        return foo, server.NewRegistration("/things/foo", foo.handler)
+    }
+    ```
+
+This technique has some caveats to be aware of:
+
+* The providing components are instantiated before the collecting component.
+* Fx treats value groups as the collecting component depending on all of the providing components. This means that the providing components cannot depend on the collecting component, as this would represent a dependency cycle.
+* Fx will instantiate _all_ declared providing components before the collecting component, regardless of whether their `Component` type is required. This may lead to components being instantiated in unexpected circumstances.

--- a/docs/public/guidelines/components/subscriptions.md
+++ b/docs/public/guidelines/components/subscriptions.md
@@ -1,0 +1,49 @@
+# Component Subscriptions
+
+Subscriptions are a common form of registration, and have support in the `pkg/util/subscriptions` package.
+
+In defining subscriptions, the component that transmits messages is the _collecting_ component, and the processes receiving components are the _providing_ components. These are matched using the message type, which must be unique across the codebase, and should not be a built-in type like `string`. Providing components provide a `subscriptions.Receiver[coll.Message]` which has a `Ch` channel from which to receive messages. Collecting components require a `subscriptions.Transmitter[coll.Message]` which has a `Notify` method to send messages.
+
+=== ":octicons-file-code-16: announcer/component.go"
+    ```go
+    // ...
+    // To subscribe to these announcements, provide a subscriptions.Subscription[announcer.Announcement].
+    // ...
+    package announcer
+    ```
+
+=== ":octicons-file-code-16: announcer/announcer.go"
+    ```go
+    func newAnnouncer(tx subscriptions.Transmitter[Anouncement]) Component {
+        return &announcer{announcementTx: tx}  // (store the transmitter)
+    }
+
+    // ... later send messages with
+    func (ann *announcer) announce(a announcement) {
+        ann.annoucementTx.Notify(a)
+    }
+    ```
+
+=== ":octicons-file-code-16: listener/listener.go"
+    ```go
+    func newListener() (Component, subscriptions.Receiver[announcer.Announcement]) {
+        rx := subscriptions.Receiver[Event]() // create a receiver
+        return &listener{announcementRx: rx}, rx  // capture the receiver _and_ return it
+    }
+
+    // ... later receive messages (usually in an actor's main loop)
+    func (l *listener) run() {
+        loop {
+            select {
+            case a := <- l.announcementRx.Ch:
+                ...
+            }
+        }
+    }
+    ```
+
+Any component receiving messages via a subscription will _automatically_ be instantiated by Fx if it is delcared in the app, regardless of whether its Component type is required by some other component. The workaround for this is to return a zero-valued Receiver when the component does not actually wish to receive messages (such as when the component is disabled by user configuration).
+
+If a receiving component does not subscribe (for example, if it is not started), it can return the zero value, `subscriptions.Receiver[Event]{}`, from its constructor. If a component returns a non-nil subscriber, it _must_ consume messages from the receiver or risk blocking the transmitter.
+
+See the `pkg/util/subscriptions` documentation for more details.

--- a/docs/public/guidelines/components/using-components.md
+++ b/docs/public/guidelines/components/using-components.md
@@ -1,0 +1,55 @@
+# Using Components and Bundles
+
+## Component Dependencies
+
+Component dependencies are automatically determined from the arguments to a component constructor. Most components have a few dependencies, and use a struct named `dependencies` to represent them:
+
+```go
+type dependencies struct {
+    fx.In
+
+    Lc fx.Lifecycle
+    Params internal.BundleParams
+    Config config.Module
+    Log log.Module
+    // ...
+}
+
+func newThing(deps dependencies) Component {
+    t := &thing{
+        log: deps.Log,
+        ...
+    }
+    deps.Lc.Append(fx.Hook{OnStart: t.start})
+    return t
+}
+```
+
+## Testing
+
+Testing for a component should use `fxtest` to create the component. This focuses testing on the API surface of the component against which other components will be built. Per-function unit tests are, of course, also great where appropriate!
+
+Here's an example testing a component with a mocked dependency on `other`:
+
+```go
+func TestMyComponent(t *testing.T) {
+    var comp Component
+    var other other.Component
+    app := fxtest.New(t,
+        Module,              // use the real version of this component
+        other.MockModule(),  // use the mock version of other
+        fx.Populate(&comp),  // get the instance of this component
+        fx.Populate(&other), // get the (mock) instance of the other component
+    )
+
+    // start and, at completion of the test, stop the components
+    defer app.RequireStart().RequireStop()
+
+    // cast `other` to its mock interface to call mock-specific methods on it
+    other.(other.Mock).SetSomeValue(10)                      // Arrange
+    comp.DoTheThing()                                        // Act
+    require.Equal(t, 20, other.(other.Mock).GetSomeResult()) // Assert
+}
+```
+
+If the component has a mock implementation, it is a good idea to test that mock implementation as well.

--- a/docs/public/how-to/components/migration.md
+++ b/docs/public/how-to/components/migration.md
@@ -1,0 +1,81 @@
+# Migrating to Components
+
+After your component has been created you can link it to other components such as flares (others like status pages, or health will come later).
+
+This page documents how to fully integrate your component in the Agent life cycle.
+
+## Flare
+
+The general idea is to register a callback within your component to be called each time a flare is created. This uses [Fx](../../architecture/components/fx.md) groups under the hood, but helpers are there to abstract all of that for you.
+
+Then, migrate the code related to your component's domain from `pkg/flare` to your component and delete it from `pkg/flare` once done.
+
+### Creating a callback
+
+To add data to a flare you will first need to register a callback, aka a `FlareBuilder`.
+
+Within your component create a method with the following signature `func (c *yourComp) fillFlare(fb flaretypes.FlareBuilder) error`.
+
+This function is called every time the Agent generates a flare, either from the CLI or from the running Agent. This callback receives a `comp/core/flare/helpers:FlareBuilder`. The `FlareBuilder` interface provides all the helpers functions needed to add data to a flare (adding files, copying directories, scrubbing data, and so on).
+
+Example:
+
+```golang
+import (
+	yaml "gopkg.in/yaml.v2"
+
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
+)
+
+func (c *myComponent) fillFlare(fb flaretypes.FlareBuilder) error {
+	fb.AddFileFromFunc(
+		"runtime_config_dump.yaml",
+		func () ([]byte, error) {
+			return yaml.Marshal(c.AllSettings())
+		},
+	)
+
+	fb.CopyFile("/etc/datadog-agent/datadog.yaml")
+	return nil
+}
+```
+
+Read the package documentation for `FlareBuilder` for more information on the API.
+
+All errors returned by the `FlareBuilder` are automatically added to a log file shipped within the flare. Ship as much data as possible in a flare instead of stopping at the first error. Returning an error does not stop the flare from being created or sent.
+
+While you can register multiple callbacks from the same component, keep all the flare code in a single callback.
+
+### Register your callback
+
+Now you need to register you callback to be called each time a flare is created. To do so your component constructor need to provide a new `comp/core/flare/helpers:Provider`. Use `comp/core/flare/helpers:NewProvider` for this.
+
+Example:
+```golang
+import (
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
+)
+
+type provides struct {
+	fx.Out
+
+	// [...]
+	FlareProvider flaretypes.Provider // Your component will provides a new Provider
+	// [...]
+}
+
+func newComponent(deps dependencies) (provides, error) {
+	// [...]
+	return provides{
+		// [...]
+		FlareProvider: flaretypes.NewProvider(myComponent.fillFlare), // NewProvider will wrap your callback in order to be use as a 'Provider'
+		// [...]
+	}, nil
+}
+```
+
+### Migrating your code
+
+Now migrate the require code from `pkg/flare` to you component callback. The code in `pkg/flare` already uses the `FlareBuilder` interface, simplifying migration. Don't forget to migrate the tests too and expand them (most of the flare features are not tested). `comp/core/flare/helpers::NewFlareBuilderMock` will provides helpers for your tests.
+
+Keep in mind that the goal is to delete `pkg/flare` once the migration to component is done.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,21 @@ nav:
   - Setup: setup.md
 - Guidelines:
   - Contributing: guidelines/contributing.md
+  - Components:
+    - Purpose: guidelines/components/purpose.md
+    - Defining Components: guidelines/components/defining-components.md
+    - Using Components: guidelines/components/using-components.md
+    - Defining Bundles: guidelines/components/defining-bundles.md
+    - Defining Apps: guidelines/components/defining-apps.md
+    - Registrations: guidelines/components/registrations.md
+    - Subscriptions: guidelines/components/subscriptions.md
+- How-to:
+  - Components:
+    - Migration: how-to/components/migration.md
+- Architecture:
+  - Components:
+    - Overview: architecture/components/overview.md
+    - Fx: architecture/components/fx.md
 
 hooks:
 - docs/public/.hooks/title_from_content.py


### PR DESCRIPTION
I moved [this directory](https://github.com/DataDog/datadog-agent/tree/main/docs/components) into the new documentation framework whilst fixing formatting and typos. I split the directory into guidelines, architecture pages, and one how-to document.