### PR TITLE
Add e2e tests for check command on linux

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -175,6 +175,7 @@ new-e2e-agent-subcommands:
       - EXTRA_PARAMS: --run TestWindowsFlareSuite
       - EXTRA_PARAMS: --run TestLinuxSecretSuite
       - EXTRA_PARAMS: --run TestWindowsSecretSuite
+      - EXTRA_PARAMS: --run TestLinuxCheckSuite
   allow_failure: true # TODO: To remove when the tests are stable
 
 new-e2e-language-detection:

--- a/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
@@ -73,6 +73,20 @@ func (agent *agentCommandRunner) Hostname(commandArgs ...agentclient.AgentArgsOp
 	return strings.Trim(output, "\n")
 }
 
+// Check runs check command and returns the runtime Agent check
+func (agent *agentCommandRunner) Check(commandArgs ...agentclient.AgentArgsOption) string {
+	return agent.executeCommand("check", commandArgs...)
+}
+
+// Check runs check command and returns the runtime Agent check or an error
+func (agent *agentCommandRunner) CheckWithError(commandArgs ...agentclient.AgentArgsOption) (string, error) {
+	args, err := optional.MakeParams(commandArgs...)
+	require.NoError(agent.t, err)
+
+	arguments := append([]string{"check"}, args.Args...)
+	return agent.executor.execute(arguments)
+}
+
 // Config runs config command and returns the runtime agent config
 func (agent *agentCommandRunner) Config(commandArgs ...agentclient.AgentArgsOption) string {
 	return agent.executeCommand("config", commandArgs...)

--- a/test/new-e2e/pkg/utils/e2e/client/agentclient/agent.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agentclient/agent.go
@@ -14,6 +14,12 @@ type Agent interface {
 	// Hostname runs hostname command and returns the runtime Agent hostname
 	Hostname(commandArgs ...AgentArgsOption) string
 
+	// Check runs check command and returns the runtime Agent check
+	Check(commandArgs ...AgentArgsOption) string
+
+	// Check runs check command and returns the runtime Agent check or an error
+	CheckWithError(commandArgs ...AgentArgsOption) (string, error)
+
 	// Config runs config command and returns the runtime agent config
 	Config(commandArgs ...AgentArgsOption) string
 

--- a/test/new-e2e/tests/agent-subcommands/check/check_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_common_test.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package check contains helpers and e2e tests of the check command
+package check
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type baseCheckSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+func (v *baseCheckSuite) TestCheckDisk() {
+	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"disk"}))
+
+	assert.Contains(v.T(), check, `"metric": "system.disk.total"`)
+	assert.Contains(v.T(), check, `"metric": "system.disk.used"`)
+	assert.Contains(v.T(), check, `"metric": "system.disk.free"`)
+}
+
+func (v *baseCheckSuite) TestUnknownCheck() {
+	_, err := v.Env().Agent.Client.CheckWithError(agentclient.WithArgs([]string{"unknown-check"}))
+	assert.Error(v.T(), err)
+	assert.Contains(v.T(), err.Error(), `Error: no valid check found`)
+}
+
+func (v *baseCheckSuite) TestCustomCheck() {
+	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello"}))
+	assert.Contains(v.T(), check, `"metric": "hello.world"`)
+	assert.Contains(v.T(), check, `"TAG_KEY:TAG_VALUE"`)
+	assert.Contains(v.T(), check, `"type": "gauge"`)
+}
+
+func (v *baseCheckSuite) TestCheckRate() {
+	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-rate", "--json"}))
+	data := parseCheckOutput([]byte(check))
+	require.NotNil(v.T(), data)
+
+	metrics := data[0].Aggregator.Metrics
+
+	assert.Equal(v.T(), len(metrics), 2)
+	assert.Equal(v.T(), metrics[0].Metric, "hello.world")
+	assert.Equal(v.T(), metrics[0].Points[0][1], 123)
+	assert.Equal(v.T(), metrics[1].Metric, "hello.world")
+	assert.Equal(v.T(), metrics[1].Points[0][1], 133)
+}
+
+func (v *baseCheckSuite) TestCheckTimes() {
+	times := 10
+	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-times", fmt.Sprint(times), "--json"}))
+
+	data := parseCheckOutput([]byte(check))
+	require.NotNil(v.T(), data)
+
+	metrics := data[0].Aggregator.Metrics
+
+	assert.Equal(v.T(), len(metrics), times)
+	for idx := 0; idx < times; idx++ {
+		assert.Equal(v.T(), metrics[idx].Points[0][1], 123+idx*10) // see fixtures/hello.py
+	}
+}

