### PR TITLE
What if we used zstd in our trace writers

### DIFF
--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.5.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.14.0
 	github.com/DataDog/sketches-go v1.4.2
+	github.com/DataDog/zstd v1.5.5
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/davecgh/go-spew v1.1.1

--- a/pkg/trace/go.sum
+++ b/pkg/trace/go.sum
@@ -8,6 +8,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.14.0 h1:10TPq
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.14.0/go.mod h1:dvIWN9pA2zWNTw5rhDWZgzZnhcfpH++d+8d1SWW6xkY=
 github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjvVA/o=
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
+github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
+github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/DataDog/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -42,38 +43,45 @@ func (s MockSampler) GetTargetTPS() float64 {
 var mockSampler = MockSampler{TargetTPS: 5, Enabled: true}
 
 func TestTraceWriter(t *testing.T) {
-	srv := newTestServer()
-	cfg := &config.AgentConfig{
-		Hostname:   testHostname,
-		DefaultEnv: testEnv,
-		Endpoints: []*config.Endpoint{{
-			APIKey: "123",
-			Host:   srv.URL,
-		}},
-		TraceWriter: &config.WriterConfig{ConnectionLimit: 200, QueueSize: 40},
-	}
+	testCases := []bool{false, true}
 
-	t.Run("ok", func(t *testing.T) {
-		testSpans := []*SampledChunks{
-			randomSampledSpans(20, 8),
-			randomSampledSpans(10, 0),
-			randomSampledSpans(40, 5),
+	for _, tc := range testCases {
+		srv := newTestServer()
+		cfg := &config.AgentConfig{
+			Hostname:   testHostname,
+			DefaultEnv: testEnv,
+			Endpoints: []*config.Endpoint{{
+				APIKey: "123",
+				Host:   srv.URL,
+			}},
+			TraceWriter: &config.WriterConfig{ConnectionLimit: 200, QueueSize: 40},
 		}
-		// Use a flush threshold that allows the first two entries to not overflow,
-		// but overflow on the third.
-		defer useFlushThreshold(testSpans[0].Size + testSpans[1].Size + 10)()
-		tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{})
-		tw.In = make(chan *SampledChunks)
-		go tw.Run()
-		for _, ss := range testSpans {
-			tw.In <- ss
+		if tc {
+			cfg.Features = map[string]struct{}{"zstd-encoding": {}}
 		}
-		tw.Stop()
-		// One payload flushes due to overflowing the threshold, and the second one
-		// because of stop.
-		assert.Equal(t, 2, srv.Accepted())
-		payloadsContain(t, srv.Payloads(), testSpans)
-	})
+
+		t.Run("ok", func(t *testing.T) {
+			testSpans := []*SampledChunks{
+				randomSampledSpans(20, 8),
+				randomSampledSpans(10, 0),
+				randomSampledSpans(40, 5),
+			}
+			// Use a flush threshold that allows the first two entries to not overflow,
+			// but overflow on the third.
+			defer useFlushThreshold(testSpans[0].Size + testSpans[1].Size + 10)()
+			tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{})
+			tw.In = make(chan *SampledChunks)
+			go tw.Run()
+			for _, ss := range testSpans {
+				tw.In <- ss
+			}
+			tw.Stop()
+			// One payload flushes due to overflowing the threshold, and the second one
+			// because of stop.
+			assert.Equal(t, 2, srv.Accepted())
+			payloadsContain(t, srv.Payloads(), testSpans, tc)
+		})
+	}
 }
 
 func TestTraceWriterMultipleEndpointsConcurrent(t *testing.T) {
@@ -122,7 +130,7 @@ func TestTraceWriterMultipleEndpointsConcurrent(t *testing.T) {
 
 	wg.Wait()
 	tw.Stop()
-	payloadsContain(t, srv.Payloads(), testSpans)
+	payloadsContain(t, srv.Payloads(), testSpans, false)
 }
 
 // useFlushThreshold sets n as the number of bytes to be used as the flush threshold
@@ -145,14 +153,23 @@ func randomSampledSpans(spans, events int) *SampledChunks {
 }
 
 // payloadsContain checks that the given payloads contain the given set of sampled spans.
-func payloadsContain(t *testing.T, payloads []*payload, sampledSpans []*SampledChunks) {
+func payloadsContain(t *testing.T, payloads []*payload, sampledSpans []*SampledChunks, shouldUseZstd bool) {
 	t.Helper()
 	var all pb.AgentPayload
 	for _, p := range payloads {
 		assert := assert.New(t)
-		gzipr, err := gzip.NewReader(p.body)
-		assert.NoError(err)
-		slurp, err := io.ReadAll(gzipr)
+		var slurp []byte
+		var err error
+		if shouldUseZstd {
+			zstdReader := zstd.NewReader(p.body)
+			assert.NotNil(zstdReader)
+			slurp, err = io.ReadAll(zstdReader)
+		} else {
+			gzipReader, err := gzip.NewReader(p.body)
+			assert.NoError(err)
+			slurp, err = io.ReadAll(gzipReader)
+		}
+
 		assert.NoError(err)
 		var payload pb.AgentPayload
 		err = proto.Unmarshal(slurp, &payload)
@@ -207,7 +224,7 @@ func TestTraceWriterFlushSync(t *testing.T) {
 		tw.FlushSync()
 		// Now all trace payloads should be sent
 		assert.Equal(t, 1, srv.Accepted())
-		payloadsContain(t, srv.Payloads(), testSpans)
+		payloadsContain(t, srv.Payloads(), testSpans, false)
 	})
 }
 
@@ -276,7 +293,7 @@ func TestTraceWriterSyncStop(t *testing.T) {
 		tw.Stop()
 		// Now all trace payloads should be sent
 		assert.Equal(t, 1, srv.Accepted())
-		payloadsContain(t, srv.Payloads(), testSpans)
+		payloadsContain(t, srv.Payloads(), testSpans, false)
 	})
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR allows using zstd to encode trace payloads. It is allowed through a new feature flag `zstd-encoding`.
It doesn't handle the stats payload yet as it's less impacting but we should look into doing it as well. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Investigations showed that we can have better compression of our payloads without performance impacts. This can lead to significant data transfer cost savings on our end, and cost savings for our customers as well.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

More information on the initial investigation in this [doc](https://docs.google.com/document/d/1HiMsdz8UDQEI-2Ry-lycCfvuMuCow_Scon8JWhCi9qc/edit)
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Scenario 1: 
- Without changes, sending traces should still work out of the box. Encoding type should be `gzip`

Scenario 2:
- Add `zstd-encoding` in `DD_APM_FEATURES`
- Sending traces work. Encoding type should be `zstd`
- CPU usage shouldn't be higher than in the 1st scenario.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
