### PR TITLE
feat(ci): Add coverage run for invoke task and set them aside go tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1040,6 +1040,7 @@ workflow:
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     
 .on_invoke_tasks_changes:
+  - <<: *if_main_branch
   - !reference [.except_mergequeue]
   - changes:
       paths:
@@ -1047,6 +1048,7 @@ workflow:
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
 
 .on_kitchen_invoke_tasks_changes:
+  - <<: *if_main_branch
   - !reference [.except_mergequeue]
   - changes:
       paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1041,7 +1041,6 @@ workflow:
     
 .on_invoke_tasks_changes:
   - <<: *if_main_branch
-  - !reference [.except_mergequeue]
   - changes:
       paths:
         - tasks/**/*
@@ -1049,7 +1048,6 @@ workflow:
 
 .on_kitchen_invoke_tasks_changes:
   - <<: *if_main_branch
-  - !reference [.except_mergequeue]
   - changes:
       paths:
         - test/kitchen/tasks/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1039,3 +1039,16 @@ workflow:
         - .gitlab/**/*
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     
+.on_invoke_tasks_changes:
+  - !reference [.except_mergequeue]
+  - changes:
+      paths:
+        - tasks/**/*
+      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+
+.on_kitchen_invoke_tasks_changes:
+  - !reference [.except_mergequeue]
+  - changes:
+      paths:
+        - test/kitchen/tasks/**/*
+      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916

--- a/.gitlab/source_test/include.yml
+++ b/.gitlab/source_test/include.yml
@@ -12,3 +12,4 @@ include:
   - .gitlab/source_test/slack.yml
   - .gitlab/source_test/golang_deps_diff.yml
   - .gitlab/source_test/notify.yml
+  - .gitlab/source_test/tooling_unit_tests.yml

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -27,11 +27,6 @@
   script:
     - !reference [.retrieve_linux_go_tools_deps]
     - inv -e install-tools
-    - python3 -m pip install -r tasks/libs/requirements-github.txt
-    - inv -e invoke-unit-tests
-    - pushd test/kitchen
-    - inv -e kitchen.invoke-unit-tests
-    - popd
     - FAST_TESTS_FLAG=""
     - if [[ "$FAST_TESTS" == "true" ]]; then FAST_TESTS_FLAG="--only-impacted-packages"; fi
     - inv -e test $FLAVORS --race --profile --rerun-fails=2 --python-runtimes "$PYTHON_RUNTIMES" --coverage --cpus $KUBERNETES_CPU_REQUEST $EXTRA_OPTS --save-result-json $TEST_OUTPUT_FILE --junit-tar "junit-${CI_JOB_NAME}.tgz" --build-stdlib $FAST_TESTS_FLAG

--- a/.gitlab/source_test/tooling_unit_tests.yml
+++ b/.gitlab/source_test/tooling_unit_tests.yml
@@ -1,0 +1,27 @@
+---
+# Unit test of internal python code
+invoke_unit_tests:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: []
+  rules:
+    - !reference [.on_invoke_tasks_changes]
+  script:
+    - source /root/.bashrc
+    - python3 -m pip install -r tasks/libs/requirements-github.txt
+    - inv -e invoke-unit-tests
+
+kitchen_invoke_unit_tests:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: []
+  rules:
+    - !reference [.on_kitchen_invoke_tasks_changes]
+  script:
+    - source /root/.bashrc
+    - python3 -m pip install -r tasks/libs/requirements-github.txt
+    - pushd test/kitchen
+    - inv -e kitchen.invoke-unit-tests
+    - popd

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -16,23 +16,6 @@ $UT_BUILD_ROOT=(Get-Location).Path
 $Env:PATH="$UT_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:PATH"
 
 & pip install -r tasks/libs/requirements-github.txt
-& inv -e invoke-unit-tests
-
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "[Error]: Some unit tests failed"
-    exit $LASTEXITCODE
-}
-
-& pushd "test\kitchen"
-
-& inv -e kitchen.invoke-unit-tests
-
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "[Error]: Some kitchen unit tests failed"
-    exit $LASTEXITCODE
-}
-
-& popd
 
 $archflag = "x64"
 if ($Env:TARGET_ARCH -eq "x86") {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Run invoke unit tests in dedicated jobs. Will add coverage afterwards

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Invoke tasks are a different workload in the datadog-agent repo.
Their UT can run independently and having a dedicated workflow (and coverage) would give rapid feedback for devx team when touching those

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
I will probably create a side workflow for kitchen.invoke-unit-tests
We could easily use [coverage-scope](https://github.com/marketplace/actions/coverage-scope) action to enforce a gating on coverage for invoke tasks

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
