### PR TITLE
[internal] Update golang.org/x/mod to v0.16.0 in internal/tools/modparser

### DIFF
--- a/internal/tools/modparser/go.mod
+++ b/internal/tools/modparser/go.mod
@@ -4,12 +4,11 @@ go 1.21.8
 
 require (
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/mod v0.5.1
+	golang.org/x/mod v0.16.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/tools/modparser/go.sum
+++ b/internal/tools/modparser/go.sum
@@ -4,10 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
-golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
-golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
-golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/mod v0.16.0 h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=
+golang.org/x/mod v0.16.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/tools/modparser/main.go
+++ b/internal/tools/modparser/main.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
+// Package main contains the logic for the go.mod file parser
 package main
 
 import (

--- a/internal/tools/modparser/main_test.go
+++ b/internal/tools/modparser/main_test.go
@@ -29,6 +29,11 @@ func TestParseMod(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name:        "Correct module with patch version in go directive",
+			modPath:     "./testdata/patchgoversion/",
+			expectedErr: nil,
+		},
+		{
 			name:        "Missing module",
 			modPath:     "./testdata/nonexistant/",
 			expectedErr: fmt.Errorf("could not read go.mod file in ./testdata/nonexistant/"),

--- a/internal/tools/modparser/testdata/patchgoversion/go.mod
+++ b/internal/tools/modparser/testdata/patchgoversion/go.mod
@@ -1,0 +1,3 @@
+module github.com/DataDog/datadog-agent/internal/tools/modparser/testdata/patchgoversion
+
+go 1.21.8


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the `golang.org/x/mod` dependency of the `internal/tools/modparser` tool from `v0.5.1` to `v0.16.0`.
Adds a unit test for the parsing of `go.mod` files with patch versions in go directives.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Earlier versions of `golang.org/x/mod/modfile` cannot correctly parse patch versions in the go directive, returning a `could not parse go.mod file in /Users/kylian.serrania/go/src/github.com/DataDog/datadog-agent/` error.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that the unit tests of `internal/tools/modparser` pass, and that the `inv -e release.update-modules 7.53.0-rc.1` command succeds (it uses the parser).