### PR TITLE
processes: add language detection for weblogic and JEE ear deployments

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1748,6 +1748,7 @@ core,github.com/spdx/tools-golang/utils,Apache-2.0,Copyright (c) 2018 The Author
 core,github.com/spf13/afero,Apache-2.0,Copyright 2013 tsuru authors. All rights reserved. | Copyright © 2014 Steve Francia <spf@spf13.com>.
 core,github.com/spf13/afero/internal/common,Apache-2.0,Copyright 2013 tsuru authors. All rights reserved. | Copyright © 2014 Steve Francia <spf@spf13.com>.
 core,github.com/spf13/afero/mem,Apache-2.0,Copyright 2013 tsuru authors. All rights reserved. | Copyright © 2014 Steve Francia <spf@spf13.com>.
+core,github.com/spf13/afero/zipfs,Apache-2.0,Copyright 2013 tsuru authors. All rights reserved. | Copyright © 2014 Steve Francia <spf@spf13.com>.
 core,github.com/spf13/cast,MIT,Copyright (c) 2014 Steve Francia
 core,github.com/spf13/cobra,Apache-2.0,Copyright © 2013 Steve Francia <spf@spf13.com>.
 core,github.com/spf13/jwalterweatherman,MIT,Copyright (c) 2014 Steve Francia

