### PR TITLE
system-probe: tests: remove test config yaml

### DIFF
--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -215,9 +215,10 @@ service_monitoring_config:
 func TestEnableHTTP2Monitoring(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableHTTP2.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+service_monitoring_config:
+  enable_http2_monitoring: true
+`)
 
 		assert.True(t, cfg.EnableHTTP2Monitoring)
 	})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -457,9 +457,15 @@ func TestHTTPReplaceRules(t *testing.T) {
 
 	t.Run("via deprecated YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDSystemProbeConfig-HTTPReplaceRulesDeprecated.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+network_config:
+  http_replace_rules:
+    - pattern: "/users/(.*)"
+      repl: "/users/?"
+    - pattern: "foo"
+      repl: "bar"
+    - pattern: "payment_id"
+`)
 
 		require.Len(t, cfg.HTTPReplaceRules, 3)
 		for i, r := range expected {
@@ -481,10 +487,15 @@ func TestHTTPReplaceRules(t *testing.T) {
 
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDSystemProbeConfig-HTTPReplaceRules.yaml")
-		require.NoError(t, err)
-		cfg := New()
-
+		cfg := configurationFromYAML(t, `
+service_monitoring_config:
+  http_replace_rules:
+    - pattern: "/users/(.*)"
+      repl: "/users/?"
+    - pattern: "foo"
+      repl: "bar"
+    - pattern: "payment_id"
+`)
 		require.Len(t, cfg.HTTPReplaceRules, 3)
 		for i, r := range expected {
 			assert.Equal(t, r, cfg.HTTPReplaceRules[i])

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -569,9 +569,10 @@ service_monitoring_config:
 func TestMaxTrackedHTTPConnections(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDSystemProbeConfig-MaxTrackedHTTPConnectionsDeprecated.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+network_config:
+  max_tracked_http_connections: 1025
+`)
 
 		require.Equal(t, cfg.MaxTrackedHTTPConnections, int64(1025))
 	})
@@ -587,9 +588,10 @@ func TestMaxTrackedHTTPConnections(t *testing.T) {
 
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDSystemProbeConfig-MaxTrackedHTTPConnections.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+service_monitoring_config:
+  max_tracked_http_connections: 1025
+`)
 
 		require.Equal(t, cfg.MaxTrackedHTTPConnections, int64(1025))
 	})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -362,9 +362,11 @@ system_probe_config:
 func TestDisablingDNSDomainCollection(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableDNSDomains.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+system_probe_config:
+  collect_dns_domains: false
+  max_dns_stats: 100
+`)
 
 		assert.False(t, cfg.CollectDNSDomains)
 	})
@@ -391,9 +393,11 @@ func TestDisablingDNSDomainCollection(t *testing.T) {
 func TestSettingMaxDNSStats(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableDNSDomains.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+system_probe_config:
+  collect_dns_domains: false
+  max_dns_stats: 100
+`)
 
 		assert.Equal(t, 100, cfg.MaxDNSStats)
 	})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1125,9 +1125,10 @@ func TestMaxClosedConnectionsBuffered(t *testing.T) {
 func TestMaxHTTPStatsBuffered(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDSystemProbeConfig-MaxHTTPStatsBufferedDeprecated.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+network_config:
+  max_http_stats_buffered: 513
+`)
 
 		require.Equal(t, cfg.MaxHTTPStatsBuffered, 513)
 	})
@@ -1143,9 +1144,10 @@ func TestMaxHTTPStatsBuffered(t *testing.T) {
 
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDSystemProbeConfig-MaxHTTPStatsBuffered.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+service_monitoring_config:
+  max_http_stats_buffered: 513
+`)
 
 		require.Equal(t, cfg.MaxHTTPStatsBuffered, 513)
 	})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -332,9 +332,10 @@ network_config:
 func TestEnablingDNSStatsCollection(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableDNSStats.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+system_probe_config:
+  collect_dns_stats: true
+`)
 
 		assert.True(t, cfg.CollectDNSStats)
 	})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -287,9 +287,10 @@ func TestDisableGatewayLookup(t *testing.T) {
 		assert.True(t, cfg.EnableGatewayLookup)
 
 		aconfig.ResetSystemProbeConfig(t)
-		_, err = sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableGwLookup.yaml")
-		require.NoError(t, err)
-		cfg = New()
+		cfg = configurationFromYAML(t, `
+network_config:
+  enable_gateway_lookup: false
+`)
 
 		assert.False(t, cfg.EnableGatewayLookup)
 	})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -61,9 +61,10 @@ system_probe_config:
 func TestDisablingProtocolClassification(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-NoPRTCLClassifying.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+network_config:
+    enable_protocol_classification: false
+`)
 
 		assert.False(t, cfg.ProtocolClassificationEnabled)
 	})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -38,9 +38,11 @@ func makeYamlConfigString(section, entry string, val int) string {
 func TestDisablingDNSInspection(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableDNS.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+system_probe_config:
+    enabled: true
+    disable_dns_inspection: true
+`)
 
 		assert.False(t, cfg.DNSInspection)
 	})
@@ -1557,7 +1559,7 @@ system_probe_config:
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := modelCfgFromYAML(t, `
 system_probe_config:
-  process_service_inference: 
+  process_service_inference:
     enabled: true`)
 		require.False(t, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
 	})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -105,9 +105,10 @@ service_monitoring_config:
 func TestEnableHTTPMonitoring(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DeprecatedEnableHTTP.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+network_config:
+  enable_http_monitoring: true
+`)
 
 		assert.True(t, cfg.EnableHTTPMonitoring)
 	})
