### PR TITLE
[SNMP Traps] Accept `username` in traps config

### DIFF
--- a/comp/snmptraps/config/config.go
+++ b/comp/snmptraps/config/config.go
@@ -27,11 +27,12 @@ const (
 // UserV3 contains the definition of one SNMPv3 user with its username and its auth
 // parameters.
 type UserV3 struct {
-	Username     string `mapstructure:"user" yaml:"user"`
-	AuthKey      string `mapstructure:"authKey" yaml:"authKey"`
-	AuthProtocol string `mapstructure:"authProtocol" yaml:"authProtocol"`
-	PrivKey      string `mapstructure:"privKey" yaml:"privKey"`
-	PrivProtocol string `mapstructure:"privProtocol" yaml:"privProtocol"`
+	Username       string `mapstructure:"user" yaml:"user"`
+	UsernameLegacy string `mapstructure:"username" yaml:"username"`
+	AuthKey        string `mapstructure:"authKey" yaml:"authKey"`
+	AuthProtocol   string `mapstructure:"authProtocol" yaml:"authProtocol"`
+	PrivKey        string `mapstructure:"privKey" yaml:"privKey"`
+	PrivProtocol   string `mapstructure:"privProtocol" yaml:"privProtocol"`
 }
 
 // TrapsConfig contains configuration for SNMP trap listeners.
@@ -122,6 +123,11 @@ func (c *TrapsConfig) BuildSNMPParams(logger log.Component) (*gosnmp.GoSNMP, err
 	// Set up user security params table from config
 	usmTable := gosnmp.NewSnmpV3SecurityParametersTable(snmpLogger)
 	for _, user := range c.Users {
+		// Backward compatibility
+		if user.Username == "" {
+			user.Username = user.UsernameLegacy
+		}
+
 		authProtocol, err := gosnmplib.GetAuthProtocol(user.AuthProtocol)
 		if err != nil {
 			return nil, err

--- a/comp/snmptraps/config/config_test.go
+++ b/comp/snmptraps/config/config_test.go
@@ -68,6 +68,13 @@ var usersV3 = []UserV3{
 		PrivKey:      "password",
 		PrivProtocol: "AES",
 	},
+	{
+		UsernameLegacy: "userlegacy",
+		AuthKey:        "password",
+		AuthProtocol:   "MD5",
+		PrivKey:        "password",
+		PrivProtocol:   "AES",
+	},
 }
 
 var usmUsers = []*gosnmp.UsmSecurityParameters{
@@ -87,6 +94,13 @@ var usmUsers = []*gosnmp.UsmSecurityParameters{
 	},
 	{
 		UserName:                 "user2",
+		AuthenticationProtocol:   gosnmp.MD5,
+		AuthenticationPassphrase: "password",
+		PrivacyProtocol:          gosnmp.AES,
+		PrivacyPassphrase:        "password",
+	},
+	{
+		UserName:                 "userlegacy",
 		AuthenticationProtocol:   gosnmp.MD5,
 		AuthenticationPassphrase: "password",
 		PrivacyProtocol:          gosnmp.AES,
@@ -185,6 +199,10 @@ func TestFullConfig(t *testing.T) {
 		{
 			"identifier: user2 has 1 entry",
 			"user2",
+		},
+		{
+			"identifier: userlegacy has 1 entry",
+			"userlegacy",
 		},
 	}
 	for _, usmConfigTest := range usmConfigTests {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Accept `username` as `user` field in SNMP Traps V3 configuration

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
