### PR TITLE
feat(ci): continue retries when jobs are not created in macos

### DIFF
--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -27,7 +27,7 @@ def concurrency_key():
     current_ref = get_git_pretty_ref()
 
     # We want workflows to run to completion on the default branch and release branches
-    if re.search(r'^.*$', current_ref):
+    if re.search(rf'^({DEFAULT_BRANCH}|\d+\.\d+\.x)$', current_ref):
         return None
 
     return current_ref

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -27,7 +27,7 @@ def concurrency_key():
     current_ref = get_git_pretty_ref()
 
     # We want workflows to run to completion on the default branch and release branches
-    if re.search(rf'^({DEFAULT_BRANCH}|\d+\.\d+\.x)$', current_ref):
+    if re.search(r'^.*$', current_ref):
         return None
 
     return current_ref

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -93,7 +93,7 @@ def trigger_macos_workflow(
     # Adding another hack to check if the workflow is not waiting a concurrency to be solved before generating the workflow jobs
     might_be_waiting = set()
 
-    MAX_WAITING_CONCURRENCY_RETRIES = 3  # Retries for up to 1h30
+    MAX_WAITING_CONCURRENCY_RETRIES = 3  # Retries for up to 1h45
     MAX_RETRIES = 30  # Retry for up to 5 minutes
     for i in range(MAX_WAITING_CONCURRENCY_RETRIES):
         for j in range(MAX_RETRIES):
@@ -101,8 +101,6 @@ def trigger_macos_workflow(
             recent_runs = gh.workflow_run_for_ref_after_date(workflow_name, github_action_ref, now)
             for recent_run in recent_runs:
                 jobs = recent_run.jobs()
-                if jobs.totalCount == 0:
-                    might_be_waiting.add(recent_run.id)
                 if jobs.totalCount >= 2:
                     if recent_run.id in might_be_waiting:
                         might_be_waiting.remove(recent_run.id)
@@ -110,7 +108,8 @@ def trigger_macos_workflow(
                         if any([step.name == workflow_id for step in job.steps]):
                             return recent_run
                 else:
-                    print("waiting for jobs to popup...")
+                    might_be_waiting.add(recent_run.id)
+                    print(f"{might_be_waiting} workflows are waiting for jobs to popup...")
                     sleep(5)
             sleep(10)
         if len(might_be_waiting) != 0:

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -63,8 +63,12 @@ def trigger_macos_workflow(
     if "GO_TEST_SKIP_FLAKE" in os.environ and workflow_name == "test.yaml":
         inputs["go_test_skip_flake"] = os.environ["GO_TEST_SKIP_FLAKE"]
 
-    # The workflow trigger endpoint doesn't return anything. You need to fetch the workflow run id
-    # by yourself.
+    # The workflow trigger endpoint doesn't return anything.
+    # You need to create a workflow UUID and fetch it by yourself.
+    # See the following
+    #  - https://github.com/orgs/community/discussions/9752
+    #  - https://github.com/orgs/community/discussions/27226
+    #  - https://stackoverflow.com/questions/69479400/get-run-id-after-triggering-a-github-workflow-dispatch-event
     workflow_id = str(uuid.uuid1())
     inputs["id"] = workflow_id
 
@@ -73,7 +77,7 @@ def trigger_macos_workflow(
             github_action_ref, "\n".join([f"  - {k}: {inputs[k]}" for k in inputs])
         )
     )
-    # Hack: get current time to only fetch workflows that started after now.
+    # Hack: get current time to only fetch workflows that started after now
     now = datetime.utcnow()
 
     gh = GithubAPI('DataDog/datadog-agent-macos-build')
@@ -86,20 +90,35 @@ def trigger_macos_workflow(
     # Thus the following hack: Send an id as input when creating a workflow on Github. The worklow will use the id and put it in the name of one of its jobs.
     # We then fetch workflows and check if it contains the id in its job name.
 
+    # Adding another hack to check if the workflow is not waiting a concurrency to be solved before generating the workflow jobs
+    might_be_waiting = set()
+
+    MAX_WAITING_CONCURRENCY_RETRIES = 3  # Retries for up to 1h30
     MAX_RETRIES = 30  # Retry for up to 5 minutes
-    for i in range(MAX_RETRIES):
-        print(f"Fetching triggered workflow (try {i + 1}/{MAX_RETRIES})")
-        recent_runs = gh.workflow_run_for_ref_after_date(workflow_name, github_action_ref, now)
-        for recent_run in recent_runs:
-            jobs = recent_run.jobs()
-            if jobs.totalCount >= 2:
-                for job in jobs:
-                    if any([step.name == workflow_id for step in job.steps]):
-                        return recent_run
-            else:
-                print("waiting for jobs to popup...")
-                sleep(5)
-        sleep(10)
+    for i in range(MAX_WAITING_CONCURRENCY_RETRIES):
+        for j in range(MAX_RETRIES):
+            print(f"Fetching triggered workflow (try {j + 1}/{MAX_RETRIES})")
+            recent_runs = gh.workflow_run_for_ref_after_date(workflow_name, github_action_ref, now)
+            for recent_run in recent_runs:
+                jobs = recent_run.jobs()
+                if jobs.totalCount == 0:
+                    might_be_waiting.add(recent_run.id)
+                if jobs.totalCount >= 2:
+                    if recent_run.id in might_be_waiting:
+                        might_be_waiting.remove(recent_run.id)
+                    for job in jobs:
+                        if any([step.name == workflow_id for step in job.steps]):
+                            return recent_run
+                else:
+                    print("waiting for jobs to popup...")
+                    sleep(5)
+            sleep(10)
+        if len(might_be_waiting) != 0:
+            print(f"Couldn't find a workflow with expected jobs, and {might_be_waiting} are workflows with no jobs")
+            print(
+                f"This is maybe due to a concurrency issue, retrying ({i + 1}/{MAX_WAITING_CONCURRENCY_RETRIES}) in 30 min"
+            )
+            sleep(1800)
 
     # Something went wrong :(
     print("Couldn't fetch workflow run that was triggered.")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Wait more time for job completion when a workflow can be blocked by another one on main/release branches (as there is concurrency but not cancellation)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Everyday we have 2 scheduled jobs on main that starts at the same time and can conflict with each other on github side. Currently the concurrent job fails within 5 min as it can't retrieve its associated workflow: it's created but it has no jobs so the matching with workflow id (which is the job name) cannot be done.
This hack allows waiting a longer time when the gitlab jobs founds a workflow with no jobs.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Test was done with a [commit](https://github.com/DataDog/datadog-agent/commit/7fcc3cbf78a4b0756351d9a58c887a9866458b94) preventing concurrency cancellation on branch
- First pipeline created, [lint job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/462989410) fetched his associated [github workflow](https://github.com/DataDog/datadog-agent-macos-build/actions/runs/8340397742)
- Second pipeline created at same time, [lint job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/462988314) is blocked and waiting for github workflow to generate his jobs.
![image](https://github.com/DataDog/datadog-agent/assets/24426034/ab2596a2-5ace-4a38-a5e0-d471a051a1de)


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
