### PR TITLE
[CWS] improve windows FRIM memory usage

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -156,7 +156,10 @@ func parseCreateHandleArgs(e *etw.DDEventRecord) (*createHandleArgs, error) {
 		return nil, fmt.Errorf("unknown version %v", e.EventHeader.EventDescriptor.Version)
 	}
 
-	filePathResolver[ca.fileObject] = ca.fileName
+	if ca.fileName != "" {
+		filePathResolver[ca.fileObject] = ca.fileName
+	}
+
 	return ca, nil
 }
 

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/etw"
 	etwimpl "github.com/DataDog/datadog-agent/comp/etw/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -157,6 +158,7 @@ func parseCreateHandleArgs(e *etw.DDEventRecord) (*createHandleArgs, error) {
 	}
 
 	if ca.fileName != "" {
+		log.Infof("push fpr: %v %s (len=%d)", ca.fileObject, ca.fileName, len(filePathResolver))
 		filePathResolver[ca.fileObject] = ca.fileName
 	}
 

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -233,6 +233,7 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 					//fmt.Printf("Received Close event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
 					ecb(ca, e.EventHeader.ProcessID)
 					if e.EventHeader.EventDescriptor.ID == idClose {
+						log.Infof("pop fpr: %v %s (len=%d)", ca.fileObject, ca.fileName, len(filePathResolver))
 						delete(filePathResolver, ca.fileObject)
 					}
 				}

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -233,8 +233,8 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 					//fmt.Printf("Received Close event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
 					ecb(ca, e.EventHeader.ProcessID)
 					if e.EventHeader.EventDescriptor.ID == idClose {
-						log.Infof("pop fpr: %v %s (len=%d)", ca.fileObject, ca.fileName, len(filePathResolver))
-						delete(filePathResolver, ca.fileObject)
+						log.Tracef("pop fpr: %v %s (len=%d)", ca.fileObject, ca.fileName, filePathResolver.Len())
+						filePathResolver.Remove(ca.fileObject)
 					}
 				}
 			case idFlush:

--- a/pkg/util/winutil/winstrings.go
+++ b/pkg/util/winutil/winstrings.go
@@ -44,8 +44,8 @@ func ConvertWindowsStringList(winput []uint16) []string {
 // of uint8, the underlying data is expected to be
 // uint16 (unicode)
 func ConvertWindowsString(winput []uint8) string {
-
-	p := (*[1 << 29]uint16)(unsafe.Pointer(&winput[0]))[: len(winput)/2 : len(winput)/2]
+	ptr := (*uint16)((unsafe.Pointer)(&winput[0]))
+	p := unsafe.Slice(ptr, len(winput)/2)
 	return windows.UTF16ToString(p)
 
 }


### PR DESCRIPTION
### What does this PR do?

This PR:
- replaces the `filePathResolver` storage with an LRU, ensuring this map is not growing indefinitely
- move this storage out of a global variable, and store it directly inside the probe itself
- do not push to this storage empty strings

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
