### PR TITLE
[EBPF-294] Add Oracle images to KMT

### DIFF
--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -154,6 +154,9 @@ kmt_run_secagent_tests_x64:
           - "debian_10"
           - "debian_11"
           - "debian_12"
+          - "oracle_7.9"
+          - "oracle_8.9"
+          - "oracle_9.3"
         TEST_SET: [all_tests]
 
 kmt_run_secagent_tests_arm64:
@@ -179,6 +182,8 @@ kmt_run_secagent_tests_arm64:
           - "fedora_38"
           - "debian_11"
           - "debian_12"
+          - "oracle_8.9"
+          - "oracle_9.3"
         TEST_SET: ["all_tests"]
 
 .kmt_secagent_cleanup:

--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -15,7 +15,10 @@
         "debian_11": "master/debian-11-generic-x86_64.qcow2.xz",
         "debian_12": "master/debian-12-generic-x86_64.qcow2.xz",
         "centos_79": "master/centos-7.9-x86_64.qcow2.xz",
-        "centos_8": "master/centos-8-x86_64.qcow2.xz"
+        "centos_8": "master/centos-8-x86_64.qcow2.xz",
+        "oracle_7.9": "guillermo.julian/cws-images/oracle-7.9-x86_64.qcow.xz",
+        "oracle_8.9": "guillermo.julian/cws-images/oracle-8.9-x86_64.qcow.xz",
+        "oracle_9.3": "guillermo.julian/cws-images/oracle-9.3-x86_64.qcow.xz"
     },
     "arm64": {
         "ubuntu_18.04": "master/ubuntu-18-arm64.qcow2.xz",
@@ -31,6 +34,8 @@
         "debian_11": "master/debian-11-generic-arm64.qcow2.xz",
         "debian_12": "master/debian-12-generic-arm64.qcow2.xz",
         "centos_79": "master/centos-7.9-arm64.qcow2.xz",
-        "centos_8": "master/centos-8-arm64.qcow2.xz"
+        "centos_8": "master/centos-8-arm64.qcow2.xz",
+        "oracle_8.9": "guillermo.julian/cws-images/oracle-8.9-arm64.qcow.xz",
+        "oracle_9.3": "guillermo.julian/cws-images/oracle-9.3-arm64.qcow.xz"
     }
 }

--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -16,9 +16,9 @@
         "debian_12": "master/debian-12-generic-x86_64.qcow2.xz",
         "centos_79": "master/centos-7.9-x86_64.qcow2.xz",
         "centos_8": "master/centos-8-x86_64.qcow2.xz",
-        "oracle_7.9": "guillermo.julian/cws-images/oracle-7.9-x86_64.qcow.xz",
-        "oracle_8.9": "guillermo.julian/cws-images/oracle-8.9-x86_64.qcow.xz",
-        "oracle_9.3": "guillermo.julian/cws-images/oracle-9.3-x86_64.qcow.xz"
+        "oracle_7.9": "master/oracle-7.9-x86_64.qcow.xz",
+        "oracle_8.9": "master/oracle-8.9-x86_64.qcow.xz",
+        "oracle_9.3": "master/oracle-9.3-x86_64.qcow.xz"
     },
     "arm64": {
         "ubuntu_18.04": "master/ubuntu-18-arm64.qcow2.xz",
@@ -35,7 +35,7 @@
         "debian_12": "master/debian-12-generic-arm64.qcow2.xz",
         "centos_79": "master/centos-7.9-arm64.qcow2.xz",
         "centos_8": "master/centos-8-arm64.qcow2.xz",
-        "oracle_8.9": "guillermo.julian/cws-images/oracle-8.9-arm64.qcow.xz",
-        "oracle_9.3": "guillermo.julian/cws-images/oracle-9.3-arm64.qcow.xz"
+        "oracle_8.9": "master/oracle-8.9-arm64.qcow.xz",
+        "oracle_9.3": "master/oracle-9.3-arm64.qcow.xz"
     }
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adds Oracle 7.9 (x64 only), 8.9 and 9.3 to KMT.

### Motivation

Bringing the KMT test images as close to Kitchen as possible for security-agent tests.

Related: https://github.com/DataDog/ami-builder/pull/159
https://datadoghq.atlassian.net/browse/EBPF-294

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
