### PR TITLE
feat(fakeintake): remove store.jsonPayloads to reduce memory footprint

### DIFF
--- a/test/fakeintake/server/server_test.go
+++ b/test/fakeintake/server/server_test.go
@@ -20,10 +20,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 )
 
 func TestServer(t *testing.T) {

--- a/test/fakeintake/server/serverstore/store.go
+++ b/test/fakeintake/server/serverstore/store.go
@@ -118,7 +118,7 @@ func (s *Store) Flush() {
 }
 
 // encodeToJSONRawPayload used to decode a raw Payload into a Json Payload
-// to how to parse the raw payload that could be JSON or Protobuf, the function
+// to know how to parse the raw payload that could be JSON or Protobuf, the function
 // need to know the route.
 func (s *Store) encodeToJSONRawPayload(rawPayload api.Payload, route string) (*api.ParsedPayload, error) {
 	if parsePayload, ok := parserMap[route]; ok {

--- a/test/fakeintake/server/serverstore/store.go
+++ b/test/fakeintake/server/serverstore/store.go
@@ -8,20 +8,21 @@
 package serverstore
 
 import (
+	"fmt"
 	"log"
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 )
 
 // Store implements a thread-safe storage for raw and json dumped payloads
 type Store struct {
 	mutex sync.RWMutex
 
-	rawPayloads  map[string][]api.Payload
-	jsonPayloads map[string][]api.ParsedPayload
+	rawPayloads map[string][]api.Payload
 
 	NbPayloads *prometheus.GaugeVec
 }
@@ -29,9 +30,8 @@ type Store struct {
 // NewStore initialise a new payloads store
 func NewStore() *Store {
 	return &Store{
-		mutex:        sync.RWMutex{},
-		rawPayloads:  map[string][]api.Payload{},
-		jsonPayloads: map[string][]api.ParsedPayload{},
+		mutex:       sync.RWMutex{},
+		rawPayloads: map[string][]api.Payload{},
 		NbPayloads: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "payloads",
 			Help: "Number of payloads collected by route",
@@ -40,7 +40,7 @@ func NewStore() *Store {
 }
 
 // AppendPayload adds a payload to the store and tries parsing and adding a dumped json to the parsed store
-func (s *Store) AppendPayload(route string, data []byte, encoding string, collectTime time.Time) error {
+func (s *Store) AppendPayload(route string, data []byte, encoding string, collectTime time.Time) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	rawPayload := api.Payload{
@@ -50,25 +50,6 @@ func (s *Store) AppendPayload(route string, data []byte, encoding string, collec
 	}
 	s.rawPayloads[route] = append(s.rawPayloads[route], rawPayload)
 	s.NbPayloads.WithLabelValues(route).Set(float64(len(s.rawPayloads[route])))
-	return s.tryParseAndAppendPayload(rawPayload, route)
-}
-
-func (s *Store) tryParseAndAppendPayload(rawPayload api.Payload, route string) error {
-	if parsePayload, ok := parserMap[route]; ok {
-		var err error
-		data, err := parsePayload(rawPayload)
-		if err != nil {
-			return err
-		}
-		parsedPayload := api.ParsedPayload{
-			Timestamp: rawPayload.Timestamp,
-			Data:      data,
-			Encoding:  rawPayload.Encoding,
-		}
-
-		s.jsonPayloads[route] = append(s.jsonPayloads[route], parsedPayload)
-	}
-	return nil
 }
 
 // CleanUpPayloadsOlderThan removes payloads older than time
@@ -87,17 +68,6 @@ func (s *Store) CleanUpPayloadsOlderThan(time time.Time) {
 		s.rawPayloads[route] = s.rawPayloads[route][lastInvalidPayloadIndex+1:]
 		s.NbPayloads.WithLabelValues(route).Set(float64(len(s.rawPayloads[route])))
 	}
-	// clean up parsed payloads
-	for route, payloads := range s.jsonPayloads {
-		// cleanup raw store
-		lastInvalidPayloadIndex := -1
-		for i, payload := range payloads {
-			if payload.Timestamp.Before(time) {
-				lastInvalidPayloadIndex = i
-			}
-		}
-		s.jsonPayloads[route] = s.jsonPayloads[route][lastInvalidPayloadIndex+1:]
-	}
 }
 
 // GetRawPayloads returns payloads collected for route `route`
@@ -110,12 +80,22 @@ func (s *Store) GetRawPayloads(route string) (payloads []api.Payload) {
 }
 
 // GetJSONPayloads returns payloads collected and parsed to json for route `route`
-func (s *Store) GetJSONPayloads(route string) (payloads []api.ParsedPayload) {
+func (s *Store) GetJSONPayloads(route string) (payloads []api.ParsedPayload, err error) {
+	if _, found := parserMap[route]; !found {
+		// Short path to returns directly if no parser is registered for the given route.
+		// No need to acquire the lock in that case.
+		return nil, fmt.Errorf("Json payload not supported for this route")
+	}
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
-	payloads = make([]api.ParsedPayload, len(s.jsonPayloads[route]))
-	copy(payloads, s.jsonPayloads[route])
-	return payloads
+
+	payloads = make([]api.ParsedPayload, 0, len(s.rawPayloads[route]))
+	for _, raw := range s.rawPayloads[route] {
+		if jsonPayload, err := s.encodeToJSONRawPayload(raw, route); err == nil && jsonPayload != nil {
+			payloads = append(payloads, *jsonPayload)
+		}
+	}
+	return payloads, nil
 }
 
 // GetRouteStats returns stats on collectedraw payloads by route
@@ -134,6 +114,25 @@ func (s *Store) Flush() {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.rawPayloads = map[string][]api.Payload{}
-	s.jsonPayloads = map[string][]api.ParsedPayload{}
 	s.NbPayloads.Reset()
+}
+
+// encodeToJSONRawPayload used to decode a raw Payload into a Json Payload
+// to how to parse the raw payload that could be JSON or Protobuf, the function
+// need to know the route.
+func (s *Store) encodeToJSONRawPayload(rawPayload api.Payload, route string) (*api.ParsedPayload, error) {
+	if parsePayload, ok := parserMap[route]; ok {
+		var err error
+		data, err := parsePayload(rawPayload)
+		if err != nil {
+			return nil, err
+		}
+		parsedPayload := &api.ParsedPayload{
+			Timestamp: rawPayload.Timestamp,
+			Data:      data,
+			Encoding:  rawPayload.Encoding,
+		}
+		return parsedPayload, nil
+	}
+	return nil, nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The goal of this commit is to use reduce the "fakeintake" memory usage
by removing the `store.jsonPayloads` and only produce the JSON payload
only at query time.
This should reduce the overall memory usage of this process and so reduce
the OOM occurence during end2end tests execustion.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

It doesn't make sense to store twice the data into the fakeintake memory. 
It seems more efficience to encode the rawPayload into json at query time
since not every test scenario is using this functionality.

The fakeintake will still allocate a good amount of memory to encode and put everything in one payload.
But it should still be less memory since previously we were also doing a copy of the jsonPayload.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Not QA needed, to validate end2end tests should past.
