### PR TITLE
Make S3 uploads easier to debug

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -138,7 +138,7 @@ variables:
   WINDOWS_TESTING_S3_BUCKET_A7: pipelines/A7/$CI_PIPELINE_ID
   WINDOWS_BUILDS_S3_BUCKET: $WIN_S3_BUCKET/builds
   DEB_RPM_TESTING_BUCKET_BRANCH: testing # branch of the DEB_TESTING_S3_BUCKET and RPM_TESTING_S3_BUCKET repos to release to, 'testing'
-  S3_CP_OPTIONS: --only-show-errors --region us-east-1 --sse AES256
+  S3_CP_OPTIONS: --no-progress --region us-east-1 --sse AES256
   S3_CP_CMD: aws s3 cp $S3_CP_OPTIONS
   S3_ARTIFACTS_URI: s3://dd-ci-artefacts-build-stable/$CI_PROJECT_NAME/$CI_PIPELINE_ID
   S3_PERMANENT_ARTIFACTS_URI: s3://dd-ci-persistent-artefacts-build-stable/$CI_PROJECT_NAME

--- a/.gitlab/deploy_packages/deploy_common.yml
+++ b/.gitlab/deploy_packages/deploy_common.yml
@@ -6,7 +6,7 @@
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*_${MAJOR_VERSION}.*${PACKAGE_ARCH}.deb" "$OMNIBUS_PACKAGE_DIR" "$S3_RELEASE_ARTIFACTS_URI/deb/${PACKAGE_ARCH}/" || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "*_${MAJOR_VERSION}.*${PACKAGE_ARCH}.deb" "$OMNIBUS_PACKAGE_DIR" "$S3_RELEASE_ARTIFACTS_URI/deb/${PACKAGE_ARCH}/"
 
 .deploy_packages_deb-6:
   extends: .deploy_packages_deb
@@ -33,7 +33,7 @@
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-${MAJOR_VERSION}.*${PACKAGE_ARCH}.rpm" "$OMNIBUS_PACKAGE_DIR" "$S3_RELEASE_ARTIFACTS_URI/${ARTIFACTS_PREFIX}rpm/${PACKAGE_ARCH}/" || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-${MAJOR_VERSION}.*${PACKAGE_ARCH}.rpm" "$OMNIBUS_PACKAGE_DIR" "$S3_RELEASE_ARTIFACTS_URI/${ARTIFACTS_PREFIX}rpm/${PACKAGE_ARCH}/"
 
 .deploy_packages_rpm-6:
   extends: .deploy_packages_rpm

--- a/.gitlab/deploy_packages/nix.yml
+++ b/.gitlab/deploy_packages/nix.yml
@@ -190,7 +190,7 @@ deploy_packages_dmg-x64-a7:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.dmg" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/dmg/x86_64/ || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.dmg" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/dmg/x86_64/
 
 # deploy dogstatsd x64, non-static binary to staging bucket
 deploy_staging_dsd:

--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -17,7 +17,7 @@ deploy_packages_windows-x64-6:
       --exclude "*"
       --include "datadog-agent-6*.msi"
       --include "datadog-agent-6*.debug.zip"
-      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ || true
+      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/
 
 #
 # Agent v7
@@ -37,7 +37,7 @@ deploy_packages_windows-x64-7:
       --exclude "*"
       --include "datadog-agent-7*.msi"
       --include "datadog-agent-7*.debug.zip"
-      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ || true
+      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/
 
 deploy_staging_windows_tags-7:
   rules:


### PR DESCRIPTION
### What does this PR do?

- Removes `|| true` from s3 upload commands on the deploy stage that could potentially mask errors (which would probably show at the artifact promotion stage).
- Changes the s3 copy command we use to be slightly more verbose, so that it will print what is copied where.

### Motivation

Missing immediate access to what the s3 command was actually doing during the investigation of a specific promotion pipeline failure.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
