### PR TITLE
Add options struct for util DoGet function

### DIFF
--- a/pkg/api/util/doget_test.go
+++ b/pkg/api/util/doget_test.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package util
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+func makeTestServer(t *testing.T, handler func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestDoGet(t *testing.T) {
+	t.Run("simple request", func(t *testing.T) {
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("test"))
+		}
+		server := makeTestServer(t, http.HandlerFunc(handler))
+		data, err := DoGet(server.Client(), server.URL, CloseConnection)
+		require.NoError(t, err)
+		require.Equal(t, "test", string(data))
+	})
+
+	t.Run("error response", func(t *testing.T) {
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}
+		server := makeTestServer(t, http.HandlerFunc(handler))
+		_, err := DoGetWithOptions(server.Client(), server.URL, &ReqOptions{})
+		require.Error(t, err)
+	})
+
+	t.Run("url error", func(t *testing.T) {
+		_, err := DoGetWithOptions(http.DefaultClient, " http://localhost", &ReqOptions{})
+		require.Error(t, err)
+	})
+
+	t.Run("request error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		server.Close()
+
+		_, err := DoGetWithOptions(server.Client(), server.URL, &ReqOptions{})
+		require.Error(t, err)
+	})
+
+	t.Run("check auth token", func(t *testing.T) {
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "Bearer mytoken", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusOK)
+		}
+		server := makeTestServer(t, http.HandlerFunc(handler))
+
+		options := &ReqOptions{Authtoken: "mytoken"}
+		data, err := DoGetWithOptions(server.Client(), server.URL, options)
+		require.NoError(t, err)
+		require.Empty(t, data)
+	})
+
+	t.Run("check global auth token", func(t *testing.T) {
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "Bearer 0123456789abcdef0123456789abcdef", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusOK)
+		}
+		server := makeTestServer(t, http.HandlerFunc(handler))
+
+		cfg := model.NewConfig("datadog", "test", strings.NewReplacer("_", "."))
+		dir := t.TempDir()
+		authTokenPath := dir + "/auth_token"
+		err := os.WriteFile(authTokenPath, []byte("0123456789abcdef0123456789abcdef"), 0644)
+		require.NoError(t, err)
+		cfg.SetWithoutSource("auth_token_file_path", authTokenPath)
+		SetAuthToken(cfg)
+
+		options := &ReqOptions{}
+		data, err := DoGetWithOptions(server.Client(), server.URL, options)
+		require.NoError(t, err)
+		require.Empty(t, data)
+	})
+
+	t.Run("context cancel", func(t *testing.T) {
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}
+		server := makeTestServer(t, http.HandlerFunc(handler))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		options := &ReqOptions{Ctx: ctx}
+		_, err := DoGetWithOptions(server.Client(), server.URL, options)
+		require.Error(t, err)
+	})
+}

--- a/pkg/cli/subcommands/health/command.go
+++ b/pkg/cli/subcommands/health/command.go
@@ -92,7 +92,7 @@ func requestHealth(_ log.Component, config config.Component, cliParams *cliParam
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(cliParams.timeout)*time.Second)
 	defer cancel()
 
-	r, err := util.DoGetWithContext(ctx, c, urlstr, util.LeaveConnectionOpen)
+	r, err := util.DoGetWithOptions(c, urlstr, &util.ReqOptions{Ctx: ctx, Conn: util.LeaveConnectionOpen})
 	if err != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add a `DoGetWithOptions` function which takes an option struct with options for `DoGet`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Being able to provide an auth token as option and stop using the global variable.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Covered by unit tests.
