### PR TITLE
[CWS] allocate net ns path from pid lazily (only if actually required)

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -619,8 +619,9 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 	offset += read
 
 	// save netns handle if applicable
-	nsPath := utils.NetNSPathFromPid(event.PIDContext.Pid)
-	_, _ = p.Resolvers.NamespaceResolver.SaveNetworkNamespaceHandle(event.PIDContext.NetNS, nsPath)
+	_, _ = p.Resolvers.NamespaceResolver.SaveNetworkNamespaceHandleLazy(event.PIDContext.NetNS, func() *utils.NetNSPath {
+		return utils.NetNSPathFromPid(event.PIDContext.Pid)
+	})
 
 	if model.GetEventTypeCategory(eventType.String()) == model.NetworkCategory {
 		if read, err = event.NetworkContext.UnmarshalBinary(data[offset:]); err != nil {

--- a/pkg/security/resolvers/netns/resolver.go
+++ b/pkg/security/resolvers/netns/resolver.go
@@ -235,7 +235,20 @@ func (nr *Resolver) GetState() int64 {
 // SaveNetworkNamespaceHandle inserts the provided process network namespace in the list of tracked network. Returns
 // true if a new entry was added.
 func (nr *Resolver) SaveNetworkNamespaceHandle(nsID uint32, nsPath *utils.NetNSPath) (*NetworkNamespace, bool) {
-	if !nr.config.NetworkEnabled || nsID == 0 || nsPath == nil {
+	return nr.SaveNetworkNamespaceHandleLazy(nsID, func() *utils.NetNSPath {
+		return nsPath
+	})
+}
+
+// SaveNetworkNamespaceHandleLazy inserts the provided process network namespace in the list of tracked network. Returns
+// true if a new entry was added.
+func (nr *Resolver) SaveNetworkNamespaceHandleLazy(nsID uint32, nsPathFunc func() *utils.NetNSPath) (*NetworkNamespace, bool) {
+	if !nr.config.NetworkEnabled || nsID == 0 || nsPathFunc == nil {
+		return nil, false
+	}
+
+	nsPath := nsPathFunc()
+	if nsPath == nil {
 		return nil, false
 	}
 


### PR DESCRIPTION
### What does this PR do?

In a lot of cases (if network is disabled, if netns is 0) we end up allocating a `utils.NetNSPath` that will be dropped 3 lines later. This PR moves this allocation into a callback to only happen if actually required.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
