### PR TITLE
SNMP Traps: Document multi-user support in the example config file

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3831,7 +3831,7 @@ api_key:
     ## @param users - list of custom objects - optional
     ## List of SNMPv3 users that can be used to listen for traps.
     ## Each user can contain:
-    ##  * username     - string - The username used by devices when sending Traps to the Agent.
+    ##  * user         - string - The username used by devices when sending Traps to the Agent.
     ##  * authKey      - string - (Optional) The passphrase to use with the given user and authProtocol
     ##  * authProtocol - string - (Optional) The authentication protocol to use when listening for traps from this user.
     ##                            Available options are: MD5, SHA, SHA224, SHA256, SHA384, SHA512.
@@ -3842,7 +3842,7 @@ api_key:
     ##                            Defaults to DES when privKey is set.
     #
     # users:
-    # - username: <USERNAME>
+    # - user: <USERNAME>
     #   authKey: <AUTHENTICATION_KEY>
     #   authProtocol: <AUTHENTICATION_PROTOCOL>
     #   privKey: <PRIVACY_KEY>

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3830,8 +3830,6 @@ api_key:
 
     ## @param users - list of custom objects - optional
     ## List of SNMPv3 users that can be used to listen for traps.
-    ## NOTE: Currently the Datadog Agent only supports having a
-    ## single user in this list.
     ## Each user can contain:
     ##  * username     - string - The username used by devices when sending Traps to the Agent.
     ##  * authKey      - string - (Optional) The passphrase to use with the given user and authProtocol


### PR DESCRIPTION
This PR documents that the Agent now supports multiple v3 users for Traps and updates the `username` parameter to `user`. This is not a change of config but this is a documentation issue.

Up until Agent 7.51, there were two issues. 1. The `config_template.yaml` file was incorrectly using `username` instead of `user` (only `user` is checked in the code) and 2. the version of `gosnmp` library that we depend on was ignoring that user parameter anyway.

In Agent 7.51, the `gosnmp` library was updated and it now verifies the username. Meaning that any Datadog user that was using `username` may start to see missing traps. To mitigate the issue, we're doing two things:
1. This PR to fix the documentation and use the correct parameter.
2. Another PR to read both `username` and `user`.
These two changes will ship with Agent 7.53