### PR TITLE
[usm] Use `ebpf.Modifer` for patching helper calls

### DIFF
--- a/pkg/ebpf/helper_call_patcher.go
+++ b/pkg/ebpf/helper_call_patcher.go
@@ -14,7 +14,16 @@ import (
 	"github.com/cilium/ebpf/asm"
 )
 
-var noopIns = asm.Mov.Reg(asm.R1, asm.R1)
+// noopIns is used in place of the eBPF helpers we wish to remove from
+// the bytecode.
+//
+// note we're using here the same noop instruction used internally by the
+// verifier:
+// https://elixir.bootlin.com/linux/v6.7/source/kernel/bpf/verifier.c#L18582
+var noopIns = asm.Instruction{
+	OpCode:   asm.Ja.Op(asm.ImmSource),
+	Constant: 0,
+}
 
 // NewHelperCallRemover provides a `Modifier` that patches eBPF bytecode
 // such that calls to the functions given by `helpers` are replaced by

--- a/pkg/network/protocols/events/configuration.go
+++ b/pkg/network/protocols/events/configuration.go
@@ -150,7 +150,19 @@ func removeRingBufferHelperCalls(m *manager.Manager) {
 	// `EnabledModifiers` and let it control the execution of the callbacks
 	patcher := ddebpf.NewHelperCallRemover(asm.FnRingbufOutput)
 	err := patcher.BeforeInit(m, nil)
+
 	if err != nil {
+		// Our production code is actually loading on all Kernels we test on CI
+		// (including those that don't support Ring Buffers) *even without
+		// patching*, presumably due to pruning/dead code elimination. The only
+		// thing failing to load was actually a small eBPF test program. So we
+		// added the patching almost as an extra safety layer.
+		//
+		// All that to say that even if the patching fails, there's still a good
+		// chance that the program will succeed to load. If it doesn't,there
+		// isn't much we can do, and the loading error will bubble up and be
+		// appropriately handled by the upstream code, which is why we don't do
+		// anything here.
 		log.Errorf("error patching eBPF bytecode: %s", err)
 	}
 }

--- a/pkg/network/protocols/events/configuration.go
+++ b/pkg/network/protocols/events/configuration.go
@@ -123,15 +123,6 @@ func eventMapName(proto string) string {
 	return proto + eventsMapSuffix
 }
 
-// noopInstruction is used for the purposes of eBPF patching (see comments
-// below)
-// we're using here the same noop instruction used internally by the verifier:
-// https://elixir.bootlin.com/linux/v6.7/source/kernel/bpf/verifier.c#L18582
-var noopInstruction = asm.Instruction{
-	OpCode:   asm.Ja.Op(asm.ImmSource),
-	Constant: 0,
-}
-
 // removeRingBufferHelperCalls is called only in the context of kernels that
 // don't support ring buffers. our eBPF code looks more or less like the
 // following:
@@ -154,24 +145,14 @@ var noopInstruction = asm.Instruction{
 // essentially replace `bpf_ringbuf_output` helper calls by a noop operation so
 // they don't result in verifier errors even when deadcode elimination fails.
 func removeRingBufferHelperCalls(m *manager.Manager) {
-	m.InstructionPatchers = append(m.InstructionPatchers, func(m *manager.Manager) error {
-		progs, err := m.GetProgramSpecs()
-		if err != nil {
-			return err
-		}
-
-		for _, p := range progs {
-			iter := p.Instructions.Iterate()
-			for iter.Next() {
-				ins := iter.Ins
-				if ins.IsBuiltinCall() && ins.Constant == int64(asm.FnRingbufOutput) {
-					*ins = noopInstruction
-				}
-			}
-		}
-
-		return nil
-	})
+	// TODO: this is not the intended API usage of a `ebpf.Modifier`.
+	// Once we have access to the `ddebpf.Manager`, add this modifier to its list of
+	// `EnabledModifiers` and let it control the execution of the callbacks
+	patcher := ddebpf.NewHelperCallRemover(asm.FnRingbufOutput)
+	err := patcher.BeforeInit(m, nil)
+	if err != nil {
+		log.Errorf("error patching eBPF bytecode: %s", err)
+	}
 }
 
 func alreadySetUp(proto string, m *manager.Manager) bool {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Use `ebpf.Modfier` introduced in https://github.com/DataDog/datadog-agent/pull/23158 for removing calls to `bpf_ringbuf_output`.

### Motivation

Remove code duplication.

### Additional Notes

Ideally we should favor the use `ddebpf.Manager` to control the execution of the `ebpf.Modifer` but this is a big refactoring that I'm leaving for a future PR.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
