### PR TITLE
Removes custom block sizes from SMP experiments

### DIFF
--- a/test/regression/cases/tcp_dd_logs_filter_exclude/lading/lading.yaml
+++ b/test/regression/cases/tcp_dd_logs_filter_exclude/lading/lading.yaml
@@ -5,7 +5,6 @@ generator:
       addr: "127.0.0.1:10000"
       variant: "datadog_log"
       bytes_per_second: "50 Mb"
-      block_sizes: ["8Kb", "4Kb", "2Kb", "1Kb", "512b", "256b", "128b"]
       maximum_prebuild_cache_size_bytes: "400 Mb"
 
 blackhole:

--- a/test/regression/cases/tcp_syslog_to_blackhole/lading/lading.yaml
+++ b/test/regression/cases/tcp_syslog_to_blackhole/lading/lading.yaml
@@ -5,7 +5,6 @@ generator:
       addr: "127.0.0.1:10000"
       variant: "syslog5424"
       bytes_per_second: "50 Mb"
-      block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
       maximum_prebuild_cache_size_bytes: "256 Mb"
 
 blackhole:

--- a/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -42,7 +42,6 @@ generator:
             set: 0
             histogram: 0
       bytes_per_second: "100 MiB"
-      block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"
 
 blackhole:

--- a/test/regression/cases/uds_dogstatsd_to_api_cpu/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_cpu/lading/lading.yaml
@@ -42,7 +42,6 @@ generator:
             set: 0
             histogram: 0
       bytes_per_second: "100 MiB"
-      block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"
 
 blackhole:


### PR DESCRIPTION
### What does this PR do?

Removes custom block sizes from all SMP experiments.

### Motivation

Custom block sizes are difficult to reason about and get right. The default values are better in all tested cases.

### Additional Notes

I have manually validated each experiment performs the same or better in terms of "amount of data generated".

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

