### PR TITLE
[CWS] reduce partial allocation when the field is not used in the rule

### DIFF
--- a/pkg/security/secl/compiler/eval/rule.go
+++ b/pkg/security/secl/compiler/eval/rule.go
@@ -242,11 +242,6 @@ func (r *Rule) GenEvaluator(model Model, parsingCtx *ast.ParsingContext) error {
 }
 
 func (r *Rule) genMacroPartials(field Field) (map[MacroID]*MacroEvaluator, error) {
-	// check that field in this rule fields
-	if !slices.Contains(r.GetFields(), field) {
-		return nil, nil
-	}
-
 	macroEvaluators := make(map[MacroID]*MacroEvaluator)
 	for _, macro := range r.Opts.MacroStore.List() {
 		var err error
@@ -273,13 +268,13 @@ func (r *Rule) genMacroPartials(field Field) (map[MacroID]*MacroEvaluator, error
 
 // GenPartials - Compiles and generates partial Evaluators
 func (r *Rule) genPartials(field Field) error {
+	if !slices.Contains(r.GetFields(), field) {
+		return nil
+	}
+
 	macroPartial, err := r.genMacroPartials(field)
 	if err != nil {
 		return err
-	}
-
-	if !slices.Contains(r.GetFields(), field) {
-		return nil
 	}
 
 	state := NewState(r.Model, field, macroPartial)

--- a/pkg/security/secl/compiler/eval/rule.go
+++ b/pkg/security/secl/compiler/eval/rule.go
@@ -7,7 +7,6 @@
 package eval
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -69,6 +68,12 @@ func NewRule(id string, expression string, opts *Opts, tags ...string) *Rule {
 	}
 }
 
+// IsPartialAvailable checks if partial have been generated for the given Field
+func (r *RuleEvaluator) IsPartialAvailable(field Field) bool {
+	_, exists := r.partialEvals[field]
+	return exists
+}
+
 // PartialEval partially evaluation of the Rule with the given Field.
 func (r *RuleEvaluator) PartialEval(ctx *Context, field Field) (bool, error) {
 	eval, ok := r.partialEvals[field]
@@ -103,19 +108,13 @@ func (r *Rule) GetFieldValues(field Field) []FieldValue {
 
 // PartialEval - Partial evaluation with the given Field
 func (r *Rule) PartialEval(ctx *Context, field Field) (bool, error) {
-	result, err := r.evaluator.PartialEval(ctx, field)
-	if err == nil {
-		return result, nil
-	}
-
-	var errNotFound *ErrFieldNotFound
-	if errors.As(err, &errNotFound) {
-		if err = r.genPartials(field); err != nil {
+	if !r.evaluator.IsPartialAvailable(field) {
+		if err := r.genPartials(field); err != nil {
 			return false, err
 		}
-		result, err = r.evaluator.PartialEval(ctx, field)
 	}
-	return result, err
+
+	return r.evaluator.PartialEval(ctx, field)
 }
 
 // GetPartialEval - Returns the Partial RuleEvaluator for the given Field


### PR DESCRIPTION
### What does this PR do?

Reduce allocation around macro partial generation, especially when they are actually not needed: no allocation in the error or no field used path.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
