### PR TITLE
Extend scrubbing for authorization and Bearer token

### DIFF
--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -60,9 +60,9 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 		Hints: []string{"Bearer"},
 		Repl:  []byte(`Bearer ***********************************************************$1`),
 	}
-	// For this one we match any letters, not just a -> f
+	// For this one we match any characters
 	hintedBearerInvalidReplacer := Replacer{
-		Regex: regexp.MustCompile(`\bBearer [a-zA-Z0-9]+\b`),
+		Regex: regexp.MustCompile(`\bBearer\s+[^*]+\b`),
 		Hints: []string{"Bearer"},
 		Repl:  []byte("Bearer " + defaultReplacement),
 	}
@@ -104,8 +104,8 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 		[]byte(`$1 "********"`),
 	)
 	snmpReplacer := matchYAMLKey(
-		`(community_string|authKey|privKey|community|authentication_key|privacy_key)`,
-		[]string{"community_string", "authKey", "privKey", "community", "authentication_key", "privacy_key"},
+		`(community_string|authKey|privKey|community|authentication_key|privacy_key|Authorization|authorization)`,
+		[]string{"community_string", "authKey", "privKey", "community", "authentication_key", "privacy_key", "Authorization", "authorization"},
 		[]byte(`$1 "********"`),
 	)
 	snmpMultilineReplacer := matchYAMLKeyWithListValue(

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -619,6 +619,30 @@ func TestBearerToken(t *testing.T) {
 		`Bearer 2fe663014abcd1850076f6d68c0355666db98758262870811cace007cd4a62bdsldijfoiwjeoimdfolisdjoijfewoa`,
 		`Bearer ********`)
 	assertClean(t,
+		`Bearer abf243d1-9ba5-4d8d-8365-ac18229eb2ac`,
+		`Bearer ********`)
+	assertClean(t,
+		`Bearer token with space`,
+		`Bearer ********`)
+	assertClean(t,
+		`Bearer     123456798`,
+		`Bearer ********`)
+	assertClean(t,
 		`AuthBearer 2fe663014abcd1850076f6d68c0355666db98758262870811cace007cd4a62ba`,
 		`AuthBearer 2fe663014abcd1850076f6d68c0355666db98758262870811cace007cd4a62ba`)
+}
+
+func TestAuthorization(t *testing.T) {
+	assertClean(t,
+		`Authorization: some auth`,
+		`Authorization: "********"`)
+	assertClean(t,
+		`  Authorization: some auth`,
+		`  Authorization: "********"`)
+	assertClean(t,
+		`- Authorization: some auth`,
+		`- Authorization: "********"`)
+	assertClean(t,
+		`  authorization: some auth`,
+		`  authorization: "********"`)
 }


### PR DESCRIPTION
### What does this PR do?

Extend scrubbing for authorization and Bearer token.

### QA

Set in an integration configuration:
```
instances:
- something: Bearer 012-345-678
  something2: Bearer 2fe663014abcd1850076f6d68c0355666db98758262870811cace007cd4a62ba
  authorization: 38bdae31-f5fb-4e7d-bf2e-1d2c8fe78b81
  [...]
```

Run the `configcheck` CLI and check the fields are correctly scrubbed:
```
instances:
- something: Bearer  ********
  something2: Bearer ***********************************************************a62ba
  authorization: "********"`)
  [...]
```
