### PR TITLE
[clusteragent/admission/controllers/webhook] Add missing config to resetMockConfig()

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -493,6 +493,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 				mockConfig.SetWithoutSource("admission_controller.inject_config.enabled", true)
 				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", true)
 				mockConfig.SetWithoutSource("admission_controller.inject_tags.enabled", false)
+				mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.enabled", false)
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", false)
 			},
 			configFunc: func() Config { return NewConfig(false, true) },

--- a/pkg/clusteragent/admission/controllers/webhook/utils_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/utils_test.go
@@ -43,6 +43,7 @@ func resetMockConfig(c *config.MockConfig) {
 	c.SetWithoutSource("admission_controller.mutate_unlabelled", false)
 	c.SetWithoutSource("admission_controller.inject_config.enabled", true)
 	c.SetWithoutSource("admission_controller.inject_tags.enabled", true)
+	c.SetWithoutSource("admission_controller.auto_instrumentation.enabled", true)
 	c.SetWithoutSource("admission_controller.namespace_selector_fallback", false)
 	c.SetWithoutSource("admission_controller.add_aks_selectors", false)
 	c.SetWithoutSource("admission_controller.admission_controller.cws_instrumentation.enabled", false)


### PR DESCRIPTION

### What does this PR do?

Fixes the `resetMockConfig()` function used in the admission controller tests. There was a missing configuration option.

This PR also fixes a test that was relying on the wrong default.

### Describe how to test/QA your changes

Skip
