### PR TITLE
[CONTINT-3914] Add container id resolver from pod uid + container name in generic metrics provider

### DIFF
--- a/pkg/util/containers/metrics/kubelet/collector_test.go
+++ b/pkg/util/containers/metrics/kubelet/collector_test.go
@@ -209,6 +209,94 @@ func TestKubeletCollectorWindows(t *testing.T) {
 	}, cID1Stats)
 }
 
+func TestContainerIDForPodUIDAndContName(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		pod         *workloadmeta.KubernetesPod
+		podUID      string
+		contName    string
+		initCont    bool
+		expectedCid string
+	}{
+		{
+			name: "pod with container",
+			pod: &workloadmeta.KubernetesPod{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindKubernetesPod,
+					ID:   "c84eb7fb-09f2-11ea-abb1-42010a84017a",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      "kube-dns-5877696fb4-m6cvp",
+					Namespace: "kube-system",
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						ID:   "cID1",
+						Name: "kubedns",
+					},
+				},
+			},
+			podUID:      "c84eb7fb-09f2-11ea-abb1-42010a84017a",
+			contName:    "kubedns",
+			initCont:    false,
+			expectedCid: "cID1",
+		},
+		{
+			name: "pod with init container",
+			pod: &workloadmeta.KubernetesPod{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindKubernetesPod,
+					ID:   "c84eb7fb-09f2-11ea-abb1-42010a84017a",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      "kube-dns-5877696fb4-m6cvp",
+					Namespace: "kube-system",
+				},
+				InitContainers: []workloadmeta.OrchestratorContainer{
+					{
+						ID:   "cID1",
+						Name: "kubedns",
+					},
+				},
+			},
+			podUID:      "c84eb7fb-09f2-11ea-abb1-42010a84017a",
+			contName:    "kubedns",
+			initCont:    true,
+			expectedCid: "cID1",
+		},
+		{
+			name:        "not found",
+			podUID:      "poduid",
+			contName:    "contname",
+			initCont:    false,
+			expectedCid: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			metadataStore := fxutil.Test[workloadmeta.Mock](t, fx.Options(
+				core.MockBundle(),
+				fx.Supply(context.Background()),
+				fx.Supply(workloadmeta.NewParams()),
+				workloadmeta.MockModule(),
+			))
+
+			kubeletMock := mock.NewKubeletMock()
+			if tt.pod != nil {
+				metadataStore.Set(tt.pod)
+			}
+
+			kubeletCollector := &kubeletCollector{
+				kubeletClient: kubeletMock,
+				metadataStore: metadataStore,
+			}
+
+			cid, err := kubeletCollector.ContainerIDForPodUIDAndContName(tt.podUID, tt.contName, tt.initCont, time.Minute)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedCid, cid)
+		})
+	}
+}
+
 func setStatsSummaryFromFile(t *testing.T, filePath string, kubeletMock *mock.KubeletMock) {
 	t.Helper()
 

--- a/pkg/util/containers/metrics/mock/mock.go
+++ b/pkg/util/containers/metrics/mock/mock.go
@@ -23,9 +23,10 @@ type MetricsProvider struct {
 
 // MetaCollector is a mocked provider.MetaCollector
 type MetaCollector struct {
-	ContainerID  string
-	CIDFromPID   map[int]string
-	CIDFromInode map[uint64]string
+	ContainerID           string
+	CIDFromPID            map[int]string
+	CIDFromInode          map[uint64]string
+	CIDFromPodUIDContName map[string]string
 }
 
 // GetSelfContainerID returns the container ID for current container.
@@ -41,9 +42,22 @@ func (mc *MetaCollector) GetContainerIDForPID(pid int, _ time.Duration) (string,
 	return "", nil
 }
 
-// GetContainerIDForInode returns a container ID for given inode.
+// GetContainerIDForInode returns a container ID for the given inode.
 func (mc *MetaCollector) GetContainerIDForInode(inode uint64, _ time.Duration) (string, error) {
 	if val, found := mc.CIDFromInode[inode]; found {
+		return val, nil
+	}
+	return "", nil
+}
+
+// ContainerIDForPodUIDAndContName returns a container ID for the given pod uid and container name.
+func (mc *MetaCollector) ContainerIDForPodUIDAndContName(podUID, contName string, initCont bool, _ time.Duration) (string, error) {
+	initPrefix := ""
+	if initCont {
+		initPrefix = "i-"
+	}
+	cacheKey := initPrefix + podUID + "/" + contName
+	if val, found := mc.CIDFromPodUIDContName[cacheKey]; found {
 		return val, nil
 	}
 	return "", nil

--- a/pkg/util/containers/metrics/provider/collector.go
+++ b/pkg/util/containers/metrics/provider/collector.go
@@ -49,9 +49,10 @@ type Collectors struct {
 	PIDs           CollectorRef[ContainerPIDsGetter]
 
 	// These collectors are used in the meta collector
-	ContainerIDForPID   CollectorRef[ContainerIDForPIDRetriever]
-	ContainerIDForInode CollectorRef[ContainerIDForInodeRetriever]
-	SelfContainerID     CollectorRef[SelfContainerIDRetriever]
+	ContainerIDForPID               CollectorRef[ContainerIDForPIDRetriever]
+	ContainerIDForInode             CollectorRef[ContainerIDForInodeRetriever]
+	SelfContainerID                 CollectorRef[SelfContainerIDRetriever]
+	ContainerIDForPodUIDAndContName CollectorRef[ContainerIDForPodUIDAndContNameRetriever]
 }
 
 func (c *Collectors) merge(runtime RuntimeMetadata, otherID string, oth *Collectors) {
@@ -61,6 +62,7 @@ func (c *Collectors) merge(runtime RuntimeMetadata, otherID string, oth *Collect
 	c.PIDs = c.PIDs.bestCollector(runtime, otherID, oth.PIDs)
 	c.ContainerIDForPID = c.ContainerIDForPID.bestCollector(runtime, otherID, oth.ContainerIDForPID)
 	c.ContainerIDForInode = c.ContainerIDForInode.bestCollector(runtime, otherID, oth.ContainerIDForInode)
+	c.ContainerIDForPodUIDAndContName = c.ContainerIDForPodUIDAndContName.bestCollector(runtime, otherID, oth.ContainerIDForPodUIDAndContName)
 	c.SelfContainerID = c.SelfContainerID.bestCollector(runtime, otherID, oth.SelfContainerID)
 }
 

--- a/pkg/util/containers/metrics/provider/collector_cache.go
+++ b/pkg/util/containers/metrics/provider/collector_cache.go
@@ -49,13 +49,14 @@ func MakeCached(providerID string, cache *Cache, collectors *Collectors) *Collec
 	}
 
 	return &Collectors{
-		Stats:               makeCached(collectors.Stats, ContainerStatsGetter(collectorCache)),
-		Network:             makeCached(collectors.Network, ContainerNetworkStatsGetter(collectorCache)),
-		OpenFilesCount:      makeCached(collectors.OpenFilesCount, ContainerOpenFilesCountGetter(collectorCache)),
-		PIDs:                makeCached(collectors.PIDs, ContainerPIDsGetter(collectorCache)),
-		ContainerIDForPID:   makeCached(collectors.ContainerIDForPID, ContainerIDForPIDRetriever(collectorCache)),
-		ContainerIDForInode: makeCached(collectors.ContainerIDForInode, ContainerIDForInodeRetriever(collectorCache)),
-		SelfContainerID:     makeCached(collectors.SelfContainerID, SelfContainerIDRetriever(collectorCache)),
+		Stats:                           makeCached(collectors.Stats, ContainerStatsGetter(collectorCache)),
+		Network:                         makeCached(collectors.Network, ContainerNetworkStatsGetter(collectorCache)),
+		OpenFilesCount:                  makeCached(collectors.OpenFilesCount, ContainerOpenFilesCountGetter(collectorCache)),
+		PIDs:                            makeCached(collectors.PIDs, ContainerPIDsGetter(collectorCache)),
+		ContainerIDForPID:               makeCached(collectors.ContainerIDForPID, ContainerIDForPIDRetriever(collectorCache)),
+		ContainerIDForInode:             makeCached(collectors.ContainerIDForInode, ContainerIDForInodeRetriever(collectorCache)),
+		SelfContainerID:                 makeCached(collectors.SelfContainerID, SelfContainerIDRetriever(collectorCache)),
+		ContainerIDForPodUIDAndContName: makeCached(collectors.ContainerIDForPodUIDAndContName, ContainerIDForPodUIDAndContNameRetriever(collectorCache)),
 	}
 }
 

--- a/pkg/util/containers/metrics/provider/collector_cache.go
+++ b/pkg/util/containers/metrics/provider/collector_cache.go
@@ -11,12 +11,13 @@ import (
 )
 
 const (
-	contCoreStatsCachePrefix  = "cs-"
-	contOpenFilesCachePrefix  = "of-"
-	contNetStatsCachePrefix   = "cns-"
-	contPidToCidCachePrefix   = "pid-"
-	contInodeToCidCachePrefix = "in-"
-	contPidsCachePrefix       = "pids-"
+	contCoreStatsCachePrefix           = "cs-"
+	contOpenFilesCachePrefix           = "of-"
+	contNetStatsCachePrefix            = "cns-"
+	contPidToCidCachePrefix            = "pid-"
+	contInodeToCidCachePrefix          = "in-"
+	contPodUIDContNameToCidCachePrefix = "pc-"
+	contPidsCachePrefix                = "pids-"
 )
 
 // collectorCache is a wrapper handling cache for collectors.
@@ -108,13 +109,27 @@ func (cc *collectorCache) GetContainerIDForPID(pid int, cacheValidity time.Durat
 	})
 }
 
