### PR TITLE
Set process comm at startup

### DIFF
--- a/cmd/agent/launcher/launcher.c
+++ b/cmd/agent/launcher/launcher.c
@@ -25,6 +25,8 @@ int main(int argc, char **argv) {
         exit(1);
     }
 
+    setenv("DD_BUNDLED_AGENT", DD_AGENT, 0);
+
     execvp(DD_AGENT_PATH, argv);
     return 1;
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -63,5 +63,8 @@ func main() {
 	}
 
 	rootCmd := agentCmdBuilder()
+	if err := setProcessName(process); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to set process name as '%s': %s\n", process, err)
+	}
 	os.Exit(runcmd.Run(rootCmd))
 }

--- a/cmd/agent/main_common.go
+++ b/cmd/agent/main_common.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+package main
+
+// nolint: deadcode, unused
+func setProcessName(_ string) error {
+	return nil
+}

--- a/cmd/agent/main_linux_cgo.go
+++ b/cmd/agent/main_linux_cgo.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && cgo
+
+package main
+
+/*
+#include <errno.h>
+#include <sys/prctl.h>
+#include <stdlib.h>
+
+int prctl_err = 0;
+
+int set_process_name () __attribute__((constructor));
+
+int set_process_name()
+{
+	const char *name = getenv("DD_BUNDLED_AGENT");
+	if (name != NULL) {
+		int ret = prctl(PR_SET_NAME, name, 0, 0);
+		if (!ret) {
+			prctl_err = errno;
+		}
+		return ret;
+	}
+	return 0;
+}
+*/
+import (
+	"C"
+)
+import "syscall"
+
+func setProcessName(_ string) error {
+	if C.prctl_err == 0 {
+		return nil
+	}
+	return syscall.Errno(C.prctl_err)
+}

--- a/cmd/agent/main_linux_no_cgo.go
+++ b/cmd/agent/main_linux_no_cgo.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && !cgo
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func setProcessName(process string) error {
+	processName := make([]byte, len(process)+1)
+	copy(processName, process)
+	_, _, err := syscall.AllThreadsSyscall(unix.SYS_PRCTL, unix.PR_SET_NAME, uintptr(unsafe.Pointer(&processName[0])), 0)
+	return err
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Set the process name to the impersonated agent.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The process name - available using /proc/1234/comm or using the eBPF
bpf_get_current_comm helper - is set by the OS to the executable name, not
argv[0]. Therefore, we need to set it manually.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Not included in the release so nothing to QA.
