### PR TITLE
[NPM-831] use type of handler to set ringbuf flag

### DIFF
--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -177,8 +177,11 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 	if err := initManager(m, connCloseEventHandler, runtimeTracer, config); err != nil {
 		return nil, nil, fmt.Errorf("could not initialize manager: %w", err)
 	}
-
-	ringbufferEnabled := connCloseEventHandler.(*ddebpf.RingBufferHandler) != nil
+	ringbufferEnabled := false
+	switch connCloseEventHandler.(type) {
+	case *ddebpf.RingBufferHandler:
+		ringbufferEnabled = true
+	}
 	util.AddBoolConst(&mgrOpts, "ringbuffers_enabled", ringbufferEnabled)
 	if ringbufferEnabled {
 		util.EnableRingbuffersViaMapEditor(&mgrOpts)

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -178,7 +178,7 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 		return nil, nil, fmt.Errorf("could not initialize manager: %w", err)
 	}
 
-	ringbufferEnabled := config.RingBufferSupportedNPM()
+	ringbufferEnabled := connCloseEventHandler.(*ddebpf.RingBufferHandler) != nil
 	util.AddBoolConst(&mgrOpts, "ringbuffers_enabled", ringbufferEnabled)
 	if ringbufferEnabled {
 		util.EnableRingbuffersViaMapEditor(&mgrOpts)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

fixes a bug introduced in https://github.com/DataDog/datadog-agent/pull/19760. It seems the cillium feature check used to determine if ringbuffers are supported on the kernel is not consistent in KMT. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/NPM-831

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