-// GetContainerIDForInode returns the container ID for given Inode
-// errors are cached as well to avoid hammering underlying collector
+// GetContainerIDForInode returns a container ID for the given inode.
+// ("", nil) will be returned if no error but the containerd ID was not found.
 func (cc *collectorCache) GetContainerIDForInode(inode uint64, cacheValidity time.Duration) (string, error) {
 	cacheKey := cc.providerID + "-" + contInodeToCidCachePrefix + strconv.FormatUint(inode, 10)
 
 	return getOrFallback(cc.cache, cacheKey, cacheValidity, func() (string, error) {
 		return cc.collectors.ContainerIDForInode.Collector.GetContainerIDForInode(inode, cacheValidity)
+	})
+}
+
+// ContainerIDForPodUIDAndContName returns a container ID for the given pod uid
+// and container name. Returns ("", nil) if the containerd ID was not found.
+func (cc *collectorCache) ContainerIDForPodUIDAndContName(podUID, contName string, initCont bool, cacheValidity time.Duration) (string, error) {
+	initPrefix := ""
+	if initCont {
+		initPrefix = "i-"
+	}
+	cacheKey := cc.providerID + "-" + contPodUIDContNameToCidCachePrefix + podUID + "/" + initPrefix + contName
+
+	return getOrFallback(cc.cache, cacheKey, cacheValidity, func() (string, error) {
+		return cc.collectors.ContainerIDForPodUIDAndContName.Collector.ContainerIDForPodUIDAndContName(podUID, contName, initCont, cacheValidity)
 	})
 }
 

