### PR TITLE
[CONTINT-3679] Add workqueue telemetry

### DIFF
--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -58,7 +58,7 @@ func NewScanner(cfg config.Config, wmeta optional.Option[workloadmeta.Component]
 				cfg.GetDuration("sbom.scan_queue.max_backoff"),
 			),
 			workqueue.RateLimitingQueueConfig{
-				Name:            "sbom",
+				Name:            "sbom_request",
 				MetricsProvider: telemetry.QueueMetricProvider{},
 			},
 		),

--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -52,11 +52,15 @@ type Scanner struct {
 // collectors.
 func NewScanner(cfg config.Config, wmeta optional.Option[workloadmeta.Component]) *Scanner {
 	return &Scanner{
-		scanQueue: workqueue.NewRateLimitingQueue(
+		scanQueue: workqueue.NewRateLimitingQueueWithConfig(
 			workqueue.NewItemExponentialFailureRateLimiter(
 				cfg.GetDuration("sbom.scan_queue.base_backoff"),
 				cfg.GetDuration("sbom.scan_queue.max_backoff"),
 			),
+			workqueue.RateLimitingQueueConfig{
+				Name:            "sbom",
+				MetricsProvider: telemetry.QueueMetricProvider{},
+			},
 		),
 		disk:  filesystem.NewDisk(),
 		wmeta: wmeta,

--- a/pkg/sbom/telemetry/telemetry.go
+++ b/pkg/sbom/telemetry/telemetry.go
@@ -157,7 +157,7 @@ func (QueueMetricProvider) NewLatencyMetric(string) workqueue.HistogramMetric {
 		subsystem,
 		"queue_latency",
 		[]string{},
-		"SBOM queue latency",
+		"SBOM queue latency in seconds",
 		[]float64{1, 15, 60, 120, 600, 1200},
 		commonOpts,
 	)}
@@ -169,7 +169,7 @@ func (QueueMetricProvider) NewWorkDurationMetric(string) workqueue.HistogramMetr
 		subsystem,
 		"queue_work_duration",
 		[]string{},
-		"SBOM queue latency",
+		"SBOM queue latency in seconds",
 		prometheus.DefBuckets,
 		commonOpts,
 	)}
@@ -181,7 +181,7 @@ func (QueueMetricProvider) NewUnfinishedWorkSecondsMetric(string) workqueue.Sett
 		subsystem,
 		"queue_unfinished_work",
 		[]string{},
-		"SBOM queue unfinished work seconds",
+		"SBOM queue unfinished work in seconds",
 		commonOpts,
 	)}
 }
@@ -192,7 +192,7 @@ func (QueueMetricProvider) NewLongestRunningProcessorSecondsMetric(string) workq
 		subsystem,
 		"queue_longest_running_processor",
 		[]string{},
-		"SBOM queue longest running processor seconds",
+		"SBOM queue longest running processor in seconds",
 		commonOpts,
 	)}
 }

