### PR TITLE
Revert "include $CI_PIPELINE_ID in s3 cp filter"

### DIFF
--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -15,8 +15,8 @@ deploy_packages_windows-x64-6:
     - $S3_CP_CMD
       --recursive
       --exclude "*"
-      --include "datadog-agent-6*$CI_PIPELINE_ID*.msi"
-      --include "datadog-agent-6*$CI_PIPELINE_ID*.debug.zip"
+      --include "datadog-agent-6*.msi"
+      --include "datadog-agent-6*.debug.zip"
       $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ || true
 
 #
@@ -35,8 +35,8 @@ deploy_packages_windows-x64-7:
     - $S3_CP_CMD
       --recursive
       --exclude "*"
-      --include "datadog-agent-7*$CI_PIPELINE_ID*.msi"
-      --include "datadog-agent-7*$CI_PIPELINE_ID*.debug.zip"
+      --include "datadog-agent-7*.msi"
+      --include "datadog-agent-7*.debug.zip"
       $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ || true
 
 deploy_staging_windows_tags-7:

--- a/.gitlab/kitchen_deploy/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy/kitchen_deploy.yml
@@ -314,7 +314,7 @@ deploy_windows_testing-a6:
     - source /root/.bashrc
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-6.*$CI_PIPELINE_ID*.msi" $OMNIBUS_PACKAGE_DIR s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET_A6 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-6.*.msi" $OMNIBUS_PACKAGE_DIR s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET_A6 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_windows_testing-a7:
   rules:
@@ -330,4 +330,4 @@ deploy_windows_testing-a7:
     - source /root/.bashrc
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7.*$CI_PIPELINE_ID*.msi" $OMNIBUS_PACKAGE_DIR s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET_A7 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7.*.msi" $OMNIBUS_PACKAGE_DIR s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET_A7 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732


### PR DESCRIPTION
Reverts DataDog/datadog-agent#23896

only dev pipelines include the pipeline ID in the MSI name.

https://datadoghq.atlassian.net/browse/WINA-703
https://datadoghq.atlassian.net/browse/CIREL-1970