### PR TITLE
provide initialize secrets component to flare

### DIFF
--- a/comp/core/flare/flare.go
+++ b/comp/core/flare/flare.go
@@ -52,8 +52,6 @@ type flare struct {
 }
 
 func newFlare(deps dependencies) (Component, rcclienttypes.TaskListenerProvider) {
-	// TODO FIX this uninitialize variable.
-	// var secretResolver secrets.Component
 	diagnoseDeps := diagnose.NewSuitesDeps(deps.Diagnosesendermanager, deps.Collector, deps.Secrets)
 	f := &flare{
 		log:          deps.Log,

--- a/comp/core/flare/flare.go
+++ b/comp/core/flare/flare.go
@@ -40,6 +40,7 @@ type dependencies struct {
 	Params                Params
 	Providers             []types.FlareCallback `group:"flare"`
 	Collector             optional.Option[collector.Component]
+	Secrets               secrets.Component
 }
 
 type flare struct {
@@ -52,8 +53,8 @@ type flare struct {
 
 func newFlare(deps dependencies) (Component, rcclienttypes.TaskListenerProvider) {
 	// TODO FIX this uninitialize variable.
-	var secretResolver secrets.Component
-	diagnoseDeps := diagnose.NewSuitesDeps(deps.Diagnosesendermanager, deps.Collector, secretResolver)
+	// var secretResolver secrets.Component
+	diagnoseDeps := diagnose.NewSuitesDeps(deps.Diagnosesendermanager, deps.Collector, deps.Secrets)
 	f := &flare{
 		log:          deps.Log,
 		config:       deps.Config,

--- a/comp/core/flare/flare_test.go
+++ b/comp/core/flare/flare_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
@@ -26,6 +28,11 @@ func TestFlareCreation(t *testing.T) {
 			t,
 			logimpl.MockModule(),
 			config.MockModule(),
+			secretsimpl.MockModule(),
+			fx.Provide(func(secretMock secrets.Mock) secrets.Component {
+				component := secretMock.(secrets.Component)
+				return component
+			}),
 			fx.Provide(func() diagnosesendermanager.Component { return nil }),
 			fx.Provide(func() Params { return Params{} }),
 			collector.NoneModule(),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Declare the secrets component as a dependency. 

### Why?
To fix a panic in `main` 

```
./bin/agent/agent flare -l -c dev/dist/datadog.yaml
Please enter your email: 
gustavo.caso@datadoghq.com
Initiating flare locally.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x103fa00d8]

goroutine 1 [running]:
github.com/DataDog/datadog-agent/pkg/autodiscovery.decryptConfig({{0x14000c9b5f0, 0x7}, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, {0x0, 0x0, ...}, ...}, ...)
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/secrets.go:26 +0x108
github.com/DataDog/datadog-agent/pkg/autodiscovery.(*reconcilingConfigManager).processNewConfig(_, {{0x14000c9b5f0, 0x7}, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, {0x0, ...}, ...})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/configmgr.go:214 +0x250
github.com/DataDog/datadog-agent/pkg/autodiscovery.(*AutoConfig).processNewConfig(_, {{0x14000c9b5f0, 0x7}, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, {0x0, ...}, ...})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/autoconfig.go:259 +0x1d4
github.com/DataDog/datadog-agent/pkg/autodiscovery.(*configPoller).collectOnce(0x14000c11740, {0x1071e4450?, 0x109941580?}, {0x111d18438?, 0x140000b1e38?}, 0x14000b2b0e0)
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/config_poller.go:195 +0x270
github.com/DataDog/datadog-agent/pkg/autodiscovery.(*configPoller).start(0x14000c11740, {0x1071e4450, 0x109941580}, 0x14000b2b0e0)
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/config_poller.go:68 +0x1a4
github.com/DataDog/datadog-agent/pkg/autodiscovery.(*AutoConfig).LoadAndRun(0x14000b2b0e0, {0x1071e4450, 0x109941580})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/autoconfig.go:196 +0x74
github.com/DataDog/datadog-agent/pkg/diagnose.diagnoseChecksInCLIProcess({0x1, 0x1, 0x0, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}}, {0x1071a2fc0?, ...}, ...)
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/diagnose/check.go:103 +0x220
github.com/DataDog/datadog-agent/pkg/diagnose.getDiagnose({0x1, 0x1, 0x0, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}}, {0x111b3d818?, ...}, ...)
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/diagnose/check.go:32 +0xe8
github.com/DataDog/datadog-agent/pkg/diagnose.getSuites.func1()
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/diagnose/runner.go:429 +0x5c
github.com/DataDog/datadog-agent/pkg/diagnose.getSuiteDiagnoses({{0x1050b7fa5?, 0x0?}, 0x140007a6400?})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/diagnose/runner.go:223 +0x3c
github.com/DataDog/datadog-agent/pkg/diagnose.getDiagnosesFromCurrentProcess({0x1, 0x1, 0x0, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}}, {0x1400017d6e0?, ...})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/diagnose/runner.go:285 +0xf0
github.com/DataDog/datadog-agent/pkg/diagnose.Run({0x1, 0x1, 0x0, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}}, {{0x111b3d818, ...}, ...})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/diagnose/runner.go:349 +0xe0
github.com/DataDog/datadog-agent/pkg/diagnose.RunStdOut({0x1071a1568?, 0x14000eb29c0}, {0x1, 0x1, 0x0, {0x0, 0x0, 0x0}, {0x0, 0x0, ...}}, ...)
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/diagnose/runner.go:368 +0xf0
github.com/DataDog/datadog-agent/pkg/flare.CompleteFlare.getDiagnoses.func5({0x1071a1568?, 0x14000eb29c0?})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/flare/archive.go:284 +0x94
github.com/DataDog/datadog-agent/pkg/flare.functionOutputToBytes(0x14000e6fae0)
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/flare/archive.go:419 +0xd0
github.com/DataDog/datadog-agent/pkg/flare.CompleteFlare.getDiagnoses.func6()
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/flare/archive.go:287 +0x20
github.com/DataDog/datadog-agent/comp/core/flare/helpers.(*builder).AddFileFromFunc(0x10517e237?, {0x1050b2be2, 0xc}, 0x1?)
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/comp/core/flare/helpers/builder.go:181 +0x30
github.com/DataDog/datadog-agent/pkg/flare.CompleteFlare({0x1071fe5b0, 0x14000cffd00}, {{0x111b3d818, 0x14000c7dea0}, {{0x0, 0x0}, 0x0}, {0x0, 0x0}})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/flare/archive.go:88 +0x4c8
github.com/DataDog/datadog-agent/comp/core/flare.(*flare).Create.func1({0x1071fe5b0?, 0x14000cffd00?})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/comp/core/flare/flare.go:124 +0x6c
github.com/DataDog/datadog-agent/comp/core/flare.(*flare).Create(0x14000e8c8f0, 0x140000b0030?, {0x0?, 0x0})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/comp/core/flare/flare.go:131 +0x384
github.com/DataDog/datadog-agent/cmd/agent/subcommands/flare.createArchive({0x1071b6050, 0x14000e8c8f0}, 0x0?, {0x0, 0x0})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/cmd/agent/subcommands/flare/command.go:365 +0xa0
github.com/DataDog/datadog-agent/cmd/agent/subcommands/flare.makeFlare({0x1071b6050, 0x14000e8c8f0}, {0x14000b9eae8?, 0x1021e7a24?}, {0x1072146d0?, 0x14000d16858?}, {0x8?, 0x0?}, 0x140004efc20, {{0x0?, ...}, ...}, ...)
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/cmd/agent/subcommands/flare/command.go:293 +0x2dc
reflect.Value.call({0x106c2bf40?, 0x10718c878?, 0x14000b9f198?}, {0x105095a1e, 0x4}, {0x14000b66580, 0x7, 0x1025a89f8?})
        /usr/local/go/src/reflect/value.go:596 +0x994
reflect.Value.Call({0x106c2bf40?, 0x10718c878?, 0x1071e4450?}, {0x14000b66580?, 0x0?, 0x0?})
        /usr/local/go/src/reflect/value.go:380 +0x94
github.com/DataDog/datadog-agent/pkg/util/fxutil.(*delayedFxInvocation).call(0x14000b17e10?)
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/util/fxutil/args.go:72 +0x98
github.com/DataDog/datadog-agent/pkg/util/fxutil.OneShot({0x106c2bf40?, 0x10718c878?}, {0x14000338fc0, 0x11, 0x11})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/pkg/util/fxutil/oneshot.go:54 +0x26c
github.com/DataDog/datadog-agent/cmd/agent/subcommands/flare.Commands.func1(0x1400039f400?, {0x140005e3c80?, 0x4?, 0x1050959da?})
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/cmd/agent/subcommands/flare/command.go:90 +0xd18
github.com/spf13/cobra.(*Command).execute(0x14000b10c00, {0x140005e3c20, 0x3, 0x3})
        /Users/gustavo.caso/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x14000bb8900)
        /Users/gustavo.caso/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/gustavo.caso/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/DataDog/datadog-agent/cmd/internal/runcmd.Run(0x14000bb8900)
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/cmd/internal/runcmd/runcmd.go:27 +0x2c
main.main()
        /Users/gustavo.caso/go/src/github.com/DataDog/datadog-agent/cmd/agent/main.go:66 +0xfc
```



<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Ensure that any flavor of the agent can generate a local flare without panics. Ex. `agent flare -l`

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
