### PR TITLE
(fleet) updater OCI repository support

### DIFF
--- a/pkg/updater/defaults/catalog.json
+++ b/pkg/updater/defaults/catalog.json
@@ -10,7 +10,7 @@
     {
       "package": "datadog-agent",
       "version": "7.53.0-devel.git.156.4681fd9.pipeline.29311299-1",
-      "url": "oci://docker.io/arbll/agent-dev@sha256:868287768e7f224fbf210a864c3da614ab19cde23ddbd8a94e747c915d8c9ab1"
+      "url": "oci://us-docker.pkg.dev/datadog-sandbox/updater-dev/agent@sha256:868287768e7f224fbf210a864c3da614ab19cde23ddbd8a94e747c915d8c9ab1"
     }
   ]
 }

--- a/pkg/updater/defaults/catalog.json
+++ b/pkg/updater/defaults/catalog.json
@@ -24,7 +24,7 @@
       "version": "7.53.0-devel.git.156.4681fd9.pipeline.29311299-1",
       "platform": "linux",
       "arch": "amd64",
-      "url": "https://storage.googleapis.com/updater-dev/datadog-agent-7.53.0-devel.git.156.4681fd9.pipeline.29311299-1-x86_64.tar",
+      "url": "oci://docker.io/arbll/agent-dev@sha256:459e066b3c85a9034f5dc394a0fb5440a07cb354f2b05ad13d34353ab8b101fd",
       "sha256": "7c32c90cbd82b714f96e95cc772b25444b038d4dd45f9f7d80b3acb4aaed8180",
       "size": 231900160
     },

--- a/pkg/updater/defaults/catalog.json
+++ b/pkg/updater/defaults/catalog.json
@@ -1,7 +1,6 @@
 {
   "packages": [
     {
-      "name": "dd-trace-java",
       "package": "dd-trace-java",
       "version": "1.31.0",
       "url": "https://storage.googleapis.com/updater-dev/dd-trace-java-1.31.0.tar",
@@ -9,34 +8,9 @@
       "size": 26594816
     },
     {
-      "name": "datadog-agent",
-      "package": "datadog-agent",
-      "version": "7.53.0-devel.git.142.5f0ff76.pipeline.29207608-1",
-      "platform": "linux",
-      "arch": "amd64",
-      "url": "https://storage.googleapis.com/updater-dev/7.53.0-devel.git.142.5f0ff76.pipeline.29207608.tar",
-      "sha256": "1648cec536615e88dd9ea13a422c735bee775c20e40a667a019c4dd0baa0dcd5",
-      "size": 231945216
-    },
-    {
-      "name": "datadog-agent",
       "package": "datadog-agent",
       "version": "7.53.0-devel.git.156.4681fd9.pipeline.29311299-1",
-      "platform": "linux",
-      "arch": "amd64",
-      "url": "oci://docker.io/arbll/agent-dev@sha256:459e066b3c85a9034f5dc394a0fb5440a07cb354f2b05ad13d34353ab8b101fd",
-      "sha256": "7c32c90cbd82b714f96e95cc772b25444b038d4dd45f9f7d80b3acb4aaed8180",
-      "size": 231900160
-    },
-    {
-      "name": "datadog-agent",
-      "package": "datadog-agent",
-      "version": "7.53.0-devel.git.156.4681fd9.pipeline.29311299-1",
-      "platform": "linux",
-      "arch": "arm64",
-      "url": "https://storage.googleapis.com/updater-dev/datadog-agent-7.53.0-devel.git.156.4681fd9.pipeline.29311299-1-aarch64.tar",
-      "sha256": "d9f2250520770be6ea8c7a88ffe3c08051db2dba050888eec8d3a61020eeb6e5",
-      "size": 203648512
+      "url": "oci://docker.io/arbll/agent-dev@sha256:868287768e7f224fbf210a864c3da614ab19cde23ddbd8a94e747c915d8c9ab1"
     }
   ]
 }

--- a/pkg/updater/download.go
+++ b/pkg/updater/download.go
@@ -15,13 +15,16 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	oci "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -48,18 +51,45 @@ func newDownloader(client *http.Client) *downloader {
 // Download downloads the Datadog Package referenced in the given Package struct.
 func (d *downloader) Download(ctx context.Context, tmpDir string, pkg Package) (oci.Image, error) {
 	log.Debugf("Downloading package %s version %s from %s", pkg.Name, pkg.Version, pkg.URL)
-
-	// TODO: Add support for OCI registries
-	image, err := d.downloadFromURL(ctx, pkg.URL, pkg.SHA256, pkg.Size, tmpDir)
+	url, err := url.Parse(pkg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse package URL: %w", err)
+	}
+	var image oci.Image
+	switch url.Scheme {
+	case "http", "https":
+		image, err = d.downloadHTTP(ctx, pkg.URL, pkg.SHA256, pkg.Size, tmpDir)
+	case "oci":
+		image, err = d.downloadRegistry(ctx, pkg.URL)
+	default:
+		return nil, fmt.Errorf("unsupported package URL scheme: %s", url.Scheme)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("could not download package from %s: %w", pkg.URL, err)
 	}
-
 	log.Debugf("Successfully downloaded package %s version %s from %s", pkg.Name, pkg.Version, pkg.URL)
 	return image, nil
 }
 
-func (d *downloader) downloadFromURL(ctx context.Context, url string, sha256hash string, size int64, tmpDir string) (oci.Image, error) {
+func (d *downloader) downloadRegistry(ctx context.Context, url string) (oci.Image, error) {
+	url = strings.TrimPrefix(url, "oci://")
+	// the image URL is parsed as a digest to ensure we use the <repository>/<image>@<digest> format
+	digest, err := name.NewDigest(url, name.StrictValidation)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse digest: %w", err)
+	}
+	platform := oci.Platform{
+		OS:           runtime.GOOS,
+		Architecture: runtime.GOARCH,
+	}
+	image, err := remote.Image(digest, remote.WithContext(ctx), remote.WithPlatform(platform))
+	if err != nil {
+		return nil, fmt.Errorf("could not download image: %w", err)
+	}
+	return image, nil
+}
+
+func (d *downloader) downloadHTTP(ctx context.Context, url string, sha256hash string, size int64, tmpDir string) (oci.Image, error) {
 	// Request the oci-layout.tar archive from the given URL
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {


### PR DESCRIPTION
This PR adds support in the updater to download images from OCI repositories.

To showcase this I merged the following two images as a multi-arch image that is now used by default:
```bash
wget https://storage.googleapis.com/updater-dev/datadog-agent-7.53.0-devel.git.156.4681fd9.pipeline.29311299-1-aarch64.tar
wget https://storage.googleapis.com/updater-dev/datadog-agent-7.53.0-devel.git.156.4681fd9.pipeline.29311299-1-x86_64.tar
datadog-package merge datadog-agent-7.53.0-*

datadog-package push us-docker.pkg.dev/datadog-sandbox/updater-dev/agent:7.53.0-devel.git.156.4681fd9.pipeline.29311299-1 merged.tar
```

Support for `.tar` OCI layouts will be kept for now.