### PR TITLE
[CONTINT-3892] unify mutation metrics for admission controller webhooks

### DIFF
--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -22,12 +22,15 @@ const (
 
 // Mutation errors
 const (
-	NilPod               = "nil_pod"
 	InvalidInput         = "invalid_input"
-	EmptyNamespace       = "empty_namespace"
 	InternalError        = "internal_error"
-	UnsupportedLanguage  = "unsupported_language"
 	ConfigInjectionError = "config_injection_error"
+)
+
+// Status tags
+const (
+	StatusSuccess = "success"
+	StatusError   = "error"
 )
 
 // Telemetry metrics
@@ -42,10 +45,7 @@ var (
 		[]string{}, "Time left before the certificate expires in hours.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	MutationAttempts = telemetry.NewGaugeWithOpts("admission_webhooks", "mutation_attempts",
-		[]string{"mutation_type", "injected"}, "Number of pod mutation attempts by mutation type",
-		telemetry.Options{NoDoubleUnderscoreSep: true})
-	MutationErrors = telemetry.NewGaugeWithOpts("admission_webhooks", "mutation_errors",
-		[]string{"mutation_type", "reason"}, "Number of mutation failures by mutation type",
+		[]string{"mutation_type", "status", "injected", "error"}, "Number of pod mutation attempts by mutation type",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	WebhooksReceived = telemetry.NewCounterWithOpts("admission_webhooks", "webhooks_received",
 		[]string{"mutation_type"}, "Number of mutation webhook requests received.",

--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -20,6 +20,16 @@ const (
 	WebhooksControllerName = "webhooks"
 )
 
+// Mutation errors
+const (
+	NilPod               = "nil_pod"
+	InvalidInput         = "invalid_input"
+	EmptyNamespace       = "empty_namespace"
+	InternalError        = "internal_error"
+	UnsupportedLanguage  = "unsupported_language"
+	ConfigInjectionError = "config_injection_error"
+)
+
 // Telemetry metrics
 var (
 	ReconcileSuccess = telemetry.NewGaugeWithOpts("admission_webhooks", "reconcile_success",
@@ -32,10 +42,10 @@ var (
 		[]string{}, "Time left before the certificate expires in hours.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	MutationAttempts = telemetry.NewGaugeWithOpts("admission_webhooks", "mutation_attempts",
-		[]string{"mutation_type", "injected", "language", "auto_detected"}, "Number of pod mutation attempts by mutation type (agent config, standard tags, lib injection).",
+		[]string{"mutation_type", "injected"}, "Number of pod mutation attempts by mutation type",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	MutationErrors = telemetry.NewGaugeWithOpts("admission_webhooks", "mutation_errors",
-		[]string{"mutation_type", "reason", "language", "auto_detected"}, "Number of mutation failures by mutation type (agent config, standard tags, lib injection).",
+		[]string{"mutation_type", "reason"}, "Number of mutation failures by mutation type",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	WebhooksReceived = telemetry.NewCounterWithOpts("admission_webhooks", "webhooks_received",
 		[]string{"mutation_type"}, "Number of mutation webhook requests received.",

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	apiCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
@@ -107,18 +108,18 @@ func (w *Webhook) MutateFunc() admission.WebhookFunc {
 
 // mutate handles mutating pod requests for the agentsidecar webhook
 func (w *Webhook) mutate(request *admission.MutateRequest) ([]byte, error) {
-	return common.Mutate(request.Raw, request.Namespace, w.injectAgentSidecar, request.DynamicClient)
+	return common.Mutate(request.Raw, request.Namespace, w.Name(), w.injectAgentSidecar, request.DynamicClient)
 }
 
-func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
+func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
 	if pod == nil {
-		return errors.New("can't inject agent sidecar into nil pod")
+		return false, errors.New(metrics.NilPod)
 	}
 
 	for _, container := range pod.Spec.Containers {
 		if container.Name == agentSidecarContainerName {
 			log.Info("skipping agent sidecar injection: agent sidecar already exists")
-			return nil
+			return false, nil
 		}
 	}
 
@@ -126,17 +127,18 @@ func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interf
 
 	err := applyProviderOverrides(agentSidecarContainer)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// User-provided overrides should always be applied last in order to have highest override-priority
 	err = applyProfileOverrides(agentSidecarContainer)
 	if err != nil {
-		return err
+		log.Errorf("Failed to apply profile overrides: %v", err)
+		return false, errors.New(metrics.InvalidInput)
 	}
 
 	pod.Spec.Containers = append(pod.Spec.Containers, *agentSidecarContainer)
-	return nil
+	return true, nil
 }
 
 func getDefaultSidecarTemplate(containerRegistry string) *corev1.Container {

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -113,7 +113,7 @@ func (w *Webhook) mutate(request *admission.MutateRequest) ([]byte, error) {
 
 func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
 	if pod == nil {
-		return false, errors.New(metrics.NilPod)
+		return false, errors.New(metrics.InvalidInput)
 	}
 
 	for _, container := range pod.Spec.Containers {
@@ -127,7 +127,8 @@ func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interf
 
 	err := applyProviderOverrides(agentSidecarContainer)
 	if err != nil {
-		return false, err
+		log.Errorf("Failed to apply provider overrides: %v", err)
+		return false, errors.New(metrics.InvalidInput)
 	}
 
 	// User-provided overrides should always be applied last in order to have highest override-priority

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -285,7 +285,7 @@ func libImageName(registry string, lang language, tag string) string {
 
 func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
 	if pod == nil {
-		return false, errors.New(metrics.NilPod)
+		return false, errors.New(metrics.InvalidInput)
 	}
 	injectApmTelemetryConfig(pod)
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -271,7 +271,7 @@ func (w *Webhook) MutateFunc() admission.WebhookFunc {
 
 // injectAutoInstrumentation injects APM libraries into pods
 func (w *Webhook) injectAutoInstrumentation(request *admission.MutateRequest) ([]byte, error) {
-	return mutatecommon.Mutate(request.Raw, request.Namespace, w.inject, request.DynamicClient)
+	return mutatecommon.Mutate(request.Raw, request.Namespace, w.Name(), w.inject, request.DynamicClient)
 }
 
 func initContainerName(lang language) string {
@@ -283,9 +283,9 @@ func libImageName(registry string, lang language, tag string) string {
 	return fmt.Sprintf(imageFormat, registry, lang, tag)
 }
 
-func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
+func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
 	if pod == nil {
-		return errors.New("cannot inject lib into nil pod")
+		return false, errors.New(metrics.NilPod)
 	}
 	injectApmTelemetryConfig(pod)
 
@@ -293,24 +293,24 @@ func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 		// if Single Step Instrumentation is enabled, pods can still opt out using the label
 		if pod.GetLabels()[common.EnabledLabelKey] == "false" {
 			log.Debugf("Skipping single step instrumentation of pod %q due to label", mutatecommon.PodString(pod))
-			return nil
+			return false, nil
 		}
 	} else if !mutatecommon.ShouldMutatePod(pod) {
 		log.Debugf("Skipping auto instrumentation of pod %q because pod mutation is not allowed", mutatecommon.PodString(pod))
-		return nil
+		return false, nil
 	}
 	for _, lang := range supportedLanguages {
 		if containsInitContainer(pod, initContainerName(lang)) {
 			// The admission can be reinvocated for the same pod
 			// Fast return if we injected the library already
 			log.Debugf("Init container %q already exists in pod %q", initContainerName(lang), mutatecommon.PodString(pod))
-			return nil
+			return false, nil
 		}
 	}
 
 	libsToInject, autoDetected := w.extractLibInfo(pod)
 	if len(libsToInject) == 0 {
-		return nil
+		return false, nil
 	}
 	// Inject env variables used for Onboarding KPIs propagation
 	var injectionType string
@@ -324,7 +324,12 @@ func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 		injectionType = localLibraryInstrumentationInstallType
 	}
 
-	return w.injectAutoInstruConfig(pod, libsToInject, autoDetected, injectionType)
+	if err := w.injectAutoInstruConfig(pod, libsToInject, autoDetected, injectionType); err != nil {
+		log.Errorf("failed to inject auto instrumentation configurations: %v", err)
+		return false, errors.New(metrics.ConfigInjectionError)
+	}
+
+	return true, nil
 }
 
 func injectApmTelemetryConfig(pod *corev1.Pod) {
@@ -579,7 +584,6 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo
 		langStr := string(lib.lang)
 		defer func() {
 			metrics.LibInjectionAttempts.Inc(langStr, strconv.FormatBool(injected), strconv.FormatBool(autoDetected), injectionType)
-			metrics.MutationAttempts.Inc(w.Name(), strconv.FormatBool(injected), langStr, strconv.FormatBool(autoDetected))
 		}()
 
 		_ = mutatecommon.InjectEnv(pod, localLibraryInstrumentationInstallTypeEnvVar)
@@ -637,14 +641,12 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo
 				}})
 		default:
 			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
-			metrics.MutationErrors.Inc(w.Name(), "unsupported language", langStr, strconv.FormatBool(autoDetected))
 			lastError = fmt.Errorf("language %q is not supported. Supported languages are %v", lib.lang, supportedLanguages)
 			continue
 		}
 
 		if err != nil {
 			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
-			metrics.MutationErrors.Inc(w.Name(), "requirements config error", langStr, strconv.FormatBool(autoDetected))
 			lastError = err
 			log.Errorf("Error injecting library config requirements: %s", err)
 		}
@@ -659,7 +661,6 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo
 		if err != nil {
 			langStr := string(lang)
 			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
-			metrics.MutationErrors.Inc(w.Name(), "cannot inject init container", langStr, strconv.FormatBool(autoDetected))
 			lastError = err
 			log.Errorf("Cannot inject init container into pod %s: %s", mutatecommon.PodString(pod), err)
 		}
@@ -667,7 +668,6 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo
 		if err != nil {
 			langStr := string(lang)
 			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
-			metrics.MutationErrors.Inc(w.Name(), "cannot inject lib config", langStr, strconv.FormatBool(autoDetected))
 			lastError = err
 			log.Errorf("Cannot inject library configuration into pod %s: %s", mutatecommon.PodString(pod), err)
 		}
@@ -676,7 +676,6 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo
 	// try to inject all if the annotation is set
 	if err := injectLibConfig(pod, "all"); err != nil {
 		metrics.LibInjectionErrors.Inc("all", strconv.FormatBool(autoDetected), injectionType)
-		metrics.MutationErrors.Inc(w.Name(), "cannot inject lib config", "all", strconv.FormatBool(autoDetected))
 		lastError = err
 		log.Errorf("Cannot inject library configuration into pod %s: %s", mutatecommon.PodString(pod), err)
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1877,7 +1877,7 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 			apmInstrumentationWebhook, errInitAPMInstrumentation = NewWebhook(wmeta)
 			require.NoError(t, errInitAPMInstrumentation)
 
-			err := apmInstrumentationWebhook.inject(tt.pod, "", fake.NewSimpleDynamicClient(scheme.Scheme))
+			_, err := apmInstrumentationWebhook.inject(tt.pod, "", fake.NewSimpleDynamicClient(scheme.Scheme))
 			require.False(t, (err != nil) != tt.wantErr)
 
 			container := tt.pod.Spec.Containers[0]

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -35,9 +35,9 @@ func Mutate(rawPod []byte, ns string, mutationType string, m MutationFunc, dc dy
 	}
 
 	if injected, err := m(&pod, ns, dc); err != nil {
-		metrics.MutationErrors.Inc(mutationType, err.Error())
+		metrics.MutationAttempts.Inc(mutationType, metrics.StatusError, strconv.FormatBool(injected), err.Error())
 	} else {
-		metrics.MutationAttempts.Inc(mutationType, strconv.FormatBool(injected))
+		metrics.MutationAttempts.Inc(mutationType, metrics.StatusSuccess, strconv.FormatBool(injected), "")
 	}
 
 	bytes, err := json.Marshal(pod)

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -11,29 +11,33 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/wI2L/jsondiff"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 
 	admCommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // MutationFunc is a function that mutates a pod
-type MutationFunc func(*corev1.Pod, string, dynamic.Interface) error
+type MutationFunc func(*corev1.Pod, string, dynamic.Interface) (bool, error)
 
 // Mutate handles mutating pods and encoding and decoding admission
 // requests and responses for the public mutate functions
-func Mutate(rawPod []byte, ns string, m MutationFunc, dc dynamic.Interface) ([]byte, error) {
+func Mutate(rawPod []byte, ns string, mutationType string, m MutationFunc, dc dynamic.Interface) ([]byte, error) {
 	var pod corev1.Pod
 	if err := json.Unmarshal(rawPod, &pod); err != nil {
 		return nil, fmt.Errorf("failed to decode raw object: %v", err)
 	}
 
-	if err := m(&pod, ns, dc); err != nil {
-		return nil, err
+	if injected, err := m(&pod, ns, dc); err != nil {
+		metrics.MutationErrors.Inc(mutationType, err.Error())
+	} else {
+		metrics.MutationAttempts.Inc(mutationType, strconv.FormatBool(injected))
 	}
 
 	bytes, err := json.Marshal(pod)

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -156,7 +156,7 @@ func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, 
 	var injectedConfig, injectedEntity bool
 
 	if pod == nil {
-		return false, errors.New(metrics.NilPod)
+		return false, errors.New(metrics.InvalidInput)
 
 	}
 

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -12,6 +12,7 @@ package cwsinstrumentation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -49,7 +50,7 @@ const (
 	webhookForCommandsName = "cws_exec_instrumentation"
 )
 
-type mutatePodExecFunc func(*corev1.PodExecOptions, string, string, *authenticationv1.UserInfo, dynamic.Interface, kubernetes.Interface) error
+type mutatePodExecFunc func(*corev1.PodExecOptions, string, string, *authenticationv1.UserInfo, dynamic.Interface, kubernetes.Interface) (bool, error)
 
 // WebhookForPods is the webhook that injects CWS pod instrumentation
 type WebhookForPods struct {
@@ -272,54 +273,50 @@ func (ci *CWSInstrumentation) WebhookForCommands() *WebhookForCommands {
 }
 
 func (ci *CWSInstrumentation) injectForCommand(request *admission.MutateRequest) ([]byte, error) {
-	return mutatePodExecOptions(request.Raw, request.Name, request.Namespace, request.UserInfo, ci.injectCWSCommandInstrumentation, request.DynamicClient, request.APIClient)
+	return mutatePodExecOptions(request.Raw, request.Name, request.Namespace, ci.webhookForCommands.Name(), request.UserInfo, ci.injectCWSCommandInstrumentation, request.DynamicClient, request.APIClient)
 }
 
-func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodExecOptions, name string, ns string, userInfo *authenticationv1.UserInfo, _ dynamic.Interface, apiClient kubernetes.Interface) error {
+func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodExecOptions, name string, ns string, userInfo *authenticationv1.UserInfo, _ dynamic.Interface, apiClient kubernetes.Interface) (bool, error) {
 	var injected bool
-	defer func() {
-		metrics.MutationAttempts.Inc(ci.webhookForCommands.Name(), strconv.FormatBool(injected), "", "")
-	}()
 
 	if exec == nil || userInfo == nil {
-		metrics.MutationErrors.Inc(ci.webhookForCommands.Name(), "nil exec or user info", "", "")
-		return fmt.Errorf("cannot inject CWS instrumentation into nil exec options or nil userInfo")
+		log.Errorf("cannot inject CWS instrumentation into nil exec options or nil userInfo")
+		return false, errors.New(metrics.InvalidInput)
+
 	}
 	if len(exec.Command) == 0 {
-		metrics.MutationErrors.Inc(ci.webhookForCommands.Name(), "empty command", "", "")
-		return nil
+		return false, nil
 	}
 
 	// is the namespace / container targeted by the instrumentation ?
 	if ci.filter.IsExcluded(nil, exec.Container, "", ns) {
-		return nil
+		return false, nil
 	}
 
 	// check if the pod has been instrumented
 	pod, err := apiClient.CoreV1().Pods(ns).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil || pod == nil {
-		metrics.MutationErrors.Inc(ci.webhookForCommands.Name(), "cannot get pod", "", "")
-		return fmt.Errorf("couldn't describe pod %s in namespace %s from the API server: %w", name, ns, err)
+		log.Errorf("couldn't describe pod %s in namespace %s from the API server: %v", name, ns, err)
+		return false, errors.New(metrics.InternalError)
 	}
 
 	// is the pod targeted by the instrumentation ?
 	if ci.filter.IsExcluded(pod.Annotations, "", "", "") {
-		return nil
+		return false, nil
 	}
 
 	// is the pod instrumentation ready ? (i.e. has the CWS Instrumentation pod admission controller run ?)
 	if !isPodCWSInstrumentationReady(pod.Annotations) {
 		// pod isn't instrumented, do not attempt to override the pod exec command
 		log.Debugf("Ignoring exec request into %s, pod not instrumented yet", common.PodString(pod))
-		return nil
+		return false, nil
 	}
 
 	// prepare the user session context
 	userSessionCtx, err := usersessions.PrepareK8SUserSessionContext(userInfo, cwsUserSessionDataMaxSize)
 	if err != nil {
-		metrics.MutationErrors.Inc(ci.webhookForCommands.Name(), "cannot serialize user info", "", "")
 		log.Debugf("ignoring instrumentation of %s: %v", common.PodString(pod), err)
-		return err
+		return false, errors.New(metrics.InternalError)
 	}
 
 	if len(exec.Command) > 7 {
@@ -333,8 +330,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 
 			if exec.Command[5] == string(userSessionCtx) {
 				log.Debugf("Exec request into %s is already instrumented, ignoring", common.PodString(pod))
-				injected = true
-				return nil
+				return true, nil
 			}
 		}
 	}
@@ -353,34 +349,30 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 	log.Debugf("Pod exec request to %s is now instrumented for CWS", common.PodString(pod))
 	injected = true
 
-	return nil
+	return injected, nil
 }
 
 func (ci *CWSInstrumentation) injectForPod(request *admission.MutateRequest) ([]byte, error) {
-	return common.Mutate(request.Raw, request.Namespace, ci.injectCWSPodInstrumentation, request.DynamicClient)
+	return common.Mutate(request.Raw, request.Namespace, ci.webhookForPods.Name(), ci.injectCWSPodInstrumentation, request.DynamicClient)
 }
 
-func (ci *CWSInstrumentation) injectCWSPodInstrumentation(pod *corev1.Pod, ns string, _ dynamic.Interface) error {
+func (ci *CWSInstrumentation) injectCWSPodInstrumentation(pod *corev1.Pod, ns string, _ dynamic.Interface) (bool, error) {
 	var injected bool
-	defer func() {
-		metrics.MutationAttempts.Inc(ci.webhookForPods.Name(), strconv.FormatBool(injected), "", "")
-	}()
 
 	if pod == nil {
-		metrics.MutationErrors.Inc(ci.webhookForPods.Name(), "nil pod", "", "")
-		return fmt.Errorf("cannot inject CWS instrumentation into nil pod")
+		return injected, errors.New(metrics.NilPod)
 	}
 
 	// is the pod targeted by the instrumentation ?
 	if ci.filter.IsExcluded(pod.Annotations, "", "", ns) {
-		return nil
+		return injected, nil
 	}
 
 	// check if the pod has already been instrumented
 	if isPodCWSInstrumentationReady(pod.Annotations) {
 		injected = true
 		// nothing to do, return
-		return nil
+		return injected, nil
 	}
 
 	// create a new volume that will be used to share cws-instrumentation across the containers of this pod
@@ -401,7 +393,7 @@ func (ci *CWSInstrumentation) injectCWSPodInstrumentation(pod *corev1.Pod, ns st
 	pod.Annotations[cwsInstrumentationPodAnotationStatus] = cwsInstrumentationPodAnotationReady
 	injected = true
 	log.Debugf("Pod %s is now instrumented for CWS", common.PodString(pod))
-	return nil
+	return injected, nil
 }
 
 func injectCWSVolume(pod *corev1.Pod) {
@@ -500,15 +492,24 @@ func labelSelectors(useNamespaceSelector bool) (namespaceSelector, objectSelecto
 
 // mutatePodExecOptions handles mutating PodExecOptions and encoding and decoding admission
 // requests and responses for the public mutate functions
-func mutatePodExecOptions(rawPodExecOptions []byte, name string, ns string, userInfo *authenticationv1.UserInfo, m mutatePodExecFunc, dc dynamic.Interface, apiClient kubernetes.Interface) ([]byte, error) {
+func mutatePodExecOptions(rawPodExecOptions []byte, name string, ns string, mutationType string, userInfo *authenticationv1.UserInfo, m mutatePodExecFunc, dc dynamic.Interface, apiClient kubernetes.Interface) ([]byte, error) {
 	var exec corev1.PodExecOptions
 	if err := json.Unmarshal(rawPodExecOptions, &exec); err != nil {
 		return nil, fmt.Errorf("failed to decode raw object: %v", err)
 	}
 
-	if err := m(&exec, name, ns, userInfo, dc, apiClient); err != nil {
+	if _, err := m(&exec, name, ns, userInfo, dc, apiClient); err != nil {
 		return nil, err
 	}
+
+	injected, err := m(&exec, name, ns, userInfo, dc, apiClient)
+
+	if err != nil {
+		metrics.MutationErrors.Inc(mutationType, err.Error())
+		return nil, err
+	}
+
+	metrics.MutationAttempts.Inc(mutationType, strconv.FormatBool(injected))
 
 	bytes, err := json.Marshal(exec)
 	if err != nil {

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -406,10 +407,15 @@ func Test_injectCWSCommandInstrumentation(t *testing.T) {
 			if err != nil {
 				require.Fail(t, "couldn't instantiate CWS Instrumentation", "%v", err)
 			} else {
-				err := ci.injectCWSCommandInstrumentation(tt.args.exec, tt.args.name, tt.args.ns, tt.args.userInfo, nil, MockK8sClientInterface{
+				injected, err := ci.injectCWSCommandInstrumentation(tt.args.exec, tt.args.name, tt.args.ns, tt.args.userInfo, nil, MockK8sClientInterface{
 					annotations: tt.args.apiClientAnnotations,
 					shouldFail:  tt.args.apiClientShouldFail,
 				})
+
+				if tt.wantErr {
+					assert.False(t, injected)
+				}
+
 				if err != nil && !tt.wantErr {
 					require.Fail(t, "CWS instrumentation shouldn't have produced an error: got %v", err)
 				}
@@ -420,6 +426,7 @@ func Test_injectCWSCommandInstrumentation(t *testing.T) {
 						require.Fail(t, "CWS instrumentation failed", "invalid exec command length %d", l)
 						return
 					}
+					assert.True(t, injected)
 					expectedCommand := fmt.Sprintf("%s%s", filepath.Join(cwsMountPath, "cws-instrumentation"), " inject --session-type k8s --data")
 					require.Equal(t, expectedCommand, strings.Join(tt.args.exec.Command[0:5], " "), "incorrect CWS instrumentation")
 					require.Equal(t, "--", tt.args.exec.Command[6], "incorrect CWS instrumentation")
@@ -701,11 +708,18 @@ func Test_injectCWSPodInstrumentation(t *testing.T) {
 			if err != nil {
 				require.Fail(t, "couldn't instantiate CWS Instrumentation", "%v", err)
 			} else {
-				if err := ci.injectCWSPodInstrumentation(tt.args.pod, tt.args.ns, nil); err != nil && !tt.wantErr {
+				injected, err := ci.injectCWSPodInstrumentation(tt.args.pod, tt.args.ns, nil)
+
+				if tt.wantErr {
+					assert.False(t, injected)
+				}
+
+				if err != nil && !tt.wantErr {
 					require.Fail(t, "CWS instrumentation shouldn't have produced an error: got %v", err)
 				}
 
 				if tt.wantInstrumentation {
+					assert.True(t, injected)
 					testInjectCWSVolume(t, tt.args.pod)
 					testInjectCWSVolumeMount(t, tt.args.pod)
 					testInjectCWSInitContainer(t, tt.args.pod, tt.expectedInitContainer)

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -126,61 +125,56 @@ func (o *ownerInfo) buildID(ns string) string {
 // mutate adds the DD_ENV, DD_VERSION, DD_SERVICE env vars to
 // the pod template from pod and higher-level resource labels
 func (w *Webhook) mutate(request *admission.MutateRequest) ([]byte, error) {
-	return common.Mutate(request.Raw, request.Namespace, func(pod *corev1.Pod, ns string, dc dynamic.Interface) error {
-		return w.injectTags(pod, ns, dc, w.wmeta)
+	return common.Mutate(request.Raw, request.Namespace, w.Name(), func(pod *corev1.Pod, ns string, dc dynamic.Interface) (bool, error) {
+		return injectTags(pod, ns, dc, w.wmeta)
 	}, request.DynamicClient)
 }
 
 // injectTags injects DD_ENV, DD_VERSION, DD_SERVICE
 // env vars into a pod template if needed
-func (w *Webhook) injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface, wmeta workloadmeta.Component) error {
+func injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface, wmeta workloadmeta.Component) (bool, error) {
 	var injected bool
-	defer func() {
-		metrics.MutationAttempts.Inc(w.Name(), strconv.FormatBool(injected), "", "")
-	}()
 
 	if pod == nil {
-		metrics.MutationErrors.Inc(w.Name(), "nil pod", "", "")
-		return errors.New("cannot inject tags into nil pod")
+		return false, errors.New(metrics.NilPod)
 	}
 
 	if !autoinstrumentation.ShouldInject(pod, wmeta) {
 		// Ignore pod if it has the label admission.datadoghq.com/enabled=false or Single step configuration is disabled
-		return nil
+		return false, nil
 	}
 
 	var found bool
 	if found, injected = injectTagsFromLabels(pod.GetLabels(), pod); found {
 		// Standard labels found in the pod's labels
 		// No need to lookup the pod's owner
-		return nil
+		return injected, nil
 	}
 
 	if ns == "" {
 		if pod.GetNamespace() != "" {
 			ns = pod.GetNamespace()
 		} else {
-			metrics.MutationErrors.Inc(w.Name(), "empty namespace", "", "")
-			return errors.New("cannot get standard tags from parent object: empty namespace")
+			return false, errors.New(metrics.EmptyNamespace)
 		}
 	}
 
 	// Try to discover standard labels on the pod's owner
 	owners := pod.GetOwnerReferences()
 	if len(owners) == 0 {
-		return nil
+		return false, nil
 	}
 
 	owner, err := getOwner(owners[0], ns, dc)
 	if err != nil {
-		metrics.MutationErrors.Inc(w.Name(), "cannot get owner", "", "")
-		return err
+		log.Error(err)
+		return false, errors.New(metrics.InternalError)
 	}
 
 	log.Debugf("Looking for standard labels on '%s/%s' - kind '%s' owner of pod %s", owner.namespace, owner.name, owner.kind, common.PodString(pod))
 	_, injected = injectTagsFromLabels(owner.labels, pod)
 
-	return nil
+	return injected, nil
 }
 
 // injectTagsFromLabels looks for standard tags in pod labels

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
@@ -136,7 +136,7 @@ func injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface, wmeta workload
 	var injected bool
 
 	if pod == nil {
-		return false, errors.New(metrics.NilPod)
+		return false, errors.New(metrics.InvalidInput)
 	}
 
 	if !autoinstrumentation.ShouldInject(pod, wmeta) {
@@ -155,7 +155,7 @@ func injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface, wmeta workload
 		if pod.GetNamespace() != "" {
 			ns = pod.GetNamespace()
 		} else {
-			return false, errors.New(metrics.EmptyNamespace)
+			return false, errors.New(metrics.InvalidInput)
 		}
 	}
 

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags_test.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags_test.go
@@ -172,8 +172,7 @@ func Test_injectTags(t *testing.T) {
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmeta.MockModule(), fx.Supply(workloadmeta.NewParams()))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := NewWebhook(wmeta)
-			err := w.injectTags(tt.pod, "ns", nil, wmeta)
+			_, err := injectTags(tt.pod, "ns", nil, wmeta)
 			assert.NoError(t, err)
 			assert.Len(t, tt.pod.Spec.Containers, 1)
 			assert.Len(t, tt.wantPodFunc().Spec.Containers, 1)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR unifies the use of `admission_webhooks_mutation_attempts` and `admission_webhooks_mutation_errors` in the admission controller webhooks. (i.e. impose having the same behaviour for all webhooks): 
- Increment the metrics in the generic mutate function instead of incrementing them separately in each webhook
- Remove unnecessary tags (i.e. `autoDetected` and `language`). These tags make sense only in the context of the auto-instrumentation webhook, which already has its own metrics.
- Remove the `admission_webhooks_mutation_attempts`
- Add `status` and `error` tag to the `admission_webhooks_mutation_attempts` metric 
- Define a list of common errors that can be returned by the webhooks and used as a value for the `error` tag in `admission_webhooks_mutation_attempts` in order to limit the cardinality and allow filtering easily.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

There are some inconsistencies and issues in a couple of telemetry metrics reported by the admission controller:
- `admission_webhooks.mutation_attempts`
- `admission_webhooks.mutation_errors`

Both metrics are reported by all the webhooks except the agent sidecar one. We should report them in that webhook too.

The metrics report the same thing in the tags, config, and CWS webhooks, but it’s different in APM. In tags, configs, and CWS, the metrics are increased by 1 on every mutate call. However, in APM, it’s increased by 1 for each library that should be injected. Also, the metric includes 2 labels that are only used by APM: “language” and “auto_detected”. 

Ideally the behavior should be the same in all webhooks and the labels too. If APM needs slightly different things, I believe it would have been better to define a metric specific for it and use both the specific one and the standard one.

For “admission_webhooks.mutation_errors”, it includes a “reason” label. The problem is that this reason is a sentence describing the error instead of an ID. This is a bit inconvenient when filtering in dashboards for example, but also, the cardinality can become a problem if we accept any sentence as a “reason”.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- The signature of the `MutationFunc` had to be changed so that it returns not only a (possible) error, but also a boolean flag indicating whether injection took place or not.
- TODO after merge:
   - Update the `datadog-cluster-agent` integration (fixtures, metrics, dashboard)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
This PR is making some non-trivial changes to the existing metrics/tags, but this should be ok for several reasons:
- Changing the error tag to use a predefined set of errors is more of a bug fix, since we should not allow assigning an arbitrary string as the error tag, this makes cardinality not limited, and also adds a lot of friction to filtering on dashboards.
- Dropping the `autoDetected` and `language` tags and the `admission_webhooks.mutation_errors` metrics. This should also be okay, since these two tags are only relevant for auto_instrumentation webhook. Other webhooks leave these tags with empty value. The auto_instrumentation webhook uses other metrics and sets these tags onto those metrics.

In all cases, based on metabase:
- No monitors are using these metrics, this means no monitors will be affected by these changes.
- The number of orgs using these metrics in their dashboards is limited, and potentially most (if not all) of them are using OOTB dashboards. OOTB dashboards should be updated after this PR is merged, so the change should normally be propagated to all orgs.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Deploy the cluster agent and enable the several webhooks, then try creating some pods/workloads and check that the telemetry seems correct. Below is a sample setup:

Deployment with helm:

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
  apm:
    instrumentation:
      enabled: true

clusterAgent:
  enabled: true
  admissionController:
    enabled: true
    mutateUnlabelled: true
  env:
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_ENABLED
      value: "true"
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_PROVIDER
      value: "fargate"
    - name: DD_ADMISSION_CONTROLLER_CWS_INSTRUMENTATION_ENABLED
      value: "true"
```

Creating a non-default namespace to have auto-instrumentation injection work (since default namespace is excluded by default):
```
kubectl create namespace another-ns
```

Create a sample pod that triggers some webhooks:

```
apiVersion: v1
kind: Pod
metadata:
  name: sample-pod
  namespace: "another-ns"
  labels:
    injectSidecarPodLabel: "true"
    agent.datadoghq.com/sidecar: "fargate"
    admission.datadoghq.com/unknown-lang-lib.version: "latest"
spec:
  containers:
    - name: nginx
      image: nginx:1.14.2
      ports:
        - containerPort: 80
```

Check the telemetry:
```
# HELP admission_webhooks_mutation_attempts Number of pod mutation attempts by mutation type
# TYPE admission_webhooks_mutation_attempts gauge
admission_webhooks_mutation_attempts{error="",injected="false",mutation_type="agent_sidecar",status="success"} 1
admission_webhooks_mutation_attempts{error="",injected="false",mutation_type="cws_exec_instrumentation",status="success"} 1
admission_webhooks_mutation_attempts{error="",injected="false",mutation_type="lib_injection",status="success"} 1
admission_webhooks_mutation_attempts{error="",injected="false",mutation_type="standard_tags",status="success"} 2
admission_webhooks_mutation_attempts{error="",injected="true",mutation_type="agent_config",status="success"} 2
admission_webhooks_mutation_attempts{error="",injected="true",mutation_type="agent_sidecar",status="success"} 1
admission_webhooks_mutation_attempts{error="",injected="true",mutation_type="cws_pod_instrumentation",status="success"} 2
admission_webhooks_mutation_attempts{error="",injected="true",mutation_type="lib_injection",status="success"} 1
```