### PR TITLE
usm: kafka: Migrate encoding to use gostreamer

### DIFF
--- a/pkg/network/encoding/marshal/format.go
+++ b/pkg/network/encoding/marshal/format.go
@@ -6,7 +6,6 @@
 package marshal
 
 import (
-	"bytes"
 	"math"
 	"reflect"
 	"unsafe"
@@ -99,12 +98,7 @@ func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionS
 	staticTags, dynamicTags = httpEncoder.GetHTTPAggregationsAndTags(conn, builder)
 	_, _ = http2Encoder.WriteHTTP2AggregationsAndTags(conn, builder)
 
-	// TODO: optimize kafkEncoder to take a writer and use gostreamer
-	if dsa := kafkaEncoder.GetKafkaAggregations(conn); dsa != nil {
-		builder.SetDataStreamsAggregations(func(b *bytes.Buffer) {
-			b.Write(dsa)
-		})
-	}
+	kafkaEncoder.WriteKafkaAggregations(conn, builder)
 
 	conn.StaticTags |= staticTags
 	tags, tagChecksum := formatTags(conn, tagsSet, dynamicTags)

--- a/pkg/network/encoding/marshal/kafka.go
+++ b/pkg/network/encoding/marshal/kafka.go
@@ -6,29 +6,19 @@
 package marshal
 
 import (
-	"sync"
+	"bytes"
+	"io"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/gogo/protobuf/proto"
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/kafka"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 )
 
-var kafkaAggregationPool = sync.Pool{
-	New: func() any {
-		return &model.KafkaAggregation{
-			Header: new(model.KafkaRequestHeader),
-		}
-	},
-}
-
 type kafkaEncoder struct {
-	byConnection *USMConnectionIndex[kafka.Key, *kafka.RequestStat]
-
-	// cached object
-	aggregations *model.DataStreamsAggregations
+	kafkaAggregationsBuilder *model.DataStreamsAggregationsBuilder
+	byConnection             *USMConnectionIndex[kafka.Key, *kafka.RequestStat]
 }
 
 func newKafkaEncoder(kafkaPayloads map[kafka.Key]*kafka.RequestStat) *kafkaEncoder {
@@ -37,30 +27,43 @@ func newKafkaEncoder(kafkaPayloads map[kafka.Key]*kafka.RequestStat) *kafkaEncod
 	}
 
 	return &kafkaEncoder{
-		aggregations: &model.DataStreamsAggregations{
-			// It's not that important to get the initial size of this slice
-			// right because we're re-using it multiple times and should quickly
-			// converge to a final size after a few calls to
-			// `GetKafkaAggregations`
-			KafkaAggregations: make([]*model.KafkaAggregation, 0, 10),
-		},
+		kafkaAggregationsBuilder: model.NewDataStreamsAggregationsBuilder(nil),
 		byConnection: GroupByConnection("kafka", kafkaPayloads, func(key kafka.Key) types.ConnectionKey {
 			return key.ConnectionKey
 		}),
 	}
 }
 
-func (e *kafkaEncoder) GetKafkaAggregations(c network.ConnectionStats) []byte {
+func (e *kafkaEncoder) WriteKafkaAggregations(c network.ConnectionStats, builder *model.ConnectionBuilder) {
 	if e == nil {
-		return nil
+		return
 	}
 
 	connectionData := e.byConnection.Find(c)
 	if connectionData == nil || len(connectionData.Data) == 0 || connectionData.IsPIDCollision(c) {
-		return nil
+		return
 	}
 
-	return e.encodeData(connectionData)
+	builder.SetDataStreamsAggregations(func(b *bytes.Buffer) {
+		e.encodeData(connectionData, b)
+	})
+}
+
+func (e *kafkaEncoder) encodeData(connectionData *USMConnectionData[kafka.Key, *kafka.RequestStat], w io.Writer) {
+	e.kafkaAggregationsBuilder.Reset(w)
+
+	for _, kv := range connectionData.Data {
+		key := kv.Key
+		stats := kv.Value
+		e.kafkaAggregationsBuilder.AddKafkaAggregations(func(builder *model.KafkaAggregationBuilder) {
+			builder.SetHeader(func(header *model.KafkaRequestHeaderBuilder) {
+				header.SetRequest_type(uint32(key.RequestAPIKey))
+				header.SetRequest_version(uint32(key.RequestVersion))
+			})
+			builder.SetTopic(key.TopicName)
+			builder.SetCount(uint32(stats.Count))
+		})
+	}
 }
 
 func (e *kafkaEncoder) Close() {
@@ -68,51 +71,5 @@ func (e *kafkaEncoder) Close() {
 		return
 	}
 
-	e.reset()
 	e.byConnection.Close()
-}
-
-func (e *kafkaEncoder) encodeData(connectionData *USMConnectionData[kafka.Key, *kafka.RequestStat]) []byte {
-	e.reset()
-
-	for _, kv := range connectionData.Data {
-		key := kv.Key
-		stats := kv.Value
-
-		kafkaAggregation := kafkaAggregationPool.Get().(*model.KafkaAggregation)
-
-		kafkaAggregation.Header.RequestType = uint32(key.RequestAPIKey)
-		kafkaAggregation.Header.RequestVersion = uint32(key.RequestVersion)
-		kafkaAggregation.Topic = key.TopicName
-		kafkaAggregation.Count = uint32(stats.Count)
-
-		e.aggregations.KafkaAggregations = append(e.aggregations.KafkaAggregations, kafkaAggregation)
-	}
-
-	serializedData, _ := proto.Marshal(e.aggregations)
-	return serializedData
-}
-
-func (e *kafkaEncoder) reset() {
-	if e == nil {
-		return
-	}
-
-	for i, kafkaAggregation := range e.aggregations.KafkaAggregations {
-		// The pooled *model.KafkaAggregation object comes along with a
-		// pre-allocated *model.KafkaHeader object as well, so we ensure that we
-		// clean both objects but keep them linked together before returning it
-		// to the pool.
-
-		header := kafkaAggregation.Header
-		header.Reset()
-
-		kafkaAggregation.Reset()
-		kafkaAggregation.Header = header
-
-		kafkaAggregationPool.Put(kafkaAggregation)
-		e.aggregations.KafkaAggregations[i] = nil
-	}
-
-	e.aggregations.KafkaAggregations = e.aggregations.KafkaAggregations[:0]
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Migrating the kafka encoding to use inline encoding and protobuf marshaling by using the gostreamer interface. This PR matches PR #19533 for http2, and #18408 for http.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Aligning the code.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Performance results showed no meaningful impact

cpu - no change
![image](https://github.com/DataDog/datadog-agent/assets/17148247/a9439fcd-4714-4eaf-9831-7137f7588e24)

rss no change
![image](https://github.com/DataDog/datadog-agent/assets/17148247/3c410c7e-fdfe-481e-a7d3-5aef35d765a8)


<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
