### PR TITLE
[ASCII-1327] Increase `configsync` test interval and add logs

### DIFF
--- a/comp/core/configsync/configsyncimpl/test_common.go
+++ b/comp/core/configsync/configsyncimpl/test_common.go
@@ -14,9 +14,9 @@ import (
 	"net/url"
 	"testing"
 
-	"go.uber.org/fx"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
@@ -71,8 +71,7 @@ func makeConfigSyncWithServer(t *testing.T, ctx context.Context, handler http.Ha
 	return cs
 }
 
-func requireConfigIsSet(t *testing.T, cfg model.Reader, key string, value interface{}) {
-	t.Helper()
-	require.Equal(t, value, cfg.Get(key))
-	require.Equal(t, model.SourceLocalConfigProcess, cfg.GetSource(key))
+func assertConfigIsSet(t assert.TestingT, cfg model.Reader, key string, value interface{}) {
+	assert.Equal(t, value, cfg.Get(key))
+	assert.Equal(t, model.SourceLocalConfigProcess, cfg.GetSource(key))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Increase the interval for one of the `configsync` integration tests, and wrap some assertion in an `EventuallyWithT`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The test was added recently and is flaky due to the timeout being too low, in particular on MacOS where the CI runners are slow.
Also added some logs to help with debugging if it happens again.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
