### PR TITLE
Improve logs agent status page and logging

### DIFF
--- a/comp/logs/agent/agent_test.go
+++ b/comp/logs/agent/agent_test.go
@@ -254,9 +254,9 @@ func (suite *AgentTestSuite) TestStatusOut() {
 	mockResult := logsStatus.Status{
 		IsRunning: true,
 		Endpoints: []string{"foo", "bar"},
-		StatusMetrics: map[string]int64{
-			"hello": 12,
-			"world": 13,
+		StatusMetrics: map[string]string{
+			"hello": "12",
+			"world": "13",
 		},
 		ProcessFileStats: map[string]uint64{
 			"CoreAgentProcessOpenFiles": 27,

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -69,6 +69,7 @@ type AutoMultilineHandler struct {
 	detectedPattern     *DetectedPattern
 	clk                 clock.Clock
 	autoMultiLineStatus *status.MappedInfo
+	tailerInfo          *status.InfoRegistry
 }
 
 // NewAutoMultilineHandler returns a new AutoMultilineHandler.
@@ -108,6 +109,7 @@ func NewAutoMultilineHandler(
 		detectedPattern:     detectedPattern,
 		clk:                 clock.New(),
 		autoMultiLineStatus: status.NewMappedInfo("Auto Multi-line"),
+		tailerInfo:          tailerInfo,
 	}
 
 	h.singleLineHandler = NewSingleLineHandler(outputFn, lineLimit)
@@ -205,7 +207,7 @@ func (h *AutoMultilineHandler) switchToMultilineHandler(r *regexp.Regexp) {
 	h.singleLineHandler = nil
 
 	// Build and start a multiline-handler
-	h.multiLineHandler = NewMultiLineHandler(h.outputFn, r, h.flushTimeout, h.lineLimit, true)
+	h.multiLineHandler = NewMultiLineHandler(h.outputFn, r, h.flushTimeout, h.lineLimit, true, h.tailerInfo)
 	h.source.RegisterInfo(h.multiLineHandler.countInfo)
 	h.source.RegisterInfo(h.multiLineHandler.linesCombinedInfo)
 	// stay with the multiline handler

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -110,7 +110,7 @@ func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Par
 	var lineHandler LineHandler
 	for _, rule := range source.Config().ProcessingRules {
 		if rule.Type == config.MultiLine {
-			lh := NewMultiLineHandler(outputFn, rule.Regex, config.AggregationTimeout(pkgConfig.Datadog), lineLimit, false)
+			lh := NewMultiLineHandler(outputFn, rule.Regex, config.AggregationTimeout(pkgConfig.Datadog), lineLimit, false, tailerInfo)
 			syncSourceInfo(source, lh)
 			lineHandler = lh
 		}
@@ -125,7 +125,7 @@ func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Par
 				// Save the pattern again for the next rotation
 				detectedPattern.Set(multiLinePattern)
 
-				lh := NewMultiLineHandler(outputFn, multiLinePattern, config.AggregationTimeout(pkgConfig.Datadog), lineLimit, true)
+				lh := NewMultiLineHandler(outputFn, multiLinePattern, config.AggregationTimeout(pkgConfig.Datadog), lineLimit, true, tailerInfo)
 				syncSourceInfo(source, lh)
 				lineHandler = lh
 			} else {

--- a/pkg/logs/internal/decoder/line_handler_benchmark_test.go
+++ b/pkg/logs/internal/decoder/line_handler_benchmark_test.go
@@ -57,7 +57,7 @@ func benchmarkMultiLineHandler(b *testing.B, logs int, line string) {
 		messages[i] = getDummyMessageWithLF(fmt.Sprintf("%s %d", line, i))
 	}
 
-	h := NewMultiLineHandler(func(*message.Message) {}, regexp.MustCompile(`^[A-Za-z_]+ \d+, \d+ \d+:\d+:\d+ (AM|PM)`), 1000*time.Millisecond, 100, false)
+	h := NewMultiLineHandler(func(*message.Message) {}, regexp.MustCompile(`^[A-Za-z_]+ \d+, \d+ \d+:\d+:\d+ (AM|PM)`), 1000*time.Millisecond, 100, false, status.NewInfoRegistry())
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/pkg/logs/internal/decoder/line_handler_test.go
+++ b/pkg/logs/internal/decoder/line_handler_test.go
@@ -96,7 +96,7 @@ func TestTrimSingleLine(t *testing.T) {
 func TestMultiLineHandler(t *testing.T) {
 	re := regexp.MustCompile(`[0-9]+\.`)
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 20, false)
+	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 20, false, status.NewInfoRegistry())
 
 	var output *message.Message
 
@@ -180,7 +180,7 @@ func TestMultiLineHandler(t *testing.T) {
 func TestTrimMultiLine(t *testing.T) {
 	re := regexp.MustCompile(`[0-9]+\.`)
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false)
+	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false, status.NewInfoRegistry())
 
 	var output *message.Message
 
@@ -209,7 +209,7 @@ func TestTrimMultiLine(t *testing.T) {
 func TestMultiLineHandlerDropsEmptyMessages(t *testing.T) {
 	re := regexp.MustCompile(`[0-9]+\.`)
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false)
+	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false, status.NewInfoRegistry())
 
 	h.process(getDummyMessage(""))
 
@@ -238,7 +238,7 @@ func TestSingleLineHandlerSendsRawInvalidMessages(t *testing.T) {
 func TestMultiLineHandlerSendsRawInvalidMessages(t *testing.T) {
 	re := regexp.MustCompile(`[0-9]+\.`)
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false)
+	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false, status.NewInfoRegistry())
 
 	h.process(getDummyMessage("1.third line"))
 	h.process(getDummyMessage("fourth line"))

--- a/pkg/logs/internal/decoder/multiline_handler.go
+++ b/pkg/logs/internal/decoder/multiline_handler.go
@@ -36,11 +36,14 @@ type MultiLineHandler struct {
 	linesCombinedInfo *status.CountInfo
 	telemetryEnabled  bool
 	linesCombined     int
-	tailerInfo        *status.InfoRegistry
 }
 
 // NewMultiLineHandler returns a new MultiLineHandler.
 func NewMultiLineHandler(outputFn func(*message.Message), newContentRe *regexp.Regexp, flushTimeout time.Duration, lineLimit int, telemetryEnabled bool, tailerInfo *status.InfoRegistry) *MultiLineHandler {
+
+	i := status.NewMappedInfo("Multi-Line Pattern")
+	i.SetMessage("Pattern", newContentRe.String())
+	tailerInfo.Register(i)
 
 	h := &MultiLineHandler{
 		outputFn:          outputFn,
@@ -52,15 +55,7 @@ func NewMultiLineHandler(outputFn func(*message.Message), newContentRe *regexp.R
 		linesCombinedInfo: status.NewCountInfo("Lines Combined"),
 		telemetryEnabled:  telemetryEnabled,
 		linesCombined:     0,
-		tailerInfo:        tailerInfo,
 	}
-
-	i := status.NewMappedInfo("Multi-Line Pattern")
-	i.SetMessage("Pattern", newContentRe.String())
-	tailerInfo.Register(i)
-	tailerInfo.Register(h.countInfo)
-	tailerInfo.Register(h.linesCombinedInfo)
-
 	return h
 }
 

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -392,7 +392,7 @@ func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Mess
 }
 
 func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, pattern *regexp.Regexp) *tailer.Tailer {
-	tailerInfo := status.NewInfoRegistry()
+	tailerInfo := t.GetInfo()
 	return t.NewRotatedTailer(file, decoder.NewDecoderFromSourceWithPattern(file.Source, pattern, tailerInfo), tailerInfo)
 }
 

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -46,7 +46,13 @@ var (
 	// TlmBytesSent is the total number of sent bytes before encoding if any
 	TlmBytesSent = telemetry.NewCounter("logs", "bytes_sent",
 		nil, "Total number of bytes send before encoding if any")
-
+	// RetryCount is the total number of times we have retried payloads that failed to send
+	RetryCount = expvar.Int{}
+	// TlmRetryCountis the total number of times we have retried payloads that failed to send
+	TlmRetryCount = telemetry.NewCounter("logs", "retry_count",
+		nil, "Total number of retried paylaods")
+	// RetryTimeSpent is the total time spent retrying payloads that failed to send
+	RetryTimeSpent = expvar.Int{}
 	// EncodedBytesSent is the total number of sent bytes after encoding if any
 	EncodedBytesSent = expvar.Int{}
 	// TlmEncodedBytesSent is the total number of sent bytes after encoding if any
@@ -74,6 +80,8 @@ func init() {
 	LogsExpvars.Set("DestinationErrors", &DestinationErrors)
 	LogsExpvars.Set("DestinationLogsDropped", &DestinationLogsDropped)
 	LogsExpvars.Set("BytesSent", &BytesSent)
+	LogsExpvars.Set("RetryCount", &RetryCount)
+	LogsExpvars.Set("RetryTimeSpent", &RetryTimeSpent)
 	LogsExpvars.Set("EncodedBytesSent", &EncodedBytesSent)
 	LogsExpvars.Set("SenderLatency", &SenderLatency)
 	LogsExpvars.Set("HttpDestinationStats", &DestinationExpVars)

--- a/pkg/logs/metrics/metrics_test.go
+++ b/pkg/logs/metrics/metrics_test.go
@@ -12,5 +12,5 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	assert.Equal(t, LogsExpvars.String(), `{"BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "HttpDestinationStats": {}, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "SenderLatency": 0}`)
+	assert.Equal(t, LogsExpvars.String(), `{"BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "HttpDestinationStats": {}, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "RetryCount": 0, "RetryTimeSpent": 0, "SenderLatency": 0}`)
 }

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -8,7 +8,9 @@ package status
 
 import (
 	"expvar"
+	"fmt"
 	"strings"
+	"time"
 
 	"go.uber.org/atomic"
 
@@ -194,12 +196,14 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 }
 
 // getMetricsStatus exposes some aggregated metrics of the log agent on the agent status
-func (b *Builder) getMetricsStatus() map[string]int64 {
-	var metrics = make(map[string]int64, 2)
-	metrics["LogsProcessed"] = b.logsExpVars.Get("LogsProcessed").(*expvar.Int).Value()
-	metrics["LogsSent"] = b.logsExpVars.Get("LogsSent").(*expvar.Int).Value()
-	metrics["BytesSent"] = b.logsExpVars.Get("BytesSent").(*expvar.Int).Value()
-	metrics["EncodedBytesSent"] = b.logsExpVars.Get("EncodedBytesSent").(*expvar.Int).Value()
+func (b *Builder) getMetricsStatus() map[string]string {
+	var metrics = make(map[string]string)
+	metrics["LogsProcessed"] = fmt.Sprintf("%v", b.logsExpVars.Get("LogsProcessed").(*expvar.Int).Value())
+	metrics["LogsSent"] = fmt.Sprintf("%v", b.logsExpVars.Get("LogsSent").(*expvar.Int).Value())
+	metrics["BytesSent"] = fmt.Sprintf("%v", b.logsExpVars.Get("BytesSent").(*expvar.Int).Value())
+	metrics["RetryCount"] = fmt.Sprintf("%v", b.logsExpVars.Get("RetryCount").(*expvar.Int).Value())
+	metrics["RetryTimeSpent"] = fmt.Sprintf("%s", time.Duration(b.logsExpVars.Get("RetryTimeSpent").(*expvar.Int).Value()))
+	metrics["EncodedBytesSent"] = fmt.Sprintf("%v", b.logsExpVars.Get("EncodedBytesSent").(*expvar.Int).Value())
 	return metrics
 }
 

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -202,7 +202,7 @@ func (b *Builder) getMetricsStatus() map[string]string {
 	metrics["LogsSent"] = fmt.Sprintf("%v", b.logsExpVars.Get("LogsSent").(*expvar.Int).Value())
 	metrics["BytesSent"] = fmt.Sprintf("%v", b.logsExpVars.Get("BytesSent").(*expvar.Int).Value())
 	metrics["RetryCount"] = fmt.Sprintf("%v", b.logsExpVars.Get("RetryCount").(*expvar.Int).Value())
-	metrics["RetryTimeSpent"] = fmt.Sprintf("%s", time.Duration(b.logsExpVars.Get("RetryTimeSpent").(*expvar.Int).Value()))
+	metrics["RetryTimeSpent"] = time.Duration(b.logsExpVars.Get("RetryTimeSpent").(*expvar.Int).Value()).String()
 	metrics["EncodedBytesSent"] = fmt.Sprintf("%v", b.logsExpVars.Get("EncodedBytesSent").(*expvar.Int).Value())
 	return metrics
 }

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -71,7 +71,7 @@ type Integration struct {
 type Status struct {
 	IsRunning        bool              `json:"is_running"`
 	Endpoints        []string          `json:"endpoints"`
-	StatusMetrics    map[string]int64  `json:"metrics"`
+	StatusMetrics    map[string]string `json:"metrics"`
 	ProcessFileStats map[string]uint64 `json:"process_file_stats"`
 	Integrations     []Integration     `json:"integrations"`
 	Tailers          []Tailer          `json:"tailers"`

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -95,13 +96,13 @@ func TestStatusDeduplicateErrorsAndWarnings(t *testing.T) {
 func TestMetrics(t *testing.T) {
 	defer Clear()
 	Clear()
-	var expected = `{"BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "", "HttpDestinationStats": {}, "IsRunning": false, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "SenderLatency": 0, "Warnings": ""}`
+	var expected = `{"BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "", "HttpDestinationStats": {}, "IsRunning": false, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "RetryCount": 0, "RetryTimeSpent": 0, "SenderLatency": 0, "Warnings": ""}`
 	assert.Equal(t, expected, metrics.LogsExpvars.String())
 
 	initStatus()
 	AddGlobalWarning("bar", "Unique Warning")
 	AddGlobalError("bar", "I am an error")
-	expected = `{"BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "I am an error", "HttpDestinationStats": {}, "IsRunning": true, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "SenderLatency": 0, "Warnings": "Unique Warning"}`
+	expected = `{"BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "I am an error", "HttpDestinationStats": {}, "IsRunning": true, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "RetryCount": 0, "RetryTimeSpent": 0, "SenderLatency": 0, "Warnings": "Unique Warning"}`
 	assert.Equal(t, expected, metrics.LogsExpvars.String())
 }
 
@@ -110,26 +111,32 @@ func TestStatusMetrics(t *testing.T) {
 	initStatus()
 
 	status := Get(false)
-	assert.Equal(t, int64(0), status.StatusMetrics["LogsProcessed"])
-	assert.Equal(t, int64(0), status.StatusMetrics["LogsSent"])
-	assert.Equal(t, int64(0), status.StatusMetrics["BytesSent"])
-	assert.Equal(t, int64(0), status.StatusMetrics["EncodedBytesSent"])
+	assert.Equal(t, "0", status.StatusMetrics["LogsProcessed"])
+	assert.Equal(t, "0", status.StatusMetrics["LogsSent"])
+	assert.Equal(t, "0", status.StatusMetrics["BytesSent"])
+	assert.Equal(t, "0", status.StatusMetrics["EncodedBytesSent"])
+	assert.Equal(t, "0", status.StatusMetrics["RetryCount"])
+	assert.Equal(t, "0s", status.StatusMetrics["RetryTimeSpent"])
 
 	metrics.LogsProcessed.Set(5)
 	metrics.LogsSent.Set(3)
 	metrics.BytesSent.Set(42)
 	metrics.EncodedBytesSent.Set(21)
+	metrics.RetryCount.Set(42)
+	metrics.RetryTimeSpent.Set(int64(time.Hour * 2))
 	status = Get(false)
 
-	assert.Equal(t, int64(5), status.StatusMetrics["LogsProcessed"])
-	assert.Equal(t, int64(3), status.StatusMetrics["LogsSent"])
-	assert.Equal(t, int64(42), status.StatusMetrics["BytesSent"])
-	assert.Equal(t, int64(21), status.StatusMetrics["EncodedBytesSent"])
+	assert.Equal(t, "5", status.StatusMetrics["LogsProcessed"])
+	assert.Equal(t, "3", status.StatusMetrics["LogsSent"])
+	assert.Equal(t, "42", status.StatusMetrics["BytesSent"])
+	assert.Equal(t, "21", status.StatusMetrics["EncodedBytesSent"])
+	assert.Equal(t, "42", status.StatusMetrics["RetryCount"])
+	assert.Equal(t, "2h0m0s", status.StatusMetrics["RetryTimeSpent"])
 
 	metrics.LogsProcessed.Set(math.MaxInt64)
 	metrics.LogsProcessed.Add(1)
 	status = Get(false)
-	assert.Equal(t, int64(math.MinInt64), status.StatusMetrics["LogsProcessed"])
+	assert.Equal(t, fmt.Sprintf("%v", math.MinInt64), status.StatusMetrics["LogsProcessed"])
 }
 
 func TestStatusEndpoints(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR does several small things:
- Upgrade backoff retry logs from `Debug` to `Warn`
- Report # of retries and time spent retrying on status page and telemetry
- Fix a bug where rotated tailers did not report mulit-line handler status (when using `agent status -v`)
- Add the currently applied pattern to a tailer using the multiline handler to the verbose status output. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

improve debugability of the logs agent. 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Send some logs and then break the connection to the intake (either via proxy, or using mock intake)
    - run `agent status` and confirm counters are increasing for retries and retry time
    - check the logs for the warning log messages
- Configure a regular `multi_line` pattern and write some logs to a file
    - confirm `agent status -v` shows the pattern in the tailer info
- Configure `auto_mulit_line_detection` and write some logs (such that a pattern matches)
    - confirm `agent status -v` shows the auto multi-line status
    - rotate the file and write a couple logs
    - confirm `agent status -v` still shows the auto multi-line status

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
