### PR TITLE
(rc) drastically improve performance when verifying multiple configurations

### DIFF
--- a/comp/core/log/go.mod
+++ b/comp/core/log/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.52.0-rc.3 // indirect
 	github.com/DataDog/datadog-go/v5 v5.5.0 // indirect
 	github.com/DataDog/go-sqllexer v0.0.9 // indirect
-	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.13.3 // indirect
 	github.com/DataDog/viper v1.12.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect

--- a/comp/core/log/go.sum
+++ b/comp/core/log/go.sum
@@ -7,8 +7,8 @@ github.com/DataDog/datadog-go/v5 v5.5.0 h1:G5KHeB8pWBNXT4Jtw0zAkhdxEAWSpWH00geHI
 github.com/DataDog/datadog-go/v5 v5.5.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/go-sqllexer v0.0.9 h1:Cx2Cu1S0hfj4coCCA8hzjM9+UNFRkcu1avIV//RU5Qw=
 github.com/DataDog/go-sqllexer v0.0.9/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
-github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
-github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
+github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.13.3 h1:hcYZMgGDMUz8Dz6PcOhgk6FF0yG4N7KErS5J3O/MpeU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.13.3/go.mod h1:Z2FPxYhi8GIFkS4WLC7RrRaGolyB9TqS2RMSwNcmczk=
 github.com/DataDog/viper v1.12.0 h1:FufyZpZPxyszafSV5B8Q8it75IhhuJwH0T7QpT6HnD0=

--- a/go.mod
+++ b/go.mod
@@ -333,7 +333,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/DataDog/aptly v1.5.3 // indirect
 	github.com/DataDog/extendeddaemonset v0.9.0-rc.2 // indirect
-	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/gostackparse v0.7.0 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DisposaBoy/JsonConfigReader v0.0.0-20201129172854-99cf318d67e7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/DataDog/go-libddwaf/v2 v2.3.1 h1:bujaT5+KnLDFQqVA5ilvVvW+evUSHow9FrTH
 github.com/DataDog/go-libddwaf/v2 v2.3.1/go.mod h1:gsCdoijYQfj8ce/T2bEDNPZFIYnmHluAgVDpuQOWMZE=
 github.com/DataDog/go-sqllexer v0.0.9 h1:Cx2Cu1S0hfj4coCCA8hzjM9+UNFRkcu1avIV//RU5Qw=
 github.com/DataDog/go-sqllexer v0.0.9/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
-github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
-github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
+github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gopsutil v1.2.2 h1:8lmthwyyCXa1NKiYcHlrtl9AAFdfbNI2gPcioCJcBPU=
 github.com/DataDog/gopsutil v1.2.2/go.mod h1:glkxNt/qRu9lnpmUEQwOIAXW+COWDTBOTEAHqbgBPts=
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=

--- a/pkg/config/remote/go.mod
+++ b/pkg/config/remote/go.mod
@@ -55,7 +55,7 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.52.0-rc.3 // indirect
-	github.com/DataDog/go-tuf v1.0.2-0.5.2
+	github.com/DataDog/go-tuf v1.1.0-0.5.2
 	github.com/DataDog/viper v1.12.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/pkg/config/remote/go.sum
+++ b/pkg/config/remote/go.sum
@@ -44,8 +44,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
-github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
+github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/viper v1.12.0 h1:FufyZpZPxyszafSV5B8Q8it75IhhuJwH0T7QpT6HnD0=
 github.com/DataDog/viper v1.12.0/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/pkg/config/remote/uptane/client_benchmark_test.go
