### PR TITLE
Add E2E test for installer service configuration

### DIFF
--- a/test/new-e2e/tests/windows/common/agent/agent.go
+++ b/test/new-e2e/tests/windows/common/agent/agent.go
@@ -35,6 +35,8 @@ const (
 	DefaultInstallPath = `C:\Program Files\Datadog\Datadog Agent`
 	// DefaultConfigRoot is the default config root for the Datadog Agent
 	DefaultConfigRoot = `C:\ProgramData\Datadog`
+	// DefaultAgentUserName is the default user name for the Datadog Agent
+	DefaultAgentUserName = `ddagentuser`
 )
 
 // GetDatadogAgentProductCode returns the product code GUID for the Datadog Agent

--- a/test/new-e2e/tests/windows/common/service.go
+++ b/test/new-e2e/tests/windows/common/service.go
@@ -14,10 +14,33 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 )
 
+// Service API constants
+// https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-query_service_configa
+const (
+	//revive:disable:var-naming match windows API names
+
+	// dwServiceType
+	SERVICE_KERNEL_DRIVER       = 0x00000001
+	SERVICE_FILE_SYSTEM_DRIVER  = 0x00000002
+	SERVICE_WIN32_OWN_PROCESS   = 0x00000010
+	SERVICE_WIN32_SHARE_PROCESS = 0x00000020
+
+	// dwStartType
+	SERVICE_SYSTEM_START = 1
+	SERVICE_AUTO_START   = 2
+	SERVICE_DEMAND_START = 3
+	SERVICE_DISABLED     = 4
+
+	//revive:enable:var-naming
+)
+
 // ServiceConfig contains information about a Windows service
 type ServiceConfig struct {
 	ServiceName        string
+	DisplayName        string
+	ImagePath          string
 	StartType          int
+	ServiceType        int
 	Status             int
 	UserName           string
 	UserSID            string
@@ -117,18 +140,28 @@ func GetServiceConfig(host *components.RemoteHost, service string) (*ServiceConf
 		return nil, err
 	}
 
-	// UserName was not added to Get-Service until PowerShell 6.0
-	if result.UserName == "" {
-		result.UserName, err = GetServiceAccountName(host, service)
+	// if it's a usermode service, get the username and SID
+	if IsUserModeServiceType(result.ServiceType) {
+		// UserName was not added to Get-Service until PowerShell 6.0
+		if result.UserName == "" {
+			result.UserName, err = GetServiceAccountName(host, service)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		err = result.FetchUserSID(host)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	err = result.FetchUserSID(host)
+	// Get-Service does not return the command line for the service
+	imagePath, err := GetServiceImagePath(host, service)
 	if err != nil {
 		return nil, err
 	}
+	result.ImagePath = imagePath
 
 	return &result, nil
 }
@@ -188,4 +221,19 @@ func GetServicePID(host *components.RemoteHost, service string) (int, error) {
 	}
 	out = strings.TrimSpace(out)
 	return strconv.Atoi(out)
+}
+
+// GetServiceImagePath returns the image path (command line) of the service
+func GetServiceImagePath(host *components.RemoteHost, service string) (string, error) {
+	return GetRegistryValue(host, fmt.Sprintf("HKLM:\\SYSTEM\\CurrentControlSet\\Services\\%s", service), "ImagePath")
+}
+
+// IsUserModeServiceType returns true if the service is a user mode service
+func IsUserModeServiceType(serviceType int) bool {
+	return serviceType == SERVICE_WIN32_OWN_PROCESS || serviceType == SERVICE_WIN32_SHARE_PROCESS
+}
+
+// IsKernelModeServiceType returns true if the service is a kernel mode service
+func IsKernelModeServiceType(serviceType int) bool {
+	return serviceType == SERVICE_KERNEL_DRIVER || serviceType == SERVICE_FILE_SYSTEM_DRIVER
 }

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -226,6 +226,11 @@ func (t *Tester) TestUninstallExpectations(tt *testing.T) {
 		windows.MakeDownLevelLogonName(t.expectedUserDomain, t.expectedUserName),
 	)
 	assert.NoError(tt, err, "uninstall should not remove agent user")
+
+	for _, serviceName := range servicetest.ExpectedInstalledServices() {
+		_, err := windows.GetServiceConfig(t.host, serviceName)
+		assert.Errorf(tt, err, "uninstall should remove service %s", serviceName)
+	}
 }
 
 // Only do some basic checks on the agent since it's a previous version

--- a/test/new-e2e/tests/windows/install-test/service-test/tester.go
+++ b/test/new-e2e/tests/windows/install-test/service-test/tester.go
@@ -7,22 +7,30 @@
 package servicetest
 
 import (
+	"fmt"
+	"strings"
+
+	infraCommon "github.com/DataDog/test-infra-definitions/common"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
-	infraCommon "github.com/DataDog/test-infra-definitions/common"
+	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Tester provides tests for the services installed by the Windows Agent
 type Tester struct {
 	host *components.RemoteHost
 
-	expectedAgentUserName   string
-	expectedAgentUserDomain string
+	expectedUserName   string
+	expectedUserDomain string
+
+	// does not include the trailing backslash
+	expectedInstallPath string
+	expectedConfigRoot  string
 }
 
 // Option is a functional option for Tester
@@ -31,8 +39,24 @@ type Option = func(*Tester) error
 // WithExpectedAgentUser sets the expected user for the Agent
 func WithExpectedAgentUser(domain string, username string) Option {
 	return func(t *Tester) error {
-		t.expectedAgentUserDomain = domain
-		t.expectedAgentUserName = username
+		t.expectedUserDomain = domain
+		t.expectedUserName = username
+		return nil
+	}
+}
+
+// WithExpectedInstallPath sets the expected install path for the agent
+func WithExpectedInstallPath(path string) Option {
+	return func(t *Tester) error {
+		t.expectedInstallPath = path
+		return nil
+	}
+}
+
+// WithExpectedConfigRoot sets the expected config root for the agent
+func WithExpectedConfigRoot(path string) Option {
+	return func(t *Tester) error {
+		t.expectedConfigRoot = path
 		return nil
 	}
 }
@@ -40,22 +64,89 @@ func WithExpectedAgentUser(domain string, username string) Option {
 // NewTester creates a new Tester
 func NewTester(host *components.RemoteHost, opts ...Option) (*Tester, error) {
 	t := &Tester{host: host}
+
+	// defaults
+	t.expectedInstallPath = windowsAgent.DefaultInstallPath
+	t.expectedConfigRoot = windowsAgent.DefaultConfigRoot
+
 	_, err := infraCommon.ApplyOption(t, opts)
 	if err != nil {
 		return nil, err
 	}
+
+	// set this default after and only if needed since it requires some remote commands
+	if t.expectedUserName == "" {
+		hostInfo, err := windowsCommon.GetHostInfo(t.host)
+		if err != nil {
+			return nil, err
+		}
+		t.expectedUserName = windowsAgent.DefaultAgentUserName
+		t.expectedUserDomain = windowsCommon.NameToNetBIOSName(hostInfo.Hostname)
+	}
+
+	// strip the trailing backslash for consistency
+	t.expectedInstallPath = strings.TrimSuffix(t.expectedInstallPath, `\`)
+	t.expectedConfigRoot = strings.TrimSuffix(t.expectedConfigRoot, `\`)
+
 	return t, nil
 }
 
-func (t *Tester) expectedServiceUsers() (windowsCommon.ServiceConfigMap, error) {
-	expectedServiceUser := windowsCommon.MakeDownLevelLogonName(t.expectedAgentUserDomain, t.expectedAgentUserName)
+// ExpectedServiceConfig returns the expected service config for the installed services
+func (t *Tester) ExpectedServiceConfig() (windowsCommon.ServiceConfigMap, error) {
+	m := windowsCommon.GetEmptyServiceConfigMap(ExpectedInstalledServices())
 
-	m := windowsCommon.GetEmptyServiceConfigMap(t.expectedInstalledServices())
-	m["DatadogAgent"].UserName = expectedServiceUser
+	// service type
+	m["datadogagent"].ServiceType = windowsCommon.SERVICE_WIN32_OWN_PROCESS
+	m["datadog-trace-agent"].ServiceType = windowsCommon.SERVICE_WIN32_OWN_PROCESS
+	m["datadog-process-agent"].ServiceType = windowsCommon.SERVICE_WIN32_OWN_PROCESS
+	m["datadog-system-probe"].ServiceType = windowsCommon.SERVICE_WIN32_OWN_PROCESS
+	m["ddnpm"].ServiceType = windowsCommon.SERVICE_KERNEL_DRIVER
+
+	// start type
+	m["datadogagent"].StartType = windowsCommon.SERVICE_AUTO_START
+	m["datadog-trace-agent"].StartType = windowsCommon.SERVICE_DEMAND_START
+	m["datadog-process-agent"].StartType = windowsCommon.SERVICE_DEMAND_START
+	m["datadog-system-probe"].StartType = windowsCommon.SERVICE_DEMAND_START
+	m["ddnpm"].StartType = windowsCommon.SERVICE_DISABLED
+
+	// dependencies
+	m["datadogagent"].ServicesDependedOn = []string{}
+	m["datadog-trace-agent"].ServicesDependedOn = []string{"datadogagent"}
+	m["datadog-process-agent"].ServicesDependedOn = []string{"datadogagent"}
+	m["datadog-system-probe"].ServicesDependedOn = []string{"datadogagent"}
+	m["ddnpm"].ServicesDependedOn = []string{}
+
+	// DisplayName
+	m["datadogagent"].DisplayName = "Datadog Agent"
+	m["datadog-trace-agent"].DisplayName = "Datadog Trace Agent"
+	m["datadog-process-agent"].DisplayName = "Datadog Process Agent"
+	m["datadog-system-probe"].DisplayName = "Datadog System Probe"
+	m["ddnpm"].DisplayName = "Datadog Network Performance Monitor"
+
+	// ImagePath
+	exePath := quotePathIfContainsSpaces(fmt.Sprintf(`%s\bin\agent.exe`, t.expectedInstallPath))
+	m["datadogagent"].ImagePath = exePath
+	// TODO: double slash is intentional, must fix the path in the installer
+	exePath = quotePathIfContainsSpaces(fmt.Sprintf(`%s\bin\agent\trace-agent.exe`, t.expectedInstallPath))
+	m["datadog-trace-agent"].ImagePath = fmt.Sprintf(`%s --config="%s\\datadog.yaml"`, exePath, t.expectedConfigRoot)
+	// TODO: double slash is intentional, must fix the path in the installer
+	exePath = quotePathIfContainsSpaces(fmt.Sprintf(`%s\bin\agent\process-agent.exe`, t.expectedInstallPath))
+	m["datadog-process-agent"].ImagePath = fmt.Sprintf(`%s --cfgpath="%s\\datadog.yaml"`, exePath, t.expectedConfigRoot)
+	exePath = quotePathIfContainsSpaces(fmt.Sprintf(`%s\bin\agent\system-probe.exe`, t.expectedInstallPath))
+	m["datadog-system-probe"].ImagePath = exePath
+	// drivers use the kernel path syntax and aren't quoted since they are file paths rather than command lines
+	m["ddnpm"].ImagePath = fmt.Sprintf(`\??\%s\bin\agent\driver\ddnpm.sys`, t.expectedInstallPath)
+
+	// User and SID
+	expectedServiceUser := windowsCommon.MakeDownLevelLogonName(t.expectedUserDomain, t.expectedUserName)
+	m["datadogagent"].UserName = expectedServiceUser
 	m["datadog-trace-agent"].UserName = expectedServiceUser
 	m["datadog-process-agent"].UserName = "LocalSystem"
 	m["datadog-system-probe"].UserName = "LocalSystem"
 	for _, s := range m {
+		if !windowsCommon.IsUserModeServiceType(s.ServiceType) {
+			continue
+		}
 		err := s.FetchUserSID(t.host)
 		if err != nil {
 			return nil, err
@@ -65,33 +156,33 @@ func (t *Tester) expectedServiceUsers() (windowsCommon.ServiceConfigMap, error) 
 	return m, nil
 }
 
-func (t *Tester) expectedInstalledServices() []string {
+// ExpectedInstalledServices returns the list of services expected to be installed
+func ExpectedInstalledServices() []string {
 	return []string{
-		"DatadogAgent",
+		"datadogagent",
 		"datadog-trace-agent",
 		"datadog-process-agent",
 		"datadog-system-probe",
+		"ddnpm",
 	}
 }
 
-// TestInstall tests the expectations for the installed services
-func (t *Tester) TestInstall(tt *testing.T) bool {
-	return tt.Run("service config", func(tt *testing.T) {
-		tt.Run("service users", func(tt *testing.T) {
-			actual, err := windowsCommon.GetServiceConfigMap(t.host, t.expectedInstalledServices())
-			require.NoError(tt, err)
-			expectedServiceUsers, err := t.expectedServiceUsers()
-			require.NoError(tt, err)
-			AssertServiceUsers(tt, expectedServiceUsers, actual)
-		})
-	})
-
+// quotePathIfContainsSpaces quotes the path if it contains spaces and returns the result.
+//
+// Due to how Windows parse the service command line, it is important to quote paths that contain spaces
+// https://kb.cybertecsecurity.com/knowledge/unquoted-service-paths
+func quotePathIfContainsSpaces(path string) string {
+	if strings.Contains(path, " ") {
+		return fmt.Sprintf(`"%s"`, path)
+	}
+	return path
 }
 
 // iterServiceConfigMaps iterates over the expected and actual service config maps and calls the provided function for each element.
 // If the function returns false, the iteration stops and the function returns false.
 // If an expected service is not found in the actual map, the function returns false.
 func iterServiceConfigMaps(t *testing.T, expected windowsCommon.ServiceConfigMap, actual windowsCommon.ServiceConfigMap, f func(*windowsCommon.ServiceConfig, *windowsCommon.ServiceConfig) bool) bool {
+	t.Helper()
 	for name, e := range expected {
 		a, ok := actual[name]
 		if !assert.True(t, ok, "service %s not found", name) {
@@ -104,11 +195,17 @@ func iterServiceConfigMaps(t *testing.T, expected windowsCommon.ServiceConfigMap
 	return true
 }
 
-// AssertServiceUsers asserts that the service users from the expected map match the actual map
-//
-// Compares UserSIDs rather than UserNames to avoid needing to handle name formatting differences
-func AssertServiceUsers(t *testing.T, expected windowsCommon.ServiceConfigMap, actual windowsCommon.ServiceConfigMap) bool {
+// AssertEqualServiceConfigValues asserts that the service config values from the expected map match the actual map
+func AssertEqualServiceConfigValues(t *testing.T, expected windowsCommon.ServiceConfigMap, actual windowsCommon.ServiceConfigMap) bool {
 	return iterServiceConfigMaps(t, expected, actual, func(expected *windowsCommon.ServiceConfig, actual *windowsCommon.ServiceConfig) bool {
-		return assert.Equal(t, expected.UserSID, actual.UserSID, "service %s user should be (%s,%s)", actual.ServiceName, expected.UserName, expected.UserSID)
+		assert.Equal(t, expected.DisplayName, actual.DisplayName, "service %s DisplayName should match", actual.ServiceName)
+		assert.Equal(t, expected.ImagePath, actual.ImagePath, "service %s ImagePath should match", actual.ServiceName)
+		assert.Equal(t, expected.StartType, actual.StartType, "service %s StartType should match", actual.ServiceName)
+		assert.Equal(t, expected.ServiceType, actual.ServiceType, "service %s ServiceType should match", actual.ServiceName)
+		// Compare UserSID rather than UserNames to avoid needing to handle name formatting differences
+		assert.Equal(t, expected.UserSID, actual.UserSID, "service %s user should be (%s,%s)", actual.ServiceName, expected.UserName, expected.UserSID)
+		assert.ElementsMatch(t, expected.ServicesDependedOn, actual.ServicesDependedOn, "service %s ServicesDependedOn should match", actual.ServiceName)
+		// continue iterating regardless of the result
+		return true
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds E2E test for the configuration of the Windows Services by the installer

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-507

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
marked draft b/c waiting on stacked PRs

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
