### PR TITLE
[CWS] only run btfhub sync job on Friday

### DIFF
--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -3,7 +3,7 @@ name: "CWS BTFHub constants sync"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 4 * * 1-5' # at 4:30 UTC every week-day
+    - cron: '30 4 * * 5' # at 4:30 UTC on Friday
 
 jobs:
   sync:


### PR DESCRIPTION
### What does this PR do?

This job currently runs everyday, which is not super useful. What we really need is to ensure the job runs before the agent freeze, and is updated regularly enough. Every fridays is a good frequency for this.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
