### PR TITLE
[USMON-802] usm: http2: Ignore query parameters

### DIFF
--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -8,6 +8,7 @@
 package http2
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -115,7 +116,13 @@ func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
 		res = tx.Stream.Path.Raw_buffer[:tx.Stream.Path.Length]
 	}
 
-	n := copy(buffer, res)
+	// Ignore query parameters
+	queryStart := bytes.IndexByte(res, byte('?'))
+	if queryStart == -1 {
+		queryStart = len(res)
+	}
+
+	n := copy(buffer, res[:queryStart])
 	return buffer[:n], true
 }
 

--- a/pkg/network/protocols/http2/model_test.go
+++ b/pkg/network/protocols/http2/model_test.go
@@ -19,9 +19,10 @@ import (
 
 func TestHTTP2Path(t *testing.T) {
 	tests := []struct {
-		name        string
-		rawPath     string
-		expectedErr bool
+		name         string
+		rawPath      string
+		expectedPath string
+		expectedErr  bool
 	}{
 		{
 			name:    "Short path",
@@ -40,6 +41,11 @@ func TestHTTP2Path(t *testing.T) {
 			name:        "Empty path",
 			rawPath:     "",
 			expectedErr: true,
+		},
+		{
+			name:         "Query string",
+			rawPath:      "/foo/bar?a=1&b=2",
+			expectedPath: "/foo/bar",
 		},
 	}
 
@@ -74,7 +80,11 @@ func TestHTTP2Path(t *testing.T) {
 					return
 				}
 				assert.True(t, ok)
-				assert.Equal(t, tt.rawPath, string(path))
+				expectedPath := tt.rawPath
+				if tt.expectedPath != "" {
+					expectedPath = tt.expectedPath
+				}
+				assert.Equal(t, expectedPath, string(path))
 			})
 		}
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Makes USM's HTTP/2 implementation strip out the query string portion of the URL and adds a test case for this.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

To have the same behaviour as the HTTP/1.1 implementation.

https://datadoghq.atlassian.net/browse/USMON-802

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
