### PR TITLE
Refactor snmp walk subcommand

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -207,7 +207,7 @@ func newSNMP(connParams *connectionParams) (*gosnmp.GoSNMP, error) {
 		return nil, fmt.Errorf("timeout cannot be 0")
 	}
 
-	version := gosnmp.Version2c
+	var version gosnmp.SnmpVersion
 	// Set the snmp version
 	if connParams.Version == "1" {
 		version = gosnmp.Version1

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -3,13 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package snmp implements 'agent snmp'.
+// Package snmp implements the 'agent snmp' subcommand.
 package snmp
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
-	"os"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -51,16 +52,8 @@ const (
 	defaultUseUnconnectedUDPSocket = false
 )
 
-// cliParams are the command-line arguments for this subcommand
-type cliParams struct {
-	*command.GlobalParams
-
-	// args are the positional command-line arguments
-	args []string
-
-	// cmd is the cobra Command, used to show help
-	cmd *cobra.Command
-
+// connectionParams are the data needed to connect to an SNMP instance.
+type connectionParams struct {
 	// general
 	snmpVersion string
 
@@ -82,219 +75,160 @@ type cliParams struct {
 	unconnectedUDPSocket bool
 }
 
-// Commands returns a slice of subcommands for the 'agent' command.
-func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	cliParams := &cliParams{
-		GlobalParams: globalParams,
-	}
-	snmpWalkCmd := &cobra.Command{
-		Use:   "walk <IP Address>[:Port] [OID] [OPTIONS]",
-		Short: "Perform a snmpwalk, if only a valid IP address is provided with the oid then the agent default snmp config will be used",
-		Long:  ``,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliParams.args = args
-			cliParams.cmd = cmd
-			return fxutil.OneShot(snmpwalk,
-				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath),
-					SecretParams: secrets.NewEnabledParams(),
-					LogParams:    logimpl.ForOneShot(command.LoggerName, "off", true)}),
-				core.Bundle(),
-			)
-		},
-	}
+// argsType is an alias so we can inject the args via fx.
+type argsType []string
 
-	snmpWalkCmd.Flags().StringVarP(&cliParams.snmpVersion, "snmp-version", "v", defaultVersion, "Specify SNMP version to use")
-
-	// snmp v1 or v2c specific
-	snmpWalkCmd.Flags().StringVarP(&cliParams.communityString, "community-string", "C", "", "Set the community string")
-
-	// snmp v3 specific
-	snmpWalkCmd.Flags().StringVarP(&cliParams.authProt, "auth-protocol", "a", defaultAuthProtocol, "Set authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)")
-	snmpWalkCmd.Flags().StringVarP(&cliParams.authKey, "auth-key", "A", defaultAuthKey, "Set authentication protocol pass phrase")
-	snmpWalkCmd.Flags().StringVarP(&cliParams.securityLevel, "security-level", "l", defaultSecurityLevel, "set security level (noAuthNoPriv|authNoPriv|authPriv)")
-	snmpWalkCmd.Flags().StringVarP(&cliParams.snmpContext, "context", "N", defaultContext, "Set context name")
-	snmpWalkCmd.Flags().StringVarP(&cliParams.user, "user-name", "u", defaultUserName, "Set security name")
-	snmpWalkCmd.Flags().StringVarP(&cliParams.privProt, "priv-protocol", "x", defaultPrivProtocol, "Set privacy protocol (DES|AES|AES192|AES192C|AES256|AES256C)")
-	snmpWalkCmd.Flags().StringVarP(&cliParams.privKey, "priv-key", "X", defaultPrivKey, "Set privacy protocol pass phrase")
-
-	// general communication options
-	snmpWalkCmd.Flags().IntVarP(&cliParams.retries, "retries", "r", defaultRetries, "Set the number of retries")
-	snmpWalkCmd.Flags().IntVarP(&cliParams.timeout, "timeout", "t", defaultTimeout, "Set the request timeout (in seconds)")
-	snmpWalkCmd.Flags().BoolVar(&cliParams.unconnectedUDPSocket, "use-unconnected-udp-socket", defaultUseUnconnectedUDPSocket, "If specified, changes net connection to be unconnected UDP socket")
-
-	snmpWalkCmd.SetArgs([]string{})
-
-	snmpCmd := &cobra.Command{
-		Use:   "snmp",
-		Short: "Snmp tools",
-		Long:  ``,
-	}
-	snmpCmd.AddCommand(snmpWalkCmd)
-
-	return []*cobra.Command{snmpCmd}
+// usageError wraps any error that indicates the user has provided invalid inputs.
+// If the main script returns a usageError it will print the usage string along
+// with the error message.
+type usageError struct {
+	e error
 }
 
