### PR TITLE
[CWS] add cache layer when computing the `NextAncestorBinaryOrArgv0` from process cache entry

### DIFF
--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -390,7 +390,8 @@ func (adm *ActivityDumpManager) insertActivityDump(newDump *ActivityDump) error 
 	}
 
 	// loop through the process cache entry tree and push traced pids if necessary
-	adm.resolvers.ProcessResolver.Walk(adm.SearchTracedProcessCacheEntryCallback(newDump))
+	pces := adm.newProcessCacheEntrySearcher(newDump)
+	adm.resolvers.ProcessResolver.Walk(pces.SearchTracedProcessCacheEntry)
 
 	// Delay the activity dump snapshot to reduce the overhead on the main goroutine
 	select {
@@ -686,40 +687,61 @@ func (adm *ActivityDumpManager) ProcessEvent(event *model.Event) {
 	}
 }
 
-// SearchTracedProcessCacheEntryCallback inserts traced pids if necessary
-func (adm *ActivityDumpManager) SearchTracedProcessCacheEntryCallback(ad *ActivityDump) func(entry *model.ProcessCacheEntry) {
-	return func(entry *model.ProcessCacheEntry) {
-		ad.Lock()
-		defer ad.Unlock()
+type processCacheEntrySearcher struct {
+	adm           *ActivityDumpManager
+	ad            *ActivityDump
+	ancestorCache map[*model.ProcessContext]*model.ProcessCacheEntry
+}
 
-		// check process lineage
-		if !ad.MatchesSelector(entry) {
+func (adm *ActivityDumpManager) newProcessCacheEntrySearcher(ad *ActivityDump) *processCacheEntrySearcher {
+	return &processCacheEntrySearcher{
+		adm:           adm,
+		ad:            ad,
+		ancestorCache: make(map[*model.ProcessContext]*model.ProcessCacheEntry),
+	}
+}
+
+func (pces *processCacheEntrySearcher) getNextAncestorBinaryOrArgv0(pc *model.ProcessContext) *model.ProcessCacheEntry {
+	if ancestor, ok := pces.ancestorCache[pc]; ok {
+		return ancestor
+	}
+	newAncestor := activity_tree.GetNextAncestorBinaryOrArgv0(pc)
+	pces.ancestorCache[pc] = newAncestor
+	return newAncestor
+}
+
+// SearchTracedProcessCacheEntry inserts traced pids if necessary
+func (pces *processCacheEntrySearcher) SearchTracedProcessCacheEntry(entry *model.ProcessCacheEntry) {
+	pces.ad.Lock()
+	defer pces.ad.Unlock()
+
+	// check process lineage
+	if !pces.ad.MatchesSelector(entry) {
+		return
+	}
+
+	if _, err := entry.HasValidLineage(); err != nil {
+		// check if the node belongs to the container
+		var mn *model.ErrProcessMissingParentNode
+		if !errors.As(err, &mn) {
 			return
 		}
+	}
 
-		if _, err := entry.HasValidLineage(); err != nil {
-			// check if the node belongs to the container
-			var mn *model.ErrProcessMissingParentNode
-			if !errors.As(err, &mn) {
-				return
-			}
-		}
+	// compute the list of ancestors, we need to start inserting them from the root
+	ancestors := []*model.ProcessCacheEntry{entry}
+	parent := pces.getNextAncestorBinaryOrArgv0(&entry.ProcessContext)
+	for parent != nil && pces.ad.MatchesSelector(entry) {
+		ancestors = append(ancestors, parent)
+		parent = pces.getNextAncestorBinaryOrArgv0(&parent.ProcessContext)
+	}
+	slices.Reverse(ancestors)
 
-		// compute the list of ancestors, we need to start inserting them from the root
-		ancestors := []*model.ProcessCacheEntry{entry}
-		parent := activity_tree.GetNextAncestorBinaryOrArgv0(&entry.ProcessContext)
-		for parent != nil && ad.MatchesSelector(entry) {
-			ancestors = append(ancestors, parent)
-			parent = activity_tree.GetNextAncestorBinaryOrArgv0(&parent.ProcessContext)
-		}
-		slices.Reverse(ancestors)
-
-		for _, parent = range ancestors {
-			_, _, err := ad.ActivityTree.CreateProcessNode(parent, activity_tree.Snapshot, false, adm.resolvers)
-			if err != nil {
-				// if one of the parents wasn't inserted, leave now
-				break
-			}
+	for _, parent = range ancestors {
+		_, _, err := pces.ad.ActivityTree.CreateProcessNode(parent, activity_tree.Snapshot, false, pces.adm.resolvers)
+		if err != nil {
+			// if one of the parents wasn't inserted, leave now
+			break
 		}
 	}
 }

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -708,9 +709,10 @@ func (adm *ActivityDumpManager) SearchTracedProcessCacheEntryCallback(ad *Activi
 		ancestors := []*model.ProcessCacheEntry{entry}
 		parent := activity_tree.GetNextAncestorBinaryOrArgv0(&entry.ProcessContext)
 		for parent != nil && ad.MatchesSelector(entry) {
-			ancestors = append([]*model.ProcessCacheEntry{parent}, ancestors...)
+			ancestors = append(ancestors, parent)
 			parent = activity_tree.GetNextAncestorBinaryOrArgv0(&parent.ProcessContext)
 		}
+		slices.Reverse(ancestors)
 
 		for _, parent = range ancestors {
 			_, _, err := ad.ActivityTree.CreateProcessNode(parent, activity_tree.Snapshot, false, adm.resolvers)


### PR DESCRIPTION
### What does this PR do?

Some profiling session https://app.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20host%3Ai-06fed244485b6463a%20&fromUser=false&my_code=enabled&selected_tf=1710780793988.486%2C1710792485051.57&sp=&viz=flame_graph&start=1710745094374&end=1710831494374&paused=true

<img width="721" alt="image" src="https://github.com/DataDog/datadog-agent/assets/2822037/d028811a-521e-4feb-8839-f4dc12f8954c">

showed that `GetNextAncestorBinaryOrArgv0` could have an insane CPU cost. The reason is that this function is called a lot, basically on every process cache entry in the cache, and then for each parent of each of those entries, resulting in a huge amount of looping and string comparisons.

This PR tries to fix the issue by adding a caching layer that will hopefully ensure that we do the work only once per process cache entry.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
