### PR TITLE
fix: agentless scanner arm64 RPM deploy job

### DIFF
--- a/.gitlab/deploy_packages/nix.yml
+++ b/.gitlab/deploy_packages/nix.yml
@@ -148,7 +148,7 @@ deploy_packages_agentless_scanner_rpm-arm64-7:
   extends: .deploy_packages_rpm-7
   needs: [ agentless_scanner_rpm-arm64 ]
   variables:
-    PACKAGE_ARCH: arm64
+    PACKAGE_ARCH: aarch64
 
 deploy_packages_suse_rpm-x64-7:
   extends: .deploy_packages_suse_rpm-7


### PR DESCRIPTION
### What does this PR do?

Updates agentless scanner arm64 RPM deploy job to look for `aarch64` as that's how RPM's are packaged.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
