### PR TITLE
[CSPM] dbs: allow empty configurations for mongo and postgres

### DIFF
--- a/pkg/compliance/dbconfig/loader.go
+++ b/pkg/compliance/dbconfig/loader.go
@@ -167,6 +167,12 @@ func LoadMongoDBConfig(ctx context.Context, hostroot string, proc *process.Proce
 	configPath := filepath.Join(hostroot, configLocalPath)
 	fi, err := os.Stat(configPath)
 	if err != nil || fi.IsDir() {
+		if proc != nil {
+			result.ConfigFileUser = "<none>"
+			result.ConfigFileGroup = "<none>"
+			result.ConfigData = map[string]interface{}{}
+			return &result, true
+		}
 		return nil, false
 	}
 
@@ -259,6 +265,13 @@ func LoadPostgreSQLConfig(ctx context.Context, hostroot string, proc *process.Pr
 
 	configPath, ok := locatePGConfigFile(hostroot, hintPath)
 	if !ok {
+		if proc != nil {
+			// postgres can be setup without a configuration file.
+			result.ConfigFileUser = "<none>"
+			result.ConfigFileGroup = "<none>"
+			result.ConfigData = map[string]interface{}{}
+			return &result, true
+		}
 		return nil, false
 	}
 	fi, err := os.Stat(filepath.Join(hostroot, configPath))

--- a/pkg/compliance/dbconfig/loader.go
+++ b/pkg/compliance/dbconfig/loader.go
@@ -151,29 +151,24 @@ func LoadDBResourceFromPID(ctx context.Context, pid int32) (*DBResource, bool) {
 func LoadMongoDBConfig(ctx context.Context, hostroot string, proc *process.Process) (*DBConfig, bool) {
 	configLocalPath := mongoDBConfigPath
 	var result DBConfig
-	if proc != nil {
-		result.ProcessUser, _ = proc.UsernameWithContext(ctx)
-		result.ProcessName, _ = proc.NameWithContext(ctx)
+	result.ProcessUser, _ = proc.UsernameWithContext(ctx)
+	result.ProcessName, _ = proc.NameWithContext(ctx)
 
-		cmdline, _ := proc.CmdlineSlice()
-		for i, arg := range cmdline {
-			if arg == "--config" && i+1 < len(cmdline) {
-				configLocalPath = filepath.Clean(cmdline[i+1])
-				break
-			}
+	cmdline, _ := proc.CmdlineSlice()
+	for i, arg := range cmdline {
+		if arg == "--config" && i+1 < len(cmdline) {
+			configLocalPath = filepath.Clean(cmdline[i+1])
+			break
 		}
 	}
 
 	configPath := filepath.Join(hostroot, configLocalPath)
 	fi, err := os.Stat(configPath)
 	if err != nil || fi.IsDir() {
-		if proc != nil {
-			result.ConfigFileUser = "<none>"
-			result.ConfigFileGroup = "<none>"
-			result.ConfigData = map[string]interface{}{}
-			return &result, true
-		}
-		return nil, false
+		result.ConfigFileUser = "<none>"
+		result.ConfigFileGroup = "<none>"
+		result.ConfigData = map[string]interface{}{}
+		return &result, true
 	}
 
 	var configData mongoDBConfig
@@ -238,41 +233,35 @@ func LoadCassandraConfig(ctx context.Context, hostroot string, proc *process.Pro
 func LoadPostgreSQLConfig(ctx context.Context, hostroot string, proc *process.Process) (*DBConfig, bool) {
 	var result DBConfig
 
-	// If a process handle is given, let's try to parse the -D command line
-	// argument containing the data directory of PG. Configuration file may be
-	// located in this directory.
-	var hintPath string
-	if proc != nil {
-		result.ProcessUser, _ = proc.UsernameWithContext(ctx)
-		result.ProcessName, _ = proc.NameWithContext(ctx)
+	// Let's try to parse the -D command line argument containing the data
+	// directory of PG. Configuration file may be located in this directory.
+	result.ProcessUser, _ = proc.UsernameWithContext(ctx)
+	result.ProcessName, _ = proc.NameWithContext(ctx)
 
-		cmdline, _ := proc.CmdlineSlice()
-		for i, arg := range cmdline {
-			if arg == "-D" && i+1 < len(cmdline) {
-				hintPath = filepath.Join(cmdline[i+1], "postgresql.conf")
-				break
-			}
-			if arg == "--config-file" && i+1 < len(cmdline) {
-				hintPath = filepath.Clean(cmdline[i+1])
-				break
-			}
-			if strings.HasPrefix(arg, "--config-file=") {
-				hintPath = filepath.Clean(strings.TrimPrefix(arg, "--config-file="))
-				break
-			}
+	var hintPath string
+	cmdline, _ := proc.CmdlineSlice()
+	for i, arg := range cmdline {
+		if arg == "-D" && i+1 < len(cmdline) {
+			hintPath = filepath.Join(cmdline[i+1], "postgresql.conf")
+			break
+		}
+		if arg == "--config-file" && i+1 < len(cmdline) {
+			hintPath = filepath.Clean(cmdline[i+1])
+			break
+		}
+		if strings.HasPrefix(arg, "--config-file=") {
+			hintPath = filepath.Clean(strings.TrimPrefix(arg, "--config-file="))
+			break
 		}
 	}
 
 	configPath, ok := locatePGConfigFile(hostroot, hintPath)
 	if !ok {
-		if proc != nil {
-			// postgres can be setup without a configuration file.
-			result.ConfigFileUser = "<none>"
-			result.ConfigFileGroup = "<none>"
-			result.ConfigData = map[string]interface{}{}
-			return &result, true
-		}
-		return nil, false
+		// postgres can be setup without a configuration file.
+		result.ConfigFileUser = "<none>"
+		result.ConfigFileGroup = "<none>"
+		result.ConfigData = map[string]interface{}{}
+		return &result, true
 	}
 	fi, err := os.Stat(filepath.Join(hostroot, configPath))
 	if err != nil || fi.IsDir() {

--- a/pkg/compliance/dbconfig/loader_test.go
+++ b/pkg/compliance/dbconfig/loader_test.go
@@ -37,11 +37,15 @@ func TestDBConfLoader(t *testing.T) {
 		proc := launchFakeProcess(ctx, t, "postgres")
 
 		res, ok := LoadDBResourceFromPID(context.Background(), int32(proc.Pid))
-		assert.False(t, ok)
-		assert.Nil(t, res)
+		assert.True(t, ok)
+		assert.NotNil(t, res)
+		assert.Equal(t, postgresqlResourceType, res.Type)
+		assert.NotNil(t, res.Config)
+		assert.NotNil(t, res.Config.ConfigData)
 
 		err := proc.Kill()
 		assert.NoError(t, err)
+		proc.Wait()
 
 		res, ok = LoadDBResourceFromPID(context.Background(), int32(proc.Pid))
 		assert.False(t, ok)
@@ -70,6 +74,11 @@ func TestDBConfLoader(t *testing.T) {
 
 		err = proc.Kill()
 		assert.NoError(t, err)
+		proc.Wait()
+
+		res, ok = LoadDBResourceFromPID(context.Background(), int32(proc.Pid))
+		assert.False(t, ok)
+		assert.Nil(t, res)
 	}
 }
 

--- a/pkg/compliance/dbconfig/loader_test.go
+++ b/pkg/compliance/dbconfig/loader_test.go
@@ -117,7 +117,14 @@ dynamic_shared_memory_type = 'overridden'`
 		t.Fatal(err)
 	}
 
-	conf, ok := LoadPostgreSQLConfig(context.Background(), hostroot, nil)
+	p := launchFakeProcess(context.Background(), t, "postgres", "--config", configPath)
+	defer func() {
+		p.Kill()
+		p.Wait()
+	}()
+	proc, err := process.NewProcess(int32(p.Pid))
+	assert.NoError(t, err)
+	conf, ok := LoadPostgreSQLConfig(context.Background(), hostroot, proc)
 	assert.Equal(t, true, ok)
 	configData := conf.ConfigData.(map[string]interface{})
 	assert.Equal(t, "/etc/postgresql/postgresql.conf", conf.ConfigFilePath)
@@ -146,7 +153,14 @@ dynamic_shared_memory_type = 'overridden'
 		t.Fatal(err)
 	}
 
-	c, ok := LoadPostgreSQLConfig(context.Background(), hostroot, nil)
+	p := launchFakeProcess(context.Background(), t, "postgres", "--config", configPath)
+	defer func() {
+		p.Kill()
+		p.Wait()
+	}()
+	proc, err := process.NewProcess(int32(p.Pid))
+	assert.NoError(t, err)
+	c, ok := LoadPostgreSQLConfig(context.Background(), hostroot, proc)
 	assert.Equal(t, true, ok)
 	configData := c.ConfigData.(map[string]interface{})
 	assert.Equal(t, "bar'\b", configData["foo"])
@@ -169,7 +183,14 @@ func TestPGConfParsingCustom(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, ok := LoadPostgreSQLConfig(context.Background(), hostroot, nil)
+	p := launchFakeProcess(context.Background(), t, "postgres", "--config", configPath)
+	defer func() {
+		p.Kill()
+		p.Wait()
+	}()
+	proc, err := process.NewProcess(int32(p.Pid))
+	assert.NoError(t, err)
+	c, ok := LoadPostgreSQLConfig(context.Background(), hostroot, proc)
 	assert.True(t, ok)
 	configData := c.ConfigData.(map[string]interface{})
 	assert.Equal(t, `envdir "/run/etc/wal-g.d/env" wal-g wal-push "%p"`, configData["archive_command"])
@@ -267,7 +288,14 @@ func TestCassandraConfParsing(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(hostroot, "/etc/cassandra/logback.xml"), []byte(cassandraLogbackSample), 0600); err != nil {
 		t.Fatal(err)
 	}
-	c, ok := LoadCassandraConfig(context.Background(), hostroot, nil)
+	p := launchFakeProcess(context.Background(), t, "java")
+	defer func() {
+		p.Kill()
+		p.Wait()
+	}()
+	proc, err := process.NewProcess(int32(p.Pid))
+	assert.NoError(t, err)
+	c, ok := LoadCassandraConfig(context.Background(), hostroot, proc)
 	assert.True(t, ok)
 	configData := c.ConfigData.(*cassandraDBConfig)
 	assert.Equal(t, uint32(0600), c.ConfigFileMode)
@@ -286,7 +314,14 @@ func TestMongoDBConfParsing(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(hostroot, "/etc/mongod.conf"), []byte(mongodConfigSample), 0600); err != nil {
 		t.Fatal(err)
 	}
-	c, ok := LoadMongoDBConfig(context.Background(), hostroot, nil)
+	p := launchFakeProcess(context.Background(), t, "mongod")
+	defer func() {
+		p.Kill()
+		p.Wait()
+	}()
+	proc, err := process.NewProcess(int32(p.Pid))
+	assert.NoError(t, err)
+	c, ok := LoadMongoDBConfig(context.Background(), hostroot, proc)
 	assert.True(t, ok)
 	configData := c.ConfigData.(*mongoDBConfig)
 	assert.Equal(t, uint32(0600), c.ConfigFileMode)


### PR DESCRIPTION
### What does this PR do?

Allow empty configurations for MongoDB and PostgreQSL config loader as both these software allow such behavior.

### Motivation

Empty state has to be supported for both these databases as it is a valid usecase.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
