### PR TITLE
[SBOM] Fix scanRequest type

### DIFF
--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -186,6 +186,7 @@ func (p *processor) processHostScanResult(result sbom.ScanResult) {
 	}
 
 	if result.Error != nil {
+		log.Errorf("Scan error: %v", result.Error)
 		sbom.Sbom = &model.SBOMEntity_Error{
 			Error: result.Error.Error(),
 		}
@@ -224,7 +225,7 @@ func (p *processor) triggerHostScan() {
 	}
 	log.Debugf("Triggering host SBOM refresh")
 
-	scanRequest := &host.ScanRequest{Path: "/"}
+	scanRequest := host.ScanRequest{Path: "/"}
 	if hostRoot := os.Getenv("HOST_ROOT"); ddConfig.IsContainerized() && hostRoot != "" {
 		scanRequest.Path = hostRoot
 	}


### PR DESCRIPTION
### What does this PR do?

This change fixes the following error:

```
2024-03-13 21:00:32 UTC | CORE | DEBUG | (pkg/collector/corechecks/sbom/processor.go:178 in processHostScanResult) | processing host scanresult: {invalid request type '*host.ScanRequest' for collector 'host' <nil> 2024-03-13 21:00:32.439957913 +0000 UTC m=+5.131362123 8.802µs <nil>}
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
