### PR TITLE
feat(ci): Fix the datadog-ci-uploader image before its removal

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,6 +181,7 @@ variables:
   DATADOG_AGENT_NIKOS_BUILDIMAGES: v30094440-66830d2d
   DATADOG_AGENT_BTF_GEN_BUILDIMAGES_SUFFIX: ""
   DATADOG_AGENT_BTF_GEN_BUILDIMAGES: v30094440-66830d2d
+  DATADOG_CI_UPLOADER_IMAGE: v30094440-66830d2d
   # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""

--- a/.gitlab/e2e_test_junit_upload/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload/e2e_test_junit_upload.yml
@@ -1,5 +1,5 @@
 .e2e_test_junit_template:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader:$DATADOG_CI_UPLOADER_IMAGE
   tags: ["arch:amd64"]
   allow_failure: true
   variables:

--- a/.gitlab/functional_test_junit_upload/functional_test_junit_upload_security-agent.yml
+++ b/.gitlab/functional_test_junit_upload/functional_test_junit_upload_security-agent.yml
@@ -3,7 +3,7 @@ functional_test_junit_upload_security_agent:
   rules:
     - !reference [.except_mergequeue]
     - when: always
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader:$DATADOG_CI_UPLOADER_IMAGE
   tags: ["arch:amd64"]
   allow_failure: true
   needs:

--- a/.gitlab/functional_test_junit_upload/functional_test_junit_upload_system_probe.yml
+++ b/.gitlab/functional_test_junit_upload/functional_test_junit_upload_system_probe.yml
@@ -6,7 +6,7 @@ functional_test_junit_upload_system_probe:
   rules:
     - !reference [.except_mergequeue]
     - when: always
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader:$DATADOG_CI_UPLOADER_IMAGE
   tags: ["arch:amd64"]
   allow_failure: true
   needs:
@@ -22,7 +22,7 @@ functional_test_junit_upload_system_probe:
 
 .functional_test_junit_upload_kmt:
   stage: functional_test_junit_upload
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader:$DATADOG_CI_UPLOADER_IMAGE
   tags: ["arch:amd64"]
   allow_failure: true
   rules:

--- a/.gitlab/kitchen_tests_upload/kitchen_tests_upload.yml
+++ b/.gitlab/kitchen_tests_upload/kitchen_tests_upload.yml
@@ -1,6 +1,6 @@
 kitchen_tests_upload_common:
   stage: kitchen_tests_upload
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader:$DATADOG_CI_UPLOADER_IMAGE
   tags: ["arch:amd64"]
   allow_failure: true
   rules:

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -45,7 +45,7 @@ notify:
 send_pipeline_stats:
   stage: notify
   # Using a buildimage image with python 3.7+, datadog-api-client and invoke installed
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader:$DATADOG_CI_UPLOADER_IMAGE
   tags: ["arch:amd64"]
   when: always
   dependencies: []

--- a/.gitlab/source_test_junit_upload/source_test_junit_upload.yml
+++ b/.gitlab/source_test_junit_upload/source_test_junit_upload.yml
@@ -3,7 +3,7 @@ source_test_junit_upload:
     - !reference [.except_mergequeue]
     - when: always
   stage: source_test_junit_upload
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader:$DATADOG_CI_UPLOADER_IMAGE
   tags: ["arch:amd64"]
   allow_failure: true
   variables:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Remove the `datadog-ci-uploader` image from the list of buildimage dependencies

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
As per #22134 the use of the uploader image should vanish. This PR fixes the image to prevent an image modification between merge of [buildimage pr](https://github.com/DataDog/datadog-agent-buildimages/pull/517) and the agent one

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
