### PR TITLE
only allow unique ebpf program name+type+module in ebpf check

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/dedup.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/dedup.go
@@ -15,37 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck/model"
 )
 
-// deduplicateProgramNames disambiguates ebpf programs by adding a numeric ID if necessary
-func deduplicateProgramNames(stats *model.EBPFStats) {
-	slices.SortStableFunc(stats.Programs, func(a, b model.EBPFProgramStats) int {
-		x := strings.Compare(a.Name, b.Name)
-		if x == 0 {
-			x = strings.Compare(a.Module, b.Module)
-			if x == 0 {
-				return int(a.ID - b.ID)
-			}
-		}
-		return x
-	})
-	// if program name is a duplicate, we need to disambiguate by adding a numeric ID
-	for i := 0; i < len(stats.Programs)-1; {
-		origName := stats.Programs[i].Name
-		origModule := stats.Programs[i].Module
-		// if we have a series of at least two entries
-		if stats.Programs[i+1].Name == origName && stats.Programs[i+1].Module == origModule {
-			// start with i, so we overwrite the first entry in series
-			j := i
-			for ; j < len(stats.Programs) && stats.Programs[j].Name == origName && stats.Programs[j].Module == origModule; j++ {
-				stats.Programs[j].Name = fmt.Sprintf("%s_%d", stats.Programs[j].Name, j-i+1)
-			}
-			i = j
-			continue
-		}
-
-		i++
-	}
-}
-
 // deduplicateMapNames disambiguates ebpf maps by adding a numeric ID if necessary
 func deduplicateMapNames(stats *model.EBPFStats) {
 	allMaps := make([]*model.EBPFMapStats, 0, len(stats.Maps))

--- a/pkg/security/resolvers/tc/resolver.go
+++ b/pkg/security/resolvers/tc/resolver.go
@@ -116,7 +116,8 @@ func (tcr *Resolver) SetupNewTCClassifierWithNetNSHandle(device model.NetDevice,
 			_ = multierror.Append(&combinedErr, fmt.Errorf("couldn't clone %s: %v", tcProbe.ProbeIdentificationPair, err))
 		} else {
 			tcr.programs[deviceKey] = newProbe
-			ebpfcheck.AddProgramNameMapping(newProbe.ID(), fmt.Sprintf("%s_%s", newProbe.EBPFFuncName, device.GetKey()), "cws")
+			// do not use dynamic program name here, it explodes cardinality
+			ebpfcheck.AddProgramNameMapping(newProbe.ID(), newProbe.EBPFFuncName, "cws")
 		}
 	}
 	return combinedErr.ErrorOrNil()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Restricts eBPF check programs to unique program name+type+module

### Motivation

TC classifier programs per interface index + network namespace was exploding cardinality

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Reduced information for cloned programs

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
