### PR TITLE
[CWS] disable arm64 kmt runs with kernel < 5.8

### DIFF
--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -171,15 +171,12 @@ kernel_matrix_testing_run_security_agent_tests_arm64:
   parallel:
     matrix:
       - TAG:
-          - "ubuntu_18.04"
-          - "ubuntu_20.04"
           - "ubuntu_22.04"
           - "ubuntu_23.10"
           - "amzn_5.4"
           - "amzn_5.10"
           - "fedora_37"
           - "fedora_38"
-          - "debian_10"
           - "debian_11"
           - "debian_12"
         TEST_SET: ["all_tests"]


### PR DESCRIPTION
### What does this PR do?

arm64 has a split memory space between user and kernel spaces. Before kernel 5.8, all `bpf_probe_read` resolved to kernel space read and thus failed to read userspace pointers.

This PR disables those tests since they will obviously fail. (and we already had no kitchen tests for those kernel for the same reason).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
