### PR TITLE
[clusteragent/admission/controllers/webhook] Use GetWebhook instead of creating a new one

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -75,7 +75,7 @@ func mutatingWebhooks(wmeta workloadmeta.Component) []MutatingWebhook {
 		agentsidecar.NewWebhook(),
 	}
 
-	apm, err := autoinstrumentation.NewWebhook(wmeta)
+	apm, err := autoinstrumentation.GetWebhook(wmeta)
 	if err == nil {
 		webhooks = append(webhooks, apm)
 	} else {

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/cwsinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -907,7 +908,9 @@ func TestGenerateTemplatesV1(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupConfig()
-			defer resetMockConfig(mockConfig) // Reset to default
+			autoinstrumentation.UnsetWebhook()       // Ensure that the webhook uses the config set above
+			defer resetMockConfig(mockConfig)        // Reset to default
+			defer autoinstrumentation.UnsetWebhook() // So other tests are not impacted
 
 			c := &ControllerV1{}
 			c.config = tt.configFunc()

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/cwsinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -903,7 +904,9 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupConfig()
-			defer resetMockConfig(mockConfig) // Reset to default
+			autoinstrumentation.UnsetWebhook()       // Ensure that the webhook uses the config set above
+			defer resetMockConfig(mockConfig)        // Reset to default
+			defer autoinstrumentation.UnsetWebhook() // So other tests are not impacted
 
 			c := &ControllerV1beta1{}
 			c.config = tt.configFunc()

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -180,6 +180,13 @@ func GetWebhook(wmeta workloadmeta.Component) (*Webhook, error) {
 	return apmInstrumentationWebhook, errInitAPMInstrumentation
 }
 
+// UnsetWebhook unsets the webhook. For testing only.
+func UnsetWebhook() {
+	initOnce = sync.Once{}
+	apmInstrumentationWebhook = nil
+	errInitAPMInstrumentation = nil
+}
+
 // apmSSINamespaceFilter returns the filter used by APM SSI to filter namespaces.
 // The filter excludes two namespaces by default: "kube-system" and the
 // namespace where datadog is installed.


### PR DESCRIPTION

### What does this PR do?

Small cleanup. The code in the webhook controller of the admission controller now calls `GetWebhook` to get the APM webhook instead of instantiating a new one.

This is done just for clarity. It doesn't fix any bug.

### Describe how to test/QA your changes

Skip.