### PR TITLE
feat(ci): Improve needs condition for new-e2e tests

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -239,6 +239,7 @@ new-e2e-cws:
   needs:
     - deploy_deb_testing-a7_x64
     - qa_cws_instrumentation
+    - qa_agent
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
@@ -284,8 +285,7 @@ new-e2e-updater:
   rules:
     !reference [.on_updater_or_e2e_changes_or_manual]
   needs:
-    - job: deploy_deb_testing-u7_arm64
-      optional: true
+    - deploy_deb_testing-u7_arm64
   variables:
     TARGETS: ./tests/updater
     TEAM: fleet

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -131,34 +131,26 @@ k8s-e2e-otlp-main:
     reports:
       junit: test/new-e2e/junit-*.xml
 
-.new_e2e_template_needs_kitchen_deploy:
+.new_e2e_template_needs_deb_x64:
   extends: .new_e2e_template
   needs:
-    - job: deploy_deb_testing-a6_x64
-      optional: true
-    - job: deploy_deb_testing-a6_arm64
-      optional: true
     - job: deploy_deb_testing-a7_x64
       optional: true
-    - job: deploy_deb_testing-a7_arm64
+
+.new_e2e_template_needs_deb_windows_x64:
+  extends: .new_e2e_template
+  needs:
+    - job: deploy_deb_testing-a7_x64
       optional: true
-    - job: deploy_deb_testing-u7_arm64
+    - job: deploy_windows_testing-a7
       optional: true
-    - job: deploy_rpm_testing-a6_x64
-      optional: true
-    - job: deploy_rpm_testing-a6_arm64
+
+.new_e2e_template_needs_deb_rpm_windows_x64:
+  extends: .new_e2e_template
+  needs:
+    - job: deploy_deb_testing-a7_x64
       optional: true
     - job: deploy_rpm_testing-a7_x64
-      optional: true
-    - job: deploy_rpm_testing-a7_arm64
-      optional: true
-    - job: deploy_suse_rpm_testing_x64-a6
-      optional: true
-    - job: deploy_suse_rpm_testing_x64-a7
-      optional: true
-    - job: deploy_suse_rpm_testing_arm64-a7
-      optional: true
-    - job: deploy_windows_testing-a6
       optional: true
     - job: deploy_windows_testing-a7
       optional: true
@@ -177,10 +169,6 @@ new-e2e-containers:
   #.on_main_or_rc_and_no_skip_e2e adding on_dev_branch_manual rules
   # and move rules to template
   rules: !reference [.on_container_or_e2e_changes_or_manual]
-  needs:
-    - qa_agent
-    - qa_dca
-    - qa_dogstatsd
   variables:
     TARGETS: ./tests/containers
     TEAM: container-integrations
@@ -193,21 +181,21 @@ new-e2e-containers:
       - EXTRA_PARAMS: --skip "Test(Kind|EKS|ECS|Docker)Suite"
 
 new-e2e-remote-config:
