### PR TITLE
[AGNTR-162] Remove unnecessary need statements in rc deployment job

### DIFF
--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -10,11 +10,6 @@ rc_kubernetes_deploy:
   needs:
     - job: docker_trigger_internal
       artifacts: false
-    - job: docker_trigger_cluster_agent_internal
-      artifacts: false
-    - job: k8s-e2e-main # Currently only require container Argo workflow
-      artifacts: false
-      optional: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:


### PR DESCRIPTION
### What does this PR do?

This PR fixes the problem in `rc_kubernetes_deployment` gitlab job in situations when the RC build pipeline fails to produce agent packages but cluster agent is built correctly. This scenario is possible, when the opposite is much less likely to happen.
The set of 'needs' for this job was taken from the original nightly deployments job, which does not have to deal with similar case.

### Motivation

Avoid bad deployments in situation when RC build failed.

### Describe how to test/QA your changes

To be tested with the next RC build. In general triggering the bad scenario should be unnecessary. 
