### PR TITLE
[USMON-795] usm: http2: Handle TLS tags

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -168,6 +168,7 @@ typedef struct {
 typedef struct {
     __u64 response_last_seen;
     __u64 request_started;
+    __u64 tags;
 
     status_code_t status_code;
     method_t request_method;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -168,7 +168,7 @@ typedef struct {
 typedef struct {
     __u64 response_last_seen;
     __u64 request_started;
-    __u64 tags;
+    __u8 tags;
 
     status_code_t status_code;
     method_t request_method;

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -818,6 +818,7 @@ int uprobe__http2_tls_headers_parser(struct pt_regs *ctx) {
             continue;
         }
         dispatcher_args_copy.data_off = current_frame.offset;
+        current_stream->tags |= args->tags;
         tls_process_headers_frame(&dispatcher_args_copy, current_stream, &http2_ctx->dynamic_index, &current_frame.frame, http2_tel);
     }
 

--- a/pkg/network/encoding/marshal/format.go
+++ b/pkg/network/encoding/marshal/format.go
@@ -97,7 +97,16 @@ func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionS
 		dynamicTags map[string]struct{}
 	)
 	staticTags, dynamicTags = httpEncoder.GetHTTPAggregationsAndTags(conn, builder)
-	_, _ = http2Encoder.WriteHTTP2AggregationsAndTags(conn, builder)
+	staticTags2, dynamicTags2 := http2Encoder.WriteHTTP2AggregationsAndTags(conn, builder)
+
+	staticTags |= staticTags2
+	if dynamicTags == nil {
+		dynamicTags = dynamicTags2
+	} else {
+		for k, v := range dynamicTags2 {
+			dynamicTags[k] = v
+		}
+	}
 
 	// TODO: optimize kafkEncoder to take a writer and use gostreamer
 	if dsa := kafkaEncoder.GetKafkaAggregations(conn); dsa != nil {

--- a/pkg/network/encoding/marshal/format.go
+++ b/pkg/network/encoding/marshal/format.go
@@ -39,6 +39,19 @@ func (ipc ipCache) Get(addr util.Address) string {
 	return v
 }
 
+func mergeDynamicTags(dynamicTags ...map[string]struct{}) (out map[string]struct{}) {
+	for _, tags := range dynamicTags {
+		if out == nil {
+			out = tags
+			continue
+		}
+		for k, v := range tags {
+			out[k] = v
+		}
+	}
+	return
+}
+
 // FormatConnection converts a ConnectionStats into an model.Connection
 func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionStats, routes map[string]RouteIdx, httpEncoder *httpEncoder, http2Encoder *http2Encoder, kafkaEncoder *kafkaEncoder, dnsFormatter *dnsFormatter, ipc ipCache, tagsSet *network.TagsSet) {
 
@@ -92,21 +105,11 @@ func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionS
 	builder.SetRouteIdx(formatRouteIdx(conn.Via, routes))
 	dnsFormatter.FormatConnectionDNS(conn, builder)
 
-	var (
-		staticTags  uint64
-		dynamicTags map[string]struct{}
-	)
-	staticTags, dynamicTags = httpEncoder.GetHTTPAggregationsAndTags(conn, builder)
-	staticTags2, dynamicTags2 := http2Encoder.WriteHTTP2AggregationsAndTags(conn, builder)
+	httpStaticTags, httpDynamicTags := httpEncoder.GetHTTPAggregationsAndTags(conn, builder)
+	http2StaticTags, http2DynamicTags := http2Encoder.WriteHTTP2AggregationsAndTags(conn, builder)
 
-	staticTags |= staticTags2
-	if dynamicTags == nil {
-		dynamicTags = dynamicTags2
-	} else {
-		for k, v := range dynamicTags2 {
-			dynamicTags[k] = v
-		}
-	}
+	staticTags := httpStaticTags | http2StaticTags
+	dynamicTags := mergeDynamicTags(httpDynamicTags, http2DynamicTags)
 
 	// TODO: optimize kafkEncoder to take a writer and use gostreamer
 	if dsa := kafkaEncoder.GetKafkaAggregations(conn); dsa != nil {

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -289,7 +289,7 @@ func (tx *EbpfTx) SetRequestMethod(_ http.Method) {
 
 // StaticTags returns the static tags of the transaction.
 func (tx *EbpfTx) StaticTags() uint64 {
-	return 0
+	return tx.Stream.Tags
 }
 
 // DynamicTags returns the dynamic tags of the transaction.

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -289,7 +289,7 @@ func (tx *EbpfTx) SetRequestMethod(_ http.Method) {
 
 // StaticTags returns the static tags of the transaction.
 func (tx *EbpfTx) StaticTags() uint64 {
-	return tx.Stream.Tags
+	return uint64(tx.Stream.Tags)
 }
 
 // DynamicTags returns the dynamic tags of the transaction.

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -64,12 +64,12 @@ type http2Path struct {
 type HTTP2Stream struct {
 	Response_last_seen uint64
 	Request_started    uint64
-	Tags               uint64
+	Tags               uint8
 	Status_code        http2StatusCode
 	Request_method     http2requestMethod
 	Path               http2Path
 	End_of_stream_seen bool
-	Pad_cgo_0          [2]byte
+	Pad_cgo_0          [1]byte
 }
 type EbpfTx struct {
 	Tuple  connTuple

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -64,6 +64,7 @@ type http2Path struct {
 type HTTP2Stream struct {
 	Response_last_seen uint64
 	Request_started    uint64
+	Tags               uint64
 	Status_code        http2StatusCode
 	Request_method     http2requestMethod
 	Path               http2Path

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -35,6 +35,7 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
+	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	usmhttp "github.com/DataDog/datadog-agent/pkg/network/protocols/http"
@@ -1173,7 +1174,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 
 			res := make(map[usmhttp.Key]int)
 			assert.Eventually(t, func() bool {
-				return validateStats(usmMonitor, res, tt.expectedEndpoints)
+				return validateStats(usmMonitor, res, tt.expectedEndpoints, s.isTLS)
 			}, time.Second*5, time.Millisecond*100, "%v != %v", res, tt.expectedEndpoints)
 			if t.Failed() {
 				for key := range tt.expectedEndpoints {
@@ -1307,7 +1308,7 @@ func (s *usmHTTP2Suite) TestDynamicTable() {
 			res := make(map[usmhttp.Key]int)
 			assert.Eventually(t, func() bool {
 				// validate the stats we get
-				require.True(t, validateStats(usmMonitor, res, tt.expectedEndpoints))
+				require.True(t, validateStats(usmMonitor, res, tt.expectedEndpoints, s.isTLS))
 
 				validateDynamicTableMap(t, usmMonitor.ebpfProgram, tt.expectedDynamicTablePathIndexes)
 
@@ -1387,7 +1388,7 @@ func (s *usmHTTP2Suite) TestRawHuffmanEncoding() {
 			res := make(map[usmhttp.Key]int)
 			assert.Eventually(t, func() bool {
 				// validate the stats we get
-				if !validateStats(usmMonitor, res, tt.expectedEndpoints) {
+				if !validateStats(usmMonitor, res, tt.expectedEndpoints, s.isTLS) {
 					return false
 				}
 
@@ -1436,7 +1437,7 @@ func TestHTTP2InFlightMapCleaner(t *testing.T) {
 }
 
 // validateStats validates that the stats we get from the monitor are as expected.
-func validateStats(usmMonitor *Monitor, res, expectedEndpoints map[usmhttp.Key]int) bool {
+func validateStats(usmMonitor *Monitor, res, expectedEndpoints map[usmhttp.Key]int, isTLS bool) bool {
 	for key, stat := range getHTTPLikeProtocolStats(usmMonitor, protocols.HTTP2) {
 		if key.DstPort == srvPort || key.SrcPort == srvPort {
 			statusCode := testutil.StatusFromPath(key.Path.Content.Get())
@@ -1445,6 +1446,10 @@ func validateStats(usmMonitor *Monitor, res, expectedEndpoints map[usmhttp.Key]i
 			// 200 as the status code.
 			if statusCode == 0 {
 				statusCode = 200
+			}
+			hasTag := stat.Data[statusCode].StaticTags == network.ConnTagGo
+			if hasTag != isTLS {
+				continue
 			}
 			count := stat.Data[statusCode].Count
 			newKey := usmhttp.Key{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adds TLS library tags to USM's HTTP/2 monitoring. These are the same tags as supported by HTTP, they're already present  in the TLS dispatcher arguments; we just need to pass them down through the layers.

Also, the tests are modified to verify that the correct tag is present (go-tls vs no tag).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/USMON-795

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
