### PR TITLE
event monitor: improve OS gating of network common code

### DIFF
--- a/pkg/network/events/monitor_others.go
+++ b/pkg/network/events/monitor_others.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !linux
+
 // Package events handles process events
 package events
 

--- a/pkg/network/events/network_consumer_others.go
+++ b/pkg/network/events/network_consumer_others.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows
+//go:build !linux
 
 // Package events handles process events
 package events


### PR DESCRIPTION
### What does this PR do?

The event monitor is currently supported only on linux. Some network code implements the required interface to "support" windows, but the code is not specific to windows and could actually be used to support all non-linux (including darwin) operating systems. This PR basically changes `windows` to `!linux` in order to support this.

Extracted from https://github.com/DataDog/datadog-agent/pull/21156

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
