### PR TITLE
[NDM] Clarify and cleanup error messages in profile loading.

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -905,14 +905,14 @@ func Test_getProfileForSysObjectID(t *testing.T) {
 			profiles:        mockProfilesWithPatternError,
 			sysObjectID:     "1.3.6.1.4.1.3375.2.1.3.4.5.11",
 			expectedProfile: "",
-			expectedError:   "failed to get most specific profile for sysObjectID `1.3.6.1.4.1.3375.2.1.3.4.5.11`, for matched oids [1.3.6.1.4.1.3375.2.1.3.***.*]: error parsing part `***` for pattern `1.3.6.1.4.1.3375.2.1.3.***.*`: strconv.Atoi: parsing \"***\": invalid syntax",
+			expectedError:   "failed to get most specific profile for sysObjectID \"1.3.6.1.4.1.3375.2.1.3.4.5.11\", for matched oids [1.3.6.1.4.1.3375.2.1.3.***.*]: error parsing part `***` for pattern `1.3.6.1.4.1.3375.2.1.3.***.*`: strconv.Atoi: parsing \"***\": invalid syntax",
 		},
 		{
 			name:            "invalid pattern", // profiles with invalid patterns are skipped, leading to: cannot get most specific oid from empty list of oids
 			profiles:        mockProfilesWithInvalidPatternError,
 			sysObjectID:     "1.3.6.1.4.1.3375.2.1.3.4.5.11",
 			expectedProfile: "",
-			expectedError:   "failed to get most specific profile for sysObjectID `1.3.6.1.4.1.3375.2.1.3.4.5.11`, for matched oids []: cannot get most specific oid from empty list of oids",
+			expectedError:   "failed to get most specific profile for sysObjectID \"1.3.6.1.4.1.3375.2.1.3.4.5.11\", for matched oids []: cannot get most specific oid from empty list of oids",
 		},
 		{
 			name:            "duplicate sysobjectid",

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig.go
@@ -14,7 +14,7 @@ func loadInitConfigProfiles(rawInitConfigProfiles ProfileConfigMap) (ProfileConf
 		if profConfig.DefinitionFile != "" {
 			profDefinition, err := readProfileDefinition(profConfig.DefinitionFile)
 			if err != nil {
-				log.Warnf("failed to read profile definition `%s`: %s", name, err)
+				log.Warnf("unable to load profile %q: %s", name, err)
 				continue
 			}
 			profConfig.Definition = *profDefinition

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_json_bundle_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_json_bundle_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
@@ -18,8 +19,9 @@ func Test_loadBundleJSONProfiles(t *testing.T) {
 	defaultTestConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "zipprofiles.d"))
 	SetGlobalProfileConfigMap(nil)
 	config.Datadog.SetWithoutSource("confd_path", defaultTestConfdPath)
-
-	resolvedProfiles, err := loadBundleJSONProfiles()
+	pth := findProfileBundleFilePath()
+	require.FileExists(t, pth)
+	resolvedProfiles, err := loadBundleJSONProfiles(pth)
 	assert.Nil(t, err)
 
 	var actualProfiles []string

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
@@ -22,7 +22,7 @@ func resolveProfiles(userProfiles, defaultProfiles ProfileConfigMap) (ProfileCon
 	rawProfiles := mergeProfiles(defaultProfiles, userProfiles)
 	userExpandedProfiles, err := loadResolveProfiles(rawProfiles, defaultProfiles)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load profiles: %s", err)
+		return nil, fmt.Errorf("failed to load profiles: %w", err)
 	}
 	return userExpandedProfiles, nil
 }
@@ -39,7 +39,7 @@ func loadResolveProfiles(pConfig ProfileConfigMap, defaultProfiles ProfileConfig
 		newProfileConfig := deepcopy.Copy(pConfig[name]).(ProfileConfig)
 		err := recursivelyExpandBaseProfiles(name, &newProfileConfig.Definition, newProfileConfig.Definition.Extends, []string{}, pConfig, defaultProfiles)
 		if err != nil {
-			log.Warnf("failed to expand profile `%s`: %s", name, err)
+			log.Warnf("failed to expand profile %q: %v", name, err)
 			continue
 		}
 		profiledefinition.NormalizeMetrics(newProfileConfig.Definition.Metrics)
@@ -47,7 +47,7 @@ func loadResolveProfiles(pConfig ProfileConfigMap, defaultProfiles ProfileConfig
 		errors = append(errors, configvalidation.ValidateEnrichMetrics(newProfileConfig.Definition.Metrics)...)
 		errors = append(errors, configvalidation.ValidateEnrichMetricTags(newProfileConfig.Definition.MetricTags)...)
 		if len(errors) > 0 {
-			log.Warnf("validation errors: %s", strings.Join(errors, "\n"))
+			log.Warnf("validation errors in profile %q: %s", name, strings.Join(errors, "\n"))
 			continue
 		}
 		profiles[name] = newProfileConfig

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver_test.go
@@ -110,7 +110,7 @@ func Test_resolveProfiles(t *testing.T) {
 			},
 			expectedProfileDefMap: ProfileConfigMap{},
 			expectedLogs: []logCount{
-				{"[WARN] loadResolveProfiles: failed to expand profile `f5-big-ip`: extend does not exist: `does_not_exist`", 1},
+				{"[WARN] loadResolveProfiles: failed to expand profile \"f5-big-ip\": extend does not exist: `does_not_exist`", 1},
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func Test_resolveProfiles(t *testing.T) {
 			userProfiles:          profilesWithInvalidExtendProfiles,
 			expectedProfileDefMap: ProfileConfigMap{},
 			expectedLogs: []logCount{
-				{"loadResolveProfiles: failed to expand profile `generic-if`: extend does not exist: `invalid`", 1},
+				{"loadResolveProfiles: failed to expand profile \"generic-if\": extend does not exist: `invalid`", 1},
 			},
 		},
 		{
@@ -126,7 +126,7 @@ func Test_resolveProfiles(t *testing.T) {
 			userProfiles:          invalidCyclicProfiles,
 			expectedProfileDefMap: ProfileConfigMap{},
 			expectedLogs: []logCount{
-				{"[WARN] loadResolveProfiles: failed to expand profile `f5-big-ip`: cyclic profile extend detected", 1},
+				{"[WARN] loadResolveProfiles: failed to expand profile \"f5-big-ip\": cyclic profile extend detected", 1},
 			},
 		},
 		{

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_test.go
@@ -88,7 +88,7 @@ func Test_getProfiles(t *testing.T) {
 		{
 			name:        "ERROR Invalid profiles.json.gz profiles",
 			mockConfd:   "zipprofiles_err.d",
-			expectedErr: "failed to load bundle json profiles",
+			expectedErr: "failed to load profiles from json bundle",
 		},
 		// yaml profiles
 		{

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_yaml.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_yaml.go
@@ -55,7 +55,7 @@ func getProfileDefinitions(profilesFolder string, isUserProfile bool) (ProfileCo
 	profilesRoot := getProfileConfdRoot(profilesFolder)
 	files, err := os.ReadDir(profilesRoot)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read dir `%s`: %v", profilesRoot, err)
+		return nil, fmt.Errorf("failed to read profile dir %q: %w", profilesRoot, err)
 	}
 
 	profiles := make(ProfileConfigMap)
@@ -71,7 +71,7 @@ func getProfileDefinitions(profilesFolder string, isUserProfile bool) (ProfileCo
 		absPath := filepath.Join(profilesRoot, fName)
 		definition, err := readProfileDefinition(absPath)
 		if err != nil {
-			log.Warnf("failed to read dir `%s`: %v", absPath, err)
+			log.Warnf("cannot load profile %q: %v", profileName, err)
 			continue
 		}
 		profiles[profileName] = ProfileConfig{
@@ -86,13 +86,13 @@ func readProfileDefinition(definitionFile string) (*profiledefinition.ProfileDef
 	filePath := resolveProfileDefinitionPath(definitionFile)
 	buf, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file `%s`: %s", filePath, err)
+		return nil, fmt.Errorf("unable to read file %q: %w", filePath, err)
 	}
 
 	profileDefinition := profiledefinition.NewProfileDefinition()
 	err = yaml.Unmarshal(buf, profileDefinition)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshall %q: %v", filePath, err)
+		return nil, fmt.Errorf("parse error in file %q: %w", filePath, err)
 	}
 	return profileDefinition, nil
 }
@@ -116,7 +116,7 @@ func getProfileConfdRoot(profileFolderName string) string {
 func getYamlUserProfiles() ProfileConfigMap {
 	userProfiles, err := getProfileDefinitions(userProfilesFolder, true)
 	if err != nil {
-		log.Warnf("failed to get user profile definitions: %s", err)
+		log.Warnf("failed to load user profile definitions: %s", err)
 		return ProfileConfigMap{}
 	}
 	return userProfiles
@@ -125,7 +125,7 @@ func getYamlUserProfiles() ProfileConfigMap {
 func getYamlDefaultProfiles() ProfileConfigMap {
 	userProfiles, err := getProfileDefinitions(defaultProfilesFolder, false)
 	if err != nil {
-		log.Warnf("failed to get default profile definitions: %s", err)
+		log.Warnf("failed to load default profile definitions: %s", err)
 		return ProfileConfigMap{}
 	}
 	return userProfiles

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_yaml_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_yaml_test.go
@@ -138,7 +138,7 @@ func Test_loadYamlProfiles_invalidExtendProfile(t *testing.T) {
 	logs := b.String()
 	assert.Nil(t, err)
 
-	assert.Equal(t, 1, strings.Count(logs, "[WARN] loadResolveProfiles: failed to expand profile `f5-big-ip"), logs)
+	assert.Equal(t, 1, strings.Count(logs, "[WARN] loadResolveProfiles: failed to expand profile \"f5-big-ip\""), logs)
 	assert.Equal(t, ProfileConfigMap{}, defaultProfiles)
 }
 
@@ -159,8 +159,8 @@ func Test_loadYamlProfiles_userAndDefaultProfileFolderDoesNotExist(t *testing.T)
 	logs := b.String()
 	assert.Nil(t, err)
 
-	assert.Equal(t, 1, strings.Count(logs, "[WARN] getYamlUserProfiles: failed to get user profile definitions"), logs)
-	assert.Equal(t, 1, strings.Count(logs, "[WARN] getYamlDefaultProfiles: failed to get default profile definitions"), logs)
+	assert.Equal(t, 1, strings.Count(logs, "[WARN] getYamlUserProfiles: failed to load user profile definitions"), logs)
+	assert.Equal(t, 1, strings.Count(logs, "[WARN] getYamlDefaultProfiles: failed to load default profile definitions"), logs)
 	assert.Equal(t, ProfileConfigMap{}, defaultProfiles)
 }
 

--- a/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
@@ -8,7 +8,6 @@
 package profile
 
 import (
-	"os"
 	"path/filepath"
 	"regexp"
 
@@ -35,12 +34,6 @@ func SetConfdPathAndCleanProfiles() {
 		file, _ = filepath.Abs(filepath.Join(".", "internal", "test", "conf.d"))
 	}
 	config.Datadog.SetWithoutSource("confd_path", file)
-}
-
-// pathExists returns true if the given path exists
-func pathExists(path string) bool {
-	_, err := os.Stat(path)
-	return !os.IsNotExist(err)
 }
 
 // FixtureProfileDefinitionMap returns a fixture of ProfileConfigMap with `f5-big-ip` profile

--- a/pkg/collector/corechecks/snmp/internal/profile/utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/utils.go
@@ -5,7 +5,11 @@
 
 package profile
 
-import "github.com/mohae/deepcopy"
+import (
+	"os"
+
+	"github.com/mohae/deepcopy"
+)
 
 // mergeProfiles merges two profiles config map
 // we use deepcopy to lower risk of modifying original profiles
@@ -18,4 +22,10 @@ func mergeProfiles(profilesA ProfileConfigMap, profilesB ProfileConfigMap) Profi
 		profiles[k] = deepcopy.Copy(v).(ProfileConfig)
 	}
 	return profiles
+}
+
+// pathExists returns true if the given path exists
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
 }


### PR DESCRIPTION
### What does this PR do?
This cleans up some of the profile loading error messages to make them more readable. Most of this is either including extra details in logged messages (like indicating which file contained various parsing errors) or some go style cleanup like using `%w` instead of `%s` when reporting an error in `fmt.Errorf`.

### Motivation

Errors in profile files are currently hard to diagnose because the error messages aren't always clear, and the profile system does its best to keep running even when there are errors so the user-facing symptoms of a profile syntax error are typically just that expected metrics don't show up. Making it clearer in the agent logs when profiles weren't parsed properly will make it easier to diagnose and fix these problems.

For [NDMII-2555](https://datadoghq.atlassian.net/browse/NDMII-2555)

### Possible Drawbacks / Trade-offs

There should not be any behavioral changes.

### Describe how to test/QA your changes

Run the agent with each of three different configurations:
 1. profiles inline in the initial config
 2. a json bundle of profiles
 3. YAML profiles in the `default_profiles` and `profiles` dirs

In all three cases, confirm that the agent loaded those profiles properly.

You can also try adding invalid profiles (e.g. malformed yaml or extending profiles that don't exist) and confirm that sensible error messages are logged.

[NDMII-2555]: https://datadoghq.atlassian.net/browse/NDMII-2555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