### PR TITLE
add experimental E2E command runner

### DIFF
--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -193,7 +193,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/skeema/knownhosts v1.2.1 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
-	github.com/spf13/cobra v1.8.0 // indirect
+	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect

--- a/test/new-e2e/tests/windows/cmd/run/README.md
+++ b/test/new-e2e/tests/windows/cmd/run/README.md
@@ -1,0 +1,21 @@
+E2E run command
+===
+
+This experimental tool can be used to run E2E snippets on Windows remote hosts.
+
+# Examples
+
+Run `agent status` command
+```sh
+go run ./tests/windows/cmd/run --host 10.1.59.199 agent cmd -- status
+```
+
+Install agent 7.51.1
+```sh
+WINDOWS_AGENT_VERSION=7.51.1-1 go run ./tests/windows/cmd/run --host 10.1.59.199 agent install -- 'TAGS="owner:myself"'
+```
+
+Uninstall the agent and delete the configuration directory
+```sh
+go run ./tests/windows/cmd/run --host 10.1.59.199 agent uninstall --remove-config
+```

--- a/test/new-e2e/tests/windows/cmd/run/cmd.go
+++ b/test/new-e2e/tests/windows/cmd/run/cmd.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	runCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/cmd/run/common"
+	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
+)
+
+func disableDefenderCmd(cmd *cobra.Command, _ []string) error {
+	host, err := runCommon.CreateRemoteHost(cmd)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Disabling Windows Defender on %s\n", host.Address)
+	err = windowsCommon.DisableDefender(host)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Init adds commands to the root command
+func Init(rootCmd *cobra.Command) {
+	var disableDefenderCmd = &cobra.Command{
+		Use:   "disable-defender",
+		Short: "Disable Windows Defender",
+		Long:  "Disable Windows Defender",
+		RunE:  disableDefenderCmd,
+	}
+
+	rootCmd.AddCommand(disableDefenderCmd)
+}

--- a/test/new-e2e/tests/windows/cmd/run/common/args.go
+++ b/test/new-e2e/tests/windows/cmd/run/common/args.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package common implements utils for the run command
+package common
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	osComp "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/components/remote"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+
+	"testing"
+)
+
+type fakeContext struct {
+	// RemoteHost unfortunately requires a *testing.T which we don't
+	// have since we aren't running via `go test`.
+	// TODO: Would it be better to run these commands through `go test` or
+	//       to make RemoteHost not require a *testing.T?
+	t testing.T
+}
+
+func (f *fakeContext) T() *testing.T {
+	return &f.t
+}
+
+// CreateRemoteHost creates a RemoteHost from the command line flags
+func CreateRemoteHost(cmd *cobra.Command) (*components.RemoteHost, error) {
+	host, err := cmd.Flags().GetString("host")
+	if err != nil {
+		return nil, err
+	}
+	username, err := cmd.Flags().GetString("username")
+	if err != nil {
+		return nil, err
+	}
+
+	h := &components.RemoteHost{
+		HostOutput: remote.HostOutput{
+			Address:   host,
+			Username:  username,
+			OSFamily:  osComp.WindowsFamily,
+			OSFlavor:  osComp.WindowsServer,
+			OSVersion: "2022",
+		},
+	}
+
+	err = h.Init(&fakeContext{})
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+// GetOutputDir creates and returns a directory that can be used to store output
+func GetOutputDir(cmd *cobra.Command) string {
+	output, _ := cmd.Flags().GetString("output")
+	output = filepath.Join(output, "cmd-run")
+	_ = os.MkdirAll(output, 0755)
+	return output
+}
+
+// Init initializes the common flags
+func Init(rootCmd *cobra.Command) {
+	rootCmd.PersistentFlags().StringP("host", "H", "", "The host to connect to")
+	_ = rootCmd.MarkPersistentFlagRequired("host")
+	rootCmd.PersistentFlags().StringP("username", "u", "Administrator", "The username to connect with")
+	rootCmd.PersistentFlags().StringP("output", "o", os.TempDir(), "The output directory")
+}

--- a/test/new-e2e/tests/windows/cmd/run/main.go
+++ b/test/new-e2e/tests/windows/cmd/run/main.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package main is the entry point for the run command
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	runCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/cmd/run/common"
+	agentCmd "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/cmd/run/subcommands/agent"
+
+	"testing"
+)
+
+func main() {
+	// for testing.T
+	testing.Init()
+
+	var rootCmd = &cobra.Command{
+		Use:   "run",
+		Short: "Run E2E functions against a remote host",
+		// Hide usage when a command returns an error
+		SilenceUsage: true,
+	}
+
+	runCommon.Init(rootCmd)
+	Init(rootCmd)
+	agentCmd.Init(rootCmd)
+
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}

