### PR TITLE
backport debian 11 ami fix #23330

### DIFF
--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -42,12 +42,12 @@
         "ec2": {
             "x86_64": {
                 "debian-10": "ami-041540a5c191757a0",
-                "debian-11": "ami-09e24b0cfe072ecef",
+                "debian-11": "ami-0607e701db389efe7",
                 "debian-12": "ami-0076a5c1d029e906a"
             },
             "arm64": {
                 "debian-10": "ami-0108ade0d057c8eba",
-                "debian-11": "ami-03ea090ddd75eb738",
+                "debian-11": "ami-00988b9ead6afb0b1",
                 "debian-12": "ami-02aab8d5301cb8d68"
             }
         }

--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -3,12 +3,12 @@
         "x86_64": {
             "debian-9":  "ami-0182559468c1975fe",
             "debian-10": "ami-041540a5c191757a0",
-            "debian-11": "ami-09e24b0cfe072ecef",
+            "debian-11": "ami-0607e701db389efe7",
             "debian-12": "ami-06db4d78cb1d3bbf9"
         },
         "arm64": {
             "debian-10": "ami-0108ade0d057c8eba",
-            "debian-11": "ami-03ea090ddd75eb738",
+            "debian-11": "ami-00988b9ead6afb0b1",
             "debian-12": "ami-02aab8d5301cb8d68"
         }
     },


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR backports https://github.com/DataDog/datadog-agent/pull/23330 to 7.51.x, fixing the issue downloading kernel headers on debian 11
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
