### PR TITLE
[oracle] Add service config parameter (DBMON-3746)

### DIFF
--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -16,7 +16,12 @@ init_config:
   #   - query: <QUERY>
   #     columns: <COLUMNS>
   #     tags: <TAGS>
-
+  #
+  ## @param service - string - optional
+  ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+  ##
+  #
+  # service: <SERVICE>
 
 ## Every instance is scheduled independent of the others.
 #
@@ -112,6 +117,13 @@ instances:
   # tags:
   #   - <KEY_1>:<VALUE_1>
   #   - <KEY_2>:<VALUE_2>
+
+  ## @param service - string - optional
+  ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+  ##
+  ## Overrides any `service` defined in the `init_config` section.
+  #
+  # service: <SERVICE>
 
   ## Configure collection of query samples
   #

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -25,6 +25,7 @@ type InitConfig struct {
 	MinCollectionInterval int           `yaml:"min_collection_interval"`
 	CustomQueries         []CustomQuery `yaml:"custom_queries"`
 	UseInstantClient      bool          `yaml:"use_instant_client"`
+	Service               string        `yaml:"service"`
 }
 
 //nolint:revive // TODO(DBM) Fix revive linter
@@ -149,6 +150,7 @@ type InstanceConfig struct {
 	ResourceManager                    resourceManagerConfig  `yaml:"resource_manager"`
 	Locks                              locksConfig            `yaml:"locks"`
 	OnlyCustomQueries                  bool                   `yaml:"only_custom_queries"`
+	Service                            string                 `yaml:"service"`
 }
 
 // CheckConfig holds the config needed for an integration instance to run.
@@ -262,6 +264,16 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	if initCfg.UseInstantClient {
 		instance.OracleClient = true
 		warnDeprecated("use_instant_client", "oracle_client in instance config")
+	}
+
+	var service string
+	if instance.Service != "" {
+		service = instance.Service
+	} else if initCfg.Service != "" {
+		service = initCfg.Service
+	}
+	if service != "" {
+		instance.Tags = append(instance.Tags, fmt.Sprintf("service:%s", service))
 	}
 
 	c := &CheckConfig{

--- a/releasenotes/notes/oracle-service-config-20db92c3b4d9f118.yaml
+++ b/releasenotes/notes/oracle-service-config-20db92c3b4d9f118.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [oracle] Add ``service`` configuration parameter.


### PR DESCRIPTION
### What does this PR do?

Adding `service` config parameter to the Oracle check.

### Motivation

Backward compatibility with the Oracle Python integration. The other db integrations also contain this parameter.

### Describe how to test/QA your changes

Check the tags with `service` set in: init config, instance config, not set at all.