### PR TITLE
[ASCII-1313] Use `NoError` instead of `Nil` in tests error assertions

### DIFF
--- a/cmd/agent/gui/checks_test.go
+++ b/cmd/agent/gui/checks_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestReadConfDir(t *testing.T) {
 	files, err := readConfDir("testdata")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	sort.Strings(files)
 	expected := []string{
@@ -32,7 +32,7 @@ func TestReadConfDir(t *testing.T) {
 
 func TestConfigsInPath(t *testing.T) {
 	files, err := getConfigsInPath("testdata")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	sort.Strings(files)
 	expected := []string{

--- a/cmd/agent/subcommands/integrations/integrations_test.go
+++ b/cmd/agent/subcommands/integrations/integrations_test.go
@@ -56,7 +56,7 @@ func TestMoveConfigurationsFilesProfiles(t *testing.T) {
 
 	moveConfigurationFiles(srcFolder, dstFolder)
 	_, err = os.Stat(filepath.Join(dstFolder, "profiles", "device.yaml"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestGetVersionFromReqLine(t *testing.T) {
@@ -97,7 +97,7 @@ func TestValidateArgs(t *testing.T) {
 	assert.NotNil(t, err)
 	args = []string{"datadog-foo"}
 	err = validateArgs(args, false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestValidateRequirement(t *testing.T) {

--- a/comp/core/flare/helpers/send_flare_test.go
+++ b/comp/core/flare/helpers/send_flare_test.go
@@ -53,7 +53,7 @@ func TestFlareHasRightForm(t *testing.T) {
 					w.Header().Set("Content-Type", "application/json")
 					lastRequest = r
 					err := lastRequest.ParseMultipartForm(1000000)
-					assert.Nil(t, err)
+					assert.NoError(t, err)
 					io.WriteString(w, "{}")
 				} else {
 					w.WriteHeader(500)
@@ -94,7 +94,7 @@ func TestFlareHasRightForm(t *testing.T) {
 					" via redirects: 503 Service Unavailable"
 				assert.Equal(t, expectedErrorMessage, err.Error())
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				av, _ := version.Agent()
 
 				assert.Equal(t, caseID, lastRequest.FormValue("case_id"))

--- a/comp/core/secrets/secretsimpl/check_rights_nix_test.go
+++ b/comp/core/secrets/secretsimpl/check_rights_nix_test.go
@@ -30,7 +30,7 @@ func TestWrongPath(t *testing.T) {
 
 func TestGroupOtherRights(t *testing.T) {
 	tmpfile, err := os.CreateTemp("", "agent-collector-test")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
 	allowGroupExec := false

--- a/comp/core/secrets/secretsimpl/check_rights_windows_test.go
+++ b/comp/core/secrets/secretsimpl/check_rights_windows_test.go
@@ -38,10 +38,10 @@ func TestWrongPath(t *testing.T) {
 
 func TestSpaceInPath(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "super temp")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tmpDir)
 	tmpFile, err := os.CreateTemp(tmpDir, "agent-collector-test")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
 	require.Nil(t, os.Chmod(tmpFile.Name(), 0700))
 	require.Nil(t, checkRights(tmpFile.Name(), false))
@@ -54,7 +54,7 @@ func TestCheckRightsDoesNotExists(t *testing.T) {
 
 func TestCheckRightsMissingCurrentUser(t *testing.T) {
 	tmpfile, err := os.CreateTemp("", "agent-collector-test")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
 	err = exec.Command("powershell", "test/setAcl.ps1",
@@ -69,7 +69,7 @@ func TestCheckRightsMissingCurrentUser(t *testing.T) {
 
 func TestCheckRightsMissingLocalSystem(t *testing.T) {
 	tmpfile, err := os.CreateTemp("", "agent-collector-test")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
 	err = exec.Command("powershell", "test/setAcl.ps1",
@@ -84,7 +84,7 @@ func TestCheckRightsMissingLocalSystem(t *testing.T) {
 
 func TestCheckRightsMissingAdministrator(t *testing.T) {
 	tmpfile, err := os.CreateTemp("", "agent-collector-test")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
 	err = exec.Command("powershell", "test/setAcl.ps1",
@@ -100,7 +100,7 @@ func TestCheckRightsMissingAdministrator(t *testing.T) {
 func TestCheckRightsExtraRights(t *testing.T) {
 	// extra rights for someone else
 	tmpfile, err := os.CreateTemp("", "agent-collector-test")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
 	err = exec.Command("powershell", "test/setAcl.ps1",
@@ -116,7 +116,7 @@ func TestCheckRightsExtraRights(t *testing.T) {
 func TestCheckRightsMissingAdmingAndLocal(t *testing.T) {
 	// missing localSystem or Administrator
 	tmpfile, err := os.CreateTemp("", "agent-collector-test")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
 	err = exec.Command("powershell", "test/setAcl.ps1",

--- a/comp/forwarder/defaultforwarder/domain_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder_test.go
@@ -49,7 +49,7 @@ func TestDomainForwarderStart(t *testing.T) {
 	forwarder := newDomainForwarderForTest(mockConfig, log, 0, false)
 	err := forwarder.Start()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	requireLenForwarderRetryQueue(t, forwarder, 0)
 	require.Len(t, forwarder.workers, 1)
 	assert.Equal(t, Started, forwarder.State())

--- a/comp/forwarder/defaultforwarder/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_test.go
@@ -88,7 +88,7 @@ func TestStart(t *testing.T) {
 	err := forwarder.Start()
 	defer forwarder.Stop()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, Started, forwarder.State())
 	require.Len(t, forwarder.domainForwarders, 1)
 	require.NotNil(t, forwarder.healthChecker)
@@ -316,7 +316,7 @@ func TestSendHTTPTransactions(t *testing.T) {
 	forwarder.Start()
 	defer forwarder.Stop()
 	err = forwarder.sendHTTPTransactions(tr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubmitV1Intake(t *testing.T) {

--- a/comp/forwarder/defaultforwarder/transaction/transaction_test.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction_test.go
@@ -56,7 +56,7 @@ func TestProcess(t *testing.T) {
 	mockConfig := pkgconfigmodel.NewConfig("test", "DD", strings.NewReplacer(".", "_"))
 	log := fxutil.Test[log.Component](t, logimpl.MockModule())
 	err := transaction.Process(context.Background(), mockConfig, log, client)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProcessInvalidDomain(t *testing.T) {
@@ -71,7 +71,7 @@ func TestProcessInvalidDomain(t *testing.T) {
 	mockConfig := pkgconfigmodel.NewConfig("test", "DD", strings.NewReplacer(".", "_"))
 	log := fxutil.Test[log.Component](t, logimpl.MockModule())
 	err := transaction.Process(context.Background(), mockConfig, log, client)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProcessNetworkError(t *testing.T) {
@@ -113,16 +113,16 @@ func TestProcessHTTPError(t *testing.T) {
 
 	errorCode = http.StatusBadRequest
 	err = transaction.Process(context.Background(), mockConfig, log, client)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	errorCode = http.StatusRequestEntityTooLarge
 	err = transaction.Process(context.Background(), mockConfig, log, client)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, transaction.ErrorCount, 1)
 
 	errorCode = http.StatusForbidden
 	err = transaction.Process(context.Background(), mockConfig, log, client)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, transaction.ErrorCount, 1)
 }
 
@@ -140,7 +140,7 @@ func TestProcessCancel(t *testing.T) {
 	mockConfig := pkgconfigmodel.NewConfig("test", "DD", strings.NewReplacer(".", "_"))
 	log := fxutil.Test[log.Component](t, logimpl.MockModule())
 	err := transaction.Process(ctx, mockConfig, log, client)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func Test_truncateBodyForLog(t *testing.T) {

--- a/pkg/api/security/security_test.go
+++ b/pkg/api/security/security_test.go
@@ -24,7 +24,7 @@ func initMockConf(t *testing.T) (model.Config, string) {
 	testDir := t.TempDir()
 
 	f, err := os.CreateTemp(testDir, "fake-datadog-yaml-")
-	require.Nil(t, err, fmt.Errorf("%v", err))
+	require.NoError(t, err, fmt.Errorf("%v", err))
 	t.Cleanup(func() {
 		f.Close()
 	})
@@ -39,10 +39,10 @@ func initMockConf(t *testing.T) (model.Config, string) {
 func TestCreateOrFetchAuthTokenValidGen(t *testing.T) {
 	config, expectTokenPath := initMockConf(t)
 	token, err := CreateOrFetchToken(config)
-	require.Nil(t, err, fmt.Sprintf("%v", err))
+	require.NoError(t, err, fmt.Sprintf("%v", err))
 	assert.True(t, len(token) > authTokenMinimalLen, fmt.Sprintf("%d", len(token)))
 	_, err = os.Stat(expectTokenPath)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestFetchAuthToken(t *testing.T) {
@@ -55,12 +55,12 @@ func TestFetchAuthToken(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 
 	newToken, err := CreateOrFetchToken(config)
-	require.Nil(t, err, fmt.Sprintf("%v", err))
+	require.NoError(t, err, fmt.Sprintf("%v", err))
 	require.True(t, len(newToken) > authTokenMinimalLen, fmt.Sprintf("%d", len(newToken)))
 	_, err = os.Stat(expectTokenPath)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	token, err = FetchAuthToken(config)
-	require.Nil(t, err, fmt.Sprintf("%v", err))
+	require.NoError(t, err, fmt.Sprintf("%v", err))
 	require.Equal(t, newToken, token)
 }

--- a/pkg/config/legacy/converter_test.go
+++ b/pkg/config/legacy/converter_test.go
@@ -16,22 +16,22 @@ import (
 
 func TestIsAffirmative(t *testing.T) {
 	value, err := isAffirmative("yes")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, value)
 
 	value, err = isAffirmative("True")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, value)
 
 	value, err = isAffirmative("1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, value)
 
 	_, err = isAffirmative("")
 	assert.NotNil(t, err)
 
 	value, err = isAffirmative("ok")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, value)
 }
 
@@ -60,7 +60,7 @@ func TestBuildProxySettings(t *testing.T) {
 	}
 
 	value, err := BuildProxySettings(agentConfig)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Empty(t, value)
 
 	// malformed url
@@ -71,32 +71,32 @@ func TestBuildProxySettings(t *testing.T) {
 	agentConfig["proxy_host"] = "foobar.baz"
 
 	value, err = BuildProxySettings(agentConfig)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, proxyOnlyHost, value)
 
 	agentConfig["proxy_port"] = "8080"
 
 	value, err = BuildProxySettings(agentConfig)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, proxyNoUser, value)
 
 	// the password alone should not be considered without an user
 	agentConfig["proxy_password"] = "mypass"
 	value, err = BuildProxySettings(agentConfig)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, proxyOnlyPass, value)
 
 	// the user alone is ok
 	agentConfig["proxy_password"] = ""
 	agentConfig["proxy_user"] = "myuser"
 	value, err = BuildProxySettings(agentConfig)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, proxyOnlyUser, value)
 
 	agentConfig["proxy_password"] = "mypass"
 	agentConfig["proxy_user"] = "myuser"
 	value, err = BuildProxySettings(agentConfig)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, proxyWithUser, value)
 }
 
@@ -125,7 +125,7 @@ func TestBuildConfigProviders(t *testing.T) {
 	agentConfig["sd_backend_username"] = "user"
 	agentConfig["sd_backend_password"] = "pass"
 	providers, err := buildConfigProviders(agentConfig)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, providers, 1)
 	p := providers[0]
 	assert.Equal(t, "etcd", p.Name)
@@ -140,7 +140,7 @@ func TestBuildConfigProviders(t *testing.T) {
 	agentConfig["sd_config_backend"] = "consul"
 	agentConfig["consul_token"] = "123456"
 	providers, err = buildConfigProviders(agentConfig)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, providers, 1)
 	p = providers[0]
 	assert.Equal(t, "consul", p.Name)
@@ -331,7 +331,7 @@ func TestExtractURLAPIKeys(t *testing.T) {
 	agentConfig["dd_url"] = ""
 	agentConfig["api_key"] = ""
 	err := extractURLAPIKeys(agentConfig, configConverter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "", config.Datadog.GetString("dd_url"))
 	assert.Equal(t, "", config.Datadog.GetString("api_key"))
 	assert.Empty(t, config.Datadog.GetStringMapStringSlice("additional_endpoints"))
@@ -340,7 +340,7 @@ func TestExtractURLAPIKeys(t *testing.T) {
 	agentConfig["dd_url"] = "https://datadoghq.com"
 	agentConfig["api_key"] = "123456789"
 	err = extractURLAPIKeys(agentConfig, configConverter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://datadoghq.com", config.Datadog.GetString("dd_url"))
 	assert.Equal(t, "123456789", config.Datadog.GetString("api_key"))
 	assert.Empty(t, config.Datadog.GetStringMapStringSlice("additional_endpoints"))
@@ -349,7 +349,7 @@ func TestExtractURLAPIKeys(t *testing.T) {
 	agentConfig["dd_url"] = "https://datadoghq.com,https://datadoghq.com,https://datadoghq.com,https://staging.com"
 	agentConfig["api_key"] = "123456789,abcdef,secret_key,secret_key2"
 	err = extractURLAPIKeys(agentConfig, configConverter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://datadoghq.com", config.Datadog.GetString("dd_url"))
 	assert.Equal(t, "123456789", config.Datadog.GetString("api_key"))
 

--- a/pkg/config/legacy/docker_test.go
+++ b/pkg/config/legacy/docker_test.go
@@ -86,14 +86,14 @@ func TestConvertDocker(t *testing.T) {
 	dst := filepath.Join(dir, "docker.yaml")
 
 	err := os.WriteFile(src, []byte(dockerDaemonLegacyConf), 0640)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	configConverter := config.NewConfigConverter()
 	err = ImportDockerConf(src, dst, true, configConverter)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	newConf, err := os.ReadFile(filepath.Join(dir, "docker.yaml"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, dockerNewConf, string(newConf))
 
@@ -114,7 +114,7 @@ func TestConvertDocker(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 
 	err = ImportDockerConf(src, dst, true, configConverter)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = os.Stat(filepath.Join(dir, "docker.yaml.bak"))
 	assert.False(t, os.IsNotExist(err))
 }

--- a/pkg/config/legacy/importer_test.go
+++ b/pkg/config/legacy/importer_test.go
@@ -17,13 +17,13 @@ import (
 func TestGetAgentConfig(t *testing.T) {
 	// load configuration from Go
 	agentConfigGo, err := GetAgentConfig("./tests/datadog.conf")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	pyConfig := map[string]string{}
 	data, err := os.ReadFile("./tests/config.json")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = json.Unmarshal(data, &pyConfig)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// ensure we've all the items
 	for key, value := range pyConfig {

--- a/pkg/config/model/viper_test.go
+++ b/pkg/config/model/viper_test.go
@@ -124,7 +124,7 @@ float_list:
 	config.ReadConfig(bytes.NewBuffer(yamlExample))
 
 	list, err := config.GetFloat64SliceE("float_list")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []float64{1.1, 2.2, 3.3}, list)
 
 	yamlExample = []byte(`---
@@ -157,7 +157,7 @@ float_list:
 	t.Setenv("DD_FLOAT_LIST", "1.1 2.2 3.3")
 
 	list, err := config.GetFloat64SliceE("float_list")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []float64{1.1, 2.2, 3.3}, list)
 }
 

--- a/pkg/config/settings/runtime_settings_test.go
+++ b/pkg/config/settings/runtime_settings_test.go
@@ -50,18 +50,18 @@ func TestRuntimeSettings(t *testing.T) {
 	runtimeSetting := runtimeTestSetting{1}
 
 	err := RegisterRuntimeSetting(&runtimeSetting)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(RuntimeSettings()))
 
 	v, err := GetRuntimeSetting(runtimeSetting.Name())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, runtimeSetting.value, v)
 
 	err = SetRuntimeSetting(runtimeSetting.Name(), 123, model.SourceDefault)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	v, err = GetRuntimeSetting(runtimeSetting.Name())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 123, v)
 
 	err = RegisterRuntimeSetting(&runtimeSetting)
@@ -77,18 +77,18 @@ func TestLogLevel(t *testing.T) {
 	assert.Equal(t, "log_level", ll.Name())
 
 	err := ll.Set("off", model.SourceDefault)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	v, err := ll.Get()
 	assert.Equal(t, "off", v)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = ll.Set("WARNING", model.SourceDefault)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	v, err = ll.Get()
 	assert.Equal(t, "warn", v)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = ll.Set("invalid", model.SourceDefault)
 	assert.NotNil(t, err)
@@ -96,7 +96,7 @@ func TestLogLevel(t *testing.T) {
 
 	v, err = ll.Get()
 	assert.Equal(t, "warn", v)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProfiling(t *testing.T) {
@@ -108,11 +108,11 @@ func TestProfiling(t *testing.T) {
 	assert.Equal(t, "datadog-agent", ll.Service)
 
 	err := ll.Set("false", model.SourceDefault)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	v, err := ll.Get()
 	assert.Equal(t, false, v)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = ll.Set("on", model.SourceDefault)
 	assert.NotNil(t, err)
@@ -149,7 +149,7 @@ func TestGetInt(t *testing.T) {
 		if c.err {
 			assert.NotNil(t, err)
 		} else {
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, v, c.exp)
 		}
 	}

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -776,7 +776,7 @@ logs_config:
 	config := ConfFromYAML(datadogYaml)
 	err := checkConflictingOptions(config)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupFipsEndpoints(t *testing.T) {

--- a/pkg/config/utils/endpoints_test.go
+++ b/pkg/config/utils/endpoints_test.go
@@ -61,7 +61,7 @@ additional_endpoints:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -93,7 +93,7 @@ additional_endpoints:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -114,7 +114,7 @@ func TestGetMultipleEndpointsEnvVar(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -148,7 +148,7 @@ additional_endpoints:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -168,7 +168,7 @@ api_key: fakeapikey
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -200,7 +200,7 @@ additional_endpoints:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -234,7 +234,7 @@ additional_endpoints:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -252,7 +252,7 @@ func TestSiteEnvVar(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://external-agent.datadoghq.eu", externalAgentURL)
 }
@@ -272,7 +272,7 @@ api_key: fakeapikey
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://external-agent.datadoghq.com", externalAgentURL)
 }
@@ -293,7 +293,7 @@ api_key: fakeapikey
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://external-agent.datadoghq.eu", externalAgentURL)
 }
@@ -314,7 +314,7 @@ func TestDDURLEnvVar(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://custom.external-agent.datadoghq.com", externalAgentURL)
 }
@@ -335,7 +335,7 @@ func TestDDDDURLEnvVar(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://custom.external-agent.datadoghq.com", externalAgentURL)
 }
@@ -360,7 +360,7 @@ func TestDDURLAndDDDDURLEnvVar(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://custom.external-agent.datadoghq.com", externalAgentURL)
 }
@@ -385,7 +385,7 @@ external_config:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://external-agent.datadoghq.com", externalAgentURL)
 }
@@ -409,7 +409,7 @@ external_config:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://custom.external-agent.datadoghq.eu", externalAgentURL)
 }
@@ -477,9 +477,9 @@ func TestAddAgentVersionToDomain(t *testing.T) {
 
 	for _, testCase := range versionURLTests {
 		appURL, err := AddAgentVersionToDomain(testCase.url, "app")
-		require.Nil(t, err)
+		require.NoError(t, err)
 		flareURL, err := AddAgentVersionToDomain(testCase.url, "flare")
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		if testCase.shouldAppendVersion {
 			assert.Equal(t, "https://"+appVersionPrefix+testCase.expectedURL, appURL)

--- a/pkg/diagnose/connectivity/core_endpoint_test.go
+++ b/pkg/diagnose/connectivity/core_endpoint_test.go
@@ -49,13 +49,13 @@ func TestSendHTTPRequestToEndpoint(t *testing.T) {
 
 	// With the correct API Key, it should be a 200
 	statusCodeWithKey, responseBodyWithKey, _, errWithKey := sendHTTPRequestToEndpoint(context.Background(), client, ts1.URL, endpointInfoTest, apiKey1)
-	assert.Nil(t, errWithKey)
+	assert.NoError(t, errWithKey)
 	assert.Equal(t, statusCodeWithKey, 200)
 	assert.Equal(t, string(responseBodyWithKey), "OK")
 
 	// With the wrong API Key, it should be a 400
 	statusCode, responseBody, _, err := sendHTTPRequestToEndpoint(context.Background(), client, ts1.URL, endpointInfoTest, apiKey2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, statusCode, 400)
 	assert.Equal(t, string(responseBody), "Bad Request")
 }

--- a/pkg/pidfile/pidfile_test.go
+++ b/pkg/pidfile/pidfile_test.go
@@ -19,11 +19,11 @@ func TestWritePID(t *testing.T) {
 
 	pidFilePath := filepath.Join(dir, "this_should_be_created", "agent.pid")
 	err := WritePID(pidFilePath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	data, err := os.ReadFile(pidFilePath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	pid, err := strconv.Atoi(string(data))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, pid, os.Getpid())
 }
 

--- a/pkg/util/cloudproviders/alibaba/alibaba_test.go
+++ b/pkg/util/cloudproviders/alibaba/alibaba_test.go
@@ -31,7 +31,7 @@ func TestGetHostname(t *testing.T) {
 	metadataURL = ts.URL
 
 	aliases, err := GetHostAliases(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	require.Len(t, aliases, 1)
 	assert.Equal(t, expected, aliases[0])
 	assert.Equal(t, lastRequest.URL.Path, "/latest/meta-data/instance-id")

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -33,7 +33,7 @@ func TestGetAlias(t *testing.T) {
 	metadataURL = ts.URL
 
 	aliases, err := GetHostAliases(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	require.Len(t, aliases, 1)
 	assert.Equal(t, expected, aliases[0])
 	assert.Equal(t, lastRequest.URL.Path, "/metadata/instance/compute/vmId")
@@ -192,7 +192,7 @@ func TestGetPublicIPv4(t *testing.T) {
 	metadataURL = ts.URL
 	val, err := GetPublicIPv4(ctx)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.True(t, strings.HasPrefix(lastRequest.URL.Path, pathPrefix))
 }

--- a/pkg/util/cloudproviders/gce/gce_tags_test.go
+++ b/pkg/util/cloudproviders/gce/gce_tags_test.go
@@ -97,7 +97,7 @@ func TestGetHostTags(t *testing.T) {
 	defer server.Close()
 	defer cache.Cache.Delete(tagsCacheKey)
 	tags, err := GetTags(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	testTags(t, tags, expectedFullTags)
 }
 
@@ -109,7 +109,7 @@ func TestGetHostTagsWithProjectID(t *testing.T) {
 	config.Datadog.SetWithoutSource("gce_send_project_id_tag", true)
 	defer config.Datadog.SetWithoutSource("gce_send_project_id_tag", false)
 	tags, err := GetTags(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	testTags(t, tags, expectedTagsWithProjectID)
 }
 
@@ -118,14 +118,14 @@ func TestGetHostTagsSuccessThenError(t *testing.T) {
 	server := mockMetadataRequest(t)
 	tags, err := GetTags(ctx)
 	require.NotNil(t, tags)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	server.Close()
 
 	server = mockMetadataRequestError(t)
 	defer server.Close()
 	defer cache.Cache.Delete(tagsCacheKey)
 	tags, err = GetTags(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	testTags(t, tags, expectedFullTags)
 }
 
@@ -142,6 +142,6 @@ func TestGetHostTagsWithNonDefaultTagFilters(t *testing.T) {
 	defer cache.Cache.Delete(tagsCacheKey)
 
 	tags, err := GetTags(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	testTags(t, tags, expectedExcludedTags)
 }

--- a/pkg/util/cloudproviders/gce/gce_test.go
+++ b/pkg/util/cloudproviders/gce/gce_test.go
@@ -40,7 +40,7 @@ func TestGetHostname(t *testing.T) {
 	metadataURL = ts.URL
 
 	val, err := GetHostname(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, "/instance/hostname", lastRequest.URL.Path)
 }
@@ -84,7 +84,7 @@ func TestGetHostAliases(t *testing.T) {
 	metadataURL = ts.URL
 
 	val, err := GetHostAliases(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"gce-custom-hostname.custom-domain.gce-project", "gce-instance-name.gce-project"}, val)
 }
 
@@ -110,7 +110,7 @@ func TestGetHostAliasesInstanceNameError(t *testing.T) {
 	metadataURL = ts.URL
 
 	val, err := GetHostAliases(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"gce-custom-hostname.custom-domain.gce-project", "gce-custom-hostname.gce-project"}, val)
 }
 
@@ -128,7 +128,7 @@ func TestGetClusterName(t *testing.T) {
 	metadataURL = ts.URL
 
 	val, err := GetClusterName(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, "/instance/attributes/cluster-name", lastRequest.URL.Path)
 }
@@ -147,7 +147,7 @@ func TestGetPublicIPv4(t *testing.T) {
 	metadataURL = ts.URL
 
 	val, err := GetPublicIPv4(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, "/instance/network-interfaces/0/access-configs/0/external-ip", lastRequest.URL.Path)
 }

--- a/pkg/util/cloudproviders/ibm/ibm_test.go
+++ b/pkg/util/cloudproviders/ibm/ibm_test.go
@@ -46,7 +46,7 @@ func TestGetToken(t *testing.T) {
 	metadataURL = ts.URL
 
 	value, expiresAt, err := getToken(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "some data", value)
 
 	expectedExpiresAt, _ := time.Parse(time.RFC3339, "2022-03-22T15:40:50.227Z")
@@ -82,7 +82,7 @@ func TestGetTokenErrorParsingDate(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	value, expiresAt, err := getToken(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "some data", value)
 
 	// expiresAt is set to time.Now() when the API returned an invalid expire date.
@@ -108,6 +108,6 @@ func TestGetHostAliases(t *testing.T) {
 	metadataURL = ts.URL
 
 	aliases, err := GetHostAliases(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"an ID"}, aliases)
 }

--- a/pkg/util/cloudproviders/oracle/oracle_test.go
+++ b/pkg/util/cloudproviders/oracle/oracle_test.go
@@ -37,7 +37,7 @@ func TestGetHostAliases(t *testing.T) {
 	metadataURL = ts.URL
 
 	aliases, err := GetHostAliases(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	require.Len(t, aliases, 1)
 	assert.Equal(t, expected, aliases[0])
 	assert.Equal(t, lastRequest.URL.Path, "/opc/v2/instance/id")

--- a/pkg/util/cloudproviders/tencent/tencent_test.go
+++ b/pkg/util/cloudproviders/tencent/tencent_test.go
@@ -35,7 +35,7 @@ func TestGetInstanceID(t *testing.T) {
 	metadataURL = ts.URL
 
 	val, err := GetInstanceID(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/meta-data/instance-id")
 }

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -34,11 +34,11 @@ func TestJSONConverter(t *testing.T) {
 
 		// Read file contents
 		yamlFile, err := os.ReadFile(fmt.Sprintf("../collector/corechecks/embed/jmx/fixtures/%s.yaml", c))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		// Parse configuration
 		err = yaml.Unmarshal(yamlFile, &cf)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		cache[c] = cf
 	}
@@ -53,7 +53,7 @@ func TestJSONConverter(t *testing.T) {
 
 	//json encode
 	_, err := json.Marshal(GetJSONSerializableMap(j))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCopyDir(t *testing.T) {

--- a/pkg/util/ec2/ec2_tags_test.go
+++ b/pkg/util/ec2/ec2_tags_test.go
@@ -41,7 +41,7 @@ func TestGetIAMRole(t *testing.T) {
 	defer resetPackageVars()
 
 	val, err := getIAMRole(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, val)
 }
 
@@ -54,7 +54,7 @@ func TestGetSecurityCreds(t *testing.T) {
 		} else if r.URL.Path == "/iam/security-credentials/test-role" {
 			w.Header().Set("Content-Type", "text/plain")
 			content, err := os.ReadFile("payloads/security_cred.json")
-			require.Nil(t, err, fmt.Sprintf("failed to load json in payloads/security_cred.json: %v", err))
+			require.NoError(t, err, fmt.Sprintf("failed to load json in payloads/security_cred.json: %v", err))
 			io.WriteString(w, string(content))
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -66,7 +66,7 @@ func TestGetSecurityCreds(t *testing.T) {
 	defer resetPackageVars()
 
 	cred, err := getSecurityCreds(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "123456", cred.AccessKeyID)
 	assert.Equal(t, "secret access key", cred.SecretAccessKey)
 	assert.Equal(t, "secret token", cred.Token)
@@ -77,7 +77,7 @@ func TestGetInstanceIdentity(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		content, err := os.ReadFile("payloads/instance_indentity.json")
-		require.Nil(t, err, fmt.Sprintf("failed to load json in payloads/instance_indentity.json: %v", err))
+		require.NoError(t, err, fmt.Sprintf("failed to load json in payloads/instance_indentity.json: %v", err))
 		io.WriteString(w, string(content))
 	}))
 	defer ts.Close()
@@ -86,7 +86,7 @@ func TestGetInstanceIdentity(t *testing.T) {
 	defer resetPackageVars()
 
 	val, err := GetInstanceIdentity(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "us-east-1", val.Region)
 	assert.Equal(t, "i-aaaaaaaaaaaaaaaaa", val.InstanceID)
 	assert.Equal(t, "REMOVED", val.AccountID)
@@ -118,7 +118,7 @@ func TestFetchEc2TagsFromIMDS(t *testing.T) {
 	confMock.SetWithoutSource("exclude_ec2_tags", []string{"ExcludedTag", "OtherExcludedTag2"})
 
 	tags, err := fetchEc2TagsFromIMDS(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"Name:some-vm",
 		"Purpose:mining",
@@ -156,7 +156,7 @@ func TestGetTags(t *testing.T) {
 	fetchTags = mockFetchTagsSuccess
 
 	tags, err := GetTags(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"tag1", "tag2"}, tags)
 }
 
@@ -180,7 +180,7 @@ func TestGetTagsErrorFullCache(t *testing.T) {
 	fetchTags = mockFetchTagsFailure
 
 	tags, err := GetTags(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"cachedTag"}, tags)
 }
 
@@ -194,16 +194,16 @@ func TestGetTagsFullWorkflow(t *testing.T) {
 	fetchTags = mockFetchTagsFailure
 
 	tags, err := GetTags(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"oldTag"}, tags)
 
 	fetchTags = mockFetchTagsSuccess
 	tags, err = GetTags(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"tag1", "tag2"}, tags)
 
 	fetchTags = mockFetchTagsFailure
 	tags, err = GetTags(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"tag1", "tag2"}, tags)
 }

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -103,14 +103,14 @@ func TestGetInstanceID(t *testing.T) {
 	// API successful, should return API result
 	responseCode = http.StatusOK
 	val, err = GetInstanceID(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
 
 	// the internal cache is populated now, should return the cached value even if API errors out
 	responseCode = http.StatusInternalServerError
 	val, err = GetInstanceID(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
 
@@ -118,7 +118,7 @@ func TestGetInstanceID(t *testing.T) {
 	responseCode = http.StatusOK
 	expected = "i-aaaaaaaaaaaaaaaaa"
 	val, err = GetInstanceID(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
 }
@@ -221,14 +221,14 @@ func TestGetHostname(t *testing.T) {
 	// API successful, should return hostname
 	responseCode = http.StatusOK
 	val, err = GetHostname(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/hostname")
 
 	// the internal cache is populated now, should return the cached hostname even if API errors out
 	responseCode = http.StatusInternalServerError
 	val, err = GetHostname(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/hostname")
 
@@ -236,7 +236,7 @@ func TestGetHostname(t *testing.T) {
 	responseCode = http.StatusOK
 	expected = "ip-20-20-20-20.ec2.internal"
 	val, err = GetHostname(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/hostname")
 

--- a/pkg/util/executable/executable_test.go
+++ b/pkg/util/executable/executable_test.go
@@ -23,7 +23,7 @@ func TestResolvePath(t *testing.T) {
 	}
 
 	actualPath, err := ResolvePath(testProgram)
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		return
 	}
 
@@ -43,12 +43,12 @@ func TestResolvePathIsAbsolute(t *testing.T) {
 	}
 
 	actualPath, err := ResolvePath(testProgram)
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		return
 	}
 
 	absPath, err := filepath.Abs(actualPath)
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		return
 	}
 

--- a/pkg/util/http/token_test.go
+++ b/pkg/util/http/token_test.go
@@ -39,7 +39,7 @@ func TestGetNewToken(t *testing.T) {
 
 	token := NewAPIToken(cb)
 	val, err := token.Get(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test", val)
 	assert.Equal(t, expireReturnValue, token.ExpirationDate)
 	assert.Equal(t, 1, nbCbCall)
@@ -48,7 +48,7 @@ func TestGetNewToken(t *testing.T) {
 	tokenReturnValue = "test2"
 
 	val, err = token.Get(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test", val)
 	assert.Equal(t, expireReturnValue, token.ExpirationDate)
 	assert.Equal(t, 1, nbCbCall)
@@ -56,7 +56,7 @@ func TestGetNewToken(t *testing.T) {
 	// expire token
 	token.ExpirationDate = time.Now().Add(-10 * time.Minute)
 	val, err = token.Get(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test2", val)
 	assert.Equal(t, expireReturnValue, token.ExpirationDate)
 	assert.Equal(t, 2, nbCbCall)

--- a/pkg/util/http/transport_test.go
+++ b/pkg/util/http/transport_test.go
@@ -22,14 +22,14 @@ func TestEmptyProxy(t *testing.T) {
 	setupTest(t)
 
 	r, err := http.NewRequest("GET", "https://test.com", nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	proxies := &pkgconfigmodel.Proxy{}
 	c := pkgconfigmodel.NewConfig("test", "DD", strings.NewReplacer(".", "_"))
 	proxyFunc := GetProxyTransportFunc(proxies, c)
 
 	proxyURL, err := proxyFunc(r)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, proxyURL)
 }
 
@@ -46,11 +46,11 @@ func TestHTTPProxy(t *testing.T) {
 	proxyFunc := GetProxyTransportFunc(proxies, c)
 
 	proxyURL, err := proxyFunc(rHTTP)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
 
 	proxyURL, err = proxyFunc(rHTTPS)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, proxyURL)
 }
 
@@ -72,20 +72,20 @@ func TestNoProxy(t *testing.T) {
 	proxyFunc := GetProxyTransportFunc(proxies, c)
 
 	proxyURL, err := proxyFunc(r1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, proxyURL)
 
 	proxyURL, err = proxyFunc(r2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
 
 	proxyURL, err = proxyFunc(r3)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://user:pass@proxy_https.com:3128", proxyURL.String())
 
 	// Validate the old behavior (when no_proxy_nonexact_match is false)
 	proxyURL, err = proxyFunc(r4)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
 }
 
@@ -111,27 +111,27 @@ func TestNoProxyNonexactMatch(t *testing.T) {
 	proxyFunc := GetProxyTransportFunc(proxies, c)
 
 	proxyURL, err := proxyFunc(r1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, proxyURL)
 
 	proxyURL, err = proxyFunc(r2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
 
 	proxyURL, err = proxyFunc(r3)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://user:pass@proxy_https.com:3128", proxyURL.String())
 
 	proxyURL, err = proxyFunc(r4)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, proxyURL)
 
 	proxyURL, err = proxyFunc(r5)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
 
 	proxyURL, err = proxyFunc(r6)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, proxyURL)
 }
 
@@ -163,7 +163,7 @@ func TestBadScheme(t *testing.T) {
 	proxyFunc := GetProxyTransportFunc(proxies, c)
 
 	proxyURL, err := proxyFunc(r1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, proxyURL)
 }
 
@@ -199,7 +199,7 @@ func TestNoProxyWarningMap(t *testing.T) {
 	proxyFunc := GetProxyTransportFunc(proxies, c)
 
 	proxyURL, err := proxyFunc(r1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
 
 	assert.True(t, noProxyIgnoredWarningMap["http://api.test_http.com"])

--- a/pkg/util/json/nested_json_test.go
+++ b/pkg/util/json/nested_json_test.go
@@ -16,7 +16,7 @@ func TestGetNestedValueExists(t *testing.T) {
 	rawJSON := []byte(`{"key":"val"}`)
 	jsonMap := make(map[string]interface{})
 	err := json.Unmarshal(rawJSON, &jsonMap)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "val", GetNestedValue(jsonMap, "key"))
 }
@@ -25,7 +25,7 @@ func TestGetNestedValueExistsNested(t *testing.T) {
 	rawJSON := []byte(`{"key":"val", "key2": {"key3": {"key4": "val2"}}}`)
 	jsonMap := make(map[string]interface{})
 	err := json.Unmarshal(rawJSON, &jsonMap)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "val2", GetNestedValue(jsonMap, "key2", "key3", "key4"))
 }
@@ -34,7 +34,7 @@ func TestGetNestedValueExistsStruct(t *testing.T) {
 	rawJSON := []byte(`{"key":"val", "key2": {"key3": {"key4": "val2"}}}`)
 	jsonMap := make(map[string]interface{})
 	err := json.Unmarshal(rawJSON, &jsonMap)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, map[string]interface{}{
 		"key4": "val2",
@@ -45,7 +45,7 @@ func TestGetNestedValueDoesntExist(t *testing.T) {
 	rawJSON := []byte(`{"key":"val", "key5": {"key3": {"key4": "val2"}}}`)
 	jsonMap := make(map[string]interface{})
 	err := json.Unmarshal(rawJSON, &jsonMap)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, nil, GetNestedValue(jsonMap, "doesnt_exist", "key3"))
 }
@@ -54,7 +54,7 @@ func TestGetNestedValueDoesntExistNested(t *testing.T) {
 	rawJSON := []byte(`{"key":"val", "key5": {"key3": {"key4": "val2"}}}`)
 	jsonMap := make(map[string]interface{})
 	err := json.Unmarshal(rawJSON, &jsonMap)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, nil, GetNestedValue(jsonMap, "key5", "doesnt_exist"))
 }
@@ -63,7 +63,7 @@ func TestGetNestedValueExistsEarly(t *testing.T) {
 	rawJSON := []byte(`{"key":"val", "key2": "val"}`)
 	jsonMap := make(map[string]interface{})
 	err := json.Unmarshal(rawJSON, &jsonMap)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, nil, GetNestedValue(jsonMap, "key2", "key1"))
 }

--- a/pkg/util/jsonquery/jsonquery_test.go
+++ b/pkg/util/jsonquery/jsonquery_test.go
@@ -40,12 +40,12 @@ func TestQueryRun(t *testing.T) {
 	value, hasValue, err := RunSingleOutput(".foo", object)
 	assert.Equal(t, "bar", value)
 	assert.True(t, hasValue)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	value, hasValue, err = RunSingleOutput(".bar", object)
 	assert.Equal(t, "", value)
 	assert.False(t, hasValue)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	value, hasValue, err = RunSingleOutput(".%bar", object)
 	assert.Equal(t, "", value)

--- a/pkg/util/log/log_not_serverless_test.go
+++ b/pkg/util/log/log_not_serverless_test.go
@@ -21,7 +21,7 @@ func TestServerlessLoggingNotInServerlessContext(t *testing.T) {
 	w := bufio.NewWriter(&b)
 
 	l, err := seelog.LoggerFromWriterWithMinLevel(w, seelog.DebugLvl)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	SetupLogger(l, "debug")
 	assert.NotNil(t, logger.Load())

--- a/pkg/util/log/log_serverless_test.go
+++ b/pkg/util/log/log_serverless_test.go
@@ -21,7 +21,7 @@ func TestServerlessLoggingInServerlessContext(t *testing.T) {
 	w := bufio.NewWriter(&b)
 
 	l, err := seelog.LoggerFromWriterWithMinLevel(w, seelog.DebugLvl)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	SetupLogger(l, "debug")
 	assert.NotNil(t, logger)

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -56,7 +56,7 @@ func TestBasicLogging(t *testing.T) {
 
 	seelog.RegisterCustomFormatter("ExtraTextContext", createExtraTextContext)
 	l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %ExtraTextContext%Msg\n")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	SetupLogger(l, "debug")
 	assert.NotNil(t, logger.Load())
@@ -115,7 +115,7 @@ func TestLogBuffer(t *testing.T) {
 	w := bufio.NewWriter(&b)
 
 	l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	Tracef("%s", "foo")
 	Debugf("%s", "foo")
@@ -141,7 +141,7 @@ func TestLogBufferWithContext(t *testing.T) {
 	w := bufio.NewWriter(&b)
 
 	l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	Tracec("baz", "number", 1, "str", "hello")
 	Debugc("baz", "number", 1, "str", "hello")
@@ -177,7 +177,7 @@ func TestCredentialScrubbingLogging(t *testing.T) {
 	w := bufio.NewWriter(&b)
 
 	l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	SetupLogger(l, "info")
 	assert.NotNil(t, logger.Load())
@@ -199,15 +199,15 @@ func TestExtraLogging(t *testing.T) {
 	wA := bufio.NewWriter(&b)
 
 	l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %Msg")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	lA, err := seelog.LoggerFromWriterWithMinLevelAndFormat(wA, seelog.DebugLvl, "[%LEVEL] %Msg")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	SetupLogger(l, "info")
 	assert.NotNil(t, logger.Load())
 
 	err = RegisterAdditionalLogger("extra", lA)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	Info("don't tell anyone: ", "SECRET")
 	Infof("this is a SECRET password: %s", "hunter2")
@@ -487,7 +487,7 @@ func TestStackDepthfLogging(t *testing.T) {
 			w := bufio.NewWriter(&b)
 
 			l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, tc.seelogLevel, "[%LEVEL] %Func: %Msg\n")
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			SetupLogger(l, tc.strLogLevel)
 

--- a/pkg/util/log/zap/zapcore_test.go
+++ b/pkg/util/log/zap/zapcore_test.go
@@ -143,7 +143,7 @@ func TestZapBasicLogging(t *testing.T) {
 			seelog.RegisterCustomFormatter("ExtraTextContext", createExtraTextContext)
 			seelog.RegisterCustomFormatter("ShortFilePath", parseShortFilePath)
 			l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] | %ShortFilePath | %ExtraTextContext%Msg")
-			require.Nil(t, err)
+			require.NoError(t, err)
 			log.SetupLogger(l, testInstance.level)
 			require.NotNil(t, logger)
 

--- a/pkg/util/profiling/profiling_test.go
+++ b/pkg/util/profiling/profiling_test.go
@@ -26,7 +26,7 @@ func TestProfiling(t *testing.T) {
 		Tags:                 []string{"1.0.0"},
 	}
 	err := Start(settings)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	Stop()
 }

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -20,7 +20,7 @@ import (
 
 func assertClean(t *testing.T, contents, cleanContents string) {
 	cleaned, err := ScrubBytes([]byte(contents))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	cleanedString := string(cleaned)
 
 	assert.Equal(t, strings.TrimSpace(cleanContents), strings.TrimSpace(cleanedString))
@@ -38,7 +38,7 @@ func TestConfigScrubbedValidYaml(t *testing.T) {
 	require.NoError(t, err)
 
 	cleaned, err := ScrubBytes([]byte(inputConfData))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// First test that the a scrubbed yaml is still a valid yaml
 	var out interface{}
@@ -64,7 +64,7 @@ func TestConfigScrubbedYaml(t *testing.T) {
 	require.NoError(t, err)
 
 	cleaned, err := ScrubYaml([]byte(inputConfData))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// First test that the a scrubbed yaml is still a valid yaml
 	var out interface{}
@@ -85,7 +85,7 @@ func TestConfigScrubbedJson(t *testing.T) {
 	inputConfData, err := os.ReadFile(inputConf)
 	require.NoError(t, err)
 	cleaned, err := ScrubJSON([]byte(inputConfData))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// First test that the a scrubbed json is still valid
 	var actualOutJSON map[string]interface{}
 	err = json.Unmarshal(cleaned, &actualOutJSON)
@@ -102,17 +102,17 @@ func TestConfigScrubbedJson(t *testing.T) {
 
 func TestEmptyYaml(t *testing.T) {
 	cleaned, err := ScrubYaml(nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "", string(cleaned))
 
 	cleaned, err = ScrubYaml([]byte(""))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "", string(cleaned))
 }
 
 func TestEmptyYamlString(t *testing.T) {
 	cleaned, err := ScrubYamlString("")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "", string(cleaned))
 }
 
@@ -483,7 +483,7 @@ other_config_with_list: [abc]
 func TestAddStrippedKeys(t *testing.T) {
 	contents := `foobar: baz`
 	cleaned, err := ScrubBytes([]byte(contents))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Sanity check
 	assert.Equal(t, contents, string(cleaned))
@@ -501,7 +501,7 @@ func TestAddStrippedKeysNewReplacer(t *testing.T) {
 	AddDefaultReplacers(newScrubber)
 
 	cleaned, err := newScrubber.ScrubBytes([]byte(contents))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, strings.TrimSpace(`foobar: "********"`), strings.TrimSpace(string(cleaned)))
 }
 
@@ -598,7 +598,7 @@ log_level: info
 	wd, _ := os.Getwd()
 	filePath := filepath.Join(wd, "test", "datadog.yaml")
 	cleaned, err := ScrubFile(filePath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	cleanedString := string(cleaned)
 
 	assert.Equal(t, cleanedConfigFile, cleanedString)

--- a/pkg/util/stat_test.go
+++ b/pkg/util/stat_test.go
@@ -18,7 +18,7 @@ func TestStats(t *testing.T) {
 	myStat := expvar.Int{}
 
 	s, err := NewStats(10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()

--- a/pkg/util/system/network_linux_test.go
+++ b/pkg/util/system/network_linux_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestParseProcessRoutes(t *testing.T) {
 	dummyProcDir, err := testutil.NewTempFolder("test-process-routes")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer dummyProcDir.RemoveAll() // clean up
 
 	for _, tc := range []struct {
@@ -108,7 +108,7 @@ func TestParseProcessRoutes(t *testing.T) {
 
 func TestParseProcessIPs(t *testing.T) {
 	dummyProcDir, err := testutil.NewTempFolder("test-process-ips")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer dummyProcDir.RemoveAll() // clean up
 
 	exampleNetFibTrieFileContent := `
@@ -244,7 +244,7 @@ Local:
 
 // func TestDefaulHostIPs(t *testing.T) {
 // 	dummyProcDir, err := testutil.NewTempFolder("test-default-host-ips")
-// 	require.Nil(t, err)
+// 	require.NoError(t, err)
 // 	defer dummyProcDir.RemoveAll()
 
 // 	t.Run("routing table contains a gateway entry", func(t *testing.T) {
@@ -278,7 +278,7 @@ Local:
 
 // 		// Verify they match the IPs returned by DefaultHostIPs()
 // 		defaultIPs, err := defaultHostIPs(dummyProcDir.RootPath)
-// 		assert.Nil(t, err)
+// 		assert.NoError(t, err)
 // 		assert.Equal(t, expectedIPs, defaultIPs)
 // 	})
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -14,7 +14,7 @@ import (
 func TestNew(t *testing.T) {
 	// full fledge
 	v, err := New("1.2.3-pre+☢", "deadbeef")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int64(1), v.Major)
 	assert.Equal(t, int64(2), v.Minor)
 	assert.Equal(t, int64(3), v.Patch)
@@ -24,12 +24,12 @@ func TestNew(t *testing.T) {
 
 	// only pre
 	v, err = New("1.2.3-pre-pre.1", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "pre-pre.1", v.Pre)
 
 	// only meta
 	v, err = New("1.2.3+☢.1+", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "☢.1+", v.Meta)
 
 	_, err = New("", "")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Replace all occurrences of `assert.Nil(t, err)` with `assert.NoError(t, err)`.
Same with `require`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Have a better error message: `assert.Nil` uses format `%#v` while `assert.NoError` uses `%+v`.
This difference results in the following outputs:
```go
var errTimeout error = &httpError{err: "net/http: timeout awaiting response headers", timeout: true}
var myerr error = &url.Error{Op: "Get", URL: "http://127.0.0.1:50854/tags/instance/Purpose", Err: errTimeout}

fmt.Printf("%#v\n", myerr)
fmt.Printf("%+v\n", myerr)
```

Will print:
```
&url.Error{Op:"Get", URL:"http://127.0.0.1:50854/tags/instance/Purpose", Err:(*main.httpError)(0x10059db70)}
Get "http://127.0.0.1:50854/tags/instance/Purpose": net/http: timeout awaiting response headers
```

With the first you can't see what the `httperror` is, while with the second you have the proper error string.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Wrote a script to perform the change only in files owned by agent-shared-components team.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
