### PR TITLE
event monitor: fix process event monitor build tag

### DIFF
--- a/pkg/process/events/consumer/events_consumer_linux.go
+++ b/pkg/process/events/consumer/events_consumer_linux.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build unix
-
 package consumer
 
 import (


### PR DESCRIPTION
### What does this PR do?

This process info copy function is not specific to unix, but to linux implementation (not supported on darwin for example). This PR fixes this build tag.

Please note that this PR not only removes the build tag, but also renames the file to take advantage of the file name derived build tag (as is currently done for the equivalent windows file).

Extracted from https://github.com/DataDog/datadog-agent/pull/21156

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
