### PR TITLE
[e2e] rename e2e junit artifacts by the CI job ID

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -118,22 +118,17 @@ k8s-e2e-otlp-main:
     E2E_COMMIT_SHA: $CI_COMMIT_SHORT_SHA
     E2E_OUTPUT_DIR: $CI_PROJECT_DIR/e2e-output
   script:
-    - inv -e new-e2e-tests.run --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS}
+    - inv -e new-e2e-tests.run --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar junit.tgz ${EXTRA_PARAMS}
   after_script:
     # Upload generated junit files
     - export DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
-    - for f in junit-new-e2e-*.tgz; do inv -e junit-upload --tgz-path "$f"; done
+    - inv -e junit-upload --tgz-path junit.tgz
   artifacts:
     expire_in: 2 weeks
     when: always
     paths:
-      # This file will be consumed by the `e2e_test_junit_upload` job in next stage to push the report to datadog.
-      # If you create a new job from this template, do not forget to update the `dependencies` of the `e2e_test_junit_upload` job.
-      - junit-*.tgz
       # Root directory of the e2e tests output, if used by the test
       - $E2E_OUTPUT_DIR
-    reports:
-      junit: test/new-e2e/junit-*.xml
 
 .new_e2e_template_needs_deb_x64:
   extends: .new_e2e_template

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -118,17 +118,19 @@ k8s-e2e-otlp-main:
     E2E_COMMIT_SHA: $CI_COMMIT_SHORT_SHA
     E2E_OUTPUT_DIR: $CI_PROJECT_DIR/e2e-output
   script:
-    - inv -e new-e2e-tests.run --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar junit.tgz ${EXTRA_PARAMS}
+    - inv -e new-e2e-tests.run --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS}
   after_script:
     # Upload generated junit files
     - export DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
-    - inv -e junit-upload --tgz-path junit.tgz
+    - inv -e junit-upload --tgz-path junit-${CI_JOB_ID}.tgz
   artifacts:
     expire_in: 2 weeks
     when: always
     paths:
       # Root directory of the e2e tests output, if used by the test
       - $E2E_OUTPUT_DIR
+      # junit tarball, kept for investigations
+      - junit-*.tgz
 
 .new_e2e_template_needs_deb_x64:
   extends: .new_e2e_template

--- a/.gitlab/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/e2e_pre_test/e2e_pre_test.yml
@@ -7,10 +7,10 @@ e2e_pre_test:
   extends: .new_e2e_template
   needs: []
   script:
-    - inv -e new-e2e-tests.run --targets ./test-infra-definition --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS}
+    - inv -e new-e2e-tests.run --targets ./test-infra-definition --junit-tar junit.tgz ${EXTRA_PARAMS}
   after_script:
     - export DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
-    - for f in junit*-e2e-*.tgz; do inv -e junit-upload --tgz-path "$f"; done
+    - inv -e junit-upload --tgz-path junit.tgz
   variables:
     TEAM: "agent-developer-tools"
     # override to use latest stable agent

--- a/.gitlab/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/e2e_pre_test/e2e_pre_test.yml
@@ -7,10 +7,10 @@ e2e_pre_test:
   extends: .new_e2e_template
   needs: []
   script:
-    - inv -e new-e2e-tests.run --targets ./test-infra-definition --junit-tar junit.tgz ${EXTRA_PARAMS}
+    - inv -e new-e2e-tests.run --targets ./test-infra-definition --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS}
   after_script:
     - export DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.datadog-agent.datadog_api_key_org2)
-    - inv -e junit-upload --tgz-path junit.tgz
+    - inv -e junit-upload --tgz-path junit-${CI_JOB_ID}.tgz
   variables:
     TEAM: "agent-developer-tools"
     # override to use latest stable agent

--- a/.gitlab/kitchen_testing/new-e2e_testing.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing.yml
@@ -39,7 +39,7 @@
         END_MAJOR_VERSION: [6]
   script:
     - export DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $INSTALL_SCRIPT_API_KEY_SSM_NAME)
-    - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION
+    - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION
 
 .new-e2e_script_upgrade7:
   variables:
@@ -52,7 +52,7 @@
         END_MAJOR_VERSION: [7]
   script:
     - export DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $INSTALL_SCRIPT_API_KEY_SSM_NAME )
-    - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION
+    - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION
 
 .new-e2e_rpm:
   variables:
@@ -61,4 +61,4 @@
     EXTRA_PARAMS: --osversion $E2E_OSVERS --platform $E2E_PLATFORM --arch $E2E_ARCH
   script:
     - export DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh ci.agent-linux-install-script.datadog_api_key)
-    - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS}
+    - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Use one single junit file to output the gotest report, name it by the job id

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We generate one single junit archive per job, thanks to https://github.com/DataDog/datadog-agent/pull/22134 we can upload reports to CI Visibility within the same job

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
