### PR TITLE
[Network Path] Fix parsing of query params

### DIFF
--- a/cmd/system-probe/modules/traceroute_test.go
+++ b/cmd/system-probe/modules/traceroute_test.go
@@ -9,7 +9,6 @@ package modules
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -53,7 +52,7 @@ func TestParseParams(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t1 *testing.T) {
-			req, err := http.NewRequestWithContext(context.Background(), "GET", fmt.Sprintf("http://example.com"), nil)
+			req, err := http.NewRequestWithContext(context.Background(), "GET", "http://example.com", nil)
 			q := req.URL.Query()
 			for k, v := range tt.params {
 				q.Add(k, v)

--- a/cmd/system-probe/modules/traceroute_test.go
+++ b/cmd/system-probe/modules/traceroute_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	tracerouteutil "github.com/DataDog/datadog-agent/pkg/networkpath/traceroute"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,12 +53,13 @@ func TestParseParams(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t1 *testing.T) {
-			req, err := http.NewRequestWithContext(context.Background(), "GET", fmt.Sprintf("http://example.com/host/%s", tt.host), nil)
+			req, err := http.NewRequestWithContext(context.Background(), "GET", fmt.Sprintf("http://example.com"), nil)
 			q := req.URL.Query()
 			for k, v := range tt.params {
 				q.Add(k, v)
 			}
 			req.URL.RawQuery = q.Encode()
+			req = mux.SetURLVars(req, map[string]string{"host": tt.host})
 
 			require.NoError(t, err)
 			config, err := parseParams(req)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Fixes a bug in the parsing of query parameters between Network Path's agent and the system probe.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
