### PR TITLE
[CWS] `upload_security_agent_tests_*` do not need `test_ebpf_*`

### DIFF
--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -103,7 +103,7 @@ kernel_matrix_testing_setup_env_security_agent_x64:
 upload_security_agent_tests_x64:
   extends:
     - .upload_security_agent_tests
-  needs: ["go_deps", "prepare_ebpf_functional_tests_x64", "tests_ebpf_x64"]
+  needs: ["go_deps", "prepare_ebpf_functional_tests_x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:
@@ -113,7 +113,7 @@ upload_security_agent_tests_x64:
 upload_security_agent_tests_arm64:
   extends:
     - .upload_security_agent_tests
-  needs: ["go_deps", "prepare_ebpf_functional_tests_arm64", "tests_ebpf_arm64"]
+  needs: ["go_deps", "prepare_ebpf_functional_tests_arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["arch:arm64"]
   variables:


### PR DESCRIPTION
### What does this PR do?

This PR removes some unneeded edge in the CI pipeline, allowing the CWS KMT tests to start/finish sooner

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
