### PR TITLE
[ASCII-1329] Remove some unknown config keys warning logs

### DIFF
--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -385,7 +385,7 @@ func setupInternalProfiling(config config.Component) error {
 		v, _ := version.Agent()
 
 		cfgSite := config.GetString(secAgentKey("internal_profiling.site"))
-		cfgURL := config.GetString(secAgentKey("security_agent.internal_profiling.profile_dd_url"))
+		cfgURL := config.GetString(secAgentKey("internal_profiling.profile_dd_url"))
 
 		// check if TRACE_AGENT_URL is set, in which case, forward the profiles to the trace agent
 		var site string

--- a/cmd/system-probe/config/adjust.go
+++ b/cmd/system-probe/config/adjust.go
@@ -21,7 +21,7 @@ var adjustMtx sync.Mutex
 func Adjust(cfg config.Config) {
 	adjustMtx.Lock()
 	defer adjustMtx.Unlock()
-	if cfg.GetBool(spNS("adjusted")) {
+	if cfg.IsKnown(spNS("adjusted")) {
 		return
 	}
 
@@ -54,7 +54,7 @@ func Adjust(cfg config.Config) {
 		cfg.Set(spNS("process_service_inference", "enabled"), false, model.SourceAgentRuntime)
 	}
 
-	cfg.Set(spNS("adjusted"), true, model.SourceAgentRuntime)
+	cfg.SetKnown(spNS("adjusted"))
 }
 
 // validateString validates the string configuration value at `key` using a custom provided function `valFn`.

--- a/cmd/system-probe/config/adjust.go
+++ b/cmd/system-probe/config/adjust.go
@@ -21,7 +21,7 @@ var adjustMtx sync.Mutex
 func Adjust(cfg config.Config) {
 	adjustMtx.Lock()
 	defer adjustMtx.Unlock()
-	if cfg.IsKnown(spNS("adjusted")) {
+	if cfg.GetBool(spNS("adjusted")) {
 		return
 	}
 
@@ -54,7 +54,7 @@ func Adjust(cfg config.Config) {
 		cfg.Set(spNS("process_service_inference", "enabled"), false, model.SourceAgentRuntime)
 	}
 
-	cfg.SetKnown(spNS("adjusted"))
+	cfg.Set(spNS("adjusted"), true, model.SourceAgentRuntime)
 }
 
 // validateString validates the string configuration value at `key` using a custom provided function `valFn`.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -258,7 +258,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("health_port", int64(0))
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("python_version", DefaultPython)
-	config.SetKnown("win_skip_com_init")
+	config.BindEnvAndSetDefault("win_skip_com_init", false)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
 	config.BindEnvAndSetDefault("remote_tagger_timeout_seconds", 30)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -258,6 +258,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("health_port", int64(0))
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("python_version", DefaultPython)
+	config.SetKnown("win_skip_com_init")
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
 	config.BindEnvAndSetDefault("remote_tagger_timeout_seconds", 30)
@@ -365,6 +366,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("secret_backend_skip_checks", false)
 	config.BindEnvAndSetDefault("secret_backend_remove_trailing_line_break", false)
 	config.BindEnvAndSetDefault("secret_refresh_interval", 0)
+	config.SetKnown("secret_audit_file_max_size")
 
 	// Use to output logs in JSON format
 	config.BindEnvAndSetDefault("log_format_json", false)
@@ -2041,6 +2043,7 @@ func bindEnvAndSetLogsConfigKeys(config pkgconfigmodel.Config, prefix string) {
 	config.BindEnvAndSetDefault(prefix+"sender_recovery_interval", DefaultForwarderRecoveryInterval)
 	config.BindEnvAndSetDefault(prefix+"sender_recovery_reset", false)
 	config.BindEnvAndSetDefault(prefix+"use_v2_api", true)
+	config.SetKnown(prefix + "dev_mode_no_ssl")
 }
 
 // IsCloudProviderEnabled checks the cloud provider family provided in

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -366,7 +366,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("secret_backend_skip_checks", false)
 	config.BindEnvAndSetDefault("secret_backend_remove_trailing_line_break", false)
 	config.BindEnvAndSetDefault("secret_refresh_interval", 0)
-	config.SetKnown("secret_audit_file_max_size")
+	config.SetDefault("secret_audit_file_max_size", 0)
 
 	// Use to output logs in JSON format
 	config.BindEnvAndSetDefault("log_format_json", false)

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -109,6 +109,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// settings for system-probe in general
 	cfg.BindEnvAndSetDefault(join(spNS, "enabled"), false, "DD_SYSTEM_PROBE_ENABLED")
 	cfg.BindEnvAndSetDefault(join(spNS, "external"), false, "DD_SYSTEM_PROBE_EXTERNAL")
+	cfg.SetKnown(join(spNS, "adjusted"))
 
 	cfg.BindEnvAndSetDefault(join(spNS, "sysprobe_socket"), defaultSystemProbeAddress, "DD_SYSPROBE_SOCKET")
 	cfg.BindEnvAndSetDefault(join(spNS, "max_conns_per_message"), defaultConnsMessageBatchSize)

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -202,6 +202,8 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	cfg.BindEnvAndSetDefault(join(spNS, "language_detection.enabled"), false)
 
+	cfg.SetKnown(join(spNS, "process_service_inference", "use_improved_algorithm"))
+
 	// For backward compatibility
 	cfg.BindEnv(join(smNS, "process_service_inference", "enabled"), "DD_SYSTEM_PROBE_PROCESS_SERVICE_INFERENCE_ENABLED")
 	cfg.BindEnv(join(spNS, "process_service_inference", "enabled"))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Set some missing configs as `known` to avoid warnings.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The config logs warnings when accessing keys that weren't declared with `SetKnown`, `SetDefault`, `BindEnv` or some other similar methods.
This PR sets some keys as known to remove warnings.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The keys that had warnings before which are fixed by this PR are:
- `secret_audit_file_max_size`
- `system_probe_config.adjusted`
- `win_skip_com_init`
- `system_probe_config.process_service_inference.use_improved_algorithm`
- `security_agent.security_agent.internal_profiling.profile_dd_url`
- `runtime_security_config.activity_dump.remote_storage.endpoints.dev_mode_no_ssl`
- `compliance_config.endpoints.dev_mode_no_ssl`
- `container_image.dev_mode_no_ssl`
- `container_lifecycle.dev_mode_no_ssl`
- `database_monitoring.activity.dev_mode_no_ssl`
- `database_monitoring.metrics.dev_mode_no_ssl`
- `database_monitoring.samples.dev_mode_no_ssl`
- `logs_config.dev_mode_no_ssl`
- `network_devices.metadata.dev_mode_no_ssl`
- `network_devices.netflow.forwarder.dev_mode_no_ssl`
- `network_devices.snmp_traps.forwarder.dev_mode_no_ssl`
- `network_path.forwarder.dev_mode_no_ssl`
- `runtime_security_config.endpoints.dev_mode_no_ssl`
- `sbom.dev_mode_no_ssl`

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