--- a/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
@@ -31,7 +31,7 @@ func TestLinuxCheckSuite(t *testing.T) {
 	e2e.Run(t, &linuxCheckSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(
 		agentparams.WithFile("/etc/datadog-agent/conf.d/hello.yaml", string(customCheckYaml), true),
 		agentparams.WithFile("/etc/datadog-agent/checks.d/hello.py", string(customCheckPython), true),
-	))), e2e.WithDevMode())
+	))))
 }
 
 func (v *linuxCheckSuite) TestCheckFlare() {

--- a/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package check contains helpers and e2e tests of the check command
+package check
+
+import (
+	_ "embed"
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type linuxCheckSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+//go:embed fixtures/hello.yaml
+var customCheckYaml []byte
+
+//go:embed fixtures/hello.py
+var customCheckPython []byte
+
+func TestLinuxCheckSuite(t *testing.T) {
+	e2e.Run(t, &linuxCheckSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(
+		agentparams.WithFile("/etc/datadog-agent/conf.d/hello.yaml", string(customCheckYaml), true),
+		agentparams.WithFile("/etc/datadog-agent/checks.d/hello.py", string(customCheckPython), true),
+	))), e2e.WithDevMode())
+}
+
+func (v *linuxCheckSuite) TestCheckDisk() {
+	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"disk"}))
+
+	assert.Contains(v.T(), check, `"metric": "system.disk.total"`)
+	assert.Contains(v.T(), check, `"metric": "system.disk.used"`)
+	assert.Contains(v.T(), check, `"metric": "system.disk.free"`)
+}
+
+func (v *linuxCheckSuite) TestUnknownCheck() {
+	_, err := v.Env().Agent.Client.CheckWithError(agentclient.WithArgs([]string{"unknown-check"}))
+	assert.Error(v.T(), err)
+	assert.Contains(v.T(), err.Error(), `Error: no valid check found`)
+}
+
+func (v *linuxCheckSuite) TestCustomCheck() {
+	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello"}))
+	assert.Contains(v.T(), check, `"metric": "hello.world"`)
+	assert.Contains(v.T(), check, `"TAG_KEY:TAG_VALUE"`)
+	assert.Contains(v.T(), check, `"type": "gauge"`)
+}
+
+func (v *linuxCheckSuite) TestCheckRate() {
+	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-rate", "--json"}))
+	data := parseCheckOutput([]byte(check))
+	require.NotNil(v.T(), data)
+
+	metrics := data[0].Aggregator.Metrics
+
+	assert.Equal(v.T(), len(metrics), 2)
+	assert.Equal(v.T(), metrics[0].Metric, "hello.world")
+	assert.Equal(v.T(), metrics[0].Points[0][1], 123)
+	assert.Equal(v.T(), metrics[1].Metric, "hello.world")
+	assert.Equal(v.T(), metrics[1].Points[0][1], 133)
+}
+
+func (v *linuxCheckSuite) TestCheckTimes() {
+	times := 10
+	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-times", fmt.Sprint(times), "--json"}))
+
+	data := parseCheckOutput([]byte(check))
+	require.NotNil(v.T(), data)
+
+	metrics := data[0].Aggregator.Metrics
+
+	assert.Equal(v.T(), len(metrics), times)
+	for idx := 0; idx < times; idx++ {
+		assert.Equal(v.T(), metrics[idx].Points[0][1], 123+idx*10) // see fixtures/hello.py
+	}
+}
+
+func (v *linuxCheckSuite) TestCheckFlare() {
+	v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--flare"}))
+	files := v.Env().RemoteHost.MustExecute("sudo ls /var/log/datadog/checks")
+	assert.Contains(v.T(), files, "check_hello")
+}

