### PR TITLE
[USM] Improve http2 kernel metrics

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-common.h
@@ -167,9 +167,21 @@ static __always_inline void reset_frame(http2_frame_t *out) {
 }
 
 // check_frame_split checks if the frame is split into multiple tcp payloads, if so, it increments the split counter.
-static __always_inline void check_frame_split(http2_telemetry_t *http2_tel, __u32 data_off, __u32 data_end, __u32 length){
-    if (data_off + length > data_end) {
-        __sync_fetch_and_add(&http2_tel->fragmented_frame_count, 1);
+static __always_inline void check_frame_split(http2_telemetry_t *http2_tel, __u32 data_off, __u32 data_end, http2_frame_t current_frame){
+    bool is_headers = current_frame.type == kHeadersFrame;
+    bool is_rst_frame = current_frame.type == kRSTStreamFrame;
+    bool is_data_end_of_stream = ((current_frame.flags & HTTP2_END_OF_STREAM) == HTTP2_END_OF_STREAM) && (current_frame.type == kDataFrame);
+    bool is_headers_end_of_stream = ((current_frame.flags & HTTP2_END_OF_STREAM) == HTTP2_END_OF_STREAM) && (is_headers);
+    if (data_off + current_frame.length > data_end) {
+        if (is_headers_end_of_stream) {
+            __sync_fetch_and_add(&http2_tel->fragmented_frame_count_headers_eos, 1);
+        } else if (is_data_end_of_stream) {
+            __sync_fetch_and_add(&http2_tel->fragmented_frame_count_data_eos, 1);
+        } else if (is_rst_frame) {
+            __sync_fetch_and_add(&http2_tel->fragmented_frame_count_rst, 1);
+        } else if (is_headers) {
+           __sync_fetch_and_add(&http2_tel->fragmented_frame_count_headers, 1);
+        }
     }
 }
 

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -243,7 +243,10 @@ typedef struct {
     __u64 exceeding_max_interesting_frames;
     __u64 exceeding_max_frames_to_filter;
     __u64 path_size_bucket[HTTP2_TELEMETRY_PATH_BUCKETS+1];
-    __u64 fragmented_frame_count;
+    __u64 fragmented_frame_count_headers;
+    __u64 fragmented_frame_count_rst;
+    __u64 fragmented_frame_count_data_eos;
+    __u64 fragmented_frame_count_headers_eos;
 } http2_telemetry_t;
 
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -551,6 +551,8 @@ static __always_inline void tls_find_relevant_frames(tls_dispatcher_arguments_t 
             break;
         }
 
+        check_frame_split(http2_tel, info->data_off, info->data_end, current_frame);
+
         // END_STREAM can appear only in Headers and Data frames.
         // Check out https://datatracker.ietf.org/doc/html/rfc7540#section-6.1 for data frame, and
         // https://datatracker.ietf.org/doc/html/rfc7540#section-6.2 for headers frame.
@@ -560,11 +562,6 @@ static __always_inline void tls_find_relevant_frames(tls_dispatcher_arguments_t 
             iteration_value->frames_array[iteration_value->frames_count].frame = current_frame;
             iteration_value->frames_array[iteration_value->frames_count].offset = info->data_off;
             iteration_value->frames_count++;
-        }
-
-        // We are not checking for frame splits in the previous condition due to a verifier issue.
-        if (is_headers_or_rst_frame || is_data_end_of_stream) {
-            check_frame_split(http2_tel, info->data_off, info->data_end, current_frame.length);
         }
 
         info->data_off += current_frame.length;
@@ -642,10 +639,10 @@ int uprobe__http2_tls_handle_first_frame(struct pt_regs *ctx) {
         bpf_map_delete_elem(&http2_remainder, &dispatcher_args_copy.tup);
     }
 
+    check_frame_split(http2_tel, dispatcher_args_copy.data_off, dispatcher_args_copy.data_end, current_frame);
     bool is_headers_or_rst_frame = current_frame.type == kHeadersFrame || current_frame.type == kRSTStreamFrame;
     bool is_data_end_of_stream = ((current_frame.flags & HTTP2_END_OF_STREAM) == HTTP2_END_OF_STREAM) && (current_frame.type == kDataFrame);
     if (is_headers_or_rst_frame || is_data_end_of_stream) {
-        check_frame_split(http2_tel, dispatcher_args_copy.data_off, dispatcher_args_copy.data_end, current_frame.length);
         iteration_value->frames_array[0].frame = current_frame;
         iteration_value->frames_array[0].offset = dispatcher_args_copy.data_off;
         iteration_value->frames_count = 1;

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -558,6 +558,9 @@ static __always_inline bool find_relevant_frames(struct __sk_buff *skb, skb_info
             break;
         }
 
+        // We are not checking for frame splits in the previous condition due to a verifier issue.
+        check_frame_split(http2_tel, skb_info->data_off,skb_info->data_end, current_frame);
+
         // END_STREAM can appear only in Headers and Data frames.
         // Check out https://datatracker.ietf.org/doc/html/rfc7540#section-6.1 for data frame, and
         // https://datatracker.ietf.org/doc/html/rfc7540#section-6.2 for headers frame.
@@ -567,11 +570,6 @@ static __always_inline bool find_relevant_frames(struct __sk_buff *skb, skb_info
             iteration_value->frames_array[iteration_value->frames_count].frame = current_frame;
             iteration_value->frames_array[iteration_value->frames_count].offset = skb_info->data_off;
             iteration_value->frames_count++;
-        }
-
-        // We are not checking for frame splits in the previous condition due to a verifier issue.
-        if (is_headers_or_rst_frame || is_data_end_of_stream) {
-            check_frame_split(http2_tel, skb_info->data_off,skb_info->data_end, current_frame.length);
         }
 
         skb_info->data_off += current_frame.length;
@@ -656,10 +654,10 @@ int socket__http2_handle_first_frame(struct __sk_buff *skb) {
         bpf_map_delete_elem(&http2_remainder, &dispatcher_args_copy.tup);
     }
 
+    check_frame_split(http2_tel, dispatcher_args_copy.skb_info.data_off, dispatcher_args_copy.skb_info.data_end, current_frame);
     bool is_headers_or_rst_frame = current_frame.type == kHeadersFrame || current_frame.type == kRSTStreamFrame;
     bool is_data_end_of_stream = ((current_frame.flags & HTTP2_END_OF_STREAM) == HTTP2_END_OF_STREAM) && (current_frame.type == kDataFrame);
     if (is_headers_or_rst_frame || is_data_end_of_stream) {
-        check_frame_split(http2_tel, dispatcher_args_copy.skb_info.data_off, dispatcher_args_copy.skb_info.data_end, current_frame.length);
         iteration_value->frames_array[0].frame = current_frame;
         iteration_value->frames_array[0].offset = dispatcher_args_copy.skb_info.data_off;
         iteration_value->frames_count = 1;

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -417,7 +417,10 @@ HTTP2Telemetry{
 	"literal values exceed message count": %d,
 	"messages with more frames than we can filter": %d,
 	"messages with more interesting frames than we can process": %d,
-	"fragmented frame count": %d,
+	"fragmented headers frame count": %d,
+	"fragmented headers frame count end of stream": %d,
+	"fragmented data frame count end of stream": %d,
+	"fragmented rst frame count": %d,
 	"path headers length distribution": {
 		"in range [0, 120)": %d,
 		"in range [120, 130)": %d,
@@ -429,7 +432,7 @@ HTTP2Telemetry{
 		"in range [180, infinity)": %d
 	}
 }`, t.Request_seen, t.Response_seen, t.End_of_stream, t.End_of_stream_rst, t.Literal_value_exceeds_frame,
-		t.Exceeding_max_frames_to_filter, t.Exceeding_max_interesting_frames, t.Fragmented_frame_count, t.Path_size_bucket[0], t.Path_size_bucket[1],
+		t.Exceeding_max_frames_to_filter, t.Exceeding_max_interesting_frames, t.Fragmented_frame_count_headers, t.Fragmented_frame_count_headers_eos, t.Fragmented_frame_count_data_eos, t.Fragmented_frame_count_rst, t.Path_size_bucket[0], t.Path_size_bucket[1],
 		t.Path_size_bucket[2], t.Path_size_bucket[3], t.Path_size_bucket[4], t.Path_size_bucket[5], t.Path_size_bucket[6],
 		t.Path_size_bucket[7])
 }

--- a/pkg/network/protocols/http2/raw_traffic.go
+++ b/pkg/network/protocols/http2/raw_traffic.go
@@ -18,6 +18,7 @@ import (
 type HeadersFrameOptions struct {
 	Headers                []hpack.HeaderField
 	DynamicTableUpdateSize uint32
+	EndStream              bool
 }
 
 // NewHeadersFrameMessage creates a new HTTP2 data frame message with the given header fields.

--- a/pkg/network/protocols/http2/telemetry.go
+++ b/pkg/network/protocols/http2/telemetry.go
@@ -66,9 +66,14 @@ type kernelTelemetry struct {
 	exceedingMaxInterestingFrames *tlsAwareCounter
 	// exceedingMaxFramesToFilter Count of times we have left with more frames to filter than the max number of frames to filter.
 	exceedingMaxFramesToFilter *tlsAwareCounter
-	// fragmentedFrameCount Count of times we have seen a fragmented frame.
-	fragmentedFrameCount *tlsAwareCounter
-
+	// fragmentedFrameCountRST Count of times we have seen a fragmented RST frame.
+	fragmentedFrameCountRST *tlsAwareCounter
+	// fragmentedHeadersFrameEOSCount Count of times we have seen a fragmented headers frame with EOS.
+	fragmentedHeadersFrameEOSCount *tlsAwareCounter
+	// fragmentedHeadersFrameCount Count of times we have seen a fragmented headers frame.
+	fragmentedHeadersFrameCount *tlsAwareCounter
+	// fragmentedDataFrameEOSCount Count of times we have seen a fragmented data frame with EOS.
+	fragmentedDataFrameEOSCount *tlsAwareCounter
 	// telemetryLastState represents the latest HTTP2 eBPF Kernel telemetry observed from the kernel
 	telemetryLastState HTTP2Telemetry
 }
@@ -77,15 +82,18 @@ type kernelTelemetry struct {
 func newHTTP2KernelTelemetry() *kernelTelemetry {
 	metricGroup := libtelemetry.NewMetricGroup("usm.http2", libtelemetry.OptPrometheus)
 	http2KernelTel := &kernelTelemetry{
-		metricGroup:                   metricGroup,
-		http2requests:                 newTLSAwareCounter(metricGroup, "requests"),
-		http2responses:                newTLSAwareCounter(metricGroup, "responses"),
-		endOfStream:                   newTLSAwareCounter(metricGroup, "eos"),
-		endOfStreamRST:                newTLSAwareCounter(metricGroup, "rst"),
-		literalValueExceedsFrame:      newTLSAwareCounter(metricGroup, "literal_value_exceeds_frame"),
-		exceedingMaxInterestingFrames: newTLSAwareCounter(metricGroup, "exceeding_max_interesting_frames"),
-		exceedingMaxFramesToFilter:    newTLSAwareCounter(metricGroup, "exceeding_max_frames_to_filter"),
-		fragmentedFrameCount:          newTLSAwareCounter(metricGroup, "exceeding_data_end")}
+		metricGroup:                    metricGroup,
+		http2requests:                  newTLSAwareCounter(metricGroup, "requests"),
+		http2responses:                 newTLSAwareCounter(metricGroup, "responses"),
+		endOfStream:                    newTLSAwareCounter(metricGroup, "eos"),
+		endOfStreamRST:                 newTLSAwareCounter(metricGroup, "rst"),
+		literalValueExceedsFrame:       newTLSAwareCounter(metricGroup, "literal_value_exceeds_frame"),
+		exceedingMaxInterestingFrames:  newTLSAwareCounter(metricGroup, "exceeding_max_interesting_frames"),
+		exceedingMaxFramesToFilter:     newTLSAwareCounter(metricGroup, "exceeding_max_frames_to_filter"),
+		fragmentedDataFrameEOSCount:    newTLSAwareCounter(metricGroup, "exceeding_data_end_data_eos"),
+		fragmentedHeadersFrameCount:    newTLSAwareCounter(metricGroup, "exceeding_data_end_headers"),
+		fragmentedHeadersFrameEOSCount: newTLSAwareCounter(metricGroup, "exceeding_data_end_headers_eos"),
+		fragmentedFrameCountRST:        newTLSAwareCounter(metricGroup, "exceeding_data_end_rst")}
 
 	for bucketIndex := range http2KernelTel.pathSizeBucket {
 		http2KernelTel.pathSizeBucket[bucketIndex] = newTLSAwareCounter(metricGroup, "path_size_bucket_"+(strconv.Itoa(bucketIndex+1)))
@@ -105,7 +113,10 @@ func (t *kernelTelemetry) update(tel *HTTP2Telemetry, isTLS bool) {
 	t.literalValueExceedsFrame.add(int64(telemetryDelta.Literal_value_exceeds_frame), isTLS)
 	t.exceedingMaxInterestingFrames.add(int64(telemetryDelta.Exceeding_max_interesting_frames), isTLS)
 	t.exceedingMaxFramesToFilter.add(int64(telemetryDelta.Exceeding_max_frames_to_filter), isTLS)
-	t.fragmentedFrameCount.add(int64(telemetryDelta.Fragmented_frame_count), isTLS)
+	t.fragmentedFrameCountRST.add(int64(telemetryDelta.Fragmented_frame_count_rst), isTLS)
+	t.fragmentedHeadersFrameEOSCount.add(int64(telemetryDelta.Fragmented_frame_count_headers_eos), isTLS)
+	t.fragmentedHeadersFrameCount.add(int64(telemetryDelta.Fragmented_frame_count_headers), isTLS)
+	t.fragmentedDataFrameEOSCount.add(int64(telemetryDelta.Fragmented_frame_count_data_eos), isTLS)
 	for bucketIndex := range t.pathSizeBucket {
 		t.pathSizeBucket[bucketIndex].add(int64(telemetryDelta.Path_size_bucket[bucketIndex]), isTLS)
 	}
@@ -120,15 +131,18 @@ func (t *kernelTelemetry) Log() {
 // Sub generates a new HTTP2Telemetry object by subtracting the values of this HTTP2Telemetry object from the other
 func (t *HTTP2Telemetry) Sub(other HTTP2Telemetry) *HTTP2Telemetry {
 	return &HTTP2Telemetry{
-		Request_seen:                     t.Request_seen - other.Request_seen,
-		Response_seen:                    t.Response_seen - other.Response_seen,
-		End_of_stream:                    t.End_of_stream - other.End_of_stream,
-		End_of_stream_rst:                t.End_of_stream_rst - other.End_of_stream_rst,
-		Literal_value_exceeds_frame:      t.Literal_value_exceeds_frame - other.Literal_value_exceeds_frame,
-		Exceeding_max_interesting_frames: t.Exceeding_max_interesting_frames - other.Exceeding_max_interesting_frames,
-		Exceeding_max_frames_to_filter:   t.Exceeding_max_frames_to_filter - other.Exceeding_max_frames_to_filter,
-		Fragmented_frame_count:           t.Fragmented_frame_count - other.Fragmented_frame_count,
-		Path_size_bucket:                 computePathSizeBucketDifferences(t.Path_size_bucket, other.Path_size_bucket),
+		Request_seen:                       t.Request_seen - other.Request_seen,
+		Response_seen:                      t.Response_seen - other.Response_seen,
+		End_of_stream:                      t.End_of_stream - other.End_of_stream,
+		End_of_stream_rst:                  t.End_of_stream_rst - other.End_of_stream_rst,
+		Literal_value_exceeds_frame:        t.Literal_value_exceeds_frame - other.Literal_value_exceeds_frame,
+		Exceeding_max_interesting_frames:   t.Exceeding_max_interesting_frames - other.Exceeding_max_interesting_frames,
+		Exceeding_max_frames_to_filter:     t.Exceeding_max_frames_to_filter - other.Exceeding_max_frames_to_filter,
+		Fragmented_frame_count_headers:     t.Fragmented_frame_count_headers - other.Fragmented_frame_count_headers,
+		Fragmented_frame_count_data_eos:    t.Fragmented_frame_count_data_eos - other.Fragmented_frame_count_data_eos,
+		Fragmented_frame_count_rst:         t.Fragmented_frame_count_rst - other.Fragmented_frame_count_rst,
+		Fragmented_frame_count_headers_eos: t.Fragmented_frame_count_headers_eos - other.Fragmented_frame_count_headers_eos,
+		Path_size_bucket:                   computePathSizeBucketDifferences(t.Path_size_bucket, other.Path_size_bucket),
 	}
 }
 

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -75,15 +75,18 @@ type EbpfTx struct {
 	Stream HTTP2Stream
 }
 type HTTP2Telemetry struct {
-	Request_seen                     uint64
-	Response_seen                    uint64
-	End_of_stream                    uint64
-	End_of_stream_rst                uint64
-	Literal_value_exceeds_frame      uint64
-	Exceeding_max_interesting_frames uint64
-	Exceeding_max_frames_to_filter   uint64
-	Path_size_bucket                 [8]uint64
-	Fragmented_frame_count           uint64
+	Request_seen                       uint64
+	Response_seen                      uint64
+	End_of_stream                      uint64
+	End_of_stream_rst                  uint64
+	Literal_value_exceeds_frame        uint64
+	Exceeding_max_interesting_frames   uint64
+	Exceeding_max_frames_to_filter     uint64
+	Path_size_bucket                   [8]uint64
+	Fragmented_frame_count_headers     uint64
+	Fragmented_frame_count_rst         uint64
+	Fragmented_frame_count_data_eos    uint64
+	Fragmented_frame_count_headers_eos uint64
 }
 
 type StaticTableEnumValue = uint8


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Improves http2 kernel metrics. 

Introduce the following metrics:
* fragmented_frame_count_headers
* fragmented_frame_count_rst
* fragmented_frame_count_data_eos
* fragmented_frame_count_headers_eos

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

To better understand the types of fragmented frames we encounter, this PR modifies the way we identify these cases, providing a clearer understanding of the root cause for each fragmented scenario.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
