### PR TITLE
[CWS] e2e tests: run cws instrumentation as user 0

### DIFF
--- a/test/new-e2e/tests/cws/fargate_test.go
+++ b/test/new-e2e/tests/cws/fargate_test.go
@@ -200,6 +200,7 @@ func TestECSFargate(t *testing.T) {
 							},
 						},
 						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("cws-instrumentation-init"), pulumi.String(ecsFgHostnamePrefix), apiKeyParam.Name),
+						User:             pulumi.StringPtr("0"),
 					},
 					"log_router": *ecsResources.FargateFirelensContainerDefinition(),
 				},


### PR DESCRIPTION
### What does this PR do?

Recent changes to cws-instrumentation added a hardcoded USER in the Dockerfile. Since we need root privileges to do some ptracing in fargate, this PR fixes the e2e tests to run the cws instrumentation container as uid 0.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
