### PR TITLE
[ASCII-1276] Fix host boot time off by one diff when called twice in test

### DIFF
--- a/comp/metadata/host/hostimpl/utils/host_nix_test.go
+++ b/comp/metadata/host/hostimpl/utils/host_nix_test.go
@@ -29,7 +29,6 @@ func TestGetHostInfo(t *testing.T) {
 	// boot time can be computed dynamically using uptime on some platforms, in which case
 	// there can be an off-by-one error
 	assert.InDelta(t, expected.BootTime, info.BootTime, 1.5)
-	assert.Equal(t, expected.BootTime, info.BootTime)
 	assert.Equal(t, expected.HostID, info.HostID)
 	assert.Equal(t, expected.Hostname, info.Hostname)
 	assert.Equal(t, expected.KernelArch, info.KernelArch)

--- a/comp/metadata/host/hostimpl/utils/host_nix_test.go
+++ b/comp/metadata/host/hostimpl/utils/host_nix_test.go
@@ -26,6 +26,9 @@ func TestGetHostInfo(t *testing.T) {
 	info := GetInformation()
 	expected, err := host.Info()
 	require.NoError(t, err)
+	// boot time can be computed dynamically using uptime on some platforms, in which case
+	// there can be an off-by-one error
+	assert.InDelta(t, expected.BootTime, info.BootTime, 1.5)
 	assert.Equal(t, expected.BootTime, info.BootTime)
 	assert.Equal(t, expected.HostID, info.HostID)
 	assert.Equal(t, expected.Hostname, info.Hostname)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Ignore potential off-by-one difference in boot time value when calling `gopsutil` `host.Info()`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The boot time can be computed dynamically from the uptime on some platforms, in which case the number of seconds can have an off by one difference depending on nanoseconds.
Just allow this off by one to avoid the test being flaky.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
