### PR TITLE
usm: kafka: Remove redundant struct

### DIFF
--- a/pkg/network/ebpf/c/protocols/kafka/types.h
+++ b/pkg/network/ebpf/c/protocols/kafka/types.h
@@ -24,16 +24,6 @@ typedef struct {
     __u16 request_api_version;
     char topic_name[TOPIC_NAME_MAX_STRING_SIZE];
     __u16 topic_name_size;
-} kafka_transaction_batch_entry_t;
-
-// Kafka transaction information associated to a certain socket (tuple_t)
-typedef struct {
-    // this field is used to disambiguate segments in the context of keep-alives
-    // we populate it with the TCP seq number of the request and then the response segments
-    __u32 tcp_seq;
-
-    __u32 current_offset_in_request_fragment;
-    kafka_transaction_batch_entry_t base;
 } kafka_transaction_t;
 
 #endif

--- a/pkg/network/ebpf/c/protocols/kafka/usm-events.h
+++ b/pkg/network/ebpf/c/protocols/kafka/usm-events.h
@@ -4,6 +4,6 @@
 #include "protocols/kafka/types.h"
 #include "protocols/events.h"
 
-USM_EVENTS_INIT(kafka, kafka_transaction_batch_entry_t, KAFKA_BATCH_SIZE);
+USM_EVENTS_INIT(kafka, kafka_transaction_t, KAFKA_BATCH_SIZE);
 
 #endif

--- a/pkg/network/protocols/kafka/types.go
+++ b/pkg/network/protocols/kafka/types.go
@@ -15,4 +15,4 @@ import "C"
 
 type ConnTuple C.conn_tuple_t
 
-type EbpfTx C.kafka_transaction_batch_entry_t
+type EbpfTx C.kafka_transaction_t


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The original kafka_transaction_t wrapped kafka_transaction_batch_entry_t with 2 other fields however, the other fields were redundant, thus after removing them we left with a reudndnat wrapper to kafka_transaction_batch_entry_t. After removing all redundnat fields and structs renamed kafka_transaction_batch_entry_t to kafka_transaction_t for the simplicity
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
code cleanup
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
