### PR TITLE
[CWS] optimizations to `genMacroPartials`

### DIFF
--- a/pkg/security/secl/compiler/eval/rule.go
+++ b/pkg/security/secl/compiler/eval/rule.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/utils"
@@ -243,34 +244,35 @@ func (r *Rule) GenEvaluator(model Model, parsingCtx *ast.ParsingContext) error {
 
 func (r *Rule) genMacroPartials(field Field) (map[Field]map[MacroID]*MacroEvaluator, error) {
 	partials := make(map[Field]map[MacroID]*MacroEvaluator)
-	for _, f := range r.GetFields() {
-		if f != field {
-			continue
-		}
-		for _, macro := range r.Opts.MacroStore.List() {
-			var err error
-			var evaluator *MacroEvaluator
-			if macro.ast != nil {
-				// NOTE(safchain) this is not working with nested macro. It will be removed once partial
-				// will be generated another way
-				evaluator, err = macroToEvaluator(macro.ast, r.Model, r.Opts, field)
-				if err != nil {
-					if err, ok := err.(*ErrAstToEval); ok {
-						return nil, fmt.Errorf("macro syntax error: %w", &ErrRuleParse{pos: err.Pos})
-					}
-					return nil, fmt.Errorf("macro compilation error: %w", err)
-				}
-			} else {
-				evaluator = macro.GetEvaluator()
-			}
 
-			macroEvaluators, exists := partials[field]
-			if !exists {
-				macroEvaluators = make(map[MacroID]*MacroEvaluator)
-				partials[field] = macroEvaluators
+	// check that field in this rule fields
+	if !slices.Contains(r.GetFields(), field) {
+		return partials, nil
+	}
+
+	for _, macro := range r.Opts.MacroStore.List() {
+		var err error
+		var evaluator *MacroEvaluator
+		if macro.ast != nil {
+			// NOTE(safchain) this is not working with nested macro. It will be removed once partial
+			// will be generated another way
+			evaluator, err = macroToEvaluator(macro.ast, r.Model, r.Opts, field)
+			if err != nil {
+				if err, ok := err.(*ErrAstToEval); ok {
+					return nil, fmt.Errorf("macro syntax error: %w", &ErrRuleParse{pos: err.Pos})
+				}
+				return nil, fmt.Errorf("macro compilation error: %w", err)
 			}
-			macroEvaluators[macro.ID] = evaluator
+		} else {
+			evaluator = macro.GetEvaluator()
 		}
+
+		macroEvaluators, exists := partials[field]
+		if !exists {
+			macroEvaluators = make(map[MacroID]*MacroEvaluator)
+			partials[field] = macroEvaluators
+		}
+		macroEvaluators[macro.ID] = evaluator
 	}
 
 	return partials, nil
@@ -283,30 +285,28 @@ func (r *Rule) genPartials(field Field) error {
 		return err
 	}
 
-	for _, f := range r.GetFields() {
-		if f != field {
-			continue
-		}
-
-		state := NewState(r.Model, field, macroPartials[field])
-		pEval, _, err := nodeToEvaluator(r.ast.BooleanExpression, r.Opts, state)
-		if err != nil {
-			return fmt.Errorf("couldn't generate partial for field %s and rule %s: %w", field, r.ID, err)
-		}
-
-		pEvalBool, ok := pEval.(*BoolEvaluator)
-		if !ok {
-			return NewTypeError(r.ast.Pos, reflect.Bool)
-		}
-
-		if pEvalBool.EvalFnc == nil {
-			pEvalBool.EvalFnc = func(ctx *Context) bool {
-				return pEvalBool.Value
-			}
-		}
-
-		r.evaluator.setPartial(field, pEvalBool.EvalFnc)
+	if !slices.Contains(r.GetFields(), field) {
+		return nil
 	}
+
+	state := NewState(r.Model, field, macroPartials[field])
+	pEval, _, err := nodeToEvaluator(r.ast.BooleanExpression, r.Opts, state)
+	if err != nil {
+		return fmt.Errorf("couldn't generate partial for field %s and rule %s: %w", field, r.ID, err)
+	}
+
+	pEvalBool, ok := pEval.(*BoolEvaluator)
+	if !ok {
+		return NewTypeError(r.ast.Pos, reflect.Bool)
+	}
+
+	if pEvalBool.EvalFnc == nil {
+		pEvalBool.EvalFnc = func(ctx *Context) bool {
+			return pEvalBool.Value
+		}
+	}
+
+	r.evaluator.setPartial(field, pEvalBool.EvalFnc)
 
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR does multiple optimizations and code improvements to the macro partials generation code:
- replace the for loop by `Contains` call, ensuring the macro generation happens only once
- remove one layer of `map` in the value returned by the macro partial generating function, fully skipping allocations in a lot of cases

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
