### PR TITLE
[CWS] handle new btfhub format

### DIFF
--- a/pkg/security/probe/constantfetch/btfhub/main.go
+++ b/pkg/security/probe/constantfetch/btfhub/main.go
@@ -305,7 +305,7 @@ outer:
 
 		switch hdr.Typeflag {
 		case tar.TypeReg:
-			if strings.HasSuffix(hdr.Name, ".btf") {
+			if hdr.Name == "vmlinux" {
 				if _, err := io.Copy(btfBuffer, tarReader); err != nil {
 					return nil, fmt.Errorf("failed to uncompress file %s: %w", hdr.Name, err)
 				}


### PR DESCRIPTION
### What does this PR do?

BTFHub is changing it's data format, the btf file in each archive will be called `vmlinux` and no longer `<kernel-version>.btf`. This PR handles this new format. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