--- a/pkg/sbom/telemetry/telemetry.go
+++ b/pkg/sbom/telemetry/telemetry.go
@@ -155,7 +155,7 @@ func (QueueMetricProvider) NewAddsMetric(string) workqueue.CounterMetric {
 func (QueueMetricProvider) NewLatencyMetric(string) workqueue.HistogramMetric {
 	return histgramWrapper{telemetry.NewHistogramWithOpts(
 		subsystem,
-		"queue_latency_seconds",
+		"queue_latency",
 		[]string{},
 		"SBOM queue latency",
 		[]float64{1, 15, 60, 120, 600, 1200},
@@ -167,7 +167,7 @@ func (QueueMetricProvider) NewLatencyMetric(string) workqueue.HistogramMetric {
 func (QueueMetricProvider) NewWorkDurationMetric(string) workqueue.HistogramMetric {
 	return histgramWrapper{telemetry.NewHistogramWithOpts(
 		subsystem,
-		"queue_work_duration_seconds",
+		"queue_work_duration",
 		[]string{},
 		"SBOM queue latency",
 		prometheus.DefBuckets,
@@ -179,7 +179,7 @@ func (QueueMetricProvider) NewWorkDurationMetric(string) workqueue.HistogramMetr
 func (QueueMetricProvider) NewUnfinishedWorkSecondsMetric(string) workqueue.SettableGaugeMetric {
 	return gaugeWrapper{telemetry.NewGaugeWithOpts(
 		subsystem,
-		"queue_unfinished_work_seconds",
+		"queue_unfinished_work",
 		[]string{},
 		"SBOM queue unfinished work seconds",
 		commonOpts,
@@ -190,7 +190,7 @@ func (QueueMetricProvider) NewUnfinishedWorkSecondsMetric(string) workqueue.Sett
 func (QueueMetricProvider) NewLongestRunningProcessorSecondsMetric(string) workqueue.SettableGaugeMetric {
 	return gaugeWrapper{telemetry.NewGaugeWithOpts(
 		subsystem,
-		"queue_longest_running_processor_seconds",
+		"queue_longest_running_processor",
 		[]string{},
 		"SBOM queue longest running processor seconds",
 		commonOpts,

--- a/pkg/sbom/telemetry/telemetry.go
+++ b/pkg/sbom/telemetry/telemetry.go
@@ -8,6 +8,9 @@ package telemetry
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/util/workqueue"
 )
 
 const (
@@ -82,3 +85,125 @@ var (
 		commonOpts,
 	)
 )
+
+// QueueMetricProvider is a workqueue.MetricsProvider that provides metrics for the SBOM queue
+type QueueMetricProvider struct{}
+
+// Ensure QueueMetricProvider implements the workqueue.MetricsProvider interface
+var _ workqueue.MetricsProvider = QueueMetricProvider{}
+
+type gaugeWrapper struct {
+	telemetry.Gauge
+}
+
+// Inc implements the workqueue.GaugeMetric interface
+func (g gaugeWrapper) Inc() {
+	g.Gauge.Inc()
+}
+
+// Dec implements the workqueue.GaugeMetric interface
+func (g gaugeWrapper) Dec() {
+	g.Gauge.Dec()
+}
+
+// Set implements the workqueue.GaugeMetric interface
+func (g gaugeWrapper) Set(v float64) {
+	g.Gauge.Set(v)
+}
+
+type counterWrapper struct {
+	telemetry.Counter
+}
+
+// Inc implements the workqueue.CounterMetric interface
+func (c counterWrapper) Inc() {
+	c.Counter.Inc()
+}
+
+type histgramWrapper struct {
+	telemetry.Histogram
+}
+
+// Observer implements the workqueue.HistogramMetric interface
+func (l histgramWrapper) Observe(value float64) {
+	l.Histogram.Observe(value)
+}
+
+// NewDepthMetric creates a new depth metric
+func (QueueMetricProvider) NewDepthMetric(string) workqueue.GaugeMetric {
+	return gaugeWrapper{telemetry.NewGaugeWithOpts(
+		subsystem,
+		"queue_depth",
+		[]string{},
+		"SBOM queue depth",
+		commonOpts,
+	)}
+}
+
+// NewAddsMetric creates a new adds metric
+func (QueueMetricProvider) NewAddsMetric(string) workqueue.CounterMetric {
+	return counterWrapper{telemetry.NewCounterWithOpts(
+		subsystem,
+		"queue_adds",
+		[]string{},
+		"SBOM queue adds",
+		commonOpts,
+	)}
+}
+
+// NewLatencyMetric creates a new latency metric
+func (QueueMetricProvider) NewLatencyMetric(string) workqueue.HistogramMetric {
+	return histgramWrapper{telemetry.NewHistogramWithOpts(
+		subsystem,
+		"queue_latency_seconds",
+		[]string{},
+		"SBOM queue latency",
+		prometheus.DefBuckets,
+		commonOpts,
+	)}
+}
+
+// NewWorkDurationMetric creates a new work duration metric
+func (QueueMetricProvider) NewWorkDurationMetric(string) workqueue.HistogramMetric {
+	return histgramWrapper{telemetry.NewHistogramWithOpts(
+		subsystem,
+		"queue_work_duration_seconds",
+		[]string{},
+		"SBOM queue latency",
+		prometheus.DefBuckets,
+		commonOpts,
+	)}
+}
+
+// NewUnfinishedWorkSecondsMetric creates a new unfinished work seconds metric
+func (QueueMetricProvider) NewUnfinishedWorkSecondsMetric(string) workqueue.SettableGaugeMetric {
+	return gaugeWrapper{telemetry.NewGaugeWithOpts(
+		subsystem,
+		"queue_unfinished_work_seconds",
+		[]string{},
+		"SBOM queue unfinished work seconds",
+		commonOpts,
+	)}
+}
+
+// NewLongestRunningProcessorSecondsMetric creates a new longest running processor seconds metric
+func (QueueMetricProvider) NewLongestRunningProcessorSecondsMetric(string) workqueue.SettableGaugeMetric {
+	return gaugeWrapper{telemetry.NewGaugeWithOpts(
+		subsystem,
+		"queue_longest_running_processor_seconds",
+		[]string{},
+		"SBOM queue longest running processor seconds",
+		commonOpts,
+	)}
+}
+
+// NewRetriesMetric creates a new retries metric
+func (QueueMetricProvider) NewRetriesMetric(string) workqueue.CounterMetric {
+	return counterWrapper{telemetry.NewCounterWithOpts(
+		subsystem,
+		"queue_retries",
+		[]string{},
+		"SBOM queue retries",
+		commonOpts,
+	)}
+}

--- a/pkg/sbom/telemetry/telemetry.go
+++ b/pkg/sbom/telemetry/telemetry.go
@@ -158,7 +158,7 @@ func (QueueMetricProvider) NewLatencyMetric(string) workqueue.HistogramMetric {
 		"queue_latency_seconds",
 		[]string{},
 		"SBOM queue latency",
-		prometheus.DefBuckets,
+		[]float64{1, 15, 60, 120, 600, 1200},
 		commonOpts,
 	)}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds telemetry to the SBOM scan queue.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We would like a better observability on the kubernetes scan queue.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent with sbom collection and telemetry enabled, configure an openmetrics check configured on it. Make sure the telemetry is collected: https://dddev.datadoghq.com/notebook/7744286/workqueue-telemetry

On helm:
```
agents:
  podAnnotations:
    ad.datadoghq.com/agent.checks: |-
      {
        "openmetrics": {
          "init_config": {},
          "instances": [
            {
              "openmetrics_endpoint": "http://localhost:6000/telemetry",
              "namespace": "datadog.agent",
              "metrics": [".*"]
            }
          ]
        }
      }
datadog:
    env:
    - name: DD_TELEMETRY_ENABLED
      value: "true"
    sbom:
    host:
      enabled: true # I have tested with false as there is currently a bug on main
    containerImage:
      enabled: true
      uncompressedLayersSupport: true
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
