### PR TITLE
[AGNTR-171] Fix the issue with RC PR generation script setting wrong references

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -558,7 +558,6 @@ def _fetch_dependency_repo_version(
     # Get the highest repo version that's not higher than the Agent version we're going to build
     # We don't want to use a tag on dependent repositories that is supposed to be used in a future
     # release of the Agent (eg. if 7.31.1-rc.1 is tagged on integrations-core while we're releasing 7.30.0).
-    print(f"allowed_major_versions={allowed_major_versions}")
     version = _get_highest_repo_version(
         repo_name,
         new_agent_version.prefix,

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -419,7 +419,7 @@ def build_compatible_version_re(allowed_major_versions, minor_version):
     the provided minor version.
     """
     return re.compile(
-        r'(v)?({})[.]({})([.](\d+))?(-devel)?(-rc\.(\d+))?'.format(  # noqa: FS002
+        r'(v)?({})[.]({})([.](\d+))+(-devel)?(-rc\.(\d+))?(?!-\w)'.format(  # noqa: FS002
             "|".join(allowed_major_versions), minor_version
         )
     )
@@ -558,6 +558,7 @@ def _fetch_dependency_repo_version(
     # Get the highest repo version that's not higher than the Agent version we're going to build
     # We don't want to use a tag on dependent repositories that is supposed to be used in a future
     # release of the Agent (eg. if 7.31.1-rc.1 is tagged on integrations-core while we're releasing 7.30.0).
+    print(f"allowed_major_versions={allowed_major_versions}")
     version = _get_highest_repo_version(
         repo_name,
         new_agent_version.prefix,

--- a/tasks/unit-tests/release_tests.py
+++ b/tasks/unit-tests/release_tests.py
@@ -9,10 +9,11 @@ from tasks import release
 from tasks.libs.version import Version
 
 
-def mocked_github_requests_get(*args, **_kwargs):
-    def fake_tag(value):
-        return SimpleNamespace(name=value)
+def fake_tag(value):
+    return SimpleNamespace(name=value)
 
+
+def mocked_github_requests_get(*args, **_kwargs):
     if args[0][-1] == "6":
         return [
             fake_tag("6.28.0-rc.1"),
@@ -49,7 +50,29 @@ def mocked_github_requests_get(*args, **_kwargs):
     ]
 
 
+def mocked_github_requests_incorrect_get(*_args, **_kwargs):
+    return [
+        fake_tag("7.28.0-test"),
+        fake_tag("7.28.0-rc.1"),
+        fake_tag("7.28.0-rc.2"),
+        fake_tag("7.28.0-beta"),
+    ]
+
+
 class TestGetHighestRepoVersion(unittest.TestCase):
+    @mock.patch('tasks.release.GithubAPI')
+    def test_ignore_incorrect_tag(self, gh_mock):
+        gh_instance = mock.MagicMock()
+        gh_instance.get_tags.side_effect = mocked_github_requests_incorrect_get
+        gh_mock.return_value = gh_instance
+        version = release._get_highest_repo_version(
+            "target-repo",
+            "",
+            release.build_compatible_version_re(release.COMPATIBLE_MAJOR_VERSIONS[7], 28),
+            release.COMPATIBLE_MAJOR_VERSIONS[7],
+        )
+        self.assertEqual(version, Version(major=7, minor=28, patch=0, rc=2))
+
     @mock.patch('tasks.release.GithubAPI')
     def test_one_allowed_major_multiple_entries(self, gh_mock):
         gh_instance = mock.MagicMock()


### PR DESCRIPTION
### What does this PR do?

This PR changes the regex pattern which we use for finding highest available version when creating new RC entries.
Previously the tags like `7.52.0-dbm-aurora-autodiscovery-beta-0.3` where still matched and produced `7.52.0` tag which is incorrect.

This situation happened couple of times in the past, it was resolved either by manually editing `release.json` file after RC PR creation or by making the team which created the villain tag to remove it.

### Motivation

Improving the way we find highest version without setting restrictions on development teams which kinds of tags they cannot use.