--- a/test/new-e2e/tests/windows/cmd/run/subcommands/agent/cmd.go
+++ b/test/new-e2e/tests/windows/cmd/run/subcommands/agent/cmd.go
@@ -1,0 +1,168 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package cmd implements the agent subcommands
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	runCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/cmd/run/common"
+	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+)
+
+func installCmd(cmd *cobra.Command, args []string) error {
+	host, err := runCommon.CreateRemoteHost(cmd)
+	if err != nil {
+		return err
+	}
+	outputDir := runCommon.GetOutputDir(cmd)
+
+	// get agent package from env
+	agentPackage, err := agent.GetPackageFromEnv()
+	if err != nil {
+		return err
+	}
+
+	msiArgs := []string{}
+	if cmd.ArgsLenAtDash() >= 0 {
+		msiArgs = append(msiArgs, args[cmd.ArgsLenAtDash():]...)
+	}
+
+	apiKey, _ := cmd.Flags().GetString("apikey")
+	if apiKey != "" {
+		msiArgs = append(msiArgs, fmt.Sprintf(`APIKEY="%s"`, apiKey))
+	}
+
+	remoteMSIPath, err := windowsCommon.GetTemporaryFile(host)
+	if err != nil {
+		return err
+	}
+	err = windowsCommon.PutOrDownloadFile(host, agentPackage.URL, remoteMSIPath)
+	if err != nil {
+		return err
+	}
+
+	strMsiArgs := strings.Join(msiArgs, " ")
+	fmt.Printf("Installing agent on %s with username %s\n", host.Address, host.Username)
+	fmt.Printf("  args: %s\n", strMsiArgs)
+	err = windowsCommon.InstallMSI(host, remoteMSIPath, strMsiArgs, filepath.Join(outputDir, "agent-install.log"))
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Agent installed")
+	return nil
+}
+
+func uninstallCmd(cmd *cobra.Command, _ []string) error {
+	host, err := runCommon.CreateRemoteHost(cmd)
+	if err != nil {
+		return err
+	}
+	outputDir := runCommon.GetOutputDir(cmd)
+
+	// get agent config dir from registry before uninstalling
+	var removeConfig bool
+	var configDir string
+	if removeConfig, _ = cmd.Flags().GetBool("remove-config"); removeConfig {
+		configDir, err = agent.GetConfigRootFromRegistry(host)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Uninstalling agent from %s with username %s\n", host.Address, host.Username)
+	err = agent.UninstallAgent(host, filepath.Join(outputDir, "agent-uninstall.log"))
+	if err != nil {
+		return err
+	}
+
+	if removeConfig && configDir != "" {
+		fmt.Println("Removing agent configuration files")
+		err = host.RemoveAll(configDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("Agent uninstalled")
+	return nil
+}
+
+func cmdCmd(cmd *cobra.Command, args []string) error {
+	host, err := runCommon.CreateRemoteHost(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Get agent install path from registry
+	installRoot, err := agent.GetInstallPathFromRegistry(host)
+	if err != nil {
+		return err
+	}
+	agentCmd := fmt.Sprintf(`& '%s'`, filepath.Join(installRoot, "bin", "agent.exe"))
+	cmdArgs := strings.Join(args[cmd.ArgsLenAtDash():], " ")
+	cmdline := fmt.Sprintf("%s %s", agentCmd, cmdArgs)
+	fmt.Printf("Running agent command: %s\n", cmdline)
+
+	out, err := host.Execute(cmdline)
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(out)
+	return nil
+}
+
+// Init initializes the agent subcommands
+func Init(rootCmd *cobra.Command) {
+	var agentCmd = &cobra.Command{
+		Use:   "agent",
+		Short: "Agent commands",
+		Long:  `Agent commands`,
+	}
+
+	// uninstall subcommand
+	var uninstallCmd = &cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstall the agent",
+		Long:  `Uninstall the agent`,
+		RunE:  uninstallCmd,
+	}
+	uninstallCmd.Flags().Bool("remove-config", false, "Remove the agent configuration files")
+
+	// install subcommand
+	var installCmd = &cobra.Command{
+		Use:     "install",
+		Short:   "Install the agent",
+		Long:    `Install the agent`,
+		Example: `WINDOWS_AGENT_VERSION=7.51.0-1 ... agent install -- 'TAGS="key_1:val_1,key_2:val_2"'`,
+		RunE:    installCmd,
+	}
+	// set a default b/c trace-agent will fail without an api key
+	installCmd.Flags().String("apikey", "00000000000000000000000000000000", "API key to use for the install")
+
+	// cmd subcommand
+	var cmdCmd = &cobra.Command{
+		Use:     "command -- [args]...",
+		Aliases: []string{"cmd"},
+		Short:   "Run an agent subcommand",
+		Long:    "Run an agent subcommand",
+		Example: `  agent cmd -- status`,
+		RunE:    cmdCmd,
+	}
+
+	agentCmd.AddCommand(uninstallCmd)
+	agentCmd.AddCommand(installCmd)
+	agentCmd.AddCommand(cmdCmd)
+
+	rootCmd.AddCommand(agentCmd)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds a command that can connect to E2E `RemoteHost`s to run one-off snippets or common tasks.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
 It is helpful during testing/debugging to be able run certain E2E operations and other helper functions without having to create a special temporary one-off "test" to run, only to remove it before committing your code.

Example scenario: your installer test fails in the middle and leaves the agent installed on the host. You can run this command to uninstall the agent and then re-run your test.
```sh
go run ./tests/windows/cmd/run --host 10.1.59.199 agent uninstall --remove-config
```

I envision it being helpful to automate things like enable/collect crash dumps, event logs, and other things we might develop for E2E tests that would be helpful to be able to run independently of an E2E test.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Go does not provide a way to use "reflect" to call package level functions by their names so there's not really a good way to support calling arbitrary helper functions with arbitrary arguments. Each helper needs to be implemented by a cobra cmd.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
