### PR TITLE
[EBPF-445] Fix flaky test PatchPrintkNewline

### DIFF
--- a/pkg/ebpf/printk_patcher_test.go
+++ b/pkg/ebpf/printk_patcher_test.go
@@ -89,7 +89,7 @@ func TestPatchPrintkNewline(t *testing.T) {
 
 	// The logdebugtest program is a kprobe on do_vfs_ioctl, so we can use that to trigger the
 	// it and check that the output is correct. We do not actually care about the arguments.
-	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(0), 0, uintptr(0)); errno != 0 {
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(0), 0xfafafefe, uintptr(0)); errno != 0 {
 		// Only valid return value is ENOTTY (invalid ioctl for device) because indeed we
 		// are not doing any valid ioctl, we just want to trigger the kprobe
 		require.Equal(t, syscall.ENOTTY, errno)

--- a/pkg/ebpf/testdata/c/logdebug-test.c
+++ b/pkg/ebpf/testdata/c/logdebug-test.c
@@ -1,4 +1,7 @@
+#include "kconfig.h"
 #include "ktypes.h"
+#include <uapi/linux/ptrace.h>
+#include "bpf_tracing.h"
 #include "bpf_helpers.h"
 #include "bpf_helpers_custom.h"
 #include <uapi/linux/bpf.h>
@@ -41,8 +44,17 @@ int somefunc(unsigned int number) {
     return pid + number;
 }
 
+static int __always_inline is_logdebug_call(struct pt_regs *ctx) {
+    u32 cmd = PT_REGS_PARM3(ctx);
+    return cmd == 0xfafafefe;
+};
+
 SEC("kprobe/do_vfs_ioctl")
 int logdebugtest(struct pt_regs *ctx) {
+    if (!is_logdebug_call(ctx)) {
+        return 0;
+    }
+
     log_debug("hi"); // small word, should get a single MovImm instruction
     log_debug("123456"); // Small word, single movImm instruction on 64-bit boundary (add 2 bytes for newline and null character)
     log_debug("1234567"); // null character has to go on next 64b word


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR changes the testing code for `PatchPrintkNewline` so that it only responds to our ioctl, avoiding flakes where other ioctl calls could be causing conflicts in the log output.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
