### PR TITLE
Add invoke task to bump test infra definition

### DIFF
--- a/tasks/buildimages.py
+++ b/tasks/buildimages.py
@@ -33,4 +33,4 @@ def update_test_infra_definitions(ctx: Context, commit_sha: str):
     update_test_infra_def(".gitlab-ci.yml", commit_sha[:12])
     os.chdir("test/new-e2e")
     ctx.run(f"go get github.com/DataDog/test-infra-definitions@{commit_sha}")
-    ctx.run(f"go mod tidy")
+    ctx.run("go mod tidy")

--- a/tasks/buildimages.py
+++ b/tasks/buildimages.py
@@ -1,8 +1,9 @@
+import os
 from typing import Optional
 
 from invoke import Context, task
 
-from tasks.pipeline import update_circleci_config, update_gitlab_config
+from tasks.pipeline import update_circleci_config, update_gitlab_config, update_test_infra_def
 
 
 @task(
@@ -18,3 +19,17 @@ def update(_: Context, image_tag: str, test_version: Optional[str] = True):
     """
     update_gitlab_config(".gitlab-ci.yml", image_tag, test_version=test_version)
     update_circleci_config(".circleci/config.yml", image_tag, test_version=test_version)
+
+
+@task(
+    help={
+        "commit_sha": "commit sha from the test-infra-definitions repository"
+    }
+)
+def update_test_infra_definitions(ctx: Context, commit_sha: str):
+    """
+    Update the test-infra-definition image version in the Gitlab CI as well as in the e2e go.mod
+    """
+    update_test_infra_def(".gitlab-ci.yml", commit_sha[:12])
+    os.chdir("test/new-e2e")
+    ctx.run(f"go get github.com/DataDog/test-infra-definitions@{commit_sha}")

--- a/tasks/buildimages.py
+++ b/tasks/buildimages.py
@@ -21,11 +21,7 @@ def update(_: Context, image_tag: str, test_version: Optional[str] = True):
     update_circleci_config(".circleci/config.yml", image_tag, test_version=test_version)
 
 
-@task(
-    help={
-        "commit_sha": "commit sha from the test-infra-definitions repository"
-    }
-)
+@task(help={"commit_sha": "commit sha from the test-infra-definitions repository"})
 def update_test_infra_definitions(ctx: Context, commit_sha: str):
     """
     Update the test-infra-definition image version in the Gitlab CI as well as in the e2e go.mod

--- a/tasks/buildimages.py
+++ b/tasks/buildimages.py
@@ -33,3 +33,4 @@ def update_test_infra_definitions(ctx: Context, commit_sha: str):
     update_test_infra_def(".gitlab-ci.yml", commit_sha[:12])
     os.chdir("test/new-e2e")
     ctx.run(f"go get github.com/DataDog/test-infra-definitions@{commit_sha}")
+    ctx.run(f"go mod tidy")

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -729,6 +729,21 @@ def verify_workspace(ctx, branch_name=None):
     return branch_name
 
 
+def update_test_infra_def(file_path, image_tag):
+    """
+    Override TEST_INFRA_DEFINITIONS_BUILDIMAGES in .gitlab-ci.yml file
+    """
+    with open(file_path, "r") as gl:
+        file_content = gl.readlines()
+    with open(file_path, "w") as gl:
+        for line in file_content:
+            test_infra_def = re.search(fr"TEST_INFRA_DEFINITIONS_BUILDIMAGES:\s*(\w+)", line)
+            if test_infra_def:
+                gl.write(line.replace(test_infra_def.group(1), image_tag))
+            else:
+                gl.write(line)
+
+
 def update_gitlab_config(file_path, image_tag, test_version):
     """
     Override variables in .gitlab-ci.yml file

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -737,7 +737,7 @@ def update_test_infra_def(file_path, image_tag):
         file_content = gl.readlines()
     with open(file_path, "w") as gl:
         for line in file_content:
-            test_infra_def = re.search(fr"TEST_INFRA_DEFINITIONS_BUILDIMAGES:\s*(\w+)", line)
+            test_infra_def = re.search(r"TEST_INFRA_DEFINITIONS_BUILDIMAGES:\s*(\w+)", line)
             if test_infra_def:
                 gl.write(line.replace(test_infra_def.group(1), image_tag))
             else:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds an invoke task to make it easier to bump the `TEST_INFRA_DEFINITIONS_BUILDIMAGES` version in the repository.
It will also sync the `test/new-e2e/go.mod` file.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Faster & error-less bump of the test-infra-definition version in the repository.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Example usage:
```
> invoke buildimages.update-test-infra-definitions --commit-sha d7725918db38ded91d9b17dda7801552f49dfcf5
go: upgraded github.com/DataDog/test-infra-definitions v0.0.0-20240318100125-f2ab6e511638 => v0.0.0-20240319181143-d7725918db38
```

https://datadoghq.atlassian.net/browse/WINA-653

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
