### PR TITLE
[rtloader/containers] Allow filtering containers by pod annotations for Python checks

### DIFF
--- a/docs/dev/checks/builtins/containers.md
+++ b/docs/dev/checks/builtins/containers.md
@@ -18,16 +18,18 @@ from specific integrations.
 
 ```python
 
-def is_excluded(name, image):
-    """Returns whether a container is excluded per name and image.
+def is_excluded(annotation, name, image, namespace):
+    """Returns whether a container is excluded per annotation, name, image and namespace.
 
     NOTE: If unicode is passed to any of the params accepting it, the
     string is encoded using the default encoding for the system where the
     Agent is running. If encoding fails, the function raises `UnicodeError`.
 
     Args:
+        annotation (string or unicode): string-ified JSON of pod annotations.
         name (string or unicode): the name of the container.
         image (string or unicode): Docker image name.
+        namespace (string or unicode): namespace of container.
 
     Returns:
         True if the container is excluded, False otherwise.

--- a/pkg/collector/python/containers.go
+++ b/pkg/collector/python/containers.go
@@ -32,7 +32,6 @@ var filter *containers.Filter
 //export IsContainerExcluded
 func IsContainerExcluded(annotation, name, image, namespace *C.char) C.int {
 	// If init failed, fallback to False
-	log.Debugf("TEST-CONT got annotation %s for name %s", annotation, name)
 	if filter == nil {
 		return 0
 	}

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -151,7 +151,7 @@ void initTaggerModule(rtloader_t *rtloader) {
 // containers module
 //
 
-int IsContainerExcluded(char *, char *, char *);
+int IsContainerExcluded(char *, char *, char *, char *);
 
 void initContainersModule(rtloader_t *rtloader) {
 	set_is_excluded_cb(rtloader, IsContainerExcluded);

--- a/pkg/collector/python/test_containers.go
+++ b/pkg/collector/python/test_containers.go
@@ -36,8 +36,10 @@ func testIsContainerExcluded(t *testing.T) {
 	assert.Nil(t, err)
 	filter.NamespaceExcludeList = append(filter.NamespaceExcludeList, r)
 
-	assert.Equal(t, IsContainerExcluded(C.CString("foo"), C.CString("bar"), C.CString("ns")), C.int(1))
-	assert.Equal(t, IsContainerExcluded(C.CString("foo"), C.CString("bar"), C.CString("white")), C.int(0))
-	assert.Equal(t, IsContainerExcluded(C.CString("foo"), C.CString("baz"), C.CString("black")), C.int(1))
-	assert.Equal(t, IsContainerExcluded(C.CString("foo"), C.CString("baz"), nil), C.int(0))
+	assert.Equal(t, IsContainerExcluded(C.CString("annotation"), C.CString("foo"), C.CString("bar"), C.CString("ns")), C.int(1))
+	assert.Equal(t, IsContainerExcluded(C.CString("annotation"), C.CString("foo"), C.CString("bar"), C.CString("white")), C.int(0))
+	assert.Equal(t, IsContainerExcluded(C.CString("annotation"), C.CString("foo"), C.CString("baz"), C.CString("black")), C.int(1))
+	assert.Equal(t, IsContainerExcluded(C.CString("annotation"), C.CString("foo"), C.CString("baz"), nil), C.int(0))
+	assert.Equal(t, IsContainerExcluded(C.CString("{'ad.datadoghq.com/not-foo.exclude_metrics': 'true'}"), C.CString("foo"), C.CString("bar"), C.CString("white")), C.int(0))
+	assert.Equal(t, IsContainerExcluded(C.CString("{'ad.datadoghq.com/foo.exclude_metrics': 'true'}"), C.CString("foo"), C.CString("bar"), C.CString("white")), C.int(0))
 }

--- a/rtloader/common/builtins/containers.c
+++ b/rtloader/common/builtins/containers.c
@@ -14,7 +14,7 @@ static PyObject *is_excluded(PyObject *self, PyObject *args);
 
 static PyMethodDef methods[] = {
     { "is_excluded", (PyCFunction)is_excluded, METH_VARARGS,
-      "Returns whether a container is excluded per anotation, name, image and namespace." },
+      "Returns whether a container is excluded per annotation, name, image and namespace." },
     { NULL, NULL } // guards
 };
 

--- a/rtloader/common/builtins/containers.c
+++ b/rtloader/common/builtins/containers.c
@@ -14,7 +14,7 @@ static PyObject *is_excluded(PyObject *self, PyObject *args);
 
 static PyMethodDef methods[] = {
     { "is_excluded", (PyCFunction)is_excluded, METH_VARARGS,
-      "Returns whether a container is excluded per name, image and namespace." },
+      "Returns whether a container is excluded per anotation, name, image and namespace." },
     { NULL, NULL } // guards
 };
 
@@ -60,14 +60,15 @@ PyObject *is_excluded(PyObject *self, PyObject *args)
         Py_RETURN_NONE;
     }
 
+    char *annotation;
     char *name;
     char *image;
     char *namespace = NULL;
-    if (!PyArg_ParseTuple(args, "ss|s", &name, &image, &namespace)) {
+    if (!PyArg_ParseTuple(args, "sss|s", &annotation, &name, &image, &namespace)) {
         return NULL;
     }
 
-    int result = cb_is_excluded(name, image, namespace);
+    int result = cb_is_excluded(annotation, name, image, namespace);
 
     if (result > 0) {
         Py_RETURN_TRUE;

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -161,8 +161,8 @@ typedef void (*cb_get_connection_info_t)(char **);
 
 // containers
 //
-// (container_name, image_name, namespace, bool_result)
-typedef int (*cb_is_excluded_t)(char *, char *, char *);
+// (annotation, container_name, image_name, namespace, bool_result)
+typedef int (*cb_is_excluded_t)(char *, char *, char *, char *);
 
 #ifdef __cplusplus
 }

--- a/rtloader/releasenotes/notes/add-annotations-to-rtloader-is-excluded-f4885a6c3083521b.yaml
+++ b/rtloader/releasenotes/notes/add-annotations-to-rtloader-is-excluded-f4885a6c3083521b.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Accept annotations in the ``containers.is_excluded`` C binding to allow 
+    filtering of Python check metrics via pod annotations.

--- a/rtloader/test/containers/containers.go
+++ b/rtloader/test/containers/containers.go
@@ -100,7 +100,7 @@ except Exception as e:
 }
 
 //export is_excluded
-func is_excluded(name *C.char, image *C.char, namespace *C.char) C.int {
+func is_excluded(annotation *C.char, name *C.char, image *C.char, namespace *C.char) C.int {
 	if C.GoString(name) == "foo" {
 		return 1
 	}

--- a/rtloader/test/containers/containers.go
+++ b/rtloader/test/containers/containers.go
@@ -20,7 +20,7 @@ import (
 #include "rtloader_mem.h"
 #include "datadog_agent_rtloader.h"
 
-extern int is_excluded(char *, char *, char *);
+extern int is_excluded(char *, char *, char *, char *);
 
 static void initContainersTests(rtloader_t *rtloader) {
    set_is_excluded_cb(rtloader, is_excluded);

--- a/rtloader/test/containers/containers_test.go
+++ b/rtloader/test/containers/containers_test.go
@@ -31,8 +31,8 @@ func TestIsExcluded(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		f.write("{},{}".format(
-			containers.is_excluded('foo', 'bar', 'ns'),
-			containers.is_excluded('baz', 'bar', 'ns'),
+			containers.is_excluded('a', 'foo', 'bar', 'ns'),
+			containers.is_excluded('a', 'baz', 'bar', 'ns'),
 		))
 	`, tmpfile.Name())
 	out, err := run(code)
