### PR TITLE
(fleet) multi-package state tracking

### DIFF
--- a/pkg/updater/local_api.go
+++ b/pkg/updater/local_api.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
 	"github.com/DataDog/datadog-agent/pkg/updater/repository"
@@ -138,8 +137,7 @@ func (l *localAPIImpl) startExperiment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Infof("Received local request to start experiment for package %s version %s", pkg, request.Version)
-	taskID := uuid.New().String()
-	err = l.updater.StartExperiment(r.Context(), pkg, request.Version, taskID)
+	err = l.updater.StartExperiment(r.Context(), pkg, request.Version)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		response.Error = &APIError{Message: err.Error()}
@@ -156,8 +154,7 @@ func (l *localAPIImpl) stopExperiment(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(response)
 	}()
 	log.Infof("Received local request to stop experiment for package %s", pkg)
-	taskID := uuid.New().String()
-	err := l.updater.StopExperiment(pkg, taskID)
+	err := l.updater.StopExperiment(r.Context(), pkg)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		response.Error = &APIError{Message: err.Error()}
@@ -174,8 +171,7 @@ func (l *localAPIImpl) promoteExperiment(w http.ResponseWriter, r *http.Request)
 		_ = json.NewEncoder(w).Encode(response)
 	}()
 	log.Infof("Received local request to promote experiment for package %s", pkg)
-	taskID := uuid.New().String()
-	err := l.updater.PromoteExperiment(pkg, taskID)
+	err := l.updater.PromoteExperiment(r.Context(), pkg)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		response.Error = &APIError{Message: err.Error()}
@@ -201,13 +197,12 @@ func (l *localAPIImpl) bootstrap(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	taskID := uuid.New().String()
 	if request.Version != "" {
 		log.Infof("Received local request to bootstrap package %s version %s", pkg, request.Version)
-		err = l.updater.BootstrapVersion(r.Context(), pkg, request.Version, taskID)
+		err = l.updater.BootstrapVersion(r.Context(), pkg, request.Version)
 	} else {
 		log.Infof("Received local request to bootstrap package %s", pkg)
-		err = l.updater.Bootstrap(r.Context(), pkg, taskID)
+		err = l.updater.Bootstrap(r.Context(), pkg)
 
 	}
 	if err != nil {

--- a/pkg/updater/remote_config.go
+++ b/pkg/updater/remote_config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
-	"github.com/DataDog/datadog-agent/pkg/updater/repository"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -63,31 +62,11 @@ func (rc *remoteConfig) Close() {
 }
 
 // SetState sets the state of the given package.
-func (rc *remoteConfig) SetState(pkg string, repoState repository.State, taskState TaskState) {
+func (rc *remoteConfig) SetState(packages []*pbgo.PackageState) {
 	if rc.client == nil {
 		return
 	}
-
-	var taskErr *pbgo.TaskError
-	if taskState.Err != nil {
-		taskErr = &pbgo.TaskError{
-			Code:    uint64(taskState.Err.Code()),
-			Message: taskState.Err.Error(),
-		}
-	}
-
-	rc.client.SetUpdaterPackagesState([]*pbgo.PackageState{
-		{
-			Package:           pkg,
-			StableVersion:     repoState.Stable,
-			ExperimentVersion: repoState.Experiment,
-			Task: &pbgo.PackageStateTask{
-				Id:    taskState.ID,
-				State: taskState.State,
-				Error: taskErr,
-			},
-		},
-	})
+	rc.client.SetUpdaterPackagesState(packages)
 }
 
 // Package represents a downloadable package.

--- a/pkg/updater/remote_config.go
+++ b/pkg/updater/remote_config.go
@@ -141,7 +141,7 @@ const (
 
 type remoteAPIRequest struct {
 	ID            string          `json:"id"`
-	Package       string          `json:"package"`
+	Package       string          `json:"package_name"`
 	ExpectedState expectedState   `json:"expected_state"`
 	Method        string          `json:"method"`
 	Params        json.RawMessage `json:"params"`

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -74,8 +74,7 @@ func (c *testRemoteConfigClient) SubmitRequest(request remoteAPIRequest) {
 
 func newTestUpdater(t *testing.T, s *testFixturesServer, rcc *testRemoteConfigClient, defaultFixture fixture) *updaterImpl {
 	rc := &remoteConfig{client: rcc}
-	u, err := newUpdater(rc, t.TempDir(), t.TempDir())
-	assert.NoError(t, err)
+	u := newUpdater(rc, t.TempDir(), t.TempDir())
 	u.catalog = s.Catalog()
 	u.bootstrapVersions[defaultFixture.pkg] = defaultFixture.version
 	u.Start(context.Background())
@@ -88,7 +87,7 @@ func TestUpdaterBootstrap(t *testing.T) {
 	rc := newTestRemoteConfigClient()
 	updater := newTestUpdater(t, s, rc, fixtureSimpleV1)
 
-	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
+	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
 
 	r := updater.repositories.Get(fixtureSimpleV1.pkg)
@@ -106,10 +105,10 @@ func TestUpdaterBootstrapCatalogUpdate(t *testing.T) {
 	updater := newTestUpdater(t, s, rc, fixtureSimpleV1)
 	updater.catalog = catalog{}
 
-	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
+	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
 	assert.Error(t, err)
 	rc.SubmitCatalog(s.Catalog())
-	err = updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
+	err = updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
 }
 
@@ -119,7 +118,7 @@ func TestUpdaterStartExperiment(t *testing.T) {
 	rc := newTestRemoteConfigClient()
 	updater := newTestUpdater(t, s, rc, fixtureSimpleV1)
 
-	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
+	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
 	rc.SubmitRequest(remoteAPIRequest{
 		ID:      uuid.NewString(),
@@ -147,7 +146,7 @@ func TestUpdaterPromoteExperiment(t *testing.T) {
 	rc := newTestRemoteConfigClient()
 	updater := newTestUpdater(t, s, rc, fixtureSimpleV1)
 
-	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
+	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
 	rc.SubmitRequest(remoteAPIRequest{
 		ID:      uuid.NewString(),
@@ -184,7 +183,7 @@ func TestUpdaterStopExperiment(t *testing.T) {
 	rc := newTestRemoteConfigClient()
 	updater := newTestUpdater(t, s, rc, fixtureSimpleV1)
 
-	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg, uuid.New().String())
+	err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
 	assert.NoError(t, err)
 	rc.SubmitRequest(remoteAPIRequest{
 		ID:      uuid.NewString(),


### PR DESCRIPTION
This PR adds multi-package state tracking.

I had to resort to using a `context.Context` to keep the remote request data we want to include as part of the state reported to RC. The pattern is an expected use of contexts but I would rather have keept this more simple to be honest.

The alternative was to pass around all the request state in the top level method of the updater. This was problematic for the local API and the local bootstrap were we'd have to "fake" requests and I was worried this would potentially lead to confusing the backend.