### PR TITLE
[agentless-scanner] Install upstart and sysv init scripts

### DIFF
--- a/omnibus/config/software/datadog-agentless-scanner-finalize.rb
+++ b/omnibus/config/software/datadog-agentless-scanner-finalize.rb
@@ -18,8 +18,16 @@ build do
     license :project_license
 
     # Move system service files
+    mkdir "/etc/init"
+    move "#{install_dir}/scripts/datadog-agentless-scanner.conf", "/etc/init"
+    if debian_target?
+                # sysvinit support for debian only for now
+                mkdir "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agentless-scanner", "/etc/init.d"
+    end
     mkdir "/lib/systemd/system"
     move "#{install_dir}/scripts/datadog-agentless-scanner.service", "/lib/systemd/system"
+
     mkdir "/var/log/datadog"
 
     # cleanup clutter


### PR DESCRIPTION
### What does this PR do?

This change also installs the `upstart` and `sysv` init scripts, along with the `systemd` init scripts that were previously installed.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
