### PR TITLE
test/new-e2e/tests/apm: do not manually pull tracegen image

### DIFF
--- a/test/new-e2e/tests/apm/tracegen.go
+++ b/test/new-e2e/tests/apm/tracegen.go
@@ -35,7 +35,6 @@ type tracegenCfg struct {
 }
 
 func runTracegenDocker(h *components.RemoteHost, service string, cfg tracegenCfg) (shutdown func()) {
-	pullLatest(h)
 	var run, rm string
 	if cfg.transport == uds {
 		run, rm = tracegenUDSCommands(service)
@@ -45,10 +44,6 @@ func runTracegenDocker(h *components.RemoteHost, service string, cfg tracegenCfg
 	h.MustExecute(rm) // kill any existing leftover container
 	h.MustExecute(run)
 	return func() { h.MustExecute(rm) }
-}
-
-func pullLatest(h *components.RemoteHost) {
-	h.MustExecute("docker pull ghcr.io/datadog/apps-tracegen:main")
 }
 
 func tracegenUDSCommands(service string) (string, string) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This causes the e2e apm tests *not* to pull the latest version of tracegen explicitly.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

It is not necessary to pull the image, and this explicit pull was causing timeouts in the tests.