--- a/pkg/util/containers/metrics/provider/collector_cache_test.go
+++ b/pkg/util/containers/metrics/provider/collector_cache_test.go
@@ -45,6 +45,10 @@ func TestCollectorCache(t *testing.T) {
 			"cID1": {1, 2, 3, 0},
 			"cID2": {},
 		},
+		cIDForPodCont: map[string]string{
+			"pc-pod1/foo":   "cID1",
+			"pc-pod1/i-foo": "cID2",
+		},
 	}
 	actualCollectors := actualCollector.getCollectors(0)
 
@@ -82,6 +86,14 @@ func TestCollectorCache(t *testing.T) {
 	cID1, err := cachedCollectors.ContainerIDForPID.Collector.GetContainerIDForPID(1, time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, "cID1", cID1)
+
+	cIDForPodCont, err := cachedCollectors.ContainerIDForPodUIDAndContName.Collector.ContainerIDForPodUIDAndContName("pc-pod1", "foo", false, time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, "cID1", cIDForPodCont)
+
+	cIDForPodCont, err = cachedCollectors.ContainerIDForPodUIDAndContName.Collector.ContainerIDForPodUIDAndContName("pc-pod1", "foo", true, time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, "cID2", cIDForPodCont)
 
 	// Changing underlying source
 	actualCollector.cStats["cID1"] = &ContainerStats{

--- a/pkg/util/containers/metrics/provider/collector_cache_test.go
+++ b/pkg/util/containers/metrics/provider/collector_cache_test.go
@@ -87,11 +87,11 @@ func TestCollectorCache(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "cID1", cID1)
 
-	cIDForPodCont, err := cachedCollectors.ContainerIDForPodUIDAndContName.Collector.ContainerIDForPodUIDAndContName("pc-pod1", "foo", false, time.Minute)
+	cIDForPodCont, err := cachedCollectors.ContainerIDForPodUIDAndContName.Collector.ContainerIDForPodUIDAndContName("pod1", "foo", false, time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, "cID1", cIDForPodCont)
 
-	cIDForPodCont, err = cachedCollectors.ContainerIDForPodUIDAndContName.Collector.ContainerIDForPodUIDAndContName("pc-pod1", "foo", true, time.Minute)
+	cIDForPodCont, err = cachedCollectors.ContainerIDForPodUIDAndContName.Collector.ContainerIDForPodUIDAndContName("pod1", "foo", true, time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, "cID2", cIDForPodCont)
 

--- a/pkg/util/containers/metrics/provider/collector_types.go
+++ b/pkg/util/containers/metrics/provider/collector_types.go
@@ -40,9 +40,16 @@ type ContainerIDForPIDRetriever interface {
 
 // ContainerIDForInodeRetriever interface
 type ContainerIDForInodeRetriever interface {
-	// GetContainerIDForInode ContainerIDForInode returns a container ID for given Inode.
+	// GetContainerIDForInode returns a container ID for the given inode.
 	// ("", nil) will be returned if no error but the containerd ID was not found.
 	GetContainerIDForInode(inode uint64, cacheValidity time.Duration) (string, error)
+}
+
+// ContainerIDForPodUIDAndContNameRetriever interface
+type ContainerIDForPodUIDAndContNameRetriever interface {
+	// ContainerIDForPodUIDAndContName returns a container ID for the given pod uid
+	// and container name. Returns ("", nil) if the containerd ID was not found.
+	ContainerIDForPodUIDAndContName(podUID, contName string, initCont bool, cacheValidity time.Duration) (string, error)
 }
 
 // SelfContainerIDRetriever interface
@@ -65,4 +72,5 @@ type MetaCollector interface {
 	ContainerIDForPIDRetriever
 	ContainerIDForInodeRetriever
 	SelfContainerIDRetriever
+	ContainerIDForPodUIDAndContNameRetriever
 }

--- a/pkg/util/containers/metrics/provider/mock.go
+++ b/pkg/util/containers/metrics/provider/mock.go
@@ -68,6 +68,15 @@ func (d *dummyCollector) GetSelfContainerID() (string, error) {
 	return d.selfContainerID, nil
 }
 
+func (d *dummyCollector) ContainerIDForPodUIDAndContName(podUID, contName string, initCont bool, _ time.Duration) (string, error) {
+	initPrefix := ""
+	if initCont {
+		initPrefix = "i-"
+	}
+	cacheKey := contPodUIDContNameToCidCachePrefix + podUID + "/" + initPrefix + contName
+	return d.cIDForPodCont[cacheKey], nil
+}
+
 // Helpers not part of Collector interface
 func (d *dummyCollector) getCollectors(priority uint8) *Collectors {
 	return &Collectors{
@@ -92,6 +101,10 @@ func (d *dummyCollector) getCollectors(priority uint8) *Collectors {
 			Priority:  priority,
 		},
 		SelfContainerID: CollectorRef[SelfContainerIDRetriever]{
+			Collector: d,
+			Priority:  priority,
+		},
+		ContainerIDForPodUIDAndContName: CollectorRef[ContainerIDForPodUIDAndContNameRetriever]{
 			Collector: d,
 			Priority:  priority,
 		},

--- a/pkg/util/containers/metrics/provider/mock.go
+++ b/pkg/util/containers/metrics/provider/mock.go
@@ -21,6 +21,7 @@ type dummyCollector struct {
 	cOpenFilesCount map[string]*uint64
 	cNetStats       map[string]*ContainerNetworkStats
 	cIDForPID       map[int]string
+	cIDForPodCont   map[string]string
 	selfContainerID string
 	err             error
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds a container id resolver from the pod uid + container name in the generic metrics provider
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We would like to use this logic to retrieve container tags in dogstatsd and APM (later). 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
It is not used yet. Unit tests should be enough
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
