### PR TITLE
[CI] Remove `PyYAML` override in winbuildscripts

### DIFF
--- a/tasks/winbuildscripts/integrationtests.ps1
+++ b/tasks/winbuildscripts/integrationtests.ps1
@@ -13,8 +13,6 @@ if ($Env:TARGET_ARCH -eq "x64") {
 $UT_BUILD_ROOT=(Get-Location).Path
 $Env:PATH="$UT_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:PATH"
 
-& $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
-
 $archflag = "x64"
 if ($Env:TARGET_ARCH -eq "x86") {
     $archflag = "x86"

--- a/tasks/winbuildscripts/lint.ps1
+++ b/tasks/winbuildscripts/lint.ps1
@@ -10,8 +10,6 @@ if ($Env:TARGET_ARCH -eq "x64") {
 $LINT_ROOT=(Get-Location).Path
 $Env:PATH="$LINT_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:PATH;$Env:VSTUDIO_ROOT\VC\Tools\Llvm\bin"
 
-& $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
-
 $archflag = "x64"
 if ($Env:TARGET_ARCH -eq "x86") {
     $archflag = "x86"

--- a/tasks/winbuildscripts/secagent.ps1
+++ b/tasks/winbuildscripts/secagent.ps1
@@ -12,8 +12,6 @@ if ($Env:TARGET_ARCH -eq "x64") {
 $PROBE_BUILD_ROOT=(Get-Location).Path
 $Env:PATH="$PROBE_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:Python2_ROOT_DIR;$Env:Python2_ROOT_DIR\Scripts;$Env:PATH"
 
-& $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
-
 & inv -e deps
 & inv -e install-tools
 

--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -12,8 +12,6 @@ if ($Env:TARGET_ARCH -eq "x64") {
 $PROBE_BUILD_ROOT=(Get-Location).Path
 $Env:PATH="$PROBE_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:Python2_ROOT_DIR;$Env:Python2_ROOT_DIR\Scripts;$Env:PATH"
 
-& $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
-
 & inv -e deps
 & inv -e install-tools
 

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -15,8 +15,6 @@ if ($Env:TARGET_ARCH -eq "x64") {
 $UT_BUILD_ROOT=(Get-Location).Path
 $Env:PATH="$UT_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:PATH"
 
-& $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
-
 & pip install -r tasks/libs/requirements-github.txt
 & inv -e invoke-unit-tests
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR removes the installation of the `PyYAML` dependency in the unit tests powershell script.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This is IMO bad practice for dependency management, we should use the one in the requirements file instead, and not override it.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

I already tried fixing this in #20422 but it didn't work. We had the same issue with `awscli` in which I fixed by reversing the path order of Python 2 and 3 in #23392. Now that the path is fixed we can properly remove this !

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
