### PR TITLE
add E2E event log helper, collect eventlog after failed test

### DIFF
--- a/test/new-e2e/tests/windows/common/eventlog.go
+++ b/test/new-e2e/tests/windows/common/eventlog.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package common
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+)
+
+// ExportEventLog exports an event log to a file
+func ExportEventLog(host *components.RemoteHost, logName string, outputPath string) error {
+	remoteOutputPath, err := GetTemporaryFile(host)
+	if err != nil {
+		return fmt.Errorf("error getting temp file path: %w", err)
+	}
+	//nolint:errcheck
+	defer host.Remove(remoteOutputPath)
+
+	// must pass /overwrite b/c the temporary file is already created
+	cmd := fmt.Sprintf("wevtutil.exe export-log '%s' '%s' /overwrite", logName, remoteOutputPath)
+	_, err = host.Execute(cmd)
+	if err != nil {
+		return fmt.Errorf("error exporting %s event log: %w", logName, err)
+	}
+
+	err = host.GetFile(remoteOutputPath, outputPath)
+	if err != nil {
+		return fmt.Errorf("error getting exported %s event log file %s: %w", logName, remoteOutputPath, err)
+	}
+
+	return nil
+}
+
+// ClearEventLog clears an event log
+func ClearEventLog(host *components.RemoteHost, logName string) error {
+	cmd := fmt.Sprintf("wevtutil.exe clear-log '%s'", logName)
+	_, err := host.Execute(cmd)
+	if err != nil {
+		return fmt.Errorf("error clearing %s event log: %w", logName, err)
+	}
+
+	return nil
+}

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -83,6 +83,7 @@ func (is *agentMSISuite) prepareHost() {
 	}
 }
 
+// TODO: this isn't called before tabular tests (e.g. TestAgentUser/...)
 func (is *agentMSISuite) BeforeTest(suiteName, testName string) {
 	if beforeTest, ok := any(&is.BaseAgentInstallerSuite).(suite.BeforeTest); ok {
 		beforeTest.BeforeTest(suiteName, testName)
@@ -93,6 +94,31 @@ func (is *agentMSISuite) BeforeTest(suiteName, testName string) {
 	// If necessary (for example for parallelization), store the snapshot per suite/test in a map
 	is.beforeInstall, err = windowsCommon.NewFileSystemSnapshot(vm, SystemPaths())
 	is.Require().NoError(err)
+
+	// Clear the event logs before each test
+	for _, logName := range []string{"System", "Application"} {
+		is.T().Logf("Clearing %s event log", logName)
+		err = windowsCommon.ClearEventLog(vm, logName)
+		is.Require().NoError(err, "should clear %s event log", logName)
+	}
+}
+
+// TODO: this isn't called after tabular tests (e.g. TestAgentUser/...)
+func (is *agentMSISuite) AfterTest(suiteName, testName string) {
+	if afterTest, ok := any(&is.BaseAgentInstallerSuite).(suite.AfterTest); ok {
+		afterTest.AfterTest(suiteName, testName)
+	}
+
+	if is.T().Failed() {
+		// If the test failed, export the event logs for debugging
+		vm := is.Env().RemoteHost
+		for _, logName := range []string{"System", "Application"} {
+			is.T().Logf("Exporting %s event log", logName)
+			outputPath := filepath.Join(is.OutputDir, fmt.Sprintf("%s.evtx", logName))
+			err := windowsCommon.ExportEventLog(vm, logName, outputPath)
+			is.Assert().NoError(err, "should export %s event log", logName)
+		}
+	}
 }
 
 func (is *agentMSISuite) TestInstall() {

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -113,10 +113,16 @@ func (is *agentMSISuite) AfterTest(suiteName, testName string) {
 		// If the test failed, export the event logs for debugging
 		vm := is.Env().RemoteHost
 		for _, logName := range []string{"System", "Application"} {
+			// collect the full event log as an evtx file
 			is.T().Logf("Exporting %s event log", logName)
 			outputPath := filepath.Join(is.OutputDir, fmt.Sprintf("%s.evtx", logName))
 			err := windowsCommon.ExportEventLog(vm, logName, outputPath)
 			is.Assert().NoError(err, "should export %s event log", logName)
+			// Log errors and warnings to the screen for easy access
+			out, err := windowsCommon.GetEventLogErrorsAndWarnings(vm, logName)
+			if is.Assert().NoError(err, "should get errors and warnings from %s event log", logName) && out != "" {
+				is.T().Logf("Errors and warnings from %s event log:\n%s", logName, out)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds E2E helpers to clear and collect Windows Event Logs

If the test fails, then the Application+System evtx files are collected, and errors/warnings are logged to the screen

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
provide debugging information when tests fail
https://datadoghq.atlassian.net/browse/WINA-620

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
It would be nice to add the clear/collect from Before/AfterTest in the base installer suite, but since the `Env` is templated we don't have access to the `RemoteHost`.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
