### PR TITLE
Do not test hostname in apm config mock test

### DIFF
--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -2517,6 +2517,8 @@ func TestMockConfig(t *testing.T) {
 		fx.Supply(corecomp.Params{}),
 		corecomp.MockModule(),
 		MockModule(),
+		// disable fetching the hostname from the core agent
+		fx.Replace(corecomp.MockParams{Overrides: map[string]interface{}{"serverless.enabled": true}}),
 	))
 	// underlying config
 	cfg := config.Object()

--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -2507,9 +2507,6 @@ func TestGenerateInstallSignature(t *testing.T) {
 }
 
 func TestMockConfig(t *testing.T) {
-	os.Setenv("DD_HOSTNAME", "foo")
-	defer func() { os.Unsetenv("DD_HOSTNAME") }()
-
 	os.Setenv("DD_SITE", "datadoghq.eu")
 	defer func() { os.Unsetenv("DD_SITE") }()
 
@@ -2517,15 +2514,12 @@ func TestMockConfig(t *testing.T) {
 		fx.Supply(corecomp.Params{}),
 		corecomp.MockModule(),
 		MockModule(),
-		// disable fetching the hostname from the core agent
-		fx.Replace(corecomp.MockParams{Overrides: map[string]interface{}{"serverless.enabled": true}}),
 	))
 	// underlying config
 	cfg := config.Object()
 	require.NotNil(t, cfg)
 
 	// values aren't set from env..
-	assert.NotEqual(t, "foo", cfg.Hostname)
 	assert.NotEqual(t, "datadoghq.eu", cfg.Site)
 
 	// but defaults are set


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Stop testing the hostname in config mock APM test.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Have the test succeed when running locally.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The test exports `DD_HOSTNAME=foo` and checks that the APM config doesn't read that variable.
When initializing the APM config, it will try to contact the core agent to fetch the hostname:
- it will try grpc first, which will fail
- then as a fallback it will try to run the agent binary hostname subcommand (`/opt/datadog-agent/bin/agent/agent hostname` on MacOS)
I suspect that in the CI there is no such binary, so it fails and nothing happens, but when running locally the binary really exists
And since `DD_HOSTNAME=foo` is set in the environment, this is given to `agent hostname`, which will happily return it, and eventually the hostname is really set to `foo`.

Following a review comment, I just removed the `hostname` part of the test since it already does the same kind of checks with `site` anyway.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
