### PR TITLE
[CWS] reduce allocation related to `ErrNoProcessContext`

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -519,7 +519,7 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 
 	if !eventWithNoProcessContext(eventType) {
 		if !isResolved {
-			event.Error = &model.ErrNoProcessContext{Err: errors.New("process context not resolved")}
+			event.Error = model.ErrNoProcessContext
 		} else if _, err := entry.HasValidLineage(); err != nil {
 			event.Error = &model.ErrProcessBrokenLineage{Err: err}
 			p.Resolvers.ProcessResolver.CountBrokenLineage()

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -172,8 +172,7 @@ func (m *EBPFMonitors) ProcessEvent(event *model.Event) {
 		)
 	}
 
-	var processContextErr *model.ErrNoProcessContext
-	if errors.As(event.Error, &processContextErr) {
+	if errors.Is(event.Error, model.ErrNoProcessContext) {
 		m.ebpfProbe.probe.DispatchCustomEvent(
 			NewAbnormalEvent(events.NoProcessContextErrorRuleID, events.NoProcessContextErrorRuleDesc, event, event.Error),
 		)

--- a/pkg/security/secl/model/errors.go
+++ b/pkg/security/secl/model/errors.go
@@ -72,19 +72,7 @@ func (e *ErrProcessIncompleteLineage) Error() string {
 }
 
 // ErrNoProcessContext defines an error for event without process context
-type ErrNoProcessContext struct {
-	Err error
-}
-
-// Error implements the error interface
-func (e *ErrNoProcessContext) Error() string {
-	return e.Err.Error()
-}
-
-// Unwrap implements the error interface
-func (e *ErrNoProcessContext) Unwrap() error {
-	return e.Err
-}
+var ErrNoProcessContext = errors.New("process context not resolved")
 
 // ErrProcessBrokenLineage returned when a process lineage is broken
 type ErrProcessBrokenLineage struct {


### PR DESCRIPTION
### What does this PR do?

This PR reduce the allocations related to ErrNoProcessContext by allocating it once as a value, instead of allocating it multiple times with always the same error content.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
