### PR TITLE
[clusteragent/admission/sidecar] Add support for APM injection on EKS Fargate

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -68,6 +68,12 @@ type MutatingWebhook interface {
 	MutateFunc() admission.WebhookFunc
 }
 
+// mutatingWebhooks returns the list of mutating webhooks. Notice that the order
+// of the webhooks returned is the order in which they will be executed. For
+// now, the only restriction is that the agent sidecar webhook needs to go after
+// the config one. The reason is that the volume mount for the APM socket added
+// by the config webhook doesn't always work on Fargate (one of the envs where
+// we use an agent sidecar), and the agent sidecar webhook needs to remove it.
 func mutatingWebhooks(wmeta workloadmeta.Component) []MutatingWebhook {
 	webhooks := []MutatingWebhook{
 		config.NewWebhook(wmeta),

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
@@ -152,10 +152,25 @@ func TestInjectAgentSidecar(t *testing.T) {
 			ExpectInjection: true,
 			ExpectedPodAfterInjection: func() *corev1.Pod {
 				sidecar := *getDefaultSidecarTemplate(commonRegistry)
-				withEnvOverrides(&sidecar, corev1.EnvVar{
-					Name:  "DD_EKS_FARGATE",
-					Value: "true",
-				})
+				_, _ = withEnvOverrides(
+					&sidecar,
+					corev1.EnvVar{
+						Name:  "DD_EKS_FARGATE",
+						Value: "true",
+					},
+					corev1.EnvVar{
+						Name:  "DD_APM_RECEIVER_SOCKET",
+						Value: "/var/run/datadog/apm.socket",
+					},
+				)
+
+				sidecar.VolumeMounts = []corev1.VolumeMount{
+					{
+						Name:      "apmsocket",
+						MountPath: "/var/run/datadog",
+						ReadOnly:  false,
+					},
+				}
 
 				return &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -163,8 +178,31 @@ func TestInjectAgentSidecar(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "container-name"},
+							{
+								Name: "container-name",
+								Env: []corev1.EnvVar{
+									{
+										Name:  "DD_TRACE_AGENT_URL",
+										Value: "unix:///var/run/datadog/apm.socket",
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "apmsocket",
+										MountPath: "/var/run/datadog",
+										ReadOnly:  false,
+									},
+								},
+							},
 							sidecar,
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "apmsocket",
+								VolumeSource: corev1.VolumeSource{
+									EmptyDir: &corev1.EmptyDirVolumeSource{},
+								},
+							},
 						},
 					},
 				}
@@ -204,18 +242,43 @@ func TestInjectAgentSidecar(t *testing.T) {
 			ExpectedPodAfterInjection: func() *corev1.Pod {
 				sidecar := *getDefaultSidecarTemplate(commonRegistry)
 
-				withEnvOverrides(&sidecar, corev1.EnvVar{
-					Name:  "DD_EKS_FARGATE",
-					Value: "true",
-				}, corev1.EnvVar{Name: "ENV_VAR_1", ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{Key: "secret-key", LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"}},
-				}},
-					corev1.EnvVar{Name: "ENV_VAR_2", Value: "value2"})
+				_, _ = withEnvOverrides(
+					&sidecar,
+					corev1.EnvVar{
+						Name:  "DD_EKS_FARGATE",
+						Value: "true",
+					},
+					corev1.EnvVar{
+						Name:  "DD_APM_RECEIVER_SOCKET",
+						Value: "/var/run/datadog/apm.socket",
+					},
+					corev1.EnvVar{
+						Name: "ENV_VAR_1",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								Key:                  "secret-key",
+								LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+							},
+						},
+					},
+					corev1.EnvVar{
+						Name:  "ENV_VAR_2",
+						Value: "value2",
+					},
+				)
 
