### PR TITLE
[CONTINT-3546] Check dd-agent UID and document doc update needed in case of change

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -176,6 +176,17 @@ RUN tar xzf s6.tgz -C / --exclude="./bin" \
   && chown root:root /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh \
   && chmod 550 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh
 
+# Check that the UID of dd-agent is still 100.
+#
+# The exact numeric value of the UID of the dd-agent user shouldn’t matter.
+# But people that don’t want to let the agent run as root might want to explicitly set a non-root user in their k8s security context.
+# And, in a k8s security context, we can only specify a numeric UID and not a username.
+# So, if the UID of the dd-agent user happen to change again and cannot be forced to 100 (because of a conflict), we need to update
+# * the documentation https://docs.datadoghq.com/data_security/kubernetes/#running-container-as-root-user
+#   (see PR https://github.com/DataDog/documentation/pull/21889)
+# * https://datadoghq.atlassian.net/wiki/spaces/TS/pages/2615709591/Why+the+containerized+Agent+runs+as+root#Agent-user
+RUN [ "$(getent passwd dd-agent | cut -d: -f 3)" -eq 100 ]
+
 # Update links to python binaries
 RUN if [ -n "$PYTHON_VERSION" ]; then \
   ln -sfn /opt/datadog-agent/embedded/bin/python${PYTHON_VERSION} /opt/datadog-agent/embedded/bin/python \


### PR DESCRIPTION
### What does this PR do?

Check if the `dd-agent` user inside the agent docker image is 100.

### Motivation

The exact numeric value of the UID of the `dd-agent` user shouldn’t matter.
But people that don’t want to let the agent run as `root` might want to explicitly set a non-`root` user in their k8s security context.
And, in a k8s security context, we can only specify a numeric UID and not a username.
So, if the UID of the `dd-agent` user happen to change again and cannot be forced to `100` (because of a conflict), we need to update
* [the public documentation](https://docs.datadoghq.com/data_security/kubernetes/#running-container-as-root-user)
  (see DataDog/documentation#21889)
* [the internal documentation](https://datadoghq.atlassian.net/wiki/spaces/TS/pages/2615709591/Why+the+containerized+Agent+runs+as+root#Agent-user)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
