### PR TITLE
(fleet) add a tracer OCI entry to the catalog

### DIFF
--- a/pkg/updater/defaults/boostrap.json
+++ b/pkg/updater/defaults/boostrap.json
@@ -1,4 +1,4 @@
 {
   "datadog-agent": "7.53.0-devel.git.156.4681fd9.pipeline.29311299-1",
-  "dd-trace-java": "1.31.0"
+  "dd-trace-java": "1.32.0-SNAPSHOT~09be0fb775~pipeline.29892278.beta.09be0fb7"
 }

--- a/pkg/updater/defaults/catalog.json
+++ b/pkg/updater/defaults/catalog.json
@@ -2,10 +2,8 @@
   "packages": [
     {
       "package": "dd-trace-java",
-      "version": "1.31.0",
-      "url": "https://storage.googleapis.com/updater-dev/dd-trace-java-1.31.0.tar",
-      "sha256": "9c0e49e671430a4a10f1dfbf64624bab34b7b190576669a37f3aaeef8fbf4a7f",
-      "size": 26594816
+      "version": "1.32.0-SNAPSHOT~09be0fb775~pipeline.29892278.beta.09be0fb7",
+      "url": "oci://us-docker.pkg.dev/datadog-sandbox/updater-dev/auto_inject-java@sha256:7235bf68d0a44afc97f5c0c720c0ad3c7be1e6099cf437546633c46ae35f30f4"
     },
     {
       "package": "datadog-agent",


### PR DESCRIPTION
This PR:
- Adds a tracer OCI to the catalog
- Fixes the handling of remote images without an explicit platform set