--- a/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
@@ -8,20 +8,17 @@ package check
 
 import (
 	_ "embed"
-	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type linuxCheckSuite struct {
-	e2e.BaseSuite[environments.Host]
+	baseCheckSuite
 }
 
 //go:embed fixtures/hello.yaml
@@ -35,56 +32,6 @@ func TestLinuxCheckSuite(t *testing.T) {
 		agentparams.WithFile("/etc/datadog-agent/conf.d/hello.yaml", string(customCheckYaml), true),
 		agentparams.WithFile("/etc/datadog-agent/checks.d/hello.py", string(customCheckPython), true),
 	))), e2e.WithDevMode())
-}
-
-func (v *linuxCheckSuite) TestCheckDisk() {
-	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"disk"}))
-
-	assert.Contains(v.T(), check, `"metric": "system.disk.total"`)
-	assert.Contains(v.T(), check, `"metric": "system.disk.used"`)
-	assert.Contains(v.T(), check, `"metric": "system.disk.free"`)
-}
-
-func (v *linuxCheckSuite) TestUnknownCheck() {
-	_, err := v.Env().Agent.Client.CheckWithError(agentclient.WithArgs([]string{"unknown-check"}))
-	assert.Error(v.T(), err)
-	assert.Contains(v.T(), err.Error(), `Error: no valid check found`)
-}
-
-func (v *linuxCheckSuite) TestCustomCheck() {
-	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello"}))
-	assert.Contains(v.T(), check, `"metric": "hello.world"`)
-	assert.Contains(v.T(), check, `"TAG_KEY:TAG_VALUE"`)
-	assert.Contains(v.T(), check, `"type": "gauge"`)
-}
-
-func (v *linuxCheckSuite) TestCheckRate() {
-	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-rate", "--json"}))
-	data := parseCheckOutput([]byte(check))
-	require.NotNil(v.T(), data)
-
-	metrics := data[0].Aggregator.Metrics
-
-	assert.Equal(v.T(), len(metrics), 2)
-	assert.Equal(v.T(), metrics[0].Metric, "hello.world")
-	assert.Equal(v.T(), metrics[0].Points[0][1], 123)
-	assert.Equal(v.T(), metrics[1].Metric, "hello.world")
-	assert.Equal(v.T(), metrics[1].Points[0][1], 133)
-}
-
-func (v *linuxCheckSuite) TestCheckTimes() {
-	times := 10
-	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-times", fmt.Sprint(times), "--json"}))
-
-	data := parseCheckOutput([]byte(check))
-	require.NotNil(v.T(), data)
-
-	metrics := data[0].Aggregator.Metrics
-
-	assert.Equal(v.T(), len(metrics), times)
-	for idx := 0; idx < times; idx++ {
-		assert.Equal(v.T(), metrics[idx].Points[0][1], 123+idx*10) // see fixtures/hello.py
-	}
 }
 
 func (v *linuxCheckSuite) TestCheckFlare() {

--- a/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
@@ -6,19 +6,18 @@
 // Package check contains helpers and e2e tests of the check command
 package check
 
-// TODO: not working yet because of the following error:
-// unable to import module 'hello': source code string cannot contain null bytes
-// Uncomment the code below when the issue is fixed
-/*type windowsCheckSuite struct {
+type windowsCheckSuite struct {
 	baseCheckSuite
 }
 
 func TestWindowsCheckSuite(t *testing.T) {
+	t.Skip("not working because of the following error: unable to import module 'hello': source code string cannot contain null bytes")
+	
 	e2e.Run(t, &windowsCheckSuite{}, e2e.WithProvisioner(
 		awshost.ProvisionerNoFakeIntake(
 			awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
 			awshost.WithAgentOptions(
 				agentparams.WithFile("C:/ProgramData/Datadog/conf.d/hello.d/conf.yaml", string(customCheckYaml), true),
 				agentparams.WithFile("C:/ProgramData/Datadog/checks.d/hello.py", string(customCheckPython), true),
-			))), e2e.WithDevMode())
-}*/
+			))))
+}

