### PR TITLE
[corechecks/networkpath] Support min_collection_interval in init_config

### DIFF
--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -6,9 +6,17 @@
 package networkpath
 
 import (
+	"fmt"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	"gopkg.in/yaml.v2"
+	"time"
 )
+
+// InitConfig is used to deserialize integration init config
+type InitConfig struct {
+	MinCollectionInterval int `yaml:"min_collection_interval"`
+}
 
 // InstanceConfig is used to deserialize integration instance config
 type InstanceConfig struct {
@@ -19,22 +27,31 @@ type InstanceConfig struct {
 	MaxTTL uint8 `yaml:"max_ttl"`
 
 	TimeoutMs uint `yaml:"timeout"` // millisecond
+
+	MinCollectionInterval int `yaml:"min_collection_interval"`
 }
 
 // CheckConfig defines the configuration of the
 // Network Path integration
 type CheckConfig struct {
-	DestHostname string
-	DestPort     uint16
-	MaxTTL       uint8
-	TimeoutMs    uint
+	DestHostname          string
+	DestPort              uint16
+	MaxTTL                uint8
+	TimeoutMs             uint
+	MinCollectionInterval time.Duration
 }
 
 // NewCheckConfig builds a new check config
-func NewCheckConfig(rawInstance integration.Data, _ integration.Data) (*CheckConfig, error) {
+func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data) (*CheckConfig, error) {
 	instance := InstanceConfig{}
+	initConfig := InitConfig{}
 
-	err := yaml.Unmarshal(rawInstance, &instance)
+	err := yaml.Unmarshal(rawInitConfig, &initConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(rawInstance, &instance)
 	if err != nil {
 		return nil, err
 	}
@@ -46,5 +63,26 @@ func NewCheckConfig(rawInstance integration.Data, _ integration.Data) (*CheckCon
 	c.MaxTTL = instance.MaxTTL
 	c.TimeoutMs = instance.TimeoutMs
 
+	minCollectionInterval, err := getMinCollectionInterval(instance, initConfig)
+	if err != nil {
+		return nil, err
+	}
+	c.MinCollectionInterval = minCollectionInterval
+
 	return c, nil
+}
+
+func getMinCollectionInterval(instance InstanceConfig, initConfig InitConfig) (time.Duration, error) {
+	var minCollectionInterval time.Duration
+	if instance.MinCollectionInterval != 0 {
+		minCollectionInterval = time.Duration(instance.MinCollectionInterval) * time.Second
+	} else if initConfig.MinCollectionInterval != 0 {
+		minCollectionInterval = time.Duration(initConfig.MinCollectionInterval) * time.Second
+	} else {
+		minCollectionInterval = defaults.DefaultCheckInterval
+	}
+	if minCollectionInterval < 0 {
+		return 0, fmt.Errorf("min collection interval must be > 0")
+	}
+	return minCollectionInterval, nil
 }

--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -8,10 +8,11 @@ package networkpath
 import (
 	"fmt"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	"gopkg.in/yaml.v2"
 	"time"
 )
+
+const DefaultCheckInterval time.Duration = 1 * time.Minute
 
 // InitConfig is used to deserialize integration init config
 type InitConfig struct {
@@ -66,7 +67,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	c.MinCollectionInterval = firstNonZero(
 		time.Duration(instance.MinCollectionInterval)*time.Second,
 		time.Duration(initConfig.MinCollectionInterval)*time.Second,
-		defaults.DefaultCheckInterval,
+		DefaultCheckInterval,
 	)
 	if c.MinCollectionInterval < 0 {
 		return nil, fmt.Errorf("min collection interval must be > 0")

--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -41,6 +41,7 @@ type CheckConfig struct {
 	MinCollectionInterval time.Duration
 }
 
+// TODO: TESTME
 // NewCheckConfig builds a new check config
 func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data) (*CheckConfig, error) {
 	instance := InstanceConfig{}

--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-const DefaultCheckInterval time.Duration = 1 * time.Minute
+const defaultCheckInterval time.Duration = 1 * time.Minute
 
 // InitConfig is used to deserialize integration init config
 type InitConfig struct {
@@ -67,7 +67,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	c.MinCollectionInterval = firstNonZero(
 		time.Duration(instance.MinCollectionInterval)*time.Second,
 		time.Duration(initConfig.MinCollectionInterval)*time.Second,
-		DefaultCheckInterval,
+		defaultCheckInterval,
 	)
 	if c.MinCollectionInterval < 0 {
 		return nil, fmt.Errorf("min collection interval must be > 0")

--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -69,7 +69,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		time.Duration(initConfig.MinCollectionInterval)*time.Second,
 		defaultCheckInterval,
 	)
-	if c.MinCollectionInterval < 0 {
+	if c.MinCollectionInterval <= 0 {
 		return nil, fmt.Errorf("min collection interval must be > 0")
 	}
 

--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -76,9 +76,9 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 }
 
 func firstNonZero(values ...time.Duration) time.Duration {
-	for _, s := range values {
-		if s != 0 {
-			return s
+	for _, value := range values {
+		if value != 0 {
+			return value
 		}
 	}
 	return 0

--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -41,7 +41,6 @@ type CheckConfig struct {
 	MinCollectionInterval time.Duration
 }
 
-// TODO: TESTME
 // NewCheckConfig builds a new check config
 func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data) (*CheckConfig, error) {
 	instance := InstanceConfig{}
@@ -49,12 +48,12 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 
 	err := yaml.Unmarshal(rawInitConfig, &initConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid init_config: %s", err)
 	}
 
 	err = yaml.Unmarshal(rawInstance, &instance)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid instance config: %s", err)
 	}
 
 	c := &CheckConfig{}

--- a/pkg/collector/corechecks/networkpath/config_test.go
+++ b/pkg/collector/corechecks/networkpath/config_test.go
@@ -1,0 +1,59 @@
+package networkpath
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func Test_firstNonZero(t *testing.T) {
+	tests := []struct {
+		name          string
+		values        []time.Duration
+		expectedValue time.Duration
+	}{
+		{
+			name:          "no value",
+			expectedValue: 0,
+		},
+		{
+			name: "one value",
+			values: []time.Duration{
+				time.Duration(10) * time.Second,
+			},
+			expectedValue: time.Duration(10) * time.Second,
+		},
+		{
+			name: "multiple values - select first",
+			values: []time.Duration{
+				time.Duration(10) * time.Second,
+				time.Duration(20) * time.Second,
+				time.Duration(30) * time.Second,
+			},
+			expectedValue: time.Duration(10) * time.Second,
+		},
+		{
+			name: "multiple values - select second",
+			values: []time.Duration{
+				time.Duration(0) * time.Second,
+				time.Duration(20) * time.Second,
+				time.Duration(30) * time.Second,
+			},
+			expectedValue: time.Duration(20) * time.Second,
+		},
+		{
+			name: "multiple values - select third",
+			values: []time.Duration{
+				time.Duration(0) * time.Second,
+				time.Duration(0) * time.Second,
+				time.Duration(30) * time.Second,
+			},
+			expectedValue: time.Duration(30) * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedValue, firstNonZero(tt.values...))
+		})
+	}
+}

--- a/pkg/collector/corechecks/networkpath/config_test.go
+++ b/pkg/collector/corechecks/networkpath/config_test.go
@@ -73,7 +73,7 @@ hostname: 1.2.3.4
 `),
 			expectedConfig: &CheckConfig{
 				DestHostname:          "1.2.3.4",
-				MinCollectionInterval: time.Duration(15) * time.Second,
+				MinCollectionInterval: time.Duration(1) * time.Minute,
 			},
 		},
 	}

--- a/pkg/collector/corechecks/networkpath/config_test.go
+++ b/pkg/collector/corechecks/networkpath/config_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package networkpath
 
 import (

--- a/pkg/collector/corechecks/networkpath/networkpath.go
+++ b/pkg/collector/corechecks/networkpath/networkpath.go
@@ -83,6 +83,11 @@ func (c *Check) SendNetPathMDToEP(sender sender.Sender, path traceroute.NetworkP
 	return nil
 }
 
+// Interval returns the scheduling time for the check
+func (c *Check) Interval() time.Duration {
+	return c.config.MinCollectionInterval
+}
+
 // Configure the networkpath check
 func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
 	// Must be called before c.CommonConfigure


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

[corechecks/networkpath] Support min_collection_interval in init_config

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This will allow user to set the same collection interval for all instances of the network_path integration.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
