### PR TITLE
[CWS] add missing SBOM config to system probe config

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -72,6 +72,8 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("sbom.cache.enabled", true)
 	cfg.BindEnvAndSetDefault("sbom.cache.max_disk_size", 1000*1000*100) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
 	cfg.BindEnvAndSetDefault("sbom.cache.clean_interval", "30m")        // used by custom cache.
+	cfg.BindEnvAndSetDefault("sbom.scan_queue.base_backoff", "5m")
+	cfg.BindEnvAndSetDefault("sbom.scan_queue.max_backoff", "1h")
 
 	// Auto exit configuration
 	cfg.BindEnvAndSetDefault("auto_exit.validation_period", 60)


### PR DESCRIPTION
### What does this PR do?

This PR adds definition for missing SBOM config that were resulting in those logs in the tests:
```
[2024-03-06 17:16:39.515] [WARN] github.com/DataDog/datadog-agent/pkg/config/model.(*safeConfig).GetDuration:342 failed to get configuration value for key "sbom.scan_queue.base_backoff": unable to cast <nil> of type <nil> to Duration
[2024-03-06 17:16:39.515] [WARN] github.com/DataDog/datadog-agent/pkg/config/model.(*safeConfig).GetDuration:342 failed to get configuration value for key "sbom.scan_queue.max_backoff": unable to cast <nil> of type <nil> to Duration
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
