### PR TITLE
[RC] refactor RC service configurations to support multiple RC service instances

### DIFF
--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -79,6 +79,12 @@ var (
 // and dispatching the configurations
 type Service struct {
 	sync.Mutex
+
+	// rcType is used to differentiate multiple RC services running in a single agent.
+	// Today, it is simply logged as a prefix in all log messages to help when triaging
+	// via logs.
+	rcType string
+
 	firstUpdate bool
 
 	defaultRefreshInterval         time.Duration
@@ -151,13 +157,31 @@ func init() {
 }
 
 type options struct {
-	traceAgentEnv    string
-	databaseFileName string
+	rcKey                          string
+	apiKey                         string
+	traceAgentEnv                  string
+	databaseFileName               string
+	configRootOverride             string
+	directorRootOverride           string
+	clientCacheBypassLimit         int
+	refresh                        time.Duration
+	refreshIntervalOverrideAllowed bool
+	maxBackoff                     time.Duration
+	clientTTL                      time.Duration
 }
 
 var defaultOptions = options{
-	traceAgentEnv:    "",
-	databaseFileName: "remote-config.db",
+	rcKey:                          "",
+	apiKey:                         "",
+	traceAgentEnv:                  "",
+	databaseFileName:               "remote-config.db",
+	configRootOverride:             "",
+	directorRootOverride:           "",
+	clientCacheBypassLimit:         defaultCacheBypassLimit,
+	refresh:                        defaultRefreshInterval,
+	refreshIntervalOverrideAllowed: true,
+	maxBackoff:                     minimalMaxBackoffTime,
+	clientTTL:                      defaultClientsTTL,
 }
 
 // Option is a service option
@@ -173,37 +197,94 @@ func WithDatabaseFileName(fileName string) func(s *options) {
 	return func(s *options) { s.databaseFileName = fileName }
 }
 
+// WithConfigRootOverride sets the service config root override
+func WithConfigRootOverride(override string) func(s *options) {
+	return func(s *options) { s.configRootOverride = override }
+}
+
+// WithDirectorRootOverride sets the service director root override
+func WithDirectorRootOverride(override string) func(s *options) {
+	return func(s *options) { s.directorRootOverride = override }
+}
+
+// WithRefreshInterval validates and sets the service refresh interval
+func WithRefreshInterval(interval time.Duration, cfgPath string) func(s *options) {
+	if interval < minimalRefreshInterval {
+		log.Warnf("%s is set to %v which is below the minimum of %v - using default refresh interval %v", cfgPath, interval, minimalRefreshInterval, defaultRefreshInterval)
+		return func(s *options) {
+			s.refresh = defaultRefreshInterval
+			s.refreshIntervalOverrideAllowed = true
+		}
+	}
+	return func(s *options) {
+		s.refresh = interval
+		s.refreshIntervalOverrideAllowed = false
+	}
+}
+
+// WithMaxBackoffInterval validates sets the service maximum retry backoff time
+func WithMaxBackoffInterval(interval time.Duration, cfgPath string) func(s *options) {
+	if interval < minimalMaxBackoffTime {
+		log.Warnf("%s is set to %v which is below the minimum of %v - setting value to %v", cfgPath, interval, minimalMaxBackoffTime, minimalMaxBackoffTime)
+		return func(s *options) {
+			s.maxBackoff = minimalMaxBackoffTime
+		}
+	} else if interval > maximalMaxBackoffTime {
+		log.Warnf("%s is set to %v which is above the maximum of %v - setting value to %v", cfgPath, interval, maximalMaxBackoffTime, maximalMaxBackoffTime)
+		return func(s *options) {
+			s.maxBackoff = maximalMaxBackoffTime
+		}
+	}
+
+	return func(s *options) {
+		s.maxBackoff = interval
+	}
+}
+
+// WithRcKey sets the service remote configuration key
+func WithRcKey(rcKey string) func(s *options) {
+	return func(s *options) { s.rcKey = rcKey }
+}
+
+// WithAPIKey sets the service API key
+func WithAPIKey(apiKey string) func(s *options) {
+	return func(s *options) { s.apiKey = apiKey }
+}
+
+// WithClientCacheBypassLimit validates and sets the service client cache bypass limit
+func WithClientCacheBypassLimit(limit int, cfgPath string) func(s *options) {
+	if limit < minCacheBypassLimit || limit > maxCacheBypassLimit {
+		log.Warnf(
+			"%s is not within accepted range (%d - %d): %d. Defaulting to %d",
+			cfgPath, minCacheBypassLimit, maxCacheBypassLimit, limit, defaultCacheBypassLimit,
+		)
+		return func(s *options) {
+			s.clientCacheBypassLimit = defaultCacheBypassLimit
+		}
+	}
+	return func(s *options) {
+		s.clientCacheBypassLimit = limit
+	}
+}
+
+// WithClientTTL validates and sets the service client TTL
+func WithClientTTL(interval time.Duration, cfgPath string) func(s *options) {
+	if interval < minimalRefreshInterval || interval > maxClientsTTL {
+		log.Warnf("%s is not within accepted range (%s - %s): %s. Defaulting to %s", cfgPath, minimalRefreshInterval, maxClientsTTL, interval, defaultClientsTTL)
+		return func(s *options) {
+			s.clientTTL = defaultClientsTTL
+		}
+	}
+	return func(s *options) {
+		s.clientTTL = interval
+	}
+}
+
 // NewService instantiates a new remote configuration management service
-func NewService(cfg model.Reader, apiKey, baseRawURL, hostname string, tags []string, telemetryReporter RcTelemetryReporter, agentVersion string, opts ...Option) (*Service, error) {
+func NewService(cfg model.Reader, rcType, baseRawURL, hostname string, tags []string, telemetryReporter RcTelemetryReporter, agentVersion string, opts ...Option) (*Service, error) {
 	options := defaultOptions
 	for _, opt := range opts {
 		opt(&options)
-	}
-
-	refreshIntervalOverrideAllowed := false // If a user provides a value we don't want to override
-	var refreshInterval time.Duration
-	if cfg.IsSet("remote_configuration.refresh_interval") {
-		refreshInterval = cfg.GetDuration("remote_configuration.refresh_interval")
-	} else {
-		refreshIntervalOverrideAllowed = true
-		refreshInterval = defaultRefreshInterval
-	}
-
-	// Either invalid (which resolves to 0) or was explicitly set below minimal. If it was invalid there would
-	// be an additional error message describing the failure to parse the value.
-	if refreshInterval < minimalRefreshInterval {
-		log.Warnf("remote_configuration.refresh_interval is set to %v which is below the minimum of %v - using default refresh interval %v", refreshInterval, minimalRefreshInterval, defaultRefreshInterval)
-		refreshInterval = defaultRefreshInterval
-		refreshIntervalOverrideAllowed = true
-	}
-
-	maxBackoffTime := cfg.GetDuration("remote_configuration.max_backoff_interval")
-	if maxBackoffTime < minimalMaxBackoffTime {
-		log.Warnf("remote_configuration.max_backoff_time is set to %v which is below the minimum of %v - setting value to %v", maxBackoffTime, minimalMaxBackoffTime, minimalMaxBackoffTime)
-		maxBackoffTime = minimalMaxBackoffTime
-	} else if maxBackoffTime > maximalMaxBackoffTime {
-		log.Warnf("remote_configuration.max_backoff_time is set to %v which is above the maximum of %v - setting value to %v", maxBackoffTime, maximalMaxBackoffTime, maximalMaxBackoffTime)
-		maxBackoffTime = maximalMaxBackoffTime
 	}
 
 	// A backoff is calculated as a range from which a random value will be selected. The formula is as follows.
@@ -221,10 +302,9 @@ func NewService(cfg model.Reader, apiKey, baseRawURL, hostname string, tags []st
 	recoveryReset := false
 
 	backoffPolicy := backoff.NewExpBackoffPolicy(minBackoffFactor, baseBackoffTime,
-		maxBackoffTime.Seconds(), recoveryInterval, recoveryReset)
+		options.maxBackoff.Seconds(), recoveryInterval, recoveryReset)
 
-	rcKey := cfg.GetString("remote_configuration.key")
-	authKeys, err := getRemoteConfigAuthKeys(apiKey, rcKey)
+	authKeys, err := getRemoteConfigAuthKeys(options.apiKey, options.rcKey)
 	if err != nil {
 		return nil, err
 	}
@@ -243,9 +323,9 @@ func NewService(cfg model.Reader, apiKey, baseRawURL, hostname string, tags []st
 	if err != nil {
 		return nil, err
 	}
-	configRoot := cfg.GetString("remote_configuration.config_root")
-	directorRoot := cfg.GetString("remote_configuration.director_root")
-	cacheKey := generateCacheKey(apiKey, configRoot)
+	configRoot := options.configRootOverride
+	directorRoot := options.directorRootOverride
+	cacheKey := generateCacheKey(options.apiKey, configRoot)
 	opt := []uptane.ClientOption{}
 	if authKeys.rcKeySet {
 		opt = append(opt, uptane.WithOrgIDCheck(authKeys.rcKey.OrgID))
@@ -263,29 +343,17 @@ func NewService(cfg model.Reader, apiKey, baseRawURL, hostname string, tags []st
 		opt...,
 	)
 	if err != nil {
+		db.Close()
 		return nil, err
 	}
 
-	clientsTTL := cfg.GetDuration("remote_configuration.clients.ttl_seconds")
-	if clientsTTL < minimalRefreshInterval || clientsTTL > maxClientsTTL {
-		log.Warnf("Configured clients ttl is not within accepted range (%s - %s): %s. Defaulting to %s", minimalRefreshInterval, maxClientsTTL, clientsTTL, defaultClientsTTL)
-		clientsTTL = defaultClientsTTL
-	}
 	clock := clock.New()
 
-	clientsCacheBypassLimit := cfg.GetInt("remote_configuration.clients.cache_bypass_limit")
-	if clientsCacheBypassLimit < minCacheBypassLimit || clientsCacheBypassLimit > maxCacheBypassLimit {
-		log.Warnf(
-			"Configured clients cache bypass limit is not within accepted range (%d - %d): %d. Defaulting to %d",
-			minCacheBypassLimit, maxCacheBypassLimit, clientsCacheBypassLimit, defaultCacheBypassLimit,
-		)
-		clientsCacheBypassLimit = defaultCacheBypassLimit
-	}
-
 	return &Service{
+		rcType:                         rcType,
 		firstUpdate:                    true,
-		defaultRefreshInterval:         refreshInterval,
-		refreshIntervalOverrideAllowed: refreshIntervalOverrideAllowed,
+		defaultRefreshInterval:         options.refresh,
+		refreshIntervalOverrideAllowed: options.refreshIntervalOverrideAllowed,
 		backoffErrorCount:              0,
 		backoffPolicy:                  backoffPolicy,
 		products:                       make(map[rdata.Product]struct{}),
@@ -293,10 +361,11 @@ func NewService(cfg model.Reader, apiKey, baseRawURL, hostname string, tags []st
 		hostname:                       hostname,
 		tags:                           tags,
 		clock:                          clock,
+		traceAgentEnv:                  options.traceAgentEnv,
 		db:                             db,
 		api:                            http,
 		uptane:                         uptaneClient,
-		clients:                        newClients(clock, clientsTTL),
+		clients:                        newClients(clock, options.clientTTL),
 		cacheBypassClients: cacheBypassClients{
 			clock:    clock,
 			requests: make(chan chan struct{}),
@@ -304,9 +373,9 @@ func NewService(cfg model.Reader, apiKey, baseRawURL, hostname string, tags []st
 			// By default, allows for 5 cache bypass every refreshInterval seconds
 			// in addition to the usual refresh.
 			currentWindow:  time.Now().UTC(),
-			windowDuration: refreshInterval,
-			capacity:       clientsCacheBypassLimit,
-			allowance:      clientsCacheBypassLimit,
+			windowDuration: options.refresh,
+			capacity:       options.clientCacheBypassLimit,
+			allowance:      options.clientCacheBypassLimit,
 		},
 		telemetryReporter: telemetryReporter,
 		agentVersion:      agentVersion,
@@ -332,7 +401,7 @@ func (s *Service) Start() {
 			case <-s.clock.After(orgStatusPollInterval):
 				s.pollOrgStatus()
 			case <-s.stopOrgPoller:
-				log.Infof("Stopping Remote Config org status poller")
+				log.Infof("[%s] Stopping Remote Config org status poller", s.rcType)
 				return
 			}
 		}
@@ -345,9 +414,9 @@ func (s *Service) Start() {
 		err := s.refresh()
 		if err != nil {
 			if s.previousOrgStatus != nil && s.previousOrgStatus.Enabled && s.previousOrgStatus.Authorized {
-				log.Errorf("Could not refresh Remote Config: %v", err)
+				log.Errorf("[%s] Could not refresh Remote Config: %v", s.rcType, err)
 			} else {
-				log.Debugf("Could not refresh Remote Config (org is disabled or key is not authorized): %v", err)
+				log.Debugf("[%s] Could not refresh Remote Config (org is disabled or key is not authorized): %v", s.rcType, err)
 			}
 		}
 
@@ -366,16 +435,16 @@ func (s *Service) Start() {
 				}
 				close(response)
 			case <-s.stopConfigPoller:
-				log.Infof("Stopping Remote Config configuration poller")
+				log.Infof("[%s] Stopping Remote Config configuration poller", s.rcType)
 				return
 			}
 
 			if err != nil {
 				if s.previousOrgStatus != nil && s.previousOrgStatus.Enabled && s.previousOrgStatus.Authorized {
 					exportedLastUpdateErr.Set(err.Error())
-					log.Errorf("Could not refresh Remote Config: %v", err)
+					log.Errorf("[%s] Could not refresh Remote Config: %v", s.rcType, err)
 				} else {
-					log.Debugf("Could not refresh Remote Config (org is disabled or key is not authorized): %v", err)
+					log.Debugf("[%s] Could not refresh Remote Config (org is disabled or key is not authorized): %v", s.rcType, err)
 				}
 			}
 		}
@@ -397,7 +466,7 @@ func (s *Service) pollOrgStatus() {
 		// Unauthorized and proxy error are caught by the main loop requesting the latest config,
 		// and it limits the error log.
 		if !errors.Is(err, api.ErrUnauthorized) && !errors.Is(err, api.ErrProxy) {
-			log.Errorf("Could not refresh Remote Config: %v", err)
+			log.Errorf("[%s] Could not refresh Remote Config: %v", s.rcType, err)
 		}
 		return
 	}
@@ -408,18 +477,16 @@ func (s *Service) pollOrgStatus() {
 		s.previousOrgStatus.Authorized != response.Authorized {
 		if response.Enabled {
 			if response.Authorized {
-				log.Infof("Remote Configuration is enabled for this organization and agent.")
+				log.Infof("[%s] Remote Configuration is enabled for this organization and agent.", s.rcType)
 			} else {
 				log.Infof(
-					"Remote Configuration is enabled for this organization but disabled for this agent. " +
-						"Add the Remote Configuration Read permission to its API key to enable it for this agent.",
-				)
+					"[%s] Remote Configuration is enabled for this organization but disabled for this agent. Add the Remote Configuration Read permission to its API key to enable it for this agent.", s.rcType)
 			}
 		} else {
 			if response.Authorized {
-				log.Infof("Remote Configuration is disabled for this organization.")
+				log.Infof("[%s] Remote Configuration is disabled for this organization.", s.rcType)
 			} else {
-				log.Infof("Remote Configuration is disabled for this organization and agent.")
+				log.Infof("[%s] Remote Configuration is disabled for this organization and agent.", s.rcType)
 			}
 		}
 	}
@@ -443,14 +510,14 @@ func (s *Service) refresh() error {
 	s.refreshProducts(activeClients)
 	previousState, err := s.uptane.TUFVersionState()
 	if err != nil {
-		log.Warnf("could not get previous TUF version state: %v", err)
+		log.Warnf("[%s] could not get previous TUF version state: %v", s.rcType, err)
 	}
 	if s.forceRefresh() || err != nil {
 		previousState = uptane.TUFVersions{}
 	}
 	clientState, err := s.getClientState()
 	if err != nil {
-		log.Warnf("could not get previous backend client state: %v", err)
+		log.Warnf("[%s] could not get previous backend client state: %v", s.rcType, err)
 	}
 	orgUUID, err := s.uptane.StoredOrgUUID()
 	if err != nil {
@@ -481,7 +548,7 @@ func (s *Service) refresh() error {
 			// If we saw the error enough time, we consider that RC not working is a normal behavior
 			// And we only log as DEBUG
 			// The agent will eventually log this error as DEBUG every maximalMaxBackoffTime
-			log.Debugf("Could not refresh Remote Config: %v", err)
+			log.Debugf("[%s] Could not refresh Remote Config: %v", s.rcType, err)
 			return nil
 		}
 		return err
@@ -501,7 +568,7 @@ func (s *Service) refresh() error {
 		if err == nil && ri > 0 && s.defaultRefreshInterval != ri {
 			s.defaultRefreshInterval = ri
 			s.cacheBypassClients.windowDuration = ri
-			log.Infof("Overriding agent's base refresh interval to %v due to backend recommendation", ri)
+			log.Infof("[%s] Overriding agent's base refresh interval to %v due to backend recommendation", s.rcType, ri)
 		}
 	}
 

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -7,6 +7,7 @@ package service
 
 import (
 	"context"
+	_ "embed"
 	"encoding/base32"
 	"encoding/json"
 	"errors"
@@ -28,7 +29,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/remote/uptane"
 	"github.com/DataDog/datadog-agent/pkg/proto/msgpgo"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/uuid"
 )
 
@@ -39,6 +39,7 @@ type mockAPI struct {
 const (
 	httpError    = "api: simulated HTTP error"
 	agentVersion = "9.9.9"
+	testEnv      = "test-env"
 )
 
 // Setup overrides for tests
@@ -138,48 +139,6 @@ var testRCKey = msgpgo.RemoteConfigKey{
 	Datacenter: "dd.com",
 }
 
-// getTraceAgentDefaultEnv returns the default env for the trace agent
-func getTraceAgentDefaultEnv(c model.Reader) string {
-	defaultEnv := ""
-	if c.IsSet("apm_config.env") {
-		defaultEnv = c.GetString("apm_config.env")
-		log.Debugf("Setting DefaultEnv to %q (from apm_config.env)", defaultEnv)
-	} else if c.IsSet("env") {
-		defaultEnv = c.GetString("env")
-		log.Debugf("Setting DefaultEnv to %q (from 'env' config option)", defaultEnv)
-	} else {
-		for _, tag := range getConfiguredTags(c, false) {
-			if strings.HasPrefix(tag, "env:") {
-				defaultEnv = strings.TrimPrefix(tag, "env:")
-				log.Debugf("Setting DefaultEnv to %q (from `env:` entry under the 'tags' config option: %q)", defaultEnv, tag)
-				return defaultEnv
-			}
-		}
-	}
-
-	return defaultEnv
-}
-
-// getConfiguredTags returns list of tags from a configuration, based on
-// `tags` (DD_TAGS) and `extra_tags“ (DD_EXTRA_TAGS), with `dogstatsd_tags` (DD_DOGSTATSD_TAGS)
-// if includeDogdstatsd is true.
-func getConfiguredTags(c model.Reader, includeDogstatsd bool) []string {
-	tags := c.GetStringSlice("tags")
-	extraTags := c.GetStringSlice("extra_tags")
-
-	var dsdTags []string
-	if includeDogstatsd {
-		dsdTags = c.GetStringSlice("dogstatsd_tags")
-	}
-
-	combined := make([]string, 0, len(tags)+len(extraTags)+len(dsdTags))
-	combined = append(combined, tags...)
-	combined = append(combined, extraTags...)
-	combined = append(combined, dsdTags...)
-
-	return combined
-}
-
 func newTestService(t *testing.T, api *mockAPI, uptane *mockUptane, clock clock.Clock) *Service {
 	cfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 
@@ -191,9 +150,13 @@ func newTestService(t *testing.T, api *mockAPI, uptane *mockUptane, clock clock.
 	serializedKey, _ := testRCKey.MarshalMsg(nil)
 	cfg.SetWithoutSource("remote_configuration.key", base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(serializedKey))
 	baseRawURL := "https://localhost"
-	traceAgentEnv := getTraceAgentDefaultEnv(cfg)
+	traceAgentEnv := testEnv
 	mockTelemetryReporter := newMockRcTelemetryReporter()
-	service, err := NewService(cfg, "abc", baseRawURL, "localhost", []string{"dogo_state:hungry"}, mockTelemetryReporter, agentVersion, WithTraceAgentEnv(traceAgentEnv))
+	options := []Option{
+		WithTraceAgentEnv(traceAgentEnv),
+		WithAPIKey("abc"),
+	}
+	service, err := NewService(cfg, "Remote Config", baseRawURL, "localhost", []string{"dogo_state:hungry"}, mockTelemetryReporter, agentVersion, options...)
 	require.NoError(t, err)
 	t.Cleanup(func() { service.Stop() })
 	service.api = api
@@ -214,6 +177,7 @@ func TestServiceBackoffFailure(t *testing.T) {
 
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
+		TraceAgentEnv:                testEnv,
 		AgentUuid:                    "test-uuid",
 		AgentVersion:                 agentVersion,
 		CurrentConfigSnapshotVersion: 0,
@@ -241,6 +205,7 @@ func TestServiceBackoffFailure(t *testing.T) {
 	// Sending the http error too
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
+		TraceAgentEnv:                testEnv,
 		AgentUuid:                    "test-uuid",
 		AgentVersion:                 agentVersion,
 		CurrentConfigSnapshotVersion: 0,
@@ -297,6 +262,7 @@ func TestServiceBackoffFailureRecovery(t *testing.T) {
 	api = &mockAPI{}
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
+		TraceAgentEnv:                testEnv,
 		AgentUuid:                    "test-uuid",
 		AgentVersion:                 agentVersion,
 		CurrentConfigSnapshotVersion: 0,
@@ -427,6 +393,7 @@ func TestService(t *testing.T) {
 	}
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
+		TraceAgentEnv:                testEnv,
 		AgentUuid:                    "test-uuid",
 		AgentVersion:                 agentVersion,
 		CurrentConfigSnapshotVersion: 0,
@@ -510,6 +477,7 @@ func TestService(t *testing.T) {
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
 		AgentUuid:                    "test-uuid",
+		TraceAgentEnv:                testEnv,
 		AgentVersion:                 agentVersion,
 		CurrentConfigRootVersion:     1,
 		CurrentConfigSnapshotVersion: 2,
@@ -619,6 +587,7 @@ func TestServiceClientPredicates(t *testing.T) {
 	uptaneClient.On("Update", lastConfigResponse).Return(nil)
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
+		TraceAgentEnv:                testEnv,
 		AgentUuid:                    "test-uuid",
 		AgentVersion:                 agentVersion,
 		CurrentConfigRootVersion:     0,
@@ -665,6 +634,7 @@ func TestServiceGetRefreshIntervalNone(t *testing.T) {
 	lastConfigResponse := &pbgo.LatestConfigsResponse{}
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
+		TraceAgentEnv:                testEnv,
 		AgentUuid:                    "test-uuid",
 		AgentVersion:                 agentVersion,
 		CurrentConfigSnapshotVersion: 0,
@@ -704,6 +674,7 @@ func TestServiceGetRefreshIntervalValid(t *testing.T) {
 	lastConfigResponse := &pbgo.LatestConfigsResponse{}
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
+		TraceAgentEnv:                testEnv,
 		AgentUuid:                    "test-uuid",
 		AgentVersion:                 agentVersion,
 		CurrentConfigSnapshotVersion: 0,
@@ -743,6 +714,7 @@ func TestServiceGetRefreshIntervalTooSmall(t *testing.T) {
 	lastConfigResponse := &pbgo.LatestConfigsResponse{}
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
+		TraceAgentEnv:                testEnv,
 		AgentUuid:                    "test-uuid",
 		AgentVersion:                 agentVersion,
 		CurrentConfigSnapshotVersion: 0,
@@ -782,6 +754,7 @@ func TestServiceGetRefreshIntervalTooBig(t *testing.T) {
 	lastConfigResponse := &pbgo.LatestConfigsResponse{}
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
+		TraceAgentEnv:                testEnv,
 		AgentUuid:                    "test-uuid",
 		AgentVersion:                 agentVersion,
 		CurrentConfigSnapshotVersion: 0,
@@ -824,6 +797,7 @@ func TestServiceGetRefreshIntervalNoOverrideAllowed(t *testing.T) {
 	lastConfigResponse := &pbgo.LatestConfigsResponse{}
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
+		TraceAgentEnv:                testEnv,
 		AgentUuid:                    "test-uuid",
 		AgentVersion:                 agentVersion,
 		CurrentConfigSnapshotVersion: 0,
@@ -903,6 +877,7 @@ func TestConfigExpiration(t *testing.T) {
 	uptaneClient.On("Update", lastConfigResponse).Return(nil)
 	api.On("Fetch", mock.Anything, &pbgo.LatestConfigsRequest{
 		Hostname:                     service.hostname,
+		TraceAgentEnv:                testEnv,
 		AgentUuid:                    "test-uuid",
 		AgentVersion:                 agentVersion,
 		CurrentConfigRootVersion:     0,
@@ -964,4 +939,206 @@ func TestOrgStatus(t *testing.T) {
 	service.pollOrgStatus()
 	assert.True(t, service.previousOrgStatus.Enabled)
 	assert.False(t, service.previousOrgStatus.Authorized)
+}
+
+func TestWithTraceAgentEnv(t *testing.T) {
+	cfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	dir := t.TempDir()
+	cfg.SetWithoutSource("run_path", dir)
+
+	baseRawURL := "https://localhost"
+	traceAgentEnv := "dog"
+	mockTelemetryReporter := newMockRcTelemetryReporter()
+	options := []Option{
+		WithTraceAgentEnv(traceAgentEnv),
+		WithAPIKey("abc"),
+	}
+	service, err := NewService(cfg, "Remote Config", baseRawURL, "localhost", []string{"dogo_state:hungry"}, mockTelemetryReporter, agentVersion, options...)
+	assert.NoError(t, err)
+	assert.Equal(t, "dog", service.traceAgentEnv)
+	assert.NotNil(t, service)
+	t.Cleanup(func() { service.Stop() })
+}
+
+func TestWithDatabaseFileName(t *testing.T) {
+	cfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	cfg.SetWithoutSource("run_path", "/tmp")
+
+	baseRawURL := "https://localhost"
+	mockTelemetryReporter := newMockRcTelemetryReporter()
+	options := []Option{
+		WithDatabaseFileName("test.db"),
+		WithAPIKey("abc"),
+	}
+	service, err := NewService(cfg, "Remote Config", baseRawURL, "localhost", []string{"dogo_state:hungry"}, mockTelemetryReporter, agentVersion, options...)
+	assert.NoError(t, err)
+	assert.Equal(t, "/tmp/test.db", service.db.Path())
+	assert.NotNil(t, service)
+	t.Cleanup(func() { service.Stop() })
+}
+
+type refreshIntervalTest struct {
+	name                                   string
+	interval                               time.Duration
+	expected                               time.Duration
+	expectedRefreshIntervalOverrideAllowed bool
+}
+
+func TestWithRefreshInterval(t *testing.T) {
+	tests := []refreshIntervalTest{
+		{
+			name:                                   "valid interval",
+			interval:                               42 * time.Second,
+			expected:                               42 * time.Second,
+			expectedRefreshIntervalOverrideAllowed: false,
+		},
+		{
+			name:                                   "interval too short",
+			interval:                               1 * time.Second,
+			expected:                               defaultRefreshInterval,
+			expectedRefreshIntervalOverrideAllowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+			cfg.SetWithoutSource("run_path", "/tmp")
+
+			baseRawURL := "https://localhost"
+			mockTelemetryReporter := newMockRcTelemetryReporter()
+			options := []Option{
+				WithRefreshInterval(tt.interval, "test.refresh_interval"),
+				WithAPIKey("abc"),
+			}
+			service, err := NewService(cfg, "Remote Config", baseRawURL, "localhost", []string{"dogo_state:hungry"}, mockTelemetryReporter, agentVersion, options...)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, service.defaultRefreshInterval)
+			assert.Equal(t, tt.expectedRefreshIntervalOverrideAllowed, service.refreshIntervalOverrideAllowed)
+			assert.NotNil(t, service)
+			service.Stop()
+		})
+	}
+}
+
+type maxBackoffIntervalTest struct {
+	name     string
+	interval time.Duration
+	expected time.Duration
+}
+
+func TestWithMaxBackoffInterval(t *testing.T) {
+
+	tests := []maxBackoffIntervalTest{
+		{
+			name:     "valid interval",
+			interval: 3 * time.Minute,
+			expected: 3 * time.Minute,
+		},
+		{
+			name:     "interval too short",
+			interval: 1 * time.Second,
+			expected: minimalMaxBackoffTime,
+		},
+		{
+			name:     "interval too long",
+			interval: 1 * time.Hour,
+			expected: maximalMaxBackoffTime,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := WithMaxBackoffInterval(tt.interval, "test.max_backoff_interval")
+			defaultOptions := &options{}
+			opt(defaultOptions)
+			assert.Equal(t, tt.expected, defaultOptions.maxBackoff)
+		})
+	}
+}
+
+type clientCacheBypassLimitTest struct {
+	name     string
+	limit    int
+	expected int
+}
+
+func TestWithClientCacheBypassLimit(t *testing.T) {
+	tests := []clientCacheBypassLimitTest{
+		{
+			name:     "valid limit",
+			limit:    5,
+			expected: 5,
+		},
+		{
+			name:     "limit too small",
+			limit:    -1,
+			expected: defaultCacheBypassLimit,
+		},
+		{
+			name:     "limit too large",
+			limit:    100000,
+			expected: defaultCacheBypassLimit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := WithClientCacheBypassLimit(tt.limit, "test.client_cache_bypass_limit")
+			defaultOptions := &options{}
+			opt(defaultOptions)
+			assert.Equal(t, tt.expected, defaultOptions.clientCacheBypassLimit)
+		})
+	}
+}
+
+type clientTTLTest struct {
+	name     string
+	ttl      time.Duration
+	expected time.Duration
+}
+
+func TestWithDirectorRootOverride(t *testing.T) {
+	cfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	cfg.SetWithoutSource("run_path", "/tmp")
+
+	baseRawURL := "https://localhost"
+	mockTelemetryReporter := newMockRcTelemetryReporter()
+	options := []Option{
+		WithDirectorRootOverride("{\"a\": \"b\"}"),
+		WithAPIKey("abc"),
+	}
+	_, err := NewService(cfg, "Remote Config", baseRawURL, "localhost", []string{"dogo_state:hungry"}, mockTelemetryReporter, agentVersion, options...)
+	// Because we used an invalid root, we should get an error. All we're trying to capture
+	// with this test is that the builder method is propagating the value properly
+	assert.Errorf(t, err, "failed to set embedded root in roots bucket: invalid meta: version field is missing")
+}
+
+func TestWithClientTTL(t *testing.T) {
+	tests := []clientTTLTest{
+		{
+			name:     "valid ttl",
+			ttl:      10 * time.Second,
+			expected: 10 * time.Second,
+		},
+		{
+			name:     "ttl too short",
+			ttl:      1 * time.Second,
+			expected: defaultClientsTTL,
+		},
+		{
+			name:     "ttl too long",
+			ttl:      1 * time.Hour,
+			expected: defaultClientsTTL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := WithClientTTL(tt.ttl, "test.client_ttl")
+			defaultOptions := &options{}
+			opt(defaultOptions)
+			assert.Equal(t, tt.expected, defaultOptions.clientTTL)
+		})
+	}
 }

--- a/pkg/config/setup/high_availability.go
+++ b/pkg/config/setup/high_availability.go
@@ -7,6 +7,7 @@ package setup
 
 import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"time"
 )
 
 func setupHighAvailability(config pkgconfigmodel.Config) {
@@ -15,4 +16,14 @@ func setupHighAvailability(config pkgconfigmodel.Config) {
 	config.BindEnv("ha.dd_url")
 	config.BindEnvAndSetDefault("ha.enabled", false)
 	config.BindEnvAndSetDefault("ha.failover", false)
+
+	config.BindEnv("ha.remote_configuration.refresh_interval")
+	config.BindEnv("ha.remote_configuration.max_backoff_time")
+	config.BindEnvAndSetDefault("ha.remote_configuration.max_backoff_interval", 5*time.Minute)
+	config.BindEnv("ha.remote_configuration.config_root")
+	config.BindEnv("ha.remote_configuration.director_root")
+	config.BindEnv("ha.remote_configuration.key")
+
+	config.BindEnvAndSetDefault("ha.remote_configuration.clients.ttl_seconds", 30*time.Second)
+	config.BindEnvAndSetDefault("ha.remote_configuration.clients.cache_bypass_limit", 5)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This is a cherry-pick of a feature that was merged to `main` (#23815) targeting `7.53` that additionally fixes an issue present in 7.52 where `traceAgentEnv` is not being propagated to RC backend requests to get the latest configs properly. This results in configurations not being delivered to some tracers and agents that should otherwise have received it.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

`traceAgentEnv` not propagating to the RC backend requests is a regression that warrants patching

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
