### PR TITLE
[clusteragent/admission/sidecar] Set ShareProcessNamespace=true on EKS Fargate

### DIFF
--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	apicommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 const commonRegistry = "gcr.io/datadoghq"
@@ -181,6 +182,7 @@ func TestInjectAgentSidecar(t *testing.T) {
 						Name: "pod-name",
 					},
 					Spec: corev1.PodSpec{
+						ShareProcessNamespace: pointer.Ptr(true),
 						Containers: []corev1.Container{
 							{
 								Name: "container-name",
@@ -297,6 +299,7 @@ func TestInjectAgentSidecar(t *testing.T) {
 						Name: "pod-name",
 					},
 					Spec: corev1.PodSpec{
+						ShareProcessNamespace: pointer.Ptr(true),
 						Containers: []corev1.Container{
 							{
 								Name: "container-name",

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 func TestProviderIsSupported(t *testing.T) {
@@ -98,6 +99,7 @@ func TestApplyProviderOverrides(t *testing.T) {
 			},
 			expectedPodAfterOverride: &corev1.Pod{
 				Spec: corev1.PodSpec{
+					ShareProcessNamespace: pointer.Ptr(true),
 					Containers: []corev1.Container{
 						{
 							Name: "app-container",
@@ -201,6 +203,7 @@ func TestApplyProviderOverrides(t *testing.T) {
 			},
 			expectedPodAfterOverride: &corev1.Pod{
 				Spec: corev1.PodSpec{
+					ShareProcessNamespace: pointer.Ptr(true),
 					Containers: []corev1.Container{
 						{
 							Name: "app-container",

--- a/releasenotes-dca/notes/admin-controller-eksfargate-shareprocessnamespace-fea146b97cbb8a20.yaml
+++ b/releasenotes-dca/notes/admin-controller-eksfargate-shareprocessnamespace-fea146b97cbb8a20.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When using the admission controller to inject an Agent sidecar on EKS
+    Fargate, `shareProcessNamespace` is now set to `true` automatically. This is
+    to ensure that the process collection feature works.


### PR DESCRIPTION

### What does this PR do?

Sets ShareProcessNamespace=true in the sidecar admission controller webhook when deploying on EKS Fargate.
This is needed by the process collection feature.

### Describe how to test/QA your changes

Deploy the Agent on EKS Fargate. You need to enable the admission controller with sidecar injection configured to enable process collection via sidecar profiles. Here's the helm chart that I used:
```yaml
clusterAgent:
  admissionController:
    enabled: true
  env:
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_ENABLED
      value: "true"
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_PROVIDER
      value: "fargate"
    - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_PROFILES
      value: "[{\"env\":[{\"name\":\"DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED\", \"value\":\"true\"}]}]"
```

Now deploy something on the Fargate namespace. The only important part is to set the labels used by the admission controller correctly. Also, make sure that `shareProcessNamespace` is not set (it will be injected automatically). Here's an example deployment that you can use:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
        admission.datadoghq.com/enabled: "true"
        agent.datadoghq.com/sidecar: "fargate"
    spec:
      serviceAccountName: datadog-agent-fargate # Make sure this matches your service account
      containers:
      - name: nginx
        image: nginx
```

Remember to create the needed RBACs for Fargate as described here: https://docs.datadoghq.com/integrations/eks_fargate/#aws-eks-fargate-rbac

Now check that process collection works as expected. In the Datadog app you should be able to see the processes both for the agent sidecar that was automatically injected and also for your container.