### PR TITLE
upgrade(updater): Add option to override the base registry URL

### DIFF
--- a/comp/updater/updater/updaterimpl/updater.go
+++ b/comp/updater/updater/updaterimpl/updater.go
@@ -46,7 +46,7 @@ func newUpdaterComponent(lc fx.Lifecycle, dependencies dependencies) (updatercom
 	if !ok {
 		return nil, errRemoteConfigRequired
 	}
-	updater, err := updater.NewUpdater(remoteConfig)
+	updater, err := updater.NewUpdater(remoteConfig, dependencies.Config)
 	if err != nil {
 		return nil, fmt.Errorf("could not create updater: %w", err)
 	}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1324,6 +1324,9 @@ func InitConfig(config pkgconfigmodel.Config) {
 	OTLP(config)
 	setupProcesses(config)
 	setupHighAvailability(config)
+
+	// Updater configuration
+	config.BindEnv("updater.registry")
 }
 
 // LoadProxyFromEnv overrides the proxy settings with environment variables

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -74,7 +74,7 @@ func (c *testRemoteConfigClient) SubmitRequest(request remoteAPIRequest) {
 
 func newTestUpdater(t *testing.T, s *testFixturesServer, rcc *testRemoteConfigClient, defaultFixture fixture) *updaterImpl {
 	rc := &remoteConfig{client: rcc}
-	u := newUpdater(rc, t.TempDir(), t.TempDir())
+	u := newUpdater(rc, t.TempDir(), t.TempDir(), "")
 	u.installer.configsDir = t.TempDir()
 	u.catalog = s.Catalog()
 	u.bootstrapVersions[defaultFixture.pkg] = defaultFixture.version


### PR DESCRIPTION
### What does this PR do?
Adds a config parameter to let customers set up their own repository (including namespaces) to pull remote updates OCI  images.

### Motivation
Let customers use the best registry for them (closest one, one their replicate...)

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
Run an agent with `updater.repository` set
