### PR TITLE
[CONTINT-3682] Workloadmeta/containerd/image Collector: Pull all image references in new image event 

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -66,9 +66,9 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 	if image.RepoDigest == "" {
 		log.Debugf("cannot get repo digest for image %s from workloadmeta store", imageID)
 		contImage, err := containerdClient.ImageOfContainer(namespace, container)
-		if err == nil {
-			// Get repo digest from containerd client. 
-			// This is a fallback mechanism in case we cannot get the repo digest 
+		if err == nil && contImage != nil {
+			// Get repo digest from containerd client.
+			// This is a fallback mechanism in case we cannot get the repo digest
 			// from workloadmeta store.
 			image.RepoDigest = contImage.Target().Digest.String()
 		}

--- a/comp/core/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -63,7 +63,16 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 	}
 
 	image.RepoDigest = util.ExtractRepoDigestFromImage(imageID, image.Registry, store) // "sha256:digest"
-
+	if image.RepoDigest == "" {
+		log.Debugf("cannot get repo digest for image %s from workloadmeta store", imageID)
+		contImage, err := containerdClient.ImageOfContainer(namespace, container)
+		if err == nil {
+			// Get repo digest from containerd client. 
+			// This is a fallback mechanism in case we cannot get the repo digest 
+			// from workloadmeta store.
+			image.RepoDigest = contImage.Target().Digest.String()
+		}
+	}
 	status, err := containerdClient.Status(namespace, container)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {

--- a/comp/core/workloadmeta/collectors/internal/containerd/container_builder_test.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/container_builder_test.go
@@ -47,10 +47,15 @@ type mockedImage struct {
 	containerd.Image
 	mockName   func() string
 	mockConfig func() (ocispec.Descriptor, error)
+	mockTarget func() ocispec.Descriptor
 }
 
 func (m *mockedImage) Config(_ context.Context) (ocispec.Descriptor, error) {
 	return m.mockConfig()
+}
+
+func (m *mockedImage) Target() ocispec.Descriptor {
+	return m.mockTarget()
 }
 
 func TestBuildWorkloadMetaContainer(t *testing.T) {
@@ -78,6 +83,9 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 	image := &mockedImage{
 		mockConfig: func() (ocispec.Descriptor, error) {
 			return ocispec.Descriptor{Digest: "my_image_id"}, nil
+		},
+		mockTarget: func() ocispec.Descriptor {
+			return ocispec.Descriptor{Digest: "my_repo_digest"}
 		},
 	}
 	container := mockedContainer{

--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -188,11 +188,11 @@ func isARepoDigest(imageName string) bool {
 	return strings.Contains(imageName, "@sha256:")
 }
 
-// PullImageReferences pull all references from containerd for a given DIGEST
-// Note: the DIGEST here is the same as digest (repo digest) field returned from "ctr -n NAMESPACE ls" 
+// pullImageReferences pulls all references from containerd for a given DIGEST
+// Note: the DIGEST here is the same as digest (repo digest) field returned from "ctr -n NAMESPACE ls"
 // rather than config.digest (imageID), which is the digest of the image config blob.
 // In general, 3 reference names are returned for a given DIGEST: repo tag, repo digest, and imageID.
-func (c *collector) PullImageReferences(namespace string, img containerd.Image) []string {
+func (c *collector) pullImageReferences(namespace string, img containerd.Image) []string {
 	var refs []string
 	referenceImages, err := c.containerdClient.ListImagesWithDigest(namespace, img.Target().Digest.String())
 	if err == nil {
@@ -201,7 +201,7 @@ func (c *collector) PullImageReferences(namespace string, img containerd.Image) 
 			refs = append(refs, imageName)
 		}
 	} else {
-		log.Infof("failed to get reference images for image: %s, repo digests will be missing: %v", img.Name(), err)
+		log.Debugf("failed to get reference images for image: %s, repo digests will be missing: %v", img.Name(), err)
 	}
 	return refs
 }
@@ -317,7 +317,7 @@ func (c *collector) createOrUpdateImageMetadata(ctx context.Context,
 	}
 	// Only pull all image references if not already present
 	if _, found := c.knownImages.getImageID(wlmImage.Name); !found {
-		references := c.PullImageReferences(namespace, img)
+		references := c.pullImageReferences(namespace, img)
 		for _, ref := range references {
 			c.knownImages.addReference(ref, wlmImage.ID)
 		}

--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -194,7 +194,13 @@ func isARepoDigest(imageName string) bool {
 // In general, 3 reference names are returned for a given DIGEST: repo tag, repo digest, and imageID.
 func (c *collector) pullImageReferences(namespace string, img containerd.Image) []string {
 	var refs []string
-	referenceImages, err := c.containerdClient.ListImagesWithDigest(namespace, img.Target().Digest.String())
+	digest := img.Target().Digest.String()
+	if !strings.HasPrefix(digest, "sha256") {
+		return refs // not a valid digest
+	}
+
+	// Get all references for the imageID
+	referenceImages, err := c.containerdClient.ListImagesWithDigest(namespace, digest)
 	if err == nil {
 		for _, image := range referenceImages {
 			imageName := image.Name()

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -57,6 +57,7 @@ type ContainerdItf interface {
 	Labels(namespace string, ctn containerd.Container) (map[string]string, error)
 	LabelsWithContext(ctx context.Context, namespace string, ctn containerd.Container) (map[string]string, error)
 	ListImages(namespace string) ([]containerd.Image, error)
+	ListImagesWithDigest(namespace string, digest string) ([]containerd.Image, error)
 	Image(namespace string, name string) (containerd.Image, error)
 	ImageOfContainer(namespace string, ctn containerd.Container) (containerd.Image, error)
 	ImageSize(namespace string, ctn containerd.Container) (int64, error)
@@ -237,6 +238,17 @@ func (c *ContainerdUtil) ListImages(namespace string) ([]containerd.Image, error
 	ctxNamespace := namespaces.WithNamespace(ctx, namespace)
 
 	return c.cl.ListImages(ctxNamespace)
+}
+
+// ListImagesWithDigest interfaces with the containerd api to list image with digest filter
+// Digest is the sha256 digest (repo digest) of the compressed image manifest which is defined in 
+// https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
+func (c *ContainerdUtil) ListImagesWithDigest(namespace string, digest string) ([]containerd.Image, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.queryTimeout)
+	defer cancel()
+	ctxNamespace := namespaces.WithNamespace(ctx, namespace)
+	filter := "target.digest==" + digest
+	return c.cl.ListImages(ctxNamespace, filter)
 }
 
 // Image interfaces with the containerd api to get an image

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -241,7 +241,7 @@ func (c *ContainerdUtil) ListImages(namespace string) ([]containerd.Image, error
 }
 
 // ListImagesWithDigest interfaces with the containerd api to list image with digest filter
-// Digest is the sha256 digest (repo digest) of the compressed image manifest which is defined in 
+// Digest is the sha256 digest (repo digest) of the compressed image manifest which is defined in
 // https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
 func (c *ContainerdUtil) ListImagesWithDigest(namespace string, digest string) ([]containerd.Image, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.queryTimeout)

--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -32,6 +32,7 @@ type MockedContainerdClient struct {
 	MockContainerWithCtx      func(ctx context.Context, namespace string, id string) (containerd.Container, error)
 	MockMetadata              func() (containerd.Version, error)
 	MockListImages            func(namespace string) ([]containerd.Image, error)
+	MockListImagesWithDigest  func(namespace string, digest string) ([]containerd.Image, error)
 	MockImage                 func(namespace string, name string) (containerd.Image, error)
 	MockImageOfContainer      func(namespace string, ctn containerd.Container) (containerd.Image, error)
 	MockImageSize             func(namespace string, ctn containerd.Container) (int64, error)
@@ -66,6 +67,11 @@ func (client *MockedContainerdClient) CheckConnectivity() *retry.Error {
 // ListImages is a mock method
 func (client *MockedContainerdClient) ListImages(namespace string) ([]containerd.Image, error) {
 	return client.MockListImages(namespace)
+}
+
+// ListImagesWithDigest is a mock method
+func (client *MockedContainerdClient) ListImagesWithDigest(namespace string, digest string) ([]containerd.Image, error) {
+	return client.MockListImagesWithDigest(namespace, digest)
 }
 
 // Image is a mock method


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Fix dangling images in container images UI when new image event is notified in workloadmeta. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
[CONTINT-3682](https://datadoghq.atlassian.net/browse/CONTINT-3682) 
Issues to be fixed in this PR:
1. When new container image is found, three events (imageID, repo digest, repo tag) are sent to workloadmeta store. Previous [PR](https://github.com/DataDog/datadog-agent/pull/22355) consolidates these events into single image event **when agent starts up**. However, after agent starts, the new image events are still not consolidated. 
2. Race condition: Container events are created at the same time as image events. So when ImageId and repo digest are not linked yet before container events are received, workloadmeta image metadata could not provide repo digest in container builder(repo digest is also part of container payload). Without it, this [PR](https://github.com/DataDog/datadog-agent/pull/23762) will not work properly. 
<img width="1443" alt="Screenshot 2024-03-28 at 10 42 48 AM" src="https://github.com/DataDog/datadog-agent/assets/3947770/adf459ba-f108-4127-9616-3fc11103a0b9">

These two issues could cause dangling image and incorrect repo digest in both live container and image check as shown in the pic. 

Proposed Solutions:

1. image.go: always pull all three reference names using the unique digest when a new image is reported
2. container_builder.go: if workloadmeta store doesn't provide repo digest, fall back to containerd image descriptor to load repo digest. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Start datadog-agent normally, then start dummy app
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: alpine-daemonset
  namespace: default
spec:
  selector:
    matchLabels:
      name: alpine-daemonset
  template:
    metadata:
      labels:
        name: alpine-daemonset
    spec:
      containers:
        - name: alpine
          image: us-east4-docker.pkg.dev/datadog-sandbox/mztest/alpine:test_image_with_fix
          command: ["sh", "-c", "while true; do sleep 1000; done"]
```
Run agent workload-list -v
result:
```
=== Entity container_image_metadata sources(merged):[runtime] id: sha256:f248939460200f8c70427d56f042621a45dcccd68bb2bcba9cb3c8a75527e389 ===
----------- Entity ID -----------
Kind: container_image_metadata ID: sha256:f248939460200f8c70427d56f042621a45dcccd68bb2bcba9cb3c8a75527e389
----------- Entity Meta -----------
Name: us-east4-docker.pkg.dev/datadog-sandbox/mztest/alpine@sha256:2f48b500c466881bc8e943610af3526262ec7e8c81a5a22ddcb33cee0681026f
Namespace: k8s.io
Annotations: 
Labels: io.cri-containerd.image:managed 
Repo tags: [us-east4-docker.pkg.dev/datadog-sandbox/mztest/alpine:test_image us-east4-docker.pkg.dev/datadog-sandbox/mztest/alpine:test_image_with_fix]
Repo digests: [us-east4-docker.pkg.dev/datadog-sandbox/mztest/alpine@sha256:2f48b500c466881bc8e943610af3526262ec7e8c81a5a22ddcb33cee0681026f]
Media Type: application/vnd.docker.distribution.manifest.v2+json
Size in bytes: 7576952
OS: linux
OS Version: 
Architecture: amd64
Variant: 
```
```
=== Entity container source:runtime id: d1fc3631f8f10aaa8adfcc731084ed76a2be74b705f242b7e24fd6316aa60c81 ===
----------- Entity ID -----------
Kind: container ID: d1fc3631f8f10aaa8adfcc731084ed76a2be74b705f242b7e24fd6316aa60c81
----------- Entity Meta -----------
Name: 
Namespace: k8s.io
Annotations: 
Labels: io.kubernetes.container.name:alpine io.cri-containerd.kind:container io.kubernetes.pod.uid:0f86827b-5c78-481e-b793-296ab0be8dbc io.kubernetes.pod.namespace:default io.kubernetes.pod.name:alpine-daemonset-bpdx7 
----------- Image -----------
Name: us-east4-docker.pkg.dev/datadog-sandbox/mztest/alpine
Tag: test_image
ID: sha256:f248939460200f8c70427d56f042621a45dcccd68bb2bcba9cb3c8a75527e389
Raw Name: us-east4-docker.pkg.dev/datadog-sandbox/mztest/alpine:test_image
Short Name: alpine
Repo Digest: sha256:2f48b500c466881bc8e943610af3526262ec7e8c81a5a22ddcb33cee0681026f
----------- Container Info -----------
```


ImageID: sha256:f248939460200f8c70427d56f042621a45dcccd68bb2bcba9cb3c8a75527e389
RepoDigest: sha256:2f48b500c466881bc8e943610af3526262ec7e8c81a5a22ddcb33cee0681026f
are reported correctly

[CONTINT-3682]: https://datadoghq.atlassian.net/browse/CONTINT-3682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