### PR TITLE
Start upload_dependencies jobs at the same time as the environment setup jobs.

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -14,7 +14,7 @@
   - !reference [.shared_filters_and_queries]
   - |
     COUNTER=0
-    while [[ $(aws ec2 describe-instances --filters $FILTER_TEAM $FILTER_MANAGED $FILTER_STATE $FILTER_PIPELINE $FILTER_TEST_COMPONENT $FILTER_INSTANCE_TYPE --output text --query $QUERY_INSTANCE_IDS  | wc -l ) != "1" && $COUNTER -le 40 ]]; do COUNTER=$[$COUNTER +1]; echo "[${COUNTER}] Waiting for instance"; sleep 30; done
+    while [[ $(aws ec2 describe-instances --filters $FILTER_TEAM $FILTER_MANAGED $FILTER_STATE $FILTER_PIPELINE $FILTER_TEST_COMPONENT $FILTER_INSTANCE_TYPE --output text --query $QUERY_INSTANCE_IDS  | wc -l ) != "1" && $COUNTER -le 80 ]]; do COUNTER=$[$COUNTER +1]; echo "[${COUNTER}] Waiting for instance"; sleep 30; done
     # check that instance is ready, or fail
     if [ $(aws ec2 describe-instances --filters $FILTER_TEAM $FILTER_MANAGED $FILTER_STATE $FILTER_PIPELINE $FILTER_TEST_COMPONENT $FILTER_INSTANCE_TYPE --output text --query $QUERY_INSTANCE_IDS | wc -l) -ne "1" ]; then
         echo "Instance NOT found"

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -1,6 +1,6 @@
 # Security agent overrides
 upload_dependencies_secagent_x64:
-  needs: []
+  needs: ["go_deps", "go_tools_deps"]
   extends:
     - .package_dependencies
   rules: !reference [.on_security_agent_changes_or_manual]
@@ -11,7 +11,7 @@ upload_dependencies_secagent_x64:
     TEST_COMPONENT: security-agent
 
 upload_dependencies_secagent_arm64:
-  needs: []
+  needs: ["go_deps", "go_tools_deps"]
   extends:
     - .package_dependencies
   rules: !reference [.on_security_agent_changes_or_manual]

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -2,7 +2,7 @@
 upload_dependencies_sysprobe_x64:
   extends:
     - .package_dependencies
-  needs: ["pull_test_dockers_x64"]
+  needs: ["pull_test_dockers_x64", "go_deps", "go_tools_deps"]
   rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   variables:
     ARCH: amd64
@@ -12,7 +12,7 @@ upload_dependencies_sysprobe_x64:
 upload_dependencies_sysprobe_arm64:
   extends:
     - .package_dependencies
-  needs: ["pull_test_dockers_arm64"]
+  needs: ["pull_test_dockers_arm64", "go_deps", "go_tools_deps"]
   rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   variables:
     ARCH: arm64


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR gives the same set of `needs` to the `upload_dependencies` jobs as the environment setup jobs.
This is done so that the upload jobs start relatively at the same time as the environment setup jobs. This reduces the chances of the upload jobs timing out before the metal instances have been launched.

The PR also increases the wait time of these jobs to 40 minutes from 20 minutes.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
