### PR TITLE
Manual Device Scan

### DIFF
--- a/pkg/networkdevice/metadata/payload.go
+++ b/pkg/networkdevice/metadata/payload.go
@@ -3,8 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(NDM) Fix revive linter
+// Package metadata defines types for describing data about a device.
 package metadata
+
+import "github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 
 // PayloadMetadataBatchSize is the number of resources per event payload
 // Resources are devices, interfaces, etc
@@ -42,6 +44,7 @@ type NetworkDevicesMetadata struct {
 	Links            []TopologyLinkMetadata `json:"links,omitempty"`
 	NetflowExporters []NetflowExporter      `json:"netflow_exporters,omitempty"`
 	Diagnoses        []DiagnosisMetadata    `json:"diagnoses,omitempty"`
+	DeviceOIDs       []DeviceOID            `json:"device_oids,omitempty"`
 	CollectTimestamp int64                  `json:"collect_timestamp"`
 }
 
@@ -70,6 +73,12 @@ type DeviceMetadata struct {
 	OsHostname     string       `json:"os_hostname,omitempty"`
 	Integration    string       `json:"integration,omitempty"` // indicates the source of the data SNMP, meraki_api, etc.
 	DeviceType     string       `json:"device_type,omitempty"`
+}
+
+// DeviceOID device scan oid data
+type DeviceOID struct {
+	*gosnmplib.PDU
+	DeviceID string `json:"device_id"`
 }
 
 // InterfaceMetadata contains interface metadata

--- a/pkg/snmp/gosnmplib/cmp.go
+++ b/pkg/snmp/gosnmplib/cmp.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package gosnmplib
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// OIDToInts converts a string OID into a list of integers.
+func OIDToInts(oid string) ([]int, error) {
+	oid = strings.Trim(strings.TrimLeft(oid, "."), ".")
+	if len(oid) == 0 {
+		return nil, nil
+	}
+	var result []int
+	for _, segment := range strings.Split(oid, ".") {
+		val, err := strconv.ParseInt(segment, 10, 0)
+		if err != nil {
+			return nil, fmt.Errorf("unparseable OID %q: %w", oid, err)
+		}
+		result = append(result, int(val))
+	}
+	return result, nil
+}
+
+// OIDRelation indicates how one OID relates to another
+type OIDRelation uint8
+
+const (
+	// EQUAL indicates two OIDs are the same
+	EQUAL OIDRelation = iota
+	// GREATER indicates that at the first point where the two OIDs differ, the first is greater than the second.
+	GREATER
+	// LESS indicates that at the first point where the two OIDs differ, the first is less than the second.
+	LESS
+	// PARENT indicates that the first OID is a parent of the second
+	PARENT
+	// CHILD indicates that the first OID is a child of the second
+	CHILD
+)
+
+// IsAfter returns true if the first OID comes lexicographically after the
+// second, either because it is strictly greater than the second or because it
+// is a child of the second.
+func (o OIDRelation) IsAfter() bool {
+	return o == GREATER || o == CHILD
+}
+
+// IsBefore returns true if the first OID comes lexicographically before the
+// second, either because it is strictly less than the second or because it is a
+// parent of the second.
+func (o OIDRelation) IsBefore() bool {
+	return o == LESS || o == PARENT
+}
+
+// CmpOIDs compares two OIDs (int slices) and indicates how the first relates to
+// the second.
+func CmpOIDs(oid1, oid2 []int) OIDRelation {
+	for i, n := range oid1 {
+		if i >= len(oid2) {
+			return CHILD
+		}
+		if n < oid2[i] {
+			return LESS
+		}
+		if n > oid2[i] {
+			return GREATER
+		}
+	}
+	if len(oid1) == len(oid2) {
+		return EQUAL
+	}
+	return PARENT
+}

