### PR TITLE
Revert "[CONTINT-3909] Add tests for dogstatsd origin detection on ECS"

### DIFF
--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -402,27 +402,17 @@ func (suite *ecsSuite) TestCPU() {
 	})
 }
 
-func (suite *ecsSuite) TestDogtstatsdUDS() {
-	suite.testDogstatsd("dogstatsd-uds")
-}
-
-func (suite *ecsSuite) TestDogtstatsdUDP() {
-	suite.testDogstatsd("dogstatsd-udp")
-}
-
-func (suite *ecsSuite) testDogstatsd(taskName string) {
+func (suite *ecsSuite) TestDogstatsd() {
+	// Test dogstatsd origin detection with UDS
 	suite.testMetric(&testMetricArgs{
 		Filter: testMetricFilterArgs{
 			Name: "custom.metric",
-			Tags: []string{
-				`^task_name:.*-` + taskName + `-ec2$`,
-			},
 		},
 		Expect: testMetricExpectArgs{
 			Tags: &[]string{
 				`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
 				`^container_id:`,
-				`^container_name:ecs-.*-` + taskName + `-ec2-`,
+				`^container_name:ecs-.*-dogstatsd-uds-ec2-`,
 				`^docker_image:ghcr.io/datadog/apps-dogstatsd:main$`,
 				`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
 				`^ecs_container_name:dogstatsd$`,
@@ -434,8 +424,8 @@ func (suite *ecsSuite) testDogstatsd(taskName string) {
 				`^series:`,
 				`^short_image:apps-dogstatsd$`,
 				`^task_arn:`,
-				`^task_family:.*-` + taskName + `-ec2$`,
-				`^task_name:.*-` + taskName + `-ec2$`,
+				`^task_family:.*-dogstatsd-uds-ec2$`,
+				`^task_name:.*-dogstatsd-uds-ec2$`,
 				`^task_version:[[:digit:]]+$`,
 			},
 		},


### PR DESCRIPTION
#incident-25908

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR reverts https://github.com/DataDog/datadog-agent/pull/23532 which breaks dogstatsd tests, due to the fact that we can't filter metrics by regexp.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
