### PR TITLE
enable language detection components only if both reporting and language detection are enabled

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -255,7 +255,7 @@ func start(log log.Component,
 	}
 
 	// Setup the leader forwarder for language detection and cluster checks
-	if config.GetBool("cluster_checks.enabled") || config.GetBool("language_detection.reporting.enabled") {
+	if config.GetBool("cluster_checks.enabled") || (config.GetBool("language_detection.enabled") && config.GetBool("language_detection.reporting.enabled")) {
 		apidca.NewGlobalLeaderForwarder(
 			config.GetInt("cluster_agent.cmd_port"),
 			config.GetInt("cluster_agent.max_connections"),

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -39,7 +39,7 @@ func storeGenerators(cfg config.Reader) []storeGenerator {
 		generators = append(generators, newPodStore)
 	}
 
-	if cfg.GetBool("language_detection.reporting.enabled") {
+	if cfg.GetBool("language_detection.enabled") && cfg.GetBool("language_detection.reporting.enabled") {
 		generators = append(generators, newDeploymentStore)
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -28,6 +28,16 @@ func TestStoreGenerators(t *testing.T) {
 			cfg: map[string]bool{
 				"cluster_agent.collect_kubernetes_tags": false,
 				"language_detection.reporting.enabled":  false,
+				"language_detection.enabled":            false,
+			},
+			expectedStoresGenerator: []storeGenerator{newNodeStore},
+		},
+		{
+			name: "All configurations disabled",
+			cfg: map[string]bool{
+				"cluster_agent.collect_kubernetes_tags": false,
+				"language_detection.reporting.enabled":  false,
+				"language_detection.enabled":            true,
 			},
 			expectedStoresGenerator: []storeGenerator{newNodeStore},
 		},
@@ -36,6 +46,7 @@ func TestStoreGenerators(t *testing.T) {
 			cfg: map[string]bool{
 				"cluster_agent.collect_kubernetes_tags": true,
 				"language_detection.reporting.enabled":  false,
+				"language_detection.enabled":            true,
 			},
 			expectedStoresGenerator: []storeGenerator{newNodeStore, newPodStore},
 		},
@@ -44,14 +55,25 @@ func TestStoreGenerators(t *testing.T) {
 			cfg: map[string]bool{
 				"cluster_agent.collect_kubernetes_tags": false,
 				"language_detection.reporting.enabled":  true,
+				"language_detection.enabled":            true,
 			},
 			expectedStoresGenerator: []storeGenerator{newNodeStore, newDeploymentStore},
+		},
+		{
+			name: "Language detection enabled",
+			cfg: map[string]bool{
+				"cluster_agent.collect_kubernetes_tags": false,
+				"language_detection.reporting.enabled":  true,
+				"language_detection.enabled":            false,
+			},
+			expectedStoresGenerator: []storeGenerator{newNodeStore},
 		},
 		{
 			name: "All configurations enabled",
 			cfg: map[string]bool{
 				"cluster_agent.collect_kubernetes_tags": true,
 				"language_detection.reporting.enabled":  true,
+				"language_detection.enabled":            true,
 			},
 			expectedStoresGenerator: []storeGenerator{newNodeStore, newPodStore, newDeploymentStore},
 		},

--- a/comp/languagedetection/client/clientimpl/client.go
+++ b/comp/languagedetection/client/clientimpl/client.go
@@ -103,7 +103,7 @@ type client struct {
 func newClient(
 	deps dependencies,
 ) clientComp.Component {
-	if !deps.Config.GetBool("language_detection.reporting.enabled") || !deps.Config.GetBool("cluster_agent.enabled") {
+	if !deps.Config.GetBool("language_detection.reporting.enabled") || !deps.Config.GetBool("language_detection.enabled") || !deps.Config.GetBool("cluster_agent.enabled") {
 		return optional.NewNoneOption[clientComp.Component]()
 	}
 

--- a/comp/languagedetection/client/clientimpl/client_test.go
+++ b/comp/languagedetection/client/clientimpl/client_test.go
@@ -48,6 +48,7 @@ func newTestClient(t *testing.T) (*client, chan *pbgo.ParentLanguageAnnotationRe
 		config.MockModule(),
 		fx.Replace(config.MockParams{Overrides: map[string]interface{}{
 			"language_detection.reporting.enabled":       "true",
+			"language_detection.enabled":                 "true",
 			"cluster_agent.enabled":                      "true",
 			"language_detection.reporting.buffer_period": "50ms",
 		}}),
@@ -70,37 +71,48 @@ func newTestClient(t *testing.T) (*client, chan *pbgo.ParentLanguageAnnotationRe
 
 func TestClientEnabled(t *testing.T) {
 	testCases := []struct {
-		languageEnabled     string
-		clusterAgentEnabled string
-		isSet               bool
+		languageDetectionEnabled          string
+		languageDetectionReportingEnabled string
+		clusterAgentEnabled               string
+		isSet                             bool
 	}{
-		{"true", "true", true},
-		{"true", "false", false},
-		{"false", "true", false},
-		{"false", "false", false},
+		{"true", "true", "true", true},
+		{"true", "true", "false", false},
+		{"false", "true", "true", false},
+		{"false", "true", "false", false},
+		{"true", "false", "true", false},
+		{"true", "false", "false", false},
+		{"false", "false", "true", false},
+		{"false", "false", "false", false},
 	}
 
 	for _, testCase := range testCases {
-		t.Run(fmt.Sprintf("language_enabled=%s, cluster_agent_enabled=%s", testCase.languageEnabled, testCase.clusterAgentEnabled), func(t *testing.T) {
-			deps := fxutil.Test[dependencies](t, fx.Options(
-				config.MockModule(),
-				fx.Replace(config.MockParams{Overrides: map[string]interface{}{
-					"language_detection.reporting.enabled": testCase.languageEnabled,
-					"cluster_agent.enabled":                testCase.clusterAgentEnabled,
-				}}),
-				telemetry.MockModule(),
-				logimpl.MockModule(),
-				fx.Supply(workloadmeta.NewParams()),
-				workloadmeta.MockModuleV2(),
-				fx.Provide(func(m workloadmeta.Mock) workloadmeta.Component {
-					return m.(workloadmeta.Component)
-				}),
-			))
+		t.Run(fmt.Sprintf(
+			"language_enabled=%s, language_detection_reporting_enabled=%s, cluster_agent_enabled=%s",
+			testCase.languageDetectionEnabled,
+			testCase.languageDetectionReportingEnabled,
+			testCase.clusterAgentEnabled),
+			func(t *testing.T) {
+				deps := fxutil.Test[dependencies](t, fx.Options(
+					config.MockModule(),
+					fx.Replace(config.MockParams{Overrides: map[string]interface{}{
+						"language_detection.enabled":           testCase.languageDetectionEnabled,
+						"language_detection.reporting.enabled": testCase.languageDetectionReportingEnabled,
+						"cluster_agent.enabled":                testCase.clusterAgentEnabled,
+					}}),
+					telemetry.MockModule(),
+					logimpl.MockModule(),
+					fx.Supply(workloadmeta.NewParams()),
+					workloadmeta.MockModuleV2(),
+					fx.Provide(func(m workloadmeta.Mock) workloadmeta.Component {
+						return m.(workloadmeta.Component)
+					}),
+				))
 
-			optionalCl := newClient(deps).(optional.Option[clientComp.Component])
-			_, ok := optionalCl.Get()
-			assert.Equal(t, testCase.isSet, ok)
-		})
+				optionalCl := newClient(deps).(optional.Option[clientComp.Component])
+				_, ok := optionalCl.Get()
+				assert.Equal(t, testCase.isSet, ok)
+			})
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR checks for both `language_detection.reporting.enabled` and `language_detection.enabled` when deciding whether or not to activate components of language detection and library injection.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Avoid unexpected behaviour in case of miss-configuration.
For example, if `language_detection.enabled` is set to `false`, while `language_detection.reporting.enabled` is set to `true`, we should not activate any component, since it will lead to wasting resources for no benefit (e.g. enabling the deployment collector in workloadmeta, enabling the handler and patcher, etc.)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- This PR is opened for 7.53.0 since the existing behaviour impacts a feature that is in beta and doesn't cause failure, it only activates extra components in case of misconfiguration.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Ensure the components are still activated and work as expected in case of correct configuration (same QA as [this](https://github.com/DataDog/datadog-agent/pull/23293) PR)
- Ensure that no extra components are activated in case `language_detection.enabled` is set to `false` whereas `language_detection.reporting.enabled` is set to `true`. (See sample QA below)


Deploying with the operator:
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  override:
    nodeAgent:
      containers:
        agent:
          env:
            - name: "DD_DOGSTATSD_TAG_CARDINALITY"
              value: "high"
            - name: "DD_LANGUAGE_DETECTION_ENABLED"
              value: "false"
            - name: "DD_LANGUAGE_DETECTION_REPORTING_ENABLED"
              value: "true"
            - name: "DD_LANGUAGE_DETECTION_REPORTING_BUFFER_PERIOD"
              value: "5s"
            - name: "DD_LANGUAGE_DETECTION_REPORTING_REFRESH_PERIOD"
              value: "10s"
            - name: "DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED"
              value: "true"
            - name: "DD_TELEMETRY_ENABLED"
              value: "true"
        process-agent:
          env:
            - name: "DD_LANGUAGE_DETECTION_ENABLED"
              value: "true"
            - name: "DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED"
              value: "true"
    clusterAgent:
      containers:
        cluster-agent:
          env:
            - name: "DD_LANGUAGE_DETECTION_ENABLED"
              value: "false"
            - name: "DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED"
              value: "true"
            - name: "DD_CLUSTER_AGENT_LANGUAGE_DETECTION_CLEANUP_PERIOD"
              value: "15s"
            - name: "DD_CLUSTER_AGENT_LANGUAGE_DETECTION_CLEANUP_LANGUAGE_TTL"
              value: "30s"
```

Create any deployment.

Ensure that:
- the deployment is not collected to workloadmeta (indicating that the kubeapiserver deployment collector is not activated)
- no cluster agent logs shows that the language detection patcher was activated (e.g. `Starting language detection patcher`)
- no agent log shows that the language detection client was activated (e.g. `Starting language detection client`)

