### PR TITLE
Set default log level in mock logger to debug

### DIFF
--- a/comp/core/log/logimpl/mock.go
+++ b/comp/core/log/logimpl/mock.go
@@ -61,6 +61,8 @@ func newMockLogger(t testing.TB, lc fx.Lifecycle) (log.Component, error) {
 
 	// flush the seelog logger when the test app stops
 	lc.Append(fx.Hook{OnStop: func(context.Context) error {
+		// stop using the logger to avoid a race condition
+		pkglog.ChangeLogLevel(seelog.Default, "debug")
 		iface.Flush()
 		return nil
 	}})

--- a/comp/core/log/logimpl/mock.go
+++ b/comp/core/log/logimpl/mock.go
@@ -14,11 +14,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/cihub/seelog"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -66,7 +66,7 @@ func newMockLogger(t testing.TB, lc fx.Lifecycle) (log.Component, error) {
 	}})
 
 	// install the logger into pkg/util/log
-	pkglog.ChangeLogLevel(iface, "off")
+	pkglog.ChangeLogLevel(iface, "debug")
 
 	return &logger{}, nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Change the default level of the mock logger component to `debug`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
It was previously set to `trace`, then disabled because too verbose.
Setting it to `debug` seems like a reasonable default for tests.
Having it enabled by default in all tests is also pretty convenient to debug. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
