### PR TITLE
[corechecks/containerd/events] Fix flaky test

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/events_test.go
+++ b/pkg/collector/corechecks/containers/containerd/events_test.go
@@ -91,7 +91,11 @@ func TestCheckEvents(t *testing.T) {
 	}
 	cha <- &en
 
-	require.Eventually(t, sub.isRunning, testTimeout, testTicker)
+	require.Eventually(t, func() bool {
+		sub.Lock()
+		defer sub.Unlock()
+		return len(sub.Events) > 0
+	}, testTimeout, testTicker)
 
 	ev := sub.Flush(time.Now().Unix())
 	assert.Len(t, ev, 1)
@@ -131,7 +135,11 @@ func TestCheckEvents(t *testing.T) {
 	cha <- &ek
 	cha <- &evnd
 
-	require.Eventually(t, sub.isRunning, testTimeout, testTicker)
+	require.Eventually(t, func() bool {
+		sub.Lock()
+		defer sub.Unlock()
+		return len(sub.Events) > 0
+	}, testTimeout, testTicker)
 
 	ev2 := sub.Flush(time.Now().Unix())
 	fmt.Printf("\n\n 2/ Flush %v\n\n", ev2)

--- a/pkg/collector/corechecks/containers/containerd/events_test.go
+++ b/pkg/collector/corechecks/containers/containerd/events_test.go
@@ -142,7 +142,6 @@ func TestCheckEvents(t *testing.T) {
 	}, testTimeout, testTicker)
 
 	ev2 := sub.Flush(time.Now().Unix())
-	fmt.Printf("\n\n 2/ Flush %v\n\n", ev2)
 	assert.Len(t, ev2, 1)
 	assert.Equal(t, ev2[0].Topic, "/tasks/oom")
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a flaky test in `pkg/collector/corechecks/containers/containerd/events_test.go`.

A couple of `Eventually` calls were waiting until the subscriber was running, but that's not enough, they need to wait until it has processed an event.

### Describe how to test/QA your changes

Skip.
