### PR TITLE
[SMP] Fix dogstatsd experiments in latest lading

### DIFF
--- a/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -13,14 +13,10 @@ generator:
             inclusive:
               min: 1
               max: 200
-          tag_key_length:
+          tag_length:
             inclusive:
-              min: 1
-              max: 100
-          tag_value_length:
-            inclusive:
-              min: 1
-              max: 100
+              min: 3
+              max: 150
           tags_per_msg:
             inclusive:
               min: 2

--- a/test/regression/cases/uds_dogstatsd_to_api_cpu/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_cpu/lading/lading.yaml
@@ -13,14 +13,10 @@ generator:
             inclusive:
               min: 1
               max: 200
-          tag_key_length:
+          tag_length:
             inclusive:
-              min: 1
-              max: 100
-          tag_value_length:
-            inclusive:
-              min: 1
-              max: 100
+              min: 3
+              max: 150
           tags_per_msg:
             inclusive:
               min: 2


### PR DESCRIPTION
### What does this PR do?

Updates the format of the dogstatsd experiments in accordance with the latest lading version.

### Motivation

Dogstatsd experiments will currently fail to generate any load. 

### Additional Notes

This has been broken since #23658 was merged (so today)

### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
