### PR TITLE
Stop sending systemd metrics when they are not set

### DIFF
--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -10,6 +10,7 @@ package systemd
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -434,7 +435,12 @@ func sendServicePropertyAsGauge(sender sender.Sender, properties map[string]inte
 	if err != nil {
 		return fmt.Errorf("error getting property %s: %v", service.propertyName, err)
 	}
-	sender.Gauge(service.metricName, float64(value), "", tags)
+
+	// When the value is `[Not set]`, dbus returns MaxUint64
+	if value != math.MaxUint64 {
+		sender.Gauge(service.metricName, float64(value), "", tags)
+	}
+
 	return nil
 }
 

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -513,6 +513,7 @@ unit_names:
 	mockSender.AssertCalled(t, "Gauge", "systemd.service.cpu_time_consumed", float64(10), "", tags)
 	mockSender.AssertCalled(t, "Gauge", "systemd.service.task_count", float64(30), "", tags)
 	mockSender.AssertCalled(t, "Gauge", "systemd.service.restart_count", float64(40), "", tags)
+	mockSender.AssertNotCalled(t, "Gauge", "systemd.service.memory_usage", float64(math.MaxUint64), "", tags)
 
 	expectedGaugeCalls := 8 /* overall metrics */
 	expectedGaugeCalls += 7 /* unit/service metrics */

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -9,6 +9,7 @@ package systemd
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -464,6 +465,60 @@ unit_names:
 	mockSender.AssertNumberOfCalls(t, "Gauge", expectedGaugeCalls)
 	mockSender.AssertNumberOfCalls(t, "Commit", 1)
 	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 4)
