### PR TITLE
Fix bug in the scrubber where 'AddStrippedKeys' would modify the given slice

### DIFF
--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -342,6 +342,7 @@ func HideKeyExceptLastFiveChars(key string) string {
 // the DefaultScrubber directly and be added to any created scrubbers.
 func AddStrippedKeys(strippedKeys []string) {
 	// API and APP keys are already handled by default rules
+	strippedKeys = slices.Clone(strippedKeys)
 	strippedKeys = slices.DeleteFunc(strippedKeys, func(s string) bool {
 		return s == "api_key" || s == "app_key"
 	})

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -510,7 +510,11 @@ some_other_key: 'bbbb'
 app_key: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacccc'
 yet_another_key: 'dddd'`
 
-		AddStrippedKeys([]string{"api_key", "some_other_key", "app_key"})
+		keys := []string{"api_key", "some_other_key", "app_key"}
+		AddStrippedKeys(keys)
+
+		// check that AddStrippedKeys didn't modify the parameter slice
+		assert.Equal(t, []string{"api_key", "some_other_key", "app_key"}, keys)
 
 		scrubbed, err := ScrubYamlString(contents)
 		require.Nil(t, err)


### PR DESCRIPTION
### What does this PR do?

This had for side effect to break secret resolution when a handle was called 'api_key' or 'app_key'.

### Describe how to test/QA your changes

Test that a secret called `api_key` is still resolved correctly.