### PR TITLE
fix(updater): Update defaults after java tracer OCI package rename

### DIFF
--- a/pkg/updater/defaults/boostrap.json
+++ b/pkg/updater/defaults/boostrap.json
@@ -1,4 +1,4 @@
 {
   "datadog-agent": "7.53.0-devel.git.156.4681fd9.pipeline.29311299-1",
-  "dd-trace-java": "1.32.0-SNAPSHOT~09be0fb775~pipeline.29892278.beta.09be0fb7"
+  "datadog-apm-library-java": "1.32.0-SNAPSHOT-a1309de641-pipeline.30019975.beta.a1309de6-1"
 }

--- a/pkg/updater/defaults/catalog.json
+++ b/pkg/updater/defaults/catalog.json
@@ -1,9 +1,10 @@
 {
   "packages": [
     {
-      "package": "dd-trace-java",
-      "version": "1.32.0-SNAPSHOT~09be0fb775~pipeline.29892278.beta.09be0fb7",
-      "url": "oci://us-docker.pkg.dev/datadog-sandbox/updater-dev/auto_inject-java@sha256:7235bf68d0a44afc97f5c0c720c0ad3c7be1e6099cf437546633c46ae35f30f4"
+      "package": "datadog-apm-library-java",
+      "version": "1.32.0-SNAPSHOT-a1309de641-pipeline.30019975.beta.a1309de6-1",
+      "url": "oci://public.ecr.aws/b1o7r7e0/updater-sandbox/datadog-apm-library-java@sha256:f26e286e73e0691578306425463f1af13fecb355dc8fae341281187122876092",
+      "sha256": "f26e286e73e0691578306425463f1af13fecb355dc8fae341281187122876092"
     },
     {
       "package": "datadog-agent",


### PR DESCRIPTION
### What does this PR do?
Updates default catalog after java tracer OCI package rename

### Motivation
[RC-1645]

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
```
# build updater
inv updater.build
# run updater
./bin/updater/updater run -c ./dev/dist/datadog.yml
# install java tracer
./bin/updater/updater bootstrap -P datadog-apm-library-java
# check installation
ls -l /opt/datadog-packages/datadog-apm-library-java/
```


[RC-1645]: https://datadoghq.atlassian.net/browse/RC-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