+}
+
+// When a value is not set (`[Not set]` when running `systemctl show my.service`), dbus returns MaxUint64
+func TestMetricValuesNotSet(t *testing.T) {
+	rawInstanceConfig := []byte(`
+unit_names:
+ - unit1.service
+`)
+
+	stats := createDefaultMockSystemdStats()
+	stats.On("ListUnits", mock.Anything).Return([]dbus.UnitStatus{
+		{Name: "unit1.service", ActiveState: "active", LoadState: "loaded"},
+	}, nil)
+	stats.On("UnixNow").Return(int64(1000))
+	stats.On("GetUnitTypeProperties", mock.Anything, "unit1.service", dbusTypeMap[typeService]).Return(getCreatePropertieWithDefaults(map[string]interface{}{
+		"CPUUsageNSec":  uint64(10),
+		"MemoryCurrent": uint64(math.MaxUint64),
+		"TasksCurrent":  uint64(30),
+		"NRestarts":     uint64(40),
+	}), nil)
+	stats.On("GetUnitTypeProperties", mock.Anything, "unit1.service", dbusTypeMap[typeUnit]).Return(map[string]interface{}{
+		"ActiveEnterTimestamp": uint64(100 * 1000 * 1000),
+	}, nil)
+
+	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
+
+	check := SystemdCheck{stats: stats}
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	check.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, nil, "test")
+
+	// setup expectation
+	mockSender := mocksender.NewMockSenderWithSenderManager(check.ID(), senderManager)
+	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Commit").Return()
+
+	// run
+	check.Run()
+
+	// assertions
+	tags := []string{"unit:unit1.service"}
+	mockSender.AssertCalled(t, "Gauge", "systemd.unit.uptime", float64(900), "", tags)
+	mockSender.AssertCalled(t, "Gauge", "systemd.unit.monitored", float64(1), "", tags)
+	mockSender.AssertCalled(t, "Gauge", "systemd.unit.active", float64(1), "", tags)
+	mockSender.AssertCalled(t, "Gauge", "systemd.unit.loaded", float64(1), "", tags)
+	mockSender.AssertCalled(t, "Gauge", "systemd.service.cpu_time_consumed", float64(10), "", tags)
+	mockSender.AssertCalled(t, "Gauge", "systemd.service.task_count", float64(30), "", tags)
+	mockSender.AssertCalled(t, "Gauge", "systemd.service.restart_count", float64(40), "", tags)
+
+	expectedGaugeCalls := 8 /* overall metrics */
+	expectedGaugeCalls += 7 /* unit/service metrics */
+	mockSender.AssertNumberOfCalls(t, "Gauge", expectedGaugeCalls)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 3)
 }
 
 func TestSubmitMetricsConditionals(t *testing.T) {

--- a/releasenotes/notes/systemd-fix-max-value-0f60792f61ec34fd.yaml
+++ b/releasenotes/notes/systemd-fix-max-value-0f60792f61ec34fd.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Stop sending systemd metrics when they are not set
+    Stop sending ``systemd`` metrics when they are not set

--- a/releasenotes/notes/systemd-fix-max-value-0f60792f61ec34fd.yaml
+++ b/releasenotes/notes/systemd-fix-max-value-0f60792f61ec34fd.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Stop sending systemd metrics when they are not set


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Stop sending systemd metrics when they are not set

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

```
ubuntu@i-0d15d476f6f593c4d:/tmp/project$ systemctl show ufw.service | grep MemoryCurrent=
MemoryCurrent=[not set]
```

In that case, `dbus` returns `18446744073709551615`, which is the max value for uint64. Example:

```
map[AllowedCPUs:[] AllowedMemoryNodes:[] AmbientCapabilities:0 AppArmorProfile:[false ] BPFProgram:[] BindPaths:[] BindReadOnlyPaths:[] BlockIOAccounting:false BlockIODeviceWeight:[] BlockIOReadBandwidth:[] BlockIOWeight:18446744073709551615 BlockIOWriteBandwidth:[] BusName: CPUAccounting:true CPUAffinity:[] CPUAffinityFromNUMA:false CPUQuotaPerSecUSec:18446744073709551615 CPUQuotaPeriodUSec:18446744073709551615 CPUSchedulingPolicy:0 CPUSchedulingPriority:0 CPUSchedulingResetOnFork:false CPUShares:18446744073709551615 CPUUsageNSec:1457000 CPUWeight:18446744073709551615 CacheDirectory:[] CacheDirectoryMode:493 CapabilityBoundingSet:18446744073709551615 CleanResult:success ConfigurationDirectory:[] ConfigurationDirectoryMode:493 ControlGroup: ControlPID:0 CoredumpFilter:51 DefaultMemoryLow:0 DefaultMemoryMin:0 Delegate:false DelegateControllers:[] DeviceAllow:[] DevicePolicy:auto DisableControllers:[] DynamicUser:false EffectiveCPUs:[] EffectiveMemoryNodes:[] Environment:[] EnvironmentFiles:[] ExecCondition:[] ExecConditionEx:[] ExecMainCode:1 ExecMainExitTimestamp:1709629064036406 ExecMainExitTimestampMonotonic:5385835 ExecMainPID:255 ExecMainStartTimestamp:1709629064014675 ExecMainStartTimestampMonotonic:5364105 ExecMainStatus:0 ExecPaths:[] ExecReload:[] ExecReloadEx:[] ExecStart:[[/lib/ufw/ufw-init [/lib/ufw/ufw-init start quiet] false 0 0 0 0 0 0 0]] ExecStartEx:[[/lib/ufw/ufw-init [/lib/ufw/ufw-init start quiet] [] 0 0 0 0 0 0 0]] ExecStartPost:[] ExecStartPostEx:[] ExecStartPre:[] ExecStartPreEx:[] ExecStop:[[/lib/ufw/ufw-init [/lib/ufw/ufw-init stop] false 0 0 0 0 0 0 0]] ExecStopEx:[[/lib/ufw/ufw-init [/lib/ufw/ufw-init stop] [] 0 0 0 0 0 0 0]] ExecStopPost:[] ExecStopPostEx:[] ExtensionImages:[] FileDescriptorStoreMax:0 FinalKillSignal:9 GID:4294967295 Group: GuessMainPID:true IOAccounting:false IODeviceLatencyTargetUSec:[] IODeviceWeight:[] IOReadBandwidthMax:[] IOReadBytes:18446744073709551615 IOReadIOPSMax:[] IOReadOperations:18446744073709551615 IOSchedulingClass:2 IOSchedulingPriority:4 IOWeight:18446744073709551615 IOWriteBandwidthMax:[] IOWriteBytes:18446744073709551615 IOWriteIOPSMax:[] IOWriteOperations:18446744073709551615 IPAccounting:false IPAddressAllow:[] IPAddressDeny:[] IPCNamespacePath: IPEgressBytes:18446744073709551615 IPEgressFilterPath:[] IPEgressPackets:18446744073709551615 IPIngressBytes:18446744073709551615 IPIngressFilterPath:[] IPIngressPackets:18446744073709551615 IgnoreSIGPIPE:true InaccessiblePaths:[] KeyringMode:private KillMode:control-group KillSignal:15 LimitAS:18446744073709551615 LimitASSoft:18446744073709551615 LimitCORE:18446744073709551615 LimitCORESoft:0 LimitCPU:18446744073709551615 LimitCPUSoft:18446744073709551615 LimitDATA:18446744073709551615 LimitDATASoft:18446744073709551615 LimitFSIZE:18446744073709551615 LimitFSIZESoft:18446744073709551615 LimitLOCKS:18446744073709551615 LimitLOCKSSoft:18446744073709551615 LimitMEMLOCK:8388608 LimitMEMLOCKSoft:8388608 LimitMSGQUEUE:819200 LimitMSGQUEUESoft:819200 LimitNICE:0 LimitNICESoft:0 LimitNOFILE:524288 LimitNOFILESoft:1024 LimitNPROC:15557 LimitNPROCSoft:15557 LimitRSS:18446744073709551615 LimitRSSSoft:18446744073709551615 LimitRTPRIO:0 LimitRTPRIOSoft:0 LimitRTTIME:18446744073709551615 LimitRTTIMESoft:18446744073709551615 LimitSIGPENDING:15557 LimitSIGPENDINGSoft:15557 LimitSTACK:18446744073709551615 LimitSTACKSoft:8388608 LoadCredential:[] LockPersonality:false LogExtraFields:[] LogLevelMax:-1 LogNamespace: LogRateLimitBurst:0 LogRateLimitIntervalUSec:0 LogsDirectory:[] LogsDirectoryMode:493 MainPID:0 ManagedOOMMemoryPressure:auto ManagedOOMMemoryPressureLimit:0 ManagedOOMPreference:none ManagedOOMSwap:auto MemoryAccounting:true MemoryAvailable:18446744073709551615 MemoryCurrent:18446744073709551615 MemoryDenyWriteExecute:false MemoryHigh:18446744073709551615 MemoryLimit:18446744073709551615 MemoryLow:0 MemoryMax:18446744073709551615 MemoryMin:0 MemorySwapMax:18446744073709551615 MountAPIVFS:false MountFlags:0 MountImages:[] NFileDescriptorStore:0 NRestarts:0 NUMAMask:[] NUMAPolicy:-1 NetworkNamespacePath: Nice:0 NoExecPaths:[] NoNewPrivileges:false NonBlocking:false NotifyAccess:none OOMPolicy:stop OOMScoreAdjust:0 PAMName: PIDFile: PassEnvironment:[] Personality: PrivateDevices:false PrivateIPC:false PrivateMounts:false PrivateNetwork:false PrivateTmp:false PrivateUsers:false ProcSubset:all ProtectClock:false ProtectControlGroups:false ProtectHome:no ProtectHostname:false ProtectKernelLogs:false ProtectKernelModules:false ProtectKernelTunables:false ProtectProc:default ProtectSystem:no ReadOnlyPaths:[] ReadWritePaths:[] ReloadResult:success RemainAfterExit:true RemoveIPC:false Restart:no RestartForceExitStatus:[[] []] RestartKillSignal:15 RestartPreventExitStatus:[[] []] RestartUSec:100000 RestrictAddressFamilies:[false []] RestrictNamespaces:18446744073709551615 RestrictRealtime:false RestrictSUIDSGID:false Result:success RootDirectory: RootDirectoryStartOnly:false RootHash:[] RootHashPath: RootHashSignature:[] RootHashSignaturePath: RootImage: RootImageOptions:[] RootVerity: RuntimeDirectory:[] RuntimeDirectoryMode:493 RuntimeDirectoryPreserve:no RuntimeMaxUSec:18446744073709551615 SELinuxContext:[false ] SameProcessGroup:false SecureBits:0 SendSIGHUP:false SendSIGKILL:true SetCredential:[] Slice:system.slice SmackProcessLabel:[false ] SocketBindAllow:[] SocketBindDeny:[] StandardError:inherit StandardErrorFileDescriptorName: StandardInput:null StandardInputData:[] StandardInputFileDescriptorName: StandardOutput:journal StandardOutputFileDescriptorName: StartupBlockIOWeight:18446744073709551615 StartupCPUShares:18446744073709551615 StartupCPUWeight:18446744073709551615 StartupIOWeight:18446744073709551615 StateDirectory:[] StateDirectoryMode:493 StatusErrno:0 StatusText: SuccessExitStatus:[[] []] SupplementaryGroups:[] SyslogFacility:3 SyslogIdentifier: SyslogLevel:6 SyslogLevelPrefix:true SyslogPriority:30 SystemCallArchitectures:[] SystemCallErrorNumber:2147483646 SystemCallFilter:[false []] SystemCallLog:[false []] TTYPath: TTYReset:false TTYVHangup:false TTYVTDisallocate:false TasksAccounting:true TasksCurrent:18446744073709551615 TasksMax:4667 TemporaryFileSystem:[] TimeoutAbortUSec:90000000 TimeoutCleanUSec:18446744073709551615 TimeoutStartFailureMode:terminate TimeoutStartUSec:18446744073709551615 TimeoutStopFailureMode:terminate TimeoutStopUSec:90000000 TimerSlackNSec:50000 Type:oneshot UID:4294967295 UMask:18 USBFunctionDescriptors: USBFunctionStrings: UnsetEnvironment:[] User: UtmpIdentifier: UtmpMode:init WatchdogSignal:6 WatchdogTimestamp:0 WatchdogTimestampMonotonic:0 WatchdogUSec:0 WorkingDirectory:]
```

In that case we should avoid sending the metric since it is not set, so it does not really exist

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
