### PR TITLE
[oracle] Automatically downgrading to deprecated Python integration mode (DBMON-3599)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -36,7 +36,7 @@ func (c *Check) init() error {
 	if err != nil {
 		isPrivilegeError, err2 := handlePrivilegeError(c, err)
 		if !c.dbmEnabled && isPrivilegeError {
-			c.oldIntegrationCompatibilityMode = true
+			c.legacyIntegrationCompatibilityMode = true
 			log.Warnf("%s missing privileges detected, falling back to deprecated Oracle integration %s", c.logPrompt, err2.Error())
 			c.initialized = true
 			if strings.HasPrefix(strings.ToUpper(c.config.Username), "C##") {

--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -33,6 +33,12 @@ func (c *Check) init() error {
 	var i vInstance
 	err := getWrapper(c, &i, "SELECT /* DD */ host_name, instance_name, version version_full FROM v$instance")
 	if err != nil {
+		isPrivilegeError, err2 := handlePrivilegeError(c, err)
+		if !c.dbmEnabled && isPrivilegeError {
+			c.oldIntegrationCompatibilityMode = true
+			log.Warnf("%s missing privileges detected, enabling deprecated integration compatibility mode %w", c.logPrompt, err2)
+			return nil
+		}
 		return fmt.Errorf("%s failed to query v$instance: %w", c.logPrompt, err)
 	}
 	c.dbVersion = i.VersionFull

--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -37,7 +37,7 @@ func (c *Check) init() error {
 		isPrivilegeError, err2 := handlePrivilegeError(c, err)
 		if !c.dbmEnabled && isPrivilegeError {
 			c.oldIntegrationCompatibilityMode = true
-			log.Warnf("%s missing privileges detected, falling back to deprecated Oracle integration %w", c.logPrompt, err2)
+			log.Warnf("%s missing privileges detected, falling back to deprecated Oracle integration %s", c.logPrompt, err2.Error())
 			c.initialized = true
 			if strings.HasPrefix(strings.ToUpper(c.config.Username), "C##") {
 				c.multitenant = true

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -108,6 +108,7 @@ type Check struct {
 	lastOracleRows                          []OracleRow // added for tests
 	databaseRole                            string
 	openMode                                string
+	oldIntegrationCompatibilityMode         bool
 }
 
 type vDatabase struct {
@@ -194,7 +195,7 @@ func (c *Check) Run() error {
 
 	dbInstanceIntervalExpired := checkIntervalExpired(&c.dbInstanceLastRun, 1800)
 
-	if dbInstanceIntervalExpired {
+	if dbInstanceIntervalExpired && !c.oldIntegrationCompatibilityMode {
 		err := sendDbInstanceMetadata(c)
 		if err != nil {
 			allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to send db instance metadata %w", c.logPrompt, err))
@@ -210,20 +211,22 @@ func (c *Check) Run() error {
 		}
 		fixTags(c)
 
-		err := c.OS_Stats()
-		if err != nil {
-			db, errConnect := c.Connect()
-			if errConnect != nil {
-				handleServiceCheck(c, errConnect)
-			} else if db == nil {
-				handleServiceCheck(c, fmt.Errorf("empty connection"))
-			} else {
+		if !c.oldIntegrationCompatibilityMode {
+			err := c.OS_Stats()
+			if err != nil {
+				db, errConnect := c.Connect()
+				if errConnect != nil {
+					handleServiceCheck(c, errConnect)
+				} else if db == nil {
+					handleServiceCheck(c, fmt.Errorf("empty connection"))
+				} else {
+					handleServiceCheck(c, nil)
+				}
+				closeDatabase(c, db)
+				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect os stats %w", c.logPrompt, err))
+			} else { //nolint:revive // TODO(DBM) Fix revive linter
 				handleServiceCheck(c, nil)
 			}
-			closeDatabase(c, db)
-			allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect os stats %w", c.logPrompt, err))
-		} else { //nolint:revive // TODO(DBM) Fix revive linter
-			handleServiceCheck(c, nil)
 		}
 
 		if c.config.SysMetrics.Enabled {
@@ -323,6 +326,9 @@ func (c *Check) Run() error {
 	}
 	sendServiceCheck(c, serviceCheckName, status, message)
 	commit(c)
+	if c.oldIntegrationCompatibilityMode {
+		log.Warnf("%s missing privileges detected, running in deprecated integration compatibility mode", c.logPrompt)
+	}
 	return allErrors
 }
 

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -224,7 +224,7 @@ func (c *Check) Run() error {
 				}
 				closeDatabase(c, db)
 				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect os stats %w", c.logPrompt, err))
-			} else { //nolint:revive // TODO(DBM) Fix revive linter
+			} else {
 				handleServiceCheck(c, nil)
 			}
 		}

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -108,7 +108,7 @@ type Check struct {
 	lastOracleRows                          []OracleRow // added for tests
 	databaseRole                            string
 	openMode                                string
-	oldIntegrationCompatibilityMode         bool
+	legacyIntegrationCompatibilityMode      bool
 }
 
 type vDatabase struct {
@@ -195,7 +195,7 @@ func (c *Check) Run() error {
 
 	dbInstanceIntervalExpired := checkIntervalExpired(&c.dbInstanceLastRun, 1800)
 
-	if dbInstanceIntervalExpired && !c.oldIntegrationCompatibilityMode {
+	if dbInstanceIntervalExpired && !c.legacyIntegrationCompatibilityMode {
 		err := sendDbInstanceMetadata(c)
 		if err != nil {
 			allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to send db instance metadata %w", c.logPrompt, err))
@@ -211,7 +211,7 @@ func (c *Check) Run() error {
 		}
 		fixTags(c)
 
-		if !c.oldIntegrationCompatibilityMode {
+		if !c.legacyIntegrationCompatibilityMode {
 			err := c.OS_Stats()
 			if err != nil {
 				db, errConnect := c.Connect()
@@ -326,7 +326,7 @@ func (c *Check) Run() error {
 	}
 	sendServiceCheck(c, serviceCheckName, status, message)
 	commit(c)
-	if c.oldIntegrationCompatibilityMode {
+	if c.legacyIntegrationCompatibilityMode {
 		log.Warnf("%s missing privileges detected, running in deprecated integration compatibility mode", c.logPrompt)
 	}
 	return allErrors

--- a/pkg/collector/corechecks/oracle-dbm/processes.go
+++ b/pkg/collector/corechecks/oracle-dbm/processes.go
@@ -78,7 +78,7 @@ func (c *Check) ProcessMemory() error {
 	rows := []ProcessesRowDB{}
 
 	var pgaQuery string
-	if c.oldIntegrationCompatibilityMode {
+	if c.legacyIntegrationCompatibilityMode {
 		pgaQuery = pgaQueryOldIntegration
 	} else {
 		if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {

--- a/pkg/collector/corechecks/oracle-dbm/processes.go
+++ b/pkg/collector/corechecks/oracle-dbm/processes.go
@@ -41,6 +41,14 @@ const pgaQuery11 = `SELECT
 FROM v$process p, v$session s
 WHERE s.paddr(+) = p.addr`
 
+const pgaQueryOldIntegration = `SELECT
+	p.pid as pid, p.program as server_process,
+	nvl(pga_used_mem,0) pga_used_mem,
+	nvl(pga_alloc_mem,0) pga_alloc_mem,
+	nvl(pga_freeable_mem,0) pga_freeable_mem,
+	nvl(pga_max_mem,0) pga_max_mem
+FROM gv$process p`
+
 type sessionTagColumns struct {
 	Sid      sql.NullInt64  `db:"SID"`
 	Username sql.NullString `db:"USERNAME"`
@@ -70,11 +78,16 @@ func (c *Check) ProcessMemory() error {
 	rows := []ProcessesRowDB{}
 
 	var pgaQuery string
-	if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
-		pgaQuery = pgaQuery12
+	if c.oldIntegrationCompatibilityMode {
+		pgaQuery = pgaQueryOldIntegration
 	} else {
-		pgaQuery = pgaQuery11
+		if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
+			pgaQuery = pgaQuery12
+		} else {
+			pgaQuery = pgaQuery11
+		}
 	}
+
 	err := selectWrapper(c, &rows, pgaQuery)
 	if err != nil {
 		return fmt.Errorf("failed to collect processes info: %w", err)

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -144,13 +144,17 @@ func (c *Check) sysMetrics() (int64, error) {
 	metricRows := []SysmetricsRowDB{}
 
 	var sysMetricsQuery string
-	if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) && !c.oldIntegrationCompatibilityMode {
-		sysMetricsQuery = sysMetricsQuery12
-	} else {
+	if c.legacyIntegrationCompatibilityMode {
 		sysMetricsQuery = sysMetricsQuery11
+	} else {
+		if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
+			sysMetricsQuery = sysMetricsQuery12
+		} else {
+			sysMetricsQuery = sysMetricsQuery11
+		}
 	}
 
-	if !c.oldIntegrationCompatibilityMode {
+	if !c.legacyIntegrationCompatibilityMode {
 		if isDbVersionGreaterOrEqualThan(c, "18") {
 			err = selectWrapper(c, &metricRows, fmt.Sprintf(sysMetricsQuery, "v$con_sysmetric"))
 			if err != nil {
@@ -165,7 +169,7 @@ func (c *Check) sysMetrics() (int64, error) {
 	}
 
 	var view string
-	if c.oldIntegrationCompatibilityMode {
+	if c.legacyIntegrationCompatibilityMode {
 		view = "gv$sysmetric"
 	} else {
 		view = "v$sysmetric"
@@ -183,7 +187,7 @@ func (c *Check) sysMetrics() (int64, error) {
 		}
 	}
 
-	if !c.oldIntegrationCompatibilityMode {
+	if !c.legacyIntegrationCompatibilityMode {
 		var overAllocationCount float64
 		err = getWrapper(c, &overAllocationCount, "SELECT value FROM v$pgastat WHERE name = 'over allocation count'")
 		if err != nil {

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -144,16 +144,18 @@ func (c *Check) sysMetrics() (int64, error) {
 	metricRows := []SysmetricsRowDB{}
 
 	var sysMetricsQuery string
-	if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
+	if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) && !c.oldIntegrationCompatibilityMode {
 		sysMetricsQuery = sysMetricsQuery12
 	} else {
 		sysMetricsQuery = sysMetricsQuery11
 	}
 
-	if isDbVersionGreaterOrEqualThan(c, "18") {
-		err = selectWrapper(c, &metricRows, fmt.Sprintf(sysMetricsQuery, "v$con_sysmetric"))
-		if err != nil {
-			return n, fmt.Errorf("failed to collect container sysmetrics: %w", err)
+	if !c.oldIntegrationCompatibilityMode {
+		if isDbVersionGreaterOrEqualThan(c, "18") {
+			err = selectWrapper(c, &metricRows, fmt.Sprintf(sysMetricsQuery, "v$con_sysmetric"))
+			if err != nil {
+				return n, fmt.Errorf("failed to collect container sysmetrics: %w", err)
+			}
 		}
 	}
 
@@ -162,8 +164,14 @@ func (c *Check) sysMetrics() (int64, error) {
 		c.sendMetric(r, seenInContainerMetrics, &n)
 	}
 
+	var view string
+	if c.oldIntegrationCompatibilityMode {
+		view = "gv$sysmetric"
+	} else {
+		view = "v$sysmetric"
+	}
 	seenInGlobalMetrics := make(map[string]bool)
-	err = selectWrapper(c, &metricRows, fmt.Sprintf(sysMetricsQuery, "v$sysmetric")+" ORDER BY begin_time DESC, metric_name ASC")
+	err = selectWrapper(c, &metricRows, fmt.Sprintf(sysMetricsQuery, view)+" ORDER BY begin_time DESC, metric_name ASC")
 	if err != nil {
 		return 0, fmt.Errorf("failed to collect sysmetrics: %w", err)
 	}
@@ -175,17 +183,19 @@ func (c *Check) sysMetrics() (int64, error) {
 		}
 	}
 
-	var overAllocationCount float64
-	err = getWrapper(c, &overAllocationCount, "SELECT value FROM v$pgastat WHERE name = 'over allocation count'")
-	if err != nil {
-		return n, fmt.Errorf("failed to get PGA over allocation count: %w", err)
-	}
-	if c.previousPGAOverAllocationCount.valid {
-		v := overAllocationCount - c.previousPGAOverAllocationCount.value
-		sendMetricWithDefaultTags(c, gauge, fmt.Sprintf("%s.%s", common.IntegrationName, "pga_over_allocation_count"), v)
-		c.previousPGAOverAllocationCount.value = overAllocationCount
-	} else {
-		c.previousPGAOverAllocationCount = pgaOverAllocationCount{value: overAllocationCount, valid: true}
+	if !c.oldIntegrationCompatibilityMode {
+		var overAllocationCount float64
+		err = getWrapper(c, &overAllocationCount, "SELECT value FROM v$pgastat WHERE name = 'over allocation count'")
+		if err != nil {
+			return n, fmt.Errorf("failed to get PGA over allocation count: %w", err)
+		}
+		if c.previousPGAOverAllocationCount.valid {
+			v := overAllocationCount - c.previousPGAOverAllocationCount.value
+			sendMetricWithDefaultTags(c, gauge, fmt.Sprintf("%s.%s", common.IntegrationName, "pga_over_allocation_count"), v)
+			c.previousPGAOverAllocationCount.value = overAllocationCount
+		} else {
+			c.previousPGAOverAllocationCount = pgaOverAllocationCount{value: overAllocationCount, valid: true}
+		}
 	}
 
 	sender.Commit()

--- a/pkg/collector/corechecks/oracle-dbm/tablespaces.go
+++ b/pkg/collector/corechecks/oracle-dbm/tablespaces.go
@@ -73,12 +73,17 @@ type rowMaxSizeDB struct {
 func (c *Check) Tablespaces() error {
 	rows := []RowDB{}
 	var tablespaceQuery, maxSizeQuery string
-	if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) && !c.oldIntegrationCompatibilityMode {
-		tablespaceQuery = tablespaceQuery12
-		maxSizeQuery = maxSizeQuery12
-	} else {
+	if c.legacyIntegrationCompatibilityMode {
 		tablespaceQuery = tablespaceQuery11
 		maxSizeQuery = maxSizeQuery11
+	} else {
+		if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
+			tablespaceQuery = tablespaceQuery12
+			maxSizeQuery = maxSizeQuery12
+		} else {
+			tablespaceQuery = tablespaceQuery11
+			maxSizeQuery = maxSizeQuery11
+		}
 	}
 	err := selectWrapper(c, &rows, tablespaceQuery)
 	if err != nil {

--- a/pkg/collector/corechecks/oracle-dbm/tablespaces.go
+++ b/pkg/collector/corechecks/oracle-dbm/tablespaces.go
@@ -73,7 +73,7 @@ type rowMaxSizeDB struct {
 func (c *Check) Tablespaces() error {
 	rows := []RowDB{}
 	var tablespaceQuery, maxSizeQuery string
-	if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
+	if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) && !c.oldIntegrationCompatibilityMode {
 		tablespaceQuery = tablespaceQuery12
 		maxSizeQuery = maxSizeQuery12
 	} else {

--- a/releasenotes/notes/oracle-compatibility-mode-b84647c963acfb06.yaml
+++ b/releasenotes/notes/oracle-compatibility-mode-b84647c963acfb06.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Automatically fall back to deprecated Oracle integration mode if privileges are missing.

--- a/releasenotes/notes/oracle-compatibility-mode-b84647c963acfb06.yaml
+++ b/releasenotes/notes/oracle-compatibility-mode-b84647c963acfb06.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Automatically fall back to deprecated Oracle integration mode if privileges are missing.
+    [oracle] Automatically fall back to deprecated Oracle integration mode if privileges are missing.


### PR DESCRIPTION
### What does this PR do?

Automatically downgrading the Oracle check to the old Python integration mode if the privileges are missing.

### Additional information

If running in the compatibility mode, the following message will be written into the log file after each check cycle:

`missing privileges detected, running in deprecated integration compatibility mode`

### Motivation

The old Python integration will be deprecated and [automatically replaced with Oracle DBM](https://github.com/DataDog/datadog-agent/pull/23069). The database users created with the old integration have less privileges than Oracle DBM requires. Consequently, the Oracle DBM check would file if the privileges weren't adjusted. To minimize the disruption for the users, the Oracle DBM check will notice missing privileges and fall back to the old integration mode.

### Describe how to test/QA your changes

Test Oracle DBM for multi-tenant and non-CDB.