### PR TITLE
Scrub auth token of any size

### DIFF
--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -611,6 +611,13 @@ func TestBearerToken(t *testing.T) {
 	assertClean(t,
 		`Error: Get "https://localhost:5001/agent/status": net/http: invalid header field value "Bearer 260a9c065b6426f81b7abae9e6bca9a16f7a842af65c940e89e3417c7aaec82d\n\n" for key Authorization`,
 		`Error: Get "https://localhost:5001/agent/status": net/http: invalid header field value "Bearer ***********************************************************ec82d\n\n" for key Authorization`)
+	// entirely clean token with different length that 64
+	assertClean(t,
+		`Bearer 2fe663014abcd18`,
+		`Bearer ********`)
+	assertClean(t,
+		`Bearer 2fe663014abcd1850076f6d68c0355666db98758262870811cace007cd4a62bdsldijfoiwjeoimdfolisdjoijfewoa`,
+		`Bearer ********`)
 	assertClean(t,
 		`AuthBearer 2fe663014abcd1850076f6d68c0355666db98758262870811cace007cd4a62ba`,
 		`AuthBearer 2fe663014abcd1850076f6d68c0355666db98758262870811cace007cd4a62ba`)

--- a/releasenotes/notes/scrub-bearer-token-of-any-size-4dc4b3856b3d6b18.yaml
+++ b/releasenotes/notes/scrub-bearer-token-of-any-size-4dc4b3856b3d6b18.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Scrub authentication bearer token of any size, even invalid, from integration configuration (when being printed
+    through the `checksconfig` CLI command or other).


### PR DESCRIPTION
### What does this PR do?
Scrub auth token of any size, not just 64bytes.

### Describe how to test/QA your changes

Setup an integration with the following line in its configuration:
```
instances:
  - test: Bearer <token>
    [...]
```

Run the `checkconfig` CLI command to verify that token is always scrubbed not matter the length.