### PR TITLE
[ASCII-1330] Fix auth token global variable race

### DIFF
--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -34,7 +34,6 @@ func SetAuthToken(config model.Reader) error {
 		return nil
 	}
 
-	// token is only set once, no need to mutex protect
 	var err error
 	token, err = security.FetchAuthToken(config)
 	return err
@@ -51,7 +50,6 @@ func CreateAndSetAuthToken(config model.Reader) error {
 		return nil
 	}
 
-	// token is only set once, no need to mutex protect
 	var err error
 	token, err = security.CreateOrFetchToken(config)
 	return err
@@ -75,7 +73,6 @@ func InitDCAAuthToken(config model.Reader) error {
 		return nil
 	}
 
-	// dcaToken is only set once, no need to mutex protect
 	var err error
 	dcaToken, err = security.CreateOrGetClusterAgentAuthToken(config)
 	return err

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -11,19 +11,24 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
 var (
-	token    string
-	dcaToken string
+	tokenLock sync.RWMutex
+	token     string
+	dcaToken  string
 )
 
 // SetAuthToken sets the session token
 // Requires that the config has been set up before calling
 func SetAuthToken(config model.Reader) error {
+	tokenLock.Lock()
+	defer tokenLock.Unlock()
+
 	// Noop if token is already set
 	if token != "" {
 		return nil
@@ -38,6 +43,9 @@ func SetAuthToken(config model.Reader) error {
 // CreateAndSetAuthToken creates and sets the authorization token
 // Requires that the config has been set up before calling
 func CreateAndSetAuthToken(config model.Reader) error {
+	tokenLock.Lock()
+	defer tokenLock.Unlock()
+
 	// Noop if token is already set
 	if token != "" {
 		return nil
@@ -51,12 +59,17 @@ func CreateAndSetAuthToken(config model.Reader) error {
 
 // GetAuthToken gets the session token
 func GetAuthToken() string {
+	tokenLock.RLock()
+	defer tokenLock.RUnlock()
 	return token
 }
 
 // InitDCAAuthToken initialize the session token for the Cluster Agent based on config options
 // Requires that the config has been set up before calling
 func InitDCAAuthToken(config model.Reader) error {
+	tokenLock.Lock()
+	defer tokenLock.Unlock()
+
 	// Noop if dcaToken is already set
 	if dcaToken != "" {
 		return nil
@@ -70,6 +83,8 @@ func InitDCAAuthToken(config model.Reader) error {
 
 // GetDCAAuthToken gets the session token
 func GetDCAAuthToken() string {
+	tokenLock.RLock()
+	defer tokenLock.RUnlock()
 	return dcaToken
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Wrap the auth token global variable in a `RWLock` to avoid races.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The auth token global variable was not protected for concurrent access, it was only initialized in the main of each binaries until now, but it started racing in tests, and it could change in the future anyway, so having a lock is safer.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Change should be covered by the CI and usual deployments.
If no race is reported anymore then this is fixed