### PR TITLE
new e2e CWS tests do not need windows packages

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -204,7 +204,7 @@ new-e2e-aml:
 new-e2e-cws:
   extends: .new_e2e_template
   rules: !reference [.on_cws_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7", "qa_agent", "qa_cws_instrumentation"]
+  needs: ["deploy_deb_testing-a7_x64", "qa_agent", "qa_cws_instrumentation"]
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent


### PR DESCRIPTION
### What does this PR do?

Currently those tests only run linux version of the agent, so no need for any dependency on windows packages.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
