### PR TITLE
[CWS] add support for fchmodat2

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/chmod.h
+++ b/pkg/security/ebpf/c/include/hooks/chmod.h
@@ -37,6 +37,10 @@ HOOK_SYSCALL_ENTRY3(fchmodat, int, dirfd, const char*, filename, umode_t, mode) 
     return trace__sys_chmod(mode);
 }
 
+HOOK_SYSCALL_ENTRY4(fchmodat2, int, dirfd, const char*, filename, umode_t, mode, int, flag) {
+    return trace__sys_chmod(mode);
+}
+
 int __attribute__((always_inline)) sys_chmod_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_CHMOD);
     if (!syscall) {
@@ -75,6 +79,11 @@ HOOK_SYSCALL_EXIT(fchmod) {
 }
 
 HOOK_SYSCALL_EXIT(fchmodat) {
+    int retval = SYSCALL_PARMRET(ctx);
+    return sys_chmod_ret(ctx, retval);
+}
+
+HOOK_SYSCALL_EXIT(fchmodat2) {
     int retval = SYSCALL_PARMRET(ctx);
     return sys_chmod_ret(ctx, retval);
 }

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -39,6 +39,12 @@ func getAttrProbes(fentry bool) []*manager.Probe {
 		},
 		SyscallFuncName: "fchmodat",
 	}, fentry, EntryAndExit)...)
+	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
+		SyscallFuncName: "fchmodat2",
+	}, fentry, EntryAndExit)...)
 
 	// chown
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -270,6 +270,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chmod", fentry, EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmod", fentry, EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmodat", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmodat2", fentry, EntryAndExit)},
 		},
 
 		// List of probes required to capture chown events

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -60,7 +60,7 @@ const (
 	SyscallTypeUtimes
 	// SyscallTypeLink link/linkat/symlink/symlinkat type
 	SyscallTypeLink
-	// SyscallTypeChmod chmod/fchmod/fchmodat type
+	// SyscallTypeChmod chmod/fchmod/fchmodat/fchmodat2 type
 	SyscallTypeChmod
 	// SyscallTypeChown chown/fchown/lchown/fchownat/fchownat2 type
 	SyscallTypeChown


### PR DESCRIPTION
### What does this PR do?

This PR adds support for the fchmodat2 syscall [added in kernel 6.6](https://lore.kernel.org/lkml/20230824-frohlocken-vorabend-725f6fdaad50@brauner/).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
