### PR TITLE
[SBOM] Disable apk-command and image-config-secret analyzers

### DIFF
--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -50,12 +50,14 @@ import (
 const (
 	cleanupTimeout = 30 * time.Second
 
-	OSAnalyzers         = "os"                 // OSAnalyzers defines an OS analyzer
-	LanguagesAnalyzers  = "languages"          // LanguagesAnalyzers defines a language analyzer
-	SecretAnalyzers     = "secret"             // SecretAnalyzers defines a secret analyzer
-	ConfigFileAnalyzers = "config"             // ConfigFileAnalyzers defines a configuration file analyzer
-	LicenseAnalyzers    = "license"            // LicenseAnalyzers defines a license analyzers
-	HistoryDockerfile   = "history-dockerfile" // HistoryDockerfile defines a history-dockerfile analyzers
+	OSAnalyzers           = "os"                  // OSAnalyzers defines an OS analyzer
+	LanguagesAnalyzers    = "languages"           // LanguagesAnalyzers defines a language analyzer
+	SecretAnalyzers       = "secret"              // SecretAnalyzers defines a secret analyzer
+	ConfigFileAnalyzers   = "config"              // ConfigFileAnalyzers defines a configuration file analyzer
+	LicenseAnalyzers      = "license"             // LicenseAnalyzers defines a license analyzer
+	TypeApkCommand        = "apk-command"         // TypeApkCommand defines a apk-command analyzer
+	HistoryDockerfile     = "history-dockerfile"  // HistoryDockerfile defines a history-dockerfile analyzer
+	TypeImageConfigSecret = "image-config-secret" // TypeImageConfigSecret defines a history-dockerfile analyzer
 )
 
 // ContainerdAccessor is a function that should return a containerd client
@@ -170,8 +172,14 @@ func DefaultDisabledCollectors(enabledAnalyzers []string) []analyzer.Type {
 	if analyzersDisabled(LicenseAnalyzers) {
 		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeLicenseFile)
 	}
+	if analyzersDisabled(TypeApkCommand) {
+		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeApkCommand)
+	}
 	if analyzersDisabled(HistoryDockerfile) {
 		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeHistoryDockerfile)
+	}
+	if analyzersDisabled(TypeImageConfigSecret) {
+		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeImageConfigSecret)
 	}
 
 	return disabledAnalyzers


### PR DESCRIPTION
### What does this PR do?

This change disables the `apk-command` and `image-config-secret` analyzers.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
