### PR TITLE
[ASCII-1281] Ensure host metadata information information is sent first 

### DIFF
--- a/comp/metadata/host/hostimpl/host.go
+++ b/comp/metadata/host/hostimpl/host.go
@@ -66,7 +66,7 @@ type provides struct {
 	fx.Out
 
 	Comp                 hostComp.Component
-	MetadataProvider     runnerimpl.Provider
+	MetadataProvider     runnerimpl.PriorityProvider
 	FlareProvider        flaretypes.Provider
 	StatusHeaderProvider status.HeaderInformationProvider
 }
@@ -102,7 +102,7 @@ func newHostProvider(deps dependencies) provides {
 	}
 	return provides{
 		Comp:             &h,
-		MetadataProvider: runnerimpl.NewProvider(h.collect),
+		MetadataProvider: runnerimpl.NewPriorityProvider(h.collect),
 		FlareProvider:    flaretypes.NewProvider(h.fillFlare),
 		StatusHeaderProvider: status.NewHeaderInformationProvider(StatusProvider{
 			Config: h.config,

--- a/comp/metadata/runner/runnerimpl/runner.go
+++ b/comp/metadata/runner/runnerimpl/runner.go
@@ -28,7 +28,7 @@ func Module() fxutil.Module {
 type MetadataProvider func(context.Context) time.Duration
 
 // PriorityMetadataProvider is the provider for metadata that needs to be execute at start time of the agent.
-// Right now the agent needs the host metadata provider to execute first to ensure metrcis tags are being reported correctly.
+// Right now the agent needs the host metadata provider to execute first to ensure host tags are being reported correctly.
 // This is a temporary workaorund until we figure a more permanent solution in the backend
 // If you need to use this provide please contact the agent-shared-components team
 type PriorityMetadataProvider func(context.Context) time.Duration
@@ -176,7 +176,7 @@ func (r *runnerImpl) handleProvider(p func(context.Context) time.Duration) {
 // start is called by FX when the application starts. Lifecycle hooks are blocking and called sequencially. We should
 // not block here.
 func (r *runnerImpl) start() error {
-	r.log.Debugf("Starting metadata runner with %d providers", len(r.providers)+len(r.priorityProviders))
+	r.log.Debugf("Starting metadata runner with %d priority providers and %d regular providers", len(r.priorityProviders), len(r.providers))
 
 	go func() {
 		for _, priorityProvider := range r.priorityProviders {

--- a/comp/metadata/runner/runnerimpl/runner.go
+++ b/comp/metadata/runner/runnerimpl/runner.go
@@ -27,6 +27,12 @@ func Module() fxutil.Module {
 // MetadataProvider is the provider for metadata
 type MetadataProvider func(context.Context) time.Duration
 
+// PriorityMetadataProvider is the provider for metadata that needs to be execute at start time of the agent.
+// Right now the agent needs the host metadata provider to execute first to ensure metrcis tags are being reported correctly.
+// This is a temporary workaorund until we figure a more permanent solution in the backend
+// If you need to use this provide please contact the agent-shared-components team
+type PriorityMetadataProvider func(context.Context) time.Duration
+
 type runnerImpl struct {
 	log    log.Component
 	config config.Component
@@ -34,6 +40,8 @@ type runnerImpl struct {
 	// providers are the metada providers to run. They're Optional because some of them can be disabled through the
 	// configuration
 	providers []optional.Option[MetadataProvider]
+	// priorityProviders are the metada providers that execute syncronously at runtime.
+	priorityProviders []optional.Option[PriorityMetadataProvider]
 
 	wg       sync.WaitGroup
 	stopChan chan struct{}
@@ -45,7 +53,8 @@ type dependencies struct {
 	Log    log.Component
 	Config config.Component
 
-	Providers []optional.Option[MetadataProvider] `group:"metadata_provider"`
+	Providers         []optional.Option[MetadataProvider]         `group:"metadata_provider"`
+	PriorityProviders []optional.Option[PriorityMetadataProvider] `group:"metadata_priority_provider"`
 }
 
 // Provider represents the callback from a metada provider. This is returned by 'NewProvider' helper.
@@ -55,10 +64,24 @@ type Provider struct {
 	Callback optional.Option[MetadataProvider] `group:"metadata_provider"`
 }
 
+// PriorityProvider represents the callback from a priority metada provider. This is returned by 'NewPriorityProvider' helper.
+type PriorityProvider struct {
+	fx.Out
+
+	Callback optional.Option[PriorityMetadataProvider] `group:"metadata_priority_provider"`
+}
+
 // NewProvider registers a new metadata provider by adding a callback to the runner.
 func NewProvider(callback MetadataProvider) Provider {
 	return Provider{
 		Callback: optional.NewOption[MetadataProvider](callback),
+	}
+}
+
+// NewPriorityProvider registers a new metadata provider by adding a callback to the runner.
+func NewPriorityProvider(callback PriorityMetadataProvider) PriorityProvider {
+	return PriorityProvider{
+		Callback: optional.NewOption[PriorityMetadataProvider](callback),
 	}
 }
 
@@ -73,10 +96,11 @@ func NewEmptyProvider() Provider {
 // createRunner instantiates a runner object
 func createRunner(deps dependencies) *runnerImpl {
 	return &runnerImpl{
-		log:       deps.Log,
-		config:    deps.Config,
-		providers: fxutil.GetAndFilterGroup(deps.Providers),
-		stopChan:  make(chan struct{}),
+		log:               deps.Log,
+		config:            deps.Config,
+		providers:         fxutil.GetAndFilterGroup(deps.Providers),
+		priorityProviders: fxutil.GetAndFilterGroup(deps.PriorityProviders),
+		stopChan:          make(chan struct{}),
 	}
 }
 
@@ -100,7 +124,7 @@ func newRunner(lc fx.Lifecycle, deps dependencies) runner.Component {
 }
 
 // handleProvider runs a provider at regular interval until the runner is stopped
-func (r *runnerImpl) handleProvider(p MetadataProvider) {
+func (r *runnerImpl) handleProvider(p func(context.Context) time.Duration) {
 	r.log.Debugf("Starting runner for MetadataProvider %#v", p)
 	r.wg.Add(1)
 
@@ -137,12 +161,24 @@ func (r *runnerImpl) handleProvider(p MetadataProvider) {
 // start is called by FX when the application starts. Lifecycle hooks are blocking and called sequencially. We should
 // not block here.
 func (r *runnerImpl) start() error {
-	r.log.Debugf("Starting metadata runner with %d providers", len(r.providers))
-	for _, optionaP := range r.providers {
-		if p, isSet := optionaP.Get(); isSet {
-			go r.handleProvider(p)
+	r.log.Debugf("Starting metadata runner with %d providers", len(r.providers)+len(r.priorityProviders))
+
+	go func() {
+		for _, optionaP := range r.priorityProviders {
+			if p, isSet := optionaP.Get(); isSet {
+				p(context.Background())
+
+				go r.handleProvider(p)
+			}
 		}
-	}
+
+		for _, optionaP := range r.providers {
+			if p, isSet := optionaP.Get(); isSet {
+				go r.handleProvider(p)
+			}
+		}
+	}()
+
 	return nil
 }
 

--- a/comp/metadata/runner/runnerimpl/runner.go
+++ b/comp/metadata/runner/runnerimpl/runner.go
@@ -180,7 +180,7 @@ func (r *runnerImpl) start() error {
 
 	go func() {
 		for _, priorityProvider := range r.priorityProviders {
-			// Execute syncronously the priority provider
+			// Execute synchronously the priority provider
 			priorityProvider(context.Background())
 
 			go r.handleProvider(priorityProvider)

--- a/comp/metadata/runner/runnerimpl/runner_test.go
+++ b/comp/metadata/runner/runnerimpl/runner_test.go
@@ -8,6 +8,7 @@ package runnerimpl
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,11 +22,14 @@ import (
 )
 
 func TestHandleProvider(t *testing.T) {
-	called := make(chan struct{})
+	wg := sync.WaitGroup{}
+
 	provider := func(context.Context) time.Duration {
-		called <- struct{}{}
+		wg.Done()
 		return 1 * time.Minute // Long timeout to block
 	}
+
+	wg.Add(1)
 
 	r := createRunner(
 		fxutil.Test[dependencies](
@@ -36,17 +40,20 @@ func TestHandleProvider(t *testing.T) {
 		))
 
 	r.start()
-	// either called receive a value or the test will fail as a timeout
-	<-called
+	// either the provider call wg.Done() or the test will fail as a timeout
+	wg.Wait()
 	assert.NoError(t, r.stop())
 }
 
 func TestRunnerCreation(t *testing.T) {
-	called := make(chan struct{})
-	callback := func(context.Context) time.Duration {
-		called <- struct{}{}
+	wg := sync.WaitGroup{}
+
+	provider := func(context.Context) time.Duration {
+		wg.Done()
 		return 1 * time.Minute // Long timeout to block
 	}
+
+	wg.Add(1)
 
 	lc := fxtest.NewLifecycle(t)
 	fxutil.Test[runner.Component](
@@ -56,14 +63,61 @@ func TestRunnerCreation(t *testing.T) {
 		config.MockModule(),
 		Module(),
 		// Supplying our provider by using the helper function
-		fx.Supply(NewProvider(callback)),
+		fx.Supply(NewProvider(provider)),
 	)
 
 	ctx := context.Background()
 	lc.Start(ctx)
 
-	// either called receive a value or the test will fail as a timeout
-	<-called
+	// either the provider call wg.Done() or the test will fail as a timeout
+	wg.Wait()
 
+	assert.NoError(t, lc.Stop(ctx))
+}
+
+func TestPriorityProviderOrder(t *testing.T) {
+	wg := sync.WaitGroup{}
+	m := sync.Mutex{}
+	eventSequence := []string{}
+
+	provider := func(context.Context) time.Duration {
+		m.Lock()
+		eventSequence = append(eventSequence, "provider")
+		m.Unlock()
+		wg.Done()
+		return 1 * time.Minute // Long timeout to block
+	}
+
+	priorityProvider := func(context.Context) time.Duration {
+		m.Lock()
+		eventSequence = append(eventSequence, "priorityProvider")
+		m.Unlock()
+		wg.Done()
+		return 1 * time.Minute // Long timeout to block
+	}
+
+	// We add 3 work unit because the priority provider are called twice at startup. One synchronousily and one asynchronosuly
+	wg.Add(3)
+
+	lc := fxtest.NewLifecycle(t)
+	fxutil.Test[runner.Component](
+		t,
+		fx.Supply(lc),
+		logimpl.MockModule(),
+		config.MockModule(),
+		Module(),
+		// Supplying our provider by using the helper function
+		fx.Supply(NewProvider(provider)),
+		fx.Supply(NewPriorityProvider(priorityProvider)),
+	)
+
+	ctx := context.Background()
+	lc.Start(ctx)
+
+	// either the provider call wg.Done() or the test will fail as a timeout
+	wg.Wait()
+	// it is expected to see twice priorityProvider. The first time is the synchronous call and the third time is the synchronous
+	// the goal of this test is to ensure priority provider are called before regular providers
+	assert.Equal(t, []string{"priorityProvider", "provider", "priorityProvider"}, eventSequence)
 	assert.NoError(t, lc.Stop(ctx))
 }

--- a/comp/metadata/runner/runnerimpl/runner_test.go
+++ b/comp/metadata/runner/runnerimpl/runner_test.go
@@ -116,8 +116,9 @@ func TestPriorityProviderOrder(t *testing.T) {
 
 	// either the provider call wg.Done() or the test will fail as a timeout
 	wg.Wait()
-	// it is expected to see twice priorityProvider. The first time is the synchronous call and the third time is the synchronous
-	// the goal of this test is to ensure priority provider are called before regular providers
-	assert.Equal(t, []string{"priorityProvider", "provider", "priorityProvider"}, eventSequence)
+	// it is expected to see three events. Priority providers are called twice at start up
+	assert.Equal(t, 3, len(eventSequence))
+	// ensure priority provider is the first provider to be executed
+	assert.Equal(t, "priorityProvider", eventSequence[0])
 	assert.NoError(t, lc.Stop(ctx))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->

### What does this PR do?

We add a new  `MetadataPriorityProvider`. This allow us to ensure the host metadata information is sent synchronously at start time. This is a workaround to an issue in the backend regarding [Metrics Tags Delay](https://datadoghq.atlassian.net/wiki/spaces/METRICSIN/pages/3082259924/Host+Tags+Delays) 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Workaround for incident https://app.datadoghq.com/incidents/25790

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

⚠️ **This change mitigates a race condition issue with the backend, but does not solve the problem 100% of the times. When doing the QA be aware that there might be cases in which the host tags are delayed** ⚠️ 


<details>
  <summary>Here is summary of the findings during the investigation of the incident</summary>
 The backend has multiple endpoints to consume different host information and create the necessary records in the database. The backend also has various ways to create a host entry in the DB.

- Via the `intake` endpoint. The data is stored in the PostgreSQL DB. The agents send the host tags information (agent V5 payload) and the system events.

- Via the `metadata` endpoint. This endpoint stores the information REDAPL.  The agent sends the metadata information to this endpoint (agent metadata, check metadata and host metadata). To our surprise, we found out that this endpoint also creates a host record in the PostgreSQL DB if not present.


Another essential thing to remember about the `intake` endpoint is that when a request is made and a host entry is read, what is read from the DB is stored in the **cache for 5 minutes**. This is to avoid doing too many reads in the DB.
In version 7.50, the agent first issues the host payload (agent V5 payload) to the  intake endpoint at startup. The payloads to the `metadata` endpoint were sent 1 minute after the agent startup. Here is the list of requests with their timestamp.

```
127.0.0.1 - - [14/Mar/2024 18:14:13] "GET /api/v1/validate?api_key=xxxxxxxxxx HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:14:19] "POST /intake/ HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:14:28] "POST /intake/ HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:14:28] "POST /api/v1/check_run HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:14:28] "POST /api/v2/series HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:14:43] "POST /api/v1/check_run HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:14:43] "POST /api/v2/series HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:14:58] "POST /api/v1/check_run HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:14:58] "POST /api/v2/series HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:15:13] "POST /api/v1/check_run HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:15:13] "POST /api/v2/series HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:15:13] "POST /api/v1/metadata HTTP/1.1" 200 -
```

Here, the first request to the intake creates the host record, and the second request to the intake endpoint is stored what is the DB in the cache.

The changes in 7.51 https://github.com/DataDog/datadog-agent/pull/20234 and https://github.com/DataDog/datadog-agent/pull/21146 relate to how the agent metadata and host payload are sent to the backend. The most significant change is that at startup, we spin up a bunch of goroutines, one per metadata provider (host tags, check metadata, agent metadata, and host metadata) and send the data to the backend.

```
127.0.0.1 - - [14/Mar/2024 18:18:08] "GET /api/v1/validate?api_key=xxxxxxxxxxx HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:18:08] "POST /api/v1/metadata HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:18:08] "POST /api/v1/metadata HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:18:14] "POST /api/v1/metadata HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:18:14] "POST /intake/ HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:18:23] "POST /intake/ HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:18:23] "POST /api/v1/check_run HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:18:23] "POST /api/v2/series HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:18:38] "POST /api/v1/check_run HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:18:38] "POST /api/v2/series HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:18:53] "POST /api/v1/check_run HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 18:18:53] "POST /api/v2/series HTTP/1.1" 200 -
```

The order in which the request is executed is random.
Here, the first request to the metadata creates the host record, and the first request to the intake endpoint is stored in the cache. This results in the cached result not having the tags.
That's why we saw an increase in tag delay in 7.51.0. Still, the delay is 5 minutes, when the cache expires and gets populated with the latest data.
The fix we suggested for 7.51.2 forced the intake payload to be sent first.

```
127.0.0.1 - - [14/Mar/2024 15:24:00] "GET /api/v1/validate?
127.0.0.1 - - [14/Mar/2024 15:24:07] "POST /intake/ HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 15:24:07] "POST /api/v1/metadata HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 15:24:07] "POST /api/v1/metadata HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 15:24:07] "POST /api/v1/metadata HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 15:24:07] "POST /intake/ HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 15:24:15] "POST /intake/ HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 15:24:15] "POST /api/v1/check_run HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 15:24:15] "POST /api/v2/series HTTP/1.1" 200 -
127.0.0.1 - - [14/Mar/2024 15:24:30] "POST /api/v1/check_run HTTP/1.1" 200 -
```

It mitigates the issue but does not solve the race condition in the backend. Since most of the requests are fired simultaneously, it is a matter of which backend service finishes processing the request first.
Since it is a race condition issue, the changes made in 7.51.0 do not affect all customers. Customers who tend to redeploy or restart the agent more often have a higher chance of hitting this race condition.
</details>




### Describe how to test/QA your changes

Ensure agent metrics have tags are present from the beginning. 
You can add system tags into the datadog configuration in the `tags` . We can add custom tags in the `datadog.yaml` file
Ex. `tags: ["foo:bar", "hello:world"]` 


To test that metrics do not have `N/A` tags. Run the agent with some custom tags. 
1. Ensure your agent shows in the UI under the infrastructure list 
<img width="1533" alt="Screenshot 2024-03-11 at 16 25 09" src="https://github.com/DataDog/datadog-agent/assets/4672858/770bbfbe-49a3-4bcb-9c7f-39f3c407ee59">
2. Go to the metrics explored and validate that when querying for our custom tags we do not get `nil` values
<img width="1266" alt="image" src="https://github.com/DataDog/datadog-agent/assets/4672858/f48b279d-53be-44fe-89b0-cac044d5c06b">

💡 In the screenshot below we can compare two agent running. One with the fix the other running from main.
<img width="2216" alt="image" src="https://github.com/DataDog/datadog-agent/assets/4672858/c154e12a-6db1-4f84-99ea-79ca97aa10ca">
We can see the one in main we see metrics with tags `N/A`

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
