### PR TITLE
Support expected_tags_duration for journald logs

### DIFF
--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/processor"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tag"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
@@ -50,6 +51,10 @@ type Tailer struct {
 	// processRawMessage indicates if we want to process and send the whole structured log message
 	// instead of on the logs content.
 	processRawMessage bool
+
+	// tagProvider provides additional tags to be attached to each log message.  It
+	// is called once for each log message.
+	tagProvider tag.Provider
 }
 
 // NewTailer returns a new tailer.
@@ -69,6 +74,7 @@ func NewTailer(source *sources.LogSource, outputChan chan *message.Message, jour
 		stop:              make(chan struct{}, 1),
 		done:              make(chan struct{}, 1),
 		processRawMessage: processRawMessage,
+		tagProvider:       tag.NewLocalProvider([]string{}),
 	}
 }
 
@@ -394,7 +400,7 @@ func (t *Tailer) getOrigin(entry *sdjournal.JournalEntry) *message.Origin {
 	applicationName := t.getApplicationName(entry, tags)
 	origin.SetSource(applicationName)
 	origin.SetService(applicationName)
-	origin.SetTags(tags)
+	origin.SetTags(append(tags, t.tagProvider.GetTags()...))
 	return origin
 }
 

--- a/pkg/logs/tailers/journald/tailer_test.go
+++ b/pkg/logs/tailers/journald/tailer_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build systemd
-
 package journald
 
 import (
@@ -17,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -582,4 +581,29 @@ func TestTailerCompareUnstructuredAndStructured(t *testing.T) {
 	assert.NoError(err2)
 
 	assert.Equal(v1, v2)
+}
+
+func TestExpectedTagDuration(t *testing.T) {
+
+	mockConfig := coreConfig.Mock(t)
+
+	tags := []string{"tag1:value1"}
+
+	mockConfig.SetWithoutSource("tags", tags)
+	defer mockConfig.SetWithoutSource("tags", nil)
+
+	mockConfig.SetWithoutSource("logs_config.expected_tags_duration", "5s")
+	defer mockConfig.SetWithoutSource("logs_config.expected_tags_duration", "0")
+
+	mockJournal := &MockJournal{m: &sync.Mutex{}}
+	source := sources.NewLogSource("", &config.LogsConfig{})
+	tailer := NewTailer(source, make(chan *message.Message, 1), mockJournal, true)
+
+	mockJournal.entries = append(mockJournal.entries, &sdjournal.JournalEntry{Fields: map[string]string{"MESSAGE": "foobar"}})
+
+	tailer.Start("")
+	assert.Equal(t, tags, (<-tailer.outputChan).Origin.Tags())
+
+	tailer.Stop()
+
 }

--- a/pkg/logs/tailers/journald/tailer_test.go
+++ b/pkg/logs/tailers/journald/tailer_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build systemd
+
 package journald
 
 import (

--- a/releasenotes/notes/journald-expected-tags-duration-053b0a54f2624ebf.yaml
+++ b/releasenotes/notes/journald-expected-tags-duration-053b0a54f2624ebf.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    ``logs_config.expected_tags_duration`` now works for journald logs.
+    ``logs_config.expected_tags_duration`` now works for ``journald`` logs.

--- a/releasenotes/notes/journald-expected-tags-duration-053b0a54f2624ebf.yaml
+++ b/releasenotes/notes/journald-expected-tags-duration-053b0a54f2624ebf.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    ``logs_config.expected_tags_duration`` now works for journald logs.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds support for `logs_config.expected_tags_duration` to journald log sources. When this setting is configured, host tags will be attached to logs for the configured period of time. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Install the agent on a linux system with systemd (ubuntu works)
2. [configure journald log collection](https://docs.datadoghq.com/integrations/journald/?tab=host)
3. configure `logs_config.expected_tags_duration` to some value like: `1m`
4. configure `tags: foo:bar` in the `datadog.yaml` to add some host tags
5. Run the agent and start `agent stream-logs`
6. Before the timeout is reached, emit some logs to journald (`systemd-cat echo "Hello Journal"`). Confirm that the tags `foo:bar` are present. 
7. After the timeout as expired, emit more logs and confirm the host tags are no longer present on the log messages. 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
