### PR TITLE
[USMO] Fix dynamic counter table TLS leak

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -998,21 +998,6 @@ delete_iteration:
     return 0;
 }
 
-// The program is responsible for cleaning the state of the HTTP2 TLS decoding once the TLS connection is terminated.
-static __always_inline void tls_termination_maps_deletion(tls_dispatcher_arguments_t *args) {
-    bpf_map_delete_elem(&tls_http2_iterations, &args->tup);
-
-    terminated_http2_batch_enqueue(&args->tup);
-    // Deleting the entry for the original tuple.
-    bpf_map_delete_elem(&http2_remainder, &args->tup);
-    bpf_map_delete_elem(&http2_dynamic_counter_table, &args->tup);
-    // In case of local host, the protocol will be deleted for both (client->server) and (server->client),
-    // so we won't reach for that path again in the code, so we're deleting the opposite side as well.
-    flip_tuple(&args->tup);
-    bpf_map_delete_elem(&http2_dynamic_counter_table, &args->tup);
-    bpf_map_delete_elem(&http2_remainder, &args->tup);
-}
-
 // http2_tls_termination is responsible for cleaning up the state of the HTTP2
 // decoding once the TLS connection is terminated.
 SEC("uprobe/http2_tls_termination")
@@ -1024,7 +1009,17 @@ int uprobe__http2_tls_termination(struct pt_regs *ctx) {
         return 0;
     }
 
-    tls_termination_maps_deletion(args);
+    bpf_map_delete_elem(&tls_http2_iterations, &args->tup);
+
+    terminated_http2_batch_enqueue(&args->tup);
+    // Deleting the entry for the original tuple.
+    bpf_map_delete_elem(&http2_remainder, &args->tup);
+    bpf_map_delete_elem(&http2_dynamic_counter_table, &args->tup);
+    // In case of local host, the protocol will be deleted for both (client->server) and (server->client),
+    // so we won't reach for that path again in the code, so we're deleting the opposite side as well.
+    flip_tuple(&args->tup);
+    bpf_map_delete_elem(&http2_dynamic_counter_table, &args->tup);
+    bpf_map_delete_elem(&http2_remainder, &args->tup);
 
     return 0;
 }

--- a/pkg/network/ebpf/c/protocols/sockfd-probes.h
+++ b/pkg/network/ebpf/c/protocols/sockfd-probes.h
@@ -39,7 +39,9 @@ int kprobe__tcp_close(struct pt_regs *ctx) {
         return 0;
     }
 
-    // Currently, we lack the pid and netns when cleaning the connection (in the http2_tls_termination function).
+    // The cleanup of the map happens either in TCP termination or during TLS shutdown event.
+    // The TCP termination is manages by the socket filter, thus it cannot clean TLS entries,
+    // as it does not have the access to the PID and NETNS.
     // Therefore, we use tls_finish to clean the connection. While this approach is not ideal, it is the best option available to us for now.
     tls_finish(ctx, &t, true);
     return 0;

--- a/pkg/network/ebpf/c/protocols/sockfd-probes.h
+++ b/pkg/network/ebpf/c/protocols/sockfd-probes.h
@@ -12,42 +12,6 @@
 
 #include "sock.h"
 #include "sockfd.h"
