### PR TITLE
[gitlab] Make CentOS 6 e2e tests work post CentOS 6 deprecation

### DIFF
--- a/test/new-e2e/tests/agent-platform/install/install.go
+++ b/test/new-e2e/tests/agent-platform/install/install.go
@@ -65,6 +65,12 @@ func Unix(t *testing.T, client *common.TestClient, options ...installparams.Opti
 		_, err := client.ExecuteWithRetry(downdloadCmd)
 		require.NoError(tt, err, "failed to download install script from %s: ", source, err)
 
+		/* If we "just run" the install script on CentOS 6, it won't install the Agent, because it
+		wants to install "7.51.1". In order to install whatever is in the yum testing repository,
+		we change /etc/redhat-release to make it look like this is CentOS 7. This is a terrible hack,
+		but it's the easiest way to make it work on an Agent stable branch. */
+		_, _ = client.Host.Execute("sudo sed -i 's/6.[0-9]*/7.10/' /etc/redhat-release")
+
 		cmd := fmt.Sprintf(`DD_API_KEY="%s" %v DD_SITE="datadoghq.eu" bash installscript.sh`, apikey, commandLine)
 		output, err := client.Host.Execute(cmd)
 		tt.Log(output)


### PR DESCRIPTION
### What does this PR do?

Fixes CentOS 6 e2e tests on 7.51.x branch.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
