### PR TITLE
[CSPM] k8s: fix support for k8s in k8s (containerized components)

### DIFF
--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -34,7 +34,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	"github.com/DataDog/datadog-agent/pkg/compliance"
-	"github.com/DataDog/datadog-agent/pkg/compliance/k8sconfig"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -128,13 +127,6 @@ func RunCheck(log log.Component, config config.Component, _ secrets.Component, s
 			statsdClient = cl
 			defer cl.Flush()
 		}
-	}
-
-	if len(checkArgs.args) == 1 && checkArgs.args[0] == "k8sconfig" {
-		_, resourceData := k8sconfig.LoadConfiguration(context.Background(), os.Getenv("HOST_ROOT"))
-		b, _ := json.MarshalIndent(resourceData, "", "  ")
-		fmt.Println(string(b))
-		return nil
 	}
 
 	var resolver compliance.Resolver

--- a/pkg/compliance/data.go
+++ b/pkg/compliance/data.go
@@ -66,6 +66,7 @@ type CheckContainerMeta struct {
 	ImageID     string `json:"image_id"`
 	ImageName   string `json:"image_name"`
 	ImageTag    string `json:"image_tag"`
+	RepoDigest  string `json:"repo_digest"`
 }
 
 // CheckEvent is the data structure sent to the backend as a result of a rule
@@ -81,7 +82,6 @@ type CheckEvent struct {
 	ResourceType string                 `json:"resource_type,omitempty"`
 	ResourceID   string                 `json:"resource_id,omitempty"`
 	Container    *CheckContainerMeta    `json:"container,omitempty"`
-	K8SManaged   *string                `json:"k8s_managed,omitempty"`
 	Tags         []string               `json:"tags"`
 	Data         map[string]interface{} `json:"data"`
 

--- a/pkg/compliance/k8sconfig/loader_test.go
+++ b/pkg/compliance/k8sconfig/loader_test.go
@@ -9,7 +9,6 @@
 package k8sconfig
 
 import (
-	"context"
 	"encoding/json"
 	"io/fs"
 	"os"
@@ -930,9 +929,9 @@ func TestBottleRocketConfigLoader(t *testing.T) {
 
 func loadTestConfiguration(t *testing.T, hostroot string, table string) *K8sNodeConfig {
 	l := &loader{hostroot: hostroot}
-	_, data := l.load(context.Background(), func(ctx context.Context) []proc {
-		return procTable(table)
-	})
+
+	_, data, ok := l.load(procTable(table))
+	assert.True(t, ok)
 	jsonData, err := json.Marshal(data)
 	assert.NoError(t, err)
 	var conf K8sNodeConfig


### PR DESCRIPTION
### What does this PR do?

Fix our support of containerized K8s components (aka. K8s in K8s).

It groups processes by container ID and resolves configuration assets relative to the container root mountpoint instead of host root. When reporting these containerized resources, it uses the container name as ID to report them.

### Motivation

K8s in K8s is an important usecase that we want to support and that was overlooked before.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
