### PR TITLE
remove process_raw_message warning for windowsevents tailer

### DIFF
--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -124,9 +124,6 @@ func NewTailer(evtapi evtapi.API, source *sources.LogSource, config *Config, out
 	}
 
 	if len(source.Config.ProcessingRules) > 0 && config.ProcessRawMessage {
-		log.Warn("The logs processing rules currently apply to the raw internal windowsevent log structure. These rules can now be applied to the message content only, and we plan to make this the default behavior in the future.")
-		log.Warn("In order to immediately switch to this new behavior, set 'process_raw_message' to 'false' in your logs integration config and adapt your processing rules accordingly.")
-		log.Warn("Please contact Datadog support for more information.")
 		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:windowsevent"})
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
removes the warning message about `process_raw_message` behavior/deprecation from the windowsevents tailer.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
There are filtering rules used by customers that the new behavior does not currently support. 
for example, `EventID` is a structured field that is not included in the eventlog rendered message.
```
       log_processing_rules:
       - type: include_at_match
         name: relevant_security_events
         pattern: '"EventID":(?:{"value":)?"(1102|4624|4625)"'
```
So we're removing the warning until there is support for actions a customer can take.

https://datadoghq.atlassian.net/browse/WINA-573

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
