### PR TITLE
Point image build and deploy jobs at nightly ECR repo when nightly build

### DIFF
--- a/.gitlab/common/container_publish_job_templates.yml
+++ b/.gitlab/common/container_publish_job_templates.yml
@@ -15,7 +15,12 @@
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - source /root/.bashrc
     - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
-    - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
+    - |
+      if [[ "$BUCKET_BRANCH" == "nightly" && ( "$IMG_SOURCES" =~ "$SRC_AGENT" || "$IMG_SOURCES" =~ "$SRC_DCA" || "$IMG_VARIABLES" =~ "$SRC_AGENT" || "$IMG_VARIABLES" =~ "$SRC_DCA" ) ]]; then
+        export ECR_RELEASE_SUFFIX="-nightly"
+      else
+        export ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
+      fi
     - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/public-images --git-ref main

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -7,7 +7,12 @@
     - aws s3 sync --only-show-errors $S3_ARTIFACTS_URI $BUILD_CONTEXT
     - TAG_SUFFIX=${TAG_SUFFIX:-}
     - BUILD_ARG=${BUILD_ARG:-}
-    - ECR_RELEASE_SUFFIX=${CI_COMMIT_TAG+-release}
+    - |
+      if [[ "$BUCKET_BRANCH" == "nightly" && ( "$IMAGE" =~ "$SRC_AGENT" || "$IMAGE" =~ "$SRC_DCA" ) ]]; then
+        export ECR_RELEASE_SUFFIX="-nightly"
+      else
+        export ECR_RELEASE_SUFFIX=${CI_COMMIT_TAG+-release}
+      fi
     - TARGET_TAG=${IMAGE}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}$TAG_SUFFIX-$ARCH
     # DockerHub login for build to limit rate limit when pulling base images
     - DOCKER_REGISTRY_LOGIN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY)

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -8,7 +8,7 @@
     - TAG_SUFFIX=${TAG_SUFFIX:-}
     - BUILD_ARG=${BUILD_ARG:-}
     - |
-      if [[ "$BUCKET_BRANCH" == "nightly" && ( "$IMAGE" =~ "$SRC_AGENT" || "$IMAGE" =~ "$SRC_DCA" ) ]]; then
+      if [[ "$BUCKET_BRANCH" == "nightly" && ( "$IMAGE" =~ "ci/datadog-agent/agent" || "$IMAGE" =~ "ci/datadog-agent/cluster-agent" ) ]]; then
         export ECR_RELEASE_SUFFIX="-nightly"
       else
         export ECR_RELEASE_SUFFIX=${CI_COMMIT_TAG+-release}

--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -28,7 +28,7 @@
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
   script:
-    - $ECR_RELEASE_SUFFIX="$(If ($CI_COMMIT_TAG) { `"-release`" } else { `"`" })"
+    - $ECR_RELEASE_SUFFIX="$(If ($BUCKET_BRANCH -eq `"nightly`") { `"-nightly`" } elseif ($CI_COMMIT_TAG) { `"-release`" } else { `"`" })"
     - $TARGET_TAG="${IMAGE}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}${SERVERCORE}-amd64"
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'


### PR DESCRIPTION
### What does this PR do?

This PR points the container image build and deploy jobs at the nightly ECR buckets for the agent and cluster-agent images, which were created [here](https://github.com/DataDog/cloudops/pull/38860)

### Motivation

As part of the beta-builds pipeline, we are going to want to release these images publicly after they have had enough time to sit in staging and production and we deem them safe. End to end, we are looking at a delay of ~2 days. Meanwhile, images in the normal agent and cluster-agent ci repos are purged after ~6 hours, which makes this plan difficult.

In the linked cloudops PR, we created 2 new ECR repos to allow us to separate these ci builds. Separate builds should have separate retention rules, so we can customize that as we need without running the risk of ballooning our ECR bill.

### Additional Notes

I have tested these changes to ensure that they do not break the existing pipelines:
[Normal branch ci](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/29981483), with `BUCKET_BRANCH` unset
[Manual pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/29988416), with `BUCKET_BRANCH` set to `nightly`

I kicked off a handful of `dev_container_deploy` jobs to make sure that the images that would use this new location work, as well as the images that will not use the new location work as well (which resulted in a [follow-up PR](https://github.com/DataDog/cloudops/pull/38902) to make the docker build work for windows agents)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
