### PR TITLE
usm: http2: Fix status codes 304 and 404

### DIFF
--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -227,8 +227,12 @@ func (tx *EbpfTx) StatusCode() uint16 {
 			return 204
 		case K206Value:
 			return 206
+		case K304Value:
+			return 304
 		case K400Value:
 			return 400
+		case K404Value:
+			return 404
 		case K500Value:
 			return 500
 		default:

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -727,9 +727,10 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		},
 		{
 			name: "validate various status codes",
-			// The purpose of this test is to verify that we support status codes that do not appear in the static table.
+			// The purpose of this test is to verify that we support status codes that both do and
+			// do not appear in the static table.
 			messageBuilder: func() [][]byte {
-				statusCodes := []int{http.StatusCreated, http.StatusMultipleChoices, http.StatusUnauthorized, http.StatusGatewayTimeout}
+				statusCodes := []int{200, 201, 204, 206, 300, 304, 400, 401, 404, 500, 504}
 				const iterationsPerStatusCode = 3
 				messages := make([][]byte, 0, len(statusCodes)*iterationsPerStatusCode)
 				for statusCodeIteration, statusCode := range statusCodes {
@@ -745,7 +746,19 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			},
 			expectedEndpoints: map[usmhttp.Key]int{
 				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/200")},
+					Method: usmhttp.MethodPost,
+				}: 3,
+				{
 					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/201")},
+					Method: usmhttp.MethodPost,
+				}: 3,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/204")},
+					Method: usmhttp.MethodPost,
+				}: 3,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/206")},
 					Method: usmhttp.MethodPost,
 				}: 3,
 				{
@@ -753,7 +766,23 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 					Method: usmhttp.MethodPost,
 				}: 3,
 				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/304")},
+					Method: usmhttp.MethodPost,
+				}: 3,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/400")},
+					Method: usmhttp.MethodPost,
+				}: 3,
+				{
 					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/401")},
+					Method: usmhttp.MethodPost,
+				}: 3,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/404")},
+					Method: usmhttp.MethodPost,
+				}: 3,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/status/500")},
 					Method: usmhttp.MethodPost,
 				}: 3,
 				{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fixes handling of status codes 304 and 404 in USM's HTTP/2 support. These are part of the static table in HPACK but were missing in a switch statement, resulting in all transactions with these codes being assigned a status code of zero and being marked as incomplete.

Also it adds all the status codes in the static table to the status codes test case.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
