### PR TITLE
[CWS] move `pkg/security/secl` back to a `go 1.21` go mod line

### DIFF
--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/security/secl
 
-go 1.21.7
+go 1.21
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -202,7 +202,7 @@ DEFAULT_MODULES = {
     "pkg/logs/status/statusinterface": GoModule("pkg/logs/status/statusinterface", independent=True),
     "pkg/logs/status/utils": GoModule("pkg/logs/status/utils", independent=True),
     "pkg/serializer": GoModule("pkg/serializer", independent=True),
-    "pkg/security/secl": GoModule("pkg/security/secl", independent=True),
+    "pkg/security/secl": GoModule("pkg/security/secl", independent=True, legacy_go_mod_version=True),
     "pkg/status/health": GoModule("pkg/status/health", independent=True),
     "pkg/remoteconfig/state": GoModule("pkg/remoteconfig/state", independent=True, used_by_otel=True),
     "pkg/util/cgroups": GoModule(

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -29,6 +29,7 @@ class GoModule:
         independent=False,
         lint_targets=None,
         used_by_otel=False,
+        legacy_go_mod_version=False,
     ):
         self.path = path
         self.targets = targets if targets else ["."]
@@ -42,6 +43,7 @@ class GoModule:
         self.importable = importable
         self.independent = independent
         self.used_by_otel = used_by_otel
+        self.legacy_go_mod_version = legacy_go_mod_version
 
         self._dependencies = None
 

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -193,9 +193,9 @@ def _update_go_mods(warn: bool, version: str, include_otel_modules: bool, dry_ru
         mod_file = f"./{path}/go.mod"
 
         if module.legacy_go_mod_version:
-            minor = _get_major_minor_version(version)
+            major_minor = _get_major_minor_version(version)
             # $ only matches \n, not \r\n, so we need to use \r?$ to make it work on Windows
-            _update_file(warn, mod_file, f"^go {PATTERN_MAJOR_MINOR}\r?$", f"go {minor}", dry_run=dry_run)
+            _update_file(warn, mod_file, f"^go {PATTERN_MAJOR_MINOR}\r?$", f"go {major_minor}", dry_run=dry_run)
         else:
             # $ only matches \n, not \r\n, so we need to use \r?$ to make it work on Windows
             _update_file(warn, mod_file, f"^go {PATTERN_MAJOR_MINOR_BUGFIX}\r?$", f"go {version}", dry_run=dry_run)

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -191,8 +191,14 @@ def _update_go_mods(warn: bool, version: str, include_otel_modules: bool, dry_ru
             # to allow them to keep using the modules
             continue
         mod_file = f"./{path}/go.mod"
-        # $ only matches \n, not \r\n, so we need to use \r?$ to make it work on Windows
-        _update_file(warn, mod_file, f"^go {PATTERN_MAJOR_MINOR_BUGFIX}\r?$", f"go {version}", dry_run=dry_run)
+
+        if module.legacy_go_mod_version:
+            minor = _get_major_minor_version(version)
+            # $ only matches \n, not \r\n, so we need to use \r?$ to make it work on Windows
+            _update_file(warn, mod_file, f"^go {PATTERN_MAJOR_MINOR}\r?$", f"go {minor}", dry_run=dry_run)
+        else:
+            # $ only matches \n, not \r\n, so we need to use \r?$ to make it work on Windows
+            _update_file(warn, mod_file, f"^go {PATTERN_MAJOR_MINOR_BUGFIX}\r?$", f"go {version}", dry_run=dry_run)
 
 
 def _create_releasenote(ctx: Context, version: str):


### PR DESCRIPTION
### What does this PR do?

`pkg/security/secl` is still imported by packages defining their go mod line as `go 1.21` resulting in dirty files (dd-go..). As is it means we need to revert `pkg/security/secl/go.mod` to `go 1.21`.

This PR also updates the rest of the go update mechanism to transparently handle this kind of legacy go mod requirement.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