@@ -54,7 +54,7 @@ func TestIsExcludedErrorTypeName(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		f.write("{},{}".format(
-			containers.is_excluded(123, 'bar', 'ns'),
+			containers.is_excluded('a', 123, 'bar', 'ns'),
 		))
 	`, tmpfile.Name())
 	out, err := run(code)
@@ -62,7 +62,7 @@ func TestIsExcludedErrorTypeName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if matched, err := regexp.Match("TypeError: argument 1 must be (str|string), not int", []byte(out)); err != nil && !matched {
+	if matched, err := regexp.Match("TypeError: argument 2 must be (str|string), not int", []byte(out)); err != nil && !matched {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 
@@ -77,14 +77,36 @@ func TestIsExcludedErrorTypeImage(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		f.write("{},{}".format(
-			containers.is_excluded('foo', 123, 'ns'),
+			containers.is_excluded('a', 'foo', 123, 'ns'),
 		))
 	`, tmpfile.Name())
 	out, err := run(code)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if matched, err := regexp.Match("TypeError: argument 2 must be (str|string), not int", []byte(out)); err != nil && !matched {
+	if matched, err := regexp.Match("TypeError: argument 3 must be (str|string), not int", []byte(out)); err != nil && !matched {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}
+
+func TestIsExcludedErrorTypeAnnotation(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	code := fmt.Sprintf(`
+	with open(r'%s', 'w') as f:
+		f.write("{},{}".format(
+			containers.is_excluded(123, 'foo', 'bar', 'ns'),
+		))
+	`, tmpfile.Name())
+	out, err := run(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matched, err := regexp.Match("TypeError: argument 1 must be (str|string), not int", []byte(out)); err != nil && !matched {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Accepts an `annotation` parameter in the rtloader `containers.is_excluded` binding to enable filtering of container metrics based on pod annotations.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Filtering by pod annotations was added a few releases ago, however this change was not extended to Python checks so kubelet metrics would not get excluded based on annotations. This change allows the exclusion annotation to work for the kubelet check as well.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->