### PR TITLE
Fix incompatible rules when building only one major version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -445,6 +445,14 @@ workflow:
     when: manual
     allow_failure: true
 
+.except_no_a6_or_no_a7:
+  - <<: *if_mergequeue
+    when: never
+  - <<: *if_not_version_6
+    when: never
+  - <<: *if_not_version_7
+    when: never
+
 .on_dev_branch_manual:
   - <<: *if_mergequeue
     when: never

--- a/.gitlab/install_script_testing/install_script_testing.yml
+++ b/.gitlab/install_script_testing/install_script_testing.yml
@@ -16,4 +16,6 @@ test_install_script:
       --variable TEST_PIPELINE_ID"
   needs: ["deploy_deb_testing-a6_x64", "deploy_rpm_testing-a6_x64", "deploy_suse_rpm_testing_x64-a6", "deploy_deb_testing-a7_x64", "deploy_rpm_testing-a7_x64", "deploy_suse_rpm_testing_x64-a7"]
   rules:
-    !reference [.on_deploy]
+    - !reference [.except_no_a6_or_no_a7]
+    - !reference [.on_deploy]
+


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix an incompatibility in our rules that makes us unable to create deploy pipeline for only one major version of the agent.  This is quite annoying for teams creating custom builds

The issue occurs with `test_install_script` job. This job was created to ensure on our nightly pipelines that the install script is still working with the version of the agent we have. It requires both the agent 6 and agent 7 to be built to run successfully.

This PR propose to disable this test on pipeline creating the build for only one major version.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
