### PR TITLE
[ASCII-1328] Reduce integration test flakiness using Eventually and a longer timeout

### DIFF
--- a/comp/core/configsync/configsyncimpl/module_integration_test.go
+++ b/comp/core/configsync/configsyncimpl/module_integration_test.go
@@ -55,7 +55,7 @@ func TestOptionalModule(t *testing.T) {
 	_, ok := csopt.Get()
 	require.True(t, ok)
 
-	time.Sleep(2 * time.Second)
-
-	assert.Equal(t, "value1", cfg.Get("key1"))
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Equal(t, "value1", cfg.Get("key1"))
+	}, 5*time.Second, 500*time.Millisecond)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Reduce integration test flakiness using Eventually and a longer timeout.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The test flaked recently on MacOS due to the runner being too slow, increasing the max timeout and moving the assertion in an `Eventually` should fix that.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
