### PR TITLE
[CSPM] Cleanups in dbconfig and new kubelet.service path

### DIFF
--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -106,15 +106,15 @@ func loadRun(_ log.Component, _ config.Component, loadArgs *loadCliParams) error
 		if loadArgs.procPid == 0 {
 			return fmt.Errorf("missing required flag --proc-pid")
 		}
-		proc, containerID, rootPath, err := getProcMeta(hostroot, int32(loadArgs.procPid))
+		proc, _, rootPath, err := getProcMeta(hostroot, int32(loadArgs.procPid))
 		if err != nil {
 			return err
 		}
-		dbresource, ok := dbconfig.LoadDBResource(ctx, rootPath, proc, containerID)
+		var ok bool
+		resourceType, resource, ok = dbconfig.LoadConfiguration(ctx, rootPath, proc)
 		if !ok {
 			return fmt.Errorf("failed to load database config from process %d in %q", loadArgs.procPid, rootPath)
 		}
-		resourceType, resource = dbresource.Type, dbresource.Config
 	default:
 		return fmt.Errorf("unknown config type %q", loadArgs.confType)
 	}

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -455,9 +455,15 @@ func (a *Agent) runDBConfigurationsExport(ctx context.Context) {
 		groups := groupProcesses(procs, dbconfig.GetProcResourceType)
 		for keyGroup, proc := range groups {
 			rootPath := filepath.Join(a.opts.HostRoot, keyGroup.rootPath)
-			resource, ok := dbconfig.LoadDBResource(ctx, rootPath, proc, keyGroup.containerID)
+			resourceType, resource, ok := dbconfig.LoadConfiguration(ctx, rootPath, proc)
 			if ok {
-				a.reportResourceLog(defaultCheckIntervalLowPriority, NewResourceLog(a.opts.Hostname, resource.Type, resource.Config))
+				log := NewResourceLog(a.opts.Hostname, resourceType, resource)
+				if keyGroup.containerID != "" {
+					log.Container = &CheckContainerMeta{
+						ContainerID: string(keyGroup.containerID),
+					}
+				}
+				a.reportResourceLog(defaultCheckIntervalLowPriority, log)
 			}
 		}
 		if sleepAborted(ctx, runTicker.C) {

--- a/pkg/compliance/dbconfig/loader.go
+++ b/pkg/compliance/dbconfig/loader.go
@@ -78,12 +78,12 @@ func GetProcResourceType(proc *process.Process) (string, bool) {
 	return "", false
 }
 
-// LoadDBResource loads and returns an optional DBResource associated with the
+// LoadConfiguration loads and returns an optional DBResource associated with the
 // given process PID.
-func LoadDBResource(ctx context.Context, rootPath string, proc *process.Process, containerID utils.ContainerID) (*DBResource, bool) {
+func LoadConfiguration(ctx context.Context, rootPath string, proc *process.Process) (string, *DBConfig, bool) {
 	resourceType, ok := GetProcResourceType(proc)
 	if !ok {
-		return nil, false
+		return "", nil, false
 	}
 	var conf *DBConfig
 	switch resourceType {
@@ -97,13 +97,9 @@ func LoadDBResource(ctx context.Context, rootPath string, proc *process.Process,
 		ok = false
 	}
 	if !ok || conf == nil {
-		return nil, false
+		return "", nil, false
 	}
-	return &DBResource{
-		Type:        resourceType,
-		ContainerID: string(containerID),
-		Config:      *conf,
-	}, true
+	return resourceType, conf, true
 }
 
 // LoadDBResourceFromPID loads and returns an optional DBResource associated

--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -68,6 +68,7 @@ func (l *loader) load(ctx context.Context, loadProcesses procsLoader) (string, *
 		"/etc/systemd/system/kubelet.service.d/kubelet.conf",
 		"/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
 		"/etc/systemd/system/kubelet.service.d/10-kubelet-args.conf",
+		"/etc/systemd/system/kubelet.service",
 		"/usr/lib/systemd/system/kubelet.service",
 		"/lib/systemd/system/kubelet.service",
 	})


### PR DESCRIPTION
### What does this PR do?

See individual commits:
  - dbconfig public methods were not aligned with existing k8sconfig, aptconfig `LoadConfiguration`
  - dbconfig tests spawning processes as been simplified a bit
  - dbconfig results were not properly passing container metadata
  - k8sconfig: add a missing possible kubelet.service path

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
