### PR TITLE
Create an e2e test for non-core agent config-refresh on Linux

### DIFF
--- a/test/new-e2e/tests/agent-shared-components/config-refresh/config_endpoint.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/config_endpoint.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package configrefresh
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+)
+
+type agentConfigEndpointInfo struct {
+	name     string
+	scheme   string
+	port     int
+	endpoint string
+}
+
+func traceConfigEndpoint(port int) agentConfigEndpointInfo {
+	return agentConfigEndpointInfo{"trace-agent", "http", port, "/config"}
+}
+
+func processConfigEndpoint(port int) agentConfigEndpointInfo {
+	return agentConfigEndpointInfo{"process-agent", "http", port, "/config/all"}
+}
+
+func securityConfigEndpoint(port int) agentConfigEndpointInfo {
+	return agentConfigEndpointInfo{"security-agent", "https", port, "/agent/config"}
+}
+
+func (endpointInfo *agentConfigEndpointInfo) url() *url.URL {
+	return &url.URL{
+		Scheme: endpointInfo.scheme,
+		Host:   net.JoinHostPort("localhost", strconv.Itoa(endpointInfo.port)),
+		Path:   endpointInfo.endpoint,
+	}
+}
+
+func (endpointInfo *agentConfigEndpointInfo) fetchCommand(authtoken string) string {
+	// -L: follow redirects
+	// -s: silent
+	// -k: allow insecure server connections
+	// -H: add a header
+	return fmt.Sprintf(
+		`curl -L -s -k -H "authorization: Bearer %s" "%s"`,
+		authtoken,
+		endpointInfo.url().String(),
+	)
+}

