### PR TITLE
Add `ns` suffix to agent_startup_time inventoryhost metadata payload to add time's order of magnitude

### DIFF
--- a/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost.go
+++ b/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost.go
@@ -84,7 +84,7 @@ type hostMetadata struct {
 
 	// from the agent itself
 	AgentVersion           string `json:"agent_version"`
-	AgentStartupTime       int64  `json:"agent_startup_time"`
+	AgentStartupTime       int64  `json:"agent_startup_time_ns"`
 	CloudProvider          string `json:"cloud_provider"`
 	CloudProviderSource    string `json:"cloud_provider_source"`
 	CloudProviderAccountID string `json:"cloud_provider_account_id"`


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Little update on field name to complete this PR: https://github.com/DataDog/datadog-agent/pull/23683.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Give more details to the payload consumer.
