### PR TITLE
Map FA tickets to FA board

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -117,6 +117,13 @@ jira_statuses = ["To Do", "In Progress", "Done"]
 github_team = "remote-config"
 github_labels = ["team/remote-config"]
 
+[teams."Fleet Automation"]
+jira_project = "FA"
+jira_issue_type = "QA"
+jira_statuses = ["To Do", "In Progress", "Done"]
+github_team = "fleet-automation"
+github_labels = ["team/fleet-automation"]
+
 [teams."Container Integrations"]
 jira_project = "CONTINT"
 jira_issue_type = "Task"

--- a/tasks/libs/github_jira_map.yaml
+++ b/tasks/libs/github_jira_map.yaml
@@ -16,7 +16,7 @@
 '@datadog/metrics-aggregation': AGGR
 '@datadog/serverless': SVLS
 '@datadog/remote-config': RC
-'@datadog/fleet': RC
+'@datadog/fleet': FA
 '@datadog/agent-all': DEFAULT_JIRA_PROJECT
 '@datadog/ebpf-platform': EBPF
 '@datadog/networks': NPM


### PR DESCRIPTION
Fleet-Automation has it's own JIRA board, their code owned tickets and notification should be routed to it