### PR TITLE
[CONTINT-3935] Bump test-infra-definitions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,7 +186,7 @@ variables:
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
   # Make sure to update test-infra-definitions version in go.mod as well
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: cc072d8d59eb
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 3eac4b5bb0c4
   DATADOG_AGENT_BUILDERS: v28719213-8dc058f
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -27,7 +27,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240322053331-cc072d8d59eb
+	github.com/DataDog/test-infra-definitions v0.0.0-20240322160927-3eac4b5bb0c4
 	github.com/aws/aws-sdk-go-v2 v1.25.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.6
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.19.0 h1:Wvz/63/q39EpVwSH1T8jVyRvP
 github.com/DataDog/datadog-api-client-go/v2 v2.19.0/go.mod h1:oD5Lx8Li3oPRa/BSBenkn4i48z+91gwYORF/+6ph71g=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20240322053331-cc072d8d59eb h1:r0+Wai8JowSxw7/e8QAiT4e3tFAl2c3KnBbwyBaArzg=
-github.com/DataDog/test-infra-definitions v0.0.0-20240322053331-cc072d8d59eb/go.mod h1:KNF9SeKFoqxSSucHpuXQ1QDmpi7HFS9yr5kM2h9ls3c=
+github.com/DataDog/test-infra-definitions v0.0.0-20240322160927-3eac4b5bb0c4 h1:dJAaa0h6EgC4q8Mi271rMHVAiQ3OBUR/VlLNQCmJq0Y=
+github.com/DataDog/test-infra-definitions v0.0.0-20240322160927-3eac4b5bb0c4/go.mod h1:KNF9SeKFoqxSSucHpuXQ1QDmpi7HFS9yr5kM2h9ls3c=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/pkg/environments/aws/docker/host.go
+++ b/test/new-e2e/pkg/environments/aws/docker/host.go
@@ -147,7 +147,7 @@ func Run(ctx *pulumi.Context, env *environments.DockerHost, params *ProvisionerP
 		return err
 	}
 
-	manager, _, err := docker.NewManager(*awsEnv.CommonEnvironment, host, true, utils.PulumiDependsOn(installEcrCredsHelperCmd))
+	manager, _, err := docker.NewManager(*awsEnv.CommonEnvironment, host, utils.PulumiDependsOn(installEcrCredsHelperCmd))
 	if err != nil {
 		return err
 	}

--- a/test/new-e2e/pkg/environments/aws/host/host.go
+++ b/test/new-e2e/pkg/environments/aws/host/host.go
@@ -180,7 +180,7 @@ func Run(ctx *pulumi.Context, env *environments.Host, params *ProvisionerParams)
 	}
 
 	if params.installDocker {
-		_, dockerRes, err := docker.NewManager(*awsEnv.CommonEnvironment, host, true)
+		_, dockerRes, err := docker.NewManager(*awsEnv.CommonEnvironment, host)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/tests/ndm/snmp/snmp_test.go
+++ b/test/new-e2e/tests/ndm/snmp/snmp_test.go
@@ -98,7 +98,7 @@ func snmpDockerProvisioner() e2e.Provisioner {
 			return err
 		}
 
-		dockerManager, _, err := docker.NewManager(*awsEnv.CommonEnvironment, host, false)
+		dockerManager, _, err := docker.NewManager(*awsEnv.CommonEnvironment, host)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
@@ -56,7 +56,7 @@ func dockerHostHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[dockerHostNginxEnv] 
 		}
 
 		// install docker.io
-		manager, _, err := docker.NewManager(*awsEnv.CommonEnvironment, nginxHost, true)
+		manager, _, err := docker.NewManager(*awsEnv.CommonEnvironment, nginxHost)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -59,7 +59,7 @@ func hostDockerHttpbinEnvProvisioner(opt ...awshost.ProvisionerOption) e2e.Pulum
 		}
 
 		// install docker.io
-		manager, _, err := docker.NewManager(*awsEnv.CommonEnvironment, nginxHost, true)
+		manager, _, err := docker.NewManager(*awsEnv.CommonEnvironment, nginxHost)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/tests/npm/ecs_1host_test.go
+++ b/test/new-e2e/tests/npm/ecs_1host_test.go
@@ -52,7 +52,7 @@ func ecsHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[ecsHttpbinEnv] {
 		}
 
 		// install docker.io
-		manager, _, err := docker.NewManager(*awsEnv.CommonEnvironment, nginxHost, true)
+		manager, _, err := docker.NewManager(*awsEnv.CommonEnvironment, nginxHost)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?

Bump the version of [`test-infra-definitions`](https://github.com/DataDog/test-infra-definitions) used in new e2e tests to https://github.com/DataDog/test-infra-definitions/commit/3eac4b5bb0c43a2050a34856428a9972d741aa3e

### Motivation

Benefit from DataDog/test-infra-definitions#710 to hopefully fix the flakiness of `TestEKSSuite` new e2e test.

### Additional Notes

Full changelog: https://github.com/DataDog/test-infra-definitions/compare/cc072d8d59eb...3eac4b5bb0c4

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
