### PR TITLE
kmt: Allow the user to specify more test flags

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -461,7 +461,7 @@ def test(
     ssh_key=None,
     verbose=True,
     test_logs=False,
-    test_extra_arguments="",
+    test_extra_arguments=None,
 ):
     stack = check_and_get_stack(stack)
     if not stacks.stack_exists(stack):
@@ -490,7 +490,7 @@ def test(
             "-verbose" if test_logs else "",
             f"-run-count {run_count}",
             "-test-root /opt/system-probe-tests",
-            f"-extra-params {test_extra_arguments}" if test_extra_arguments != "" else "",
+            f"-extra-params {test_extra_arguments}" if test_extra_arguments is not None else "",
         ]
         for d in domains:
             d.copy(ctx, f"{tmp.name}", "/tmp")

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -445,6 +445,7 @@ def build_run_config(run, packages):
         "ssh-key": "SSH key to use for connecting to a remote EC2 instance hosting the target VM",
         "verbose": "Enable full output of all commands executed",
         "test-logs": "Set 'gotestsum' verbosity to 'standard-verbose' to print all test logs. Default is 'testname'",
+        "test-extra-arguments": "Extra arguments to pass to the test runner, see `go help testflag` for more details",
     }
 )
 def test(
@@ -460,6 +461,7 @@ def test(
     ssh_key=None,
     verbose=True,
     test_logs=False,
+    test_extra_arguments="",
 ):
     stack = check_and_get_stack(stack)
     if not stacks.stack_exists(stack):
@@ -488,6 +490,7 @@ def test(
             "-verbose" if test_logs else "",
             f"-run-count {run_count}",
             "-test-root /opt/system-probe-tests",
+            f"-extra-params {test_extra_arguments}" if test_extra_arguments != "" else "",
         ]
         for d in domains:
             d.copy(ctx, f"{tmp.name}", "/tmp")

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -46,6 +46,7 @@ type testConfig struct {
 	verbose           bool
 	packagesRunConfig map[string]packageRunConfiguration
 	testDirRoot       string
+	extraParams       string
 }
 
 const ciVisibility = "/ci-visibility"
@@ -113,6 +114,10 @@ func buildCommandArgs(pkg string, xmlpath string, jsonpath string, file string, 
 		"--rerun-fails-max-failures=100",
 		"--raw-command", "--",
 		"/go/bin/test2json", "-t", "-p", pkg, file, "-test.v", fmt.Sprintf("-test.count=%d", testConfig.runCount), "-test.timeout=" + getTimeout(pkg).String(),
+	}
+
+	if testConfig.extraParams != "" {
+		args = append(args, strings.Split(testConfig.extraParams, " ")...)
 	}
 
 	packagesRunConfig := testConfig.packagesRunConfig
@@ -232,6 +237,7 @@ func buildTestConfiguration() (*testConfig, error) {
 	verbose := flag.Bool("verbose", false, "if set to true verbosity level is 'standard-verbose', otherwise it is 'testname'")
 	runCount := flag.Int("run-count", 1, "number of times to run the test")
 	testRoot := flag.String("test-root", "/opt/kernel-version-testing/system-probe-tests", "directory containing test packages")
+	extraParams := flag.String("extra-params", "", "extra parameters to pass to the test runner")
 
 	flag.Parse()
 
@@ -256,6 +262,7 @@ func buildTestConfiguration() (*testConfig, error) {
 		retryCount:        *retryPtr,
 		packagesRunConfig: breakdown,
 		testDirRoot:       *testRoot,
+		extraParams:       *extraParams,
 	}, nil
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Allows the kmt user to specify more testflag options to customize the local run.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Customize local runs.
For example allow adding `-test.failfast`

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
