### PR TITLE
Remove unnecessary helper fn.

### DIFF
--- a/comp/snmptraps/config/config_test.go
+++ b/comp/snmptraps/config/config_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/gosnmp/gosnmp"
+	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
-	"gopkg.in/yaml.v2"
 )
 
 const mockedHostname = "VeryLongHostnameThatDoesNotFitIntoTheByteArray"
@@ -30,20 +30,6 @@ var expectedEngineID = "\x80\xff\xff\xff\xff\x67\xb2\x0f\xe4\xdf\x73\x7a\xce\x28
 var expectedEngineIDs = map[string]string{
 	"VeryLongHostnameThatDoesNotFitIntoTheByteArray": "\x80\xff\xff\xff\xff\x67\xb2\x0f\xe4\xdf\x73\x7a\xce\x28\x47\x03\x8f\x57\xe6\x5c\x98",
 	"VeryLongHostnameThatIsDifferent":                "\x80\xff\xff\xff\xff\xe7\x21\xcc\xd7\x0b\xe1\x60\xc5\x18\xd7\xde\x17\x86\xb0\x7d\x36",
-}
-
-// structify converts any yamlizable object to a plain map[string]any
-func structify[T any](obj T) (map[string]any, error) {
-	out, err := yaml.Marshal(obj)
-	if err != nil {
-		return nil, err
-	}
-	result := make(map[string]any)
-	err = yaml.Unmarshal(out, result)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
 }
 
 var usersV3 = []UserV3{
@@ -105,7 +91,8 @@ func withConfig(t testing.TB, trapConfig *TrapsConfig, globalNamespace string) f
 		overrides["network_devices.namespace"] = globalNamespace
 	}
 	if trapConfig != nil {
-		rawTrapConfig, err := structify(trapConfig)
+		rawTrapConfig := make(map[string]any)
+		err := mapstructure.Decode(trapConfig, &rawTrapConfig)
 		require.NoError(t, err)
 		overrides["network_devices.snmp_traps"] = rawTrapConfig
 	}


### PR DESCRIPTION
### What does this PR do?

Minor code cleanup - remove a helper fn that I wrote before I knew that `mapstructure` could already do this.

### Additional Notes

No QA needed: only a test file changes and the test still passes.