--- a/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package check contains helpers and e2e tests of the check command
+package check
+
+// TODO: not working yet because of the following error:
+// unable to import module 'hello': source code string cannot contain null bytes
+// Uncomment the code below when the issue is fixed
+/*type windowsCheckSuite struct {
+	baseCheckSuite
+}
+
+func TestWindowsCheckSuite(t *testing.T) {
+	e2e.Run(t, &windowsCheckSuite{}, e2e.WithProvisioner(
+		awshost.ProvisionerNoFakeIntake(
+			awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
+			awshost.WithAgentOptions(
+				agentparams.WithFile("C:/ProgramData/Datadog/conf.d/hello.d/conf.yaml", string(customCheckYaml), true),
+				agentparams.WithFile("C:/ProgramData/Datadog/checks.d/hello.py", string(customCheckPython), true),
+			))), e2e.WithDevMode())
+}*/

--- a/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
@@ -6,13 +6,23 @@
 // Package check contains helpers and e2e tests of the check command
 package check
 
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+)
+
 type windowsCheckSuite struct {
 	baseCheckSuite
 }
 
 func TestWindowsCheckSuite(t *testing.T) {
 	t.Skip("not working because of the following error: unable to import module 'hello': source code string cannot contain null bytes")
-	
+
 	e2e.Run(t, &windowsCheckSuite{}, e2e.WithProvisioner(
 		awshost.ProvisionerNoFakeIntake(
 			awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),

--- a/test/new-e2e/tests/agent-subcommands/check/fixtures/hello.py
+++ b/test/new-e2e/tests/agent-subcommands/check/fixtures/hello.py
@@ -1,0 +1,21 @@
+# the following try/except block will make the custom check compatible with any Agent version
+try:
+    # first, try to import the base class from new versions of the Agent...
+    from datadog_checks.base import AgentCheck
+except ImportError:
+    # ...if the above failed, the check is running in Agent version < 6.6.0
+    from checks import AgentCheck
+
+# content of the special variable __version__ will be shown in the Agent status page
+__version__ = "1.0.0"
+
+
+# flake8: noqa
+class HelloCheck(AgentCheck):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.value = 123
+
+    def check(self, instance):
+        self.gauge('hello.world', self.value, tags=['TAG_KEY:TAG_VALUE'] + self.instance.get('tags', []))
+        self.value += 10

--- a/test/new-e2e/tests/agent-subcommands/check/fixtures/hello.yaml
+++ b/test/new-e2e/tests/agent-subcommands/check/fixtures/hello.yaml
@@ -1,0 +1,1 @@
+instances: [{}]

--- a/test/new-e2e/tests/agent-subcommands/check/fixtures/hello.yaml
+++ b/test/new-e2e/tests/agent-subcommands/check/fixtures/hello.yaml
@@ -1,1 +1,3 @@
+init_config:
+
 instances: [{}]

--- a/test/new-e2e/tests/agent-subcommands/check/parse.go
+++ b/test/new-e2e/tests/agent-subcommands/check/parse.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package check
+
+import (
+	"encoding/json"
+)
+
+type root struct {
+	Aggregator aggregator `json:"aggregator"`
+}
+
+type aggregator struct {
+	Metrics []metric `json:"metrics"`
+}
+
+type metric struct {
+	Host           string   `json:"host"`
+	Interval       int      `json:"interval"`
+	Metric         string   `json:"metric"`
+	Points         [][]int  `json:"points"`
+	SourceTypeName string   `json:"source_type_name"`
+	Tags           []string `json:"tags"`
+	Type           string   `json:"type"`
+}
+
+func parseCheckOutput(check []byte) []root {
+	var data []root
+	if err := json.Unmarshal([]byte(check), &data); err != nil {
+		return nil
+	}
+
+	return data
+}


### PR DESCRIPTION
### What does this PR do?

Add e2e tests for `check` subcommand. Only for Linux now because of a encoding issue when creating file on Windows.

### Motivation

ASCII-1250

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
