### PR TITLE
[CI] Use a different codecov flag for each distro

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -5,6 +5,7 @@ Miscellaneous functions, no tasks here
 
 import json
 import os
+import platform
 import re
 import sys
 import time
@@ -66,6 +67,21 @@ def bin_name(name):
     if sys.platform == 'win32':
         return f"{name}.exe"
     return name
+
+
+def get_distro():
+    """
+    Get the distro name. Windows and Darwin stays the same.
+    Linux is the only one that needs to be determined using the /etc/os-release file.
+    """
+    system = platform.system()
+    if system == 'Linux':
+        if os.path.isfile('/etc/os-release'):
+            with open('/etc/os-release', encoding="utf-8") as f:
+                for line in f:
+                    if line.startswith('ID='):
+                        return line.strip()[3:]
+    return system.lower()
 
 
 def get_goenv(ctx, var):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds a more precise codecov flag (to differentiate linux platforms).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Since we're now reporting Codecov reports on almost all CI jobs (thanks to #23680), we need to differentiate the different linux distributions. Left like that they'd all report as `Linux`.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
