### PR TITLE
Disable Oracle 7

### DIFF
--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -154,7 +154,6 @@ kmt_run_secagent_tests_x64:
           - "debian_10"
           - "debian_11"
           - "debian_12"
-          - "oracle_7.9"
           - "oracle_8.9"
           - "oracle_9.3"
         TEST_SET: [all_tests]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Disable Oracle 7 from KMT Ci

### Motivation

Reducing CI duration, as Oracle 7 jobs are timing out (3h).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
