### PR TITLE
[CWS] ensure event is assigned to correct event ID in self tests

### DIFF
--- a/pkg/security/probe/selftests/tester_linux.go
+++ b/pkg/security/probe/selftests/tester_linux.go
@@ -163,11 +163,11 @@ func (t *SelfTester) WaitForResult(cb func(success []eval.RuleID, fails []eval.R
 				for _, selfTest := range t.selfTests {
 					if !selfTest.IsSuccess() {
 						selfTest.HandleEvent(event)
-					}
 
-					if selfTest.IsSuccess() {
-						id := selfTest.GetRuleDefinition().ID
-						events[id] = event.Event
+						if selfTest.IsSuccess() {
+							id := selfTest.GetRuleDefinition().ID
+							events[id] = event.Event
+						}
 					}
 				}
 				t.Unlock()


### PR DESCRIPTION
### What does this PR do?

If the self test event type was already a success the new event would overwrite the event stored for this event, resulting in "chown" events being stored for the "open" event type. This PR ensure we store the correct event for each event type.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
