### PR TITLE
[gitlab] Only run macOS unit tests on full pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -816,6 +816,11 @@ workflow:
   - <<: *if_main_branch
   - <<: *if_release_branch
 
+.on_main_or_release_branch_or_all_builds:
+  - <<: *if_main_branch
+  - <<: *if_release_branch
+  - <<: *if_run_all_builds
+
 .except_main_or_release_branch:
   - <<: *if_main_branch
     when: never

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -1,6 +1,7 @@
 tests_macos:
   stage: source_test
-  rules: !reference [.on_a6]
+  # HACK: Run macOS unit tests only on full pipelines, to limit the use of macOS GitHub runners.
+  rules: !reference [.on_main_or_release_branch_or_all_builds]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:
@@ -27,7 +28,7 @@ tests_macos:
 
 lint_macos:
   stage: source_test
-  rules: !reference [.on_a6]
+  rules: !reference [.on_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Changes the rules associated with the macOS unit tests to only run on full pipelines and main / release branches.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Because of org-wide resource constraints, we need to reduce the amount of macOS workflows that we run. This attempt tries to remove unit tests and keep linters, because:
- linters run faster than unit tests
- linters will still catch compilation errors (eg. variables / functions that are not defined on macOS)
- unit tests do still run on Linux on Windows, so the "only" thing we lose are unit tests that would behave differently on macOS. This does happen (so we'll get more failures reaching main), but is relatively rare.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

Some macOS-specific failures won't be caught in PRs, and will reach main.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check PR pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/29961756
