### PR TITLE
[ASCII-1257] Avoid panic in case of error in configcheck e2e test

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_common_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type baseConfigCheckSuite struct {
@@ -80,23 +81,27 @@ Config for instance ID: cpu:e331d61ed1323219
 ~
 ===`
 
-	result, err := MatchCheckToTemplate("uptime", sampleCheck)
-	assert.NoError(t, err)
+	t.Run("uptime", func(t *testing.T) {
+		result, err := MatchCheckToTemplate("uptime", sampleCheck)
+		require.NoError(t, err)
 
-	assert.Contains(t, result.CheckName, "uptime")
-	assert.Contains(t, result.Filepath, "file:/etc/datadog-agent/conf.d/uptime.d/conf.yaml.default")
-	assert.Contains(t, result.InstanceID, "uptime:c72f390abdefdf1a")
-	assert.Contains(t, result.Settings, "key: value")
-	assert.Contains(t, result.Settings, "path: http://example.com/foo")
-	assert.NotContains(t, result.Settings, "{}")
+		assert.Contains(t, result.CheckName, "uptime")
+		assert.Contains(t, result.Filepath, "file:/etc/datadog-agent/conf.d/uptime.d/conf.yaml.default")
+		assert.Contains(t, result.InstanceID, "uptime:c72f390abdefdf1a")
+		assert.Contains(t, result.Settings, "key: value")
+		assert.Contains(t, result.Settings, "path: http://example.com/foo")
+		assert.NotContains(t, result.Settings, "{}")
+	})
 
-	result, err = MatchCheckToTemplate("cpu", sampleCheck)
-	assert.NoError(t, err)
+	t.Run("cpu", func(t *testing.T) {
+		result, err := MatchCheckToTemplate("cpu", sampleCheck)
+		require.NoError(t, err)
 
-	assert.Contains(t, result.CheckName, "cpu")
-	assert.Contains(t, result.Filepath, "file:/etc/datadog-agent/conf.d/cpu.d/conf.yaml.default")
-	assert.Contains(t, result.InstanceID, "cpu:e331d61ed1323219")
-	assert.Contains(t, result.Settings, "{}")
+		assert.Contains(t, result.CheckName, "cpu")
+		assert.Contains(t, result.Filepath, "file:/etc/datadog-agent/conf.d/cpu.d/conf.yaml.default")
+		assert.Contains(t, result.InstanceID, "cpu:e331d61ed1323219")
+		assert.Contains(t, result.Settings, "{}")
+	})
 }
 
 func VerifyDefaultInstalledCheck(t *testing.T, output string, testChecks []CheckConfigOutput) {
@@ -105,7 +110,7 @@ func VerifyDefaultInstalledCheck(t *testing.T, output string, testChecks []Check
 	for _, testCheck := range testChecks {
 		t.Run(fmt.Sprintf("default - %s test", testCheck.CheckName), func(t *testing.T) {
 			result, err := MatchCheckToTemplate(testCheck.CheckName, output)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Contains(t, result.Filepath, testCheck.Filepath)
 			assert.Contains(t, result.InstanceID, testCheck.InstanceID)
 			assert.Contains(t, result.Settings, testCheck.Settings)

--- a/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_nix_test.go
@@ -8,10 +8,12 @@ package configcheck
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 )
 
 type linuxConfigCheckSuite struct {
@@ -109,7 +111,7 @@ func (v *linuxConfigCheckSuite) TestWithAddedIntegrationsCheck() {
 	output := v.Env().Agent.Client.ConfigCheck()
 
 	result, err := MatchCheckToTemplate("http_check", output)
-	assert.NoError(v.T(), err)
+	require.NoError(v.T(), err)
 	assert.Contains(v.T(), result.Filepath, "file:/etc/datadog-agent/conf.d/http_check.d/conf.yaml")
 	assert.Contains(v.T(), result.InstanceID, "http_check:")
 	assert.Contains(v.T(), result.Settings, "name: My First Service")

--- a/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_win_test.go
@@ -8,9 +8,11 @@ package configcheck
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
@@ -112,7 +114,7 @@ func (v *windowsConfigCheckSuite) TestWithAddedIntegrationsCheck() {
 	output := v.Env().Agent.Client.ConfigCheck()
 
 	result, err := MatchCheckToTemplate("http_check", output)
-	assert.NoError(v.T(), err)
+	require.NoError(v.T(), err)
 	assert.Contains(v.T(), result.Filepath, "file:C:\\ProgramData\\Datadog\\conf.d\\http_check.d\\conf.yaml")
 	assert.Contains(v.T(), result.InstanceID, "http_check:")
 	assert.Contains(v.T(), result.Settings, "name: My First Service")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Avoid some `panic` in case of error in configcheck e2e tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Using `assert` doesn't stop the execution of the test, but in that case if the test doesn't stop in case of error then it will panic, which makes the output much harder to read.
Changing some `assert.NoError(t, err)` into `require.NoError(t, err)` to fix that.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This doesn't fix the actual test failure, it just helps with readability if it happens again.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
