### PR TITLE
[CWS] improve memory maps file collection

### DIFF
--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -9,6 +9,7 @@
 package activitytree
 
 import (
+	"bufio"
 	"fmt"
 	"math/rand"
 	"net"
@@ -21,10 +22,6 @@ import (
 	"syscall"
 	"time"
 
-	// shirou/gopsutil uses different logic for getting the memory maps Path
-	// it assumes space-separation and the path is last
-	// DD: combines 6th+ fields into the path
-	legacyprocess "github.com/DataDog/gopsutil/process"
 	"github.com/prometheus/procfs"
 	"github.com/shirou/gopsutil/v3/process"
 	"golang.org/x/sys/unix"
@@ -163,29 +160,31 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent 
 const MaxMmapedFiles = 128
 
 func snapshotMemoryMappedFiles(pid int32, processEventPath string) ([]string, error) {
-	fakeprocess := legacyprocess.Process{Pid: pid}
-	stats, err := fakeprocess.MemoryMaps(false)
-	if err != nil || stats == nil {
+	smapsPath := kernel.HostProc(strconv.Itoa(int(pid)), "smaps")
+	smapsFile, err := os.Open(smapsPath)
+	if err != nil {
 		return nil, err
 	}
+	defer smapsFile.Close()
 
 	files := make([]string, 0, MaxMmapedFiles)
-	for _, mm := range *stats {
-		if len(files) >= MaxMmapedFiles {
-			break
-		}
+	scanner := bufio.NewScanner(smapsFile)
 
-		if len(mm.Path) == 0 {
+	for scanner.Scan() && len(files) < MaxMmapedFiles {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+
+		if len(fields) < 6 || strings.HasSuffix(fields[0], ":") {
 			continue
 		}
 
-		if mm.Path != processEventPath {
-			continue
+		path := strings.Join(fields[5:], " ")
+		if len(path) != 0 && path != processEventPath {
+			files = append(files, path)
 		}
-
-		files = append(files, mm.Path)
 	}
-	return files, nil
+
+	return files, scanner.Err()
 }
 
 func (pn *ProcessNode) snapshotBoundSockets(p *process.Process, stats *Stats, newEvent func() *model.Event) {

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package activitytree holds activitytree related files
+package activitytree
+
+import (
+	"os"
+	"testing"
+
+	legacyprocess "github.com/DataDog/gopsutil/process"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSnapshotMemoryMappedFiles(t *testing.T) {
+	pid := os.Getpid()
+
+	// gopsutil
+	fakeprocess := legacyprocess.Process{Pid: int32(pid)}
+	smapsPtr, err := fakeprocess.MemoryMaps(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if smapsPtr == nil {
+		t.Fatal("nil smaps")
+	}
+
+	var gopsutilFiles []string
+	for _, smap := range *smapsPtr {
+		if len(gopsutilFiles) == MaxMmapedFiles {
+			break
+		}
+		if len(smap.Path) == 0 {
+			continue
+		}
+		gopsutilFiles = append(gopsutilFiles, smap.Path)
+	}
+
+	// hand-made version
+	ownImplemFiles, err := snapshotMemoryMappedFiles(int32(pid), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, gopsutilFiles, ownImplemFiles)
+}


### PR DESCRIPTION
### What does this PR do?

For some time now we have hit issues with collecting the list of memory mapped files. In https://github.com/DataDog/datadog-agent/pull/17393, we introduced a max amount of collected files, but the call to gopsutil was still parsing the whole smaps file (and returning all stat entries).

This PR is the final challenger to this issue:
- stripped down algorithm, collecting only the paths: no memory used aggregating other entries (especially the ones without path)
- loop stops when we reach the max, actually respecting it which was not the case before
- removes the usage of legacy gopsutil, which is always good

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
