### PR TITLE
[CI] Add the `-no_warn_duplicate_libraries` ldflag when running inv test on `XCode >15`

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -231,7 +231,7 @@ def get_build_flags(
     if sys.platform == "darwin":
         # On macOS work around https://github.com/golang/go/issues/38824
         # as done in https://go-review.googlesource.com/c/go/+/372798
-        extldflags += "-Wl,-bind_at_load,-no_warn_duplicate_libraries"
+        extldflags += "-Wl,-bind_at_load"
 
         # On macOS when using XCode 15 the -no_warn_duplicate_libraries linker flag is needed to avoid getting ld warnings
         # for duplicate libraries: `ld: warning: ignoring duplicate libraries: '-ldatadog-agent-rtloader', '-ldl'`.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds the `-no_warn_duplicate_libraries` flag when running inv test on XCode >15.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

If you currently run the inv test invoke task on a MacOS machine with XCode 15 you’ll encounter some warning messages. Warnings should in theory be fine but we’re using gotestsum which is handling warning as errors, breaking its run [1]. Examples:
```
> inv -e test --rerun-fails=2 --coverage
=== FAIL: comp/trace/config TestMockConfig (2.29s)
    writer.go:40: [Fx] ...
    config_test.go:2526: 
                Error Trace:    /Users/alexandre.menasria/datadog-agent/comp/trace/config/config_test.go:2526
                Error:          Should not be: "foo"
                Test:           TestMockConfig

=== Errors
ld: warning: ignoring duplicate libraries: '-ldatadog-agent-rtloader', '-ldl'
...
ld: warning: ignoring duplicate libraries: '-ldatadog-agent-rtloader', '-ldl'
```

```
> inv -e test --rerun-fails=2 --coverage  
Using default modules and targets
--- Setting rtloader paths to lib:/Users/alexandre.menasria/datadog-agent/dev/lib | header:/Users/alexandre.menasria/datadog-agent/dev/include | common headers:
--- Flavor base: unit tests
-----  Module '/Users/alexandre.menasria/datadog-agent'
cd /Users/alexandre.menasria/datadog-agent && gotestsum  --jsonfile "module_test_output.json"  --format pkgname --rerun-fails=2 --packages="./pkg/... ./cmd/... ./comp/..." --raw-command /Users/alexandre.menasria/datadog-agent/test_with_coverage.sh -- -mod=mod -tags "kubelet ec2 oracle apm clusterchecks kubeapiserver consul jmx process gce fargateprocess python test orchestrator etcd otlp zlib zk" -gcflags="" -ldflags="-X github.com/DataDog/datadog-agent/pkg/version.Commit=165f0d4a19 -X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=7.53.0-devel+git.191.165f0d4 -X github.com/DataDog/datadog-agent/pkg/serializer.AgentPayloadVersion=v5.0.105 -X github.com/DataDog/datadog-agent/pkg/config/setup.ForceDefaultPython=true -X github.com/DataDog/datadog-agent/pkg/config/setup.DefaultPython=3 -r /Users/alexandre.menasria/datadog-agent/dev/lib '-extldflags=-Wl,-bind_at_load ' "   -vet=off  -timeout 180s -short -covermode=count  
✓  pkg/aggregator (6.615s) (coverage: 67.5% of statements)
✓  pkg/aggregator/internal/tags (683ms) (coverage: 91.4% of statements)
✓  pkg/aggregator/internal/util (328ms) (coverage: 100.0% of statements)
✓  pkg/aggregator/mocksender (744ms) (coverage: 61.7% of statements)
∅  pkg/aggregator/sender
✓  pkg/autodiscovery (1.051s) (coverage: 70.7% of statements)
✓  pkg/autodiscovery/common/types (312ms) (coverage: 46.3% of statements)
✓  pkg/autodiscovery/common/utils (686ms) (coverage: 84.1% of statements)
✓  pkg/autodiscovery/configresolver (776ms) (coverage: 87.5% of statements)
✓  pkg/autodiscovery/integration (339ms) (coverage: 64.0% of statements)
✓  pkg/autodiscovery/listeners (3.006s) (coverage: 41.7% of statements)
∅  pkg/autodiscovery/providers/names
✓  pkg/autodiscovery/scheduler (680ms) (coverage: 80.0% of statements)
∅  pkg/autodiscovery/telemetry
∅  pkg/cli/standalone
# github.com/DataDog/datadog-agent/pkg/cli/subcommands/check.test
ld: warning: ignoring duplicate libraries: '-ldatadog-agent-rtloader', '-ldl'
✓  pkg/cli/subcommands/check (1.03s) (coverage: 12.4% of statements)
✓  pkg/autodiscovery/providers (6.094s) (coverage: 60.8% of statements)
# github.com/DataDog/datadog-agent/pkg/cli/subcommands/clusterchecks.test
ld: warning: ignoring duplicate libraries: '-ldatadog-agent-rtloader', '-ldl'
✓  pkg/cli/subcommands/clusterchecks (882ms) (coverage: 26.2% of statements)
✓  pkg/cli/subcommands/config (1.238s) (coverage: 20.3% of statements)
# github.com/DataDog/datadog-agent/pkg/cli/subcommands/dcaconfigcheck.test
ld: warning: ignoring duplicate libraries: '-ldatadog-agent-rtloader', '-ldl'
# github.com/DataDog/datadog-agent/pkg/cli/subcommands/dcaflare.test
ld: warning: ignoring duplicate libraries: '-ldatadog-agent-rtloader', '-ldl'
✓  pkg/cli/subcommands/dcaconfigcheck (897ms) (coverage: 85.7% of statements)
```

This most likely happens because the `-ldl` and `-ldatadig-agent-rtloader` flags are added in several places (e.g in [pkg/collector/python/aggregator.go](https://github.com/DataDog/datadog-agent/blob/de157bfec3ac33c10e0812889162619a85368875/pkg/collector/python/aggregator.go/#L20-L25) and in [pkg/collector/python/datadog_agent.go](https://github.com/DataDog/datadog-agent/blob/de157bfec3ac33c10e0812889162619a85368875/pkg/collector/python/datadog_agent.go/#L30-L36)). 

[From this article it seems that this warning was not silent anymore since Xcode 15](https://indiestack.com/2023/10/xcode-15-duplicate-library-linker-warnings/). 

[1] Runs are broken like this:
- If no test fails but the warning appears `gotestsum` will return an exit code != 0.
- If a test fails and the warning appears `gotestsum` won’t rerun the test (because it doesn’t rerun on failure outside of the test).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
