### PR TITLE
[CONTINT-3931] Clean SBOM cache enabled option

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1170,7 +1170,6 @@ func InitConfig(config pkgconfigmodel.Config) {
 
 	config.BindEnvAndSetDefault("sbom.cache_directory", filepath.Join(defaultRunPath, "sbom-agent"))
 	config.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
-	config.BindEnvAndSetDefault("sbom.cache.enabled", true)
 	config.BindEnvAndSetDefault("sbom.cache.max_disk_size", 1000*1000*100) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
 	config.BindEnvAndSetDefault("sbom.cache.clean_interval", "1h")         // used by custom cache.
 	config.BindEnvAndSetDefault("sbom.scan_queue.base_backoff", "5m")

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -70,7 +70,6 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("sbom.host.analyzers", []string{"os"})
 	cfg.BindEnvAndSetDefault("sbom.cache_directory", filepath.Join(defaultRunPath, "sbom-sysprobe"))
 	cfg.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
-	cfg.BindEnvAndSetDefault("sbom.cache.enabled", true)
 	cfg.BindEnvAndSetDefault("sbom.cache.max_disk_size", 1000*1000*100) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
 	cfg.BindEnvAndSetDefault("sbom.cache.clean_interval", "30m")        // used by custom cache.
 	cfg.BindEnvAndSetDefault("sbom.scan_queue.base_backoff", "5m")

--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -107,7 +107,7 @@ func (c *ScannerCacheCleaner) clean() error {
 	return nil
 }
 
-// setKeysForEntity sets keys to .
+// setKeysForEntity sets keys of items stored in the cache for the given entity.
 func (c *ScannerCacheCleaner) setKeysForEntity(entity string, cachedKeys []string) {
 	c.cachedKeysForEntity[entity] = cachedKeys
 }
@@ -172,7 +172,7 @@ func (c *ScannerCache) PutBlob(blobID string, blobInfo types.BlobInfo) error {
 
 // DeleteBlobs implements cache.Cache#DeleteBlobs does nothing because the cache cleaning logic is
 // managed by CacheCleaner
-func (c *ScannerCache) DeleteBlobs([]string) error { //nolint:revive // TODO fix revive unusued-parameter
+func (c *ScannerCache) DeleteBlobs([]string) error {
 	return nil
 }
 

--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -235,7 +235,7 @@ func (c *ScannerCache) GetBlob(id string) (types.BlobInfo, error) {
 // PersistentCache is a cache that uses a persistent database for storage.
 type PersistentCache struct {
 	lruCache                     *simplelru.LRU[string, struct{}]
-	db                           PersistentDB
+	db                           BoltDB
 	mutex                        sync.RWMutex
 	currentCachedObjectTotalSize int
 	maximumCachedObjectSize      int
@@ -245,7 +245,7 @@ type PersistentCache struct {
 // NewPersistentCache creates a new instance of PersistentCache and returns a pointer to it.
 func NewPersistentCache(
 	maxCachedObjectSize int,
-	localDB PersistentDB,
+	localDB BoltDB,
 ) (*PersistentCache, error) {
 
 	persistentCache := &PersistentCache{

--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -52,14 +52,14 @@ func NewCustomBoltCache(wmeta optional.Option[workloadmeta.Component], cacheDir 
 	if err != nil {
 		return nil, err
 	}
-	cache, err := newPersistentCache(
+	c, err := newPersistentCache(
 		maxDiskSize,
 		db,
 	)
 	if err != nil {
 		return nil, err
 	}
-	trivyCache := &ScannerCache{cache: cache, wmeta: wmeta}
+	trivyCache := &ScannerCache{cache: c, wmeta: wmeta, cachedKeysForEntity: make(map[string][]string)}
 	return trivyCache, nil
 }
 
@@ -539,3 +539,5 @@ func (c *memoryCache) Close() (err error) {
 func (c *memoryCache) Clear() (err error) {
 	return c.Close()
 }
+func (c *memoryCache) clean() error                      { return nil }
+func (c *memoryCache) setKeysForEntity(string, []string) {}

--- a/pkg/util/trivy/cache_test.go
+++ b/pkg/util/trivy/cache_test.go
@@ -32,7 +32,7 @@ var (
 
 func TestCustomBoltCache_Artifacts(t *testing.T) {
 	deps := createCacheDeps(t)
-	cache, _, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
+	cache, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -54,7 +54,7 @@ func TestCustomBoltCache_Artifacts(t *testing.T) {
 
 func TestCustomBoltCache_Blobs(t *testing.T) {
 	deps := createCacheDeps(t)
-	cache, _, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
+	cache, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -76,7 +76,7 @@ func TestCustomBoltCache_Blobs(t *testing.T) {
 
 func TestCustomBoltCache_MissingBlobs(t *testing.T) {
 	deps := createCacheDeps(t)
-	cache, _, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
+	cache, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -109,7 +109,7 @@ func TestCustomBoltCache_MissingBlobs(t *testing.T) {
 
 func TestCustomBoltCache_Clear(t *testing.T) {
 	deps := createCacheDeps(t)
-	cache, _, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
+	cache, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -129,7 +129,7 @@ func TestCustomBoltCache_Clear(t *testing.T) {
 
 func TestCustomBoltCache_CurrentObjectSize(t *testing.T) {
 	deps := createCacheDeps(t)
-	cache, _, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
+	cache, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -146,7 +146,7 @@ func TestCustomBoltCache_CurrentObjectSize(t *testing.T) {
 	}
 
 	// Check that the currentCachedObjectTotalSize is equal to the size of the two artifacts
-	persistentCache := cache.Cache
+	persistentCache := cache.(*ScannerCache).cache
 	require.Equal(t, len(serializedArtifactInfo)*len(artifactIDs), persistentCache.GetCurrentCachedObjectTotalSize())
 
 	// Remove one artifact and check that currentCachedObjectTotalSize is the size of 1 artifact
@@ -162,7 +162,7 @@ func TestCustomBoltCache_CurrentObjectSize(t *testing.T) {
 
 func TestCustomBoltCache_Eviction(t *testing.T) {
 	deps := createCacheDeps(t)
-	cache, _, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
+	cache, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -184,7 +184,7 @@ func TestCustomBoltCache_Eviction(t *testing.T) {
 	}
 
 	// Make sure the first artifact is evicted while others are still there
-	persistentCache := cache.Cache
+	persistentCache := cache.(*ScannerCache).cache
 	require.Equal(t, totalSize-artifactSize["key0"], persistentCache.GetCurrentCachedObjectTotalSize())
 
 	for i := 1; i < cacheSize+1; i++ {
@@ -204,7 +204,8 @@ func TestCustomBoltCache_DiskSizeLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	deps := createCacheDeps(t)
-	cache, _, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), len(serializedArtifactInfo))
+	c, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), len(serializedArtifactInfo))
+	cache := c.(*ScannerCache)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -225,7 +226,7 @@ func TestCustomBoltCache_DiskSizeLimit(t *testing.T) {
 	_, err = cache.GetArtifact("key1")
 	require.Error(t, err)
 
-	persistentCache := cache.Cache
+	persistentCache := cache.cache
 	require.Equal(t, len(serializedArtifactInfo), persistentCache.GetCurrentCachedObjectTotalSize())
 }
 
@@ -267,7 +268,7 @@ func TestCustomBoltCache_GarbageCollector(t *testing.T) {
 
 	workloadmetaStore.Reset([]workloadmeta.Entity{image1, image2, image3}, workloadmeta.SourceAll)
 
-	cache, cacheCleaner, err := NewCustomBoltCache(optional.NewOption[workloadmeta.Component](workloadmetaStore), t.TempDir(), defaultDiskSize)
+	cache, err := NewCustomBoltCache(optional.NewOption[workloadmeta.Component](workloadmetaStore), t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -276,15 +277,15 @@ func TestCustomBoltCache_GarbageCollector(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// link image1 to artifact key1, an owned blob and a shared blob
-	cacheCleaner.setKeysForEntity("image1", []string{"key1", "blob1", "sharedBlob"})
+	cache.setKeysForEntity("image1", []string{"key1", "blob1", "sharedBlob"})
 	// link image2 to artifact key2, an owned blob and a shared blob
-	cacheCleaner.setKeysForEntity("image2", []string{"key2", "blob2", "sharedBlob"})
+	cache.setKeysForEntity("image2", []string{"key2", "blob2", "sharedBlob"})
 
 	// Create a goroutine that calls cacheCleaner.Clean every 500ms
 	go func() {
 		cleanTicker := time.NewTicker(500 * time.Millisecond)
 		for range cleanTicker.C {
-			cacheCleaner.clean()
+			cache.clean()
 		}
 	}()
 
@@ -360,7 +361,7 @@ func TestCustomBoltCache_GarbageCollector(t *testing.T) {
 	serializedBlobInfo, err := json.Marshal(newTestBlobInfo())
 	require.NoError(t, err)
 
-	persistentCache := cache.Cache
+	persistentCache := cache.(*ScannerCache).cache
 	require.Equal(t, 2*len(serializedBlobInfo)+len(serializedArtifactInfo), persistentCache.GetCurrentCachedObjectTotalSize())
 }
 

--- a/pkg/util/trivy/cache_test.go
+++ b/pkg/util/trivy/cache_test.go
@@ -146,7 +146,7 @@ func TestCustomBoltCache_CurrentObjectSize(t *testing.T) {
 	}
 
 	// Check that the currentCachedObjectTotalSize is equal to the size of the two artifacts
-	persistentCache := cache.(*ScannerCache).Cache.(*PersistentCache)
+	persistentCache := cache.Cache
 	require.Equal(t, len(serializedArtifactInfo)*len(artifactIDs), persistentCache.GetCurrentCachedObjectTotalSize())
 
 	// Remove one artifact and check that currentCachedObjectTotalSize is the size of 1 artifact
@@ -184,7 +184,7 @@ func TestCustomBoltCache_Eviction(t *testing.T) {
 	}
 
 	// Make sure the first artifact is evicted while others are still there
-	persistentCache := cache.(*ScannerCache).Cache.(*PersistentCache)
+	persistentCache := cache.Cache
 	require.Equal(t, totalSize-artifactSize["key0"], persistentCache.GetCurrentCachedObjectTotalSize())
 
 	for i := 1; i < cacheSize+1; i++ {
@@ -225,7 +225,7 @@ func TestCustomBoltCache_DiskSizeLimit(t *testing.T) {
 	_, err = cache.GetArtifact("key1")
 	require.Error(t, err)
 
-	persistentCache := cache.(*ScannerCache).Cache.(*PersistentCache)
+	persistentCache := cache.Cache
 	require.Equal(t, len(serializedArtifactInfo), persistentCache.GetCurrentCachedObjectTotalSize())
 }
 
@@ -284,7 +284,7 @@ func TestCustomBoltCache_GarbageCollector(t *testing.T) {
 	go func() {
 		cleanTicker := time.NewTicker(500 * time.Millisecond)
 		for range cleanTicker.C {
-			cacheCleaner.Clean()
+			cacheCleaner.clean()
 		}
 	}()
 
@@ -360,7 +360,7 @@ func TestCustomBoltCache_GarbageCollector(t *testing.T) {
 	serializedBlobInfo, err := json.Marshal(newTestBlobInfo())
 	require.NoError(t, err)
 
-	persistentCache := cache.(*ScannerCache).Cache.(*PersistentCache)
+	persistentCache := cache.Cache
 	require.Equal(t, 2*len(serializedBlobInfo)+len(serializedArtifactInfo), persistentCache.GetCurrentCachedObjectTotalSize())
 }
 

--- a/pkg/util/trivy/db.go
+++ b/pkg/util/trivy/db.go
@@ -25,24 +25,6 @@ const (
 // onDeleteCallback describes a callback function that is called before deleting an entry from a PersistentDB.
 type onDeleteCallback = func(key string, value []byte) error
 
-// PersistentDB describes an interface for a persistent key-value store.
-type PersistentDB interface {
-	// Clear closes the database and removes all stored data.
-	Clear() error
-	// Close closes the database connection.
-	Close() error
-	// Delete deletes a set of keys from the database and invokes the specified callback for each key before committing the transaction.
-	Delete(keys []string, callback onDeleteCallback) error
-	// Get returns the value associated with the given key. If the key is not found, it returns nil.
-	Get(key string) ([]byte, error)
-	// Store stores a key-value pair in the database.
-	Store(key string, value []byte) error
-	// ForEach invokes the specified function for every key-value pair in the database.
-	ForEach(func(string, []byte) error) error
-	// Size returns the number of key-value pairs in the database.
-	Size() (uint, error)
-}
-
 // BoltDB implements the PersistentDB interface. It holds a bolt.DB instance and the storage directory.
 type BoltDB struct {
 	db        *bolt.DB
@@ -76,7 +58,7 @@ func NewBoltDB(cacheDir string) (BoltDB, error) {
 	}, nil
 }
 
-// Clear implements PersistentDB
+// Clear clears the cache directory.
 func (b BoltDB) Clear() error {
 	if err := b.Close(); err != nil {
 		return err
@@ -84,12 +66,12 @@ func (b BoltDB) Clear() error {
 	return os.RemoveAll(b.directory)
 }
 
-// Close implements PersistentDB
+// Close closes the db.
 func (b BoltDB) Close() error {
 	return b.db.Close()
 }
 
-// Delete implements PersistentDB
+// Delete deletes the given keys from the database and calls the callback for each deleted key-value pair.
 func (b BoltDB) Delete(keys []string, callback onDeleteCallback) error {
 	err := b.db.Update(func(tx *bolt.Tx) error {
 		bucket, err := tx.CreateBucketIfNotExists([]byte(boltBucket))
@@ -110,7 +92,7 @@ func (b BoltDB) Delete(keys []string, callback onDeleteCallback) error {
 	return err
 }
 
-// Get implements PersistentDB
+// Get retrieves the value attached to the given key.
 func (b BoltDB) Get(key string) ([]byte, error) {
 	var res []byte
 	return res, b.db.View(func(tx *bolt.Tx) error {
@@ -123,7 +105,7 @@ func (b BoltDB) Get(key string) ([]byte, error) {
 	})
 }
 
-// Store implements PersistentDB
+// Store inserts a key in the database.
 func (b BoltDB) Store(key string, value []byte) error {
 	return b.db.Update(func(tx *bolt.Tx) error {
 		bucket, err := tx.CreateBucketIfNotExists([]byte(boltBucket))
@@ -134,7 +116,7 @@ func (b BoltDB) Store(key string, value []byte) error {
 	})
 }
 
-// ForEach implements PersistentDB
+// ForEach runs a function for each key in the db.
 func (b BoltDB) ForEach(f func(string, []byte) error) error {
 	return b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(boltBucket))
@@ -145,7 +127,7 @@ func (b BoltDB) ForEach(f func(string, []byte) error) error {
 	})
 }
 
-// Size implements PersistentDB. It is different from the total size of cached objects
+// Size returns the size of the database file.
 func (b BoltDB) Size() (uint, error) {
 	var res uint
 	return res, b.db.View(func(tx *bolt.Tx) error {

--- a/pkg/util/trivy/db.go
+++ b/pkg/util/trivy/db.go
@@ -72,6 +72,7 @@ func (b BoltDB) Close() error {
 }
 
 // Delete deletes the given keys from the database and calls the callback for each deleted key-value pair.
+// It returns an error if the transaction fails and returns nil if the key doesn't exist.
 func (b BoltDB) Delete(keys []string, callback onDeleteCallback) error {
 	err := b.db.Update(func(tx *bolt.Tx) error {
 		bucket, err := tx.CreateBucketIfNotExists([]byte(boltBucket))

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -70,7 +70,7 @@ type Collector struct {
 	config           CollectorConfig
 	cacheInitialized sync.Once
 	cache            cache.Cache
-	cacheCleaner     CacheCleaner
+	cacheCleaner     *ScannerCacheCleaner
 	osScanner        ospkg.Scanner
 	langScanner      langpkg.Scanner
 	vulnClient       vulnerability.Client
@@ -206,14 +206,14 @@ func (c *Collector) Close() error {
 // CleanCache cleans the cache
 func (c *Collector) CleanCache() error {
 	if c.cacheCleaner != nil {
-		return c.cacheCleaner.Clean()
+		return c.cacheCleaner.clean()
 	}
 	return nil
 }
 
 // getCache returns the cache with the cache Cleaner. It should initializes the cache
 // only once to avoid blocking the CLI with the `flock` file system.
-func (c *Collector) getCache() (cache.Cache, CacheCleaner, error) {
+func (c *Collector) getCache() (cache.Cache, *ScannerCacheCleaner, error) {
 	var err error
 	c.cacheInitialized.Do(func() {
 		c.cache, c.cacheCleaner, err = NewCustomBoltCache(


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR cleans the SBOM cache enabled option and does some cleanup in the SBOM cache code.
It removes many layers of abstraction.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Enable SBOM collection of container images on helm with and without this [option](https://github.com/DataDog/helm-charts/blob/01b4c40b74533e78e73f53e266b2dc939589cabd/charts/datadog/values.yaml#L716). Make sure that SBOMs are collected properly.

Note: we could not test without this option for now as it is already broken on main. 
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