-  extends: .new_e2e_template_needs_kitchen_deploy
+  extends: .new_e2e_template_needs_deb_x64
   rules: !reference [.on_rc_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/remote-config
     TEAM: remote-config
 
 new-e2e-agent-shared-components:
-  extends: .new_e2e_template_needs_kitchen_deploy
+  extends: .new_e2e_template_needs_deb_x64
   rules: !reference [.on_asc_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/agent-shared-components
     TEAM: agent-shared-components
 
 new-e2e-agent-subcommands:
-  extends: .new_e2e_template_needs_kitchen_deploy
+  extends: .new_e2e_template_needs_deb_windows_x64
   rules: !reference [.on_subcommands_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/agent-subcommands
@@ -233,29 +221,32 @@ new-e2e-agent-subcommands:
       - EXTRA_PARAMS: --run TestLinuxCheckSuite
 
 new-e2e-language-detection:
-  extends: .new_e2e_template_needs_kitchen_deploy
+  extends: .new_e2e_template_needs_deb_x64
   rules: !reference [.on_language-detection_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/language-detection
     TEAM: processes
 
 new-e2e-npm:
-  extends: .new_e2e_template_needs_kitchen_deploy
+  extends: .new_e2e_template_needs_deb_rpm_windows_x64
   rules: !reference [.on_npm_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/npm
     TEAM: network-performance-monitoring
 
 new-e2e-aml:
-  extends: .new_e2e_template_needs_kitchen_deploy
+  extends: .new_e2e_template_needs_deb_windows_x64
   rules: !reference [.on_aml_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/agent-metric-logs
     TEAM: agent-metric-logs
 
 new-e2e-cws:
-  extends: .new_e2e_template_needs_kitchen_deploy
+  extends: .new_e2e_template
   rules: !reference [.on_cws_or_e2e_changes_or_manual]
+  needs:
+    - deploy_deb_testing-a7_x64
+    - qa_cws_instrumentation
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
@@ -266,7 +257,7 @@ new-e2e-cws:
       - EXTRA_PARAMS: --run TestECSFargate
 
 new-e2e-process:
-  extends: .new_e2e_template_needs_kitchen_deploy
+  extends: .new_e2e_template_needs_deb_windows_x64
   rules: !reference [.on_process_or_e2e_changes_or_manual]
   variables:
     TARGETS: ./tests/process
@@ -297,9 +288,12 @@ new-e2e-apm:
       - EXTRA_PARAMS: --run TestVMFakeintakeSuiteTCP
 
 new-e2e-updater:
-  extends: .new_e2e_template_needs_kitchen_deploy
+  extends: .new_e2e_template
   rules:
     !reference [.on_updater_or_e2e_changes_or_manual]
+  needs:
+    - job: deploy_deb_testing-u7_arm64
+      optional: true
   variables:
     TARGETS: ./tests/updater
     TEAM: fleet

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -134,26 +134,13 @@ k8s-e2e-otlp-main:
 .new_e2e_template_needs_deb_x64:
   extends: .new_e2e_template
   needs:
-    - job: deploy_deb_testing-a7_x64
-      optional: true
+    - deploy_deb_testing-a7_x64
 
 .new_e2e_template_needs_deb_windows_x64:
   extends: .new_e2e_template
   needs:
-    - job: deploy_deb_testing-a7_x64
-      optional: true
-    - job: deploy_windows_testing-a7
-      optional: true
-
-.new_e2e_template_needs_deb_rpm_windows_x64:
-  extends: .new_e2e_template
-  needs:
-    - job: deploy_deb_testing-a7_x64
-      optional: true
-    - job: deploy_rpm_testing-a7_x64
-      optional: true
-    - job: deploy_windows_testing-a7
-      optional: true
+    - deploy_deb_testing-a7_x64
+    - deploy_windows_testing-a7
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template
@@ -228,8 +215,13 @@ new-e2e-language-detection:
     TEAM: processes
 
 new-e2e-npm:
-  extends: .new_e2e_template_needs_deb_rpm_windows_x64
+  extends: .new_e2e_template
   rules: !reference [.on_npm_or_e2e_changes_or_manual]
+  needs:
+    - qa_agent
+    - deploy_deb_testing-a7_x64
+    - deploy_rpm_testing-a7_x64
+    - deploy_windows_testing-a7
   variables:
     TARGETS: ./tests/npm
     TEAM: network-performance-monitoring

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -21,59 +21,77 @@
   - export DATADOG_AGENT_APP_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $E2E_TESTS_APP_KEY_SSM_NAME)
   - export DATADOG_AGENT_RC_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $E2E_TESTS_RC_KEY_SSM_NAME)
 
-k8s-e2e-cws-dev:
+.k8s_e2e_template_needs_dev:
   extends: .k8s_e2e_template
-  rules: !reference [.on_dev_branch_manual]
-  needs: []
+  needs:
+    - dev_branch_multiarch-a7
+    - dca_dev_branch
+
+.k8s_e2e_template_dev:
+  extends: .k8s_e2e_template_needs_dev
+  script:
+    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=$ARGO_WORKFLOW
+
+.k8s_e2e_template_dev_with_cws_cspm_init:
+  extends: .k8s_e2e_template_needs_dev
   script:
     - !reference [.k8s-e2e-cws-cspm-init]
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=cws
+    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=$ARGO_WORKFLOW
+
+.k8s_e2e_template_needs_main:
+  extends: .k8s_e2e_template
+  needs:
+    - dev_master-a7
+    - dca_dev_master
+
+.k8s_e2e_template_main_with_cws_cspm_init:
+  extends: .k8s_e2e_template_needs_main
+  script:
+    - !reference [.k8s-e2e-cws-cspm-init]
+    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=$ARGO_WORKFLOW
+
+.k8s_e2e_template_main:
+  extends: .k8s_e2e_template_needs_main
+  script:
+    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=$ARGO_WORKFLOW
+
+k8s-e2e-cws-dev:
+  extends: .k8s_e2e_template_dev_with_cws_cspm_init
+  rules: !reference [.on_dev_branch_manual]
+  variables:
+    ARGO_WORKFLOW: cws
 
 k8s-e2e-cws-main:
-  extends: .k8s_e2e_template
+  extends: .k8s_e2e_template_main_with_cws_cspm_init
   rules: !reference [.on_main]
-  # needs:
-  #   - dev_master-a6
-  #   - dev_master-a7
   retry: 1
-  script:
-    - !reference [.k8s-e2e-cws-cspm-init]
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=cws
+  variables:
+    ARGO_WORKFLOW: cws
 
 k8s-e2e-cspm-dev:
-  extends: .k8s_e2e_template
+  extends: .k8s_e2e_template_dev_with_cws_cspm_init
   rules: !reference [.on_dev_branch_manual]
-  needs: []
-  script:
-    - !reference [.k8s-e2e-cws-cspm-init]
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=cspm
+  variables:
+    ARGO_WORKFLOW: cspm
 
 k8s-e2e-cspm-main:
-  extends: .k8s_e2e_template
+  extends: .k8s_e2e_template_main_with_cws_cspm_init
   rules: !reference [.on_main]
-  # needs:
-  #   - dev_master-a6
-  #   - dev_master-a7
   retry: 1
-  script:
-    - !reference [.k8s-e2e-cws-cspm-init]
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=cspm
+  variables:
+    ARGO_WORKFLOW: cspm
 
 k8s-e2e-otlp-dev:
-  extends: .k8s_e2e_template
+  extends: .k8s_e2e_template_dev
   rules: !reference [.on_dev_branch_manual]
-  needs: [] # we can't explicitly define the dependencies because a job cannot depend on other manual jobs.
-  script:
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 --dca-image=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG} --argo-workflow=otlp
+  variables:
+    ARGO_WORKFLOW: otlp
 
 k8s-e2e-otlp-main:
-  extends: .k8s_e2e_template
+  extends: .k8s_e2e_template_main
   rules: !reference [.on_main]
-  # needs:
-  #   - dev_master-a6
-  #   - dev_master-a7
-  script:
-    - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=otlp
+  variables:
+    ARGO_WORKFLOW: otlp
 
 .new_e2e_template:
   stage: e2e
@@ -113,8 +131,48 @@ k8s-e2e-otlp-main:
     reports:
       junit: test/new-e2e/junit-*.xml
 
-new-e2e-containers:
+.new_e2e_template_needs_kitchen_deploy:
   extends: .new_e2e_template
+  needs:
+    - job: deploy_deb_testing-a6_x64
+      optional: true
+    - job: deploy_deb_testing-a6_arm64
+      optional: true
+    - job: deploy_deb_testing-a7_x64
+      optional: true
+    - job: deploy_deb_testing-a7_arm64
+      optional: true
+    - job: deploy_deb_testing-u7_arm64
+      optional: true
+    - job: deploy_rpm_testing-a6_x64
+      optional: true
+    - job: deploy_rpm_testing-a6_arm64
+      optional: true
+    - job: deploy_rpm_testing-a7_x64
+      optional: true
+    - job: deploy_rpm_testing-a7_arm64
+      optional: true
+    - job: deploy_suse_rpm_testing_x64-a6
+      optional: true
+    - job: deploy_suse_rpm_testing_x64-a7
+      optional: true
+    - job: deploy_suse_rpm_testing_arm64-a7
+      optional: true
+    - job: deploy_windows_testing-a6
+      optional: true
+    - job: deploy_windows_testing-a7
+      optional: true
+
+.new_e2e_template_needs_container_deploy:
+  extends: .new_e2e_template
+  needs:
+    - qa_agent
+    - qa_dca
+    - qa_dogstatsd
+
+new-e2e-containers:
+  extends:
+    - .new_e2e_template_needs_container_deploy
   # TODO once images are deployed to ECR for dev branches, update
   #.on_main_or_rc_and_no_skip_e2e adding on_dev_branch_manual rules
   # and move rules to template
@@ -135,25 +193,22 @@ new-e2e-containers:
       - EXTRA_PARAMS: --skip "Test(Kind|EKS|ECS|Docker)Suite"
 
 new-e2e-remote-config:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_rc_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/remote-config
     TEAM: remote-config
 
 new-e2e-agent-shared-components:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_asc_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/agent-shared-components
     TEAM: agent-shared-components
 
 new-e2e-agent-subcommands:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_subcommands_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/agent-subcommands
     TEAM: agent-shared-components
@@ -178,33 +233,29 @@ new-e2e-agent-subcommands:
       - EXTRA_PARAMS: --run TestLinuxCheckSuite
 
 new-e2e-language-detection:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_language-detection_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/language-detection
     TEAM: processes
 
 new-e2e-npm:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_npm_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7", "qa_agent"]
   variables:
     TARGETS: ./tests/npm
     TEAM: network-performance-monitoring
 
 new-e2e-aml:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_aml_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/agent-metric-logs
     TEAM: agent-metric-logs
 
 new-e2e-cws:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_cws_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7", "qa_agent", "qa_cws_instrumentation"]
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
@@ -215,28 +266,23 @@ new-e2e-cws:
       - EXTRA_PARAMS: --run TestECSFargate
 
 new-e2e-process:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules: !reference [.on_process_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-a7_x64", "deploy_windows_testing-a7"]
   variables:
     TARGETS: ./tests/process
     TEAM: processes
 
 new-e2e-orchestrator:
-  extends: .new_e2e_template
-  rules: !reference [.on_orchestrator_or_e2e_changes_or_manual]
-  needs:
-    - qa_agent
-    - qa_dca
-    - qa_dogstatsd
+  extends:
+    - .new_e2e_template_needs_container_deploy
+  rules: !reference [.on_main_or_rc_and_no_skip_e2e]
   variables:
     TARGETS: ./tests/orchestrator
     TEAM: container-app
 
 new-e2e-apm:
   extends: .new_e2e_template
-  rules:
-    !reference [.on_apm_or_e2e_changes_or_manual]
+  rules: !reference [.on_apm_or_e2e_changes_or_manual]
   needs:
     - qa_agent
     - deploy_deb_testing-a7_x64
@@ -251,10 +297,9 @@ new-e2e-apm:
       - EXTRA_PARAMS: --run TestVMFakeintakeSuiteTCP
 
 new-e2e-updater:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_kitchen_deploy
   rules:
     !reference [.on_updater_or_e2e_changes_or_manual]
-  needs: ["deploy_deb_testing-u7_arm64"]
   variables:
     TARGETS: ./tests/updater
     TEAM: fleet


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add precise needs condition for all new-e2e tests
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Prevent faliures for test not having the correct definition (`npm`) and accelerate execution for others

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
I initially wanted to put a default condition on the template but it induces issues.
CWS e2e tests seems not to require the `qa_agent` job
- [test fargate](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/463225878)
- [test AgentSuite](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/463367701)

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
