### PR TITLE
[NPM] Fix propagating DefaultKProbeMaxActive to CO-RE tracer

### DIFF
--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -284,6 +284,7 @@ func loadCORETracer(config *config.Config, mgrOpts manager.Options, perfHandlerT
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
 		o.ConstantEditors = mgrOpts.ConstantEditors
 		o.DefaultKprobeAttachMethod = mgrOpts.DefaultKprobeAttachMethod
+		o.DefaultKProbeMaxActive = mgrOpts.DefaultKProbeMaxActive
 		m, closeFn, err = loadTracerFromAsset(ar, false, true, config, o, perfHandlerTCP)
 		return err
 	})

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -85,6 +85,7 @@ var (
 	coreTracerLoader          = loadCORETracer
 	rcTracerLoader            = loadRuntimeCompiledTracer
 	prebuiltTracerLoader      = loadPrebuiltTracer
+	tracerLoaderFromAsset     = loadTracerFromAsset
 	tracerOffsetGuesserRunner = offsetguess.TracerOffsets.Offsets
 
 	errCORETracerNotSupported = errors.New("CO-RE tracer not supported on this platform")
@@ -274,7 +275,7 @@ func loadCORETracer(config *config.Config, mgrOpts manager.Options, connCloseEve
 		o.ConstantEditors = mgrOpts.ConstantEditors
 		o.DefaultKprobeAttachMethod = mgrOpts.DefaultKprobeAttachMethod
 		o.DefaultKProbeMaxActive = mgrOpts.DefaultKProbeMaxActive
-		m, closeFn, err = loadTracerFromAsset(ar, false, true, config, o, connCloseEventHandler)
+		m, closeFn, err = tracerLoaderFromAsset(ar, false, true, config, o, connCloseEventHandler)
 		return err
 	})
 
@@ -288,7 +289,7 @@ func loadRuntimeCompiledTracer(config *config.Config, mgrOpts manager.Options, c
 	}
 	defer buf.Close()
 
-	return loadTracerFromAsset(buf, true, false, config, mgrOpts, connCloseEventHandler)
+	return tracerLoaderFromAsset(buf, true, false, config, mgrOpts, connCloseEventHandler)
 }
 
 func loadPrebuiltTracer(config *config.Config, mgrOpts manager.Options, connCloseEventHandler ddebpf.EventHandler) (*manager.Manager, func(), error) {
@@ -307,7 +308,7 @@ func loadPrebuiltTracer(config *config.Config, mgrOpts manager.Options, connClos
 		config.CollectUDPv6Conns = false
 	}
 
-	return loadTracerFromAsset(buf, false, false, config, mgrOpts, connCloseEventHandler)
+	return tracerLoaderFromAsset(buf, false, false, config, mgrOpts, connCloseEventHandler)
 }
 
 func isCORETracerSupported() error {

--- a/pkg/network/tracer/connection/kprobe/tracer_test.go
+++ b/pkg/network/tracer/connection/kprobe/tracer_test.go
@@ -16,6 +16,7 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
@@ -286,4 +287,37 @@ func TestCORETracerSupported(t *testing.T) {
 		assert.True(t, coreCalled)
 		assert.False(t, prebuiltCalled)
 	}
+}
+
+func TestDefaultKprobeMaxActiveSet(t *testing.T) {
+	prevLoader := tracerLoaderFromAsset
+	tracerLoaderFromAsset = func(buf bytecode.AssetReader, runtimeTracer, coreTracer bool, config *config.Config, mgrOpts manager.Options, connCloseEventHandler ddebpf.EventHandler) (*manager.Manager, func(), error) {
+		assert.Equal(t, mgrOpts.DefaultKProbeMaxActive, 128)
+		return nil, nil, nil
+	}
+	t.Cleanup(func() { tracerLoaderFromAsset = prevLoader })
+
+	t.Run("CO-RE", func(t *testing.T) {
+		cfg := config.New()
+		cfg.EnableCORE = true
+		cfg.AllowRuntimeCompiledFallback = false
+		_, _, _, err := LoadTracer(cfg, manager.Options{DefaultKProbeMaxActive: 128}, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("prebuilt", func(t *testing.T) {
+		cfg := config.New()
+		cfg.EnableCORE = false
+		cfg.AllowRuntimeCompiledFallback = false
+		_, _, _, err := LoadTracer(cfg, manager.Options{DefaultKProbeMaxActive: 128}, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("runtime_compiled", func(t *testing.T) {
+		cfg := config.New()
+		cfg.EnableCORE = false
+		cfg.AllowRuntimeCompiledFallback = true
+		_, _, _, err := LoadTracer(cfg, manager.Options{DefaultKProbeMaxActive: 128}, nil)
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix passing `DefaultKProbeMaxActive` while loading CO-RE tracer. We moved over to using this option in https://github.com/DataDog/datadog-agent/commit/6da3631fafae36180a71e98bb5803122e950c5e4, but did not fix this code, resulting in max active actually not being set on the kretprobes when CO-RE is used.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
