### PR TITLE
cws-instrumentation: push missing rc and versioned tags

### DIFF
--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -18,12 +18,24 @@ include:
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
     - export IMG_DESTINATIONS="${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}"
 
-deploy_containers-cws-instrumentation-rc:
+# will push the `7.xx.y-rc.z` tags
+deploy_containers-cws-instrumentation-rc-versioned:
+  extends: .deploy_containers-cws-instrumentation-base
+  rules: !reference [.on_deploy_a7_rc]
+
+# will update the `rc` tag
+deploy_containers-cws-instrumentation-rc-mutable:
   extends: .deploy_containers-cws-instrumentation-base
   rules: !reference [.on_deploy_a7_rc]
   variables:
     VERSION: rc
 
+# will push the `7.xx.y` tags
+deploy_containers-cws-instrumentation-final-versioned:
+  extends: .deploy_containers-cws-instrumentation-base
+  rules: !reference [.on_deploy_a7_manual_final]
+
+# will update the `latest` tag
 deploy_containers-cws-instrumentation-latest:
   extends: .deploy_containers-cws-instrumentation-base
   rules: !reference [.on_deploy_a7_manual_final]


### PR DESCRIPTION
### What does this PR do?

Currently we only push:
- `rc` tag on rc pipelines
- `latest` tag on final release

This PR adds (for example for 7.53):
- `7.53.0-rc.X` on rc pipelines
- `7.53.0` when releasing

### Motivation

Have more similar tags to other products.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
