### PR TITLE
Untie Remote Configuration db from API Key value

### DIFF
--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -319,7 +319,7 @@ func NewService(cfg model.Reader, rcType, baseRawURL, hostname string, tags []st
 	}
 
 	dbPath := path.Join(cfg.GetString("run_path"), options.databaseFileName)
-	db, err := openCacheDB(dbPath, agentVersion)
+	db, err := openCacheDB(dbPath, agentVersion, authKeys.apiKey)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -34,8 +34,9 @@ const databaseLockTimeout = time.Second
 // AgentMetadata is data stored in bolt DB to determine whether or not
 // the agent has changed and the RC cache should be cleared
 type AgentMetadata struct {
-	Version    string `json:"version"`
-	APIKeyHash string `json:"api-key-hash"`
+	Version      string    `json:"version"`
+	APIKeyHash   string    `json:"api-key-hash"`
+	CreationTime time.Time `json:"creation-time"`
 }
 
 // hashAPIKey hashes the API key to avoid storing it in plain text using SHA256
@@ -78,8 +79,9 @@ func addMetadata(db *bbolt.DB, agentVersion string, apiKeyHash string) error {
 			return err
 		}
 		metaData, err := json.Marshal(AgentMetadata{
-			Version:    agentVersion,
-			APIKeyHash: apiKeyHash,
+			Version:      agentVersion,
+			APIKeyHash:   apiKeyHash,
+			CreationTime: time.Now(),
 		})
 		if err != nil {
 			return err

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -128,7 +128,7 @@ func openCacheDB(path string, agentVersion string, apiKey string) (*bbolt.DB, er
 	}
 
 	if metadata.Version != agentVersion || metadata.APIKeyHash != apiKeyHash {
-		log.Infof("Different agent version detected")
+		log.Infof("Different agent version or API Key detected")
 		_ = db.Close()
 		return recreate(path, agentVersion, apiKeyHash)
 	}

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -6,6 +6,7 @@
 package service
 
 import (
+	"crypto/sha256"
 	"encoding/base32"
 	"encoding/json"
 	"errors"
@@ -33,10 +34,16 @@ const databaseLockTimeout = time.Second
 // AgentMetadata is data stored in bolt DB to determine whether or not
 // the agent has changed and the RC cache should be cleared
 type AgentMetadata struct {
-	Version string `json:"version"`
+	Version    string `json:"version"`
+	APIKeyHash string `json:"api-key-hash"`
 }
 
-func recreate(path string, agentVersion string) (*bbolt.DB, error) {
+// hashAPIKey hashes the API key to avoid storing it in plain text using SHA256
+func hashAPIKey(apiKey string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(apiKey)))
+}
+
+func recreate(path string, agentVersion string, apiKeyHash string) (*bbolt.DB, error) {
 	log.Infof("Clear remote configuration database")
 	_, err := os.Stat(path)
 	if err != nil && !os.IsNotExist(err) {
@@ -61,17 +68,18 @@ func recreate(path string, agentVersion string) (*bbolt.DB, error) {
 		}
 		return nil, err
 	}
-	return db, addMetadata(db, agentVersion)
+	return db, addMetadata(db, agentVersion, apiKeyHash)
 }
 
-func addMetadata(db *bbolt.DB, agentVersion string) error {
+func addMetadata(db *bbolt.DB, agentVersion string, apiKeyHash string) error {
 	return db.Update(func(tx *bbolt.Tx) error {
 		bucket, err := tx.CreateBucketIfNotExists([]byte(metaBucket))
 		if err != nil {
 			return err
 		}
 		metaData, err := json.Marshal(AgentMetadata{
-			Version: agentVersion,
+			Version:    agentVersion,
+			APIKeyHash: apiKeyHash,
 		})
 		if err != nil {
 			return err
@@ -80,7 +88,9 @@ func addMetadata(db *bbolt.DB, agentVersion string) error {
 	})
 }
 
-func openCacheDB(path string, agentVersion string) (*bbolt.DB, error) {
+func openCacheDB(path string, agentVersion string, apiKey string) (*bbolt.DB, error) {
+	apiKeyHash := hashAPIKey(apiKey)
+
 	db, err := bbolt.Open(path, 0600, &bbolt.Options{
 		Timeout: databaseLockTimeout,
 	})
@@ -88,7 +98,7 @@ func openCacheDB(path string, agentVersion string) (*bbolt.DB, error) {
 		if errors.Is(err, bbolt.ErrTimeout) {
 			return nil, fmt.Errorf("rc db is locked. Please check if another instance of the agent is running and using the same `run_path` parameter")
 		}
-		return recreate(path, agentVersion)
+		return recreate(path, agentVersion, apiKeyHash)
 	}
 
 	metadata := new(AgentMetadata)
@@ -112,13 +122,13 @@ func openCacheDB(path string, agentVersion string) (*bbolt.DB, error) {
 	})
 	if err != nil {
 		_ = db.Close()
-		return recreate(path, agentVersion)
+		return recreate(path, agentVersion, apiKeyHash)
 	}
 
-	if metadata.Version != agentVersion {
+	if metadata.Version != agentVersion || metadata.APIKeyHash != apiKeyHash {
 		log.Infof("Different agent version detected")
 		_ = db.Close()
-		return recreate(path, agentVersion)
+		return recreate(path, agentVersion, apiKeyHash)
 	}
 
 	return db, nil

--- a/pkg/config/remote/service/util_test.go
+++ b/pkg/config/remote/service/util_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/proto/msgpgo"
 )
 
+const apiKey = "37d58c60b8ac337293ce2ca6b28b19eb"
+
 func TestAuthKeys(t *testing.T) {
 	tests := []struct {
 		rcKey  string
@@ -118,7 +120,7 @@ func TestRemoteConfigNewDB(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// should add the version to newly created databases
-	db, err := openCacheDB(filepath.Join(dir, "remote-config.db"), "9.9.9")
+	db, err := openCacheDB(filepath.Join(dir, "remote-config.db"), "9.9.9", apiKey)
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -134,7 +136,7 @@ func TestRemoteConfigReopenNoVersionChange(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// should add the version to newly created databases
-	db, err := openCacheDB(filepath.Join(dir, "remote-config.db"), agentVersion)
+	db, err := openCacheDB(filepath.Join(dir, "remote-config.db"), agentVersion, apiKey)
 	require.NoError(t, err)
 
 	metadata, err := getVersion(db)
@@ -144,7 +146,7 @@ func TestRemoteConfigReopenNoVersionChange(t *testing.T) {
 	require.NoError(t, addData(db))
 	require.NoError(t, db.Close())
 
-	db, err = openCacheDB(filepath.Join(dir, "remote-config.db"), agentVersion)
+	db, err = openCacheDB(filepath.Join(dir, "remote-config.db"), agentVersion, apiKey)
 	require.NoError(t, err)
 	defer db.Close()
 	require.NoError(t, checkData(db))
@@ -158,7 +160,7 @@ func TestRemoteConfigOldDB(t *testing.T) {
 	dbPath := filepath.Join(dir, "remote-config.db")
 
 	// create database with current version
-	db, err := openCacheDB(dbPath, agentVersion)
+	db, err := openCacheDB(dbPath, agentVersion, apiKey)
 	require.NoError(t, err)
 
 	require.NoError(t, addData(db))
@@ -174,7 +176,7 @@ func TestRemoteConfigOldDB(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	// reopen database
-	db, err = openCacheDB(dbPath, agentVersion)
+	db, err = openCacheDB(dbPath, agentVersion, apiKey)
 	require.NoError(t, err)
 
 	// check version after the database opens

--- a/pkg/config/remote/uptane/client.go
+++ b/pkg/config/remote/uptane/client.go
@@ -81,10 +81,10 @@ func WithConfigRootOverride(site string, configRootOverride string) ClientOption
 type OrgUUIDProvider func() (string, error)
 
 // NewClient creates a new uptane client
-func NewClient(cacheDB *bbolt.DB, cacheKey string, orgUUIDProvider OrgUUIDProvider, options ...ClientOption) (c *Client, err error) {
+func NewClient(cacheDB *bbolt.DB, orgUUIDProvider OrgUUIDProvider, options ...ClientOption) (c *Client, err error) {
 	transactionalStore := newTransactionalStore(cacheDB)
-	targetStore := newTargetStore(transactionalStore, cacheKey)
-	orgStore := newOrgStore(transactionalStore, cacheKey)
+	targetStore := newTargetStore(transactionalStore)
+	orgStore := newOrgStore(transactionalStore)
 
 	c = &Client{
 		configRemoteStore:   newRemoteStoreConfig(targetStore),
@@ -99,11 +99,11 @@ func NewClient(cacheDB *bbolt.DB, cacheKey string, orgUUIDProvider OrgUUIDProvid
 		o(c)
 	}
 
-	if c.configLocalStore, err = newLocalStoreConfig(transactionalStore, cacheKey, c.site, c.configRootOverride); err != nil {
+	if c.configLocalStore, err = newLocalStoreConfig(transactionalStore, c.site, c.configRootOverride); err != nil {
 		return nil, err
 	}
 
-	if c.directorLocalStore, err = newLocalStoreDirector(transactionalStore, cacheKey, c.site, c.directorRootOverride); err != nil {
+	if c.directorLocalStore, err = newLocalStoreDirector(transactionalStore, c.site, c.directorRootOverride); err != nil {
 		return nil, err
 	}
 

--- a/pkg/config/remote/uptane/client_benchmark_test.go
+++ b/pkg/config/remote/uptane/client_benchmark_test.go
@@ -46,7 +46,7 @@ func BenchmarkVerify(b *testing.B) {
 			repository := newTestRepository(2, 1, configTargets, directorTargets, targetFiles)
 			cfg := newTestConfig(repository)
 			db := getBenchmarkDB(b)
-			client, err := newTestClient(db, "cachekey", cfg)
+			client, err := newTestClient(db, cfg)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/config/remote/uptane/local_store.go
+++ b/pkg/config/remote/uptane/local_store.go
@@ -33,11 +33,11 @@ type localStore struct {
 	store *transactionalStore
 }
 
-func newLocalStore(db *transactionalStore, repository string, cacheKey string, initialRoots meta.EmbeddedRoots) (*localStore, error) {
+func newLocalStore(db *transactionalStore, repository string, initialRoots meta.EmbeddedRoots) (*localStore, error) {
 	s := &localStore{
 		store:       db,
-		metasBucket: fmt.Sprintf("%s_%s_metas", cacheKey, repository),
-		rootsBucket: fmt.Sprintf("%s_%s_roots", cacheKey, repository),
+		metasBucket: fmt.Sprintf("%s_metas", repository),
+		rootsBucket: fmt.Sprintf("%s_roots", repository),
 	}
 	err := s.init(initialRoots)
 	return s, err
@@ -173,10 +173,10 @@ func (s *localStore) Flush() error {
 	return s.store.commit()
 }
 
-func newLocalStoreDirector(db *transactionalStore, cacheKey string, site string, directorRootOverride string) (*localStore, error) {
-	return newLocalStore(db, "director", cacheKey, meta.RootsDirector(site, directorRootOverride))
+func newLocalStoreDirector(db *transactionalStore, site string, directorRootOverride string) (*localStore, error) {
+	return newLocalStore(db, "director", meta.RootsDirector(site, directorRootOverride))
 }
 
-func newLocalStoreConfig(db *transactionalStore, cacheKey string, site string, configRootOverride string) (*localStore, error) {
-	return newLocalStore(db, "config", cacheKey, meta.RootsConfig(site, configRootOverride))
+func newLocalStoreConfig(db *transactionalStore, site string, configRootOverride string) (*localStore, error) {
+	return newLocalStore(db, "config", meta.RootsConfig(site, configRootOverride))
 }

--- a/pkg/config/remote/uptane/local_store_test.go
+++ b/pkg/config/remote/uptane/local_store_test.go
@@ -35,7 +35,7 @@ func TestLocalStore(t *testing.T) {
 	}
 	transactionalStore := newTransactionalStore(db)
 
-	store, err := newLocalStore(transactionalStore, "test", "testkey", embededRoots)
+	store, err := newLocalStore(transactionalStore, "test", embededRoots)
 	assert.NoError(t, err)
 	storeRoot1 := json.RawMessage(embededRoots[1])
 	storeRoot2 := json.RawMessage(embededRoots[2])

--- a/pkg/config/remote/uptane/org_store.go
+++ b/pkg/config/remote/uptane/org_store.go
@@ -15,10 +15,10 @@ type orgStore struct {
 	orgBucket string
 }
 
-func newOrgStore(db *transactionalStore, cacheKey string) *orgStore {
+func newOrgStore(db *transactionalStore) *orgStore {
 	return &orgStore{
 		db:        db,
-		orgBucket: fmt.Sprintf("%s_org", cacheKey),
+		orgBucket: "org",
 	}
 }
 

--- a/pkg/config/remote/uptane/remote_store_test.go
+++ b/pkg/config/remote/uptane/remote_store_test.go
@@ -96,7 +96,7 @@ func TestRemoteStoreConfig(t *testing.T) {
 	db := newTransactionalStore(getTestDB(t))
 	defer db.commit()
 
-	targetStore := newTargetStore(db, "testcachekey")
+	targetStore := newTargetStore(db)
 	store := newRemoteStoreConfig(targetStore)
 
 	testUpdate1 := generateUpdate(1)
@@ -161,7 +161,7 @@ func TestRemoteStoreConfig(t *testing.T) {
 func TestRemoteStoreDirector(t *testing.T) {
 	db := newTransactionalStore(getTestDB(t))
 	defer db.commit()
-	targetStore := newTargetStore(db, "testcachekey")
+	targetStore := newTargetStore(db)
 	store := newRemoteStoreDirector(targetStore)
 
 	testUpdate1 := generateUpdate(1)

--- a/pkg/config/remote/uptane/target_store.go
+++ b/pkg/config/remote/uptane/target_store.go
@@ -6,8 +6,6 @@
 package uptane
 
 import (
-	"fmt"
-
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 )
 
@@ -17,10 +15,10 @@ type targetStore struct {
 	targetBucket string
 }
 
-func newTargetStore(db *transactionalStore, cacheKey string) *targetStore {
+func newTargetStore(db *transactionalStore) *targetStore {
 	return &targetStore{
 		db:           db,
-		targetBucket: fmt.Sprintf("%s_targets", cacheKey),
+		targetBucket: "targets",
 	}
 }
 

--- a/pkg/config/remote/uptane/target_store_test.go
+++ b/pkg/config/remote/uptane/target_store_test.go
@@ -17,7 +17,7 @@ func TestTargetStore(t *testing.T) {
 	db := newTransactionalStore(getTestDB(t))
 	defer db.commit()
 
-	store := newTargetStore(db, "testcachekey")
+	store := newTargetStore(db)
 
 	target1 := &pbgo.File{
 		Path: "2/APM_SAMPLING/target1",


### PR DESCRIPTION
To allow changing the API Key at runtime the remote configuration service is not storing data in the database in a trying it together with API keys.

When the key is rotated it will not invalidate the buckets, but at restart it will detect that the key has changed and reset the database

New Metadata
```
{
  "version": "7.54.0-devel",
  "api-key-hash": "....",
  "creation-time": "2024-04-03T11:35:49.104193+02:00"
}
```


QA

- Agents and tracers should receive configurations function as normal
- Verify that the the database metadata now contains a hash of the key and the creation date
- Verify that the agent starting up with a database configured for a different datacenter (different roots) will recover by wiping the database and restarting 
