### PR TITLE
[CSPM] k8s: do not rely on file extensions to choose a parser for configs

### DIFF
--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -98,7 +98,10 @@ func (l *loader) load(ctx context.Context, loadProcesses procsLoader) (string, *
 	}
 
 	if len(l.errs) > 0 {
-		node.Errors = l.errs
+		node.Errors = make([]string, 0, len(l.errs))
+		for _, err := range l.errs {
+			node.Errors = append(node.Errors, err.Error())
+		}
 	}
 
 	resourceType := "kubernetes_worker_node"

--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -194,7 +194,7 @@ func (l *loader) loadMeta(name string, loadContent bool) (string, os.FileInfo, [
 		return name, nil, nil, false
 	}
 	var b []byte
-	const maxSize = 64 * 1024
+	const maxSize = 512 * 1024
 	if loadContent && info.Size() < maxSize {
 		f, err := os.Open(name)
 		if err != nil {

--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -240,18 +240,11 @@ func (l *loader) loadConfigFileMeta(name string) *K8sConfigFileMeta {
 	}
 
 	var content interface{}
-	switch filepath.Ext(name) {
-	case ".yaml", ".yml":
-		if err := yaml.Unmarshal(b, &content); err != nil {
-			l.pushError(err)
-			content = b
-		}
-	case ".json":
-		if err := json.Unmarshal(b, &content); err != nil {
-			l.pushError(err)
-			content = b
-		}
-	default:
+	erru := json.Unmarshal(b, &content)
+	if erru != nil {
+		erru = yaml.Unmarshal(b, &content)
+	}
+	if erru != nil {
 		content = string(b)
 	}
 
@@ -464,15 +457,12 @@ func (l *loader) loadKubeconfigMeta(name string) *K8sKubeconfigMeta {
 	}
 
 	var source k8SKubeconfigSource
-	var err error
-	switch filepath.Ext(name) {
-	case ".json":
-		err = json.Unmarshal(b, &source)
-	default:
-		err = yaml.Unmarshal(b, &source)
+	erru := json.Unmarshal(b, &source)
+	if erru != nil {
+		erru = yaml.Unmarshal(b, &source)
 	}
-	if err != nil {
-		l.pushError(err)
+	if erru != nil {
+		l.pushError(erru)
 		return nil
 	}
 

--- a/pkg/compliance/k8sconfig/types.go
+++ b/pkg/compliance/k8sconfig/types.go
@@ -31,7 +31,7 @@ type K8sNodeConfig struct {
 		KubeApiserver        *K8sConfigFileMeta `json:"kubeApiserver,omitempty"`
 		KubeScheduler        *K8sConfigFileMeta `json:"kubeScheduler,omitempty"`
 	} `json:"manifests"`
-	Errors []error `json:"errors,omitempty"`
+	Errors []string `json:"errors,omitempty"`
 }
 
 type K8sManagedEnvConfig struct {


### PR DESCRIPTION
### What does this PR do?

Various fixes. See individual commits.

Most important one is to avoid relying on file path extensions to determine which parser using. And instead try both json and yaml parser.

### Motivation

Bottlerocket does not have extensions on its kubelet file. We can't know the encoding without looking at the file content.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
