### PR TITLE
[ASCII-1379] Write response in `/agent/jmx/status` to avoid errors

### DIFF
--- a/comp/api/api/apiimpl/internal/agent/agent_jmx.go
+++ b/comp/api/api/apiimpl/internal/agent/agent_jmx.go
@@ -92,6 +92,8 @@ func setJMXStatus(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Errorf("unable to parse jmx status: %s", err)
 		http.Error(w, err.Error(), 500)
+	} else {
+		w.WriteHeader(http.StatusOK)
 	}
 
 	jmxStatus.SetStatus(status)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Write a StatusOK response in the `/agent/jmx/status` endpoint to avoid spamming errors. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Customers complained there started seeing the following errors in their logs:
```
CMD API Server: POST /agent/jmx/status from 127.0.0.1:37420 to localhost:5001 took 234.762µs and returned http code 0
```
The `http code 0` means that the API server did not write a response.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
QA done manually.