### PR TITLE
[SBOM] Disable HistoryDockerfile analyzer

### DIFF
--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -50,11 +50,12 @@ import (
 const (
 	cleanupTimeout = 30 * time.Second
 
-	OSAnalyzers         = "os"        // OSAnalyzers defines an OS analyzer
-	LanguagesAnalyzers  = "languages" // LanguagesAnalyzers defines a language analyzer
-	SecretAnalyzers     = "secret"    // SecretAnalyzers defines a secret analyzer
-	ConfigFileAnalyzers = "config"    // ConfigFileAnalyzers defines a configuration file analyzer
-	LicenseAnalyzers    = "license"   // LicenseAnalyzers defines a license analyzers
+	OSAnalyzers         = "os"                 // OSAnalyzers defines an OS analyzer
+	LanguagesAnalyzers  = "languages"          // LanguagesAnalyzers defines a language analyzer
+	SecretAnalyzers     = "secret"             // SecretAnalyzers defines a secret analyzer
+	ConfigFileAnalyzers = "config"             // ConfigFileAnalyzers defines a configuration file analyzer
+	LicenseAnalyzers    = "license"            // LicenseAnalyzers defines a license analyzers
+	HistoryDockerfile   = "history-dockerfile" // HistoryDockerfile defines a history-dockerfile analyzers
 )
 
 // ContainerdAccessor is a function that should return a containerd client
@@ -168,6 +169,9 @@ func DefaultDisabledCollectors(enabledAnalyzers []string) []analyzer.Type {
 	}
 	if analyzersDisabled(LicenseAnalyzers) {
 		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeLicenseFile)
+	}
+	if analyzersDisabled(HistoryDockerfile) {
+		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeHistoryDockerfile)
 	}
 
 	return disabledAnalyzers


### PR DESCRIPTION
### What does this PR do?

This change disables the `HistoryDockerfile` analyzer,

This misconfiguration analyzer was added in Trivy on 2023-01-30. This was part of the recent bump of Trivy to version 2024-02-28.

However, misconfiguration analyzers were disabled in our version of Trivy, because they depend on the trivy-iac library, which allocates very large structures at init time.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
