### PR TITLE
Remove some popups when running tests on macos

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
@@ -263,7 +263,7 @@ func TestCollection(t *testing.T) {
 			grpcServer := grpc.NewServer()
 			pbgo.RegisterProcessEntityStreamServer(grpcServer, server)
 
-			lis, err := net.Listen("tcp", ":0")
+			lis, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
 
 			go func() {

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
@@ -157,7 +157,7 @@ func TestCollection(t *testing.T) {
 	grpcServer := grpc.NewServer()
 	pbgo.RegisterAgentSecureServer(grpcServer, server)
 
-	lis, err := net.Listen("tcp", ":0")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	go func() {

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -131,7 +131,7 @@ func TestReceiverRequestBodyLength(t *testing.T) {
 func TestListenTCP(t *testing.T) {
 	t.Run("measured", func(t *testing.T) {
 		r := &HTTPReceiver{conf: &config.AgentConfig{ConnectionLimit: 0}}
-		ln, err := r.listenTCP(":0")
+		ln, err := r.listenTCP("127.0.0.1:0")
 		require.NoError(t, err)
 		defer ln.Close()
 		_, ok := ln.(*measuredListener)
@@ -140,7 +140,7 @@ func TestListenTCP(t *testing.T) {
 
 	t.Run("limited", func(t *testing.T) {
 		r := &HTTPReceiver{conf: &config.AgentConfig{ConnectionLimit: 10}}
-		ln, err := r.listenTCP(":0")
+		ln, err := r.listenTCP("127.0.0.1:0")
 		require.NoError(t, err)
 		defer ln.Close()
 		_, ok := ln.(*rateLimitedListener)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Bind some tests to `localhost` instead of `0.0.0.0`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Running those tests on MacOS displays a pop-up asking to agree to the connection.
Binding to `localhost` instead removes that pop-up.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
