### PR TITLE
[CWS] Remove UID / GID from cws instrumentation security context

### DIFF
--- a/Dockerfiles/cws-instrumentation/Dockerfile
+++ b/Dockerfiles/cws-instrumentation/Dockerfile
@@ -1,4 +1,4 @@
 FROM scratch
 ARG TARGETARCH
 COPY --chmod=0755 cws-instrumentation.$TARGETARCH /cws-instrumentation
-USER 10000
+USER 1000

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -41,8 +41,6 @@ const (
 	cwsInstrumentationPodAnotationReady  = "ready"
 	cwsInjectorInitContainerName         = "cws-instrumentation"
 	cwsUserSessionDataMaxSize            = 1024
-	cwsInjectorInitContainerUser         = int64(10000)
-	cwsInjectorInitContainerGroup        = int64(10000)
 
 	// PodLabelEnabled is used to label pods that should be instrumented or skipped by the CWS mutating webhook
 	PodLabelEnabled = "admission.datadoghq.com/cws-instrumentation.enabled"
@@ -451,9 +449,6 @@ func injectCWSInitContainer(pod *corev1.Pod, resources *corev1.ResourceRequireme
 		}
 	}
 
-	runAsUser := cwsInjectorInitContainerUser
-	runAsGroup := cwsInjectorInitContainerGroup
-
 	initContainer := corev1.Container{
 		Name:    cwsInjectorInitContainerName,
 		Image:   image,
@@ -463,11 +458,6 @@ func injectCWSInitContainer(pod *corev1.Pod, resources *corev1.ResourceRequireme
 				Name:      cwsVolumeName,
 				MountPath: cwsMountPath,
 			},
-		},
-		// Set a default user and group to support pod deployments with a `runAsNonRoot` security context
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:  &runAsUser,
-			RunAsGroup: &runAsGroup,
 		},
 	}
 	if resources != nil {

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
@@ -446,8 +446,6 @@ func Test_injectCWSCommandInstrumentation(t *testing.T) {
 
 func Test_injectCWSPodInstrumentation(t *testing.T) {
 	commonRegistry := "gcr.io/datadoghq"
-	runAsUser := cwsInjectorInitContainerUser
-	runAsGroup := cwsInjectorInitContainerGroup
 
 	type args struct {
 		pod *corev1.Pod
@@ -501,10 +499,6 @@ func Test_injectCWSPodInstrumentation(t *testing.T) {
 						MountPath: cwsMountPath,
 					},
 				},
-				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:  &runAsUser,
-					RunAsGroup: &runAsGroup,
-				},
 			},
 			wantInstrumentation: true,
 		},
@@ -528,10 +522,6 @@ func Test_injectCWSPodInstrumentation(t *testing.T) {
 						MountPath: cwsMountPath,
 					},
 				},
-				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:  &runAsUser,
-					RunAsGroup: &runAsGroup,
-				},
 			},
 			wantInstrumentation: true,
 		},
@@ -554,10 +544,6 @@ func Test_injectCWSPodInstrumentation(t *testing.T) {
 						Name:      cwsVolumeName,
 						MountPath: cwsMountPath,
 					},
-				},
-				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:  &runAsUser,
-					RunAsGroup: &runAsGroup,
 				},
 			},
 			wantInstrumentation: true,
@@ -592,10 +578,6 @@ func Test_injectCWSPodInstrumentation(t *testing.T) {
 						Name:      cwsVolumeName,
 						MountPath: cwsMountPath,
 					},
-				},
-				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:  &runAsUser,
-					RunAsGroup: &runAsGroup,
 				},
 			},
 			wantInstrumentation: true,
@@ -657,10 +639,6 @@ func Test_injectCWSPodInstrumentation(t *testing.T) {
 						MountPath: cwsMountPath,
 					},
 				},
-				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:  &runAsUser,
-					RunAsGroup: &runAsGroup,
-				},
 			},
 			wantInstrumentation: true,
 		},
@@ -700,10 +678,6 @@ func Test_injectCWSPodInstrumentation(t *testing.T) {
 						Name:      cwsVolumeName,
 						MountPath: cwsMountPath,
 					},
-				},
-				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:  &runAsUser,
-					RunAsGroup: &runAsGroup,
 				},
 			},
 			wantInstrumentation: true,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR removes the UID / GID from the cws instrumentation security context as it turns out it would break OpenShift deployments. However, we're keeping the UID definition in the `cws-instrumentation` Dockerfile.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This patch will fix the `runAsNonRoot` bug described [here](https://github.com/DataDog/datadog-agent/pull/23629) while ensuring we keep OpenShift support.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
