### PR TITLE
Allow users to optionally set region for DBM aurora auto-discovery

### DIFF
--- a/comp/core/autodiscovery/listeners/dbm_aurora.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora.go
@@ -71,7 +71,7 @@ func NewDBMAuroraListener(Config) (ServiceListener, error) {
 	if err != nil {
 		return nil, err
 	}
-	client, region, err := aws.NewRDSClient()
+	client, region, err := aws.NewRDSClient(config.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -974,6 +974,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.metrics.")
 	config.BindEnvAndSetDefault("database_monitoring.autodiscovery.aurora.enabled", false)
 	config.BindEnvAndSetDefault("database_monitoring.autodiscovery.aurora.discovery_interval", 300)
+	config.BindEnvAndSetDefault("database_monitoring.autodiscovery.aurora.region", "")
 	config.BindEnvAndSetDefault("database_monitoring.autodiscovery.aurora.query_timeout", 10)
 	config.BindEnvAndSetDefault("database_monitoring.autodiscovery.aurora.tags", []string{"datadoghq.com/scrape:true"})
 

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -467,19 +467,22 @@ func TestDatabaseMonitoringAurora(t *testing.T) {
 				assert.Equal(t, config.GetInt("database_monitoring.autodiscovery.aurora.discovery_interval"), 300)
 				assert.Equal(t, config.GetInt("database_monitoring.autodiscovery.aurora.query_timeout"), 10)
 				assert.Equal(t, config.Get("database_monitoring.autodiscovery.aurora.tags"), []string{"datadoghq.com/scrape:true"})
+				assert.Equal(t, config.GetString("database_monitoring.autodiscovery.aurora.region"), "")
 			},
 		},
 		{
-			name: "auto discovery query timeout and discovery interval are set from DD env vars",
+			name: "auto discovery query timeout, region and discovery interval are set from DD env vars",
 			setup: func(t *testing.T, config pkgconfigmodel.Config) {
 				t.Setenv("DD_DATABASE_MONITORING_AUTODISCOVERY_AURORA_ENABLED", "true")
 				t.Setenv("DD_DATABASE_MONITORING_AUTODISCOVERY_AURORA_DISCOVERY_INTERVAL", "15")
 				t.Setenv("DD_DATABASE_MONITORING_AUTODISCOVERY_AURORA_QUERY_TIMEOUT", "1")
+				t.Setenv("DD_DATABASE_MONITORING_AUTODISCOVERY_AURORA_REGION", "us-west-2")
 			},
 			tests: func(t *testing.T, config pkgconfigmodel.Config) {
 				assert.True(t, config.GetBool("database_monitoring.autodiscovery.aurora.enabled"))
 				assert.Equal(t, config.GetInt("database_monitoring.autodiscovery.aurora.discovery_interval"), 15)
 				assert.Equal(t, config.GetInt("database_monitoring.autodiscovery.aurora.query_timeout"), 1)
+				assert.Equal(t, config.GetString("database_monitoring.autodiscovery.aurora.region"), "us-west-2")
 				assert.Equal(t, config.Get("database_monitoring.autodiscovery.aurora.tags"), []string{"datadoghq.com/scrape:true"})
 			},
 		},

--- a/pkg/databasemonitoring/config/config.go
+++ b/pkg/databasemonitoring/config/config.go
@@ -34,5 +34,6 @@ func NewAuroraAutodiscoveryConfig() (AuroraConfig, error) {
 	discoveryConfigs.QueryTimeout = coreconfig.Datadog.GetInt(autoDiscoveryAuroraConfigKey + ".query_timeout")
 	discoveryConfigs.DiscoveryInterval = coreconfig.Datadog.GetInt(autoDiscoveryAuroraConfigKey + ".discovery_interval")
 	discoveryConfigs.Tags = coreconfig.Datadog.GetStringSlice(autoDiscoveryAuroraConfigKey + ".tags")
+	discoveryConfigs.Region = coreconfig.Datadog.GetString(autoDiscoveryAuroraConfigKey + ".region")
 	return discoveryConfigs, nil
 }

--- a/releasenotes/notes/Allow-DBM-auto-discovery-to-optionally-set-region-d3006501542da7bf.yaml
+++ b/releasenotes/notes/Allow-DBM-auto-discovery-to-optionally-set-region-d3006501542da7bf.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    This change allows DBM Autodiscovery users to optionally set the region for where their aurora clusters are running.
+    This can be used in lieu of relying on IMDS to discover the region through instance metadata. This is a nicer experience for users
+    running in Docker, who would be required to complete extra steps in their instance metadata configuration to allow the Docker container
+    access to the instance metadata.


### PR DESCRIPTION
### What does this PR do?

This is a follow-up PR to the feature added in https://github.com/DataDog/datadog-agent/pull/23216, and allows customers to optionally set a `region` field in their auto-discovery configuration. E.g:

```yaml
database_monitoring:
  autodiscovery:
    aurora:
      region: "us-west-2"
      enabled: true
```
**Note:** The default behavior is to rely on IMDS (instance metadata) to resolve the region of where the agent is currently running. The go AWS SDK requires the region to establish a new session. 

### Motivation

We have customers who are interested in using the feature in docker, and right now if the instance uses the IMDSv2 API (the default for new instances) they will see errors like this on start-up:

```
2024-03-28 19:03:33 UTC | CORE | WARN | (pkg/util/ec2/imds_helpers.go:82 in doHTTPRequest) | ec2_prefer_imdsv2 is set to true in the configuration but the agent was unable to proceed: Put "http://169.254.169.254/latest/api/token": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2024-03-28 19:03:33 UTC | CORE | ERROR | (comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go:395 in initListenerCandidates) | database-monitoring-aurora listener cannot start: unable to fetch EC2 API to get identity: status code 401 trying to GET http://169.254.169.254/latest/dynamic/instance-identity/document/
```

There are two ways to fix this:

1. Run the container in `--network host`
2. Increase the number of allowable network hops for your instance metadata service. From AWS docs:

> In a container environment, if the hop limit is 1, the IMDSv2 response does not return because going to the container is considered an additional network hop. To avoid the process of falling back to IMDSv1 and the resultant delay, in a container environment we recommend that you set the hop limit to 2

This extra requirement makes things a bit cumbersome for customers, so we can opt to allow them to pass a region via an environment variable or configuration in the `datadog.yaml`. The default behavior will remain to query the instance metadata service. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
