### PR TITLE
[fleet] Add back dd-updater user

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	// root user is changed to dd-agent to avoid permission issues
-	rootToDDAgent()
+	// root user is changed to dd-updater to avoid permission issues
+	rootToDDUpdater()
 	os.Exit(runcmd.Run(command.MakeCommand(subcommands.UpdaterSubcommands())))
 }

--- a/cmd/updater/user_all.go
+++ b/cmd/updater/user_all.go
@@ -15,8 +15,8 @@ import (
 	"syscall"
 )
 
-func moveToDDAgent() error {
-	usr, err := user.Lookup("dd-agent")
+func moveToDDUpdater() error {
+	usr, err := user.Lookup("dd-updater")
 	if err != nil {
 		return err
 	}
@@ -27,14 +27,14 @@ func moveToDDAgent() error {
 	return syscall.Setuid(uid)
 }
 
-func rootToDDAgent() {
+func rootToDDUpdater() {
 	userID := syscall.Getuid()
 	if userID != 0 {
 		return
 	}
-	fmt.Println("Program run as root, downgrading to dd-agent user.")
+	fmt.Println("Program run as root, downgrading to dd-updater user.")
 
-	if err := moveToDDAgent(); err != nil {
-		fmt.Printf("Failed to downgrade to dd-agent user, running as root: %v\n", err)
+	if err := moveToDDUpdater(); err != nil {
+		fmt.Printf("Failed to downgrade to dd-updater user, running as root: %v\n", err)
 	}
 }

--- a/cmd/updater/user_windows.go
+++ b/cmd/updater/user_windows.go
@@ -6,4 +6,4 @@
 // Package main implements 'updater'.
 package main
 
-func rootToDDAgent() {}
+func rootToDDUpdater() {}

--- a/omnibus/config/templates/updater/datadog-updater.service.erb
+++ b/omnibus/config/templates/updater/datadog-updater.service.erb
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 PIDFile=<%= install_dir %>/run/updater.pid
-User=dd-agent
+User=dd-updater
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
 ExecStart=<%= install_dir %>/bin/updater/updater run -p <%= install_dir %>/run/updater.pid

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -110,7 +110,7 @@ chown -R dd-updater:dd-updater ${PACKAGES_LOCK_DIR}
 chmod -R 755 ${PACKAGES_DIR}
 # Lock_dir is world writable as any application with a tracer injected
 # needs to write the PID
-chmod -R 666 ${PACKAGES_LOCK_DIR}
+chmod -R 766 ${PACKAGES_LOCK_DIR}
 
 # Make system-probe configs read-only
 chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -108,9 +108,9 @@ chown -R dd-updater:dd-updater ${PACKAGES_DIR}
 chown -R dd-updater:dd-updater ${PACKAGES_LOCK_DIR}
 
 chmod -R 755 ${PACKAGES_DIR}
-# Lock_dir is world writable as any application with a tracer injected
-# needs to write the PID
-chmod -R 766 ${PACKAGES_LOCK_DIR}
+# Lock_dir is world read/write/x as any application with a tracer injected
+# needs to write PID files
+chmod -R 777 ${PACKAGES_LOCK_DIR}
 
 # Make system-probe configs read-only
 chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -33,7 +33,9 @@ add_user_and_group() {
 set -e
 case "$1" in
     configure)
+        add_user_and_group 'dd-updater' $PACKAGES_DIR
         add_user_and_group 'dd-agent' $PACKAGES_DIR/datadog-agent
+        usermod -aG dd-agent dd-updater
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;
@@ -98,15 +100,17 @@ set -e
 
 # Set proper rights to the dd-agent user
 chown -R dd-agent:dd-agent ${CONFIG_DIR}
+chmod -R g+rw ${CONFIG_DIR}
 chown -R dd-agent:dd-agent ${LOG_DIR}
-chown -R dd-agent:dd-agent ${INSTALL_DIR}
-chown -R dd-agent:dd-agent ${PACKAGES_DIR}
-chown -R dd-agent:dd-agent ${PACKAGES_LOCK_DIR}
+chmod -R g+rw ${LOG_DIR}
+chown -R dd-updater:dd-updater ${INSTALL_DIR}
+chown -R dd-updater:dd-updater ${PACKAGES_DIR}
+chown -R dd-updater:dd-updater ${PACKAGES_LOCK_DIR}
 
 chmod -R 755 ${PACKAGES_DIR}
 # Lock_dir is world writable as any application with a tracer injected
 # needs to write the PID
-chown -R 666 ${PACKAGES_LOCK_DIR}
+chmod -R 666 ${PACKAGES_LOCK_DIR}
 
 # Make system-probe configs read-only
 chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true
@@ -133,8 +137,6 @@ chmod 750 ${UPDATER_HELPER}
 setcap cap_setuid+ep ${UPDATER_HELPER}
 
 $INSTALL_DIR/bin/updater/updater bootstrap -P datadog-agent
-# Bootstrap installs first agent with root ownership, overriding to dd-agent
-chown -R dd-agent:dd-agent ${PACKAGES_DIR}
 
 # start updater
 SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-updater || true

--- a/omnibus/package-scripts/updater-deb/postrm
+++ b/omnibus/package-scripts/updater-deb/postrm
@@ -16,8 +16,10 @@ case "$1" in
     purge)
         echo "Deleting dd-agent user"
         deluser dd-agent --quiet
+        deluser dd-updater --quiet
         echo "Deleting dd-agent group"
         (getent group dd-agent >/dev/null && delgroup dd-agent --quiet) || true
+        (getent group dd-updater >/dev/null && delgroup dd-updater --quiet) || true
         echo "Force-deleting $INSTALL_DIR"
         rm -rf $INSTALL_DIR
         rm -rf $LOG_DIR

--- a/pkg/updater/repository/repositories_test.go
+++ b/pkg/updater/repository/repositories_test.go
@@ -11,11 +11,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/updater/service"
 )
 
 func newTestRepositories(t *testing.T) *Repositories {
 	rootPath := t.TempDir()
 	locksRootPath := t.TempDir()
+	assert.Nil(t, service.BuildHelperForTests(rootPath, t.TempDir(), true))
 	repositories := NewRepositories(rootPath, locksRootPath)
 	return repositories
 }

--- a/pkg/updater/repository/repository.go
+++ b/pkg/updater/repository/repository.go
@@ -13,9 +13,11 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/DataDog/gopsutil/process"
 
+	"github.com/DataDog/datadog-agent/pkg/updater/service"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -361,6 +363,11 @@ func movePackageFromSource(packageName string, rootPath string, lockedPackages m
 	if err != nil {
 		return "", fmt.Errorf("could not move source: %w", err)
 	}
+	if strings.HasSuffix(rootPath, "datadog-agent") {
+		if err := service.ChownDDAgent(targetPath); err != nil {
+			return "", err
+		}
+	}
 
 	return targetPath, nil
 }
@@ -387,7 +394,7 @@ func (r *repositoryFiles) cleanup() error {
 			pkgRepositoryPath := filepath.Join(r.rootPath, file.Name())
 			pkgLocksPath := filepath.Join(r.locksPath, file.Name())
 			log.Debugf("package %s isn't locked, removing it", pkgRepositoryPath)
-			if err := os.RemoveAll(pkgRepositoryPath); err != nil {
+			if err := service.RemoveAll(pkgRepositoryPath); err != nil {
 				log.Errorf("could not remove package %s directory, will retry: %v", pkgRepositoryPath, err)
 			}
 			if err := os.RemoveAll(pkgLocksPath); err != nil {

--- a/pkg/updater/repository/repository_test.go
+++ b/pkg/updater/repository/repository_test.go
@@ -13,11 +13,13 @@ import (
 	"path"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/updater/service"
 	"github.com/stretchr/testify/assert"
 )
 
 func createTestRepository(t *testing.T, dir string, stablePackageName string) *Repository {
 	repositoryPath := path.Join(dir, "repository")
+	assert.Nil(t, service.BuildHelperForTests(repositoryPath, t.TempDir(), true))
 	locksPath := path.Join(dir, "run")
 	os.MkdirAll(repositoryPath, 0755)
 	os.MkdirAll(locksPath, 0777)

--- a/pkg/updater/service/cmd_executor.go
+++ b/pkg/updater/service/cmd_executor.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package service provides a way to interact with os services
+package service
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+var updaterHelper = filepath.Join(setup.InstallPath, "bin", "updater", "updater-helper")
+
+// ChownDDAgent changes the owner of the given path to the dd-agent user.
+func ChownDDAgent(path string) error {
+	return executeCommand(`{"command":"chown dd-agent","path":"` + path + `"}`)
+}
+
+// RemoveAll removes all files under a given path under /opt/datadog-packages regardless of their owner.
+func RemoveAll(path string) error {
+	return executeCommand(`{"command":"rm","path":"` + path + `"}`)
+}
+
+func executeCommand(command string) error {
+	cmd := exec.Command(updaterHelper, command)
+	cmd.Stdout = os.Stdout
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	stderrOutput, err := io.ReadAll(stderr)
+	if err != nil {
+		return err
+	}
+	if err := cmd.Wait(); err != nil {
+		return errors.New(string(stderrOutput))
+	}
+	return nil
+}
+
+// BuildHelperForTests builds the updater-helper binary for test
+func BuildHelperForTests(pkgDir, binPath string, skipUIDCheck bool) error {
+	updaterHelper = filepath.Join(binPath, "/updater-helper")
+	localPath, _ := filepath.Abs(".")
+	targetDir := "datadog-agent/pkg"
+	index := strings.Index(localPath, targetDir)
+	pkgPath := localPath[:index+len(targetDir)]
+	helperPath := filepath.Join(pkgPath, "updater", "service", "helper", "main.go")
+	cmd := exec.Command("go", "build", fmt.Sprintf(`-ldflags=-X main.pkgDir=%s -X main.testSkipUID=%v`, pkgDir, skipUIDCheck), "-o", updaterHelper, helperPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/pkg/updater/service/cmd_executor_windows.go
+++ b/pkg/updater/service/cmd_executor_windows.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package service provides a way to interact with os services
+package service
+
+import "os"
+
+// ChownDDAgent changes the owner of the given path to the dd-agent user.
+func ChownDDAgent(_ string) error {
+	return nil
+}
+
+// RemoveAll removes the versioned files at a given path.
+func RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+// BuildHelperForTests builds the updater-helper binary for test
+func BuildHelperForTests(_, _ string, _ bool) error {
+	return nil
+}

--- a/pkg/updater/service/helper/main.go
+++ b/pkg/updater/service/helper/main.go
@@ -24,7 +24,13 @@ import (
 var (
 	installPath string
 	systemdPath = "/lib/systemd/system" // todo load it at build time from omnibus
+	pkgDir      = "/opt/datadog-packages"
+	testSkipUID = ""
 )
+
+func enforceUID() bool {
+	return testSkipUID != "true"
+}
 
 type privilegeCommand struct {
 	Command string `json:"command,omitempty"`
@@ -84,7 +90,7 @@ func buildPathCommand(inputCommand privilegeCommand) (*exec.Cmd, error) {
 	if absPath != path || err != nil {
 		return nil, fmt.Errorf("invalid path")
 	}
-	if !strings.HasPrefix(path, "/opt/datadog-packages") {
+	if !strings.HasPrefix(path, pkgDir) {
 		return nil, fmt.Errorf("invalid path")
 	}
 	switch inputCommand.Command {
@@ -115,26 +121,25 @@ func executeCommand() error {
 		return err
 	}
 
-	// only root or dd-agent can execute this command
-	if currentUser != 0 {
-		ddAgentUser, err := user.Lookup("dd-agent")
+	// only root or dd-updater can execute this command
+	if currentUser != 0 && enforceUID() {
+		ddUpdaterUser, err := user.Lookup("dd-updater")
 		if err != nil {
-			return fmt.Errorf("failed to lookup dd-agent user: %s", err)
+			return fmt.Errorf("failed to lookup dd-updater user: %s", err)
 		}
-		if strconv.Itoa(currentUser) != ddAgentUser.Uid {
-			return fmt.Errorf("only root or dd-agent can execute this command")
+		if strconv.Itoa(currentUser) != ddUpdaterUser.Uid {
+			return fmt.Errorf("only root or dd-updater can execute this command")
 		}
+		if err := syscall.Setuid(0); err != nil {
+			return fmt.Errorf("failed to setuid: %s", err)
+		}
+		defer func() {
+			err := syscall.Setuid(currentUser)
+			if err != nil {
+				log.Printf("Failed to set back to current user: %s", err)
+			}
+		}()
 	}
-
-	if err := syscall.Setuid(0); err != nil {
-		return fmt.Errorf("failed to setuid: %s", err)
-	}
-	defer func() {
-		err := syscall.Setuid(currentUser)
-		if err != nil {
-			log.Printf("Failed to set back to current user: %s", err)
-		}
-	}()
 
 	log.Printf("Running command: %s", command.String())
 	return command.Run()

--- a/pkg/updater/service/systemd.go
+++ b/pkg/updater/service/systemd.go
@@ -10,13 +10,6 @@ package service
 
 import (
 	"encoding/json"
-	"errors"
-	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
-
-	"github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 type unitCommand string
@@ -37,8 +30,6 @@ type privilegeCommand struct {
 	Unit    string `json:"unit,omitempty"`
 	Path    string `json:"path,omitempty"`
 }
-
-var updaterHelper = filepath.Join(setup.InstallPath, "bin", "updater", "updater-helper")
 
 func stopUnit(unit string) error {
 	return executeCommand(wrapUnitCommand(stopCommand, unit))
@@ -66,27 +57,6 @@ func removeUnit(unit string) error {
 
 func systemdReload() error {
 	return executeCommand(systemdReloadCommand)
-}
-
-func executeCommand(command string) error {
-	cmd := exec.Command(updaterHelper, command)
-	cmd.Stdout = os.Stdout
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	stderrOutput, err := io.ReadAll(stderr)
-	if err != nil {
-		return err
-	}
-	if err := cmd.Wait(); err != nil {
-		return errors.New(string(stderrOutput))
-	}
-	return nil
 }
 
 func wrapUnitCommand(command unitCommand, unit string) string {

--- a/pkg/updater/service/systemd_test.go
+++ b/pkg/updater/service/systemd_test.go
@@ -10,8 +10,6 @@ package service
 import (
 	_ "embed"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -20,10 +18,7 @@ import (
 )
 
 func testSetup(t *testing.T) {
-	tmpDir := os.TempDir()
-	updaterHelper = filepath.Join(tmpDir, "/updater-helper")
-	cmd := exec.Command("go", "build", "-o", updaterHelper, "./helper/main.go")
-	assert.Nil(t, cmd.Run())
+	assert.Nil(t, BuildHelperForTests(os.TempDir(), os.TempDir(), false))
 }
 
 func TestInvalidCommands(t *testing.T) {
@@ -50,7 +45,7 @@ func TestAssertWorkingCommands(t *testing.T) {
 	testSetup(t)
 
 	// missing permissions on test setup, e2e tests verify the successful commands
-	successErr := "error: failed to lookup dd-agent user: user: unknown user dd-agent\n"
+	successErr := "error: failed to lookup dd-updater user: user: unknown user dd-updater\n"
 
 	require.Equal(t, successErr, startUnit("datadog-agent").Error())
 	assert.Equal(t, successErr, stopUnit("datadog-agent").Error())

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -11,6 +11,8 @@ package updater
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
@@ -19,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/updater/service"
 )
 
 type testRemoteConfigClient struct {
@@ -73,13 +76,21 @@ func (c *testRemoteConfigClient) SubmitRequest(request remoteAPIRequest) {
 }
 
 func newTestUpdater(t *testing.T, s *testFixturesServer, rcc *testRemoteConfigClient, defaultFixture fixture) *updaterImpl {
+	u, _, _ := newTestUpdaterWithPaths(t, s, rcc, defaultFixture)
+	return u
+}
+
+func newTestUpdaterWithPaths(t *testing.T, s *testFixturesServer, rcc *testRemoteConfigClient, defaultFixture fixture) (*updaterImpl, string, string) {
 	rc := &remoteConfig{client: rcc}
-	u := newUpdater(rc, t.TempDir(), t.TempDir(), "")
+	rootPath := t.TempDir()
+	locksPath := t.TempDir()
+	u := newUpdater(rc, rootPath, t.TempDir(), "")
 	u.installer.configsDir = t.TempDir()
+	assert.Nil(t, service.BuildHelperForTests(rootPath, t.TempDir(), true))
 	u.catalog = s.Catalog()
 	u.bootstrapVersions[defaultFixture.pkg] = defaultFixture.version
 	u.Start(context.Background())
-	return u
+	return u, rootPath, locksPath
 }
 
 func TestUpdaterBootstrap(t *testing.T) {
@@ -97,6 +108,50 @@ func TestUpdaterBootstrap(t *testing.T) {
 	assert.Equal(t, fixtureSimpleV1.version, state.Stable)
 	assert.False(t, state.HasExperiment())
 	assertEqualFS(t, s.PackageFS(fixtureSimpleV1), r.StableFS())
+}
+
+func TestUpdaterPurge(t *testing.T) {
+	s := newTestFixturesServer(t)
+	defer s.Close()
+	rc := newTestRemoteConfigClient()
+	updater, rootPath, locksPath := newTestUpdaterWithPaths(t, s, rc, fixtureSimpleV1)
+
+	bootstrapAndAssert := func() {
+		err := updater.Bootstrap(context.Background(), fixtureSimpleV1.pkg)
+		assert.NoError(t, err)
+
+		r := updater.repositories.Get(fixtureSimpleV1.pkg)
+		state, err := r.GetState()
+		assert.NoError(t, err)
+		assert.Equal(t, fixtureSimpleV1.version, state.Stable)
+		assert.False(t, state.HasExperiment())
+		assertEqualFS(t, s.PackageFS(fixtureSimpleV1), r.StableFS())
+	}
+	bootstrapAndAssert()
+	assert.Nil(t, os.WriteFile(filepath.Join(locksPath, "not_empty"), []byte("morbier\n"), 0644))
+	assertDirNotEmpty(t, locksPath)
+	assertDirNotEmpty(t, rootPath)
+	purge(locksPath, rootPath)
+	assertDirExistAndEmpty(t, locksPath)
+	assertDirExistAndEmpty(t, rootPath)
+	bootstrapAndAssert()
+	assertDirNotEmpty(t, rootPath)
+}
+
+func assertDirNotEmpty(t *testing.T, path string) {
+	_, err := os.Stat(path)
+	assert.Nil(t, err)
+	entry, err := os.ReadDir(path)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, entry)
+}
+
+func assertDirExistAndEmpty(t *testing.T, path string) {
+	_, err := os.Stat(path)
+	assert.Nil(t, err)
+	entry, err := os.ReadDir(path)
+	assert.Nil(t, err)
+	assert.Len(t, entry, 0)
 }
 
 func TestUpdaterBootstrapWithRC(t *testing.T) {

--- a/test/new-e2e/tests/updater/linux_test.go
+++ b/test/new-e2e/tests/updater/linux_test.go
@@ -48,20 +48,20 @@ func (v *vmUpdaterSuite) TestUserGroupsCreation() {
 
 func (v *vmUpdaterSuite) TestSharedAgentDirs() {
 	for _, dir := range []string{confDir, logDir} {
-		require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%U" %s`, dir)))
-		require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%G" %s`, dir)))
-		require.Equal(v.T(), "drwxrwxr-x\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%A" %s`, dir)))
+		require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(`stat -c "%U" `+dir))
+		require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(`stat -c "%G" `+dir))
+		require.Equal(v.T(), "drwxrwxr-x\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+dir))
 	}
 }
 
 func (v *vmUpdaterSuite) TestUpdaterDirs() {
 	for _, dir := range []string{locksDir, packagesDir, installDir} {
-		require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%U" %s`, dir)))
-		require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%G" %s`, dir)))
+		require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(`stat -c "%U" `+dir))
+		require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(`stat -c "%G" `+dir))
 	}
-	require.Equal(v.T(), "drw-rw-rw-\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%A" %s`, locksDir)))
-	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%A" %s`, packagesDir)))
-	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%A" %s`, installDir)))
+	require.Equal(v.T(), "drw-rw-rw-\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+locksDir))
+	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+packagesDir))
+	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+installDir))
 }
 
 func (v *vmUpdaterSuite) TestAgentUnitsLoaded() {

--- a/test/new-e2e/tests/updater/linux_test.go
+++ b/test/new-e2e/tests/updater/linux_test.go
@@ -59,7 +59,7 @@ func (v *vmUpdaterSuite) TestUpdaterDirs() {
 		require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(`stat -c "%U" `+dir))
 		require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(`stat -c "%G" `+dir))
 	}
-	require.Equal(v.T(), "drw-rw-rw-\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+locksDir))
+	require.Equal(v.T(), "drwxrw-rw-\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+locksDir))
 	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+packagesDir))
 	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+installDir))
 }

--- a/test/new-e2e/tests/updater/linux_test.go
+++ b/test/new-e2e/tests/updater/linux_test.go
@@ -59,7 +59,7 @@ func (v *vmUpdaterSuite) TestUpdaterDirs() {
 		require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(`stat -c "%U" `+dir))
 		require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(`stat -c "%G" `+dir))
 	}
-	require.Equal(v.T(), "drwxrw-rw-\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+locksDir))
+	require.Equal(v.T(), "drwxrwxrwx\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+locksDir))
 	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+packagesDir))
 	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" `+installDir))
 }

--- a/test/new-e2e/tests/updater/linux_test.go
+++ b/test/new-e2e/tests/updater/linux_test.go
@@ -18,6 +18,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	confDir     = "/etc/datadog-agent"
+	logDir      = "/var/log/datadog"
+	locksDir    = "/var/run/datadog-packages"
+	packagesDir = "/opt/datadog-packages"
+	installDir  = "/opt/datadog/updater"
+)
+
 type vmUpdaterSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
@@ -29,15 +37,31 @@ func TestUpdaterSuite(t *testing.T) {
 	)))
 }
 
-func (v *vmUpdaterSuite) TestUpdaterOwnership() {
-	// updater user exists and is a system user
+func (v *vmUpdaterSuite) TestUserGroupsCreation() {
+	// users exist and is a system user
 	require.Equal(v.T(), "/usr/sbin/nologin\n", v.Env().RemoteHost.MustExecute(`getent passwd dd-agent | cut -d: -f7`), "unexpected: user does not exist or is not a system user")
-	// owner
-	require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(`stat -c "%U" /opt/datadog/updater`))
-	// group
-	require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(`stat -c "%G" /opt/datadog/updater`))
-	// permissions
-	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(`stat -c "%A" /opt/datadog/updater`))
+	require.Equal(v.T(), "/usr/sbin/nologin\n", v.Env().RemoteHost.MustExecute(`getent passwd dd-updater | cut -d: -f7`), "unexpected: user does not exist or is not a system user")
+	require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(`getent group dd-updater | cut -d":" -f1`), "unexpected: group does not exist")
+	require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(`getent group dd-agent | cut -d":" -f1`), "unexpected: group does not exist")
+	require.Equal(v.T(), "dd-updater dd-agent\n", v.Env().RemoteHost.MustExecute("id -Gn dd-updater"), "dd-updater not in correct groups")
+}
+
+func (v *vmUpdaterSuite) TestSharedAgentDirs() {
+	for _, dir := range []string{confDir, logDir} {
+		require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%U" %s`, dir)))
+		require.Equal(v.T(), "dd-agent\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%G" %s`, dir)))
+		require.Equal(v.T(), "drwxrwxr-x\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%A" %s`, dir)))
+	}
+}
+
+func (v *vmUpdaterSuite) TestUpdaterDirs() {
+	for _, dir := range []string{locksDir, packagesDir, installDir} {
+		require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%U" %s`, dir)))
+		require.Equal(v.T(), "dd-updater\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%G" %s`, dir)))
+	}
+	require.Equal(v.T(), "drw-rw-rw-\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%A" %s`, locksDir)))
+	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%A" %s`, packagesDir)))
+	require.Equal(v.T(), "drwxr-xr-x\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`stat -c "%A" %s`, installDir)))
 }
 
 func (v *vmUpdaterSuite) TestAgentUnitsLoaded() {
@@ -53,7 +77,7 @@ func (v *vmUpdaterSuite) TestAgentUnitsLoaded() {
 	}
 }
 
-func (v *vmUpdaterSuite) TestPurge() {
+func (v *vmUpdaterSuite) TestPurgeAndInstall() {
 	v.Env().RemoteHost.MustExecute("sudo /opt/datadog/updater/bin/updater/updater purge")
 	stableUnits := []string{
 		"datadog-agent.service",
@@ -71,4 +95,9 @@ func (v *vmUpdaterSuite) TestPurge() {
 		)
 	}
 	v.Env().RemoteHost.MustExecute("sudo /opt/datadog/updater/bin/updater/updater bootstrap -P datadog-agent")
+
+	for _, unit := range stableUnits {
+		require.Equal(v.T(), "enabled\n", v.Env().RemoteHost.MustExecute(fmt.Sprintf(`systemctl is-enabled %s`, unit)))
+	}
+	require.Equal(v.T(), "1\n", v.Env().RemoteHost.MustExecute(`sudo ls -l /opt/datadog-packages/datadog-agent/ | awk '$9 != "stable" && $3 == "dd-agent" && $4 == "dd-agent"' | wc -l`))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

- add back dd-updater user
- rm commands now pass through the helper to avoid permission issues when removing a package
- agent packages are chown to dd-agent
- fixed purge to not delete /opt/datadog-packages, only the nested elements

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
