### PR TITLE
Add Windows MSI E2E test for custom install paths

### DIFF
--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -42,6 +42,7 @@
       - E2E_MSI_TEST: TestInstallOpts
       - E2E_MSI_TEST: TestSubServicesOpts/all-subservices
       - E2E_MSI_TEST: TestSubServicesOpts/no-subservices
+      - E2E_MSI_TEST: TestInstallAltDir
 
 # Agent 6
 .new-e2e_windows_a6_x86_64:

--- a/test/kitchen/test-definitions/windows-install-test.yml
+++ b/test/kitchen/test-definitions/windows-install-test.yml
@@ -47,31 +47,3 @@ suites:
           WIXFAILWHENDEFERRED=1
       dd-agent-rspec:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
-
-  - name: win-alt-dir
-    run_list:
-      - "recipe[dd-agent-system-files-check::list-files-before-install]"
-      - "recipe[dd-agent-install::_install_windows_base]"
-    attributes:
-      datadog:
-        <% dd_agent_config.each do |key, value| %>
-        <%= key %>: "<%= value %>"
-        <% end %>
-      dd-agent-install:
-        <% if ENV['AGENT_VERSION'] %>
-        windows_version: "<%= ENV['AGENT_VERSION'] %>"
-        <% end %>
-        windows_agent_url: <%= windows_agent_url %>
-        <% if ENV['WINDOWS_AGENT_FILE'] %>
-        windows_agent_filename: "<%= ENV['WINDOWS_AGENT_FILE'] %>"
-        <% end %>
-        agent_install_options: >
-          APIKEY=<%= api_key %>
-          APPLICATIONDATADIRECTORY=c:\altconfroot
-          PROJECTLOCATION=c:\ddagent
-
-      dd-agent-rspec:
-        skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
-        APPLICATIONDATADIRECTORY: c:\altconfroot
-        PROJECTLOCATION: c:\ddagent
-