-#include "http2/decoding-tls.h"
-
-// handle_http2_termination is a helper function that is called when a TCP connection is closed.
-static __always_inline void handle_http2_termination (struct pt_regs *ctx, struct sock *sk){
-    conn_tuple_t t;
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    if (read_conn_tuple(&t, sk, pid_tgid, CONN_TYPE_TCP)) {
-        return;
-    }
-
-    conn_tuple_t normalized_tuple = t;
-    normalize_tuple(&normalized_tuple);
-    normalized_tuple.pid = 0;
-    normalized_tuple.netns = 0;
-
-    protocol_stack_t *stack = get_protocol_stack(&normalized_tuple);
-    if (!stack) {
-        return;
-    }
-
-    protocol_t protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
-    if (protocol != PROTOCOL_HTTP2) {
-        return;
-    }
-
-    const __u32 zero = 0;
-    tls_dispatcher_arguments_t *args = bpf_map_lookup_elem(&tls_dispatcher_arguments, &zero);
-    if (args == NULL) {
-        log_debug("dispatcher failed to save arguments for tls tail call");
-        return;
-    }
-    bpf_memset(args, 0, sizeof(tls_dispatcher_arguments_t));
-    bpf_memcpy(&args->tup, &t, sizeof(conn_tuple_t));
-    tls_termination_maps_deletion(args);
-    return;
-}
 
 SEC("kprobe/tcp_close")
 int kprobe__tcp_close(struct pt_regs *ctx) {
@@ -69,8 +33,15 @@ int kprobe__tcp_close(struct pt_regs *ctx) {
     bpf_map_delete_elem(&sock_by_pid_fd, pid_fd);
     bpf_map_delete_elem(&pid_fd_by_sock, &sk);
 
-    // The probe contains PID and netns information, which we utilize to attempt to clean up resources for HTTP/2 TLS.
-    handle_http2_termination(ctx, sk);
+    conn_tuple_t t;
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    if (!read_conn_tuple(&t, sk, pid_tgid, CONN_TYPE_TCP)) {
+        return 0;
+    }
+
+    // Currently, we lack the pid and netns when cleaning the connection (in the http2_tls_termination function).
+    // Therefore, we use tls_finish to clean the connection. While this approach is not ideal, it is the best option available to us for now.
+    tls_finish(ctx, &t, true);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/protocols/sockfd-probes.h
+++ b/pkg/network/ebpf/c/protocols/sockfd-probes.h
@@ -30,6 +30,12 @@ int kprobe__tcp_close(struct pt_regs *ctx) {
     bpf_memcpy(&pid_fd_copy, pid_fd, sizeof(pid_fd_t));
     pid_fd = &pid_fd_copy;
 
+    conn_tuple_t t;
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    if (read_conn_tuple(&t, sk, pid_tgid, CONN_TYPE_TCP)) {
+        tls_http2_finish(ctx, &t);
+    }
+
     bpf_map_delete_elem(&sock_by_pid_fd, pid_fd);
     bpf_map_delete_elem(&pid_fd_by_sock, &sk);
     return 0;

--- a/pkg/network/ebpf/c/protocols/sockfd-probes.h
+++ b/pkg/network/ebpf/c/protocols/sockfd-probes.h
@@ -39,9 +39,9 @@ int kprobe__tcp_close(struct pt_regs *ctx) {
         return 0;
     }
 
-    // The cleanup of the map happens either in TCP termination or during TLS shutdown event.
-    // The TCP termination is manages by the socket filter, thus it cannot clean TLS entries,
-    // as it does not have the access to the PID and NETNS.
+    // The cleanup of the map happens either during TCP termination or during the TLS shutdown event.
+    // TCP termination is managed by the socket filter, thus it cannot clean TLS entries,
+    // as it does not have access to the PID and NETNS.
     // Therefore, we use tls_finish to clean the connection. While this approach is not ideal, it is the best option available to us for now.
     tls_finish(ctx, &t, true);
     return 0;

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -107,6 +107,37 @@ static __always_inline void tls_process(struct pt_regs *ctx, conn_tuple_t *t, vo
     bpf_tail_call_compat(ctx, &tls_process_progs, prog);
 }
 
+static __always_inline void tls_http2_finish(struct pt_regs *ctx, conn_tuple_t *t) {
+    conn_tuple_t final_tuple = {0};
+    conn_tuple_t normalized_tuple = *t;
+    normalize_tuple(&normalized_tuple);
+    normalized_tuple.pid = 0;
+    normalized_tuple.netns = 0;
+
+    protocol_stack_t *stack = get_protocol_stack(&normalized_tuple);
+    if (!stack) {
+        return;
+    }
+
+    tls_prog_t prog;
+    protocol_t protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
+    if (protocol != PROTOCOL_HTTP2) {
+        return;
+    }
+    prog = TLS_HTTP2_TERMINATION;
+    final_tuple = *t;
+
+    const __u32 zero = 0;
+    tls_dispatcher_arguments_t *args = bpf_map_lookup_elem(&tls_dispatcher_arguments, &zero);
+    if (args == NULL) {
+        log_debug("dispatcher failed to save arguments for tls tail call");
+        return;
+    }
+    bpf_memset(args, 0, sizeof(tls_dispatcher_arguments_t));
+    bpf_memcpy(&args->tup, &final_tuple, sizeof(conn_tuple_t));
+    bpf_tail_call_compat(ctx, &tls_process_progs, prog);
+}
+
 static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t) {
     conn_tuple_t final_tuple = {0};
     conn_tuple_t normalized_tuple = *t;

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -123,6 +123,8 @@ static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t, boo
     protocol_t protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
     switch (protocol) {
     case PROTOCOL_HTTP:
+        // We use tcp_close to clean up the http2_dynamic_counter that contains TLS entries to properly clean the map.
+        // We do not want to affect the HTTP process, so we skip the case of HTTP to avoid any impact on the HTTP process.
         if (skip_http) {return;}
         prog = TLS_HTTP_TERMINATION;
         final_tuple = normalized_tuple;

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -107,7 +107,7 @@ static __always_inline void tls_process(struct pt_regs *ctx, conn_tuple_t *t, vo
     bpf_tail_call_compat(ctx, &tls_process_progs, prog);
 }
 
-static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t) {
+static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t, bool skip_http) {
     conn_tuple_t final_tuple = {0};
     conn_tuple_t normalized_tuple = *t;
     normalize_tuple(&normalized_tuple);
@@ -123,6 +123,7 @@ static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t) {
     protocol_t protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
     switch (protocol) {
     case PROTOCOL_HTTP:
+        if (skip_http) {return;}
         prog = TLS_HTTP_TERMINATION;
         final_tuple = normalized_tuple;
         break;

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -123,8 +123,10 @@ static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t, boo
     protocol_t protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
     switch (protocol) {
     case PROTOCOL_HTTP:
-        // We use tcp_close to clean up the http2_dynamic_counter that contains TLS entries to properly clean the map.
-        // We do not want to affect the HTTP process, so we skip the case of HTTP to avoid any impact on the HTTP process.
+        // HTTP is a special case. As of today, regardless of TLS or plaintext traffic, we ignore the PID and NETNS while processing it.
+        // The termination, both for TLS and plaintext, for HTTP traffic is taken care of in the socket filter.
+        // Until we split the TLS and plaintext management for HTTP traffic, there are flows (such as those being called from tcp_close)
+        // in which we don't want to terminate HTTP traffic, but instead leave it to the socket filter.
         if (skip_http) {return;}
         prog = TLS_HTTP_TERMINATION;
         final_tuple = normalized_tuple;

--- a/pkg/network/ebpf/c/protocols/tls/java/erpc_handlers.h
+++ b/pkg/network/ebpf/c/protocols/tls/java/erpc_handlers.h
@@ -77,7 +77,7 @@ int kprobe_handle_close_connection(struct pt_regs *ctx) {
     if (exists != NULL){
         // tls_finish can launch a tail call, thus cleanup should be done before.
         bpf_map_delete_elem(&java_tls_connections, &connection);
-        tls_finish(ctx, &connection);
+        tls_finish(ctx, &connection, false);
     }
     return 0;
 }

--- a/pkg/network/ebpf/c/protocols/tls/native-tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls.h
@@ -341,7 +341,7 @@ int uprobe__SSL_shutdown(struct pt_regs *ctx) {
 
     // tls_finish can launch a tail call, thus cleanup should be done before.
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_ctx);
-    tls_finish(ctx, t);
+    tls_finish(ctx, t, false);
 
     return 0;
 }
@@ -518,7 +518,7 @@ static __always_inline void gnutls_goodbye(struct pt_regs *ctx, void *ssl_sessio
 
     // tls_finish can launch a tail call, thus cleanup should be done before.
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_session);
-    tls_finish(ctx, t);
+    tls_finish(ctx, t, false);
 }
 
 // int gnutls_bye (gnutls_session_t session, gnutls_close_request_t how)

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -319,7 +319,7 @@ int uprobe__crypto_tls_Conn_Close(struct pt_regs *ctx) {
 
     conn_tuple_t copy = *t;
     // tls_finish can launch a tail call, thus cleanup should be done before.
-    tls_finish(ctx, &copy);
+    tls_finish(ctx, &copy, false);
     return 0;
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix HTTP/2 TLS leaks in the http2_dynamic_counter table.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The cleanup of the map happens either in TCP termination or during TLS shutdown event. The TCP termination is manages by the socket filter, thus it cannot clean TLS entries, as it does not have the access to the PID and NETNS. The actual server is not shutting down the TLS connection before closing the socket, so we never clean the entries.

This PR uses `tls_finish` for the cleaning of http2_dynamic_counter entris when we see tcp_close.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
