### PR TITLE
[CONTINT-3750] Create a dedicate group allowed to run the secret backends

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -169,11 +169,13 @@ RUN tar xzf s6.tgz -C / --exclude="./bin" \
   # - Remove the /var/run -> /run symlink and create a legit /var/run folder
   # as some docker versions re-create /run from zero at container start
   && adduser --system --no-create-home --disabled-password --ingroup root dd-agent \
+  && addgroup --system secret-manager \
+  && usermod -a -G secret-manager dd-agent \
   && rm /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog \
   && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ \
   && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ \
   && chmod 755 /probe.sh /initlog.sh \
-  && chown root:root /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh \
+  && chown root:secret-manager /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh \
   && chmod 550 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh
 
 # Update links to python binaries

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -20,8 +20,12 @@ COPY ./install_info etc/datadog-agent/install_info
 COPY entrypoint.sh .
 COPY readsecret.sh readsecret_multiple_providers.sh ./
 
-RUN chmod 755 entrypoint.sh \
-    && chown root:root readsecret.sh readsecret_multiple_providers.sh \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y adduser \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && addgroup --system secret-manager \
+    && chmod 755 entrypoint.sh \
+    && chown root:secret-manager readsecret.sh readsecret_multiple_providers.sh \
     && chmod 550 readsecret.sh readsecret_multiple_providers.sh \
     && chmod g+r,g+w,g+X -R etc/datadog-agent/ \
     && chmod +x opt/datadog-agent/bin/datadog-cluster-agent \
@@ -79,6 +83,8 @@ COPY --from=builder /output /
 # of an empty folder. Creating .placeholder files as a workaround.
 #
 RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agent \
+    && addgroup --system secret-manager \
+    && usermod -a -G secret-manager dd-agent \
     && mkdir -p /var/log/datadog/ /conf.d \
     && touch /var/log/datadog/.placeholder \
     && touch /tmp/.placeholder \


### PR DESCRIPTION
### What does this PR do?

Create a dedicated `secret-manager` group allowed to execute the secret-backends shipped in the docker image.

### Motivation

The agent and the cluster-agent are [checking the permissions of a secret backend before invoking it](https://github.com/DataDog/datadog-agent/blob/main/comp/core/secrets/secretsimpl/check_rights_nix.go).
By default, it enforces that the agent user is also the owner of the file and that the file is executable only by this user.
If `secret_backend_command_allow_group_exec_perm` is set, which is the case in the [agent](https://github.com/DataDog/datadog-agent/blob/e195386d3170d9de366d6ac0017ec55f095a0fcc/Dockerfiles/agent/Dockerfile#L124-L125) and [cluster agent](https://github.com/DataDog/datadog-agent/blob/e195386d3170d9de366d6ac0017ec55f095a0fcc/Dockerfiles/cluster-agent/Dockerfile#L64-L65) docker images, then, it allows group to have execution rights on the file.

The secret backends used to belong to `root:root`, meaning that paranoid users that want to run the agent with a non-root users have to be in the `root` group in order to use the secret backends.
With this change, it’s not needed anymore.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the cluster-agent with a non-root user that has `101` as a supplementary group.
Validate that it can decode secrets.
