### PR TITLE
fix(fast-tests): Count all packages of a module as modified when go.mod changes

### DIFF
--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -756,7 +756,7 @@ def get_impacted_packages(ctx, build_tags=None):
 
     # Modification to go.mod and go.sum should force the tests of the whole module to run
     for file in files:
-        if file.endswith(".mod") or file.endswith(".sum"):
+        if file.endswith("go.mod") or file.endswith("go.sum"):
             with ctx.cd(os.path.dirname(file)):
                 all_packages = ctx.run(
                     f'go list -tags "{" ".join(build_tags)}" ./...', hide=True, warn=True

--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -757,13 +757,10 @@ def get_impacted_packages(ctx, build_tags=None):
     # Modification to go.mod and go.sum should force the tests of the whole module to run
     for file in files:
         if file.endswith(".mod") or file.endswith(".sum"):
-            print("FILE: ", file)
-            print("RUNNING: ", f'go list -tags "{" ".join(build_tags)}" ./{os.path.dirname(file)}/...')
             with ctx.cd(os.path.dirname(file)):
                 all_packages = ctx.run(
                     f'go list -tags "{" ".join(build_tags)}" ./...', hide=True, warn=True
                 ).stdout.splitlines()
-                print("ADDING PACKAGES: ", all_packages)
                 modified_packages.update(set(all_packages))
 
     # Modification to fixture folders count as modification to their parent package


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Improve a bit fast unit tests to make sure that we consider all the packages of a module as modified when `go.mod` or `go.sum` changes

When computing impacted packages, when a go.mod file is modified it is better to consider all the packages of a module are modified

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