--- a/pkg/snmp/gosnmplib/cmp_test.go
+++ b/pkg/snmp/gosnmplib/cmp_test.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package gosnmplib_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOIDToInts(t *testing.T) {
+	for _, tc := range []struct {
+		oid      string
+		expected []int
+	}{
+		{"1.2.3.4", []int{1, 2, 3, 4}},
+		{".0.101.99999.1.1.1.3.0.0.", []int{0, 101, 99999, 1, 1, 1, 3, 0, 0}},
+		{"0", []int{0}},
+		{"..0..", []int{0}},
+		{".", nil},
+		{"", nil},
+		{".-1.-10.10.-1", []int{-1, -10, 10, -1}}, // this shouldn't come up but better safe than sorry
+	} {
+		t.Run(tc.oid, func(t *testing.T) {
+			got, err := gosnmplib.OIDToInts(tc.oid)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+
+	t.Run("Failure", func(t *testing.T) {
+		_, err := gosnmplib.OIDToInts("non-numeric.1.2.3")
+		var e *strconv.NumError
+		assert.ErrorAs(t, err, &e)
+	})
+}
+
+func TestOIDRelation(t *testing.T) {
+	for _, tc := range []struct {
+		val    gosnmplib.OIDRelation
+		after  bool
+		before bool
+	}{
+		{gosnmplib.EQUAL, false, false},
+		{gosnmplib.CHILD, true, false},
+		{gosnmplib.PARENT, false, true},
+		{gosnmplib.GREATER, true, false},
+		{gosnmplib.LESS, false, true},
+	} {
+		assert.Equal(t, tc.after, tc.val.IsAfter())
+		assert.Equal(t, tc.before, tc.val.IsBefore())
+	}
+}
+
+func TestCmpOIDs(t *testing.T) {
+	for _, tc := range []struct {
+		a, b   []int
+		result gosnmplib.OIDRelation
+	}{
+		{[]int{1, 2, 3}, []int{1, 2, 3}, gosnmplib.EQUAL},
+		{[]int{1, 2, 3}, []int{1, 2}, gosnmplib.CHILD},
+		{[]int{1, 2}, []int{1, 2, 3}, gosnmplib.PARENT},
+		{[]int{1, 2, 3}, []int{1, 2, 4}, gosnmplib.LESS},
+		{[]int{1, 2, 3}, []int{1, 2, 2}, gosnmplib.GREATER},
+		{[]int{1, 1, 2, 3, 5, 8, 13}, []int{1, 2, 1, 2, 4, 7, 12}, gosnmplib.LESS},
+		{[]int{1, 1}, []int{1, 2, 1, 2, 4, 7, 12}, gosnmplib.LESS},
+		{[]int{1, 10}, []int{1, 2, 1, 2, 4, 7, 12}, gosnmplib.GREATER},
+		{[]int{1, 2}, []int{1, 2, 1, 2, 4, 7, 12}, gosnmplib.PARENT},
+	} {
+		assert.Equal(t, tc.result, gosnmplib.CmpOIDs(tc.a, tc.b))
+	}
+}

--- a/pkg/snmp/gosnmplib/gosnmp_auth.go
+++ b/pkg/snmp/gosnmplib/gosnmp_auth.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(NDM) Fix revive linter
+// Package gosnmplib provides helpers to go with gosnmp.
 package gosnmplib
 
 import (

--- a/pkg/snmp/gosnmplib/gosnmp_utils.go
+++ b/pkg/snmp/gosnmplib/gosnmp_utils.go
@@ -39,7 +39,14 @@ func IsStringPrintable(bytesValue []byte) bool {
 	return true
 }
 
-// GetValueFromPDU converts the value from an  SnmpPDU to a standard type
+// GetValueFromPDU converts the value from an SnmpPDU to a standard type.
+// Octet and Bit strings will be returned as []byte.
+// All integer and float types will be returned as float64.
+// IPs and OIDs will be returned as strings; OIDs will have any leading '.' stripped.
+// Unsupported types:
+//   - gosnmp.Opaque: gosnmp never returns these, instead processing them recursively
+//     See https://github.com/gosnmp/gosnmp/blob/dc320dac5b53d95a366733fd95fb5851f2099387/helper.go#L195-L205
+//   - Boolean, Null: Although ASN1 allows these, SNMP does not (if someone needs a bool they use an enumerated integer instead)
 func GetValueFromPDU(pduVariable gosnmp.SnmpPDU) (interface{}, error) {
 	switch pduVariable.Type {
 	case gosnmp.OctetString, gosnmp.BitString:

--- a/pkg/snmp/gosnmplib/pdu.go
+++ b/pkg/snmp/gosnmplib/pdu.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package gosnmplib
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// PDU represents a data unit from an SNMP request, with smart typing.
+type PDU struct {
+	OID  string         `json:"oid"`
+	Type gosnmp.Asn1BER `json:"type"`
+	// Value is the stringified version of the value; if Type is OctetString or BitString, it is base64 encoded.
+	Value string `json:"value"`
+}
+
+// PDUFromSNMP packages a gosnmp.SnmpPDU as a PDU
+func PDUFromSNMP(pdu *gosnmp.SnmpPDU) (*PDU, error) {
+	value, err := GetValueFromPDU(*pdu)
+	if err != nil {
+		return nil, err
+	}
+	record := PDU{
+		OID:  strings.TrimLeft(pdu.Name, "."),
+		Type: pdu.Type,
+	}
+	if err := record.SetValue(value); err != nil {
+		return nil, fmt.Errorf("unsupported PDU type for OID %s: %w", pdu.Name, err)
+	}
+	return &record, nil
+}
+
+// RawValue returns the value as a []byte, int64, float64, or plain string, depending on the type.
+func (d *PDU) RawValue() (any, error) {
+	switch d.Type {
+	case gosnmp.OctetString, gosnmp.BitString:
+		return base64.StdEncoding.DecodeString(d.Value)
+	case gosnmp.Integer, gosnmp.Counter32, gosnmp.Gauge32, gosnmp.TimeTicks, gosnmp.Counter64, gosnmp.Uinteger32:
+		return strconv.ParseInt(d.Value, 10, 64)
+	case gosnmp.OpaqueFloat:
+		return strconv.ParseFloat(d.Value, 32)
+	case gosnmp.OpaqueDouble:
+		return strconv.ParseFloat(d.Value, 64)
+	case gosnmp.IPAddress, gosnmp.ObjectIdentifier:
+		return d.Value, nil
+	default:
+		return nil, fmt.Errorf("oid %s: invalid type: %s", d.OID, d.Type.String())
+	}
+}
+
+// SetValue sets the value. The input should be a []byte, int64, float64, or plain string, depending on the type.
+func (d *PDU) SetValue(value any) error {
+	var ok bool
+	switch value := value.(type) {
+	case []byte:
+		if d.Type == gosnmp.OctetString || d.Type == gosnmp.BitString {
+			d.Value = base64.StdEncoding.EncodeToString(value)
+			ok = true
+		}
+	case int, int64:
+		if slices.Contains([]gosnmp.Asn1BER{gosnmp.Integer, gosnmp.Counter32, gosnmp.Gauge32, gosnmp.TimeTicks, gosnmp.Counter64, gosnmp.Uinteger32, gosnmp.OpaqueFloat, gosnmp.OpaqueDouble}, d.Type) {
+			d.Value = fmt.Sprintf("%d", value)
+			ok = true
+		}
+	case float32, float64:
+		// If the ASN type is an integer type, cast the float to an int64 if (and only if) it's already integral.
+		if slices.Contains([]gosnmp.Asn1BER{gosnmp.Integer, gosnmp.Counter32, gosnmp.Gauge32, gosnmp.TimeTicks, gosnmp.Counter64, gosnmp.Uinteger32}, d.Type) {
+			var f float64
+			if v, is32 := value.(float32); is32 {
+				f = float64(v)
+			} else {
+				f = value.(float64)
+			}
+			r := math.Round(f)
+			if math.Abs(r-f) > 1e-6 {
+				return fmt.Errorf("cannot use non-integer float %f as value for type %s", value, d.Type.String())
+			}
+			d.Value = fmt.Sprintf("%.0f", r)
+			ok = true
+		} else if slices.Contains([]gosnmp.Asn1BER{gosnmp.OpaqueFloat, gosnmp.OpaqueDouble}, d.Type) {
+			d.Value = fmt.Sprintf("%f", value)
+			ok = true
+		}
+	case string:
+		if d.Type == gosnmp.IPAddress || d.Type == gosnmp.ObjectIdentifier {
+			d.Value = value
+			ok = true
+		}
+	}
+	if !ok {
+		return fmt.Errorf("cannot use %T as value for type %s", value, d.Type.String())
+	}
+	return nil
+}

--- a/pkg/snmp/gosnmplib/pdu_test.go
+++ b/pkg/snmp/gosnmplib/pdu_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package gosnmplib_test
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+)
+
+type testCase struct {
+	asn1ber gosnmp.Asn1BER
+	input   any
+	value   string
+	// nil if the input should cause an error
+	rawValue any
+}
+
+func TestDeviceOID(t *testing.T) {
+	for _, tc := range []testCase{
+		{gosnmp.BitString, []byte("hello, world"), "aGVsbG8sIHdvcmxk", []byte("hello, world")},
+		{gosnmp.OctetString, []byte("hello, world"), "aGVsbG8sIHdvcmxk", []byte("hello, world")},
+		{gosnmp.OctetString, "hello, world", "", nil},
+		{gosnmp.OctetString, 100, "", nil},
+		{gosnmp.OctetString, "aGVsbG8sIHdvcmxk", "", nil},
+		{gosnmp.Counter32, 100, "100", int64(100)},
+		{gosnmp.Counter64, 100, "100", int64(100)},
+		{gosnmp.Gauge32, 100, "100", int64(100)},
+		{gosnmp.Uinteger32, 100, "100", int64(100)},
+		{gosnmp.TimeTicks, 100, "100", int64(100)},
+		{gosnmp.Integer, 100, "100", int64(100)},
+		{gosnmp.Integer, 100.01, "", nil},
+		{gosnmp.Integer, "hello, world", "", nil},
+		{gosnmp.Integer, []byte("100"), "", nil},
+		{gosnmp.Integer, "100", "", nil},
+		{gosnmp.Integer, float32(101.00), "101", int64(101)},
+		{gosnmp.Integer, float64(-95.00), "-95", int64(-95)},
+		{gosnmp.OpaqueDouble, 100, "100", float64(100)},
+		{gosnmp.OpaqueFloat, 100, "100", float64(100)},
+		{gosnmp.OpaqueFloat, "hello, world", "", nil},
+		{gosnmp.OpaqueFloat, []byte("100"), "", nil},
+		{gosnmp.OpaqueFloat, "100", "", nil},
+		{gosnmp.OpaqueFloat, 100.1, "100.100000", float64(100.1)},
+		{gosnmp.OpaqueFloat, float64(100.1), "100.100000", float64(100.1)},
+		{gosnmp.ObjectIdentifier, "1.2.3.4.5.6.7", "1.2.3.4.5.6.7", "1.2.3.4.5.6.7"},
+		{gosnmp.IPAddress, "127.0.0.1", "127.0.0.1", "127.0.0.1"},
+		{gosnmp.IPAddress, []byte("127.0.0.1"), "", nil},
+		{gosnmp.IPAddress, 127, "", nil},
+	} {
+		d := gosnmplib.PDU{
+			Type: tc.asn1ber,
+		}
+		if tc.rawValue == nil {
+			assert.Error(t, d.SetValue(tc.input))
+		} else {
+			assert.NoError(t, d.SetValue(tc.input))
+			assert.Equal(t, tc.value, d.Value)
+			val, err := d.RawValue()
+			assert.NoError(t, err)
+			switch tval := val.(type) {
+			case float32, float64:
+				assert.InEpsilon(t, tc.rawValue, tval, 1e-6)
+			default:
+				assert.Equal(t, tc.rawValue, tval)
+			}
+		}
+	}
+	t.Run("BadValue", func(t *testing.T) {
+		for _, tc := range []struct {
+			asn1ber gosnmp.Asn1BER
+			value   string
+		}{
+			{gosnmp.Counter32, "not_an_int"},
+			{gosnmp.Counter32, "1.05"},
+			{gosnmp.OpaqueDouble, "not_a_number"},
+			{gosnmp.OctetString, "invalid_bytes"},
+		} {
+			d := gosnmplib.PDU{
+				Type:  tc.asn1ber,
+				Value: tc.value,
+			}
+			_, err := d.RawValue()
+			assert.Error(t, err)
+		}
+	})
+}

--- a/pkg/snmp/gosnmplib/walk.go
+++ b/pkg/snmp/gosnmplib/walk.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package gosnmplib
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+const (
+	// Note that gosnmp.walk uses ".1.3.6.1.2.1" as its base ID, but we
+	// sometimes want things like LLDP data that are under lower prefixes
+	// (LLDP goes under .1.0.*). So we just start as low as possible.
+	baseOID = ".0.0"
+	// Java SNMP uses 50, snmp-net uses 10
+	defaultMaxRepetitions = 50
+)
+
+// ConditionalWalk mimics gosnmp.GoSNMP.Walk, except that the walkFn can return
+// a next OID to walk from. Use e.g. SkipOIDRowsNaive to skip over additional
+// rows.
+// This code is adapated directly from gosnmp's walk function.
+func ConditionalWalk(session *gosnmp.GoSNMP, rootOID string, useBulk bool, walkFn func(dataUnit gosnmp.SnmpPDU) (string, error)) error {
+	if rootOID == "" || rootOID == "." {
+		rootOID = baseOID
+	}
+
+	if !strings.HasPrefix(rootOID, ".") {
+		rootOID = string(".") + rootOID
+	}
+
+	oid := rootOID
+	requests := 0
+	maxReps := session.MaxRepetitions
+
+	if maxReps == 0 {
+		maxReps = defaultMaxRepetitions
+	}
+
+RequestLoop:
+	for {
+		requests++
+		var response *gosnmp.SnmpPacket
+		var err error
+		if useBulk {
+			response, err = session.GetBulk([]string{oid}, 0, maxReps)
+		} else {
+			response, err = session.GetNext([]string{oid})
+		}
+		if err != nil {
+			return err
+		}
+		if len(response.Variables) == 0 {
+			break RequestLoop
+		}
+		if response.Error != gosnmp.NoError {
+			session.Logger.Printf("ConditionalWalk terminated with %s", response.Error.String())
+			break RequestLoop
+		}
+
+		for i, pdu := range response.Variables {
+			if pdu.Type == gosnmp.EndOfMibView || pdu.Type == gosnmp.NoSuchObject || pdu.Type == gosnmp.NoSuchInstance {
+				session.Logger.Printf("ConditionalWalk terminated with type 0x%x", pdu.Type)
+				break RequestLoop
+			}
+			// skip PDUs that are less than our next OID when we're handling
+			// multiple PDUs from one getBulk
+			if i > 0 {
+				next, err := OIDToInts(oid)
+				if err != nil {
+					return err
+				}
+				this, err := OIDToInts(pdu.Name)
+				if err != nil {
+					return err
+				}
+				// Skip this PDU if our next OID is after this one - it means we
+				// skipped it because of walkFn
+				if CmpOIDs(next, this).IsAfter() {
+					continue
+				}
+			}
+			// Report our pdu
+			oid, err = walkFn(pdu)
+			if err != nil {
+				return err
+			}
+			if oid == "" {
+				oid = pdu.Name
+			}
+		}
+	}
+	session.Logger.Printf("ConditionalWalk completed in %d requests", requests)
+	return nil
+}
+
+// SkipOIDRowsNaive takes an OID and returns a suitable OID to pass to GetNext
+// in order to fetch the next OID after the given one excluding additional table
+// rows. If the OID is for a scalar value, it is returned unchanged; otherwise,
+// it is the OID for a row in a table, and the returned OID will be just less
+// than the first OID for the next column of the table.
+//
+// This is a naive, MIB-less algorithm based on the fact that if a table has OID
+// X, then the TableEntry that describes the table type will have OID `X.1` and
+// every column in the table will have an OID like `X.1.n`. Thus, if we grab the
+// last segment other than the end that is `1` in the input OID, and increment
+// the next segment by 1, there's a good chance we'll get the next row.
+//
+// Three caveats: first, if a table index ends in .0, this will mistake it for a
+// scalar and return it. Second, if a table index contains '.1.', we will
+// interpret that as the table index instead. Third, if the first row of a table
+// has OID .1, then that will also be mistaken for the table entry. In all three
+// of these cases, the result is that we end up grabbing additional rows of a
+// table, but we will never skip over any rows or scalars, so it is safe to use
+// this to determine a superset of all OIDs present on a device.
+//
+// It is unlikely we can do better than this without having relevant MIB data.
+func SkipOIDRowsNaive(oid string) string {
+	oid = strings.TrimRight(strings.TrimLeft(oid, "."), ".")
+	if strings.HasSuffix(oid, ".0") { // Possibly a scalar OID
+		return oid
+	}
+	idx := strings.LastIndex(oid, ".1.") // Try to find the table Entry OID
+	if idx == -1 {                       // Not a table OID
+		return oid
+	}
+	tableOid := oid[0:idx]
+	rowFullIndex := oid[idx+3:] // +3 to skip `.1.`
+	rowFirstIndex := strings.Split(rowFullIndex, ".")[0]
+	rowFirstIndexNum, err := strconv.Atoi(rowFirstIndex)
+	if err != nil { // This shouldn't be possible unless the OID is malformed
+		return oid
+	}
+	// `1` is the table entry oid, it's always `1`
+	return tableOid + ".1." + strconv.Itoa(rowFirstIndexNum+1)
+}

--- a/pkg/snmp/gosnmplib/walk_test.go
+++ b/pkg/snmp/gosnmplib/walk_test.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package gosnmplib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkipOIDRowsNaive(t *testing.T) {
+	for _, tc := range []struct{ oid, expected string }{
+		{"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.1.0"},
+		{".1.3.6.1.2.1.1.1.0.", "1.3.6.1.2.1.1.1.0"},
+		{"1.3.6.1.2.1.1.9.1.2.1", "1.3.6.1.2.1.1.9.1.3"},
+		// breakdown example: column ID 1, key 127.0.0.1 is interpreted as column ID 127
+		{"1.3.6.1.2.1.4.20.1.1.127.0.0.1", "1.3.6.1.2.1.4.20.1.1.128"},
+		// breakdown example: column ID 1, key ending in 0 is interpreted as scalar
+		{"1.3.6.1.2.1.4.24.4.1.1.195.200.251.0.0.255.255.255.0.0.0.0.0", "1.3.6.1.2.1.4.24.4.1.1.195.200.251.0.0.255.255.255.0.0.0.0.0"},
+		// breakdown example: key containing '.1.':
+		{"1.3.6.1.2.1.4.22.1.1.2.192.168.1.1", "1.3.6.1.2.1.4.22.1.1.2.192.168.1.2"},
+	} {
+		assert.Equal(t, tc.expected, SkipOIDRowsNaive(tc.oid))
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This adds an `snmp scan` command that does a partial snmp walk of a device and sends that data to the backend.

### Motivation

NDMII-2395: we want to be able to use this data to streamline the process of editing profiles.

### QA

The only QA necessary is to verify that the `agent snmp walk` command still runs; while this PR adds all the code to support the scan command, it doesn't actually connect it to the CLI app (because there is additional backend work ongoing, so right now the scan command just gathers some data and sends it for the backend to discard as meaningless).

### Additional Notes

Some backend work will be necessary before this functions completely (the backend needs to support the transmitted data).
