### PR TITLE
[CWS] fix stuck callback in testetwregistrynotifications

### DIFF
--- a/pkg/security/probe/probe_kernel_reg_windows_test.go
+++ b/pkg/security/probe/probe_kernel_reg_windows_test.go
@@ -160,8 +160,9 @@ func TestETWRegistryNotifications(t *testing.T) {
 		select {
 		case <-et.loopExited:
 			return true
+		default:
+			return false
 		}
-		return false
 	}, 4*time.Second, 250*time.Millisecond, "did not get notification")
 
 	stopLoop(et, &wg)


### PR DESCRIPTION
### What does this PR do?

If for some reason the test fails and `<-et.loopExited` blocks, then we never exit the `Eventually`. This PR fixes this issue by returning directly and taking advantage of the periodic retry of the Eventually itself.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
