### PR TITLE
orchestrator: Collect all node resources capacity

### DIFF
--- a/releasenotes/notes/collect-node-capacities-a4fa1256cba0f172.yaml
+++ b/releasenotes/notes/collect-node-capacities-a4fa1256cba0f172.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Collect all node resource capacities and allocatable metrics for cluster management.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

https://datadoghq.atlassian.net/browse/CAP-1582


This pull request collects all the node's resources capacities and allocatable.
We used to only collect the `supportedResources` and then set the appropriate unit in milli or the default.
Now we collect all the possible resources and set the value as milli if specified or the default unit.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We want to collect capacities such as GPUs (`nvidia.com/gpu`, `amd.com/gpu`, etc.). There are a lot of possible resource names and we cannot list them all so we will collect all of them.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
