### PR TITLE
[CWS] use string interner while unmarshalling strings from kernel

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -337,6 +337,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_fentry"), false)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_fentry_amd64"), false)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_fentry_arm64"), false)
+	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.intern_strings"), false)
 	eventMonitorBindEnv(cfg, join(evNS, "event_stream.buffer_size"))
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "envs_with_value"), []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE", "GLIBC_TUNABLES"})
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "runtime_compilation.enabled"), false)

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -100,6 +100,9 @@ type Config struct {
 	// EventStreamUseFentry specifies whether to use eBPF fentry when available instead of kprobes
 	EventStreamUseFentry bool
 
+	// EventStreamInternStrings specifies if unmarshalled strings should be interned
+	EventStreamInternStrings bool
+
 	// RuntimeCompilationEnabled defines if the runtime-compilation is enabled
 	RuntimeCompilationEnabled bool
 
@@ -163,6 +166,7 @@ func NewConfig() (*Config, error) {
 		EventStreamUseRingBuffer:     getBool("event_stream.use_ring_buffer"),
 		EventStreamBufferSize:        getInt("event_stream.buffer_size"),
 		EventStreamUseFentry:         getEventStreamFentryValue(),
+		EventStreamInternStrings:     getBool("event_stream.intern_strings"),
 		EnvsWithValue:                getStringSlice("envs_with_value"),
 		NetworkEnabled:               getBool("network.enabled"),
 		StatsPollingInterval:         time.Duration(getInt("events_stats.polling_interval")) * time.Second,

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -105,7 +105,7 @@ func (fh *EBPFFieldHandlers) ResolveFileFieldsInUpperLayer(_ *model.Event, f *mo
 // ResolveXAttrName returns the string representation of the extended attribute name
 func (fh *EBPFFieldHandlers) ResolveXAttrName(_ *model.Event, e *model.SetXAttrEvent) string {
 	if len(e.Name) == 0 {
-		e.Name, _ = model.UnmarshalString(e.NameRaw[:], 200)
+		e.Name, _ = model.UnmarshalString(e.NameRaw[:], 200, nil)
 	}
 	return e.Name
 }

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -30,7 +30,7 @@ func TestProcessArgsFlags(t *testing.T) {
 		"-9", "-", "--",
 	}
 
-	resolver, _ := process.NewEBPFResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
+	resolver, _ := process.NewEBPFResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{}, nil,
 		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
 
 	e := model.Event{
@@ -93,7 +93,7 @@ func TestProcessArgsOptions(t *testing.T) {
 		"--", "---", "-9",
 	}
 
-	resolver, _ := process.NewEBPFResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
+	resolver, _ := process.NewEBPFResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{}, nil,
 		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
 
 	e := model.Event{

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1476,7 +1476,7 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts, wmeta optional
 
 	var interner model.StringInterner
 	if config.Probe.EventStreamInternStrings {
-		interner = utils.NewStringInterner()
+		interner = utils.NewLRUStringInterner(8192)
 	}
 
 	p := &EBPFProbe{

--- a/pkg/security/resolvers/dentry/resolver.go
+++ b/pkg/security/resolvers/dentry/resolver.go
@@ -392,7 +392,7 @@ func (dr *Resolver) ResolveFromMap(pathKey model.PathKey, cache bool) (string, e
 		if pathLeaf.Name[0] == '/' {
 			name = "/"
 		} else {
-			name = model.NullTerminatedString(pathLeaf.Name[:])
+			name = model.NullTerminatedString(pathLeaf.Name[:], nil)
 			filenameParts = append(filenameParts, name)
 		}
 
@@ -563,7 +563,7 @@ func (dr *Resolver) ResolveFromERPC(pathKey model.PathKey, cache bool) (string, 
 			break
 		}
 
-		segment := model.NullTerminatedString(dr.erpcSegment[i:])
+		segment := model.NullTerminatedString(dr.erpcSegment[i:], nil)
 		filenameParts = append(filenameParts, segment)
 		i += len(segment) + 1
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -251,7 +251,7 @@ var argsEnvsInterner = utils.NewLRUStringInterner(argsEnvsValueCacheSize)
 
 func parseStringArray(data []byte) ([]string, bool) {
 	truncated := false
-	values, err := model.UnmarshalStringArray(data)
+	values, err := model.UnmarshalStringArray(data, nil)
 	if err != nil || len(data) == model.MaxArgEnvSize {
 		if len(values) > 0 {
 			values[len(values)-1] += "..."
@@ -449,7 +449,7 @@ func (p *EBPFResolver) retrieveExecFileFields(procExecPath string) (*model.FileF
 	}
 
 	var fileFields model.FileFields
-	if _, err := fileFields.UnmarshalBinary(data); err != nil {
+	if _, err := fileFields.UnmarshalBinary(data, nil); err != nil {
 		return nil, fmt.Errorf("unable to unmarshal entry for inode `%d`", inode)
 	}
 
@@ -784,12 +784,12 @@ func (p *EBPFResolver) resolveFromKernelMaps(pid, tid uint32, inode uint64) *mod
 	entry := p.NewProcessCacheEntry(model.PIDContext{Pid: pid, Tid: tid, ExecInode: inode})
 
 	var ctrCtx model.ContainerContext
-	read, err := ctrCtx.UnmarshalBinary(procCache)
+	read, err := ctrCtx.UnmarshalBinary(procCache, nil)
 	if err != nil {
 		return nil
 	}
 
-	if _, err := entry.UnmarshalProcEntryBinary(procCache[read:]); err != nil {
+	if _, err := entry.UnmarshalProcEntryBinary(procCache[read:], nil); err != nil {
 		return nil
 	}
 
@@ -798,7 +798,7 @@ func (p *EBPFResolver) resolveFromKernelMaps(pid, tid uint32, inode uint64) *mod
 		return nil
 	}
 
-	if _, err := entry.UnmarshalPidCacheBinary(pidCache); err != nil {
+	if _, err := entry.UnmarshalPidCacheBinary(pidCache, nil); err != nil {
 		return nil
 	}
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -251,7 +251,7 @@ var argsEnvsInterner = utils.NewLRUStringInterner(argsEnvsValueCacheSize)
 
 func parseStringArray(data []byte) ([]string, bool) {
 	truncated := false
-	values, err := model.UnmarshalStringArray(data, nil)
+	values, err := model.UnmarshalStringArray(data, argsEnvsInterner)
 	if err != nil || len(data) == model.MaxArgEnvSize {
 		if len(values) > 0 {
 			values[len(values)-1] += "..."
@@ -259,7 +259,6 @@ func parseStringArray(data []byte) ([]string, bool) {
 		truncated = true
 	}
 
-	argsEnvsInterner.DeduplicateSlice(values)
 	return values, truncated
 }
 

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -34,7 +34,7 @@ func testCacheSize(t *testing.T, resolver *EBPFResolver) {
 }
 
 func TestFork1st(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestFork1st(t *testing.T) {
 }
 
 func TestFork2nd(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestFork2nd(t *testing.T) {
 }
 
 func TestForkExec(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestForkExec(t *testing.T) {
 }
 
 func TestOrphanExec(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +226,7 @@ func TestOrphanExec(t *testing.T) {
 }
 
 func TestForkExecExec(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +297,7 @@ func TestForkExecExec(t *testing.T) {
 }
 
 func TestForkReuse(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestForkReuse(t *testing.T) {
 }
 
 func TestForkForkExec(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,7 +468,7 @@ func TestForkForkExec(t *testing.T) {
 }
 
 func TestExecBomb(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -537,7 +537,7 @@ func TestExecBomb(t *testing.T) {
 }
 
 func TestExecLostFork(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -579,7 +579,7 @@ func TestExecLostFork(t *testing.T) {
 }
 
 func TestExecLostExec(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -622,7 +622,7 @@ func TestExecLostExec(t *testing.T) {
 }
 
 func TestIsExecExecRuntime(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -683,7 +683,7 @@ func TestIsExecExecRuntime(t *testing.T) {
 }
 
 func TestIsExecExecSnapshot(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -37,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/time"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/usergroup"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/usersessions"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -62,7 +63,7 @@ type EBPFResolvers struct {
 }
 
 // NewEBPFResolvers creates a new instance of EBPFResolvers
-func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdClient statsd.ClientInterface, scrubber *procutil.DataScrubber, eRPC *erpc.ERPC, opts Opts, wmeta optional.Option[workloadmeta.Component]) (*EBPFResolvers, error) {
+func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdClient statsd.ClientInterface, scrubber *procutil.DataScrubber, interner model.StringInterner, eRPC *erpc.ERPC, opts Opts, wmeta optional.Option[workloadmeta.Component]) (*EBPFResolvers, error) {
 	dentryResolver, err := dentry.NewResolver(config.Probe, statsdClient, eRPC)
 	if err != nil {
 		return nil, err
@@ -140,7 +141,7 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 	}
 
 	processResolver, err := process.NewEBPFResolver(manager, config.Probe, statsdClient,
-		scrubber, containerResolver, mountResolver, cgroupsResolver, userGroupResolver, timeResolver, pathResolver, processOpts)
+		interner, scrubber, containerResolver, mountResolver, cgroupsResolver, userGroupResolver, timeResolver, pathResolver, processOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/resolvers/usersessions/resolver_linux.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux.go
@@ -44,7 +44,7 @@ func (e *UserSessionData) UnmarshalBinary(data []byte) error {
 	}
 
 	e.SessionType = usersession.Type(data[0])
-	e.RawData += model.NullTerminatedString(data[1:])
+	e.RawData += model.NullTerminatedString(data[1:], nil)
 	return nil
 }
 

--- a/pkg/security/secl/model/model_helpers_unix.go
+++ b/pkg/security/secl/model/model_helpers_unix.go
@@ -326,7 +326,7 @@ type PathLeaf struct {
 
 // GetName returns the path value as a string
 func (pl *PathLeaf) GetName() string {
-	return NullTerminatedString(pl.Name[:])
+	return NullTerminatedString(pl.Name[:], nil)
 }
 
 // SetName sets the path name

--- a/pkg/security/secl/model/unmarshallers_test.go
+++ b/pkg/security/secl/model/unmarshallers_test.go
@@ -91,7 +91,7 @@ func TestSyscallsEvent_UnmarshalBinary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &SyscallsEvent{}
-			_, err := e.UnmarshalBinary(tt.args)
+			_, err := e.UnmarshalBinary(tt.args, nil)
 			if err != nil {
 				if err == tt.wantErr {
 					return

--- a/pkg/security/secl/model/utils.go
+++ b/pkg/security/secl/model/utils.go
@@ -61,12 +61,21 @@ func UnmarshalString(data []byte, size int) (string, error) {
 }
 
 // NullTerminatedString returns null-terminated string
-func NullTerminatedString(d []byte) string {
+func NullTerminatedString(d []byte, interner func([]byte) string) string {
+	b := nullTerminatedBytes(d)
+
+	if interner != nil {
+		return interner(b)
+	}
+	return string(b)
+}
+
+func nullTerminatedBytes(d []byte) []byte {
 	idx := bytes.IndexByte(d, 0)
 	if idx == -1 {
-		return string(d)
+		return d
 	}
-	return string(d[:idx])
+	return d[:idx]
 }
 
 // UnmarshalPrintableString unmarshal printable string

--- a/pkg/security/secl/model/utils_test.go
+++ b/pkg/security/secl/model/utils_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestUnmarshalString(t *testing.T) {
 	array := []byte{65, 66, 67, 0, 0, 0, 65, 66}
-	str, err := UnmarshalString(array, 8)
+	str, err := UnmarshalString(array, 8, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +27,7 @@ func BenchmarkNullTerminatedString(b *testing.B) {
 	array := []byte{65, 66, 67, 0, 0, 0, 65, 66}
 	var s string
 	for i := 0; i < b.N; i++ {
-		s = NullTerminatedString(array)
+		s = NullTerminatedString(array, nil)
 	}
 	runtime.KeepAlive(s)
 }

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -836,7 +836,7 @@ func (adm *ActivityDumpManager) SnapshotTracedCgroups() {
 			continue
 		}
 
-		if _, err = event.ContainerContext.UnmarshalBinary(containerIDB[:]); err != nil {
+		if _, err = event.ContainerContext.UnmarshalBinary(containerIDB[:], nil); err != nil {
 			seclog.Errorf("couldn't unmarshal container ID from traced_cgroups key: %v", err)
 			// remove invalid entry
 			_ = adm.tracedCgroupsMap.Delete(containerIDB)

--- a/pkg/security/utils/lru_interner.go
+++ b/pkg/security/utils/lru_interner.go
@@ -30,6 +30,14 @@ func NewLRUStringInterner(size int) *LRUStringInterner {
 	}
 }
 
+// DeduplicateBytes returns a possibly de-duplicated string from bytes
+func (si *LRUStringInterner) DeduplicateBytes(value []byte) string {
+	si.Lock()
+	defer si.Unlock()
+
+	return si.deduplicateUnsafe(string(value))
+}
+
 // Deduplicate returns a possibly de-duplicated string
 func (si *LRUStringInterner) Deduplicate(value string) string {
 	si.Lock()
@@ -45,14 +53,4 @@ func (si *LRUStringInterner) deduplicateUnsafe(value string) string {
 
 	si.store.Add(value, value)
 	return value
-}
-
-// DeduplicateSlice returns a possibly de-duplicated string slice
-func (si *LRUStringInterner) DeduplicateSlice(values []string) {
-	si.Lock()
-	defer si.Unlock()
-
-	for i := range values {
-		values[i] = si.deduplicateUnsafe(values[i])
-	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds the option (disabled by default for now) to intern strings coming from unmarshalling functions. This PR also switches from our LRU based implementation to the more common util GC-based implementation (used by other system probe products).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
