### PR TITLE
fix system probe status provider

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -325,8 +325,8 @@ func getSharedFxOption() fx.Option {
 		fx.Provide(func(config config.Component) status.InformationProvider {
 			return status.NewInformationProvider(clusteragentStatus.GetProvider(config))
 		}),
-		fx.Provide(func(config config.Component) status.InformationProvider {
-			return status.NewInformationProvider(systemprobeStatus.GetProvider(config))
+		fx.Provide(func(sysprobeconfig sysprobeconfig.Component) status.InformationProvider {
+			return status.NewInformationProvider(systemprobeStatus.GetProvider(sysprobeconfig))
 		}),
 		fx.Provide(func(config config.Component) status.InformationProvider {
 			return status.NewInformationProvider(httpproxyStatus.GetProvider(config))

--- a/pkg/status/systemprobe/status.go
+++ b/pkg/status/systemprobe/status.go
@@ -46,13 +46,9 @@ type Provider struct {
 
 // GetProvider if system probe is enabled returns status.Provider otherwise returns nil
 func GetProvider(conf config.Component) status.Provider {
-	if conf.GetBool("system_probe_config.enabled") {
-		return Provider{
-			SocketPath: conf.GetString("system_probe_config.sysprobe_socket"),
-		}
+	return Provider{
+		SocketPath: conf.GetString("system_probe_config.sysprobe_socket"),
 	}
-
-	return nil
 }
 
 //go:embed status_templates
@@ -77,7 +73,7 @@ func (p Provider) JSON(_ bool, stats map[string]interface{}) error {
 
 // Text renders the text output
 func (p Provider) Text(_ bool, buffer io.Writer) error {
-	return status.RenderText(templatesFS, "clusteragent.tmpl", buffer, p.getStatusInfo())
+	return status.RenderText(templatesFS, "systemprobe.tmpl", buffer, p.getStatusInfo())
 }
 
 // HTML renders the html output

--- a/pkg/status/systemprobe/status.go
+++ b/pkg/status/systemprobe/status.go
@@ -13,8 +13,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 )
 
@@ -45,10 +45,16 @@ type Provider struct {
 }
 
 // GetProvider if system probe is enabled returns status.Provider otherwise returns nil
-func GetProvider(conf config.Component) status.Provider {
-	return Provider{
-		SocketPath: conf.GetString("system_probe_config.sysprobe_socket"),
+func GetProvider(config sysprobeconfig.Component) status.Provider {
+	systemProbeConfig := config.SysProbeObject()
+
+	if systemProbeConfig.Enabled {
+		return Provider{
+			SocketPath: systemProbeConfig.SocketAddress,
+		}
 	}
+
+	return nil
 }
 
 //go:embed status_templates

--- a/pkg/status/systemprobe/status_unsupported.go
+++ b/pkg/status/systemprobe/status_unsupported.go
@@ -9,8 +9,8 @@
 package systemprobe
 
 import (
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 )
 
 // GetStatus returns a notice that it is not supported on systems that do not at least build the process agent
@@ -21,6 +21,6 @@ func GetStatus(stats map[string]interface{}, _ string) {
 }
 
 // GetProvider returns nil
-func GetProvider(_ config.Component) status.Provider {
+func GetProvider(_ sysprobeconfig.Component) status.Provider {
 	return nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

The system probe status had to issues:
- It was using the right template path 
- It was using a deprecated config flag to validate if it should display information or not `"system_probe_config.enabled"`

This PR ensure that we are using the correct template `systemprobe.tmpl` and rather than using `system_probe_config.enabled` we use `system_probe_config.sysprobe_socket` to get the system probe util. In the case of running in unsupported environments it will fails: https://github.com/DataDog/datadog-agent/blob/5ccdf73909ea7f7ecaf2d2f41111f74f320bd8aa/pkg/process/net/common_unsupported.go#L32-L34

With this changes we warranty that the system probe output gets displayed as part of the agent status output 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Ensure system probe output is displayed in the `status.log` in the flare archive.

1. Run agent via docker with system-probe enabled, for instance
```
docker run -it --rm --name ddog --cgroupns host --pid host -v /var/run/docker.sock:/var/run/docker.sock:ro -v /:/host/root -e HOST_ROOT=/host/root -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -v /sys/kernel/debug:/sys/kernel/debug -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /var/tmp/datadog-agent/system-probe/build:/var/tmp/datadog-agent/system-probe/build -v /var/tmp/datadog-agent/system-probe/kernel-headers:/var/tmp/datadog-agent/system-probe/kernel-headers -v /etc/apt:/host/etc/apt:ro -v /etc/yum.repos.d:/host/etc/yum.repos.d:ro -v /etc/zypp:/host/etc/zypp:ro -v /etc/pki:/host/etc/pki:ro -v /etc/yum/vars:/host/etc/yum/vars:ro -v /etc/dnf/vars:/host/etc/dnf/vars:ro -v /etc/rhsm:/host/etc/rhsm:ro -e DD_API_KEY=<api key< -e DD_PROCESS_AGENT_ENABLED=true -v /etc/os-release:/host/etc/os-release:ro -v /sys/kernel/debug:/sys/kernel/debug --security-opt apparmor:unconfined --cap-add=SYS_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE --cap-add=NET_ADMIN --cap-add=NET_BROADCAST --cap-add=NET_RAW --cap-add=IPC_LOCK --cap-add=CHOWN -e DD_LOG_LEVEL=debug -e DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED=true datadog/agent:7.52.0-rc.<tag>
```

2. Get a flare from the agent
`docker exec -it ddog agent flare`

3. Ensure having the following section in `status.log`
```
============
System Probe
============

  Status: Running
  Uptime: 15.000358569s
  Last Updated: 2024-03-11 19:31:13 IST / 2024-03-11 17:31:13 UTC (1710178273000)

  USM
  ===
    Status: <no value>

  NPM
  ===
    Status: Running
    Last Check: 2024-03-11 19:30:52 IST / 2024-03-11 17:30:52 UTC (1710178252000)

  Event Monitor
  ================
    Status: Running
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
