### PR TITLE
[CWS] use create time instead of ppid for user kill action

### DIFF
--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -24,6 +24,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+const (
+	userSpaceKillWithinMillis = 1000
+)
+
 // ProcessKiller defines a process killer structure
 type ProcessKiller struct {
 	sync.Mutex
@@ -86,18 +90,21 @@ func (p *ProcessKiller) KillFromUserspace(pid uint32, sig uint32, ev *model.Even
 		return errors.New("process not found in procfs")
 	}
 
-	ppid, err := proc.Ppid()
-	if err != nil {
-		return errors.New("process not found in procfs")
-	}
-
 	name, err := proc.Name()
 	if err != nil {
 		return errors.New("process not found in procfs")
 	}
 
-	if ev.ProcessContext.PPid != uint32(ppid) || ev.ProcessContext.Comm != name {
-		return fmt.Errorf("not sharing the same namespace: %d/%d || %s/%s", ev.ProcessContext.PPid, ppid, ev.ProcessContext.Comm, name)
+	createdAt, err := proc.CreateTime()
+	if err != nil {
+		return errors.New("process not found in procfs")
+	}
+	evCreatedAt := ev.ProcessContext.ExecTime.UnixMilli()
+
+	within := uint64(evCreatedAt) >= uint64(createdAt-userSpaceKillWithinMillis) && uint64(evCreatedAt) <= uint64(createdAt+userSpaceKillWithinMillis)
+
+	if !within || ev.ProcessContext.Comm != name {
+		return fmt.Errorf("not sharing the same namespace: %s/%s", ev.ProcessContext.Comm, name)
 	}
 
 	return syscall.Kill(int(pid), syscall.Signal(sig))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

In case of kubectl exec or in ebpfless mode the ppid may be 0. Compare the create time of the process instead which has to be within 2sec with this PR.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
