### PR TITLE
[CSPM] k8s: fault tolerant when dealing with unreachable configuration data

### DIFF
--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -29,7 +29,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const version = "202312"
+const version = "202403"
 
 const (
 	k8sManifestsDir   = "/etc/kubernetes/manifests"
@@ -73,12 +73,21 @@ func (l *loader) load(ctx context.Context, loadProcesses procsLoader) (string, *
 		"/lib/systemd/system/kubelet.service",
 	})
 
-	node.AdminKubeconfig = l.loadKubeconfigMeta(filepath.Join(k8sKubeconfigsDir, "admin.conf"))
-
-	node.Manifests.KubeApiserver = l.loadConfigFileMeta(filepath.Join(k8sManifestsDir, "kube-apiserver.yaml"))
-	node.Manifests.KubeContollerManager = l.loadConfigFileMeta(filepath.Join(k8sManifestsDir, "kube-controller-manager.yaml"))
-	node.Manifests.KubeScheduler = l.loadConfigFileMeta(filepath.Join(k8sManifestsDir, "kube-scheduler.yaml"))
-	node.Manifests.Etcd = l.loadConfigFileMeta(filepath.Join(k8sManifestsDir, "etcd.yaml"))
+	if c, ok := l.loadKubeconfigMeta(filepath.Join(k8sKubeconfigsDir, "admin.conf")); ok {
+		node.AdminKubeconfig = c
+	}
+	if c, ok := l.loadConfigFileMeta(filepath.Join(k8sManifestsDir, "kube-apiserver.yaml")); ok {
+		node.Manifests.KubeApiserver = c
+	}
+	if c, ok := l.loadConfigFileMeta(filepath.Join(k8sManifestsDir, "kube-controller-manager.yaml")); ok {
+		node.Manifests.KubeContollerManager = c
+	}
+	if c, ok := l.loadConfigFileMeta(filepath.Join(k8sManifestsDir, "kube-scheduler.yaml")); ok {
+		node.Manifests.KubeScheduler = c
+	}
+	if c, ok := l.loadConfigFileMeta(filepath.Join(k8sManifestsDir, "etcd.yaml")); ok {
+		node.Manifests.Etcd = c
+	}
 
 	for _, proc := range loadProcesses(ctx) {
 		switch proc.name {
@@ -145,8 +154,8 @@ func (l *loader) detectManagedEnvironment(flags map[string]string, kubelet *K8sK
 				env := &K8sManagedEnvConfig{
 					Name: "eks",
 				}
-				eksMeta := l.loadConfigFileMeta("/etc/eks/release")
-				if eksMeta != nil {
+				eksMeta, ok := l.loadConfigFileMeta("/etc/eks/release")
+				if ok {
 					env.Metadata = eksMeta.Content
 				}
 				return env
@@ -220,7 +229,7 @@ func (l *loader) loadMeta(name string, loadContent bool) (string, os.FileInfo, [
 func (l *loader) loadDirMeta(name string) *K8sDirMeta {
 	_, info, _, ok := l.loadMeta(name, false)
 	if !ok {
-		return nil
+		return &K8sDirMeta{Path: name}
 	}
 	return &K8sDirMeta{
 		Path:  name,
@@ -232,18 +241,18 @@ func (l *loader) loadDirMeta(name string) *K8sDirMeta {
 
 func (l *loader) loadServiceFileMeta(names []string) *K8sConfigFileMeta {
 	for _, name := range names {
-		meta := l.loadConfigFileMeta(name)
-		if meta != nil {
+		meta, ok := l.loadConfigFileMeta(name)
+		if ok {
 			return meta
 		}
 	}
 	return nil
 }
 
-func (l *loader) loadConfigFileMeta(name string) *K8sConfigFileMeta {
+func (l *loader) loadConfigFileMeta(name string) (*K8sConfigFileMeta, bool) {
 	_, info, b, ok := l.loadMeta(name, true)
 	if !ok {
-		return nil
+		return &K8sConfigFileMeta{Path: name}, false
 	}
 
 	var content interface{}
@@ -261,7 +270,7 @@ func (l *loader) loadConfigFileMeta(name string) *K8sConfigFileMeta {
 		Group:   utils.GetFileGroup(info),
 		Mode:    uint32(info.Mode()),
 		Content: content,
-	}
+	}, true
 }
 
 func (l *loader) getConfigFromPath(meta *K8sConfigFileMeta, path string) (map[string]interface{}, string, bool) {
@@ -297,17 +306,18 @@ func (l *loader) configFileMetaHasField(meta *K8sConfigFileMeta, path string) bo
 }
 
 func (l *loader) loadKubeletConfigFileMeta(name string) *K8sConfigFileMeta {
-	meta := l.loadConfigFileMeta(name)
-	if meta == nil {
-		return nil
+	meta, ok := l.loadConfigFileMeta(name)
+	if !ok {
+		return &K8sConfigFileMeta{Path: name}
 	}
 	content, ok := meta.Content.(map[string]interface{})
 	if !ok {
-		return nil
+		l.pushError(fmt.Errorf("kubelet configuration loaded from %q is not a valid configuration", name))
+		return &K8sConfigFileMeta{Path: name}
 	}
 	if kind := content["kind"]; kind != "KubeletConfiguration" {
 		l.pushError(fmt.Errorf(`kubelet configuration loaded from %q is expected to be of kind "KubeletConfiguration"`, name))
-		return nil
+		return &K8sConfigFileMeta{Path: name}
 	}
 	// specifically parse key/cert files path to load their associated meta info.
 	if keyPath, ok := content["tlsPrivateKeyFile"].(string); ok {
@@ -329,12 +339,12 @@ func (l *loader) loadKubeletConfigFileMeta(name string) *K8sConfigFileMeta {
 func (l *loader) loadAdmissionConfigFileMeta(name string) *K8sAdmissionConfigFileMeta {
 	_, info, b, ok := l.loadMeta(name, true)
 	if !ok {
-		return nil
+		return &K8sAdmissionConfigFileMeta{Path: name}
 	}
 	var content k8sAdmissionConfigSource
 	if err := yaml.Unmarshal(b, &content); err != nil {
 		l.pushError(err)
-		return nil
+		return &K8sAdmissionConfigFileMeta{Path: name}
 	}
 	var result K8sAdmissionConfigFileMeta
 	for _, plugin := range content.Plugins {
@@ -342,7 +352,9 @@ func (l *loader) loadAdmissionConfigFileMeta(name string) *K8sAdmissionConfigFil
 		if plugin.Configuration != nil {
 			added.Configuration = plugin.Configuration
 		} else if plugin.Path != "" {
-			added.Configuration = l.loadConfigFileMeta(plugin.Path)
+			if c, ok := l.loadConfigFileMeta(plugin.Path); ok {
+				added.Configuration = c
+			}
 		}
 		result.Plugins = append(result.Plugins, added)
 	}
@@ -355,13 +367,13 @@ func (l *loader) loadAdmissionConfigFileMeta(name string) *K8sAdmissionConfigFil
 
 func (l *loader) loadEncryptionProviderConfigFileMeta(name string) *K8sEncryptionProviderConfigFileMeta {
 	_, info, b, ok := l.loadMeta(name, true)
-	if ok {
-		return nil
+	if !ok {
+		return &K8sEncryptionProviderConfigFileMeta{Path: name}
 	}
 	var content K8sEncryptionProviderConfigFileMeta
 	if err := yaml.Unmarshal(b, &content); err != nil {
 		l.pushError(err)
-		return nil
+		return &K8sEncryptionProviderConfigFileMeta{Path: name}
 	}
 	content.Path = name
 	content.User = utils.GetFileUser(info)
@@ -372,8 +384,8 @@ func (l *loader) loadEncryptionProviderConfigFileMeta(name string) *K8sEncryptio
 
 func (l *loader) loadTokenFileMeta(name string) *K8sTokenFileMeta {
 	_, info, _, ok := l.loadMeta(name, false)
-	if ok {
-		return nil
+	if !ok {
+		return &K8sTokenFileMeta{Path: name}
 	}
 	return &K8sTokenFileMeta{
 		Path:  name,
@@ -386,7 +398,7 @@ func (l *loader) loadTokenFileMeta(name string) *K8sTokenFileMeta {
 func (l *loader) loadKeyFileMeta(name string) *K8sKeyFileMeta {
 	_, info, _, ok := l.loadMeta(name, false)
 	if !ok {
-		return nil
+		return &K8sKeyFileMeta{Path: name}
 	}
 	var meta K8sKeyFileMeta
 	meta.Path = name
@@ -400,11 +412,15 @@ func (l *loader) loadKeyFileMeta(name string) *K8sKeyFileMeta {
 func (l *loader) loadCertFileMeta(name string) *K8sCertFileMeta {
 	fullpath, info, certData, ok := l.loadMeta(name, true)
 	if !ok {
-		return nil
+		return &K8sCertFileMeta{
+			Path: name,
+		}
 	}
 	meta := l.extractCertData(certData)
 	if meta == nil {
-		return nil
+		return &K8sCertFileMeta{
+			Path: name,
+		}
 	}
 	meta.Path = name
 	meta.User = utils.GetFileUser(info)
@@ -452,15 +468,15 @@ func (l *loader) extractCertData(certData []byte) *K8sCertFileMeta {
 	data.Certificate.Organization = c.Subject.Organization
 	data.Certificate.DNSNames = c.DNSNames
 	data.Certificate.IPAddresses = c.IPAddresses
-	data.Certificate.NotAfter = c.NotAfter
-	data.Certificate.NotBefore = c.NotBefore
+	data.Certificate.NotAfter = &c.NotAfter
+	data.Certificate.NotBefore = &c.NotBefore
 	return &data
 }
 
-func (l *loader) loadKubeconfigMeta(name string) *K8sKubeconfigMeta {
+func (l *loader) loadKubeconfigMeta(name string) (*K8sKubeconfigMeta, bool) {
 	_, info, b, ok := l.loadMeta(name, true)
 	if !ok {
-		return nil
+		return &K8sKubeconfigMeta{Path: name}, false
 	}
 
 	var source k8SKubeconfigSource
@@ -470,7 +486,7 @@ func (l *loader) loadKubeconfigMeta(name string) *K8sKubeconfigMeta {
 	}
 	if erru != nil {
 		l.pushError(erru)
-		return nil
+		return &K8sKubeconfigMeta{Path: name}, false
 	}
 
 	content := &K8SKubeconfig{
@@ -542,7 +558,7 @@ func (l *loader) loadKubeconfigMeta(name string) *K8sKubeconfigMeta {
 		Group:      utils.GetFileGroup(info),
 		Mode:       uint32(info.Mode()),
 		Kubeconfig: content,
-	}
+	}, true
 }
 
 // in OpenSSH >= 2.6, a fingerprint is now displayed as base64 SHA256.

--- a/pkg/compliance/k8sconfig/loader_test.go
+++ b/pkg/compliance/k8sconfig/loader_test.go
@@ -695,6 +695,22 @@ func TestKubAdmConfigLoader(t *testing.T) {
 	tmpDir := t.TempDir()
 	conf := loadTestConfiguration(t, tmpDir, kubadmProcTable)
 	assert.Empty(t, conf.Errors)
+
+	etcd := conf.Components.Etcd
+	assert.NotNil(t, etcd)
+
+	assert.Equal(t, false, *etcd.AutoTls)
+	assert.Equal(t, "/etc/kubernetes/pki/etcd/server.crt", etcd.CertFile.Path)
+	assert.Equal(t, true, *etcd.ClientCertAuth)
+	assert.Equal(t, "/var/lib/etcd", etcd.DataDir.Path)
+	assert.Equal(t, "/etc/kubernetes/pki/etcd/server.key", etcd.KeyFile.Path)
+	assert.Equal(t, false, *etcd.PeerAutoTls)
+	assert.Equal(t, "/etc/kubernetes/pki/etcd/peer.crt", etcd.PeerCertFile.Path)
+	assert.Equal(t, true, *etcd.PeerClientCertAuth)
+	assert.Equal(t, "/etc/kubernetes/pki/etcd/peer.key", etcd.PeerKeyFile.Path)
+	assert.Equal(t, "/etc/kubernetes/pki/etcd/ca.crt", etcd.PeerTrustedCaFile.Path)
+	assert.Equal(t, "TLS1.2", *etcd.TlsMinVersion)
+	assert.Equal(t, "/etc/kubernetes/pki/etcd/ca.crt", etcd.TrustedCaFile.Path)
 }
 
 func TestKubEksConfigLoader(t *testing.T) {

--- a/pkg/compliance/k8sconfig/types.go
+++ b/pkg/compliance/k8sconfig/types.go
@@ -41,24 +41,24 @@ type K8sManagedEnvConfig struct {
 
 type K8sDirMeta struct {
 	Path  string `json:"path"`
-	User  string `json:"user"`
-	Group string `json:"group"`
-	Mode  uint32 `json:"mode"`
+	User  string `json:"user,omitempty"`
+	Group string `json:"group,omitempty"`
+	Mode  uint32 `json:"mode,omitempty"`
 }
 
 type K8sConfigFileMeta struct {
 	Path    string      `json:"path"`
-	User    string      `json:"user"`
-	Group   string      `json:"group"`
-	Mode    uint32      `json:"mode"`
-	Content interface{} `json:"content" jsonschema:"type=object"`
+	User    string      `json:"user,omitempty"`
+	Group   string      `json:"group,omitempty"`
+	Mode    uint32      `json:"mode,omitempty"`
+	Content interface{} `json:"content,omitempty" jsonschema:"type=object"`
 }
 
 type K8sTokenFileMeta struct {
 	Path  string `json:"path"`
-	User  string `json:"user"`
-	Group string `json:"group"`
-	Mode  uint32 `json:"mode"`
+	User  string `json:"user,omitempty"`
+	Group string `json:"group,omitempty"`
+	Mode  uint32 `json:"mode,omitempty"`
 }
 
 // https://github.com/kubernetes/kubernetes/blob/6356023cb42d681b7ad0e6d14d1652247d75b797/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go#L30
@@ -77,31 +77,31 @@ type (
 	}
 
 	K8sAdmissionConfigFileMeta struct {
+		Path    string                          `json:"path"`
 		User    string                          `json:"user,omitempty"`
 		Group   string                          `json:"group,omitempty"`
-		Path    string                          `json:"path,omitempty"`
 		Mode    uint32                          `json:"mode,omitempty"`
 		Plugins []*K8sAdmissionPluginConfigMeta `json:"plugins"`
 	}
 )
 
 type K8sKubeconfigMeta struct {
-	Path       string         `json:"path,omitempty"`
+	Path       string         `json:"path"`
 	User       string         `json:"user,omitempty"`
 	Group      string         `json:"group,omitempty"`
 	Mode       uint32         `json:"mode,omitempty"`
-	Kubeconfig *K8SKubeconfig `json:"kubeconfig"`
+	Kubeconfig *K8SKubeconfig `json:"kubeconfig,omitempty"`
 }
 
 type K8sKeyFileMeta struct {
-	Path  string `json:"path,omitempty"`
+	Path  string `json:"path"`
 	User  string `json:"user,omitempty"`
 	Group string `json:"group,omitempty"`
 	Mode  uint32 `json:"mode,omitempty"`
 }
 
 type K8sCertFileMeta struct {
-	Path        string `json:"path,omitempty"`
+	Path        string `json:"path"`
 	User        string `json:"user,omitempty"`
 	Group       string `json:"group,omitempty"`
 	Mode        uint32 `json:"mode,omitempty"`
@@ -109,16 +109,16 @@ type K8sCertFileMeta struct {
 	DirGroup    string `json:"dirGroup,omitempty"`
 	DirMode     uint32 `json:"dirMode,omitempty"`
 	Certificate struct {
-		Fingerprint    string    `json:"fingerprint"`
-		SerialNumber   string    `json:"serialNumber,omitempty"`
-		SubjectKeyId   string    `json:"subjectKeyId,omitempty"`
-		AuthorityKeyId string    `json:"authorityKeyId,omitempty"`
-		CommonName     string    `json:"commonName"`
-		Organization   []string  `json:"organization,omitempty"`
-		DNSNames       []string  `json:"dnsNames,omitempty"`
-		IPAddresses    []net.IP  `json:"ipAddresses,omitempty"`
-		NotAfter       time.Time `json:"notAfter"`
-		NotBefore      time.Time `json:"notBefore"`
+		Fingerprint    string     `json:"fingerprint,omitempty"`
+		SerialNumber   string     `json:"serialNumber,omitempty"`
+		SubjectKeyId   string     `json:"subjectKeyId,omitempty"`
+		AuthorityKeyId string     `json:"authorityKeyId,omitempty"`
+		CommonName     string     `json:"commonName,omitempty"`
+		Organization   []string   `json:"organization,omitempty"`
+		DNSNames       []string   `json:"dnsNames,omitempty"`
+		IPAddresses    []net.IP   `json:"ipAddresses,omitempty"`
+		NotAfter       *time.Time `json:"notAfter,omitempty"`
+		NotBefore      *time.Time `json:"notBefore,omitempty"`
 	} `json:"certificate"`
 }
 

--- a/pkg/compliance/k8sconfig/types_generated.go
+++ b/pkg/compliance/k8sconfig/types_generated.go
@@ -103,7 +103,7 @@ func (l *loader) newK8sKubeApiserverConfig(flags map[string]string) *K8sKubeApis
 	}
 	if v, ok := flags["--audit-policy-file"]; ok {
 		delete(flags, "--audit-policy-file")
-		res.AuditPolicyFile = l.loadConfigFileMeta(v)
+		res.AuditPolicyFile, _ = l.loadConfigFileMeta(v)
 	}
 	if v, ok := flags["--authorization-mode"]; ok {
 		delete(flags, "--authorization-mode")
@@ -300,11 +300,11 @@ func (l *loader) newK8sKubeSchedulerConfig(flags map[string]string) *K8sKubeSche
 	var res K8sKubeSchedulerConfig
 	if v, ok := flags["--config"]; ok {
 		delete(flags, "--config")
-		res.Config = l.loadConfigFileMeta(v)
+		res.Config, _ = l.loadConfigFileMeta(v)
 	}
 	if v, ok := flags["--authentication-kubeconfig"]; ok {
 		delete(flags, "--authentication-kubeconfig")
-		res.AuthenticationKubeconfig = l.loadKubeconfigMeta(v)
+		res.AuthenticationKubeconfig, _ = l.loadKubeconfigMeta(v)
 	}
 	if v, ok := flags["--authorization-kubeconfig"]; ok {
 		delete(flags, "--authorization-kubeconfig")
@@ -331,7 +331,7 @@ func (l *loader) newK8sKubeSchedulerConfig(flags map[string]string) *K8sKubeSche
 	}
 	if v, ok := flags["--kubeconfig"]; ok {
 		delete(flags, "--kubeconfig")
-		res.Kubeconfig = l.loadKubeconfigMeta(v)
+		res.Kubeconfig, _ = l.loadKubeconfigMeta(v)
 	}
 	if v, ok := flags["--profiling"]; ok {
 		delete(flags, "--profiling")
@@ -434,7 +434,7 @@ func (l *loader) newK8sKubeControllerManagerConfig(flags map[string]string) *K8s
 	var res K8sKubeControllerManagerConfig
 	if v, ok := flags["--authentication-kubeconfig"]; ok {
 		delete(flags, "--authentication-kubeconfig")
-		res.AuthenticationKubeconfig = l.loadKubeconfigMeta(v)
+		res.AuthenticationKubeconfig, _ = l.loadKubeconfigMeta(v)
 	}
 	if v, ok := flags["--authorization-kubeconfig"]; ok {
 		delete(flags, "--authorization-kubeconfig")
@@ -469,7 +469,7 @@ func (l *loader) newK8sKubeControllerManagerConfig(flags map[string]string) *K8s
 	}
 	if v, ok := flags["--kubeconfig"]; ok {
 		delete(flags, "--kubeconfig")
-		res.Kubeconfig = l.loadKubeconfigMeta(v)
+		res.Kubeconfig, _ = l.loadKubeconfigMeta(v)
 	}
 	if v, ok := flags["--profiling"]; ok {
 		delete(flags, "--profiling")
@@ -578,7 +578,7 @@ func (l *loader) newK8sKubeProxyConfig(flags map[string]string) *K8sKubeProxyCon
 	var res K8sKubeProxyConfig
 	if v, ok := flags["--config"]; ok {
 		delete(flags, "--config")
-		res.Config = l.loadConfigFileMeta(v)
+		res.Config, _ = l.loadConfigFileMeta(v)
 	}
 	if v, ok := flags["--bind-address"]; ok {
 		delete(flags, "--bind-address")
@@ -601,7 +601,7 @@ func (l *loader) newK8sKubeProxyConfig(flags map[string]string) *K8sKubeProxyCon
 	}
 	if v, ok := flags["--kubeconfig"]; ok {
 		delete(flags, "--kubeconfig")
-		res.Kubeconfig = l.loadKubeconfigMeta(v)
+		res.Kubeconfig, _ = l.loadKubeconfigMeta(v)
 	}
 	if v, ok := flags["--profiling"]; ok {
 		delete(flags, "--profiling")
@@ -709,11 +709,11 @@ func (l *loader) newK8sKubeletConfig(flags map[string]string) *K8sKubeletConfig 
 	}
 	if v, ok := flags["--image-credential-provider-config"]; ok {
 		delete(flags, "--image-credential-provider-config")
-		res.ImageCredentialProviderConfig = l.loadConfigFileMeta(v)
+		res.ImageCredentialProviderConfig, _ = l.loadConfigFileMeta(v)
 	}
 	if v, ok := flags["--kubeconfig"]; ok {
 		delete(flags, "--kubeconfig")
-		res.Kubeconfig = l.loadKubeconfigMeta(v)
+		res.Kubeconfig, _ = l.loadKubeconfigMeta(v)
 	}
 	if v, ok := flags["--make-iptables-util-chains"]; ok {
 		delete(flags, "--make-iptables-util-chains")

--- a/pkg/compliance/tools/k8s_types_generator/main.go
+++ b/pkg/compliance/tools/k8s_types_generator/main.go
@@ -442,7 +442,7 @@ func printKomponentCode(komp *komponent) string {
 		case "[]string":
 			return fmt.Sprintf("res.%s = strings.Split(%s, \",\")", toGoField(c.flagName), v)
 		case "*K8sKubeconfigMeta":
-			return fmt.Sprintf("res.%s = l.loadKubeconfigMeta(%s)", toGoField(c.flagName), v)
+			return fmt.Sprintf("res.%s, _ = l.loadKubeconfigMeta(%s)", toGoField(c.flagName), v)
 		case "*K8sCertFileMeta":
 			return fmt.Sprintf("res.%s = l.loadCertFileMeta(%s)", toGoField(c.flagName), v)
 		case "*K8sKeyFileMeta":
@@ -453,7 +453,7 @@ func printKomponentCode(komp *komponent) string {
 			if komp.name == "kubelet" && c.flagName == "config" {
 				return fmt.Sprintf("res.%s = l.loadKubeletConfigFileMeta(%s)", toGoField(c.flagName), v)
 			}
-			return fmt.Sprintf("res.%s = l.loadConfigFileMeta(%s)", toGoField(c.flagName), v)
+			return fmt.Sprintf("res.%s, _ = l.loadConfigFileMeta(%s)", toGoField(c.flagName), v)
 		case "*K8sKubeletConfigFileMeta":
 			return fmt.Sprintf("res.%s = l.loadKubeletConfigFileMeta(%s)", toGoField(c.flagName), v)
 		case "*K8sAdmissionConfigFileMeta":


### PR DESCRIPTION
### What does this PR do?

Fix cases where the security-agent is legitimately failing to load configuration data.

This may happened in a numerous number of scenario. One that we have observed is the case of containerized K8s components having to load their data from a locally mounted `tmpfs` unreachable from the agent.

### Motivation

Avoid false negatives when security-agent is not able to read parts of the configuration data of a k8s component.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
