### PR TITLE
e2e: update butane version to v0.20.0

### DIFF
--- a/test/e2e/scripts/setup-instance/01-ignition.sh
+++ b/test/e2e/scripts/setup-instance/01-ignition.sh
@@ -20,8 +20,8 @@ case "$(uname)" in
 esac
 
 curl -O     "https://fedoraproject.org/fedora.gpg"
-curl -LOC - "https://github.com/coreos/butane/releases/download/v0.16.0/${butane}"
-curl -LO    "https://github.com/coreos/butane/releases/download/v0.16.0/${butane}.asc"
+curl -LOC - "https://github.com/coreos/butane/releases/download/v0.20.0/${butane}"
+curl -LO    "https://github.com/coreos/butane/releases/download/v0.20.0/${butane}.asc"
 
 gpgv --keyring ./fedora.gpg "${butane}.asc" "$butane"
 chmod +x "$butane"


### PR DESCRIPTION

### What does this PR do?

Butane v0.16.0 as used before is signed with an old fedora key, not easily accessible anymore. This PR bumps the butane version (only used to build the config image) to fix this.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
