### PR TITLE
ci: Fix secagent/sysprobe rules overriding 'when' for jobs that use them

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1034,7 +1034,6 @@ workflow:
   - changes:
       paths: *security_agent_change_paths
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
-    when: on_success
   - when: manual
     allow_failure: true
 
@@ -1093,7 +1092,6 @@ workflow:
   - changes:
       paths: *system_probe_change_paths
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
-    when: on_success
   - when: manual
     allow_failure: true
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR removes the `when: on_success` specification on the security agent and system probe common rules. It is not really needed as it's already the default, and configuring it means that if the job has another option for `when` it will get overwritten.

### Motivation

Fixing the KMT cleanup jobs that were not running when the environment setup jobs failed. 

We noticed in [this pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/30870620), where the [setup job for KMT](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/470199879) failed after the EC2 instance was already created, but the [cleanup job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/470199975) did not run.

We noticed in this case because the setup job failed before the shutdown timer was configured. After inspection, we checked and saw that more cleanup jobs are not triggering, however they get shut down by the automatic timer so they didn't get caught by our leftover instance monitors.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Tested with three pipelines:
* [A pipeline that does not have automatically triggered KMT jobs](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/30908527)
* [A pipeline that has KMT jobs](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/30910399)
* [A pipeline that has setup-env and test failures](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/30912575)