### PR TITLE
[CWS] fix a security dump segfault

### DIFF
--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -196,6 +196,8 @@ func (adm *ActivityDumpManager) resolveTags() {
 
 	var err error
 	for _, ad := range dumps {
+		ad.Lock()
+		defer ad.Unlock()
 		err = ad.ResolveTags()
 		if err != nil {
 			seclog.Warnf("couldn't resolve activity dump tags (will try again later): %v", err)
@@ -236,7 +238,7 @@ func (adm *ActivityDumpManager) resolveTags() {
 		}
 
 		if shouldFinalize {
-			ad.Finalize(true)
+			ad.finalize(true)
 			adm.RemoveDump(ad)
 		}
 	}

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -198,7 +198,8 @@ func (adm *ActivityDumpManager) resolveTags() {
 	for _, ad := range dumps {
 		ad.Lock()
 		defer ad.Unlock()
-		err = ad.ResolveTags()
+
+		err = ad.resolveTags()
 		if err != nil {
 			seclog.Warnf("couldn't resolve activity dump tags (will try again later): %v", err)
 		}


### PR DESCRIPTION
### What does this PR do?

This PR fixes a race condition on the activity dumps for which the `GetWorkloadSelector` was not protected by a mutex

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
