### PR TITLE
AMLII-1574 - Adding `dirname` tag for full file path log configurations

### DIFF
--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -311,9 +311,9 @@ func (t *Tailer) readForever() {
 
 // buildTailerTags groups the file tag, directory (if wildcard path) and user tags
 func (t *Tailer) buildTailerTags() []string {
-	tags := []string{fmt.Sprintf("filename:%s", filepath.Base(t.file.Path))}
-	if t.file.IsWildcardPath {
-		tags = append(tags, fmt.Sprintf("dirname:%s", filepath.Dir(t.file.Path)))
+	tags := []string{
+		fmt.Sprintf("filename:%s", filepath.Base(t.file.Path)),
+		fmt.Sprintf("dirname:%s", filepath.Dir(t.file.Path)),
 	}
 	return tags
 }

--- a/pkg/logs/tailers/file/tailer_test.go
+++ b/pkg/logs/tailers/file/tailer_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-
 package file
 
 import (
@@ -45,7 +43,7 @@ func (suite *TailerTestSuite) SetupTest() {
 	var err error
 	suite.testDir = suite.T().TempDir()
 
-	suite.testPath = fmt.Sprintf("%s/tailer.log", suite.testDir)
+	suite.testPath = filepath.Join(suite.testDir, "tailer.log")
 	f, err := os.Create(suite.testPath)
 	suite.Nil(err)
 	suite.testFile = f
@@ -249,7 +247,9 @@ func (suite *TailerTestSuite) TestWithBlanklines() {
 
 func (suite *TailerTestSuite) TestTailerIdentifier() {
 	suite.tailer.StartFromBeginning()
-	suite.Equal(fmt.Sprintf("file:%s/tailer.log", suite.testDir), suite.tailer.Identifier())
+	suite.Equal(
+		fmt.Sprintf("file:%s", filepath.Join(suite.testDir, "tailer.log")),
+		suite.tailer.Identifier())
 }
 
 func (suite *TailerTestSuite) TestOriginTagsWhenTailingFiles() {
@@ -263,6 +263,7 @@ func (suite *TailerTestSuite) TestOriginTagsWhenTailingFiles() {
 	tags := msg.Origin.Tags()
 	suite.ElementsMatch([]string{
 		"filename:" + filepath.Base(suite.testFile.Name()),
+		"dirname:" + filepath.Dir(suite.testFile.Name()),
 	}, tags)
 }
 
@@ -320,6 +321,7 @@ func (suite *TailerTestSuite) TestBuildTagsFileOnly() {
 	tags := suite.tailer.buildTailerTags()
 	suite.ElementsMatch([]string{
 		"filename:" + filepath.Base(suite.testFile.Name()),
+		"dirname:" + filepath.Dir(suite.testFile.Name()),
 	}, tags)
 }
 

--- a/releasenotes/notes/adding-dirname-tag-to-all-log-files-6318f7f0405e82e7.yaml
+++ b/releasenotes/notes/adding-dirname-tag-to-all-log-files-6318f7f0405e82e7.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Adding ``dirname`` tag for full filepath log configurations. This tag
+    was only added previously if using a wildcard filepath log configuration.

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/file-tailing/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/file-tailing/file_tailing_test.go
@@ -31,8 +31,10 @@ type LinuxFakeintakeSuite struct {
 //go:embed log-config/config.yaml
 var logConfig string
 
-const logFileName = "hello-world.log"
-const logFilePath = utils.LinuxLogsFolderPath + "/" + logFileName
+const (
+	logFileName = "hello-world.log"
+	logFilePath = utils.LinuxLogsFolderPath + "/" + logFileName
+)
 
 // TestE2EVMFakeintakeSuite runs the E2E test suite for the log agent with a VM and fake intake.
 func TestE2EVMFakeintakeSuite(t *testing.T) {
@@ -114,8 +116,13 @@ func (s *LinuxFakeintakeSuite) testLogCollection() {
 	// Generate log
 	utils.AppendLog(s, logFileName, "hello-world", 1)
 
+	// Given expected tags
+	expectedTags := []string{
+		fmt.Sprintf("filename:%s", logFileName),
+		fmt.Sprintf("dirname:%s", utils.LinuxLogsFolderPath),
+	}
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-world")
+	utils.CheckLogsExpected(s, "hello", "hello-world", expectedTags)
 }
 
 func (s *LinuxFakeintakeSuite) testLogNoPermission() {
@@ -158,7 +165,7 @@ func (s *LinuxFakeintakeSuite) testLogCollectionAfterPermission() {
 	t.Logf("Permissions granted for log file.")
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-after-permission-world")
+	utils.CheckLogsExpected(s, "hello", "hello-after-permission-world", []string{})
 }
 
 func (s *LinuxFakeintakeSuite) testLogCollectionBeforePermission() {
@@ -182,7 +189,7 @@ func (s *LinuxFakeintakeSuite) testLogCollectionBeforePermission() {
 	utils.AppendLog(s, logFileName, "access-granted", 1)
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "access-granted")
+	utils.CheckLogsExpected(s, "hello", "access-granted", []string{})
 }
 
 func (s *LinuxFakeintakeSuite) testLogRecreateRotation() {
@@ -206,5 +213,5 @@ func (s *LinuxFakeintakeSuite) testLogRecreateRotation() {
 	utils.AppendLog(s, logFileName, "hello-world-new-content", 1)
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-world-new-content")
+	utils.CheckLogsExpected(s, "hello", "hello-world-new-content", []string{})
 }

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/journald/journald_tailing_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/journald/journald_tailing_test.go
@@ -95,7 +95,7 @@ func (s *LinuxJournaldFakeintakeSuite) journaldLogCollection() {
 	appendJournaldLog(s, "hello-world", 1)
 
 	// Check that the generated log is collected
-	utils.CheckLogsExpected(s, "hello", "hello-world")
+	utils.CheckLogsExpected(s, "hello", "hello-world", []string{})
 }
 
 func (s *LinuxJournaldFakeintakeSuite) journaldIncludeServiceLogCollection() {
@@ -141,7 +141,7 @@ func (s *LinuxJournaldFakeintakeSuite) journaldIncludeServiceLogCollection() {
 		agentReady := s.Env().Agent.Client.IsReady()
 		if assert.Truef(c, agentReady, "Agent is not ready after restart") {
 			// Check that the agent service log is collected
-			utils.CheckLogsExpected(s, "random-logger", "less important")
+			utils.CheckLogsExpected(s, "random-logger", "less important", []string{})
 		}
 	}, 1*time.Minute, 5*time.Second)
 

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/utils/file_tailing_utils.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/utils/file_tailing_utils.go
@@ -29,6 +29,8 @@ const LinuxLogsFolderPath = "/var/log/e2e_test_logs"
 // WindowsLogsFolderPath is the folder where log files will be stored for Windows tests
 const WindowsLogsFolderPath = "C:\\logs\\e2e_test_logs"
 
+type ddtags []string
+
 // LogsTestSuite is an interface for the log agent test suite.
 type LogsTestSuite interface {
 	T() *testing.T
@@ -135,7 +137,7 @@ func FetchAndFilterLogs(ls LogsTestSuite, service, content string) ([]*aggregato
 }
 
 // CheckLogsExpected verifies the presence of expected logs.
-func CheckLogsExpected(ls LogsTestSuite, service, content string) {
+func CheckLogsExpected(ls LogsTestSuite, service, content string, expectedTags ddtags) {
 	t := ls.T()
 	t.Helper()
 
@@ -145,6 +147,10 @@ func CheckLogsExpected(ls LogsTestSuite, service, content string) {
 			intakeLog := logsToString(logs)
 			if assert.NotEmpty(c, logs, "Expected logs with content: '%s' not found. Instead, found: %s", content, intakeLog) {
 				t.Logf("Logs from service: '%s' with content: '%s' collected", service, content)
+				log := logs[0]
+				for _, expectedTag := range expectedTags {
+					assert.Contains(t, log.Tags, expectedTag)
+				}
 			}
 		}
 	}, 2*time.Minute, 10*time.Second)

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/windows-log/file-tailing/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/windows-log/file-tailing/file_tailing_test.go
@@ -33,8 +33,10 @@ type WindowsFakeintakeSuite struct {
 //go:embed log-config/config.yaml
 var logConfig string
 
-const logFileName = "hello-world.log"
-const logFilePath = utils.WindowsLogsFolderPath + "\\" + logFileName
+const (
+	logFileName = "hello-world.log"
+	logFilePath = utils.WindowsLogsFolderPath + "\\" + logFileName
+)
 
 // TestE2EVMFakeintakeSuite runs the E2E test suite for the log agent with a VM and fake intake.
 func TestE2EVMFakeintakeSuite(t *testing.T) {
@@ -122,8 +124,13 @@ func (s *WindowsFakeintakeSuite) testLogCollection() {
 	// Generate log
 	utils.AppendLog(s, logFileName, "hello-world", 1)
 
+	// Given expected tags
+	expectedTags := []string{
+		fmt.Sprintf("filename:%s", logFileName),
+		fmt.Sprintf("dirname:%s", utils.WindowsLogsFolderPath),
+	}
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-world")
+	utils.CheckLogsExpected(s, "hello", "hello-world", expectedTags)
 
 }
 
@@ -162,7 +169,7 @@ func (s *WindowsFakeintakeSuite) testLogCollectionAfterPermission() {
 	t.Logf("Permissions granted for log file.")
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-after-permission-world")
+	utils.CheckLogsExpected(s, "hello", "hello-after-permission-world", []string{})
 }
 
 func (s *WindowsFakeintakeSuite) testLogCollectionBeforePermission() {
@@ -185,7 +192,7 @@ func (s *WindowsFakeintakeSuite) testLogCollectionBeforePermission() {
 	utils.AppendLog(s, logFileName, "access-granted", 1)
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "access-granted")
+	utils.CheckLogsExpected(s, "hello", "access-granted", []string{})
 }
 
 func (s *WindowsFakeintakeSuite) testLogRecreateRotation() {
@@ -210,6 +217,6 @@ func (s *WindowsFakeintakeSuite) testLogRecreateRotation() {
 	utils.AppendLog(s, logFileName, "hello-world-new-content", 1)
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-world-new-content")
+	utils.CheckLogsExpected(s, "hello", "hello-world-new-content", []string{})
 
 }


### PR DESCRIPTION
### What does this PR do?

When using full file path log configuration the `dirname` tag is now added to logs sent. This before would only be added if using a wildcard path log configuration.

### Motivation

This change makes it easier to group all log sources whether they use wildcard path or full file path by the `dirname` tag.

### Additional Notes

None.

### Possible Drawbacks / Trade-offs

One more extra tag is sent with full file path log configurations.

### Describe how to test/QA your changes

Should be covered by e2e.
