### PR TITLE
Fix fakeintake port override

### DIFF
--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -123,10 +123,7 @@ func NewServer(options ...func(*Server)) *Server {
 		Registry:          registry,
 	}))
 
-	fi.server = http.Server{
-		Handler: mux,
-		Addr:    ":0",
-	}
+	fi.server.Handler = mux
 
 	return fi
 }

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -124,6 +124,9 @@ func NewServer(options ...func(*Server)) *Server {
 	}))
 
 	fi.server.Handler = mux
+	if fi.server.Addr == "" {
+		fi.server.Addr = ":0"
+	}
 
 	return fi
 }

--- a/test/fakeintake/server/server_test.go
+++ b/test/fakeintake/server/server_test.go
@@ -41,6 +41,12 @@ func testServer(t *testing.T, opts ...func(*Server)) {
 		assert.Empty(t, fi.URL())
 	})
 
+	t.Run("should use the hard coded port", func(t *testing.T) {
+		opts = append(opts, WithAddress("localhost:1234"))
+		fi := NewServer(opts...)
+		assert.Equal(t, "localhost:1234", fi.server.Addr)
+	})
+
 	t.Run("should return error when calling stop on a non-started server", func(t *testing.T) {
 		fi := NewServer(opts...)
 		err := fi.Stop()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
#incident-26323
The fakeintake is not listening to the port 80 because the port is overriden

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