--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 )
 
 const (
@@ -22,6 +23,21 @@ func NewHostAgentClient(t *testing.T, host *components.RemoteHost, waitForAgentR
 	commandRunner := newAgentCommandRunner(t, newAgentHostExecutor(host))
 
 	if waitForAgentReady {
+		if err := commandRunner.waitForReadyTimeout(agentReadyTimeout); err != nil {
+			return nil, err
+		}
+	}
+
+	return commandRunner, nil
+}
+
+// NewHostAgentClientWithParams creates an Agent client for host install with custom parameters
+func NewHostAgentClientWithParams(t *testing.T, host *components.RemoteHost, options ...agentclientparams.Option) (agentclient.Agent, error) {
+	params := agentclientparams.NewParams(options...)
+	ae := newAgentHostExecutorWithInstallPath(host, params.AgentInstallPath)
+	commandRunner := newAgentCommandRunner(t, ae)
+
+	if params.ShouldWaitForReady {
 		if err := commandRunner.waitForReadyTimeout(agentReadyTimeout); err != nil {
 			return nil, err
 		}

--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -20,7 +20,7 @@ const (
 
 // NewHostAgentClient creates an Agent client for host install
 func NewHostAgentClient(t *testing.T, host *components.RemoteHost, waitForAgentReady bool) (agentclient.Agent, error) {
-	commandRunner := newAgentCommandRunner(t, newAgentHostExecutor(host))
+	commandRunner := newAgentCommandRunner(t, newDefaultAgentHostExecutor(host))
 
 	if waitForAgentReady {
 		if err := commandRunner.waitForReadyTimeout(agentReadyTimeout); err != nil {
@@ -34,7 +34,15 @@ func NewHostAgentClient(t *testing.T, host *components.RemoteHost, waitForAgentR
 // NewHostAgentClientWithParams creates an Agent client for host install with custom parameters
 func NewHostAgentClientWithParams(t *testing.T, host *components.RemoteHost, options ...agentclientparams.Option) (agentclient.Agent, error) {
 	params := agentclientparams.NewParams(options...)
-	ae := newAgentHostExecutorWithInstallPath(host, params.AgentInstallPath)
+
+	var ae agentCommandExecutor
+	if len(params.AgentInstallPath) > 0 {
+		baseCommand := agentHostBaseCommandWithInstallPath(host, params.AgentInstallPath)
+		ae = newAgentHostExecutor(host, baseCommand)
+	} else {
+		ae = newDefaultAgentHostExecutor(host)
+	}
+
 	commandRunner := newAgentCommandRunner(t, ae)
 
 	if params.ShouldWaitForReady {

--- a/test/new-e2e/pkg/utils/e2e/client/agent_host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_host.go
@@ -54,8 +54,8 @@ func (ae agentHostExecutor) execute(arguments []string) (string, error) {
 
 // defaultWindowsAgentInstallPath returns a reasonable default for the AgentInstallPath.
 //
-// If the AgentInstallPath is not provided, it will attempt to read the install path from the registry.
-// If the registry key is not found, it will return the default install path.
+// If the Agent is installed, the installPath is read from the registry.
+// If the registry key is not found, returns the default install path.
 func defaultWindowsAgentInstallPath(host *components.RemoteHost) string {
 	path, err := windowsAgent.GetInstallPathFromRegistry(host)
 	if err != nil {

--- a/test/new-e2e/pkg/utils/e2e/client/agentclientparams/agent_client_params.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agentclientparams/agent_client_params.go
@@ -11,10 +11,12 @@ package agentclientparams
 //
 // The available options are:
 //   - [WithSkipWaitForAgentReady]
+//   - [WithAgentInstallPath]
 //
 // [Functional options pattern]: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
 type Params struct {
 	ShouldWaitForReady bool
+	AgentInstallPath   string
 }
 
 // Option alias to a functional option changing a given Params instance
@@ -41,5 +43,12 @@ func applyOption(instance *Params, options ...Option) *Params {
 func WithSkipWaitForAgentReady() Option {
 	return func(p *Params) {
 		p.ShouldWaitForReady = false
+	}
+}
+
+// WithAgentInstallPath sets the agent installation path
+func WithAgentInstallPath(path string) Option {
+	return func(p *Params) {
+		p.AgentInstallPath = path
 	}
 }

--- a/test/new-e2e/tests/agent-platform/common/helper/windows.go
+++ b/test/new-e2e/tests/agent-platform/common/helper/windows.go
@@ -5,31 +5,48 @@
 
 package helper
 
+import (
+	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+)
+
 // Windows implement helper function for Windows distributions
-type Windows struct{}
+type Windows struct {
+	installFolder string
+	configFolder  string
+}
 
 var _ Helper = &Windows{}
 
 // NewWindowsHelper create a new instance of Windows helper
-func NewWindowsHelper() *Windows { return &Windows{} }
+func NewWindowsHelper() *Windows {
+	return NewWindowsHelperWithCustomPaths(windowsAgent.DefaultInstallPath, windowsAgent.DefaultConfigRoot)
+}
+
+// NewWindowsHelperWithCustomPaths create a new instance of Windows helper with custom paths
+func NewWindowsHelperWithCustomPaths(installFolder, configFolder string) *Windows {
+	return &Windows{
+		installFolder: installFolder,
+		configFolder:  configFolder,
+	}
+}
 
 // GetInstallFolder return the install folder path
-func (u *Windows) GetInstallFolder() string { return `C:\Program Files\Datadog\Datadog Agent\` }
+func (w *Windows) GetInstallFolder() string { return w.installFolder + "\\" }
 
 // GetConfigFolder return the config folder path
-func (u *Windows) GetConfigFolder() string { return `C:\ProgramData\Datadog\` }
+func (w *Windows) GetConfigFolder() string { return w.configFolder + "\\" }
 
 // GetBinaryPath return the datadog-agent binary path
-func (u *Windows) GetBinaryPath() string { return u.GetInstallFolder() + `bin\agent.exe` }
+func (w *Windows) GetBinaryPath() string { return w.GetInstallFolder() + `bin\agent.exe` }
 
 // GetConfigFileName return the config file name
-func (u *Windows) GetConfigFileName() string { return "datadog.yaml" }
+func (w *Windows) GetConfigFileName() string { return "datadog.yaml" }
 
 // GetServiceName return the service name
-func (u *Windows) GetServiceName() string { return "datadogagent" }
+func (w *Windows) GetServiceName() string { return "datadogagent" }
 
 // AgentProcesses return the list of agent processes
-func (u *Windows) AgentProcesses() []string {
+func (w *Windows) AgentProcesses() []string {
 	return []string{
 		"agent.exe",
 		"process-agent.exe",

--- a/test/new-e2e/tests/windows/common/agent/agent.go
+++ b/test/new-e2e/tests/windows/common/agent/agent.go
@@ -31,6 +31,10 @@ const (
 	DatadogCodeSignatureThumbprint = `B03F29CC07566505A718583E9270A6EE17678742`
 	// RegistryKeyPath is the root registry key that the Datadog Agent uses to store some state
 	RegistryKeyPath = "HKLM:\\SOFTWARE\\Datadog\\Datadog Agent"
+	// DefaultInstallPath is the default install path for the Datadog Agent
+	DefaultInstallPath = `C:\Program Files\Datadog\Datadog Agent`
+	// DefaultConfigRoot is the default config root for the Datadog Agent
+	DefaultConfigRoot = `C:\ProgramData\Datadog`
 )
 
 // GetDatadogAgentProductCode returns the product code GUID for the Datadog Agent

--- a/test/new-e2e/tests/windows/common/agent/agent_install_params.go
+++ b/test/new-e2e/tests/windows/common/agent/agent_install_params.go
@@ -23,7 +23,9 @@ type InstallAgentParams struct {
 
 	msi.InstallAgentParams
 	// Installer parameters
-	WixFailWhenDeferred string `installer_arg:"WIXFAILWHENDEFERRED"`
+	WixFailWhenDeferred      string `installer_arg:"WIXFAILWHENDEFERRED"`
+	ProjectLocation          string `installer_arg:"PROJECTLOCATION"`
+	ApplicationDataDirectory string `installer_arg:"APPLICATIONDATADIRECTORY"`
 	// Installer parameters for agent config
 	APIKey                  string `installer_arg:"APIKEY"`
 	Tags                    string `installer_arg:"TAGS"`
@@ -267,6 +269,22 @@ func WithProcessDiscoveryEnabled(processDiscoveryEnabled string) InstallAgentOpt
 func WithAPMEnabled(apmEnabled string) InstallAgentOption {
 	return func(i *InstallAgentParams) error {
 		i.APMEnabled = apmEnabled
+		return nil
+	}
+}
+
+// WithApplicationDataDirectory specifies the APPLICATIONDATADIRECTORY parameter.
+func WithApplicationDataDirectory(applicationDataDirectory string) InstallAgentOption {
+	return func(i *InstallAgentParams) error {
+		i.ApplicationDataDirectory = applicationDataDirectory
+		return nil
+	}
+}
+
+// WithProjectLocation specifies the PROJECTLOCATION parameter.
+func WithProjectLocation(projectLocation string) InstallAgentOption {
+	return func(i *InstallAgentParams) error {
+		i.ProjectLocation = projectLocation
 		return nil
 	}
 }

--- a/test/new-e2e/tests/windows/common/utils.go
+++ b/test/new-e2e/tests/windows/common/utils.go
@@ -7,6 +7,8 @@ package common
 
 import (
 	"fmt"
+	"strings"
+
 	"golang.org/x/text/encoding/unicode"
 )
 
@@ -21,4 +23,17 @@ func ConvertUTF16ToUTF8(content []byte) ([]byte, error) {
 		return nil, fmt.Errorf("failed to convert UTF-16 to UTF-8: %v", err)
 	}
 	return utf8, nil
+}
+
+// TrimTrailingSlashesAndLower trims trailing slashes and lowercases the path for use in simple comparisons.
+//
+// Some cases may require a more comprehensive comparison, which could be made by normalizing the path on the host
+// via PowerShell, to support removing dot paths, resolving links, etc
+func TrimTrailingSlashesAndLower(path string) string {
+	// Normalize paths
+	// trim trailing slashes
+	path = strings.TrimSuffix(path, `\`)
+	// windows paths are case-insensitive
+	path = strings.ToLower(path)
+	return path
 }

--- a/test/new-e2e/tests/windows/install-test/assert.go
+++ b/test/new-e2e/tests/windows/install-test/assert.go
@@ -19,6 +19,21 @@ import (
 	"testing"
 )
 
+// AssertEqualPathf compares two paths case insensitively, ignoring trailing slashes
+func AssertEqualPathf(t *testing.T, expected string, actual string, fmt string, args ...any) bool {
+	t.Helper()
+
+	// Normalize paths
+	// trim trailing slashes
+	expected = strings.TrimSuffix(expected, `\`)
+	actual = strings.TrimSuffix(actual, `\`)
+	// windows paths are case-insensitive
+	expected = strings.ToLower(expected)
+	actual = strings.ToLower(actual)
+
+	return assert.Equalf(t, expected, actual, fmt, args...)
+}
+
 // AssertInstalledUserInRegistry checks the registry for the installed user and domain
 func AssertInstalledUserInRegistry(t *testing.T, host *components.RemoteHost, expecteddomain string, expectedusername string) bool {
 	// check registry keys

--- a/test/new-e2e/tests/windows/install-test/assert.go
+++ b/test/new-e2e/tests/windows/install-test/assert.go
@@ -19,21 +19,6 @@ import (
 	"testing"
 )
 
-// AssertEqualPathf compares two paths case insensitively, ignoring trailing slashes
-func AssertEqualPathf(t *testing.T, expected string, actual string, fmt string, args ...any) bool {
-	t.Helper()
-
-	// Normalize paths
-	// trim trailing slashes
-	expected = strings.TrimSuffix(expected, `\`)
-	actual = strings.TrimSuffix(actual, `\`)
-	// windows paths are case-insensitive
-	expected = strings.ToLower(expected)
-	actual = strings.ToLower(actual)
-
-	return assert.Equalf(t, expected, actual, fmt, args...)
-}
-
 // AssertInstalledUserInRegistry checks the registry for the installed user and domain
 func AssertInstalledUserInRegistry(t *testing.T, host *components.RemoteHost, expecteddomain string, expectedusername string) bool {
 	// check registry keys

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -216,6 +216,33 @@ func (is *agentMSISuite) TestInstall() {
 	is.uninstallAgentAndRunUninstallTests(t)
 }
 
+func (is *agentMSISuite) TestInstallAltDir() {
+	vm := is.Env().RemoteHost
+	is.prepareHost()
+
+	installPath := `C:\altdir`
+	configRoot := `C:\altconfroot`
+
+	// initialize test helper
+	t := is.newTester(vm,
+		WithExpectedInstallPath(installPath),
+		WithExpectedConfigRoot(configRoot),
+	)
+
+	// install the agent
+	_ = is.installAgentPackage(vm, is.AgentPackage,
+		windowsAgent.WithProjectLocation(installPath),
+		windowsAgent.WithApplicationDataDirectory(configRoot),
+	)
+
+	// run tests
+	if !t.TestInstallExpectations(is.T()) {
+		is.T().FailNow()
+	}
+
+	is.uninstallAgentAndRunUninstallTests(t)
+}
+
 func (is *agentMSISuite) TestUpgrade() {
 	vm := is.Env().RemoteHost
 	is.prepareHost()

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -248,21 +248,11 @@ func (t *Tester) testCurrentVersionExpectations(tt *testing.T) {
 
 	tt.Run("agent paths in registry", func(tt *testing.T) {
 		installPathFromRegistry, err := windowsAgent.GetInstallPathFromRegistry(t.host)
-		assert.NoError(tt, err)
+		assert.NoError(tt, err, "InstallPath should be in registry")
+		AssertEqualPathf(tt, t.expectedInstallPath, installPathFromRegistry, "install path matches registry")
 		configRootFromRegistry, err := windowsAgent.GetConfigRootFromRegistry(t.host)
-		assert.NoError(tt, err)
-		tcs := []struct {
-			expected string
-			actual   string
-		}{
-			{t.expectedInstallPath, installPathFromRegistry},
-			{t.expectedConfigRoot, configRootFromRegistry},
-		}
-		for _, tc := range tcs {
-			tc.expected = strings.TrimSuffix(tc.expected, "\\")
-			tc.actual = strings.TrimSuffix(tc.actual, "\\")
-			assert.Equal(tt, tc.expected, tc.actual)
-		}
+		assert.NoError(tt, err, "ConfigRoot should be in registry")
+		AssertEqualPathf(tt, t.expectedConfigRoot, configRootFromRegistry, "config root matches registry")
 	})
 
 	tt.Run("agent user in registry", func(tt *testing.T) {

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -216,9 +216,10 @@ func (t *Tester) TestUninstallExpectations(tt *testing.T) {
 	for _, configPath := range configPaths {
 		configPath := filepath.Join(t.expectedConfigRoot, configPath)
 		_, err = t.host.Lstat(configPath)
-		assert.NoError(tt, err, "uninstall should not remove config files")
-		_, err = t.host.Lstat(configPath + ".example")
-		assert.ErrorIs(tt, err, fs.ErrNotExist, "uninstall should remove example config files")
+		assert.NoError(tt, err, "uninstall should not remove %s config file", configPath)
+		examplePath := configPath + ".example"
+		_, err = t.host.Lstat(examplePath)
+		assert.ErrorIs(tt, err, fs.ErrNotExist, "uninstall should remove %s example config files", examplePath)
 	}
 
 	_, err = windows.GetSIDForUser(t.host,
@@ -257,6 +258,21 @@ func (t *Tester) testCurrentVersionExpectations(tt *testing.T) {
 
 	tt.Run("agent user in registry", func(tt *testing.T) {
 		AssertInstalledUserInRegistry(tt, t.host, t.expectedUserDomain, t.expectedUserName)
+	})
+
+	tt.Run("creates config files", func(tt *testing.T) {
+		configPaths := []string{
+			"datadog.yaml",
+			"system-probe.yaml",
+		}
+		for _, configPath := range configPaths {
+			configPath := filepath.Join(t.expectedConfigRoot, configPath)
+			_, err := t.host.Lstat(configPath)
+			assert.NoError(tt, err, "install should create %s config file", configPath)
+			examplePath := configPath + ".example"
+			_, err = t.host.Lstat(examplePath)
+			assert.NoError(tt, err, "install should create %s example config files", examplePath)
+		}
 	})
 
 	serviceTester, err := servicetest.NewTester(t.host,

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -250,10 +250,16 @@ func (t *Tester) testCurrentVersionExpectations(tt *testing.T) {
 	tt.Run("agent paths in registry", func(tt *testing.T) {
 		installPathFromRegistry, err := windowsAgent.GetInstallPathFromRegistry(t.host)
 		assert.NoError(tt, err, "InstallPath should be in registry")
-		AssertEqualPathf(tt, t.expectedInstallPath, installPathFromRegistry, "install path matches registry")
+		assert.Equalf(tt,
+			windows.TrimTrailingSlashesAndLower(t.expectedInstallPath),
+			windows.TrimTrailingSlashesAndLower(installPathFromRegistry),
+			"install path matches registry")
 		configRootFromRegistry, err := windowsAgent.GetConfigRootFromRegistry(t.host)
 		assert.NoError(tt, err, "ConfigRoot should be in registry")
-		AssertEqualPathf(tt, t.expectedConfigRoot, configRootFromRegistry, "config root matches registry")
+		assert.Equalf(tt,
+			windows.TrimTrailingSlashesAndLower(t.expectedConfigRoot),
+			windows.TrimTrailingSlashesAndLower(configRootFromRegistry),
+			"config root matches registry")
 	})
 
 	tt.Run("agent user in registry", func(tt *testing.T) {

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -7,18 +7,22 @@ package installtest
 
 import (
 	"fmt"
+	"io/fs"
+	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	agentClient "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	agentClientParams "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common"
+	commonHelper "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/helper"
 	windows "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/install-test/service-test"
 
-	"testing"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 // Tester is a test helper for testing agent installations
@@ -35,6 +39,9 @@ type Tester struct {
 
 	expectedAgentVersion      string
 	expectedAgentMajorVersion string
+
+	expectedInstallPath string
+	expectedConfigRoot  string
 }
 
 // TesterOption is a function that can be used to configure a Tester
@@ -47,13 +54,14 @@ func NewTester(tt *testing.T, host *components.RemoteHost, opts ...TesterOption)
 	var err error
 
 	t.host = host
-	t.InstallTestClient = common.NewWindowsTestClient(tt, t.host)
 	t.hostInfo, err = windows.GetHostInfo(t.host)
 	if err != nil {
 		return nil, err
 	}
 	t.expectedUserName = "ddagentuser"
 	t.expectedUserDomain = windows.NameToNetBIOSName(t.hostInfo.Hostname)
+	t.expectedInstallPath = windowsAgent.DefaultInstallPath
+	t.expectedConfigRoot = windowsAgent.DefaultConfigRoot
 
 	for _, opt := range opts {
 		opt(t)
@@ -70,6 +78,16 @@ func NewTester(tt *testing.T, host *components.RemoteHost, opts ...TesterOption)
 		}
 	}) {
 		tt.FailNow()
+	}
+
+	t.InstallTestClient = common.NewWindowsTestClient(tt, t.host)
+	t.InstallTestClient.Helper = commonHelper.NewWindowsHelperWithCustomPaths(t.expectedInstallPath, t.expectedConfigRoot)
+	t.InstallTestClient.AgentClient, err = agentClient.NewHostAgentClientWithParams(tt, t.host,
+		agentClientParams.WithSkipWaitForAgentReady(),
+		agentClientParams.WithAgentInstallPath(t.expectedInstallPath),
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	return t, nil
@@ -97,6 +115,20 @@ func WithExpectedAgentUser(domain string, user string) TesterOption {
 	return func(t *Tester) {
 		t.expectedUserDomain = domain
 		t.expectedUserName = user
+	}
+}
+
+// WithExpectedInstallPath sets the expected install path for the agent
+func WithExpectedInstallPath(path string) TesterOption {
+	return func(t *Tester) {
+		t.expectedInstallPath = path
+	}
+}
+
+// WithExpectedConfigRoot sets the expected config root for the agent
+func WithExpectedConfigRoot(path string) TesterOption {
+	return func(t *Tester) {
+		t.expectedConfigRoot = path
 	}
 }
 
@@ -171,6 +203,28 @@ func (t *Tester) TestUninstallExpectations(tt *testing.T) {
 		// this helper uses require so wrap it in a subtest so we can continue even if it fails
 		common.CheckUninstallation(tt, t.InstallTestClient)
 	})
+
+	_, err := t.host.Lstat(t.expectedInstallPath)
+	assert.ErrorIs(tt, err, fs.ErrNotExist, "uninstall should remove install path")
+	_, err = t.host.Lstat(t.expectedConfigRoot)
+	assert.NoError(tt, err, "uninstall should not remove config root")
+
+	configPaths := []string{
+		"datadog.yaml",
+		"system-probe.yaml",
+	}
+	for _, configPath := range configPaths {
+		configPath := filepath.Join(t.expectedConfigRoot, configPath)
+		_, err = t.host.Lstat(configPath)
+		assert.NoError(tt, err, "uninstall should not remove config files")
+		_, err = t.host.Lstat(configPath + ".example")
+		assert.ErrorIs(tt, err, fs.ErrNotExist, "uninstall should remove example config files")
+	}
+
+	_, err = windows.GetSIDForUser(t.host,
+		windows.MakeDownLevelLogonName(t.expectedUserDomain, t.expectedUserName),
+	)
+	assert.NoError(tt, err, "uninstall should not remove agent user")
 }
 
 // Only do some basic checks on the agent since it's a previous version
@@ -181,7 +235,37 @@ func (t *Tester) testPreviousVersionExpectations(tt *testing.T) {
 // More in depth checks on current version
 func (t *Tester) testCurrentVersionExpectations(tt *testing.T) {
 	common.CheckInstallation(tt, t.InstallTestClient)
-	tt.Run("user in registry", func(tt *testing.T) {
+
+	// If install paths differ from default ensure the defaults don't exist
+	if t.expectedInstallPath != windowsAgent.DefaultInstallPath {
+		_, err := t.host.Lstat(windowsAgent.DefaultInstallPath)
+		assert.ErrorIs(tt, err, fs.ErrNotExist, "default install path should not exist")
+	}
+	if t.expectedConfigRoot != windowsAgent.DefaultConfigRoot {
+		_, err := t.host.Lstat(windowsAgent.DefaultConfigRoot)
+		assert.ErrorIs(tt, err, fs.ErrNotExist, "default config root should not exist")
+	}
+
+	tt.Run("agent paths in registry", func(tt *testing.T) {
+		installPathFromRegistry, err := windowsAgent.GetInstallPathFromRegistry(t.host)
+		assert.NoError(tt, err)
+		configRootFromRegistry, err := windowsAgent.GetConfigRootFromRegistry(t.host)
+		assert.NoError(tt, err)
+		tcs := []struct {
+			expected string
+			actual   string
+		}{
+			{t.expectedInstallPath, installPathFromRegistry},
+			{t.expectedConfigRoot, configRootFromRegistry},
+		}
+		for _, tc := range tcs {
+			tc.expected = strings.TrimSuffix(tc.expected, "\\")
+			tc.actual = strings.TrimSuffix(tc.actual, "\\")
+			assert.Equal(tt, tc.expected, tc.actual)
+		}
+	})
+
+	tt.Run("agent user in registry", func(tt *testing.T) {
 		AssertInstalledUserInRegistry(tt, t.host, t.expectedUserDomain, t.expectedUserName)
 	})
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add Windows MSI E2E test for custom install paths

Adds an `AgentInstallPath` parameter to the E2E `AgentClient`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-507

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
seems like after https://github.com/DataDog/test-infra-definitions/pull/675 we might be able to include the agent install path in the `agent.HostAgentOutput`, making it available for when `components.RemoteHostAgent` is created.


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
