### PR TITLE
[CWS-1468] include agent metadata part to backend JSON schema

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -18,6 +18,43 @@ CSM Threats logs have the following JSON schema:
 {
     "$id": "https://github.com/DataDog/datadog-agent/tree/main/pkg/security/serializers",
     "$defs": {
+        "AgentContext": {
+            "properties": {
+                "rule_id": {
+                    "type": "string"
+                },
+                "rule_version": {
+                    "type": "string"
+                },
+                "rule_actions": {
+                    "items": true,
+                    "type": "array"
+                },
+                "policy_name": {
+                    "type": "string"
+                },
+                "policy_version": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "os": {
+                    "type": "string"
+                },
+                "arch": {
+                    "type": "string"
+                },
+                "origin": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+                "rule_id"
+            ]
+        },
         "AnomalyDetectionSyscallEvent": {
             "properties": {
                 "syscall": {
@@ -1335,6 +1372,12 @@ CSM Threats logs have the following JSON schema:
         }
     },
     "properties": {
+        "agent": {
+            "$ref": "#/$defs/AgentContext"
+        },
+        "title": {
+            "type": "string"
+        },
         "evt": {
             "$ref": "#/$defs/EventContext"
         },
@@ -1405,13 +1448,18 @@ CSM Threats logs have the following JSON schema:
     },
     "additionalProperties": false,
     "type": "object",
-    "description": "EventSerializer serializes an event to JSON"
+    "required": [
+        "agent",
+        "title"
+    ]
 }
 
 {{< /code-block >}}
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
+| `agent` | $ref | Please see [AgentContext](#agentcontext) |
+| `title` | string |  |
 | `evt` | $ref | Please see [EventContext](#eventcontext) |
 | `date` | string |  |
 | `file` | $ref | Please see [FileEvent](#fileevent) |
@@ -1434,6 +1482,52 @@ CSM Threats logs have the following JSON schema:
 | `mount` | $ref | Please see [MountEvent](#mountevent) |
 | `anomaly_detection_syscall` | $ref | Please see [AnomalyDetectionSyscallEvent](#anomalydetectionsyscallevent) |
 | `usr` | $ref | Please see [UserContext](#usercontext) |
+
+## `AgentContext`
+
+
+{{< code-block lang="json" collapsible="true" >}}
+{
+    "properties": {
+        "rule_id": {
+            "type": "string"
+        },
+        "rule_version": {
+            "type": "string"
+        },
+        "rule_actions": {
+            "items": true,
+            "type": "array"
+        },
+        "policy_name": {
+            "type": "string"
+        },
+        "policy_version": {
+            "type": "string"
+        },
+        "version": {
+            "type": "string"
+        },
+        "os": {
+            "type": "string"
+        },
+        "arch": {
+            "type": "string"
+        },
+        "origin": {
+            "type": "string"
+        }
+    },
+    "additionalProperties": false,
+    "type": "object",
+    "required": [
+        "rule_id"
+    ]
+}
+
+{{< /code-block >}}
+
+
 
 ## `AnomalyDetectionSyscallEvent`
 

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -2,6 +2,43 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/DataDog/datadog-agent/tree/main/pkg/security/serializers",
   "$defs": {
+    "AgentContext": {
+      "properties": {
+        "rule_id": {
+          "type": "string"
+        },
+        "rule_version": {
+          "type": "string"
+        },
+        "rule_actions": {
+          "items": true,
+          "type": "array"
+        },
+        "policy_name": {
+          "type": "string"
+        },
+        "policy_version": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "arch": {
+          "type": "string"
+        },
+        "origin": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "rule_id"
+      ]
+    },
     "AnomalyDetectionSyscallEvent": {
       "properties": {
         "syscall": {
@@ -1319,6 +1356,12 @@
     }
   },
   "properties": {
+    "agent": {
+      "$ref": "#/$defs/AgentContext"
+    },
+    "title": {
+      "type": "string"
+    },
     "evt": {
       "$ref": "#/$defs/EventContext"
     },
@@ -1389,5 +1432,8 @@
   },
   "additionalProperties": false,
   "type": "object",
-  "description": "EventSerializer serializes an event to JSON"
+  "required": [
+    "agent",
+    "title"
+  ]
 }

--- a/pkg/security/probe/doc_generator/backend_doc_gen.go
+++ b/pkg/security/probe/doc_generator/backend_doc_gen.go
@@ -18,9 +18,17 @@ import (
 
 	"github.com/invopop/jsonschema"
 
+	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/serializers"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
+
+// CWSEvent is a similar struct to what we actually send to the backend, except in the real case
+// we actually do some struct-less string concatenation optimization
+type CWSEvent struct {
+	events.BackendEvent         `json:",inline"`
+	serializers.EventSerializer `json:",inline"`
+}
 
 func generateBackendJSON(output string) error {
 	reflector := jsonschema.Reflector{
@@ -35,7 +43,7 @@ func generateBackendJSON(output string) error {
 	}
 	reflector.CommentMap = cleanupEasyjson(reflector.CommentMap)
 
-	schema := reflector.Reflect(&serializers.EventSerializer{})
+	schema := reflector.Reflect(&CWSEvent{})
 	schema.ID = "https://github.com/DataDog/datadog-agent/tree/main/pkg/security/serializers"
 
 	schemaJSON, err := json.MarshalIndent(schema, "", "  ")


### PR DESCRIPTION
### What does this PR do?

This PR adds the CWS event metadata (agent version, kernel version etc) to the backend event JSON schema.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