+++ b/pkg/config/remote/uptane/client_benchmark_test.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package uptane
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/go-tuf/data"
+	"go.etcd.io/bbolt"
+
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+)
+
+func getBenchmarkDB(b *testing.B) *bbolt.DB {
+	dir := b.TempDir()
+	db, err := bbolt.Open(dir+"/remote-config.db", 0600, &bbolt.Options{})
+	if err != nil {
+		panic(err)
+	}
+	b.Cleanup(func() {
+		db.Close()
+	})
+	return db
+}
+
+func BenchmarkVerify(b *testing.B) {
+	for i := 1; i < 100; i *= 2 {
+		b.Run(fmt.Sprintf("verify-%d-configs", i), func(b *testing.B) {
+			configTargets := data.TargetFiles{}
+			directorTargets := data.TargetFiles{}
+			targetFiles := []*pbgo.File{}
+			target, meta := generateTarget()
+			for j := 0; j < i; j++ {
+				targetPath := fmt.Sprintf("datadog/2/DEBUG/id/%d", j)
+				configTargets[targetPath] = meta
+				directorTargets[targetPath] = meta
+				targetFiles = append(targetFiles, &pbgo.File{
+					Path: targetPath,
+					Raw:  target,
+				})
+			}
+			repository := newTestRepository(2, 1, configTargets, directorTargets, targetFiles)
+			cfg := newTestConfig(repository)
+			db := getBenchmarkDB(b)
+			client, err := newTestClient(db, "cachekey", cfg)
+			if err != nil {
+				b.Fatal(err)
+			}
+			err = client.Update(repository.toUpdate())
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				client.cachedVerify = false
+				err = client.verify()
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/config/remote/uptane/client_benchmark_test.go
+++ b/pkg/config/remote/uptane/client_benchmark_test.go
@@ -28,7 +28,7 @@ func getBenchmarkDB(b *testing.B) *bbolt.DB {
 }
 
 func BenchmarkVerify(b *testing.B) {
-	for i := 1; i < 100; i *= 2 {
+	for i := 1; i <= 128; i *= 2 {
 		b.Run(fmt.Sprintf("verify-%d-configs", i), func(b *testing.B) {
 			configTargets := data.TargetFiles{}
 			directorTargets := data.TargetFiles{}

--- a/pkg/config/remote/uptane/client_test.go
+++ b/pkg/config/remote/uptane/client_test.go
@@ -50,6 +50,7 @@ func newTestClient(db *bbolt.DB, name string, cfg model.Config) (*Client, error)
 	}
 	return NewClient(db, name, getTestOrgUUIDProvider(2), opts...)
 }
+
 func TestClientState(t *testing.T) {
 	testRepository1 := newTestRepository(2, 1, nil, nil, nil)
 	cfg := newTestConfig(testRepository1)

--- a/pkg/remoteconfig/state/go.mod
+++ b/pkg/remoteconfig/state/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/remoteconfig/state
 go 1.21.8
 
 require (
-	github.com/DataDog/go-tuf v1.0.2-0.5.2
+	github.com/DataDog/go-tuf v1.1.0-0.5.2
 	github.com/pkg/errors v0.9.1
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0
 	github.com/stretchr/testify v1.9.0

--- a/pkg/remoteconfig/state/go.sum
+++ b/pkg/remoteconfig/state/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
-github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
+github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -46,7 +46,7 @@ require (
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
 	github.com/DataDog/go-sqllexer v0.0.9 // indirect
-	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/cgroups/v3 v3.0.2 // indirect

--- a/pkg/trace/go.sum
+++ b/pkg/trace/go.sum
@@ -39,8 +39,8 @@ github.com/DataDog/datadog-go/v5 v5.5.0 h1:G5KHeB8pWBNXT4Jtw0zAkhdxEAWSpWH00geHI
 github.com/DataDog/datadog-go/v5 v5.5.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/go-sqllexer v0.0.9 h1:Cx2Cu1S0hfj4coCCA8hzjM9+UNFRkcu1avIV//RU5Qw=
 github.com/DataDog/go-sqllexer v0.0.9/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
-github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
-github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
+github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.13.3 h1:hcYZMgGDMUz8Dz6PcOhgk6FF0yG4N7KErS5J3O/MpeU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.13.3/go.mod h1:Z2FPxYhi8GIFkS4WLC7RrRaGolyB9TqS2RMSwNcmczk=
 github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjvVA/o=

--- a/releasenotes/notes/rc-performance-multi-config-e1530e77fdc05dd2.yaml
+++ b/releasenotes/notes/rc-performance-multi-config-e1530e77fdc05dd2.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The performance of Remote Config has been significantly improved when large amounts of configurations are received.


### PR DESCRIPTION
### What does this PR do ?

This PR uses the batch operations introduced in https://github.com/DataDog/go-tuf/pull/67 to improve the verification performance of the RC service. It is aimed at scaling better when many configurations are received by the agent. 

To give an example, in a scenario where the agent is receiving 128 configs, the max we have seen in real life scenarios, we went from 1600ms to 13ms on my CPU, a `99.18%` decrease.

It should fix the two issues we have seen in prod:
- Remote Config verification taking up to 10% of the CPU used by the agent in some clusters
- Agents with 100s of Dynamic Instrumentation configs being almost always working on verification and not answering the connected tracers

Raw results:
```
benchmark                                 old ns/op      new ns/op     delta
BenchmarkVerify/verify-1-configs-12       2366747        2341795       -1.05%
BenchmarkVerify/verify-2-configs-12       5135915        2469946       -51.91%
BenchmarkVerify/verify-4-configs-12       11120302       2637195       -76.28%
BenchmarkVerify/verify-8-configs-12       25292809       2975712       -88.23%
BenchmarkVerify/verify-16-configs-12      60258463       3743521       -93.79%
BenchmarkVerify/verify-32-configs-12      170096629      5154561       -96.97%
BenchmarkVerify/verify-64-configs-12      515783400      8012378       -98.45%
BenchmarkVerify/verify-128-configs-12     1699531400     13946932      -99.18%

benchmark                                 old allocs     new allocs     delta
BenchmarkVerify/verify-1-configs-12       7014           7014           +0.00%
BenchmarkVerify/verify-2-configs-12       14831          7554           -49.07%
BenchmarkVerify/verify-4-configs-12       32990          8603           -73.92%
BenchmarkVerify/verify-8-configs-12       79419          10683          -86.55%
BenchmarkVerify/verify-16-configs-12      213570         14889          -93.03%
BenchmarkVerify/verify-32-configs-12      643968         23285          -96.38%
BenchmarkVerify/verify-64-configs-12      2153727        39994          -98.14%
BenchmarkVerify/verify-128-configs-12     7758737        73306          -99.06%

benchmark                                 old bytes     new bytes     delta
BenchmarkVerify/verify-1-configs-12       376539        376411        -0.03%
BenchmarkVerify/verify-2-configs-12       799136        411481        -48.51%
BenchmarkVerify/verify-4-configs-12       1815733       483825        -73.35%
BenchmarkVerify/verify-8-configs-12       4397357       600218        -86.35%
BenchmarkVerify/verify-16-configs-12      13190050      929495        -92.95%
BenchmarkVerify/verify-32-configs-12      43301026      1563221       -96.39%
BenchmarkVerify/verify-64-configs-12      151027728     2783854       -98.16%
BenchmarkVerify/verify-128-configs-12     572859936     5325649       -99.07%
```

Note: I expect even better results in real life scenarios because we have much more TUF metadata than in the benchmark test where there's only one top targets and no delegated targets.

### Followup work

This PR should address all known issues with RC performance in the agent. There's still room for improvements by improving JSON operations in the TUF library but given that it's not trivial (it uses a custom canonical JSON lib) and we haven't seen issues with low amounts of configs let's wait for now.