### PR TITLE
[comp/snmptraps] Fix status template error

### DIFF
--- a/comp/snmptraps/status/statusimpl/status.go
+++ b/comp/snmptraps/status/statusimpl/status.go
@@ -113,7 +113,7 @@ func (p Provider) populateStatus() map[string]interface{} {
 	return stats
 }
 
-func getDroppedPackets() int64 {
+func getDroppedPackets() float64 {
 	aggregatorMetrics, ok := expvar.Get("aggregator").(*expvar.Map)
 	if !ok {
 		return 0
@@ -128,7 +128,7 @@ func getDroppedPackets() int64 {
 	if !ok {
 		return 0
 	}
-	return droppedPackets.Value()
+	return float64(droppedPackets.Value())
 }
 
 // GetStatus returns key-value data for use in status reporting of the traps server.
@@ -140,7 +140,7 @@ func GetStatus() map[string]interface{} {
 	metrics := make(map[string]interface{})
 	json.Unmarshal(metricsJSON, &metrics) //nolint:errcheck
 	if dropped := getDroppedPackets(); dropped > 0 {
-		metrics["PacketsDropped"] = float64(dropped)
+		metrics["PacketsDropped"] = dropped
 	}
 	status["metrics"] = metrics
 	if startError != nil {

--- a/comp/snmptraps/status/statusimpl/status.go
+++ b/comp/snmptraps/status/statusimpl/status.go
@@ -140,7 +140,7 @@ func GetStatus() map[string]interface{} {
 	metrics := make(map[string]interface{})
 	json.Unmarshal(metricsJSON, &metrics) //nolint:errcheck
 	if dropped := getDroppedPackets(); dropped > 0 {
-		metrics["PacketsDropped"] = dropped
+		metrics["PacketsDropped"] = float64(dropped)
 	}
 	status["metrics"] = metrics
 	if startError != nil {

--- a/comp/snmptraps/status/statusimpl/status_test.go
+++ b/comp/snmptraps/status/statusimpl/status_test.go
@@ -7,6 +7,10 @@ package statusimpl
 
 import (
 	"bytes"
+	"expvar"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
+	_ "github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +18,14 @@ import (
 
 func TestStatusProvider(t *testing.T) {
 	provider := Provider{}
+
+	// Set SNMP Traps errors
+	aggregatorMetrics, ok := expvar.Get("aggregator").(*expvar.Map)
+	require.True(t, ok)
+	epErrors, ok := aggregatorMetrics.Get("EventPlatformEventsErrors").(*expvar.Map)
+	require.True(t, ok)
+	epErrors.Add(eventplatform.EventTypeSnmpTraps, 42)
+	require.True(t, ok)
 
 	tests := []struct {
 		name       string

--- a/comp/snmptraps/status/statusimpl/status_test.go
+++ b/comp/snmptraps/status/statusimpl/status_test.go
@@ -8,12 +8,13 @@ package statusimpl
 import (
 	"bytes"
 	"expvar"
-	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
-	_ "github.com/DataDog/datadog-agent/pkg/aggregator"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
+	_ "github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 func TestStatusProvider(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Context: 

There is a possible bug in this PR https://github.com/DataDog/datadog-agent/pull/22115 for snmp with snmp.tmpl . I'm getting this on mimic2 server:
```
template: snmp.tmpl:6:35: executing "snmp.tmpl" at <$value>: wrong type for value; expected float64; got int64
```

The issue is that PacketsDropped value define here is a int64, but the template only works with float64.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Steps:

Due to limitation/complexity to trigger the Dropped Packets error, we need to modify slightly the code locally:

1/ Modify locally the code to add this line:

```
aggregatorEventPlatformEventsErrors.Add(event.eventType, 1)
```

just after https://github.com/DataDog/datadog-agent/blob/63f3c76fd79585e066f53fd60c188fdfc247de33/pkg/aggregator/aggregator.go#L794

this will help trigger the SNMP Traps Packet Dropped error. 

Note: this is a workaround to trigger the packet dropped error since it's hard to trigger it otherwise.

2/ Configure SNMP Traps in datadog.yaml:

```
network_devices:
  snmp_traps:
    enabled: true
    port: 9162
    bind_host: 0.0.0.0
    community_strings:
      - 'public'
      - 'default'
```



3/ 
Send snmp traps like this:

```
$ snmptrap -d -v 2c -c public123 127.0.0.1:1161 '' NET-SNMP-EXAMPLES-MIB::netSnmpExampleHeartbeatNotification netSnmpExampleHeartbeatRate i 123456
```

4/ Verify SNMP Traps `Packets Dropped` status is displayed correctly, example:

```
==========
SNMP Traps
==========
  Packets: 2
  Packets Auth Errors: 0
  Packets Dropped: 2
```
