### PR TITLE
Read and propagate helm config for security products

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1838,6 +1838,93 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 				mockConfig.SetWithoutSource("apm_config.instrumentation.lib_versions", map[string]string{"ruby": "v1.2.3"})
 			},
 		},
+		{
+			name: "Single Step Instrumentation: enable ASM",
+			pod: common.FakePodWithParent(
+				"ns",
+				map[string]string{},
+				map[string]string{},
+				[]corev1.EnvVar{},
+				"replicaset", "test-app-123",
+			),
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
+					Value: installTime,
+				},
+				{
+					Name:  "DD_INSTRUMENTATION_INSTALL_ID",
+					Value: uuid,
+				},
+				{
+					Name:  "DD_APPSEC_ENABLED",
+					Value: "true",
+				},
+			},
+			expectedInjectedLibraries: map[string]string{},
+			wantErr:                   false,
+			setupConfig: func() {
+				mockConfig.SetWithoutSource("asm_config.enabled", true)
+			},
+		},
+		{
+			name: "Single Step Instrumentation: enable iast",
+			pod: common.FakePodWithParent(
+				"ns",
+				map[string]string{},
+				map[string]string{},
+				[]corev1.EnvVar{},
+				"replicaset", "test-app-123",
+			),
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
+					Value: installTime,
+				},
+				{
+					Name:  "DD_INSTRUMENTATION_INSTALL_ID",
+					Value: uuid,
+				},
+				{
+					Name:  "DD_IAST_ENABLED",
+					Value: "true",
+				},
+			},
+			expectedInjectedLibraries: map[string]string{},
+			wantErr:                   false,
+			setupConfig: func() {
+				mockConfig.SetWithoutSource("iast_config.enabled", true)
+			},
+		},
+		{
+			name: "Single Step Instrumentation: disable sca",
+			pod: common.FakePodWithParent(
+				"ns",
+				map[string]string{},
+				map[string]string{},
+				[]corev1.EnvVar{},
+				"replicaset", "test-app-123",
+			),
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
+					Value: installTime,
+				},
+				{
+					Name:  "DD_INSTRUMENTATION_INSTALL_ID",
+					Value: uuid,
+				},
+				{
+					Name:  "DD_SCA_ENABLED",
+					Value: "false",
+				},
+			},
+			expectedInjectedLibraries: map[string]string{},
+			wantErr:                   false,
+			setupConfig: func() {
+				mockConfig.SetWithoutSource("sca_config.enabled", false)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -82,6 +82,16 @@ func setupAPM(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("apm_config.instrumentation.disabled_namespaces", []string{}, "DD_APM_INSTRUMENTATION_DISABLED_NAMESPACES")
 	config.BindEnvAndSetDefault("apm_config.instrumentation.lib_versions", map[string]string{}, "DD_APM_INSTRUMENTATION_LIB_VERSIONS")
 
+	config.BindEnv("asm_config.enabled", "DD_APPSEC_ENABLED_PROPAGATE")
+	config.BindEnvAndSetDefault("asm_config.enabled_namespaces", []string{}, "DD_APPSEC_ENABLED_PROPAGATE_NAMESPACES")
+	config.BindEnvAndSetDefault("asm_config.disabled_namespaces", []string{}, "DD_APPSEC_DISABLED_PROPAGATE_NAMESPACES")
+	config.BindEnv("iast_config.enabled", "DD_IAST_ENABLED_PROPAGATE")
+	config.BindEnvAndSetDefault("iast_config.enabled_namespaces", []string{}, "DD_IAST_ENABLED_PROPAGATE_NAMESPACES")
+	config.BindEnvAndSetDefault("iast_config.disabled_namespaces", []string{}, "DD_IAST_DISABLED_PROPAGATE_NAMESPACES")
+	config.BindEnv("sca_config.enabled", "DD_SCA_ENABLED_PROPAGATE")
+	config.BindEnvAndSetDefault("sca_config.enabled_namespaces", []string{}, "DD_SCA_ENABLED_PROPAGATE_NAMESPACES")
+	config.BindEnvAndSetDefault("sca_config.disabled_namespaces", []string{}, "DD_SCA_DISABLED_PROPAGATE_NAMESPACES")
+
 	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")
 	config.BindEnv("apm_config.receiver_timeout", "DD_APM_RECEIVER_TIMEOUT")
 	config.BindEnv("apm_config.max_payload_size", "DD_APM_MAX_PAYLOAD_SIZE")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR is indent to allow ASM, IAST and SCA to be enabled (or disabled) by Helm Charts config on the controller pod. The cluster-agent, running on the controller pod, will read some environment variables and use this to mutate the configuration of other pod to set the environment variables that will activate products within the client libraries.

### Motivation

This will make it easier for k8s clients (at least those using Helm Charts) to activate our products. Simplified installation is a common request.

### Additional Notes

The PR will is designed to work with this PR: https://github.com/DataDog/helm-charts/pull/1337

Each product will have env var with the following format:

* `DD_product_ENABLED_PROPAGATE` - overall enable disable switch
* `DD_product_ENABLED_PROPAGATE_NAMESPACES`  - filter for namespaces where the products should enabled
* `DD_product_DISABLED_PROPAGATE_NAMESPACES` - filter for namespaces where the products shouldn't enabled

It will result in the a variable with the following format be propagated to all pods (or those conforming to the filters):

`DD_product_ENABLED`


### Possible Drawbacks / Trade-offs

Adds more complexity to our config handling.

### Describe how to test/QA your changes

* Unit tests have been added
* Manual end to end testing has been preformed