### PR TITLE
invoke(update-test-infra): Add a flag to update only go mod

### DIFF
--- a/tasks/buildimages.py
+++ b/tasks/buildimages.py
@@ -22,11 +22,13 @@ def update(_: Context, image_tag: str, test_version: Optional[str] = True):
 
 
 @task(help={"commit_sha": "commit sha from the test-infra-definitions repository"})
-def update_test_infra_definitions(ctx: Context, commit_sha: str):
+def update_test_infra_definitions(ctx: Context, commit_sha: str, go_mod_only: bool = False):
     """
     Update the test-infra-definition image version in the Gitlab CI as well as in the e2e go.mod
     """
-    update_test_infra_def(".gitlab-ci.yml", commit_sha[:12])
+    if not go_mod_only:
+        update_test_infra_def(".gitlab-ci.yml", commit_sha[:12])
+
     os.chdir("test/new-e2e")
     ctx.run(f"go get github.com/DataDog/test-infra-definitions@{commit_sha}")
     ctx.run("go mod tidy")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add a flag so we can run test-infra-update without changing the docker image. This can be useful because the docker image is published only once the test-infra PR is merged, while the Go version can be updated while working on the PR.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
