### PR TITLE
[oracle] Only custom query (DBMON-3655)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -146,6 +146,7 @@ type InstanceConfig struct {
 	Asm                                asmConfig              `yaml:"asm"`
 	ResourceManager                    resourceManagerConfig  `yaml:"resource_manager"`
 	Locks                              locksConfig            `yaml:"locks"`
+	OnlyCustomQueries                  bool                   `yaml:"only_custom_queries"`
 }
 
 // CheckConfig holds the config needed for an integration instance to run.

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -162,6 +162,8 @@ func (c *Check) Run() error {
 		c.db = db
 	}
 
+	// Backward compatibility for old Python integration
+
 	if !c.initialized {
 		err := c.init()
 		if err != nil {

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -169,14 +169,12 @@ func (c *Check) Run() error {
 
 	metricIntervalExpired := checkIntervalExpired(&c.metricLastRun, c.config.MetricCollectionInterval)
 
-	if metricIntervalExpired && (len(c.config.InstanceConfig.CustomQueries) > 0 || len(c.config.InitConfig.CustomQueries) > 0) {
-		err := c.CustomQueries()
-		if c.config.OnlyCustomQueries {
-			return err
+	if c.config.OnlyCustomQueries {
+		var err error
+		if metricIntervalExpired && (len(c.config.InstanceConfig.CustomQueries) > 0 || len(c.config.InitConfig.CustomQueries) > 0) {
+			err = c.CustomQueries()
 		}
-		if err != nil {
-			allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to execute custom queries %w", c.logPrompt, err))
-		}
+		return err
 	}
 
 	if !c.initialized {
@@ -245,6 +243,12 @@ func (c *Check) Run() error {
 			err := c.ProcessMemory()
 			if err != nil {
 				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect process memory %w", c.logPrompt, err))
+			}
+		}
+		if metricIntervalExpired && (len(c.config.InstanceConfig.CustomQueries) > 0 || len(c.config.InitConfig.CustomQueries) > 0) {
+			err := c.CustomQueries()
+			if err != nil {
+				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to execute custom queries %w", c.logPrompt, err))
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Adding the `only_custom_query` configuration parameter.

### Motivation

Compatibility with the Oracle Python integration.

### Additional Notes

The Oracle Python integration introduced this parameter for the customers who didn't want to grant permissions to Oracle system views. We are introducing the parameter just for backward compatibility and keeping it hidden, as minimal privileges on some system views ensure  useful tags, such es host name, database version, etc.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Set the parameter `only_custom_queries` to `true` and check that:
- custom metrics are gathered
-  no other metrics are gathered.

Remove the parameter and check that there are no errors in the log file.