### PR TITLE
[dca] Do not load language detection patcher if disabled

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -390,7 +390,7 @@ func start(log log.Component,
 		}()
 	}
 
-	if config.GetBool("cluster_agent.language_detection.patcher.enabled") {
+	if config.GetBool("language_detection.enabled") && config.GetBool("cluster_agent.language_detection.patcher.enabled") {
 		if err = languagedetection.Start(mainCtx, wmeta, log); err != nil {
 			log.Errorf("Cannot start language detection patcher: %v", err)
 		}


### PR DESCRIPTION
### What does this PR do?

This PR does not load the language detection patcher in the cluster agent if `language_detection.enabled` is set to false

### Motivation

Follow-up to https://github.com/DataDog/datadog-agent/pull/23621, the middle point in the QA section was not working as expected

### Additional Notes

I have tested this locally and confirmed that the log line no longer exists when `language_detection.enabled` is set to false, and does show up when `language_detection.enabled` is set to true

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Same as https://github.com/DataDog/datadog-agent/pull/23621. Specifically:
Ensure that:
- no cluster agent logs shows that the language detection patcher was activated (e.g. Starting language detection patcher)

... as the other points in PR have been validated