### PR TITLE
[CONTINT-3776] Fix dual shipping recovery in logs client 

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2035,7 +2035,7 @@ func bindEnvAndSetLogsConfigKeys(config pkgconfigmodel.Config, prefix string) {
 	config.BindEnvAndSetDefault(prefix+"sender_backoff_base", DefaultLogsSenderBackoffBase)
 	config.BindEnvAndSetDefault(prefix+"sender_backoff_max", DefaultLogsSenderBackoffMax)
 	config.BindEnvAndSetDefault(prefix+"sender_recovery_interval", DefaultForwarderRecoveryInterval)
-	config.BindEnvAndSetDefault(prefix+"sender_recovery_reset", false)
+	config.BindEnvAndSetDefault(prefix+"sender_recovery_reset", true)
 	config.BindEnvAndSetDefault(prefix+"use_v2_api", true)
 }
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2035,7 +2035,7 @@ func bindEnvAndSetLogsConfigKeys(config pkgconfigmodel.Config, prefix string) {
 	config.BindEnvAndSetDefault(prefix+"sender_backoff_base", DefaultLogsSenderBackoffBase)
 	config.BindEnvAndSetDefault(prefix+"sender_backoff_max", DefaultLogsSenderBackoffMax)
 	config.BindEnvAndSetDefault(prefix+"sender_recovery_interval", DefaultForwarderRecoveryInterval)
-	config.BindEnvAndSetDefault(prefix+"sender_recovery_reset", true)
+	config.BindEnvAndSetDefault(prefix+"sender_recovery_reset", false)
 	config.BindEnvAndSetDefault(prefix+"use_v2_api", true)
 }
 

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -222,13 +222,12 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 	for {
 
 		d.retryLock.Lock()
-		backoffDuration := d.backoff.GetBackoffDuration(d.nbErrors)
+		nbErrors := d.nbErrors
 		d.retryLock.Unlock()
+		backoffDuration := d.backoff.GetBackoffDuration(nbErrors)
 		d.blockedUntil = time.Now().Add(backoffDuration)
 		if d.blockedUntil.After(time.Now()) {
-			d.retryLock.Lock()
-			log.Warnf("%s: sleeping until %v before retrying. Backoff duration %s due to %d errors", d.url, d.blockedUntil, backoffDuration.String(), d.nbErrors)
-			d.retryLock.Unlock()
+			log.Warnf("%s: sleeping until %v before retrying. Backoff duration %s due to %d errors", d.url, d.blockedUntil, backoffDuration.String(), nbErrors)
 			d.waitForBackoff()
 			metrics.RetryTimeSpent.Add(int64(backoffDuration))
 			metrics.RetryCount.Add(1)

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -75,7 +75,6 @@ type Destination struct {
 	// Retry
 	backoff        backoff.Policy
 	nbErrors       int
-	blockedUntil   time.Time
 	retryLock      sync.Mutex
 	shouldRetry    bool
 	lastRetryError error
@@ -225,10 +224,10 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 		nbErrors := d.nbErrors
 		d.retryLock.Unlock()
 		backoffDuration := d.backoff.GetBackoffDuration(nbErrors)
-		d.blockedUntil = time.Now().Add(backoffDuration)
-		if d.blockedUntil.After(time.Now()) {
-			log.Warnf("%s: sleeping until %v before retrying. Backoff duration %s due to %d errors", d.url, d.blockedUntil, backoffDuration.String(), nbErrors)
-			d.waitForBackoff()
+		blockedUntil := time.Now().Add(backoffDuration)
+		if blockedUntil.After(time.Now()) {
+			log.Warnf("%s: sleeping until %v before retrying. Backoff duration %s due to %d errors", d.url, blockedUntil, backoffDuration.String(), nbErrors)
+			d.waitForBackoff(blockedUntil)
 			metrics.RetryTimeSpent.Add(int64(backoffDuration))
 			metrics.RetryCount.Add(1)
 			metrics.TlmRetryCount.Add(1)
@@ -443,8 +442,8 @@ func CheckConnectivityDiagnose(endpoint config.Endpoint, cfg pkgconfigmodel.Read
 	return destination.url, completeCheckConnectivity(ctx, destination)
 }
 
-func (d *Destination) waitForBackoff() {
-	ctx, cancel := context.WithDeadline(d.destinationsContext.Context(), d.blockedUntil)
+func (d *Destination) waitForBackoff(blockedUntil time.Time) {
+	ctx, cancel := context.WithDeadline(d.destinationsContext.Context(), blockedUntil)
 	defer cancel()
 	<-ctx.Done()
 }

--- a/releasenotes/notes/fix-dual-shipping-9bab40a3a0f216f6.yaml
+++ b/releasenotes/notes/fix-dual-shipping-9bab40a3a0f216f6.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fixed a bug in the dual shipping feature where events were not being
+    Fixed a bug in the Dual Shipping feature where events were not being
     emitted on endpoint recovery.

--- a/releasenotes/notes/fix-dual-shipping-9bab40a3a0f216f6.yaml
+++ b/releasenotes/notes/fix-dual-shipping-9bab40a3a0f216f6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug in the dual shipping feature where events were not being
+    emitted on endpoint recovery.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
We noticed that the container image and SBOM e2e tests were flaky because the images were not received by the fakeintake when we expected them to be.

We found that the image was sent to the fakeintake but the following log was spammed every two minutes:
```
2024-03-14 17:05:02 UTC | CORE | WARN | (pkg/logs/client/http/destination.go:230 in sendAndRetry) | http://fakeintake-service:80/api/v2/sbom: sleeping until 2024-03-14 17:07:02.411400667 +0000 UTC m=+143.352370720 before retrying. Backoff duration 2m0s due to 7 errors
```
It turns out that the fakeintake started after the agent, so for the first minutes we received only HTTP 503 responses.
As you can see in this [notebook](https://dddev.datadoghq.com/notebook/7671321/investigation-of-testsbom-and-testcontainerimage-flakiness), the fakeintake would still receive a payload every 2 minutes.
However, we still had the log because the number of errors was never decreased.

After deep investigation, it turns out that the `retryLock` seems to be responsible here. Before the number of errors could get updated, another goroutine would lock it.

Finally, I believe we should get a fast recovery by default.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent on kubernetes with the fakeintake, sbom collection and dual shipping enabled. 

For sbom collection with helm, set the following to `true`: https://github.com/DataDog/helm-charts/blob/40d8e3313397b3f901f0b65af81c2be04add0fe6/charts/datadog/values.yaml#L707-L720

For the fakeintake, add the following env vars to your agent:
```
    - name: DD_CONTAINER_IMAGE_ADDITIONAL_ENDPOINTS
      value: '[{"host": "fakeintake-service:80", "use_ssl": false}]'
    - name: DD_SBOM_ADDITIONAL_ENDPOINTS
      value: '[{"host": "fakeintake-service:80", "use_ssl": false }]'
    - name: DD_SBOM_SENDER_RECOVERY_RESET
      value: 'true'
    - name: DD_ADDITIONAL_ENDPOINTS
      value: '[{"fakeintake-service:80": ["FAKEAPIKEY"], "use_ssl": false }]'
```

Finally, deploy the fakeintake with 
```
--- 
apiVersion: apps/v1
kind: Deployment
metadata:
  name: fakeintake-deployment
spec:
  replicas: 1
  selector:
    matchLabels:
      app: fakeintake
  template:
    metadata:
      labels:
        app: fakeintake
      annotations:
        ad.datadoghq.com/fakeintake.checks: |-
          {
            "openmetrics": {
              "init_config": {},
              "instances": [
                {
                  "openmetrics_endpoint": "http://%%host%%/metrics",
                  "namespace": "fakeintake",
                  "metrics": [".*"]
                }
              ]
            }
          }
    spec:
      containers:
      - name: fakeintake
        image: public.ecr.aws/datadog/fakeintake:latest
        ports:
        - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: fakeintake-service
spec:
  selector:
    app: fakeintake
  ports:
    - protocol: TCP
      port: 80
      targetPort: 80
```

In order to reproduce, deploy the agent first then deploy the fakeintake after the above log is shown (approximatively 3 minutes after agent starts).

Deploy the fakeintake, the log should not appear anymore and the fakeintake should receive a lot more payloads.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
