### PR TITLE
[CWS] use generic `SortFunc` when guessing the service tag

### DIFF
--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -9,7 +9,8 @@
 package probe
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
@@ -24,8 +25,8 @@ func bestGuessServiceTag(serviceValues []string) string {
 	firstGuess := serviceValues[0]
 
 	// first we sort base on len, biggest len first
-	sort.Slice(serviceValues, func(i, j int) bool {
-		return len(serviceValues[j]) < len(serviceValues[i]) // reverse
+	slices.SortFunc(serviceValues, func(a, b string) int {
+		return cmp.Compare(len(b), len(a)) // reverse
 	})
 
 	// we then compare [i] and [i + 1] to check if [i + 1] is a prefix of [i]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR reduces some usage of reflect (in legacy sort function) and replaces it with the new style generic based sorting function.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
