### PR TITLE
(rc) use the director repository to download TUF targets

### DIFF
--- a/pkg/config/remote/uptane/client.go
+++ b/pkg/config/remote/uptane/client.go
@@ -192,7 +192,7 @@ func (c *Client) unsafeTargetFile(path string) ([]byte, error) {
 		return nil, err
 	}
 	buffer := &bufferDestination{}
-	err = c.configTUFClient.Download(path, buffer)
+	err = c.directorTUFClient.Download(path, buffer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR uses the director repository instead of the config repository to
get targets when clients ask for them. Functionally there should be no
change but some TUF internals make the director repo much more
efficient due to the absence of delegations.

This is a followup of
https://github.com/DataDog/datadog-agent/pull/23811. That first PR made
the verification much more efficient, potentially leading to the RC
service being more available to local tracers leading to increased
number of queries processed by the agent. This PR is to avoid a
"regression" on that front.