### PR TITLE
Release cleanup after 7.52.0 release - latest_stable update

### DIFF
--- a/release.json
+++ b/release.json
@@ -2,8 +2,8 @@
     "base_branch": "main",
     "current_milestone": "7.53.0",
     "last_stable": {
-        "6": "6.51.1",
-        "7": "7.51.1"
+        "6": "6.52.0",
+        "7": "7.52.0"
     },
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "master",


### PR DESCRIPTION
Update `latest_stable` field to `7.52.0` after Agent 7.52.0 release,