-//nolint:revive // TODO(NDM) Fix revive linter
-func snmpwalk(config config.Component, cliParams *cliParams) error {
-	var (
-		address      string
-		deviceIP     string
-		oid          string
-		port         uint16
-		value        uint64
-		setVersion   gosnmp.SnmpVersion
-		authProtocol gosnmp.SnmpV3AuthProtocol
-		privProtocol gosnmp.SnmpV3PrivProtocol
-		msgFlags     gosnmp.SnmpV3MsgFlags
-	)
-	// Get args
-	if len(cliParams.args) == 0 {
-		fmt.Print("Missing argument: IP address\n")
-		cliParams.cmd.Help() //nolint:errcheck
-		os.Exit(1)
-		return nil
-	} else if len(cliParams.args) == 1 {
-		address = cliParams.args[0]
-		oid = defaultOID
-	} else if len(cliParams.args) == 2 {
-		address = cliParams.args[0]
-		oid = cliParams.args[1]
-	} else {
-		fmt.Printf("The number of arguments must be between 1 and 2. %d arguments were given.\n", len(cliParams.args))
-		cliParams.cmd.Help() //nolint:errcheck
-		os.Exit(1)
-		return nil
+func (u usageError) Error() string {
+	if u.e != nil {
+		return u.e.Error()
 	}
-	if strings.Contains(address, ":") {
-		deviceIP = address[:strings.Index(address, ":")]
-		value, _ = strconv.ParseUint(address[strings.Index(address, ":")+1:], 0, 16)
-		port = uint16(value)
-	} else {
-		//If the customer provides only 1 argument : the ip_address
-		//We check the ip address configuration in the agent runtime and we use it for the snmpwalk
-		deviceIP = address
-		//Allow the possibility to pass the config file as an argument to the command
+	return "Usage error"
+}
+
+func (u usageError) Unwrap() error {
+	return u.e
+}
+
+// usagef is a shorthand for creating a simple usageError.
+func usagef(msg string, args ...any) usageError {
+	return usageError{fmt.Errorf(msg, args...)}
+}
+
+// getParams tries to parse deviceAddr as host:port; if it can, it just returns
+// (host, port, params, nil). If the address is not a host:port pair, then it
+// assumes it is a plain IP address, and queries the running agent for the
+// configuration for that address.
+func getParams(deviceAddr string, connParams *connectionParams) (string, uint16, *connectionParams, error) {
+	deviceIP, port, hasPort := parseIPWithMaybePort(deviceAddr)
+
+	if !hasPort {
+		fmt.Println("No port provided. Loading details from agent config.")
+		// If the customer provides only the ip_address then we fetch parameters from the agent runtime.
+		// Allow the possibility to pass the config file as an argument to the command
 		snmpConfigList, err := parse.GetConfigCheckSnmp()
 		instance := parse.GetIPConfig(deviceIP, snmpConfigList)
 		if err != nil {
-			fmt.Printf("Couldn't parse the SNMP config : %v \n", err)
+			return "", 0, nil, fmt.Errorf("unable to load SNMP config from agent: %w", err)
 		}
 		if instance.IPAddress != "" {
-			cliParams.snmpVersion = instance.Version
+			connParams.snmpVersion = instance.Version
 			port = instance.Port
 
 			// v1 & v2c
-			cliParams.communityString = instance.CommunityString
+			connParams.communityString = instance.CommunityString
 
 			// v3
-			cliParams.user = instance.Username
-			cliParams.authProt = instance.AuthProtocol
-			cliParams.authKey = instance.AuthKey
-			cliParams.privProt = instance.PrivProtocol
-			cliParams.privKey = instance.PrivKey
-			cliParams.snmpContext = instance.Context
+			connParams.user = instance.Username
+			connParams.authProt = instance.AuthProtocol
+			connParams.authKey = instance.AuthKey
+			connParams.privProt = instance.PrivProtocol
+			connParams.privKey = instance.PrivKey
+			connParams.snmpContext = instance.Context
 
 			// communication
-			cliParams.retries = instance.Retries
+			connParams.retries = instance.Retries
 			if instance.Timeout != 0 {
-				cliParams.timeout = instance.Timeout
+				connParams.timeout = instance.Timeout
 			}
 		}
 	}
+
 	if port == 0 {
 		port = defaultPort
 	}
+	return deviceIP, port, connParams, nil
+}
 
+// newSNMP validates connection parameters and builds a GoSNMP from them.
+func newSNMP(deviceIP string, port uint16, connParams *connectionParams) (*gosnmp.GoSNMP, error) {
 	// Communication options check
-	if cliParams.timeout == 0 {
-		fmt.Printf("Timeout can not be 0 \n")
-		cliParams.cmd.Help() //nolint:errcheck
-		os.Exit(1)
-		return nil
+	if connParams.timeout == 0 {
+		return nil, fmt.Errorf("timeout cannot be 0")
 	}
 
 	// Authentication check
-	if cliParams.communityString == "" && cliParams.user == "" {
+	if connParams.communityString == "" && connParams.user == "" {
 		// Set default community string if version 1 or 2c and no given community string
-		if cliParams.snmpVersion == "1" || cliParams.snmpVersion == "2c" {
-			cliParams.communityString = defaultCommunityString
+		if connParams.snmpVersion == "1" || connParams.snmpVersion == "2c" {
+			connParams.communityString = defaultCommunityString
 		} else {
-			fmt.Printf("No authentication mechanism specified \n")
-			cliParams.cmd.Help() //nolint:errcheck
-			os.Exit(1)
-			return nil
+			return nil, fmt.Errorf("no authentication mechanism specified")
 		}
 	}
 
+	version := gosnmp.Version2c
 	// Set the snmp version
-	if cliParams.snmpVersion == "1" {
-		setVersion = gosnmp.Version1
-	} else if cliParams.snmpVersion == "2c" || (cliParams.snmpVersion == "" && cliParams.communityString != "") {
-		setVersion = gosnmp.Version2c
-	} else if cliParams.snmpVersion == "3" || (cliParams.snmpVersion == "" && cliParams.user != "") {
-		setVersion = gosnmp.Version3
+	if connParams.snmpVersion == "1" {
+		version = gosnmp.Version1
+	} else if connParams.snmpVersion == "2c" || (connParams.snmpVersion == "" && connParams.communityString != "") {
+		version = gosnmp.Version2c
+	} else if connParams.snmpVersion == "3" || (connParams.snmpVersion == "" && connParams.user != "") {
+		version = gosnmp.Version3
 	} else {
-		fmt.Printf("SNMP version not supported: %s, using default version 2c. \n", cliParams.snmpVersion) // match default version of the core check
-		setVersion = gosnmp.Version2c
+		fmt.Printf("SNMP version not supported: %s, using default version 2c. \n", connParams.snmpVersion) // match default version of the core check
 	}
-
+	securityParams := &gosnmp.UsmSecurityParameters{}
+	var msgFlags gosnmp.SnmpV3MsgFlags
 	// Set v3 security parameters
-	if setVersion == gosnmp.Version3 {
+	if version == gosnmp.Version3 {
+		securityParams.UserName = connParams.user
+		securityParams.AuthenticationPassphrase = connParams.authKey
+		securityParams.PrivacyPassphrase = connParams.privKey
+
 		// Authentication Protocol
-		switch strings.ToLower(cliParams.authProt) {
+		switch strings.ToLower(connParams.authProt) {
 		case "":
-			authProtocol = gosnmp.NoAuth
+			securityParams.AuthenticationProtocol = gosnmp.NoAuth
 		case "md5":
-			authProtocol = gosnmp.MD5
+			securityParams.AuthenticationProtocol = gosnmp.MD5
 		case "sha":
-			authProtocol = gosnmp.SHA
+			securityParams.AuthenticationProtocol = gosnmp.SHA
 		case "sha224", "sha-224":
-			authProtocol = gosnmp.SHA224
+			securityParams.AuthenticationProtocol = gosnmp.SHA224
 		case "sha256", "sha-256":
-			authProtocol = gosnmp.SHA256
+			securityParams.AuthenticationProtocol = gosnmp.SHA256
 		case "sha384", "sha-384":
-			authProtocol = gosnmp.SHA384
+			securityParams.AuthenticationProtocol = gosnmp.SHA384
 		case "sha512", "sha-512":
-			authProtocol = gosnmp.SHA512
+			securityParams.AuthenticationProtocol = gosnmp.SHA512
 		default:
-			fmt.Printf("Unsupported authentication protocol: %s \n", cliParams.authProt)
-			cliParams.cmd.Help() //nolint:errcheck
-			os.Exit(1)
-			return nil
+			return nil, fmt.Errorf("unsupported authentication protocol: %s", connParams.authProt)
 		}
 
 		// Privacy Protocol
-		switch strings.ToLower(cliParams.privProt) {
+		switch strings.ToLower(connParams.privProt) {
 		case "":
-			privProtocol = gosnmp.NoPriv
+			securityParams.PrivacyProtocol = gosnmp.NoPriv
 		case "des":
-			privProtocol = gosnmp.DES
+			securityParams.PrivacyProtocol = gosnmp.DES
 		case "aes":
-			privProtocol = gosnmp.AES
+			securityParams.PrivacyProtocol = gosnmp.AES
 		case "aes192":
-			privProtocol = gosnmp.AES192
+			securityParams.PrivacyProtocol = gosnmp.AES192
 		case "aes192c":
-			privProtocol = gosnmp.AES192C
+			securityParams.PrivacyProtocol = gosnmp.AES192C
 		case "aes256":
-			privProtocol = gosnmp.AES256
+			securityParams.PrivacyProtocol = gosnmp.AES256
 		case "aes256c":
-			privProtocol = gosnmp.AES256C
+			securityParams.PrivacyProtocol = gosnmp.AES256C
 		default:
-			fmt.Printf("Unsupported privacy protocol: %s \n", cliParams.privProt)
-			cliParams.cmd.Help() //nolint:errcheck
-			os.Exit(1)
-			return nil
+			return nil, fmt.Errorf("unsupported privacy protocol: %s", connParams.privProt)
 		}
 
 		// MsgFlags
-		switch strings.ToLower(cliParams.securityLevel) {
+		switch strings.ToLower(connParams.securityLevel) {
 		case "":
 			msgFlags = gosnmp.NoAuthNoPriv
-			if cliParams.privKey != "" {
+			if connParams.privKey != "" {
 				msgFlags = gosnmp.AuthPriv
-			} else if cliParams.authKey != "" {
+			} else if connParams.authKey != "" {
 				msgFlags = gosnmp.AuthNoPriv
 			}
 
@@ -305,48 +239,133 @@ func snmpwalk(config config.Component, cliParams *cliParams) error {
 		case "authnopriv":
 			msgFlags = gosnmp.AuthNoPriv
 		default:
-			fmt.Printf("Unsupported security level: %s \n", cliParams.securityLevel)
-			cliParams.cmd.Help() //nolint:errcheck
-			os.Exit(1)
-			return nil
+			return nil, fmt.Errorf("unsupported security level: %s", connParams.securityLevel)
 		}
 	}
 	// Set SNMP parameters
-	snmp := gosnmp.GoSNMP{
-		Target:    deviceIP,
-		Port:      port,
-		Community: cliParams.communityString,
-		Transport: "udp",
-		Version:   setVersion,
-		Timeout:   time.Duration(cliParams.timeout * int(time.Second)),
-		Retries:   cliParams.retries,
-		// v3
-		SecurityModel: gosnmp.UserSecurityModel,
-		ContextName:   cliParams.snmpContext,
-		MsgFlags:      msgFlags,
-		SecurityParameters: &gosnmp.UsmSecurityParameters{
-			UserName:                 cliParams.user,
-			AuthenticationProtocol:   authProtocol,
-			AuthenticationPassphrase: cliParams.authKey,
-			PrivacyProtocol:          privProtocol,
-			PrivacyPassphrase:        cliParams.privKey,
+	return &gosnmp.GoSNMP{
+		Target:                  deviceIP,
+		Port:                    port,
+		Community:               connParams.communityString,
+		Transport:               "udp",
+		Version:                 version,
+		Timeout:                 time.Duration(connParams.timeout * int(time.Second)),
+		Retries:                 connParams.retries,
+		SecurityModel:           gosnmp.UserSecurityModel,
+		ContextName:             connParams.snmpContext,
+		MsgFlags:                msgFlags,
+		SecurityParameters:      securityParams,
+		UseUnconnectedUDPSocket: connParams.unconnectedUDPSocket,
+	}, nil
+}
+
+// Commands returns a slice of subcommands for the 'agent' command.
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	connParams := &connectionParams{}
+	snmpCmd := &cobra.Command{
+		Use:   "snmp",
+		Short: "Snmp tools",
+		Long:  ``,
+	}
+
+	snmpCmd.PersistentFlags().StringVarP(&connParams.snmpVersion, "snmp-version", "v", defaultVersion, "Specify SNMP version to use")
+
+	// snmp v1 or v2c specific
+	snmpCmd.PersistentFlags().StringVarP(&connParams.communityString, "community-string", "C", "", "Set the community string")
+
+	// snmp v3 specific
+	snmpCmd.PersistentFlags().StringVarP(&connParams.authProt, "auth-protocol", "a", defaultAuthProtocol, "Set authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)")
+	snmpCmd.PersistentFlags().StringVarP(&connParams.authKey, "auth-key", "A", defaultAuthKey, "Set authentication protocol pass phrase")
+	snmpCmd.PersistentFlags().StringVarP(&connParams.securityLevel, "security-level", "l", defaultSecurityLevel, "set security level (noAuthNoPriv|authNoPriv|authPriv)")
+	snmpCmd.PersistentFlags().StringVarP(&connParams.snmpContext, "context", "N", defaultContext, "Set context name")
+	snmpCmd.PersistentFlags().StringVarP(&connParams.user, "user-name", "u", defaultUserName, "Set security name")
+	snmpCmd.PersistentFlags().StringVarP(&connParams.privProt, "priv-protocol", "x", defaultPrivProtocol, "Set privacy protocol (DES|AES|AES192|AES192C|AES256|AES256C)")
+	snmpCmd.PersistentFlags().StringVarP(&connParams.privKey, "priv-key", "X", defaultPrivKey, "Set privacy protocol pass phrase")
+
+	// general communication options
+	snmpCmd.PersistentFlags().IntVarP(&connParams.retries, "retries", "r", defaultRetries, "Set the number of retries")
+	snmpCmd.PersistentFlags().IntVarP(&connParams.timeout, "timeout", "t", defaultTimeout, "Set the request timeout (in seconds)")
+	snmpCmd.PersistentFlags().BoolVar(&connParams.unconnectedUDPSocket, "use-unconnected-udp-socket", defaultUseUnconnectedUDPSocket, "If specified, changes net connection to be unconnected UDP socket")
+
+	snmpWalkCmd := &cobra.Command{
+		Use:   "walk <IP Address>[:Port] [OID]",
+		Short: "Perform an snmpwalk, if only a valid IP address is provided with the oid then the agent default snmp config will be used",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := fxutil.OneShot(snmpwalk,
+				fx.Supply(connParams, globalParams, cmd),
+				fx.Provide(func() argsType { return args }),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath),
+					SecretParams: secrets.NewEnabledParams(),
+					LogParams:    logimpl.ForOneShot(command.LoggerName, "off", true)}),
+				core.Bundle(),
+			)
+			if err != nil {
+				var ue usageError
+				if errors.As(err, &ue) {
+					fmt.Println("Usage:", cmd.UseLine())
+				}
+				return err
+			}
+			return nil
 		},
-		UseUnconnectedUDPSocket: cliParams.unconnectedUDPSocket,
+	}
+	snmpCmd.AddCommand(snmpWalkCmd)
+
+	return []*cobra.Command{snmpCmd}
+}
+
+// parseIPWithMaybePort splits an address into a host and port if possible.
+// The return value is (host, port, ok) where ok will be true if
+// and only if the parsing succeeded. If it fails, we assume that
+// this address is only an IP address.
+func parseIPWithMaybePort(address string) (string, uint16, bool) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return address, 0, false
+	}
+	pnum, err := strconv.ParseUint(port, 0, 16)
+	if err != nil {
+		return address, 0, false
+	}
+	return host, uint16(pnum), true
+}
+
+// snmpwalk walks every SNMP value and prints it, in the style of the unix snmpwalk command.
+func snmpwalk(connParams *connectionParams, args argsType) error {
+	// Parse args
+	if len(args) == 0 {
+		return usagef("missing argument: IP address")
+	}
+	deviceAddr := args[0]
+	oid := defaultOID
+	if len(args) > 1 {
+		oid = args[1]
+	}
+	if len(args) > 2 {
+		return usagef("the number of arguments must be between 1 and 2. %d arguments were given.", len(args))
+	}
+	// Load config if needed
+	deviceIP, port, connParams, err := getParams(deviceAddr, connParams)
+	if err != nil {
+		return err
 	}
 	// Establish connection
-	err := snmp.Connect()
+	snmp, err := newSNMP(deviceIP, port, connParams)
 	if err != nil {
-		fmt.Printf("Connect err: %v\n", err)
-		os.Exit(1)
-		return nil
+		// newSNMP only returns parsing errors, so any problem is a usage error
+		return usageError{err}
+	}
+	if err := snmp.Connect(); err != nil {
+		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", deviceIP, port, err)
 	}
 	defer snmp.Conn.Close()
 
 	// Perform a snmpwalk using Walk for all versions
 	err = snmp.Walk(oid, printValue)
 	if err != nil {
-		fmt.Printf("Walk Error: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("walk error: %w", err)
 	}
 
 	return nil

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -362,8 +362,8 @@ func snmpwalk(connParams *connectionParams, args argsType, conf config.Component
 	return nil
 }
 
+// printValue prints a PDU in a similar style to snmpwalk -Ont
 func printValue(pdu gosnmp.SnmpPDU) error {
-
 	fmt.Printf("%s = ", pdu.Name)
 
 	switch pdu.Type {
@@ -383,13 +383,13 @@ func printValue(pdu gosnmp.SnmpPDU) error {
 	case gosnmp.TimeTicks:
 		fmt.Print(pdu.Value, "\n")
 	case gosnmp.Counter32:
-		fmt.Printf("Counter 32: %d\n", pdu.Value.(uint))
+		fmt.Printf("Counter32: %d\n", pdu.Value.(uint))
 	case gosnmp.Counter64:
-		fmt.Printf("Counter 64: %d\n", pdu.Value.(uint64))
+		fmt.Printf("Counter64: %d\n", pdu.Value.(uint64))
 	case gosnmp.Integer:
 		fmt.Printf("INTEGER: %d\n", pdu.Value.(int))
 	case gosnmp.Gauge32:
-		fmt.Printf("Gauge 32: %d\n", pdu.Value.(uint))
+		fmt.Printf("Gauge32: %d\n", pdu.Value.(uint))
 	case gosnmp.IPAddress:
 		fmt.Printf("IpAddress: %s\n", pdu.Value.(string))
 	default:

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -105,14 +105,14 @@ func usagef(msg string, args ...any) usageError {
 // (host, port, params, nil). If the address is not a host:port pair, then it
 // assumes it is a plain IP address, and queries the running agent for the
 // configuration for that address.
-func getParams(deviceAddr string, connParams *connectionParams) (string, uint16, *connectionParams, error) {
+func getParams(deviceAddr string, connParams *connectionParams, conf config.Component) (string, uint16, *connectionParams, error) {
 	deviceIP, port, hasPort := parseIPWithMaybePort(deviceAddr)
 
 	if !hasPort {
 		fmt.Println("No port provided. Loading details from agent config.")
 		// If the customer provides only the ip_address then we fetch parameters from the agent runtime.
 		// Allow the possibility to pass the config file as an argument to the command
-		snmpConfigList, err := parse.GetConfigCheckSnmp()
+		snmpConfigList, err := parse.GetConfigCheckSnmp(conf)
 		instance := parse.GetIPConfig(deviceIP, snmpConfigList)
 		if err != nil {
 			return "", 0, nil, fmt.Errorf("unable to load SNMP config from agent: %w", err)
@@ -333,7 +333,7 @@ func parseIPWithMaybePort(address string) (string, uint16, bool) {
 }
 
 // snmpwalk walks every SNMP value and prints it, in the style of the unix snmpwalk command.
-func snmpwalk(connParams *connectionParams, args argsType) error {
+func snmpwalk(connParams *connectionParams, args argsType, conf config.Component) error {
 	// Parse args
 	if len(args) == 0 {
 		return usagef("missing argument: IP address")
@@ -347,7 +347,7 @@ func snmpwalk(connParams *connectionParams, args argsType) error {
 		return usagef("the number of arguments must be between 1 and 2. %d arguments were given.", len(args))
 	}
 	// Load config if needed
-	deviceIP, port, connParams, err := getParams(deviceAddr, connParams)
+	deviceIP, port, connParams, err := getParams(deviceAddr, connParams, conf)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/subcommands/snmp/command_test.go
+++ b/cmd/agent/subcommands/snmp/command_test.go
@@ -20,8 +20,8 @@ func TestCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "walk", "1.2.3.4", "10.9.8.7", "-v", "3", "-r", "10"},
 		snmpwalk,
-		func(cliParams *cliParams) {
-			require.Equal(t, []string{"1.2.3.4", "10.9.8.7"}, cliParams.args)
+		func(cliParams *connectionParams, args argsType) {
+			require.Equal(t, argsType{"1.2.3.4", "10.9.8.7"}, args)
 			require.Equal(t, "3", cliParams.snmpVersion)
 			require.Equal(t, 10, cliParams.retries)
 			require.False(t, cliParams.unconnectedUDPSocket)
@@ -31,8 +31,8 @@ func TestCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "walk", "1.2.3.4", "10.9.8.7", "--use-unconnected-udp-socket"},
 		snmpwalk,
-		func(cliParams *cliParams) {
-			require.Equal(t, []string{"1.2.3.4", "10.9.8.7"}, cliParams.args)
+		func(cliParams *connectionParams, args argsType) {
+			require.Equal(t, argsType{"1.2.3.4", "10.9.8.7"}, args)
 			require.True(t, cliParams.unconnectedUDPSocket)
 		})
 }

--- a/cmd/agent/subcommands/snmp/optionsflag.go
+++ b/cmd/agent/subcommands/snmp/optionsflag.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package snmp
+
+import (
+	"fmt"
+	"strings"
+)
+
+// OptPairs is just a useful type alias to avoid writing this out multiple times.
+type OptPairs[T any] []struct {
+	key string
+	val T
+}
+
+// Options represents an ordered map of choices
+type Options[T any] struct {
+	Options map[string]T
+	Order   []string
+}
+
+// OptsStr provides a '|'-delimited list of all nonempty options.
+func (o Options[T]) OptsStr() string {
+	var keys []string
+	for _, k := range o.Order {
+		if k == "" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, "|")
+}
+
+// getOpt returns the key that matches choice, case-insensitively.
+func (o Options[T]) getOpt(choice string) (string, bool) {
+	choice = strings.ToLower(choice)
+	for opt := range o.Options {
+		if choice == strings.ToLower(opt) {
+			return opt, true
+		}
+	}
+	return "", false
+}
+
+// getVal returns the value whose key matches choice, case-insensitively.
+func (o Options[T]) getVal(choice string) (T, bool) {
+	if key, ok := o.getOpt(choice); ok {
+		return o.Options[key], true
+	}
+	// return a zero-value T
+	var t T
+	return t, false
+}
+
+// Flag creates a flag using these options and storing the selected choice in target.
+func (o Options[T]) Flag(target *string) OptionsFlag[T] {
+	return OptionsFlag[T]{o, target, "option"}
+}
+
+// TypedFlag is the same as Flag but lets you customize how the type of flag is shown in the help.
+func (o Options[T]) TypedFlag(target *string, typeName string) OptionsFlag[T] {
+	return OptionsFlag[T]{o, target, typeName}
+}
+
+// NewOptions creates a new Options object from a set of pairs.
+// We don't just create one directly from a map because map iteration order is random.
+func NewOptions[T any](pairs OptPairs[T]) Options[T] {
+	var order []string
+	opts := make(map[string]T)
+	for _, pair := range pairs {
+		order = append(order, pair.key)
+		opts[pair.key] = pair.val
+	}
+	return Options[T]{opts, order}
+}
+
+// OptionsFlag is an implementation of pflag.Value that complains when set to an invalid option.
+type OptionsFlag[T any] struct {
+	opts     Options[T]
+	value    *string
+	typeName string
+}
+
+// String returns a string representation of this value.
+func (a OptionsFlag[T]) String() string {
+	if a.value == nil {
+		return ""
+	}
+	return *a.value
+}
+
+// Set sets the value, returning an error if the given choice isn't valid.
+func (a OptionsFlag[T]) Set(p string) error {
+	if opt, ok := a.opts.getOpt(p); ok {
+		*a.value = opt
+		return nil
+	}
+	// note: we don't need to put p itself in this error because cobra prints the flag and the value as part of the error. For example:
+	// Error: invalid argument "foo" for "-x, --priv-protocol" flag: must be one of AES|AES192|AES192C|AES256|AES256C|DES
+	return fmt.Errorf("must be one of %s", a.opts.OptsStr())
+}
+
+// Type is how the value is represented in the auto-generated help.
+func (a OptionsFlag[T]) Type() string {
+	return a.typeName
+}

--- a/cmd/agent/subcommands/snmp/optionsflag_test.go
+++ b/cmd/agent/subcommands/snmp/optionsflag_test.go
@@ -57,7 +57,7 @@ func TestOptsFlag(t *testing.T) {
 	flag := m.Flag(&s)
 
 	assert.Equal(t, flag.String(), "")
-	assert.Equal(t, flag.Type(), "string")
+	assert.Equal(t, flag.Type(), "option")
 
 	for _, tc := range testCases {
 		if !tc.ok {

--- a/cmd/agent/subcommands/snmp/optionsflag_test.go
+++ b/cmd/agent/subcommands/snmp/optionsflag_test.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package snmp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var vals = OptPairs[int]{
+	{"", 1},
+	{"TWO", 2},
+	{"three", 3},
+	{"fOUr", 4},
+}
+
+var testCases = []struct {
+	choice      string
+	expectedKey string
+	expectedVal int
+	ok          bool
+}{
+	{"TWO", "TWO", 2, true},
+	{"two", "TWO", 2, true},
+	{"three", "three", 3, true},
+	{"THREE", "three", 3, true},
+	{"FouR", "fOUr", 4, true},
+	{"", "", 1, true},
+	{"five", "", 0, false},
+}
+
+func TestOptions(t *testing.T) {
+	m := NewOptions(vals)
+
+	assert.Equal(t, "TWO|three|fOUr", m.OptsStr())
+	for _, tc := range testCases {
+		gotKey, ok := m.getOpt(tc.choice)
+		assert.Equal(t, tc.ok, ok)
+		if ok {
+			assert.Equal(t, tc.expectedKey, gotKey)
+		}
+		gotVal, ok := m.getVal(tc.choice)
+		assert.Equal(t, tc.ok, ok)
+		if ok {
+			assert.Equal(t, tc.expectedVal, gotVal)
+		}
+	}
+}
+
+func TestOptsFlag(t *testing.T) {
+	m := NewOptions(vals)
+	var s string
+	flag := m.Flag(&s)
+
+	assert.Equal(t, flag.String(), "")
+	assert.Equal(t, flag.Type(), "string")
+
+	for _, tc := range testCases {
+		if !tc.ok {
+			old := s
+			err := flag.Set(tc.choice)
+			assert.ErrorContains(t, err, "TWO|three|fOUr")
+			assert.Equal(t, s, old)
+		} else {
+			assert.NoError(t, flag.Set(tc.choice))
+			assert.Equal(t, tc.expectedKey, s)
+			assert.Equal(t, tc.expectedKey, flag.String())
+		}
+	}
+}

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -316,3 +316,33 @@ func TestParseConfigSnmpMain(t *testing.T) {
 	assert.Equal(t, Exoutput, Output)
 
 }
+
+func TestIPDecodeHook(t *testing.T) {
+	bConf := []byte(`
+snmp_listener:
+    configs:
+    - network_address: 127.0.0.1/30
+      snmp_version: 1
+      community_string: public
+      ignored_ip_addresses:
+        - 10.0.1.0
+        - 10.0.1.1
+`)
+	rawConf := make(map[string]any)
+	require.NoError(t, yaml.Unmarshal(bConf, &rawConf))
+	conf := fxutil.Test[config.Component](t,
+		config.MockModule(),
+		fx.Replace(config.MockParams{Overrides: rawConf}),
+	)
+
+	Output, _ := parseConfigSnmpMain(conf)
+	Exoutput := []SNMPConfig{
+		{
+			Version:         "1",
+			CommunityString: "public",
+			NetAddress:      "127.0.0.1/30",
+		},
+	}
+	assert.Equal(t, Exoutput, Output)
+
+}


### PR DESCRIPTION
## What does this PR do?

This PR refactors the `agent snmp walk` subcommand to fix some issues and make parts of it more reusable.

## Motivation

I am in the process of making another snmp subcommand, and want to reuse most of the arguments and processing used in `snmp walk`; this change will make that much easier. I also found some issues with the snmp walk command, which I have fixed.

## Changes

### Loading config from the agent

Previously, if the user specified a port number then this subcommand wouldn't try to load any configuration from the agent, requiring the user to provide all relevant data (e.g. authentication data, timeout lengths, etc.). If the user **didn't** provide a port number, then the subcommand would fetch config from the agent, look up the SNMP entry corresponding to the given IP address, and use that data, ignoring any parameters that the user provided.

After this PR, the behavior is that the subcommand will always try to load data from the agent, but any values provided by the user will overwrite those from the agent. If the agent is unreachable, the subcommand will print a warning, but will run anyway (so that it still functions even if you don't have a running agent).

This fixes [NDMII-2450](https://datadoghq.atlassian.net/browse/NDMII-2450) and [NDMII-2541](https://datadoghq.atlassian.net/browse/NDMII-2541)

### Smarter IP parsing

Previously the script assumed that if there was a `:` in the given IP address, then it was a `host:port` pair and the last segment should be parsed as a port. Now, it uses golang's built-in `net.SplitHostPort`, which means that it will correctly identify IPv6 addresses (which also contain colons) and other names; if an IP or hostname contains colons, it must be encased in square brackets, so e.g. to walk localhost on an explicit port you would write
```sh
agent snmp walk '[::1]:161'
```

### Proper version/community defaults

Previously the behavior around defaults was slightly weird - if you didn't pass in a version or passed in an unrecognized version, and also didn't provide a community string, it would complain with a generic "no authentication method provided", but if you explicitly passed in version 1 or 2c then it would default to community="public".

The new behavior is
1. If you pass in an unrecognized version, it complains
2. If you don't pass in any version, but you do provide a username, it defaults to version 3
3. Otherwise, if you don't pass in any version, it defaults to version 2c
4. If it ends up using version 1 or version 2c (regardless of whether you told it to explicitly or it default to it), then a missing community string will default to "public".
5. If it ends up using version 3 and you didn't provide a username, it complains `username is required for snmp v3`.

### Cosmetic changes and bugfixes

 * When a user enters invalid input, the CLI will only show the error message and the usage string, not the full help text (which was obscuring the actual error message previously)
 * Several error messages have been made clearer (in particular, if the local agent is unreachable, it will say this instead of "unexpected end of JSON input")
 * If the datadog config has SNMP entries where network_address is not a valid CIDR address, this subcommand will no longer panic.
 * Counters and Gauges are now formatted as e.g. `Gauge32` instead of `Gauge 32` in the output, to match how `snmpwalk` formats things
 * It will no longer fail to read local config if the local config has `ignored_ip_addresses` set (this is issue NDMII-2541 ).

## Possible Drawbacks / Trade-offs

In the specific case where the agent is reachable but very slow to provide config, it could be frustrating that an snmp walk  with all necessary parameters specified nonetheless checks the config, but this is difficult to avoid without some fairly complex logic to decide how many parameters must be specified before we ignore local config (for example, if you provide all the necessary credentials etc but do not explicitly set a timeout, would you be surprised if the timeout in your config file was ignored?). It is easier to just request it every time, which in nearly cases should be fine - either the agent will reply immediately, or the connection will be refused.

## Describe how to test/QA your changes

Run `agent snmp walk <someaddress>` against the address of a working SNMP agent (you can spin up one on `localhost:161` with `docker run -p 161:161/udp tandrup/snmpsim`) and confirm that it generates the expected data (which should roughly match the output of `snmpwalk -c public <someaddress>:<someport>`).

For thoroughness, I tested it several different ways, including calling it with missing arguments:
 * `agent snmp walk localhost` should default to SNMP v2c with the `public` community on port 161
 * `agent snmp walk localhost:162` should fail immediately because the connection is rejected
 * `agent snmp walk localhost -v 3` should fail immediately, complaining that you must provide a username
 * `agent snmp walk -u simulator -l authPriv -a MD5 -x DES -A auctoritas -X privatus -v 3 --timeout=1 -N 4c9184f37cff01bcdc32dc486ec36961 localhost` should work if you're using `snmpsim` as described above, except I'm not sure how it generates that context name so you might need to look for the context name in the snmpsim logs and replace `4c9184f37cff01bcdc32dc486ec36961` with whatever identifier your copy is using.
 * If you configure your local agent with e.g.
```yaml
snmp_listeners:
  configs:
    - network_address: 127.0.0.1/32
      port: 161
      snmp_version: 3
      timeout: 1
      retries: 3
      user: simulator
      authKey: auctoritas
      authProtocol: MD5
      privKey: privatus
      privProtocol: DES
      context_name: 4c9184f37cff01bcdc32dc486ec36961
```
then `agent snmp walk 127.0.0.1 -v3` should work (again assuming you set the right context name), and overriding any of the auth values should make it stop working (the `-v3` is technically redundant but it makes sure you're not accidentally testing the default `v2c` instead).

[NDMII-2450]: https://datadoghq.atlassian.net/browse/NDMII-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