### PR TITLE
Update OTLP benchmark test with large traces

### DIFF
--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -34,6 +35,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
 )
 
@@ -2048,7 +2050,43 @@ func TestMarshalSpanLinks(t *testing.T) {
 	}
 }
 
+func generateTraceRequest(traceCount int, spanCount int, attrCount int, attrLength int) ptraceotlp.ExportRequest {
+	traces := make([]testutil.OTLPResourceSpan, traceCount)
+	for k := 0; k < traceCount; k++ {
+		spans := make([]*testutil.OTLPSpan, spanCount)
+		for i := 0; i < spanCount; i++ {
+			attributes := make(map[string]interface{})
+			for j := 0; j < attrCount; j++ {
+				attributes["key_"+strconv.Itoa(j)] = strings.Repeat("x", attrLength)
+			}
+
+			spans[i] = &testutil.OTLPSpan{
+				Name:       "/path",
+				TraceState: "state",
+				Kind:       ptrace.SpanKindServer,
+				Attributes: attributes,
+				StatusCode: ptrace.StatusCodeOk,
+			}
+		}
+		rattributes := make(map[string]interface{})
+		for j := 0; j < attrCount; j++ {
+			rattributes["key_"+strconv.Itoa(j)] = strings.Repeat("x", attrLength)
+		}
+		rattributes["service.name"] = "test-service"
+		rattributes["deployment.environment"] = "test-env"
+		rspans := testutil.OTLPResourceSpan{
+			Spans:      spans,
+			LibName:    "stats-agent-test",
+			LibVersion: "0.0.1",
+			Attributes: rattributes,
+		}
+		traces[k] = rspans
+	}
+	return testutil.NewOTLPTracesRequest(traces)
+}
+
 func BenchmarkProcessRequest(b *testing.B) {
+	largeTraces := generateTraceRequest(10, 100, 100, 100)
 	metadata := http.Header(map[string][]string{
 		header.Lang:        {"go"},
 		header.ContainerID: {"containerdID"},
@@ -2071,7 +2109,7 @@ func BenchmarkProcessRequest(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		r.processRequest(context.Background(), metadata, otlpTestTracesRequest)
+		r.processRequest(context.Background(), metadata, largeTraces)
 	}
 	b.StopTimer()
 	end <- struct{}{}

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -140,6 +140,14 @@ func NewTestConfig(t *testing.T) *config.AgentConfig {
 	return cfg
 }
 
+func NewBenchmarkTestConfig(b *testing.B) *config.AgentConfig {
+	cfg := config.New()
+	attributesTranslator, err := attributes.NewTranslator(componenttest.NewNopTelemetrySettings())
+	require.NoError(b, err)
+	cfg.OTLPReceiver.AttributesTranslator = attributesTranslator
+	return cfg
+}
+
 func TestOTLPMetrics(t *testing.T) {
 	assert := assert.New(t)
 	cfg := NewTestConfig(t)
@@ -2105,7 +2113,8 @@ func BenchmarkProcessRequest(b *testing.B) {
 		}
 	}()
 
-	r := NewOTLPReceiver(out, nil, &statsd.NoOpClient{}, &timing.NoopReporter{})
+	cfg := NewBenchmarkTestConfig(b)
+	r := NewOTLPReceiver(out, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Modifies existing benchmark test for `processRequest` and `ReceiveResourceSpans` for larger trace payloads.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

This benchmark test can be run in `pkg/trace/api` with the following command:
```
❯ go test -run=XXX -bench=BenchmarkProcessRequest -tags=test
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/trace/api
BenchmarkProcessRequest-10    	     141	   8413292 ns/op	10020732 B/op	    8313 allocs/op
PASS
ok  	github.com/DataDog/datadog-agent/pkg/trace/api	2.674s
```
