### PR TITLE
Correct logger to avoid to log when logger is disable

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -309,11 +309,13 @@ func logWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLogFunc f
 
 	l.l.Lock()
 
-	shouldLog := l.shouldLog(logLevel)
+	isInnerNil := l.inner == nil
 
-	if l.inner == nil && !fallbackStderr {
-		addLogToBuffer(bufferFunc)
-	} else if shouldLog {
+	if isInnerNil {
+		if !fallbackStderr {
+			addLogToBuffer(bufferFunc)
+		}
+	} else if l.shouldLog(logLevel) {
 		defer l.l.Unlock()
 		s := BuildLogEntry(v...)
 		return scrubAndLogFunc(s)
@@ -326,7 +328,7 @@ func logWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLogFunc f
 	// where error messages had been lost before Logger had been initialized. Adjusting
 	// just for that case because if the error log should not be logged - because it has
 	// been suppressed then it should be taken into account.
-	if fallbackStderr && shouldLog {
+	if fallbackStderr && isInnerNil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", logLevel.String(), err.Error())
 	}
 	return err
@@ -367,11 +369,13 @@ func logFormatWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLog
 
 	l.l.Lock()
 
-	shouldLog := l.shouldLog(logLevel)
+	isInnerNil := l.inner == nil
 
-	if l.inner == nil && !fallbackStderr {
-		addLogToBuffer(bufferFunc)
-	} else if shouldLog {
+	if isInnerNil {
+		if !fallbackStderr {
+			addLogToBuffer(bufferFunc)
+		}
+	} else if l.shouldLog(logLevel) {
 		defer l.l.Unlock()
 		return scrubAndLogFunc(format, params...)
 	}
@@ -383,7 +387,7 @@ func logFormatWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLog
 	// where error messages had been lost before Logger had been initialized. Adjusting
 	// just for that case because if the error log should not be logged - because it has
 	// been suppressed then it should be taken into account.
-	if fallbackStderr && shouldLog {
+	if fallbackStderr && isInnerNil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", logLevel.String(), err.Error())
 	}
 	return err
@@ -428,11 +432,13 @@ func logContextWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLo
 
 	l.l.Lock()
 
-	shouldLog := l.shouldLog(logLevel)
+	isInnerNil := l.inner == nil
 
-	if l.inner == nil && !fallbackStderr {
-		addLogToBuffer(bufferFunc)
-	} else if shouldLog {
+	if isInnerNil {
+		if !fallbackStderr {
+			addLogToBuffer(bufferFunc)
+		}
+	} else if l.shouldLog(logLevel) {
 		l.inner.SetContext(context)
 		l.inner.SetAdditionalStackDepth(defaultStackDepth + depth) //nolint:errcheck
 		err := scrubAndLogFunc(message)
@@ -445,7 +451,7 @@ func logContextWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLo
 	l.l.Unlock()
 
 	err := formatErrorc(message, context...)
-	if fallbackStderr && shouldLog {
+	if fallbackStderr && isInnerNil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", logLevel.String(), err.Error())
 	}
 	return err

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -309,9 +309,11 @@ func logWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLogFunc f
 
 	l.l.Lock()
 
+	shouldLog := l.shouldLog(logLevel)
+
 	if l.inner == nil && !fallbackStderr {
 		addLogToBuffer(bufferFunc)
-	} else if l.shouldLog(logLevel) {
+	} else if shouldLog {
 		defer l.l.Unlock()
 		s := BuildLogEntry(v...)
 		return scrubAndLogFunc(s)
@@ -324,7 +326,7 @@ func logWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLogFunc f
 	// where error messages had been lost before Logger had been initialized. Adjusting
 	// just for that case because if the error log should not be logged - because it has
 	// been suppressed then it should be taken into account.
-	if fallbackStderr {
+	if fallbackStderr && shouldLog {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", logLevel.String(), err.Error())
 	}
 	return err
@@ -365,9 +367,11 @@ func logFormatWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLog
 
 	l.l.Lock()
 
+	shouldLog := l.shouldLog(logLevel)
+
 	if l.inner == nil && !fallbackStderr {
 		addLogToBuffer(bufferFunc)
-	} else if l.shouldLog(logLevel) {
+	} else if shouldLog {
 		defer l.l.Unlock()
 		return scrubAndLogFunc(format, params...)
 	}
@@ -379,7 +383,7 @@ func logFormatWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLog
 	// where error messages had been lost before Logger had been initialized. Adjusting
 	// just for that case because if the error log should not be logged - because it has
 	// been suppressed then it should be taken into account.
-	if fallbackStderr {
+	if fallbackStderr && shouldLog {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", logLevel.String(), err.Error())
 	}
 	return err
@@ -424,9 +428,11 @@ func logContextWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLo
 
 	l.l.Lock()
 
+	shouldLog := l.shouldLog(logLevel)
+
 	if l.inner == nil && !fallbackStderr {
 		addLogToBuffer(bufferFunc)
-	} else if l.shouldLog(logLevel) {
+	} else if shouldLog {
 		l.inner.SetContext(context)
 		l.inner.SetAdditionalStackDepth(defaultStackDepth + depth) //nolint:errcheck
 		err := scrubAndLogFunc(message)
@@ -439,7 +445,7 @@ func logContextWithError(logLevel seelog.LogLevel, bufferFunc func(), scrubAndLo
 	l.l.Unlock()
 
 	err := formatErrorc(message, context...)
-	if fallbackStderr {
+	if fallbackStderr && shouldLog {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", logLevel.String(), err.Error())
 	}
 	return err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix log issue happening: logging even when the logger is disable 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

![image](https://github.com/DataDog/datadog-agent/assets/93274433/50be5b45-43f6-4d35-b884-054b2a3c6204)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

`datadog-agent flare -l` and `datadog-agent diagnose -l` should behave the same as before