### PR TITLE
[e2e] add custom workload option to k8s environments

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,7 +185,7 @@ variables:
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
   # Make sure to update test-infra-definitions version in go.mod as well
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: eb67dd1667e4
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: f2ab6e511638
   DATADOG_AGENT_BUILDERS: v22276738-b36b132
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded
@@ -206,7 +206,7 @@ variables:
   RUN_UNIT_TESTS: "auto" # Should be "auto", "on", "off" it will change the trigger condition for unit tests on branch != main
   # skip known flaky tests by default
   GO_TEST_SKIP_FLAKE: "true"
-  
+
   # List of parameters retrieved from AWS SSM
   # They must be defined as environment variables in the GitLab CI/CD settings, to ease rotation if needed
   AGENT_QA_PROFILE_SSM_NAME: ci.datadog-agent.agent-qa-profile  # agent-ci-experience

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,7 +185,7 @@ variables:
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
   # Make sure to update test-infra-definitions version in go.mod as well
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: f2ab6e511638
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 5642ab39608a
   DATADOG_AGENT_BUILDERS: v22276738-b36b132
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/test/new-e2e/examples/kind_test.go
+++ b/test/new-e2e/examples/kind_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/kubernetes"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/dogstatsd"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
+	compkube "github.com/DataDog/test-infra-definitions/components/kubernetes"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,7 +28,16 @@ type myKindSuite struct {
 }
 
 func TestMyKindSuite(t *testing.T) {
-	e2e.Run(t, &myKindSuite{}, e2e.WithProvisioner(awskubernetes.Provisioner(awskubernetes.WithoutFakeIntake())))
+	e2e.Run(t, &myKindSuite{}, e2e.WithProvisioner(
+		awskubernetes.Provisioner(
+			awskubernetes.WithoutFakeIntake(),
+			awskubernetes.WithWorkloadApp(func(e config.CommonEnvironment, kubeProvider *kubernetes.Provider) (*compkube.Workload, error) {
+				return nginx.K8sAppDefinition(e, kubeProvider, "nginx", nil)
+			}),
+			awskubernetes.WithWorkloadApp(func(e config.CommonEnvironment, kubeProvider *kubernetes.Provider) (*compkube.Workload, error) {
+				return dogstatsd.K8sAppDefinition(e, kubeProvider, "dogstatsd", 8125, "/var/run/datadog/dsd.socket")
+			}),
+		)))
 }
 
 func (v *myKindSuite) TestClusterAgentInstalled() {

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -244,10 +244,6 @@ require (
 
 require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.30.0 // indirect
-	github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.30.0 // indirect
-	github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.30.0 // indirect
-	github.com/pulumi/pulumi-azure-native-sdk/v2 v2.30.0 // indirect
 	github.com/pulumi/pulumi-docker/sdk/v4 v4.5.1 // indirect
 	github.com/pulumi/pulumi-eks/sdk/v2 v2.2.1 // indirect
 )

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -27,7 +27,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240312182905-eb67dd1667e4
+	github.com/DataDog/test-infra-definitions v0.0.0-20240318100125-f2ab6e511638
 	github.com/aws/aws-sdk-go-v2 v1.25.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.6
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -27,7 +27,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240318100125-f2ab6e511638
+	github.com/DataDog/test-infra-definitions v0.0.0-20240315190045-5642ab39608a
 	github.com/aws/aws-sdk-go-v2 v1.25.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.6
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1
@@ -244,6 +244,10 @@ require (
 
 require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.30.0 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.30.0 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.30.0 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/v2 v2.30.0 // indirect
 	github.com/pulumi/pulumi-docker/sdk/v4 v4.5.1 // indirect
 	github.com/pulumi/pulumi-eks/sdk/v2 v2.2.1 // indirect
 )

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.19.0 h1:Wvz/63/q39EpVwSH1T8jVyRvP
 github.com/DataDog/datadog-api-client-go/v2 v2.19.0/go.mod h1:oD5Lx8Li3oPRa/BSBenkn4i48z+91gwYORF/+6ph71g=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20240312182905-eb67dd1667e4 h1:VJK6IGOJkQQngvhUP1QEM0O0crboxlLFzVvO/2YOZy0=
-github.com/DataDog/test-infra-definitions v0.0.0-20240312182905-eb67dd1667e4/go.mod h1:e2N24reKK2YalYpReudXYPTIiCRU+mWBq8vKVaYrQ7E=
+github.com/DataDog/test-infra-definitions v0.0.0-20240318100125-f2ab6e511638 h1:OgjcK75SKzcoeivBZsXZek9ubgtFzpxQDRFzISg3iTk=
+github.com/DataDog/test-infra-definitions v0.0.0-20240318100125-f2ab6e511638/go.mod h1:KNF9SeKFoqxSSucHpuXQ1QDmpi7HFS9yr5kM2h9ls3c=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,6 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.19.0 h1:Wvz/63/q39EpVwSH1T8jVyRvP
 github.com/DataDog/datadog-api-client-go/v2 v2.19.0/go.mod h1:oD5Lx8Li3oPRa/BSBenkn4i48z+91gwYORF/+6ph71g=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
+github.com/DataDog/test-infra-definitions v0.0.0-20240315190045-5642ab39608a h1:FAY93TQaM+fY0bWhGqN5XqNBgIa/03KMGSejdK3saJY=
+github.com/DataDog/test-infra-definitions v0.0.0-20240315190045-5642ab39608a/go.mod h1:KNF9SeKFoqxSSucHpuXQ1QDmpi7HFS9yr5kM2h9ls3c=
 github.com/DataDog/test-infra-definitions v0.0.0-20240318100125-f2ab6e511638 h1:OgjcK75SKzcoeivBZsXZek9ubgtFzpxQDRFzISg3iTk=
 github.com/DataDog/test-infra-definitions v0.0.0-20240318100125-f2ab6e511638/go.mod h1:KNF9SeKFoqxSSucHpuXQ1QDmpi7HFS9yr5kM2h9ls3c=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
@@ -372,6 +374,14 @@ github.com/pulumi/pulumi-aws/sdk/v6 v6.25.0 h1:KstWR3AnkXD72ow0xxOzsAkihF+Kdzdda
 github.com/pulumi/pulumi-aws/sdk/v6 v6.25.0/go.mod h1:Ar4SJq3jbKLps3879H5ZvwUt/VnFp/GKbWw1mhjeQek=
 github.com/pulumi/pulumi-awsx/sdk/v2 v2.5.0 h1:sCzgswv1p7G8RUkvUjDgDnrdi7vBRxTtA8Hwtoqabsc=
 github.com/pulumi/pulumi-awsx/sdk/v2 v2.5.0/go.mod h1:lv+hzv8kilWjMNOPcJS8cddJa51d3IdCOPY7cNd2NuU=
+github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.30.0 h1:Zv5fc3sEUpTJs6CKGgq15p/V+qcpehPyBV0gt/v4Hjk=
+github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.30.0/go.mod h1:7qUlHbil4nHAX6L4uLMsZ2CLIOsIimpOfz2gYSjyTRc=
+github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.30.0 h1:uQK4DBsG/xKburzd5+D4AZq9nS8KnNL5cBlo+aq0ESo=
+github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.30.0/go.mod h1:P9FKt4pPp66Qf4Og2fHtayStJwQtqfdBD7/5M0WhH2s=
+github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.30.0 h1:NseE+tCpYxQVp8SoMJdqF0C0YaIo695Uncj8KaPtLbk=
+github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.30.0/go.mod h1:tHHJMZxE7vR/iLzpd/YYkOCGw6mDOjK99WteVwzqIrs=
+github.com/pulumi/pulumi-azure-native-sdk/v2 v2.30.0 h1:G+zBipeTb13Bjkkkt11zTiVpfMxQi04Oui1BSkzFKfg=
+github.com/pulumi/pulumi-azure-native-sdk/v2 v2.30.0/go.mod h1:lFDN9WdOaA136pQCoyHAeCxrrD56TLpZnf16VB0UwrE=
 github.com/pulumi/pulumi-command/sdk v0.9.2 h1:2siCFR8pS2sSwXkeWiLrprGEtBL54FsHTzdyl125UuI=
 github.com/pulumi/pulumi-command/sdk v0.9.2/go.mod h1:VeUXTI/iTgKVjRChRJbLRlBVGxAH+uymscfwzBC2VqY=
 github.com/pulumi/pulumi-docker/sdk/v4 v4.5.1 h1:gyuuECcHaPPop7baKfjapJJYnra6s/KdG4QITGu0kAI=

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -14,8 +14,6 @@ github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53y
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/test-infra-definitions v0.0.0-20240315190045-5642ab39608a h1:FAY93TQaM+fY0bWhGqN5XqNBgIa/03KMGSejdK3saJY=
 github.com/DataDog/test-infra-definitions v0.0.0-20240315190045-5642ab39608a/go.mod h1:KNF9SeKFoqxSSucHpuXQ1QDmpi7HFS9yr5kM2h9ls3c=
-github.com/DataDog/test-infra-definitions v0.0.0-20240318100125-f2ab6e511638 h1:OgjcK75SKzcoeivBZsXZek9ubgtFzpxQDRFzISg3iTk=
-github.com/DataDog/test-infra-definitions v0.0.0-20240318100125-f2ab6e511638/go.mod h1:KNF9SeKFoqxSSucHpuXQ1QDmpi7HFS9yr5kM2h9ls3c=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=
@@ -374,14 +372,6 @@ github.com/pulumi/pulumi-aws/sdk/v6 v6.25.0 h1:KstWR3AnkXD72ow0xxOzsAkihF+Kdzdda
 github.com/pulumi/pulumi-aws/sdk/v6 v6.25.0/go.mod h1:Ar4SJq3jbKLps3879H5ZvwUt/VnFp/GKbWw1mhjeQek=
 github.com/pulumi/pulumi-awsx/sdk/v2 v2.5.0 h1:sCzgswv1p7G8RUkvUjDgDnrdi7vBRxTtA8Hwtoqabsc=
 github.com/pulumi/pulumi-awsx/sdk/v2 v2.5.0/go.mod h1:lv+hzv8kilWjMNOPcJS8cddJa51d3IdCOPY7cNd2NuU=
-github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.30.0 h1:Zv5fc3sEUpTJs6CKGgq15p/V+qcpehPyBV0gt/v4Hjk=
-github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.30.0/go.mod h1:7qUlHbil4nHAX6L4uLMsZ2CLIOsIimpOfz2gYSjyTRc=
-github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.30.0 h1:uQK4DBsG/xKburzd5+D4AZq9nS8KnNL5cBlo+aq0ESo=
-github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.30.0/go.mod h1:P9FKt4pPp66Qf4Og2fHtayStJwQtqfdBD7/5M0WhH2s=
-github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.30.0 h1:NseE+tCpYxQVp8SoMJdqF0C0YaIo695Uncj8KaPtLbk=
-github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.30.0/go.mod h1:tHHJMZxE7vR/iLzpd/YYkOCGw6mDOjK99WteVwzqIrs=
-github.com/pulumi/pulumi-azure-native-sdk/v2 v2.30.0 h1:G+zBipeTb13Bjkkkt11zTiVpfMxQi04Oui1BSkzFKfg=
-github.com/pulumi/pulumi-azure-native-sdk/v2 v2.30.0/go.mod h1:lFDN9WdOaA136pQCoyHAeCxrrD56TLpZnf16VB0UwrE=
 github.com/pulumi/pulumi-command/sdk v0.9.2 h1:2siCFR8pS2sSwXkeWiLrprGEtBL54FsHTzdyl125UuI=
 github.com/pulumi/pulumi-command/sdk v0.9.2/go.mod h1:VeUXTI/iTgKVjRChRJbLRlBVGxAH+uymscfwzBC2VqY=
 github.com/pulumi/pulumi-docker/sdk/v4 v4.5.1 h1:gyuuECcHaPPop7baKfjapJJYnra6s/KdG4QITGu0kAI=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add workloadApps option to Kind provisioner

test-infra-definitions changelog: https://github.com/DataDog/test-infra-definitions/compare/eb67dd1667e4...5642ab39608a

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

AML and others need to add custom workload apps to their Kind environment. This PR adds a `WithWorkloadApp` option to the Kind provider.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This option works fine when apps do not have dependencies on resources previously declared in the kind run function (agent, fakeintake). If any app needs to wait for any other resource, then we recommend defining a custom run function.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
