### PR TITLE
[CWS] fix ECS Fargate container ID pattern

### DIFF
--- a/pkg/security/common/containerutils/utils.go
+++ b/pkg/security/common/containerutils/utils.go
@@ -13,9 +13,9 @@ import (
 
 // ContainerIDPatternStr defines the regexp used to match container IDs
 // ([0-9a-fA-F]{64}) is standard container id used pretty much everywhere, length: 64
-// ([0-9a-fA-F]{32}-[0-9]{10}) is container id used by AWS ECS, length: 43
+// ([0-9a-fA-F]{32}-\d+) is container id used by AWS ECS, length: 43
 // ([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4}) is container id used by Garden, length: 28
-var ContainerIDPatternStr = "([0-9a-fA-F]{64})|([0-9a-fA-F]{32}-[0-9]{10})|([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4})"
+var ContainerIDPatternStr = "([0-9a-fA-F]{64})|([0-9a-fA-F]{32}-\\d+)|([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4})"
 var containerIDPattern = regexp.MustCompile(ContainerIDPatternStr)
 
 var containerIDCoreChars = "0123456789abcdefABCDEF"

--- a/pkg/security/common/containerutils/utils_test.go
+++ b/pkg/security/common/containerutils/utils_test.go
@@ -81,6 +81,10 @@ func TestFindContainerID(t *testing.T) {
 			input:  "prefix0123456789aAbBcCdDeEfF0123456789-0123456789suffix",
 			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
 		},
+		{ // ECS short
+			input:  "/ecs/0123456789aAbBcCdDeEfF0123456789/0123456789aAbBcCdDeEfF0123456789-012345678",
+			output: "0123456789aAbBcCdDeEfF0123456789-012345678",
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Similarly to #24186, this PR fixes the pattern used by the CWS tracer to parse ECS Fargate container IDs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