-				withResourceLimits(&sidecar, corev1.ResourceRequirements{
+				_ = withResourceLimits(&sidecar, corev1.ResourceRequirements{
 					Limits:   corev1.ResourceList{"cpu": resource.MustParse("1"), "memory": resource.MustParse("512Mi")},
 					Requests: corev1.ResourceList{"cpu": resource.MustParse("0.5"), "memory": resource.MustParse("256Mi")},
 				})
+
+				sidecar.VolumeMounts = []corev1.VolumeMount{
+					{
+						Name:      "apmsocket",
+						MountPath: "/var/run/datadog",
+						ReadOnly:  false,
+					},
+				}
 
 				return &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -223,8 +286,31 @@ func TestInjectAgentSidecar(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "container-name"},
+							{
+								Name: "container-name",
+								Env: []corev1.EnvVar{
+									{
+										Name:  "DD_TRACE_AGENT_URL",
+										Value: "unix:///var/run/datadog/apm.socket",
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "apmsocket",
+										MountPath: "/var/run/datadog",
+										ReadOnly:  false,
+									},
+								},
+							},
 							sidecar,
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "apmsocket",
+								VolumeSource: corev1.VolumeSource{
+									EmptyDir: &corev1.EmptyDirVolumeSource{},
+								},
+							},
 						},
 					},
 				}

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
@@ -162,11 +162,15 @@ func TestInjectAgentSidecar(t *testing.T) {
 						Name:  "DD_APM_RECEIVER_SOCKET",
 						Value: "/var/run/datadog/apm.socket",
 					},
