### PR TITLE
Fix broken internal image deploy jobs on nightly build

### DIFF
--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -25,7 +25,11 @@ docker_trigger_internal:
     - source /root/.bashrc
     - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
-    - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
+    - |
+      if [ "$BUCKET_BRANCH" = "nightly" ]; then
+        RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"
+        TMPL_SRC_REPO="${TMPL_SRC_REPO}-nightly"
+      fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master
       --variable IMAGE_VERSION
@@ -68,7 +72,11 @@ docker_trigger_cluster_agent_internal:
     - source /root/.bashrc
     - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.gitlab_pipelines_scheduler_token)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
-    - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
+    - |
+      if [ "$BUCKET_BRANCH" = "nightly" ]; then
+        RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"
+        TMPL_SRC_REPO="${TMPL_SRC_REPO}-nightly"
+      fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master
       --variable IMAGE_VERSION


### PR DESCRIPTION
### What does this PR do?

Points the internal_image_deploy jobs at the nightly ECR repos when it is a nightly build

### Motivation

Fixes the currently failing internal_image_deploy jobs
Follow-up to https://github.com/DataDog/datadog-agent/pull/23697

### Additional Notes

[Currently failing pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/30075986)
Specific failing jobs:
- [agent](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/459424851)
- [cluster-agent](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/459424852)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
