### PR TITLE
Add new sql obfuscation mode normalize_only

### DIFF
--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -260,7 +260,7 @@ type sqlConfig struct {
 
 	// RemoveSpaceBetweenParentheses specifies whether to remove spaces between parentheses.
 	// By default, spaces are inserted between parentheses during normalization.
-	// This option is only valid when ObfuscationMode is "obfuscate_and_normalize".
+	// This option is only valid when ObfuscationMode is "normalize_only" or "obfuscate_and_normalize".
 	RemoveSpaceBetweenParentheses bool `json:"remove_space_between_parentheses"`
 
 	// KeepNull specifies whether to disable obfuscate NULL value with ?.
@@ -277,12 +277,12 @@ type sqlConfig struct {
 
 	// KeepTrailingSemicolon specifies whether to keep trailing semicolon.
 	// By default, trailing semicolon is removed during normalization.
-	// This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
+	// This option is only valid when ObfuscationMode is "normalize_only" or "obfuscate_and_normalize".
 	KeepTrailingSemicolon bool `json:"keep_trailing_semicolon"`
 
 	// KeepIdentifierQuotation specifies whether to keep identifier quotation, e.g. "my_table" or [my_table].
 	// By default, identifier quotation is removed during normalization.
-	// This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
+	// This option is only valid when ObfuscationMode is "normalize_only" or "obfuscate_and_normalize".
 	KeepIdentifierQuotation bool `json:"keep_identifier_quotation"`
 }
 

--- a/pkg/obfuscate/obfuscate.go
+++ b/pkg/obfuscate/obfuscate.go
@@ -107,6 +107,7 @@ type ObfuscationMode string
 
 // ObfuscationMode valid values
 const (
+	NormalizeOnly         = ObfuscationMode("normalize_only")
 	ObfuscateOnly         = ObfuscationMode("obfuscate_only")
 	ObfuscateAndNormalize = ObfuscationMode("obfuscate_and_normalize")
 )
@@ -145,12 +146,12 @@ type SQLConfig struct {
 
 	// ObfuscationMode specifies the obfuscation mode to use for go-sqllexer pkg.
 	// When specified, obfuscator will attempt to use go-sqllexer pkg to obfuscate (and normalize) SQL queries.
-	// Valid values are "obfuscate_only", "obfuscate_and_normalize"
+	// Valid values are "normalize_only", "obfuscate_only", "obfuscate_and_normalize"
 	ObfuscationMode ObfuscationMode `json:"obfuscation_mode" yaml:"obfuscation_mode"`
 
 	// RemoveSpaceBetweenParentheses specifies whether to remove spaces between parentheses.
 	// By default, spaces are inserted between parentheses during normalization.
-	// This option is only valid when ObfuscationMode is "obfuscate_and_normalize".
+	// This option is only valid when ObfuscationMode is "normalize_only" or "obfuscate_and_normalize".
 	RemoveSpaceBetweenParentheses bool `json:"remove_space_between_parentheses" yaml:"remove_space_between_parentheses"`
 
 	// KeepNull specifies whether to disable obfuscate NULL value with ?.
@@ -167,12 +168,12 @@ type SQLConfig struct {
 
 	// KeepTrailingSemicolon specifies whether to keep trailing semicolon.
 	// By default, trailing semicolon is removed during normalization.
-	// This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
+	// This option is only valid when ObfuscationMode is "normalize_only" or "obfuscate_and_normalize".
 	KeepTrailingSemicolon bool `json:"keep_trailing_semicolon" yaml:"keep_trailing_semicolon"`
 
 	// KeepIdentifierQuotation specifies whether to keep identifier quotation, e.g. "my_table" or [my_table].
 	// By default, identifier quotation is removed during normalization.
-	// This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
+	// This option is only valid when ObfuscationMode is "normalize_only" or "obfuscate_and_normalize".
 	KeepIdentifierQuotation bool `json:"keep_identifier_quotation" yaml:"keep_identifier_quotation"`
 
 	// Cache reports whether the obfuscator should use a LRU look-up cache for SQL obfuscations.

--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -2406,6 +2406,187 @@ func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 	}
 }
 
+func TestSQLLexerNormalization(t *testing.T) {
+	tests := []struct {
+		name                          string
+		query                         string
+		expected                      string
+		collectProcedures             bool
+		removeSpaceBetweenParentheses bool
+		keepTrailingSemicolon         bool
+		keepIdentifierQuotation       bool
+		keepSQLAlias                  bool
+		metadata                      SQLMetadata
+	}{
+		{
+			name:     "simple query normalization",
+			query:    "SELECT * FROM users WHERE id = 1",
+			expected: "SELECT * FROM users WHERE id = 1",
+			metadata: SQLMetadata{
+				Size:      11,
+				TablesCSV: "users",
+				Commands: []string{
+					"SELECT",
+				},
+				Comments:   []string{},
+				Procedures: []string{},
+			},
+		},
+		{
+			name: "normalizaton with comments and keepSQLAlias",
+			query: `
+			-- comment
+			/* comment */
+			SELECT id as id, name as n FROM users123 WHERE id in (1,2,3)`,
+			expected:     "SELECT id as id, name as n FROM users123 WHERE id in ( 1, 2, 3 )",
+			keepSQLAlias: true,
+			metadata: SQLMetadata{
+				Size:      37,
+				TablesCSV: "users123",
+				Commands: []string{
+					"SELECT",
+				},
+				Comments: []string{
+					"-- comment",
+					"/* comment */",
+				},
+				Procedures: []string{},
+			},
+		},
+		{
+			name:     "normalizaton with dollar quoted function",
+			query:    "SELECT $func$INSERT INTO table VALUES ('a', 1, 2)$func$ FROM users",
+			expected: "SELECT $func$INSERT INTO table VALUES ( 'a', 1, 2 )$func$ FROM users",
+			metadata: SQLMetadata{
+				Size:      11,
+				TablesCSV: "users",
+				Commands: []string{
+					"SELECT",
+				},
+				Comments:   []string{},
+				Procedures: []string{},
+			},
+		},
+		{
+			name:              "normalization with stored procedure enabled",
+			query:             "CREATE PROCEDURE TestProc AS BEGIN SELECT * FROM users WHERE id = 1 END",
+			expected:          "CREATE PROCEDURE TestProc AS BEGIN SELECT * FROM users WHERE id = 1 END",
+			collectProcedures: true,
+			metadata: SQLMetadata{
+				Size:      30,
+				TablesCSV: "users",
+				Commands: []string{
+					"CREATE",
+					"BEGIN",
+					"SELECT",
+				},
+				Comments: []string{},
+				Procedures: []string{
+					"TestProc",
+				},
+			},
+		},
+		{
+			name:              "normalization with stored procedure disabled",
+			query:             "CREATE PROCEDURE TestProc AS BEGIN UPDATE users SET name = 'test' WHERE id = 1 END",
+			expected:          "CREATE PROCEDURE TestProc AS BEGIN UPDATE users SET name = 'test' WHERE id = 1 END",
+			collectProcedures: false,
+			metadata: SQLMetadata{
+				Size:      22,
+				TablesCSV: "users",
+				Commands: []string{
+					"CREATE",
+					"BEGIN",
+					"UPDATE",
+				},
+				Comments:   []string{},
+				Procedures: []string{},
+			},
+		},
+		{
+			name:     "normalization with query with null boolean and positional parameter",
+			query:    "SELECT * FROM users WHERE id = 1 AND address = $1 and id = $2 AND deleted IS NULL AND active is TRUE",
+			expected: "SELECT * FROM users WHERE id = 1 AND address = $1 and id = $2 AND deleted IS NULL AND active is TRUE",
+			metadata: SQLMetadata{
+				Size:      11,
+				TablesCSV: "users",
+				Commands: []string{
+					"SELECT",
+				},
+				Comments:   []string{},
+				Procedures: []string{},
+			},
+		},
+		{
+			name:                          "normalization with remove space between parentheses",
+			query:                         "SELECT * FROM users WHERE id = 1 AND (name = 'test' OR name = 'test2')",
+			expected:                      "SELECT * FROM users WHERE id = 1 AND (name = 'test' OR name = 'test2')",
+			removeSpaceBetweenParentheses: true,
+			metadata: SQLMetadata{
+				Size:      11,
+				TablesCSV: "users",
+				Commands: []string{
+					"SELECT",
+				},
+				Comments:   []string{},
+				Procedures: []string{},
+			},
+		},
+		{
+			name:                  "normalization with keep trailing semicolon",
+			query:                 "SELECT * FROM users WHERE id = 1 AND name = 'test';",
+			expected:              "SELECT * FROM users WHERE id = 1 AND name = 'test';",
+			keepTrailingSemicolon: true,
+			metadata: SQLMetadata{
+				Size:      11,
+				TablesCSV: "users",
+				Commands: []string{
+					"SELECT",
+				},
+				Comments:   []string{},
+				Procedures: []string{},
+			},
+		},
+		{
+			name:                    "normalization with keep identifier quotation",
+			query:                   `SELECT * FROM "users" WHERE id = 1 AND name = 'test'`,
+			expected:                `SELECT * FROM "users" WHERE id = 1 AND name = 'test'`,
+			keepIdentifierQuotation: true,
+			metadata: SQLMetadata{
+				Size:      11,
+				TablesCSV: "users",
+				Commands: []string{
+					"SELECT",
+				},
+				Comments:   []string{},
+				Procedures: []string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oq, err := NewObfuscator(Config{
+				SQL: SQLConfig{
+					ObfuscationMode:               "normalize_only",
+					KeepSQLAlias:                  tt.keepSQLAlias,
+					TableNames:                    true,
+					CollectCommands:               true,
+					CollectComments:               true,
+					CollectProcedures:             tt.collectProcedures,
+					RemoveSpaceBetweenParentheses: tt.removeSpaceBetweenParentheses,
+					KeepTrailingSemicolon:         tt.keepTrailingSemicolon,
+					KeepIdentifierQuotation:       tt.keepIdentifierQuotation,
+				},
+			}).ObfuscateSQLString(tt.query)
+			require.NoError(t, err)
+			require.NotNil(t, oq)
+			assert.Equal(t, tt.expected, oq.Query)
+			assert.Equal(t, tt.metadata, oq.Metadata)
+		})
+	}
+}
+
 func TestSQLLexerObfuscationModeInvalid(t *testing.T) {
 	t.Run("ObfuscateMode with invalid value", func(t *testing.T) {
 		oq, err := NewObfuscator(Config{

--- a/releasenotes/notes/sql-obfuscation-mode-normalize-only-3501d2552b15f712.yaml
+++ b/releasenotes/notes/sql-obfuscation-mode-normalize-only-3501d2552b15f712.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    dbm: add new SQL obfuscation mode ``normalize_only`` to support normalizing SQL without obfuscating it. 
+    This mode is useful for customers who want to view unobfuscated SQL statements.
+    By default, ``ObfuscationMode`` is set to ``obfuscate_and_normalize`` and every SQL statement is obfuscated and normalized.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds new SQL obfuscation mode `normalize_only` to support normalizing SQL without obfuscating it. 
This new mode is useful for customers who want to view unobfuscated SQL statements.
By default, `ObfuscationMode` is still set to `obfuscate_and_normalize` and every SQL statement is obfuscated and normalized.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
