### PR TITLE
Improve detection for valid environment to run KMT

### DIFF
--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -91,16 +91,19 @@ def local_vms_in_config(vmconfig):
     return False
 
 
-def kvm_ok(ctx):
+def kvm_ok():
     if not os.path.exists("/dev/kvm"):
-        error(f"[-] /dev/kvm not found. KVM not available on system")
+        error("[-] /dev/kvm not found. KVM not available on system")
         raise Exit("KVM not available")
 
     info("[+] Kvm available on system")
 
 
 def check_user_in_group(ctx, group):
-    res = ctx.run(f"cat /proc/$$/status | grep '^Groups:' | grep $(cat /etc/group | grep '{group}:' | cut -d ':' -f 3)", warn=True)
+    res = ctx.run(
+        f"cat /proc/$$/status | grep '^Groups:' | grep $(cat /etc/group | grep '{group}:' | cut -d ':' -f 3)",
+        warn=True,
+    )
     if res.ok:
         return True
 
@@ -137,7 +140,7 @@ def check_env(ctx):
         raise Exit("Local machines only supported on Linux and MacOS")
 
     if platform.system() == "Linux":
-        kvm_ok(ctx)
+        kvm_ok()
         # on macOS libvirt runs as the local user, so no need to check for group membership
         check_user_in_kvm(ctx)
         check_user_in_libvirt(ctx)

--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -92,7 +92,7 @@ def local_vms_in_config(vmconfig):
 
 
 def kvm_ok(ctx):
-    if os.path.exists("/dev/kvm"):
+    if not os.path.exists("/dev/kvm"):
         error(f"[-] /dev/kvm not found. KVM not available on system")
         raise Exit("KVM not available")
 

--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -100,16 +100,27 @@ def kvm_ok(ctx):
 
 
 def check_user_in_group(ctx, group):
-    ctx.run(f"cat /proc/$$/status | grep '^Groups:' | grep $(cat /etc/group | grep '{group}:' | cut -d ':' -f 3)")
-    info(f"[+] User '{os.getlogin()}' in group '{group}'")
+    res = ctx.run(f"cat /proc/$$/status | grep '^Groups:' | grep $(cat /etc/group | grep '{group}:' | cut -d ':' -f 3)", warn=True)
+    if res.ok:
+        return True
+
+    return False
 
 
 def check_user_in_kvm(ctx):
-    check_user_in_group(ctx, "kvm")
+    if not check_user_in_group(ctx, "kvm"):
+        error("You must add user '{os.getlogin()}' to group 'kvm'")
+        raise Exit("User '{os.getlogin()}' not in group 'kvm'")
+
+    info(f"[+] User '{os.getlogin()}' in group 'kvm'")
 
 
 def check_user_in_libvirt(ctx):
-    check_user_in_group(ctx, "libvirt")
+    if not check_user_in_group(ctx, "libvirt"):
+        error("You must add user '{os.getlogin()}' to group 'libvirt'")
+        raise Exit("User '{os.getlogin()}' not in group 'libvirt'")
+
+    info(f"[+] User '{os.getlogin()}' in group 'libvirt'")
 
 
 def check_libvirt_sock_perms():

--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -92,7 +92,10 @@ def local_vms_in_config(vmconfig):
 
 
 def kvm_ok(ctx):
-    ctx.run("kvm-ok")
+    if os.path.exists("/dev/kvm"):
+        error(f"[-] /dev/kvm not found. KVM not available on system")
+        raise Exit("KVM not available")
+
     info("[+] Kvm available on system")
 
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR replaces `kvm-ok` with a manual check for `/dev/kvm` to determine if KVM based acceleration is supported on the host machine.
It also emits helpful messages if the current user is not a member of the required groups.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
`kvm-ok` requires adding `cpu-checker` as a dependency in the environment setup script. This is unnecessary since the tool just checks for the existence of `/dev/kvm`. We can do this ourselves.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