+					corev1.EnvVar{
+						Name:  "DD_DOGSTATSD_SOCKET",
+						Value: "/var/run/datadog/dsd.socket",
+					},
 				)
 
 				sidecar.VolumeMounts = []corev1.VolumeMount{
 					{
-						Name:      "apmsocket",
+						Name:      "ddsockets",
 						MountPath: "/var/run/datadog",
 						ReadOnly:  false,
 					},
@@ -185,10 +189,14 @@ func TestInjectAgentSidecar(t *testing.T) {
 										Name:  "DD_TRACE_AGENT_URL",
 										Value: "unix:///var/run/datadog/apm.socket",
 									},
+									{
+										Name:  "DD_DOGSTATSD_URL",
+										Value: "unix:///var/run/datadog/dsd.socket",
+									},
 								},
 								VolumeMounts: []corev1.VolumeMount{
 									{
-										Name:      "apmsocket",
+										Name:      "ddsockets",
 										MountPath: "/var/run/datadog",
 										ReadOnly:  false,
 									},
@@ -198,7 +206,7 @@ func TestInjectAgentSidecar(t *testing.T) {
 						},
 						Volumes: []corev1.Volume{
 							{
-								Name: "apmsocket",
+								Name: "ddsockets",
 								VolumeSource: corev1.VolumeSource{
 									EmptyDir: &corev1.EmptyDirVolumeSource{},
 								},
@@ -253,6 +261,10 @@ func TestInjectAgentSidecar(t *testing.T) {
 						Value: "/var/run/datadog/apm.socket",
 					},
 					corev1.EnvVar{
+						Name:  "DD_DOGSTATSD_SOCKET",
+						Value: "/var/run/datadog/dsd.socket",
+					},
+					corev1.EnvVar{
 						Name: "ENV_VAR_1",
 						ValueFrom: &corev1.EnvVarSource{
 							SecretKeyRef: &corev1.SecretKeySelector{
@@ -274,7 +286,7 @@ func TestInjectAgentSidecar(t *testing.T) {
 
 				sidecar.VolumeMounts = []corev1.VolumeMount{
 					{
-						Name:      "apmsocket",
+						Name:      "ddsockets",
 						MountPath: "/var/run/datadog",
 						ReadOnly:  false,
 					},
@@ -293,10 +305,14 @@ func TestInjectAgentSidecar(t *testing.T) {
 										Name:  "DD_TRACE_AGENT_URL",
 										Value: "unix:///var/run/datadog/apm.socket",
 									},
+									{
+										Name:  "DD_DOGSTATSD_URL",
+										Value: "unix:///var/run/datadog/dsd.socket",
+									},
 								},
 								VolumeMounts: []corev1.VolumeMount{
 									{
-										Name:      "apmsocket",
+										Name:      "ddsockets",
 										MountPath: "/var/run/datadog",
 										ReadOnly:  false,
 									},
@@ -306,7 +322,7 @@ func TestInjectAgentSidecar(t *testing.T) {
 						},
 						Volumes: []corev1.Volume{
 							{
-								Name: "apmsocket",
+								Name: "ddsockets",
 								VolumeSource: corev1.VolumeSource{
 									EmptyDir: &corev1.EmptyDirVolumeSource{},
 								},

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers.go
@@ -12,6 +12,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	configWebhook "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -20,6 +22,10 @@ import (
 //     Provider Overrides     //
 //                            //
 ////////////////////////////////
+
+const apmSocketDir = "/var/run/datadog"
+const apmSocket = apmSocketDir + "/apm.socket"
+const apmSocketVolumeName = "apmsocket"
 
 // providerIsSupported indicates whether the provider is supported by agent sidecar injection
 func providerIsSupported(provider string) bool {
@@ -34,34 +40,150 @@ func providerIsSupported(provider string) bool {
 	}
 }
 
-func applyProviderOverrides(container *corev1.Container) error {
+// applyProviderOverrides applies the necessary overrides for the provider
+// configured. It returns a boolean that indicates if the pod was mutated.
+func applyProviderOverrides(pod *corev1.Pod) (bool, error) {
 	provider := config.Datadog.GetString("admission_controller.agent_sidecar.provider")
 
 	if !providerIsSupported(provider) {
-		return fmt.Errorf("unsupported provider: %v", provider)
+		return false, fmt.Errorf("unsupported provider: %v", provider)
 	}
 
 	switch provider {
 	case providerFargate:
-		return applyFargateOverrides(container)
+		return applyFargateOverrides(pod)
 	}
 
-	return nil
+	return false, nil
 }
 
-func applyFargateOverrides(container *corev1.Container) error {
-	if container == nil {
-		return fmt.Errorf("can't apply profile overrides to nil containers")
+// applyFargateOverrides applies the necessary overrides for EKS Fargate.
+// For the agent sidecar container:
+//   - Sets DD_EKS_FARGATE=true
+//   - Deletes the volume and volumeMounts for the APM socket added by the
+//     config webhook when the injection mode is set to "socket". The volume is
+//     "HostPath" and those don't work on Fargate. Notice that this means that
+//     the agent sidecar webhook needs to be run after the config one. This is
+//     guaranteed by the mutatingWebhooks function in the webhook package.
+//   - Creates an "emptyDir" volume instead.
+//   - Configures the APM UDS path with DD_APM_RECEIVER_SOCKET.
+//
+// For the application containers:
+//   - Sets DD_TRACE_AGENT_URL to the APM UDS path configured for the agent.
+//
+// This function returns a boolean that indicates if the pod was mutated.
+func applyFargateOverrides(pod *corev1.Pod) (bool, error) {
+	if pod == nil {
+		return false, fmt.Errorf("can't apply profile overrides to nil pod")
 	}
 
-	err := withEnvOverrides(container, corev1.EnvVar{
-		Name:  "DD_EKS_FARGATE",
-		Value: "true",
+	mutated := false
+
+	deleted := deleteConfigWebhookVolumeAndMounts(pod)
+	mutated = mutated || deleted
+
+	volume, volumeMount := apmSocketVolume()
+	injected := common.InjectVolume(pod, volume, volumeMount)
+	mutated = mutated || injected
+
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == agentSidecarContainerName {
+			overridden, err := applyOverridesAgentContainer(&pod.Spec.Containers[i])
+			if err != nil {
+				return mutated, err
+			}
+			mutated = mutated || overridden
+		} else {
+			overridden, err := applyOverridesAppContainer(&pod.Spec.Containers[i])
+			if err != nil {
+				return mutated, err
+			}
+			mutated = mutated || overridden
+		}
+	}
+
+	return mutated, nil
+}
+
+func applyOverridesAgentContainer(container *corev1.Container) (bool, error) {
+	return withEnvOverrides(
+		container,
+		corev1.EnvVar{
+			Name:  "DD_EKS_FARGATE",
+			Value: "true",
+		},
+		corev1.EnvVar{
+			Name:  "DD_APM_RECEIVER_SOCKET",
+			Value: apmSocket,
+		},
+	)
+}
+
+func applyOverridesAppContainer(container *corev1.Container) (bool, error) {
+	return withEnvOverrides(container, corev1.EnvVar{
+		Name:  "DD_TRACE_AGENT_URL",
+		Value: "unix://" + apmSocket,
 	})
+}
 
-	if err != nil {
-		return err
+func apmSocketVolume() (corev1.Volume, corev1.VolumeMount) {
+	volume := corev1.Volume{
+		Name: apmSocketVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
 	}
 
-	return nil
+	volumeMount := corev1.VolumeMount{
+		Name:      apmSocketVolumeName,
+		MountPath: apmSocketDir,
+		ReadOnly:  false, // Need RW for UDS APM socket
+	}
+
+	return volume, volumeMount
+}
+
+// deleteConfigWebhookVolumeAndMounts deletes the volume and volumeMounts added
+// by the config webhook. Returns a boolean that indicates if the pod was
+// mutated.
+func deleteConfigWebhookVolumeAndMounts(pod *corev1.Pod) bool {
+	mutated := false
+
+	// Delete the volume added by the config webhook
+	for i, vol := range pod.Spec.Volumes {
+		if vol.Name == configWebhook.DatadogVolumeName {
+			pod.Spec.Volumes = append(pod.Spec.Volumes[:i], pod.Spec.Volumes[i+1:]...)
+			mutated = true
+			break
+		}
+	}
+
+	deleted := deleteConfigWebhookVolumeMounts(pod.Spec.Containers)
+	mutated = mutated || deleted
+
+	deleted = deleteConfigWebhookVolumeMounts(pod.Spec.InitContainers)
+	mutated = mutated || deleted
+
+	return mutated
+}
+
+// deleteConfigWebhookVolumeMounts deletes the volumeMounts added by the config
+// webhook. Returns a boolean that indicates if the pod was mutated.
+func deleteConfigWebhookVolumeMounts(containers []corev1.Container) bool {
+	mutated := false
+
+	for i, container := range containers {
+		for j, volMount := range container.VolumeMounts {
+			if volMount.Name == configWebhook.DatadogVolumeName {
+				containers[i].VolumeMounts = append(
+					containers[i].VolumeMounts[:j],
+					containers[i].VolumeMounts[j+1:]...,
+				)
+				mutated = true
+				break
+			}
+		}
+	}
+
+	return mutated
 }

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
@@ -106,10 +106,14 @@ func TestApplyProviderOverrides(t *testing.T) {
 									Name:  "DD_TRACE_AGENT_URL",
 									Value: "unix:///var/run/datadog/apm.socket",
 								},
+								{
+									Name:  "DD_DOGSTATSD_URL",
+									Value: "unix:///var/run/datadog/dsd.socket",
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "apmsocket",
+									Name:      "ddsockets",
 									MountPath: "/var/run/datadog",
 									ReadOnly:  false,
 								},
@@ -126,10 +130,14 @@ func TestApplyProviderOverrides(t *testing.T) {
 									Name:  "DD_APM_RECEIVER_SOCKET",
 									Value: "/var/run/datadog/apm.socket",
 								},
+								{
+									Name:  "DD_DOGSTATSD_SOCKET",
+									Value: "/var/run/datadog/dsd.socket",
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "apmsocket",
+									Name:      "ddsockets",
 									MountPath: "/var/run/datadog",
 									ReadOnly:  false,
 								},
@@ -138,7 +146,7 @@ func TestApplyProviderOverrides(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: "apmsocket",
+							Name: "ddsockets",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
@@ -201,10 +209,14 @@ func TestApplyProviderOverrides(t *testing.T) {
 									Name:  "DD_TRACE_AGENT_URL",
 									Value: "unix:///var/run/datadog/apm.socket",
 								},
+								{
+									Name:  "DD_DOGSTATSD_URL",
+									Value: "unix:///var/run/datadog/dsd.socket",
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "apmsocket",
+									Name:      "ddsockets",
 									MountPath: "/var/run/datadog",
 									ReadOnly:  false,
 								},
@@ -221,10 +233,14 @@ func TestApplyProviderOverrides(t *testing.T) {
 									Name:  "DD_APM_RECEIVER_SOCKET",
 									Value: "/var/run/datadog/apm.socket",
 								},
+								{
+									Name:  "DD_DOGSTATSD_SOCKET",
+									Value: "/var/run/datadog/dsd.socket",
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "apmsocket",
+									Name:      "ddsockets",
 									MountPath: "/var/run/datadog",
 									ReadOnly:  false,
 								},
@@ -233,7 +249,7 @@ func TestApplyProviderOverrides(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: "apmsocket",
+							Name: "ddsockets",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
@@ -55,70 +55,225 @@ func TestProviderIsSupported(t *testing.T) {
 
 func TestApplyProviderOverrides(t *testing.T) {
 	mockConfig := config.Mock(t)
+	hostPathType := corev1.HostPathDirectoryOrCreate
 
 	tests := []struct {
-		name                           string
-		provider                       string
-		baseContainer                  *corev1.Container
-		expectedContainerAfterOverride *corev1.Container
-		expectError                    bool
+		name                     string
+		provider                 string
+		basePod                  *corev1.Pod
+		expectedPodAfterOverride *corev1.Pod
+		expectError              bool
+		expectMutated            bool
 	}{
 		{
-			name:                           "nil container should be skipped",
-			provider:                       "fargate",
-			baseContainer:                  nil,
-			expectedContainerAfterOverride: nil,
-			expectError:                    true,
+			name:                     "nil pod should be skipped",
+			provider:                 "fargate",
+			basePod:                  nil,
+			expectedPodAfterOverride: nil,
+			expectError:              true,
+			expectMutated:            false,
 		},
 		{
-			name:                           "empty provider",
-			provider:                       "",
-			baseContainer:                  &corev1.Container{},
-			expectedContainerAfterOverride: &corev1.Container{},
-			expectError:                    false,
+			name:                     "empty provider",
+			provider:                 "",
+			basePod:                  &corev1.Pod{},
+			expectedPodAfterOverride: &corev1.Pod{},
+			expectError:              false,
+			expectMutated:            false,
 		},
 		{
-			name:          "fargate provider",
-			provider:      "fargate",
-			baseContainer: &corev1.Container{},
-			expectedContainerAfterOverride: &corev1.Container{
-				Env: []corev1.EnvVar{
-					{
-						Name:  "DD_EKS_FARGATE",
-						Value: "true",
+			name:     "fargate provider",
+			provider: "fargate",
+			basePod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "app-container",
+						},
+						{
+							Name: agentSidecarContainerName,
+						},
 					},
 				},
 			},
-			expectError: false,
+			expectedPodAfterOverride: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "app-container",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "DD_TRACE_AGENT_URL",
+									Value: "unix:///var/run/datadog/apm.socket",
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "apmsocket",
+									MountPath: "/var/run/datadog",
+									ReadOnly:  false,
+								},
+							},
+						},
+						{
+							Name: agentSidecarContainerName,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "DD_EKS_FARGATE",
+									Value: "true",
+								},
+								{
+									Name:  "DD_APM_RECEIVER_SOCKET",
+									Value: "/var/run/datadog/apm.socket",
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "apmsocket",
+									MountPath: "/var/run/datadog",
+									ReadOnly:  false,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "apmsocket",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+			expectError:   false,
+			expectMutated: true,
 		},
 		{
-			name:                           "unsupported provider",
-			provider:                       "foo-provider",
-			baseContainer:                  &corev1.Container{},
-			expectedContainerAfterOverride: &corev1.Container{},
-			expectError:                    true,
+			// This test checks that the volume and volume mounts set by the
+			// config webhook are replaced by ones that works on Fargate.
+			name:     "fargate provider - with volume set by the config webhook",
+			provider: "fargate",
+			basePod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "app-container",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "datadog",
+									MountPath: "/var/run/datadog",
+									ReadOnly:  false,
+								},
+							},
+						},
+						{
+							Name: agentSidecarContainerName,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "datadog",
+									MountPath: "/var/run/datadog",
+									ReadOnly:  false,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "datadog",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Type: &hostPathType,
+									Path: "/var/run/datadog",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPodAfterOverride: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "app-container",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "DD_TRACE_AGENT_URL",
+									Value: "unix:///var/run/datadog/apm.socket",
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "apmsocket",
+									MountPath: "/var/run/datadog",
+									ReadOnly:  false,
+								},
+							},
+						},
+						{
+							Name: agentSidecarContainerName,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "DD_EKS_FARGATE",
+									Value: "true",
+								},
+								{
+									Name:  "DD_APM_RECEIVER_SOCKET",
+									Value: "/var/run/datadog/apm.socket",
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "apmsocket",
+									MountPath: "/var/run/datadog",
+									ReadOnly:  false,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "apmsocket",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+			expectError:   false,
+			expectMutated: true,
+		},
+		{
+			name:                     "unsupported provider",
+			provider:                 "foo-provider",
+			basePod:                  &corev1.Pod{},
+			expectedPodAfterOverride: &corev1.Pod{},
+			expectError:              true,
+			expectMutated:            false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			mockConfig.SetWithoutSource("admission_controller.agent_sidecar.provider", test.provider)
-			err := applyProviderOverrides(test.baseContainer)
+			mutated, err := applyProviderOverrides(test.basePod)
+			assert.Equal(tt, test.expectMutated, mutated)
 
 			if test.expectError {
 				assert.Error(tt, err)
 			} else {
 				assert.NoError(tt, err)
 
-				if test.expectedContainerAfterOverride == nil {
-					assert.Nil(tt, test.baseContainer)
+				if test.expectedPodAfterOverride == nil {
+					assert.Nil(tt, test.basePod)
 				} else {
-					assert.NotNil(tt, test.baseContainer)
+					assert.NotNil(tt, test.basePod)
 					assert.Truef(tt,
-						reflect.DeepEqual(*test.baseContainer, *test.expectedContainerAfterOverride),
+						reflect.DeepEqual(*test.basePod, *test.expectedPodAfterOverride),
 						"overrides not applied as expected. expected %v, but found %v",
-						*test.expectedContainerAfterOverride,
-						*test.baseContainer,
+						*test.expectedPodAfterOverride,
+						*test.basePod,
 					)
 				}
 			}

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -35,7 +35,8 @@ func Mutate(rawPod []byte, ns string, mutationType string, m MutationFunc, dc dy
 	}
 
 	if injected, err := m(&pod, ns, dc); err != nil {
-		metrics.MutationAttempts.Inc(mutationType, metrics.StatusError, strconv.FormatBool(injected), err.Error())
+		metrics.MutationAttempts.Inc(mutationType, metrics.StatusError, strconv.FormatBool(false), err.Error())
+		return nil, fmt.Errorf("failed to mutate pod: %v", err)
 	} else {
 		metrics.MutationAttempts.Inc(mutationType, metrics.StatusSuccess, strconv.FormatBool(injected), "")
 	}

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -34,12 +34,13 @@ func Mutate(rawPod []byte, ns string, mutationType string, m MutationFunc, dc dy
 		return nil, fmt.Errorf("failed to decode raw object: %v", err)
 	}
 
-	if injected, err := m(&pod, ns, dc); err != nil {
+	injected, err := m(&pod, ns, dc)
+	if err != nil {
 		metrics.MutationAttempts.Inc(mutationType, metrics.StatusError, strconv.FormatBool(false), err.Error())
 		return nil, fmt.Errorf("failed to mutate pod: %v", err)
-	} else {
-		metrics.MutationAttempts.Inc(mutationType, metrics.StatusSuccess, strconv.FormatBool(injected), "")
 	}
+
+	metrics.MutationAttempts.Inc(mutationType, metrics.StatusSuccess, strconv.FormatBool(injected), "")
 
 	bytes, err := json.Marshal(pod)
 	if err != nil {

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -41,8 +41,8 @@ const (
 	socket  = "socket"
 	service = "service"
 
-	// Volume name
-	datadogVolumeName = "datadog"
+	// DatadogVolumeName is the name of the volume used to mount the socket
+	DatadogVolumeName = "datadog"
 
 	webhookName = "agent_config"
 )
@@ -170,7 +170,7 @@ func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, 
 	case service:
 		injectedConfig = common.InjectEnv(pod, agentHostServiceEnvVar)
 	case socket:
-		volume, volumeMount := buildVolume(datadogVolumeName, config.Datadog.GetString("admission_controller.inject_config.socket_path"), true)
+		volume, volumeMount := buildVolume(DatadogVolumeName, config.Datadog.GetString("admission_controller.inject_config.socket_path"), true)
 		injectedVol := common.InjectVolume(pod, volume, volumeMount)
 		injectedEnv := common.InjectEnv(pod, traceURLSocketEnvVar)
 		injectedEnv = common.InjectEnv(pod, dogstatsdURLSocketEnvVar) || injectedEnv

--- a/releasenotes-dca/notes/apm-injection-eks-fargate-245574e8eb26b555.yaml
+++ b/releasenotes-dca/notes/apm-injection-eks-fargate-245574e8eb26b555.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM library injection now works on EKS Fargate when the admission controller
+    is configured to add an Agent sidecar in EKS Fargate.


### PR DESCRIPTION
### What does this PR do?

Modifies the sidecar admission controller webhook so that APM library injection works when deployed on EKS Fargate.

It was not working because the "config" webhook creates a "HostPath" volume to mount the APM socket and that doesn't work on EKS Fargate.

This PR deletes the volume and volume mounts created by the "config" webhook when using EKS Fargate and creates an "emptyDir" volume instead. It also sets the needed envs so that the sidecar Agent receives traces via UDS.


### Describe how to test/QA your changes

Deploy the Agent on EKS Fargate. You need to enable the admission controller with APM and sidecar injection. Here's the helm chart that I used:
```
datadog:
  processAgent:
    processCollection: true
  env:
    - name: DD_LANGUAGE_DETECTION_ENABLED
      value: "true"
    - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
      value: "true"
clusterAgent:
  admissionController:
    enabled: true
  env:
    - name: DD_LANGUAGE_DETECTION_ENABLED
      value: "true"
    - name: DD_APM_INSTRUMENTATION_ENABLED
      value: "true"
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_ENABLED
      value: "true"
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_PROVIDER
      value: "fargate"
```

You'll also need an app with profiling enabled. For testing purposes I've used this:
```
import ddtrace.profiling.auto
import time

while True:
  time.sleep(60)
```

And finally deploy the app in the Fargate namespace:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-python-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: python
  template:
    metadata:
      labels:
        app: python
        admission.datadoghq.com/enabled: "true"
        agent.datadoghq.com/sidecar: "fargate"
      annotations:
        admission.datadoghq.com/python-lib.version: "v2.3.0"
    spec:
      serviceAccountName: datadog-agent  # Make sure this matches your service account
      shareProcessNamespace: true
      containers:
      - name: my-python-app
        image: YOUR_IMAGE_HERE
        command: ["python", "./test.py"] # Make sure this matches what's in your image
```

Remember to create the needed RBACs for Fargate as described here: https://docs.datadoghq.com/integrations/eks_fargate/#aws-eks-fargate-rbac

You should see APM traces in the Datadog app for your service and they should include the container tags such as `container_name`, `image_name`, `image_tag`, etc.