### PR TITLE
(fleet) async processing of requests in the updater

### DIFF
--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -130,6 +130,7 @@ func TestUpdaterStartExperiment(t *testing.T) {
 		Method: methodStartExperiment,
 		Params: json.RawMessage(`{"version":"` + fixtureSimpleV2.version + `"}`),
 	})
+	updater.requestsWG.Wait()
 
 	r := updater.repositories.Get(fixtureSimpleV1.pkg)
 	state, err := r.GetState()
@@ -157,6 +158,7 @@ func TestUpdaterPromoteExperiment(t *testing.T) {
 		Method: methodStartExperiment,
 		Params: json.RawMessage(`{"version":"` + fixtureSimpleV2.version + `"}`),
 	})
+	updater.requestsWG.Wait()
 	rc.SubmitRequest(remoteAPIRequest{
 		ID:      uuid.NewString(),
 		Package: fixtureSimpleV1.pkg,
@@ -166,6 +168,7 @@ func TestUpdaterPromoteExperiment(t *testing.T) {
 		},
 		Method: methodPromoteExperiment,
 	})
+	updater.requestsWG.Wait()
 
 	r := updater.repositories.Get(fixtureSimpleV1.pkg)
 	state, err := r.GetState()
@@ -192,6 +195,7 @@ func TestUpdaterStopExperiment(t *testing.T) {
 		Method: methodStartExperiment,
 		Params: json.RawMessage(`{"version":"` + fixtureSimpleV2.version + `"}`),
 	})
+	updater.requestsWG.Wait()
 	r := updater.repositories.Get(fixtureSimpleV1.pkg)
 	state, err := r.GetState()
 	assert.NoError(t, err)
@@ -205,6 +209,7 @@ func TestUpdaterStopExperiment(t *testing.T) {
 		},
 		Method: methodStopExperiment,
 	})
+	updater.requestsWG.Wait()
 
 	state, err = r.GetState()
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR makes the processing of requests from the backend async in the updater. This will avoid locking the RC client for extended periods of time and allow us to modify its state while we are executing the request.