@@ -125,9 +126,10 @@ func TestEnableHTTPMonitoring(t *testing.T) {
 
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableHTTP.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+service_monitoring_config:
+  enable_http_monitoring: true
+`)
 
 		assert.True(t, cfg.EnableHTTPMonitoring)
 	})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -83,9 +83,10 @@ network_config:
 func TestEnableHTTPStatsByStatusCode(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDSystemProbeConfig-EnableHTTPStatusCodeAggr.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+service_monitoring_config:
+  enable_http_stats_by_status_code: true
+`)
 
 		assert.True(t, cfg.EnableHTTPStatsByStatusCode)
 	})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -309,9 +309,10 @@ network_config:
 func TestIgnoreConntrackInitFailure(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-IgnoreCTInitFailure.yaml")
-		require.NoError(t, err)
-		cfg := New()
+		cfg := configurationFromYAML(t, `
+network_config:
+  ignore_conntrack_init_failure: true
+`)
 
 		assert.True(t, cfg.IgnoreConntrackInitFailure)
 	})

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DeprecatedEnableHTTP.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DeprecatedEnableHTTP.yaml
@@ -1,2 +1,0 @@
-network_config:
-  enable_http_monitoring: true

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableDNS.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableDNS.yaml
@@ -1,3 +1,0 @@
-system_probe_config:
-    enabled: true
-    disable_dns_inspection: true

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableDNSDomains.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableDNSDomains.yaml
@@ -1,3 +1,0 @@
-system_probe_config:
-  collect_dns_domains: false
-  max_dns_stats: 100

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableGwLookup.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableGwLookup.yaml
@@ -1,2 +1,0 @@
-network_config:
-  enable_gateway_lookup: false

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableDNSStats.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableDNSStats.yaml
@@ -1,2 +1,0 @@
-system_probe_config:
-    collect_dns_stats: true

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableHTTP.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableHTTP.yaml
@@ -1,2 +1,0 @@
-service_monitoring_config:
-  enable_http_monitoring: true

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableHTTP2.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableHTTP2.yaml
@@ -1,2 +1,0 @@
-service_monitoring_config:
-  enable_http2_monitoring: true

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-IgnoreCTInitFailure.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-IgnoreCTInitFailure.yaml
@@ -1,2 +1,0 @@
-network_config:
-  ignore_conntrack_init_failure: true

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-NoPRTCLClassifying.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-NoPRTCLClassifying.yaml
@@ -1,2 +1,0 @@
-network_config:
-    enable_protocol_classification: false

--- a/pkg/network/config/testdata/TestDDSystemProbeConfig-EnableHTTPStatusCodeAggr.yaml
+++ b/pkg/network/config/testdata/TestDDSystemProbeConfig-EnableHTTPStatusCodeAggr.yaml
@@ -1,2 +1,0 @@
-service_monitoring_config:
-  enable_http_stats_by_status_code: true

--- a/pkg/network/config/testdata/TestDDSystemProbeConfig-HTTPReplaceRules.yaml
+++ b/pkg/network/config/testdata/TestDDSystemProbeConfig-HTTPReplaceRules.yaml
@@ -1,7 +1,0 @@
-service_monitoring_config:
-  http_replace_rules:
-    - pattern: "/users/(.*)"
-      repl: "/users/?"
-    - pattern: "foo"
-      repl: "bar"
-    - pattern: "payment_id"

--- a/pkg/network/config/testdata/TestDDSystemProbeConfig-HTTPReplaceRulesDeprecated.yaml
+++ b/pkg/network/config/testdata/TestDDSystemProbeConfig-HTTPReplaceRulesDeprecated.yaml
@@ -1,7 +1,0 @@
-network_config:
-  http_replace_rules:
-    - pattern: "/users/(.*)"
-      repl: "/users/?"
-    - pattern: "foo"
-      repl: "bar"
-    - pattern: "payment_id"

--- a/pkg/network/config/testdata/TestDDSystemProbeConfig-MaxHTTPStatsBuffered.yaml
+++ b/pkg/network/config/testdata/TestDDSystemProbeConfig-MaxHTTPStatsBuffered.yaml
@@ -1,2 +1,0 @@
-service_monitoring_config:
-  max_http_stats_buffered: 513

--- a/pkg/network/config/testdata/TestDDSystemProbeConfig-MaxHTTPStatsBufferedDeprecated.yaml
+++ b/pkg/network/config/testdata/TestDDSystemProbeConfig-MaxHTTPStatsBufferedDeprecated.yaml
@@ -1,2 +1,0 @@
-network_config:
-  max_http_stats_buffered: 513

--- a/pkg/network/config/testdata/TestDDSystemProbeConfig-MaxTrackedHTTPConnections.yaml
+++ b/pkg/network/config/testdata/TestDDSystemProbeConfig-MaxTrackedHTTPConnections.yaml
@@ -1,2 +1,0 @@
-service_monitoring_config:
-  max_tracked_http_connections: 1025

--- a/pkg/network/config/testdata/TestDDSystemProbeConfig-MaxTrackedHTTPConnectionsDeprecated.yaml
+++ b/pkg/network/config/testdata/TestDDSystemProbeConfig-MaxTrackedHTTPConnectionsDeprecated.yaml
@@ -1,2 +1,0 @@
-network_config:
-  max_tracked_http_connections: 1025


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Removes actual configuration test files required for `pkg/network/config/config_test.go` in favor of in-memory configuration.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Remove redundant files
Align tests to use a single method (as we used a mix of in-memory and actual files)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
