### PR TITLE
SMP - lading upgrade from 0.20.8 -> 0.20.9

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -18,7 +18,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.12.0
-    LADING_VERSION: 0.20.8
+    LADING_VERSION: 0.20.9
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the


### PR DESCRIPTION
### What does this PR do?

Updates the version of lading used in regression detector experiments to pick up on the latest improvements.

### Motivation

See[ lading release notes](https://github.com/DataDog/lading/releases/tag/v0.20.9)


### Additional Notes

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

