### PR TITLE
[ASCII-1165] Remove netflow global server

### DIFF
--- a/comp/netflow/server/server.go
+++ b/comp/netflow/server/server.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -22,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder"
 	nfconfig "github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/DataDog/datadog-agent/comp/netflow/flowaggregator"
-	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 type dependencies struct {
@@ -41,32 +39,6 @@ type provides struct {
 	StatusProvider status.InformationProvider
 }
 
-// NetflowServerStatus represents the status of the server including details about
-// listeners which are working and those which have closed.
-type NetflowServerStatus struct {
-	TotalListeners         int
-	OpenListeners          int
-	ClosedListeners        int
-	WorkingListenerDetails []NetflowListenerStatus
-	ClosedListenerDetails  []NetflowListenerStatus
-}
-
-// NetflowListenerStatus handles logic related to pulling config information and associating it to an error.
-type NetflowListenerStatus struct {
-	Config    nfconfig.ListenerConfig
-	Error     string
-	FlowCount int64
-}
-
-// TODO: (components)
-// The Status command is not yet a component.
-// Therefore, the globalServer variable below is used as a temporary workaround.
-// globalServer is only used on getting the status of the server.
-var (
-	globalServer   = &Server{}
-	globalServerMu sync.Mutex
-)
-
 // newServer configures a netflow server.
 func newServer(lc fx.Lifecycle, deps dependencies) (provides, error) {
 	conf := deps.Config.Get()
@@ -82,14 +54,12 @@ func newServer(lc fx.Lifecycle, deps dependencies) (provides, error) {
 		logger:  deps.Logger,
 	}
 
-	globalServerMu.Lock()
-	globalServer = server
-	globalServerMu.Unlock()
-
 	var statusProvider status.Provider
 
 	if conf.Enabled {
-		statusProvider = Provider{}
+		statusProvider = Provider{
+			server: server,
+		}
 
 		// netflow is enabled, so start the server
 		lc.Append(fx.Hook{
@@ -176,46 +146,4 @@ func (s *Server) Stop() {
 		}
 	}
 	s.running = false
-}
-
-// IsEnabled checks if the netflow functionality is enabled in the configuration.
-func IsEnabled() bool {
-	return config.Datadog.GetBool("network_devices.netflow.enabled")
-}
-
-// GetStatus retrieves the current status of the server with details about
-// all listeners and categorizes them into working and closed.
-func GetStatus() NetflowServerStatus {
-	globalServerMu.Lock()
-	defer globalServerMu.Unlock()
-
-	if globalServer == nil {
-		return NetflowServerStatus{}
-	}
-
-	workingListeners := []NetflowListenerStatus{}
-	closedListenersList := []NetflowListenerStatus{}
-
-	for _, listener := range globalServer.listeners {
-		errorString := listener.error.Load()
-		if errorString != "" {
-			closedListenersList = append(closedListenersList, NetflowListenerStatus{
-				Config: listener.config,
-				Error:  errorString,
-			})
-		} else {
-			workingListeners = append(workingListeners, NetflowListenerStatus{
-				Config:    listener.config,
-				FlowCount: listener.flowCount.Load(),
-			})
-		}
-	}
-
-	return NetflowServerStatus{
-		TotalListeners:         int(len(globalServer.listeners)),
-		OpenListeners:          int(len(workingListeners)),
-		ClosedListeners:        int(len(closedListenersList)),
-		WorkingListenerDetails: workingListeners,
-		ClosedListenerDetails:  closedListenersList,
-	}
 }

--- a/comp/netflow/server/status_templates/netflow.tmpl
+++ b/comp/netflow/server/status_templates/netflow.tmpl
@@ -2,7 +2,8 @@
   Total Listeners: {{.TotalListeners}}
   Open Listeners: {{.OpenListeners}}
   Closed Listeners: {{.ClosedListeners}}
-  {{ if .OpenListeners }}
+  {{- if .OpenListeners }}
+
   === Open Listener Details ===
   {{- range $index, $NetflowListenerStatus := .WorkingListenerDetails }}
   ---------
@@ -14,9 +15,10 @@
   Flows Received: {{$NetflowListenerStatus.FlowCount}}
   ---------
   {{- end }}
-  {{ end }}
+  {{- end }}
 
-  {{ if .ClosedListeners }}
+  {{- if .ClosedListeners }}
+
   === Closed Listener Details ===
   {{- range $index, $NetflowListenerStatus := .ClosedListenerDetails }}
   ---------
@@ -28,5 +30,5 @@
   Error: {{$NetflowListenerStatus.Error}}
   ---------
   {{- end }}
-  {{ end }}
+  {{- end }}
 {{- end }}

--- a/comp/netflow/server/status_templates/netflowHTML.tmpl
+++ b/comp/netflow/server/status_templates/netflowHTML.tmpl
@@ -5,7 +5,7 @@
         Total Listeners: {{.TotalListeners}}
         <br>Open Listeners: {{.OpenListeners}}
         <br>Closed Listeners: {{.ClosedListeners}}
-        {{ if .OpenListeners }}
+        {{- if .OpenListeners }}
         <span class="stat_subtitle">Open Listener Details</span>
         {{- range $index, $NetflowListenerStatus := .WorkingListenerDetails }}
         BindHost: {{$NetflowListenerStatus.Config.BindHost}}
@@ -17,9 +17,9 @@
         <br>
         <br>
         {{- end }}
-        {{ end }}
+        {{- end }}
         <br>
-        {{ if .ClosedListeners }}
+        {{- if .ClosedListeners }}
         <br>
         <span class="stat_subtitle">Closed Listener Details</span>
         {{- range $index, $NetflowListenerStatus := .ClosedListenerDetails }}
@@ -32,7 +32,7 @@
         <br>
         <br>
         {{- end }}
-        {{ end }}
+        {{- end }}
     </span>
   </div>
 {{- end -}}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Remove `globalServer` and `globalServerMu`. Since the netflow server has its own status provider, we no longer needs those globals variables.

A part form that I remove some of the JSON marshal and unmarshalling, and added more test coverage to the status provider.

### Motivation

Remove global variables 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Ensure the netflow information is displayed correct is the status out. Validate that the JSON and text version are correct.
- Ensure the GUI displays the netflow information correctly. 
