### PR TITLE
[CWS] add config option to skip the timeout when using remote workloadmeta client

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -26,7 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
-	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -193,12 +192,7 @@ func (c *GenericCollector) Run() {
 			}
 		}
 
-		var response interface{}
-		err := grpcutil.DoWithTimeout(func() error {
-			var err error
-			response, err = c.stream.Recv()
-			return err
-		}, streamRecvTimeout)
+		response, err := c.stream.Recv()
 		if err != nil {
 			// at the end of stream, but its OK
 			if err == io.EOF {

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
@@ -120,7 +120,7 @@ func (s *streamHandler) HandleResponse(resp interface{}) ([]workloadmeta.Collect
 }
 
 func (s *streamHandler) HandleResync(store workloadmeta.Component, events []workloadmeta.CollectorEvent) {
-	var entities []workloadmeta.Entity
+	entities := make([]workloadmeta.Entity, 0, len(events))
 	for _, event := range events {
 		entities = append(entities, event.Entity)
 	}

--- a/comp/core/workloadmeta/server/server.go
+++ b/comp/core/workloadmeta/server/server.go
@@ -56,7 +56,7 @@ func (s *Server) StreamEntities(in *pb.WorkloadmetaStreamRequest, out pb.AgentSe
 			}
 			eventBundle.Acknowledge()
 
-			var protobufEvents []*pb.WorkloadmetaEvent
+			protobufEvents := make([]*pb.WorkloadmetaEvent, 0, len(eventBundle.Events))
 
 			for _, event := range eventBundle.Events {
 				protobufEvent, err := protoutils.ProtobufEventFromWorkloadmetaEvent(event)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1216,6 +1216,9 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("security_agent.remote_tagger", true)
 	config.BindEnvAndSetDefault("security_agent.remote_workloadmeta", false) // TODO: switch this to true when ready
 
+	// debug config to enable a remote client to receive data from the workloadmeta agent without a timeout
+	config.BindEnvAndSetDefault("workloadmeta.remote.recv_without_timeout", false)
+
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.enabled", false, "DD_SECURITY_AGENT_INTERNAL_PROFILING_ENABLED")
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.site", DefaultSite, "DD_SECURITY_AGENT_INTERNAL_PROFILING_SITE", "DD_SITE")
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.profile_dd_url", "", "DD_SECURITY_AGENT_INTERNAL_PROFILING_DD_URL", "DD_APM_INTERNAL_PROFILING_DD_URL")


### PR DESCRIPTION
### What does this PR do?

This PR optimizes the stream operation of the remote workload meta collector, by letting the `Recv` do its job and removing the `DoWithTimeout` call.

Each `DoWithTimeout` call creates a new goroutime, a new timer, and then select on it incurring a huge cost for each `Recv` Call.

`DoWithTimeout` is good for unfrequent calls, for example in the tagger where there is a real request/response model. In the case of a stream where we expect a lot of events to go through, this starts to be a bottleneck. Moreover we actually don't really want to have a 10 min timeout, if the connection is still up and the stream flowing we can continue receiving events.

Notebook showing the improvement https://ddstaging.datadoghq.com/notebook/7655823/paul-mar-12-2024-09-52

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
