### PR TITLE
WIP - sort composite tags immediately before serializing them

### DIFF
--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -289,6 +289,7 @@ func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buff
 				return err
 			}
 
+			serie.Tags.Sort()
 			err = serie.Tags.ForEachErr(func(tag string) error {
 				return ps.String(seriesTags, tag)
 			})

--- a/pkg/serializer/internal/metrics/sketch_series_list.go
+++ b/pkg/serializer/internal/metrics/sketch_series_list.go
@@ -183,6 +183,7 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 				return err
 			}
 
+			ss.Tags.Sort()
 			err = ss.Tags.ForEachErr(func(tag string) error {
 				return ps.String(sketchTags, tag)
 			})

--- a/pkg/tagset/composite_tags.go
+++ b/pkg/tagset/composite_tags.go
@@ -7,6 +7,7 @@ package tagset
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 )
 
@@ -59,6 +60,12 @@ func CombineCompositeTagsAndSlice(compositeTags CompositeTags, tags []string) Co
 // be copied. Prefer constructing a complete value in one go with NewCompositeTags instead.
 func (t *CompositeTags) CombineWithSlice(tags []string) {
 	*t = CombineCompositeTagsAndSlice(*t, tags)
+}
+
+// Hack
+func (t CompositeTags) Sort() {
+	sort.Strings(t.tags1)
+	sort.Strings(t.tags2)
 }
 
 // ForEach applies `callback` to each tag


### PR DESCRIPTION
There's probably a more CPU-efficient way to do this but it will let us estimate the potential compression impact.