### PR TITLE
[clusteragent/admission/sidecar] Simplify TestApplyProviderOverrides

### DIFF
--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
@@ -8,10 +8,11 @@
 package agentsidecar
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -274,26 +275,20 @@ func TestApplyProviderOverrides(t *testing.T) {
 		t.Run(test.name, func(tt *testing.T) {
 			mockConfig.SetWithoutSource("admission_controller.agent_sidecar.provider", test.provider)
 			mutated, err := applyProviderOverrides(test.basePod)
-			assert.Equal(tt, test.expectMutated, mutated)
 
 			if test.expectError {
 				assert.Error(tt, err)
-			} else {
-				assert.NoError(tt, err)
-
-				if test.expectedPodAfterOverride == nil {
-					assert.Nil(tt, test.basePod)
-				} else {
-					assert.NotNil(tt, test.basePod)
-					assert.Truef(tt,
-						reflect.DeepEqual(*test.basePod, *test.expectedPodAfterOverride),
-						"overrides not applied as expected. expected %v, but found %v",
-						*test.expectedPodAfterOverride,
-						*test.basePod,
-					)
-				}
+				return
 			}
 
+			require.NoError(tt, err)
+			assert.Equal(tt, test.expectMutated, mutated)
+			assert.True(
+				tt,
+				cmp.Equal(test.expectedPodAfterOverride, test.basePod),
+				"overrides not applied as expected. diff: %s",
+				cmp.Diff(test.expectedPodAfterOverride, test.basePod),
+			)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Small refactor.
Simplifies `TestApplyProviderOverrides` in `pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go` by using early returns and `cmp.Equal` + `cmp.Diff` to easily check the diff between structs.

### Describe how to test/QA your changes

Skip.
