### PR TITLE
pkg/trace/api: report statsd metrics 2x more frequently in the receiver

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -624,7 +624,7 @@ func (r *HTTPReceiver) loop() {
 	var lastLog time.Time
 	accStats := info.NewReceiverStats()
 
-	t := time.NewTicker(10 * time.Second)
+	t := time.NewTicker(5 * time.Second)
 	defer t.Stop()
 	tw := time.NewTicker(r.conf.WatchdogInterval)
 	defer tw.Stop()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Report statsd metrics 2x more frequently in the receiver. The new value (5s) is aligned with the writer's flush interval.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The previous interval (10s) can be too long to flush health metrics.

A spike of traffic can OOM the trace-agent, and receiver metrics wouldn't reflect that spike because the OOM happens before the next timer tick.

This PR aims to mitigate the data loss by setting up a more frequent flush interval.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The issue described in the motivation has been seen IRL, where the writer and receiver metrics didn't match in a restarting trace-agent.

Note that the writer already flushes its health metrics every 5s.

<img width="488" alt="image" src="https://github.com/DataDog/datadog-agent/assets/38987709/f41f2e92-9dc7-4b7b-a604-baad2cba861f">


<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

This will result in sending more statsd payloads, but the client-side aggregation is enabled in the statsd client and should mitigate the performance penalty. This change has also been macro-benchmarked and profiled before merge.

Alternatively, I considered sending the metrics right away instead of accumulating and sending asynchronously, but that approach would require a large refactor and won't remove atomics anyway since they're used for expvar, not only for statsd. The current approach (this PR) is cheaper in terms of performance and maintainability, it's less intrusive to the hot path of the receiver.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- The APM e2e tests pass
- Manual performance testing and profiling has been done before merging the PR
  - `version:7.53.0-devel_git.412.b319598` is the commit of the this PR
  - `version:7.53.0-devel_git.409.4190167` is the commit of the nightly build

![image](https://github.com/DataDog/datadog-agent/assets/38987709/5b70083c-4bba-4d2b-9cff-ec9d60fe92ce)

![image](https://github.com/DataDog/datadog-agent/assets/38987709/bb5e3648-2d0c-4cd2-90ec-912672a04df3)

**The PR has no impact on the CPU and memory usage compared to the nightly build. The resource usage of `github.com/DataDog/datadog-go/v5/statsd` stayed stable on both commits (<1% CPU and 11% memory of profile)**

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