--- a/test/new-e2e/tests/agent-shared-components/config-refresh/config_endpoint.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/config_endpoint.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build test
-
 package configrefresh
 
 import (

--- a/test/new-e2e/tests/agent-shared-components/config-refresh/docs.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/docs.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package configrefresh contains e2e tests for the config refresh feature.
+package configrefresh

--- a/test/new-e2e/tests/agent-shared-components/config-refresh/fixtures/config.yaml.tmpl
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/fixtures/config.yaml.tmpl
@@ -1,0 +1,27 @@
+api_key: ENC[api_key]
+log_level: debug
+auth_token_file_path: {{.AuthTokenFilePath}}
+
+secret_backend_command: {{.SecretResolver}}
+secret_backend_arguments:
+  - {{.SecretDirectory}}
+secret_backend_remove_trailing_line_break: true
+# weakens permissions on the secret backend command to allow group execution
+secret_backend_command_allow_group_exec_perm: true
+
+agent_ipc:
+  port: {{.AgentIpcPort}}
+  config_refresh_interval: {{.ConfigRefreshIntervalSec}}
+
+apm_config:
+  enabled: true
+  debug:
+    port: {{.ApmCmdPort}}
+
+security_agent:
+  cmd_port: {{.SecurityCmdPort}}
+
+process_config:
+  process_collection:
+    enabled: true
+  cmd_port: {{.ProcessCmdPort}}

--- a/test/new-e2e/tests/agent-shared-components/config-refresh/fixtures/secret-resolver.py
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/fixtures/secret-resolver.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import os.path
+import sys
+
+
+# this script resolves secret from disk
+# a single argument should be given, the directory in which to look for secrets
+# for each requested handle, it will try to read a file named as the handle in the directory
+def main():
+    if len(sys.argv) != 2:
+        raise Exception("expected a single argument being the secret directory path")
+
+    cwd = sys.argv[1]
+
+    content = sys.stdin.read()
+    obj = json.loads(content)
+    handles = obj['secrets']
+
+    result = {}
+    for h in handles:
+        with open(os.path.join(cwd, h)) as reader:
+            key = reader.read().strip()
+        result[h] = {'value': key}
+
+    print(json.dumps(result))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/new-e2e/tests/agent-shared-components/config-refresh/fixtures/security-agent.yaml
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/fixtures/security-agent.yaml
@@ -1,0 +1,2 @@
+runtime_security_config:
+  enabled: true

--- a/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_test.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_test.go
@@ -1,0 +1,200 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package configrefresh
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"html/template"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
+)
+
+const (
+	agentIpcPort             = 5004
+	securityCmdPort          = 5010
+	apmCmdPort               = 5012
+	processCmdPort           = 6162
+	configRefreshIntervalSec = 10
+)
+
+//go:embed fixtures/config.yaml.tmpl
+var coreConfigTmpl string
+
+//go:embed fixtures/security-agent.yaml
+var securityAgentConfig string
+
+//go:embed fixtures/secret-resolver.py
+var secretResolverScript []byte
+
+var (
+	apiKey1 = strings.Repeat("1", 32)
+	apiKey2 = strings.Repeat("2", 32)
+)
+
+type configRefreshSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+func TestConfigRefreshSuite(t *testing.T) {
+	e2e.Run(t, &configRefreshSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
+}
+
+func (v *configRefreshSuite) TestConfigRefresh() {
+	rootDir := "/tmp/" + v.T().Name()
+	v.Env().RemoteHost.MkdirAll(rootDir)
+
+	authTokenFilePath := "/etc/datadog-agent/auth_token"
+	secretResolverPath := filepath.Join(rootDir, "secret-resolver.py")
+	apiKeyFile := filepath.Join(rootDir, "api_key")
+
+	v.T().Log("Setting up the secret resolver and the initial api key file")
+
+	secretResolverOptions := fileOptions{usergroup: "dd-agent:root", perm: "750", content: secretResolverScript}
+	createFile(v.T(), v.Env().RemoteHost, secretResolverPath, secretResolverOptions)
+	createFile(v.T(), v.Env().RemoteHost, apiKeyFile, fileOptions{content: []byte(apiKey1)})
+
+	// fill the config template
+	templateVars := map[string]interface{}{
+		"AuthTokenFilePath":        authTokenFilePath,
+		"SecretDirectory":          rootDir,
+		"SecretResolver":           secretResolverPath,
+		"ConfigRefreshIntervalSec": configRefreshIntervalSec,
+		"ApmCmdPort":               apmCmdPort,
+		"ProcessCmdPort":           processCmdPort,
+		"SecurityCmdPort":          securityCmdPort,
+		"AgentIpcPort":             agentIpcPort,
+	}
+	coreconfig := fillTmplConfig(v.T(), coreConfigTmpl, templateVars)
+
+	// start the agent with that configuration
+	v.UpdateEnv(awshost.Provisioner(
+		awshost.WithAgentOptions(
+			agentparams.WithAgentConfig(coreconfig),
+			agentparams.WithSecurityAgentConfig(securityAgentConfig),
+			agentparams.WithSkipAPIKeyInConfig(), // api_key is already provided in the config
+		),
+	))
+
+	// get auth token
+	authtokenContent := v.Env().RemoteHost.MustExecute("sudo cat " + authTokenFilePath)
+	authtoken := strings.TrimSpace(authtokenContent)
+
+	// check that the agents are using the first key
+	// initially they all resolve it using the secret resolver
+	assertAgentsUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey1)
+
+	// update api_key
+	v.Env().RemoteHost.WriteFile(apiKeyFile, []byte(apiKey2))
+
+	// trigger a refresh of the core-agent secrets
+	secretRefreshOutput := v.Env().Agent.Client.Secret(agentclient.WithArgs([]string{"refresh"}))
+	// ensure the api_key was refreshed, fail directly otherwise
+	require.Contains(v.T(), secretRefreshOutput, "api_key")
+
+	// wait for the refresh to be effective
+	v.T().Log("Waiting for the config refresh to be effective")
+	time.Sleep(1.5 * configRefreshIntervalSec * time.Second)
+
+	// and check that the agents are using the new key
+	assertAgentsUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey2)
+}
+
+type fileOptions struct {
+	usergroup string
+	content   []byte
+	perm      string
+}
+
+func createFile(t *testing.T, host *components.RemoteHost, filepath string, options fileOptions) {
+	t.Logf("File '%s': creating", filepath)
+
+	// remove it if it exists
+	host.MustExecute("rm -f " + filepath)
+
+	_, err := host.WriteFile(filepath, options.content)
+	require.NoError(t, err)
+
+	if options.perm != "" {
+		t.Logf("File '%s': setting permissions %s", filepath, options.perm)
+		host.MustExecute(fmt.Sprintf("sudo chmod %s %s", options.perm, filepath))
+	}
+
+	if options.usergroup != "" {
+		t.Logf("File '%s': setting user:group %s", filepath, options.usergroup)
+		host.MustExecute(fmt.Sprintf("sudo chown %s %s", options.usergroup, filepath))
+	}
+}
+
+// assertAgentsUseKey checks that all agents are using the given key.
+func assertAgentsUseKey(t *testing.T, host *components.RemoteHost, authtoken, key string) {
+	t.Helper()
+
+	for _, endpoint := range []agentConfigEndpointInfo{
+		traceConfigEndpoint(apmCmdPort),
+		processConfigEndpoint(processCmdPort),
+		securityConfigEndpoint(securityCmdPort),
+	} {
+		cmd := endpoint.fetchCommand(authtoken)
+		t.Logf("Fetching config from %s: %s", endpoint.name, cmd)
+		cfg, err := host.Execute(cmd)
+		if assert.NoErrorf(t, err, "failed to fetch config from %s", endpoint.name) {
+			assertConfigHasKey(t, cfg, key, "checking key used by "+endpoint.name)
+		}
+	}
+}
+
+// assertConfigHasKey checks that configYAML contains the given key.
+// As the config is scrubbed, it only checks the last 5 characters of the keys.
+func assertConfigHasKey(t *testing.T, configYAML, key string, context string) {
+	t.Helper()
+
+	var cfg map[string]interface{}
+	err := yaml.Unmarshal([]byte(configYAML), &cfg)
+	if !assert.NoError(t, err, context) {
+		return
+	}
+
+	if !assert.Contains(t, cfg, "api_key", context) {
+		return
+	}
+
+	keyEnd := key[len(key)-5:]
+	actual := cfg["api_key"].(string)
+	actualEnd := actual[len(actual)-5:]
+
+	assert.Equal(t, keyEnd, actualEnd, context)
+}
+
+// fillTmplConfig fills the template with the given variables and returns the result.
+func fillTmplConfig(t *testing.T, tmplContent string, templateVars any) string {
+	t.Helper()
+
+	var buffer bytes.Buffer
+
+	tmpl, err := template.New("").Parse(tmplContent)
+	require.NoError(t, err)
+
+	err = tmpl.Execute(&buffer, templateVars)
+	require.NoError(t, err)
+
+	return buffer.String()
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add an e2e test for the config sync feature introduced in https://github.com/DataDog/datadog-agent/pull/23211.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
- Prevent accidentally breaking that feature
- Increase confidence
- Avoid manual QA

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Only on Linux for now.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
