### PR TITLE
[oracle] Add user parameter (DBMON-3726)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -237,8 +237,10 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	}
 
 	if instance.Username == "" {
+		// For the backward compatibility with the Python integration
 		if instance.User != "" {
 			instance.Username = instance.User
+			warnDeprecated("user", "username")
 		} else {
 			return nil, fmt.Errorf("`username` is not configured")
 		}
@@ -289,4 +291,8 @@ func GetConnectData(c InstanceConfig) string {
 		p = fmt.Sprintf("%s/%s", p, c.ServiceName)
 	}
 	return p
+}
+
+func warnDeprecated(old string, new string) {
+	log.Warnf("The config parameter %s is deprecated and will be removed in future versions. Please use %s instead.", old, new)
 }

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -118,6 +118,7 @@ type InstanceConfig struct {
 	Port                               int                    `yaml:"port"`
 	ServiceName                        string                 `yaml:"service_name"`
 	Username                           string                 `yaml:"username"`
+	User                               string                 `yaml:"user"`
 	Password                           string                 `yaml:"password"`
 	TnsAlias                           string                 `yaml:"tns_alias"`
 	TnsAdmin                           string                 `yaml:"tns_admin"`
@@ -232,6 +233,14 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 			}
 		} else {
 			instance.Port = 1521
+		}
+	}
+
+	if instance.Username == "" {
+		if instance.User != "" {
+			instance.Username = instance.User
+		} else {
+			return nil, fmt.Errorf("`username` is not configured")
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Adding `user` parameter (next to the existing `username`)

### Motivation

Compatibility with the oracle Python integration.

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

`username` and `user` should both work. If neither of them is configured, the check should fail with the explicit error message.