### PR TITLE
[CWS] fix security-agent status policy state

### DIFF
--- a/pkg/security/agent/status_templates/runtimesecurity.tmpl
+++ b/pkg/security/agent/status_templates/runtimesecurity.tmpl
@@ -34,8 +34,8 @@
   Policies
   ========
     {{ range $policy := .policiesStatus }}
-      {{ $policy.name }}:
-        source: {{ $policy.source }}
+      {{ $policy.Name }}:
+        source: {{ $policy.Source }}
         rules:
           {{- range $status := $policy.Status }}
             - {{ $status.ID }}: {{ $status.Status }}{{- if $status.Error }} ({{- $status.Error }}){{- end }}

--- a/pkg/security/proto/api/api.pb.go
+++ b/pkg/security/proto/api/api.pb.go
@@ -1164,8 +1164,8 @@ type PolicyStatus struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Name   string        `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Source string        `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	Name   string        `protobuf:"bytes,1,opt,name=Name,proto3" json:"Name,omitempty"`
+	Source string        `protobuf:"bytes,2,opt,name=Source,proto3" json:"Source,omitempty"`
 	Status []*RuleStatus `protobuf:"bytes,3,rep,name=Status,proto3" json:"Status,omitempty"`
 }
 

--- a/pkg/security/proto/api/api.proto
+++ b/pkg/security/proto/api/api.proto
@@ -100,8 +100,8 @@ message RuleStatus {
 }
 
 message PolicyStatus {
-    string name = 1;
-    string source = 2;
+    string Name = 1;
+    string Source = 2;
     repeated RuleStatus Status = 3;
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR fixes the security-agent status command not reporting the policy files status.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The security-agent status command should report the loaded policies.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