--- a/pkg/process/metadata/parser/java/jee.go
+++ b/pkg/process/metadata/parser/java/jee.go
@@ -225,7 +225,10 @@ func normalizeContextRoot(contextRoots ...string) []string {
 func doExtractContextRoots(vendor serverVendor, app string, fs afero.Fs) []string {
 	fsCloser, ear, err := vfsAndTypeFromAppPath(app, fs)
 	if err != nil {
-		return nil
+		if ear {
+			return nil
+		}
+		return doDefaultExtraction(vendor, app)
 	}
 	defer fsCloser.Close()
 	if ear {
@@ -242,6 +245,11 @@ func doExtractContextRoots(vendor serverVendor, app string, fs afero.Fs) []strin
 			return []string{value}
 		}
 	}
+	return doDefaultExtraction(vendor, app)
+}
+
+// doDefaultExtraction return the default naming for an application depending on the vendor
+func doDefaultExtraction(vendor serverVendor, app string) []string {
 	defaultFinder, ok := defaultContextNameExtractors[vendor]
 	if ok {
 		return []string{defaultFinder(app)}

--- a/pkg/process/metadata/parser/java/jee.go
+++ b/pkg/process/metadata/parser/java/jee.go
@@ -155,7 +155,7 @@ func vfsAndTypeFromAppPath(appPath string, fs afero.Fs) (*fileSystemCloser, bool
 		isEar = true
 	} else if ext != ".war" {
 		// only ear and war are supported
-		return nil, isEar, errUnhandledDeployment
+		return nil, false, errUnhandledDeployment
 	}
 	fi, err := fs.Stat(appPath)
 	if err != nil {

--- a/pkg/process/metadata/parser/java/jee.go
+++ b/pkg/process/metadata/parser/java/jee.go
@@ -7,9 +7,14 @@
 package javaparser
 
 import (
+	"archive/zip"
 	"encoding/xml"
-	"io"
+	"errors"
+	"path/filepath"
 	"strings"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/afero/zipfs"
 )
 
 // appserver is an enumeration of application server types
@@ -35,20 +40,54 @@ const (
 	jbossStandaloneMain string = "org.jboss.as.standalone"
 	jbossDomainMain     string = "org.jboss.as.server"
 	jbossSysProp        string = "-Djboss.home.dir="
+	applicationXMLPath  string = "/META-INF/application.xml"
 )
 
-// applicationXml is used to unmarshal information from a standard EAR's application.xml
-// example doc: https://docs.oracle.com/cd/E13222_01/wls/docs61/programming/app_xml.html
-type applicationXml struct {
-	XMLName     xml.Name `xml:"application"`
-	ContextRoot []string `xml:"module>web>context-root"`
-}
+var (
+	errUnhandledDeployment = errors.New("unhandled deployment type")
+)
 
-// extractContextRootFromApplicationXml parses a standard application.xml file extracting
+type (
+	// applicationXML is used to unmarshal information from a standard EAR's application.xml
+	// example doc: https://docs.oracle.com/cd/E13222_01/wls/docs61/programming/app_xml.html
+	applicationXML struct {
+		XMLName     xml.Name `xml:"application"`
+		ContextRoot []string `xml:"module>web>context-root"`
+	}
+	// deployedAppFindFn is used to find the application deployed on a domainHome
+	// args should be supplied since some vendors may require additional information from them (i.e. server name)
+	deployedAppFindFn func(domainHome string, args []string, fs afero.Fs) ([]string, bool)
+	// warContextRootFindFn is used to extract the context root from a vendor defined configuration inside the war.
+	// if not found it returns en empty string and false
+	warContextRootFindFn func(fs afero.Fs) (string, bool)
+	// defaultWarContextRootFn returns the default naming that apply for a certain fileName.
+	// it is usually the file without the extension, but it can differ for some vendors (i.e. tomcat)
+	defaultWarContextRootFn func(fileName string) string
+)
+
+// definitions of standard extractors
+var (
+	deploymentFinders = map[serverVendor]deployedAppFindFn{
+		weblogic: weblogicFindDeployedApps,
+	}
+	contextRootFinders = map[serverVendor]warContextRootFindFn{
+		weblogic: weblogicExtractWarContextRoot,
+	}
+	defaultContextNameExtractors = map[serverVendor]defaultWarContextRootFn{
+		weblogic: standardExtractContextFromWarName,
+	}
+)
+
+// extractContextRootFromApplicationXML parses a standard application.xml file extracting
 // mount points for web application (aka context roots).
-func extractContextRootFromApplicationXml(reader io.Reader) ([]string, error) {
-	var a applicationXml
-	err := xml.NewDecoder(reader).Decode(&a)
+func extractContextRootFromApplicationXML(fs afero.Fs) ([]string, error) {
+	reader, err := fs.Open(applicationXMLPath)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	var a applicationXML
+	err = xml.NewDecoder(reader).Decode(&a)
 	if err != nil {
 		return nil, err
 	}
@@ -56,15 +95,16 @@ func extractContextRootFromApplicationXml(reader io.Reader) ([]string, error) {
 }
 
 // resolveAppServerFromCmdLine parses the command line and tries to extract a couple of evidences for each known application server.
-// The first is the server home (usually defined by a service
+// The first is the server home (usually defined by a system property) and the second is the main class / jar entry point.
+// It returns the serverVendor (unknown in case it cannot be determined with precision) and the domain path if applicable.
 func resolveAppServerFromCmdLine(args []string) (serverVendor, string) {
 	hint1, hint2 := unknown, unknown
 	var baseDir string
 	for _, a := range args {
 		if hint1 == unknown {
 			if strings.HasPrefix(a, wlsHomeSysProp) {
+				// use the CWD for weblogic since the wlsHome is the home of the weblogic installation and not of the domain
 				hint1 = weblogic
-				baseDir = strings.TrimPrefix(a, wlsHomeSysProp)
 			} else if strings.HasPrefix(a, tomcatSysProp) {
 				hint1 = tomcat
 				baseDir = strings.TrimPrefix(a, tomcatSysProp)
@@ -94,4 +134,120 @@ func resolveAppServerFromCmdLine(args []string) (serverVendor, string) {
 		}
 	}
 	return hint1 & hint2, baseDir
+}
+
+// standardExtractContextFromWarName is the standard algorithm to deduce context root from war name.
+// It returns the filename (or directory name if the deployment is exploded) without the extension
+func standardExtractContextFromWarName(fileName string) string {
+	dir, file := filepath.Split(fileName)
+	f := file
+	if len(f) == 0 {
+		f = dir
+	}
+	return strings.TrimSuffix(f, filepath.Ext(f))
+}
+
+// vfsAndTypeFromAppPath inspects the appPath and returns a valid fileSystemCloser in case the deployment is an ear or a war.
+func vfsAndTypeFromAppPath(appPath string, fs afero.Fs) (*fileSystemCloser, bool, error) {
+	ext := strings.ToLower(filepath.Clean(filepath.Ext(appPath)))
+	isEar := false
+	if ext == ".ear" {
+		isEar = true
+	} else if ext != ".war" {
+		// only ear and war are supported
+		return nil, isEar, errUnhandledDeployment
+	}
+	fi, err := fs.Stat(appPath)
+	if err != nil {
+		return nil, isEar, err
+	}
+
+	if fi.IsDir() {
+		return &fileSystemCloser{
+			fs: afero.NewBasePathFs(fs, appPath),
+		}, isEar, nil
+	}
+	f, err := fs.Open(appPath)
+	if err != nil {
+		return nil, false, err
+	}
+	r, err := zip.NewReader(f, fi.Size())
+	if err != nil {
+		_ = f.Close()
+		return nil, isEar, err
+	}
+	return &fileSystemCloser{
+		fs: zipfs.New(r),
+		cf: f.Close,
+	}, isEar, nil
+}
+
+// serviceName translate service vendor enumeration to the service name tag. Returns empty if not supported
+func defaultIfNoContextRoots(s serverVendor) []string {
+	switch s {
+	case jboss:
+		return []string{"jboss"}
+	case tomcat:
+		return []string{"tomcat"}
+	case weblogic:
+		return []string{"weblogic"}
+	case websphere:
+		return []string{"websphere"}
+	}
+	return nil
+}
+
+// ExtractServiceNamesForJEEServer takes args, cws and the fs (for testability reasons) and, after having determined the vendor,
+// If the vendor can be determined, it returns the context roots if found, otherwise the server name.
+// If the vendor is unknown, it returns a nil slice
+func ExtractServiceNamesForJEEServer(args []string, cwd string, fs afero.Fs) []string {
+	vendor, domainHome := resolveAppServerFromCmdLine(args)
+	if vendor == unknown {
+		return nil
+	}
+	// check if able to find which applications are deployed
+	deploymentFinder, ok := deploymentFinders[vendor]
+	if !ok {
+		return defaultIfNoContextRoots(vendor)
+	}
+	if len(domainHome) == 0 {
+		// for some servers this info is not available. Default to cwd
+		domainHome = cwd
+	}
+	apps, ok := deploymentFinder(domainHome, args, fs)
+	if !ok {
+		return defaultIfNoContextRoots(vendor)
+	}
+	var contextRoots []string
+	for _, app := range apps {
+		fsCloser, ear, err := vfsAndTypeFromAppPath(app, fs)
+		if err != nil {
+			continue
+		}
+		if ear {
+			value, err := extractContextRootFromApplicationXML(fsCloser.fs)
+			if err == nil {
+				contextRoots = append(contextRoots, value...)
+			}
+			_ = fsCloser.Close()
+			continue
+		}
+		vendorWarFinder, ok := contextRootFinders[vendor]
+		if ok {
+			value, ok := vendorWarFinder(fsCloser.fs)
+			_ = fsCloser.Close()
+			if ok {
+				contextRoots = append(contextRoots, value)
+				continue
+			}
+		}
+		defaultFinder, ok := defaultContextNameExtractors[vendor]
+		if ok {
+			contextRoots = append(contextRoots, defaultFinder(app))
+		}
+	}
+	if len(contextRoots) == 0 {
+		return defaultIfNoContextRoots(vendor)
+	}
+	return contextRoots
 }

--- a/pkg/process/metadata/parser/java/jee.go
+++ b/pkg/process/metadata/parser/java/jee.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package javaparser contains functions to autodetect service name for java applications
+package javaparser
+
+import (
+	"encoding/xml"
+	"io"
+	"strings"
+)
+
+// appserver is an enumeration of application server types
+type serverVendor uint8
+
+// appserver enums
+const (
+	unknown serverVendor = 0
+	jboss                = 1 << (iota - 1)
+	tomcat
+	weblogic
+	websphere
+)
+
+const (
+	// app servers hints
+	wlsServerMainClass  string = "weblogic.Server"
+	wlsHomeSysProp      string = "-Dwls.home="
+	websphereJar        string = "ws-server.jar"
+	websphereMainClass  string = "defaultServer"
+	tomcatMainClass     string = "org.apache.catalina.startup.Bootstrap"
+	tomcatSysProp       string = "-Dcatalina.base="
+	jbossStandaloneMain string = "org.jboss.as.standalone"
+	jbossDomainMain     string = "org.jboss.as.server"
+	jbossSysProp        string = "-Djboss.home.dir="
+)
+
+// applicationXml is used to unmarshal information from a standard EAR's application.xml
+// example doc: https://docs.oracle.com/cd/E13222_01/wls/docs61/programming/app_xml.html
+type applicationXml struct {
+	XMLName     xml.Name `xml:"application"`
+	ContextRoot []string `xml:"module>web>context-root"`
+}
+
+// extractContextRootFromApplicationXml parses a standard application.xml file extracting
+// mount points for web application (aka context roots).
+func extractContextRootFromApplicationXml(reader io.Reader) ([]string, error) {
+	var a applicationXml
+	err := xml.NewDecoder(reader).Decode(&a)
+	if err != nil {
+		return nil, err
+	}
+	return a.ContextRoot, nil
+}
+
+// resolveAppServerFromCmdLine parses the command line and tries to extract a couple of evidences for each known application server.
+// The first is the server home (usually defined by a service
+func resolveAppServerFromCmdLine(args []string) (serverVendor, string) {
+	hint1, hint2 := unknown, unknown
+	var baseDir string
+	for _, a := range args {
+		if hint1 == unknown {
+			if strings.HasPrefix(a, wlsHomeSysProp) {
+				hint1 = weblogic
+				baseDir = strings.TrimPrefix(a, wlsHomeSysProp)
+			} else if strings.HasPrefix(a, tomcatSysProp) {
+				hint1 = tomcat
+				baseDir = strings.TrimPrefix(a, tomcatSysProp)
+			} else if strings.HasPrefix(a, jbossSysProp) {
+				hint1 = jboss
+				baseDir = strings.TrimPrefix(a, jbossSysProp)
+			} else if strings.HasSuffix(a, websphereJar) {
+				// Use the CWD of the process as websphere baseDir
+				hint1 = websphere
+			}
+		}
+		if hint2 == unknown {
+			// only return a match if it's exact meaning that the hint and the evidence are matching the same server type.
+			switch a {
+			case wlsServerMainClass:
+				hint2 = weblogic
+			case tomcatMainClass:
+				hint2 = tomcat
+			case websphereMainClass:
+				hint2 = websphere
+			case jbossDomainMain, jbossStandaloneMain:
+				hint2 = jboss
+			}
+		}
+		if hint1 != unknown && hint2 != unknown {
+			break
+		}
+	}
+	return hint1 & hint2, baseDir
+}

--- a/pkg/process/metadata/parser/java/jee.go
+++ b/pkg/process/metadata/parser/java/jee.go
@@ -9,7 +9,7 @@ package javaparser
 import (
 	"archive/zip"
 	"encoding/xml"
-	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -41,10 +41,6 @@ const (
 	jbossDomainMain      string = "org.jboss.as.server"
 	jbossSysProp         string = "-Djboss.home.dir="
 	applicationXMLPath   string = "/META-INF/application.xml"
-)
-
-var (
-	errUnhandledDeployment = errors.New("unhandled deployment type")
 )
 
 type (
@@ -155,7 +151,7 @@ func vfsAndTypeFromAppPath(appPath string, fs afero.Fs) (*fileSystemCloser, bool
 		isEar = true
 	} else if ext != ".war" {
 		// only ear and war are supported
-		return nil, false, errUnhandledDeployment
+		return nil, false, fmt.Errorf("unhandled deployment type %s", ext)
 	}
 	fi, err := fs.Stat(appPath)
 	if err != nil {

--- a/pkg/process/metadata/parser/java/jee.go
+++ b/pkg/process/metadata/parser/java/jee.go
@@ -31,16 +31,16 @@ const (
 
 const (
 	// app servers hints
-	wlsServerMainClass  string = "weblogic.Server"
-	wlsHomeSysProp      string = "-Dwls.home="
-	websphereJar        string = "ws-server.jar"
-	websphereMainClass  string = "defaultServer"
-	tomcatMainClass     string = "org.apache.catalina.startup.Bootstrap"
-	tomcatSysProp       string = "-Dcatalina.base="
-	jbossStandaloneMain string = "org.jboss.as.standalone"
-	jbossDomainMain     string = "org.jboss.as.server"
-	jbossSysProp        string = "-Djboss.home.dir="
-	applicationXMLPath  string = "/META-INF/application.xml"
+	wlsServerMainClass   string = "weblogic.Server"
+	wlsHomeSysProp       string = "-Dwls.home="
+	websphereHomeSysProp string = "-Dserver.root="
+	websphereMainClass   string = "com.ibm.ws.runtime.WsServer"
+	tomcatMainClass      string = "org.apache.catalina.startup.Bootstrap"
+	tomcatSysProp        string = "-Dcatalina.base="
+	jbossStandaloneMain  string = "org.jboss.as.standalone"
+	jbossDomainMain      string = "org.jboss.as.server"
+	jbossSysProp         string = "-Djboss.home.dir="
+	applicationXMLPath   string = "/META-INF/application.xml"
 )
 
 var (
@@ -111,9 +111,9 @@ func resolveAppServerFromCmdLine(args []string) (serverVendor, string) {
 			} else if strings.HasPrefix(a, jbossSysProp) {
 				hint1 = jboss
 				baseDir = strings.TrimPrefix(a, jbossSysProp)
-			} else if strings.HasSuffix(a, websphereJar) {
-				// Use the CWD of the process as websphere baseDir
+			} else if strings.HasPrefix(a, websphereHomeSysProp) {
 				hint1 = websphere
+				baseDir = strings.TrimPrefix(a, websphereHomeSysProp)
 			}
 		}
 		if hint2 == unknown {

--- a/pkg/process/metadata/parser/java/jee.go
+++ b/pkg/process/metadata/parser/java/jee.go
@@ -20,7 +20,7 @@ import (
 // appserver is an enumeration of application server types
 type serverVendor uint8
 
-// appserver enums
+// appserver bitwise enums. Each element should be a power of two. The first element, unknown is 0.
 const (
 	unknown serverVendor = 0
 	jboss                = 1 << (iota - 1)
@@ -240,6 +240,8 @@ func ExtractServiceNamesForJEEServer(args []string, cwd string, fs afero.Fs) []s
 				contextRoots = append(contextRoots, value)
 				continue
 			}
+		} else {
+			_ = fsCloser.Close()
 		}
 		defaultFinder, ok := defaultContextNameExtractors[vendor]
 		if ok {

--- a/pkg/process/metadata/parser/java/jee_test.go
+++ b/pkg/process/metadata/parser/java/jee_test.go
@@ -237,3 +237,34 @@ func TestWeblogicExtractServiceNamesForJEEServer(t *testing.T) {
 		"app3",         // derived from the war filename
 	}, extractedContextRoots)
 }
+
+// TestNormalizeContextRoot runs tests cases for context root normalization.
+func TestNormalizeContextRoot(t *testing.T) {
+	tests := []struct {
+		name     string
+		arg      []string
+		expected []string
+	}{
+		{
+			name: "Should strip / from context roots",
+			arg: []string{
+				"/test1",
+				"test2",
+				"/test3/test4",
+			},
+			expected: []string{
+				"test1",
+				"test2",
+				"test3/test4",
+			},
+		},
+		{
+			name: "should handle empty slices",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, normalizeContextRoot(tt.arg...))
+		})
+	}
+}

--- a/pkg/process/metadata/parser/java/jee_test.go
+++ b/pkg/process/metadata/parser/java/jee_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package javaparser
 
 import (

--- a/pkg/process/metadata/parser/java/jee_test.go
+++ b/pkg/process/metadata/parser/java/jee_test.go
@@ -71,19 +71,26 @@ func TestResolveAppServerFromCmdLine(t *testing.T) {
 			expectedVendor: weblogic,
 		},
 		{
-			name: "websphere",
-			rawCmd: `/opt/java/openjdk/bin/java -javaagent:/opt/ol/wlp/bin/tools/ws-javaagent.jar -Djava.awt.headless=true
--Djdk.attach.allowAttachSelf=true --add-exportsjava.base/sun.security.action=ALL-UNNAMED --add-exportsjava.naming/com.sun.jndi.ldap=ALL-UNNAMED
---add-exportsjava.naming/com.sun.jndi.url.ldap=ALL-UNNAMED --add-exportsjdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED
---add-exportsjava.security.jgss/sun.security.krb5.internal=ALL-UNNAMED --add-exportsjdk.attach/sun.tools.attach=ALL-UNNAMED
---add-opensjava.base/java.util=ALL-UNNAMED --add-opensjava.base/java.lang=ALL-UNNAMED --add-opensjava.base/java.util.concurrent=ALL-UNNAMED
---add-opensjava.base/java.io=ALL-UNNAMED --add-opensjava.naming/javax.naming.spi=ALL-UNNAMED --add-opensjdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
---add-opensjava.naming/javax.naming=ALL-UNNAMED --add-opensjava.rmi/java.rmi=ALL-UNNAMED --add-opensjava.sql/java.sql=ALL-UNNAMED
---add-opensjava.management/javax.management=ALL-UNNAMED --add-opensjava.base/java.lang.reflect=ALL-UNNAMED --add-opensjava.desktop/java.awt.image=ALL-UNNAMED
---add-opensjava.base/java.security=ALL-UNNAMED --add-opensjava.base/java.net=ALL-UNNAMED --add-opensjava.base/java.text=ALL-UNNAMED
---add-opensjava.base/sun.net.www.protocol.https=ALL-UNNAMED --add-exportsjdk.management.agent/jdk.internal.agent=ALL-UNNAMED
---add-exportsjava.base/jdk.internal.vm=ALL-UNNAMED -jar /opt/ol/wlp/bin/tools/ws-server.jar defaultServer`,
-			expectedHome:   "",
+			name: "websphere traditional 9.x",
+			rawCmd: `/opt/IBM/WebSphere/AppServer/java/8.0/bin/java -Dosgi.install.area=/opt/IBM/WebSphere/AppServer
+-Dwas.status.socket=43471 -Dosgi.configuration.area=/opt/IBM/WebSphere/AppServer/profiles/AppSrv01/servers/server1/configuration
+-Djava.awt.headless=true -Dosgi.framework.extensions=com.ibm.cds,com.ibm.ws.eclipse.adaptors
+-Xshareclasses:name=webspherev9_8.0_64_%g,nonFatal -Dcom.ibm.xtq.processor.overrideSecureProcessing=true -Xcheck:dump
+-Djava.security.properties=/opt/IBM/WebSphere/AppServer/properties/java.security -Djava.security.policy=/opt/IBM/WebSphere/AppServer/properties/java.policy
+-Dcom.ibm.CORBA.ORBPropertyFilePath=/opt/IBM/WebSphere/AppServer/properties -Xbootclasspath/p:/opt/IBM/WebSphere/AppServer/java/8.0/jre/lib/ibmorb.jar
+-classpath /opt/IBM/WebSphere/AppServer/profiles/AppSrv01/properties:/opt/IBM/WebSphere/AppServer/properties:/opt/IBM/WebSphere/AppServer/lib/startup.jar:shortened.jar
+-Dibm.websphere.internalClassAccessMode=allow -Xms50m -Xmx1962m -Xcompressedrefs -Xscmaxaot12M -Xscmx90M
+-Dws.ext.dirs=/opt/IBM/WebSphere/AppServer/java/8.0/lib:/opt/IBM/WebSphere/AppServer/profiles/AppSrv01/classes:shortened
+-Dderby.system.home=/opt/IBM/WebSphere/AppServer/derby -Dcom.ibm.itp.location=/opt/IBM/WebSphere/AppServer/bin
+-Djava.util.logging.configureByServer=true -Duser.install.root=/opt/IBM/WebSphere/AppServer/profiles/AppSrv01
+-Djava.ext.dirs=/opt/IBM/WebSphere/AppServer/tivoli/tam:/opt/IBM/WebSphere/AppServer/javaext:/opt/IBM/WebSphere/AppServer/java/8.0/jre/lib/ext
+-Djavax.management.builder.initial=com.ibm.ws.management.PlatformMBeanServerBuilder -Dwas.install.root=/opt/IBM/WebSphere/AppServer
+-Djava.util.logging.manager=com.ibm.ws.bootstrap.WsLogManager -Dserver.root=/opt/IBM/WebSphere/AppServer/profiles/AppSrv01
+-Dcom.ibm.security.jgss.debug=off -Dcom.ibm.security.krb5.Krb5Debug=off -Djava.util.prefs.userRoot=/home/was/ -Xnoloa
+-Djava.library.path=/opt/IBM/WebSphere/AppServer/lib/native/linux/x86_64/:/opt/IBM/WebSphere/AppServer/java/8.0/jre/lib/amd64/compressedrefs:shortened
+com.ibm.wsspi.bootstrap.WSPreLauncher -nosplash -application com.ibm.ws.bootstrap.WSLauncher com.ibm.ws.runtime.WsServer
+/opt/IBM/WebSphere/AppServer/profiles/AppSrv01/config DefaultCell01 DefaultNode01 server1`,
+			expectedHome:   "/opt/IBM/WebSphere/AppServer/profiles/AppSrv01",
 			expectedVendor: websphere,
 		},
 		{

--- a/pkg/process/metadata/parser/java/jee_test.go
+++ b/pkg/process/metadata/parser/java/jee_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
-
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/process/metadata/parser/java/jee_test.go
+++ b/pkg/process/metadata/parser/java/jee_test.go
@@ -8,6 +8,7 @@ package javaparser
 import (
 	"archive/zip"
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -34,7 +35,7 @@ func TestResolveAppServerFromCmdLine(t *testing.T) {
 -jar /home/app/Downloads/wildfly-18.0.0.Final/jboss-modules.jar -mp /home/app/Downloads/wildfly-18.0.0.Final/modules org.jboss.as.standalone
 -Djboss.home.dir=/home/app/Downloads/wildfly-18.0.0.Final -Djboss.server.base.dir=/home/app/Downloads/wildfly-18.0.0.Final/standalone`,
 			expectedVendor: jboss,
-			expectedHome:   "/home/app/Downloads/wildfly-18.0.0.Final",
+			expectedHome:   "/home/app/Downloads/wildfly-18.0.0.Final/standalone",
 		},
 		{
 			name: "wildfly 18 domain",
@@ -49,7 +50,7 @@ func TestResolveAppServerFromCmdLine(t *testing.T) {
 -Dlogging.configuration=file:/home/app/Downloads/wildfly-18.0.0.Final/domain/configuration/default-server-logging.properties
 -jar /home/app/Downloads/wildfly-18.0.0.Final/jboss-modules.jar -mp /home/app/Downloads/wildfly-18.0.0.Final/modules org.jboss.as.server`,
 			expectedVendor: jboss,
-			expectedHome:   "/home/app/Downloads/wildfly-18.0.0.Final",
+			expectedHome:   filepath.FromSlash("/home/app/Downloads/wildfly-18.0.0.Final/domain"),
 		},
 		{
 			name: "tomcat 10.x",

--- a/pkg/process/metadata/parser/java/jee_test.go
+++ b/pkg/process/metadata/parser/java/jee_test.go
@@ -1,0 +1,102 @@
+package javaparser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveAppServerFromCmdLine(t *testing.T) {
+	tests := []struct {
+		name           string
+		rawCmd         string
+		expectedVendor serverVendor
+		expectedHome   string
+	}{
+		{
+			name: "wildfly 18 standalone",
+			rawCmd: `/home/app/.sdkman/candidates/java/17.0.4.1-tem/bin/java -D[Standalone] -server
+-Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true
+-Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true
+--add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
+--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED -Dorg.jboss.boot.log.file=/home/app/Downloads/wildfly-18.0.0.Final/standalone/log/server.log
+-Dlogging.configuration=file:/home/app/Downloads/wildfly-18.0.0.Final/standalone/configuration/logging.properties
+-jar /home/app/Downloads/wildfly-18.0.0.Final/jboss-modules.jar -mp /home/app/Downloads/wildfly-18.0.0.Final/modules org.jboss.as.standalone
+-Djboss.home.dir=/home/app/Downloads/wildfly-18.0.0.Final -Djboss.server.base.dir=/home/app/Downloads/wildfly-18.0.0.Final/standalone`,
+			expectedVendor: jboss,
+			expectedHome:   "/home/app/Downloads/wildfly-18.0.0.Final",
+		},
+		{
+			name: "wildfly 18 domain",
+			rawCmd: `/home/app/.sdkman/candidates/java/17.0.4.1-tem/bin/java --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED -D[Server:server-one]
+-D[pcid:780891833] -Xms64m -Xmx512m -server -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true
+-Djboss.home.dir=/home/app/Downloads/wildfly-18.0.0.Final -Djboss.modules.system.pkgs=org.jboss.byteman
+-Djboss.server.log.dir=/home/app/Downloads/wildfly-18.0.0.Final/domain/servers/server-one/log
+-Djboss.server.temp.dir=/home/app/Downloads/wildfly-18.0.0.Final/domain/servers/server-one/tmp
+-Djboss.server.data.dir=/home/app/Downloads/wildfly-18.0.0.Final/domain/servers/server-one/data
+-Dorg.jboss.boot.log.file=/home/app/Downloads/wildfly-18.0.0.Final/domain/servers/server-one/log/server.log
+-Dlogging.configuration=file:/home/app/Downloads/wildfly-18.0.0.Final/domain/configuration/default-server-logging.properties
+-jar /home/app/Downloads/wildfly-18.0.0.Final/jboss-modules.jar -mp /home/app/Downloads/wildfly-18.0.0.Final/modules org.jboss.as.server`,
+			expectedVendor: jboss,
+			expectedHome:   "/home/app/Downloads/wildfly-18.0.0.Final",
+		},
+		{
+			name: "tomcat 10.x",
+			rawCmd: `java -Djava.util.logging.config.file=/app/Code/tomcat/apache-tomcat-10.0.27/conf/logging.properties
+-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Djdk.tls.ephemeralDHKeySize=2048
+-Djava.protocol.handler.pkgs=org.apache.catalina.webresources -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
+-Dignore.endorsed.dirs= -classpath /app/Code/tomcat/apache-tomcat-10.0.27/bin/bootstrap.jar:/app/Code/tomcat/apache-tomcat-10.0.27/bin/tomcat-juli.jar
+-Dcatalina.base=/app/Code/tomcat/apache-tomcat-10.0.27/myserver -Dcatalina.home=/app/Code/tomcat/apache-tomcat-10.0.27
+-Djava.io.tmpdir=/app/Code/tomcat/apache-tomcat-10.0.27/temp org.apache.catalina.startup.Bootstrap start`,
+			expectedVendor: tomcat,
+			expectedHome:   "/app/Code/tomcat/apache-tomcat-10.0.27/myserver",
+		},
+		{
+			name: "weblogic 12",
+			rawCmd: `/u01/jdk/bin/java -Djava.security.egd=file:/dev/./urandom -cp /u01/oracle/wlserver/server/lib/weblogic-launcher.jar
+-Dlaunch.use.env.classpath=true -Dweblogic.Name=AdminServer -Djava.security.policy=/u01/oracle/wlserver/server/lib/weblogic.policy
+-Djava.system.class.loader=com.oracle.classloader.weblogic.LaunchClassLoader -javaagent:/u01/oracle/wlserver/server/lib/debugpatch-agent.jar
+-da -Dwls.home=/u01/oracle/wlserver/server -Dweblogic.home=/u01/oracle/wlserver/server weblogic.Server`,
+			expectedVendor: weblogic,
+			expectedHome:   "/u01/oracle/wlserver/server",
+		},
+		{
+			name: "websphere",
+			rawCmd: `/opt/java/openjdk/bin/java -javaagent:/opt/ol/wlp/bin/tools/ws-javaagent.jar -Djava.awt.headless=true
+-Djdk.attach.allowAttachSelf=true --add-exportsjava.base/sun.security.action=ALL-UNNAMED --add-exportsjava.naming/com.sun.jndi.ldap=ALL-UNNAMED
+--add-exportsjava.naming/com.sun.jndi.url.ldap=ALL-UNNAMED --add-exportsjdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED
+--add-exportsjava.security.jgss/sun.security.krb5.internal=ALL-UNNAMED --add-exportsjdk.attach/sun.tools.attach=ALL-UNNAMED
+--add-opensjava.base/java.util=ALL-UNNAMED --add-opensjava.base/java.lang=ALL-UNNAMED --add-opensjava.base/java.util.concurrent=ALL-UNNAMED
+--add-opensjava.base/java.io=ALL-UNNAMED --add-opensjava.naming/javax.naming.spi=ALL-UNNAMED --add-opensjdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
+--add-opensjava.naming/javax.naming=ALL-UNNAMED --add-opensjava.rmi/java.rmi=ALL-UNNAMED --add-opensjava.sql/java.sql=ALL-UNNAMED
+--add-opensjava.management/javax.management=ALL-UNNAMED --add-opensjava.base/java.lang.reflect=ALL-UNNAMED --add-opensjava.desktop/java.awt.image=ALL-UNNAMED
+--add-opensjava.base/java.security=ALL-UNNAMED --add-opensjava.base/java.net=ALL-UNNAMED --add-opensjava.base/java.text=ALL-UNNAMED
+--add-opensjava.base/sun.net.www.protocol.https=ALL-UNNAMED --add-exportsjdk.management.agent/jdk.internal.agent=ALL-UNNAMED
+--add-exportsjava.base/jdk.internal.vm=ALL-UNNAMED -jar /opt/ol/wlp/bin/tools/ws-server.jar defaultServer`,
+			expectedHome:   "",
+			expectedVendor: websphere,
+		},
+		{
+			// weblogic cli have the same system properties than normal weblogic server run (sourced from setWlsEnv.sh)
+			// however, the main entry point changes (weblogic.Deployer) hence should be recognized as unknown
+			name: "weblogic deployer",
+			rawCmd: `/u01/jdk/bin/java -Djava.security.egd=file:/dev/./urandom -cp /u01/oracle/wlserver/server/lib/weblogic-launcher.jar
+-Dlaunch.use.env.classpath=true -Dweblogic.Name=AdminServer -Djava.security.policy=/u01/oracle/wlserver/server/lib/weblogic.policy
+-Djava.system.class.loader=com.oracle.classloader.weblogic.LaunchClassLoader -javaagent:/u01/oracle/wlserver/server/lib/debugpatch-agent.jar
+-da -Dwls.home=/u01/oracle/wlserver/server -Dweblogic.home=/u01/oracle/wlserver/server weblogic.Deployer -upload -target myserver -deploy some.war`,
+			expectedVendor: unknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vendor, home := resolveAppServerFromCmdLine(strings.Split(strings.ReplaceAll(tt.rawCmd, "\n", " "), " "))
+			require.Equal(t, tt.expectedVendor, vendor)
+			// the base dir is making sense only when the vendor has been properly understood
+			if tt.expectedVendor != unknown {
+				require.Equal(t, tt.expectedHome, home)
+			}
+		})
+	}
+}

--- a/pkg/process/metadata/parser/java/spring.go
+++ b/pkg/process/metadata/parser/java/spring.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package javaparser contains functions to autodetect service name for java applications
 package javaparser
 
 import (

--- a/pkg/process/metadata/parser/java/testdata/weblogic/config/config.xml
+++ b/pkg/process/metadata/parser/java/testdata/weblogic/config/config.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<domain xsi:schemaLocation="http://xmlns.oracle.com/weblogic/security/wls http://xmlns.oracle.com/weblogic/security/wls/1.0/wls.xsd http://xmlns.oracle.com/weblogic/domain http://xmlns.oracle.com/weblogic/1.0/domain.xsd http://xmlns.oracle.com/weblogic/security http://xmlns.oracle.com/weblogic/1.0/security.xsd http://xmlns.oracle.com/weblogic/security/xacml http://xmlns.oracle.com/weblogic/security/xacml/1.0/xacml.xsd"
+        xmlns="http://xmlns.oracle.com/weblogic/domain" xmlns:sec="http://xmlns.oracle.com/weblogic/security"
+        xmlns:wls="http://xmlns.oracle.com/weblogic/security/wls" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <name>base_domain</name>
+    <domain-version>12.2.1.4.0</domain-version>
+    <security-configuration xmlns:xacml="http://xmlns.oracle.com/weblogic/security/xacml"
+                            xmlns:pas="http://xmlns.oracle.com/weblogic/security/providers/passwordvalidator">
+        <name>base_domain</name>
+        <realm>
+            <sec:authentication-provider xsi:type="wls:default-authenticatorType">
+                <sec:name>DefaultAuthenticator</sec:name>
+            </sec:authentication-provider>
+            <sec:authentication-provider xsi:type="wls:default-identity-asserterType">
+                <sec:name>DefaultIdentityAsserter</sec:name>
+                <sec:active-type>AuthenticatedUser</sec:active-type>
+                <sec:active-type>weblogic-jwt-token</sec:active-type>
+            </sec:authentication-provider>
+            <sec:role-mapper xsi:type="xacml:xacml-role-mapperType">
+                <sec:name>XACMLRoleMapper</sec:name>
+            </sec:role-mapper>
+            <sec:authorizer xsi:type="xacml:xacml-authorizerType">
+                <sec:name>XACMLAuthorizer</sec:name>
+            </sec:authorizer>
+            <sec:adjudicator xsi:type="wls:default-adjudicatorType">
+                <sec:name>DefaultAdjudicator</sec:name>
+            </sec:adjudicator>
+            <sec:credential-mapper xsi:type="wls:default-credential-mapperType">
+                <sec:name>DefaultCredentialMapper</sec:name>
+            </sec:credential-mapper>
+            <sec:cert-path-provider xsi:type="wls:web-logic-cert-path-providerType">
+                <sec:name>WebLogicCertPathProvider</sec:name>
+            </sec:cert-path-provider>
+            <sec:cert-path-builder>WebLogicCertPathProvider</sec:cert-path-builder>
+            <sec:name>myrealm</sec:name>
+            <sec:password-validator xsi:type="pas:system-password-validatorType">
+                <sec:name>SystemPasswordValidator</sec:name>
+                <pas:min-password-length>8</pas:min-password-length>
+                <pas:min-numeric-or-special-characters>1</pas:min-numeric-or-special-characters>
+            </sec:password-validator>
+        </realm>
+        <default-realm>myrealm</default-realm>
+        <node-manager-username>weblogic</node-manager-username>
+    </security-configuration>
+    <server>
+        <name>AdminServer</name>
+        <ssl>
+            <name>AdminServer</name>
+            <enabled>true</enabled>
+        </ssl>
+        <listen-address/>
+        <server-life-cycle-timeout-val>30</server-life-cycle-timeout-val>
+        <startup-timeout>0</startup-timeout>
+    </server>
+    <embedded-ldap>
+        <name>base_domain</name>
+    </embedded-ldap>
+    <administration-port-enabled>true</administration-port-enabled>
+    <configuration-version>12.2.1.4.0</configuration-version>
+    <app-deployment>
+        <name>sample</name>
+        <target>AdminServer</target>
+        <module-type>war</module-type>
+        <source-path>java/testdata/weblogic/test.war</source-path>
+        <security-dd-model>DDOnly</security-dd-model>
+        <staging-mode>stage</staging-mode>
+        <plan-staging-mode>stage</plan-staging-mode>
+        <cache-in-app-directory>false</cache-in-app-directory>
+    </app-deployment>
+    <app-deployment>
+        <name>sample2</name>
+        <target>AnotherServer</target>
+        <module-type>war</module-type>
+        <source-path>/u01/oracle/user_projects/tmp/sample2.war</source-path>
+        <security-dd-model>DDOnly</security-dd-model>
+        <staging-mode>stage</staging-mode>
+        <plan-staging-mode>stage</plan-staging-mode>
+        <cache-in-app-directory>false</cache-in-app-directory>
+    </app-deployment>
+    <app-deployment>
+        <name>sample3</name>
+        <target>AdminServer</target>
+        <module-type>war</module-type>
+        <source-path>./sample3.war</source-path>
+        <security-dd-model>DDOnly</security-dd-model>
+        <staging-mode>unstaged</staging-mode>
+        <plan-staging-mode>unstaged</plan-staging-mode>
+        <cache-in-app-directory>false</cache-in-app-directory>
+    </app-deployment>
+    <app-deployment>
+        <name>sample4</name>
+        <target>AdminServer</target>
+        <module-type>war</module-type>
+        <source-path>/u01/oracle/user_projects/tmp/sample4.war</source-path>
+        <security-dd-model>DDOnly</security-dd-model>
+        <staging-mode>stage</staging-mode>
+        <plan-staging-mode>stage</plan-staging-mode>
+        <cache-in-app-directory>false</cache-in-app-directory>
+    </app-deployment>
+    <admin-server-name>AdminServer</admin-server-name>
+</domain>

--- a/pkg/process/metadata/parser/java/testdata/weblogic/config/config.xml
+++ b/pkg/process/metadata/parser/java/testdata/weblogic/config/config.xml
@@ -97,5 +97,15 @@
         <plan-staging-mode>stage</plan-staging-mode>
         <cache-in-app-directory>false</cache-in-app-directory>
     </app-deployment>
+    <app-deployment>
+        <name>some_ear</name>
+        <target>AdminServer</target>
+        <module-type>ear</module-type>
+        <source-path>java/testdata/weblogic/test.ear</source-path>
+        <security-dd-model>DDOnly</security-dd-model>
+        <staging-mode>stage</staging-mode>
+        <plan-staging-mode>stage</plan-staging-mode>
+        <cache-in-app-directory>false</cache-in-app-directory>
+    </app-deployment>
     <admin-server-name>AdminServer</admin-server-name>
 </domain>

--- a/pkg/process/metadata/parser/java/testdata/weblogic/test.ear/META-INF/application.xml
+++ b/pkg/process/metadata/parser/java/testdata/weblogic/test.ear/META-INF/application.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application xmlns="http://java.sun.com/xml/ns/javaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_6.xsd"
+             version="6">
+    <display-name>sample-ear</display-name>
+    <module>
+        <web>
+            <web-uri>some-webapp.war</web-uri>
+            <context-root>some_context_root</context-root>
+        </web>
+    </module>
+</application>

--- a/pkg/process/metadata/parser/java/testdata/weblogic/test.ear/META-INF/application.xml
+++ b/pkg/process/metadata/parser/java/testdata/weblogic/test.ear/META-INF/application.xml
@@ -7,7 +7,7 @@
     <module>
         <web>
             <web-uri>some-webapp.war</web-uri>
-            <context-root>some_context_root</context-root>
+            <context-root>/some_context_root</context-root>
         </web>
     </module>
 </application>

--- a/pkg/process/metadata/parser/java/testdata/weblogic/test.war/META-INF/weblogic.xml
+++ b/pkg/process/metadata/parser/java/testdata/weblogic/test.war/META-INF/weblogic.xml
@@ -1,0 +1,4 @@
+<weblogic-web-app xmlns="http://xmlns.oracle.com/weblogic/weblogic-web-app" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://xmlns.oracle.com/weblogic/weblogic-web-app http://xmlns.oracle.com/weblogic/weblogic-web-app/1.4/weblogic-web-app.xsd">
+    <context-root>my_context</context-root>
+</weblogic-web-app>

--- a/pkg/process/metadata/parser/java/util.go
+++ b/pkg/process/metadata/parser/java/util.go
@@ -13,9 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/spf13/afero"
-
 	"github.com/rickar/props"
+	"github.com/spf13/afero"
 	"github.com/vibrantbyte/go-antpath/antpath"
 )
 
@@ -46,7 +45,7 @@ func (y *mapSource) GetDefault(key string, defVal string) string {
 
 type closeFn func() error
 
-// fileSystemCloser wraps a FileSystem with a Closer in case the filesystem has been created with a stream the
+// fileSystemCloser wraps a FileSystem with a Closer in case the filesystem has been created with a stream that
 // should be closed after its usage.
 type fileSystemCloser struct {
 	fs afero.Fs

--- a/pkg/process/metadata/parser/java/weblogic.go
+++ b/pkg/process/metadata/parser/java/weblogic.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package javaparser
+
+import (
+	"encoding/xml"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+)
+
+// weblogic vendor specific constants
+const (
+	wlsServerNameSysProp string = "-Dwls.Name="
+	wlsServerConfigFile  string = "config.xml"
+	wlsServerConfigDir   string = "config"
+	weblogicXMLFile      string = "/META-INF/weblogic.xml"
+)
+
+type (
+	// weblogicDeploymentInfo reflects the domain type of weblogic config.xml
+	weblogicDeploymentInfo struct {
+		XMLName       xml.Name                `xml:"domain"`
+		AppDeployment []weblogicAppDeployment `xml:"app-deployment"`
+	}
+
+	// weblogicAppDeployment reflects a deployment information in config.xml
+	weblogicAppDeployment struct {
+		Target      string `xml:"target"`
+		SourcePath  string `xml:"source-path"`
+		StagingMode string `xml:"staging-mode"`
+	}
+
+	// weblogicXMLContextRoot allows to extract the context-root tag value from weblogic.xml on war archives
+	weblogicXMLContextRoot struct {
+		XMLName     xml.Name `xml:"weblogic-web-app"`
+		ContextRoot string   `xml:"context-root"`
+	}
+)
+
+// weblogicFindDeployedApps looks for deployed application in the provided domainHome.
+// The args is required here because used to determine the current server name.
+// it returns paths for staged only applications and bool being true if at least one application is found
+func weblogicFindDeployedApps(domainHome string, args []string, fs afero.Fs) ([]string, bool) {
+	serverName, ok := extractJavaPropertyFromArgs(args, wlsServerNameSysProp)
+	if !ok {
+		return nil, false
+	}
+	serverConfigFile, err := fs.Open(filepath.Join(domainHome, wlsServerConfigDir, wlsServerConfigFile))
+	if err != nil {
+		return nil, false
+	}
+	defer serverConfigFile.Close()
+	if !canSafelyParse(serverConfigFile) {
+		return nil, false
+	}
+	var deployInfos weblogicDeploymentInfo
+	err = xml.NewDecoder(serverConfigFile).Decode(&deployInfos)
+
+	if err != nil {
+		return nil, false
+	}
+	var sourcePaths []string
+	for _, di := range deployInfos.AppDeployment {
+		if di.StagingMode == "stage" && di.Target == serverName {
+			sourcePaths = append(sourcePaths, di.SourcePath)
+		}
+	}
+	return sourcePaths, len(sourcePaths) > 0
+}
+
+func weblogicExtractWarContextRoot(warFS afero.Fs) (string, bool) {
+	// vfs package will internally clean the filename to comply with the os separators
+	file, err := warFS.Open(weblogicXMLFile)
+	if err != nil {
+		return "", false
+	}
+	defer file.Close()
+	var wlsXML weblogicXMLContextRoot
+	if xml.NewDecoder(file).Decode(&wlsXML) != nil || len(wlsXML.ContextRoot) == 0 {
+		return "", false
+	}
+	return wlsXML.ContextRoot, true
+}

--- a/pkg/process/metadata/parser/java/weblogic_test.go
+++ b/pkg/process/metadata/parser/java/weblogic_test.go
@@ -32,6 +32,7 @@ func TestWeblogicFindDeployedApps(t *testing.T) {
 			expected: []string{
 				"java/testdata/weblogic/test.war",
 				"/u01/oracle/user_projects/tmp/sample4.war",
+				"java/testdata/weblogic/test.ear",
 			},
 		},
 		{

--- a/pkg/process/metadata/parser/java/weblogic_test.go
+++ b/pkg/process/metadata/parser/java/weblogic_test.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package javaparser
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/afero/zipfs"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWeblogicFindDeployedApps tests the ability to extract deployed application from a weblogic config.xml
+// The file contains staged and non-staged deployments for different servers.
+// It is expected that only the staged deployment of `AdminServer` are returned.
+func TestWeblogicFindDeployedApps(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverName string
+		expected   []string
+	}{
+		{
+			name:       "multiple deployments for multiple server - extract for AdminServer",
+			serverName: "AdminServer",
+			expected: []string{
+				"java/testdata/weblogic/test.war",
+				"/u01/oracle/user_projects/tmp/sample4.war",
+			},
+		},
+		{
+			name:     "server name is missing",
+			expected: nil,
+		},
+	}
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	domainHome := filepath.Join(cwd, "testdata", "weblogic")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var args []string
+			if len(tt.serverName) > 0 {
+				args = append(args, wlsServerNameSysProp+tt.serverName)
+			}
+			value, ok := weblogicFindDeployedApps(domainHome, args, afero.NewOsFs())
+			require.Equal(t, len(value) > 0, ok)
+			require.Equal(t, tt.expected, value)
+		})
+	}
+}
+
+func TestWeblogicExtractWarContextRoot(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverName string
+		xmlContent string
+		expected   string
+	}{
+		{
+			name: "war with weblogic.xml and context-root",
+			xmlContent: `
+<weblogic-web-app xmlns="http://xmlns.oracle.com/weblogic/weblogic-web-app" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://xmlns.oracle.com/weblogic/weblogic-web-app
+http://xmlns.oracle.com/weblogic/weblogic-web-app/1.4/weblogic-web-app.xsd">
+<context-root>my-context</context-root>
+</weblogic-web-app>`,
+			expected: "my-context",
+		},
+		{
+			name: "weblogic.xml without context-root",
+			xmlContent: `
+<weblogic-web-app xmlns="http://xmlns.oracle.com/weblogic/weblogic-web-app" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://xmlns.oracle.com/weblogic/weblogic-web-app
+http://xmlns.oracle.com/weblogic/weblogic-web-app/1.4/weblogic-web-app.xsd"/>`,
+			expected: "",
+		},
+		{
+			name:     "no weblogic.xml in the war",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// create an in memory zip to emulate a war
+			buf := bytes.NewBuffer([]byte{})
+			writer := zip.NewWriter(buf)
+			if len(tt.xmlContent) > 0 {
+				require.NoError(t, writeFile(writer, weblogicXMLFile, tt.xmlContent))
+			}
+			require.NoError(t, writer.Close())
+
+			// now create a zip reader to pass to the tested function
+			reader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+			require.NoError(t, err)
+			value, ok := weblogicExtractWarContextRoot(zipfs.New(reader))
+			require.Equal(t, len(tt.expected) > 0, ok)
+			require.Equal(t, tt.expected, value)
+		})
+	}
+}
+
+// TestWeblogicExtractExplodedWarContextRoot tests the ability to extract context root from weblogic.xml
+// when the deployment is exploded (aka is a directory and not a war archive)
+func TestWeblogicExtractExplodedWarContextRoot(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	fs := afero.NewBasePathFs(afero.NewOsFs(), filepath.Join(cwd, "testdata", "weblogic", "test.war"))
+	value, ok := weblogicExtractWarContextRoot(fs)
+	require.True(t, ok)
+	require.Equal(t, "my_context", value)
+}

--- a/pkg/process/metadata/parser/service.go
+++ b/pkg/process/metadata/parser/service.go
@@ -415,7 +415,7 @@ func advancedGuessJavaServiceName(se *ServiceExtractor, process *procutil.Proces
 	contextRoots := javaparser.ExtractServiceNamesForJEEServer(args, process.Cwd, afero.NewOsFs())
 	if len(contextRoots) > 0 {
 		// use a `;` separated list to surface multiple service names found
-		return strings.Join(contextRoots, ";"), true
+		return contextRoots, true
 	}
 	// try to introspect the jar to get service name from spring application name
 	// TODO: pass process envs

--- a/pkg/process/metadata/parser/service.go
+++ b/pkg/process/metadata/parser/service.go
@@ -13,10 +13,9 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/spf13/afero"
-
 	"github.com/Masterminds/semver"
 	"github.com/cihub/seelog"
+	"github.com/spf13/afero"
 
 	"github.com/DataDog/datadog-agent/pkg/process/metadata"
 	javaparser "github.com/DataDog/datadog-agent/pkg/process/metadata/parser/java"

--- a/pkg/process/metadata/parser/service_test.go
+++ b/pkg/process/metadata/parser/service_test.go
@@ -372,7 +372,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 			},
 			cwd:                  "java/testdata/weblogic",
 			useImprovedAlgorithm: true,
-			expectedServiceTags:  []string{"process_context:my_context", "process_context:some_context_root"},
+			expectedServiceTags:  []string{"process_context:my_context", "process_context:sample4", "process_context:some_context_root"},
 		},
 		{
 			name: "tomcat - old naming for backward compatibility",

--- a/pkg/process/metadata/parser/service_test.go
+++ b/pkg/process/metadata/parser/service_test.go
@@ -360,7 +360,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 				"weblogic.Server",
 			},
 			useImprovedAlgorithm: true,
-			expectedServiceTag:   "process_context:weblogic",
+			expectedServiceTags:  []string{"process_context:weblogic"},
 		},
 		{
 			name: "weblogic with multiple services found",
@@ -372,7 +372,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 			},
 			cwd:                  "java/testdata/weblogic",
 			useImprovedAlgorithm: true,
-			expectedServiceTag:   "process_context:my_context;some_context_root",
+			expectedServiceTags:  []string{"process_context:my_context", "process_context:some_context_root"},
 		},
 		{
 			name: "tomcat - old naming for backward compatibility",
@@ -381,7 +381,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 				"-Dcatalina.base=somewhere",
 				"org.apache.catalina.startup.Bootstrap",
 			},
-			expectedServiceTag: "process_context:catalina",
+			expectedServiceTags: []string{"process_context:catalina"},
 		},
 		{
 			name: "tomcat - improved algorithm",
@@ -391,7 +391,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 				"org.apache.catalina.startup.Bootstrap",
 			},
 			useImprovedAlgorithm: true,
-			expectedServiceTag:   "process_context:tomcat",
+			expectedServiceTags:  []string{"process_context:tomcat"},
 		},
 	}
 

--- a/pkg/process/metadata/parser/service_test.go
+++ b/pkg/process/metadata/parser/service_test.go
@@ -364,7 +364,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 			expectedServiceTag:   "process_context:weblogic",
 		},
 		{
-			name: "weblogic with a found context root name",
+			name: "weblogic with multiple services found",
 			cmdline: []string{
 				"java",
 				"-Dwls.home=testdata/weblogic",
@@ -373,7 +373,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 			},
 			cwd:                  "java/testdata/weblogic",
 			useImprovedAlgorithm: true,
-			expectedServiceTag:   "process_context:my_context",
+			expectedServiceTag:   "process_context:my_context;some_context_root",
 		},
 		{
 			name: "tomcat - old naming for backward compatibility",

--- a/pkg/process/metadata/parser/service_test.go
+++ b/pkg/process/metadata/parser/service_test.go
@@ -6,7 +6,6 @@
 package parser
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -395,8 +394,6 @@ func TestExtractServiceMetadata(t *testing.T) {
 			expectedServiceTag:   "process_context:tomcat",
 		},
 	}
-	_, err := os.Getwd()
-	require.NoError(t, err)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR brings the first milestone for Java enterprise server service detection, by enabling
* server vendor detection (i.e. jboss, weblogic, tomcat,...)
* list of deployed application context root extraction

Please note that this extraction is opt in (system_probe_config.process_service_inference.use_improved_algorithm has to be explicitly set to true)


#### Some preamble

An application server is usually able to run multiple application at the same time. When APM instruments an application server, by default it uses the root context of a web application as service name.

The root context is a sort of base path the application is serving requests. It can be defined in a couple of ways:

* The deployment is an EAR. It means that is an archive containing other archives (.war). It contains a file (`application.xml`) that maps each webapp to its root context. This is standardised across vendors
* The deployment is a WAR. In this case each vendor has a specific way to express the context root. As a default, the filename without the extension is commonly used as context root.

In order to know which application are deployed on an application server being executed, there is the need to parse the vendor specific configuration in order to see which applications are enabled for the deployment.

#### Vendor detection algorithm 

The algorithm cycles through the cmd line and looks for a couple of evidences in order to be sure that the matching is correct. Generally we match:

1.  The main class entrypoint / jar name
2. A typical system properties defined by the server cmd line (typically the domain home, used also later on).

If mismatch, `unknown` will be returned

#### Generic Java Enterprise context extraction

1. Determine the vendor
2. Extract the deployments (ear and war only) for the current server from the config (can be archives or directories)
3. Extract the context root for each deployment
  1. for an EAR use the application.xml file
  2. for a WAR first use the vendor specific method, then the default one (can be based on the filename or more complex like for tomcat)

#### Specific war context root extraction for weblogic

Weblogic war file can define their context root by specifying it on a file called `weblogic.xml`

#### Reporting process_context for  that multiservice use case

All the context roots are reported as service names. This implies as many `process_context:x` tags.
If the context roots cannot be extracted but the server vendor can be detected, the server vendor name will be used


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
