### PR TITLE
Removing Endpoint from the public config API

### DIFF
--- a/pkg/config/aliases.go
+++ b/pkg/config/aliases.go
@@ -188,8 +188,6 @@ type (
 	Listeners = pkgconfigsetup.Listeners
 	// MappingProfile Alias
 	MappingProfile = pkgconfigsetup.MappingProfile
-	// Endpoint Alias
-	Endpoint = pkgconfigsetup.Endpoint
 )
 
 // GetObsPipelineURL Alias using Datadog config

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -176,14 +176,6 @@ type MetricMapping struct {
 	Tags      map[string]string `mapstructure:"tags" json:"tags" yaml:"tags"`
 }
 
-// Endpoint represent a datadog endpoint
-type Endpoint struct {
-	Site   string `mapstructure:"site" json:"site" yaml:"site"`
-	URL    string `mapstructure:"url" json:"url" yaml:"url"`
-	APIKey string `mapstructure:"api_key" json:"api_key" yaml:"api_key"`
-	APPKey string `mapstructure:"app_key" json:"app_key" yaml:"app_key"`
-}
-
 // DataType represent the generic data type (e.g. metrics, logs) that can be sent by the Agent
 type DataType string
 

--- a/pkg/util/kubernetes/autoscalers/datadogclient.go
+++ b/pkg/util/kubernetes/autoscalers/datadogclient.go
@@ -22,16 +22,25 @@ import (
 )
 
 const (
-	metricsEndpointPrefix = "https://api."
-	metricsEndpointConfig = "external_metrics_provider.endpoint"
+	metricsEndpointPrefix          = "https://api."
+	metricsEndpointConfig          = "external_metrics_provider.endpoint"
+	metricsRedundantEndpointConfig = "external_metrics_provider.endpoints"
 )
+
+// endpoint represent a datadog endpoint
+type endpoint struct {
+	Site   string `mapstructure:"site" json:"site" yaml:"site"`
+	URL    string `mapstructure:"url" json:"url" yaml:"url"`
+	APIKey string `mapstructure:"api_key" json:"api_key" yaml:"api_key"`
+	APPKey string `mapstructure:"app_key" json:"app_key" yaml:"app_key"`
+}
 
 // NewDatadogClient configures and returns a new DatadogClient
 func NewDatadogClient() (DatadogClient, error) {
-	if config.Datadog.IsSet("external_metrics_provider.endpoints") {
-		var endpoints []config.Endpoint
-		if err := config.Datadog.UnmarshalKey("external_metrics_provider.endpoints", &endpoints); err != nil {
-			return nil, log.Errorf("could not parse external_metrics_provider.endpoints: %v", err)
+	if config.Datadog.IsSet(metricsRedundantEndpointConfig) {
+		var endpoints []endpoint
+		if err := config.Datadog.UnmarshalKey(metricsRedundantEndpointConfig, &endpoints); err != nil {
+			return nil, log.Errorf("could not parse %s: %v", metricsRedundantEndpointConfig, err)
 		}
 
 		return newDatadogFallbackClient(endpoints)
@@ -58,22 +67,22 @@ func newDatadogSingleClient() (*datadog.Client, error) {
 	//   - DD_EXTERNAL_METRICS_PROVIDER_ENDPOINT
 	//   - DATADOG_HOST
 	//   - DD_SITE
-	endpoint := os.Getenv("DATADOG_HOST")
-	if config.Datadog.GetString(metricsEndpointConfig) != "" || endpoint == "" {
-		endpoint = utils.GetMainEndpoint(config.Datadog, metricsEndpointPrefix, metricsEndpointConfig)
+	ddEndpoint := os.Getenv("DATADOG_HOST")
+	if config.Datadog.GetString(metricsEndpointConfig) != "" || ddEndpoint == "" {
+		ddEndpoint = utils.GetMainEndpoint(config.Datadog, metricsEndpointPrefix, metricsEndpointConfig)
 	}
 
 	if appKey == "" || apiKey == "" {
 		return nil, errors.New("missing the api/app key pair to query Datadog")
 	}
 
-	log.Infof("Initialized the Datadog Client for HPA with endpoint %q", endpoint)
+	log.Infof("Initialized the Datadog Client for HPA with endpoint %q", ddEndpoint)
 
 	client := datadog.NewClient(apiKey, appKey)
 	client.HttpClient.Transport = httputils.CreateHTTPTransport(config.Datadog)
 	client.RetryTimeout = 3 * time.Second
 	client.ExtraHeader["User-Agent"] = "Datadog-Cluster-Agent"
-	client.SetBaseUrl(endpoint)
+	client.SetBaseUrl(ddEndpoint)
 
 	return client, nil
 }
@@ -98,9 +107,9 @@ type datadogFallbackClient struct {
 }
 
 // NewDatadogFallbackClient generates a new client able to query metrics to a second Datadog endpoint if the first one fails
-func newDatadogFallbackClient(endpoints []config.Endpoint) (*datadogFallbackClient, error) {
+func newDatadogFallbackClient(endpoints []endpoint) (*datadogFallbackClient, error) {
 	if len(endpoints) == 0 {
-		return nil, log.Errorf("external_metrics_provider.endpoints must be non-empty")
+		return nil, log.Errorf("%s must be non-empty", metricsRedundantEndpointConfig)
 	}
 
 	defaultClient, err := newDatadogSingleClient()
@@ -117,12 +126,12 @@ func newDatadogFallbackClient(endpoints []config.Endpoint) (*datadogFallbackClie
 			},
 		},
 	}
-	for _, endpoint := range endpoints {
-		client := datadog.NewClient(endpoint.APIKey, endpoint.APPKey)
+	for _, e := range endpoints {
+		client := datadog.NewClient(e.APIKey, e.APPKey)
 		client.HttpClient.Transport = httputils.CreateHTTPTransport(config.Datadog)
 		client.RetryTimeout = 3 * time.Second
 		client.ExtraHeader["User-Agent"] = "Datadog-Cluster-Agent"
-		client.SetBaseUrl(endpoint.URL)
+		client.SetBaseUrl(e.URL)
 		ddFallbackClient.clients = append(
 			ddFallbackClient.clients,
 			&datadogIndividualClient{


### PR DESCRIPTION
### What does this PR do?

This reduces the API from the config package and prevent other packages from using it for other fields by mistake.

### Describe how to test/QA your changes

SImply QA that `external_metrics_provider.endpoints` settings can still be used like before.