### PR TITLE
[ASCII-1350] Add agent startup time to `inventoryagent`

### DIFF
--- a/comp/metadata/inventoryagent/README.md
+++ b/comp/metadata/inventoryagent/README.md
@@ -37,6 +37,7 @@ The payload is a JSON dict with the following fields
 - `agent_metadata` - **dict of string to JSON type**:
   - `hostname_source` - **string**: the source for the agent hostname (see pkg/util/hostname/providers.go:GetWithProvider).
   - `agent_version` - **string**: the version of the Agent.
+  - `agent_startup_time_ms` - **int**: the Agent startup timestamp (Unix milliseconds timestamp).
   - `flavor` - **string**: the flavor of the Agent. The Agent can be build under different flavor such as standalone
     dogstatsd, iot, serverless ... (see `pkg/util/flavor` package).
   - `config_apm_dd_url` - **string**: the configuration value `apm_config.dd_url` (scrubbed)

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
@@ -170,6 +171,7 @@ func (ia *inventoryagent) initData() {
 	}
 
 	ia.data["agent_version"] = version.AgentVersion
+	ia.data["agent_startup_time_ms"] = pkgconfigsetup.StartTime.UnixMilli()
 	ia.data["flavor"] = flavor.GetFlavor()
 }
 

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -255,8 +255,8 @@ func (ia *inventoryagent) fetchProcessAgentMetadata() {
 
 func (ia *inventoryagent) fetchSystemProbeMetadata() {
 	// If the system-probe configuration is not loaded we fallback on zero value for all metadata
-	getBoolSysProbe := func(key string) bool { return false }
-	getIntSysProbe := func(key string) int { return 0 }
+	getBoolSysProbe := func(_ string) bool { return false }
+	getIntSysProbe := func(_ string) int { return 0 }
 
 	localSysProbeConf, isSet := ia.sysprobeConf.Get()
 	if isSet {

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -335,7 +335,7 @@ func TestFetchSecurityAgent(t *testing.T) {
 	assert.False(t, ia.data["feature_cspm_enabled"].(bool))
 	assert.False(t, ia.data["feature_cspm_host_benchmarks_enabled"].(bool))
 
-	fetchSecurityConfig = func(config pkgconfigmodel.Reader) (string, error) {
+	fetchSecurityConfig = func(_ pkgconfigmodel.Reader) (string, error) {
 		return `compliance_config:
   enabled: true
   host_benchmarks:
@@ -378,7 +378,7 @@ func TestFetchProcessAgent(t *testing.T) {
 	// default to true in the process agent configuration
 	assert.True(t, ia.data["feature_processes_container_enabled"].(bool))
 
-	fetchProcessConfig = func(config pkgconfigmodel.Reader) (string, error) {
+	fetchProcessConfig = func(_ pkgconfigmodel.Reader) (string, error) {
 		return `
 process_config:
   process_collection:
@@ -427,7 +427,7 @@ func TestFetchTraceAgent(t *testing.T) {
 	}
 	assert.Equal(t, "", ia.data["config_apm_dd_url"].(string))
 
-	fetchTraceConfig = func(config pkgconfigmodel.Reader) (string, error) {
+	fetchTraceConfig = func(_ pkgconfigmodel.Reader) (string, error) {
 		return `
 apm_config:
   enabled: true

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -25,6 +25,7 @@ import (
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -170,6 +171,7 @@ func TestInitData(t *testing.T) {
 
 	expected := map[string]any{
 		"agent_version":                    version.AgentVersion,
+		"agent_startup_time_ms":            pkgconfigsetup.StartTime.UnixMilli(),
 		"flavor":                           flavor.GetFlavor(),
 		"config_apm_dd_url":                "http://name:********@someintake.example.com/",
 		"config_dd_url":                    "http://name:********@someintake.example.com/",

--- a/comp/metadata/inventoryhost/README.md
+++ b/comp/metadata/inventoryhost/README.md
@@ -18,7 +18,7 @@ The payload is a JSON dict with the following fields
 
 - `hostname` - **string**: the hostname of the agent as shown on the status page.
 - `uuid` - **string**: a unique identifier of the agent, used in case the hostname is empty.
-- `timestamp` - **int**: the timestamp when the payload was created (Unix nanoseconds timestamp).
+- `timestamp` - **int**: the timestamp when the payload was created.
 - `host_metadata` - **dict of string to JSON type**:
   - `cpu_cores` - **int**: the number of core for the host.
   - `cpu_logical_processors` - **int**:  the number of logical cores for the host.
@@ -41,7 +41,6 @@ The payload is a JSON dict with the following fields
   - `ipv6_address` - **string**: the IPV6 address for the host.
   - `mac_address` - **string**: the MAC address for the host.
   - `agent_version` - **string**: the version of the Agent that sent this payload.
-  - `agent_startup_time` - **int**: the Agent startup timestamp (Unix nanoseconds timestamp).
   - `cloud_provider` - **string**: the name of the cloud provider detected by the Agent.
   - `cloud_provider_source` - **string**: the data source used to know that the Agent is running on `cloud_provider`.
     This is different for each cloud provider. For now ony AWS is supported.

--- a/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost.go
+++ b/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost.go
@@ -12,8 +12,6 @@ import (
 	"fmt"
 	"time"
 
-	"go.uber.org/fx"
-
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/comp/core/log"
@@ -22,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryhost"
 	pkgUtils "github.com/DataDog/datadog-agent/comp/metadata/packagesigning/utils"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/gohai/cpu"
 	"github.com/DataDog/datadog-agent/pkg/gohai/memory"
 	"github.com/DataDog/datadog-agent/pkg/gohai/network"
@@ -35,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/uuid"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"go.uber.org/fx"
 )
 
 // Module defines the fx options for this component.
@@ -84,7 +82,6 @@ type hostMetadata struct {
 
 	// from the agent itself
 	AgentVersion           string `json:"agent_version"`
-	AgentStartupTime       int64  `json:"agent_startup_time_ns"`
 	CloudProvider          string `json:"cloud_provider"`
 	CloudProviderSource    string `json:"cloud_provider_source"`
 	CloudProviderAccountID string `json:"cloud_provider_account_id"`
@@ -230,7 +227,6 @@ func (ih *invHost) fillData() {
 	}
 
 	ih.data.AgentVersion = version.AgentVersion
-	ih.data.AgentStartupTime = pkgconfigsetup.StartTime.UnixNano()
 	ih.data.HypervisorGuestUUID = dmi.GetHypervisorUUID()
 	ih.data.DmiProductUUID = dmi.GetProductUUID()
 	ih.data.DmiBoardAssetTag = dmi.GetBoardAssetTag()

--- a/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost_test.go
+++ b/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl/utils"
 	pkgUtils "github.com/DataDog/datadog-agent/comp/metadata/packagesigning/utils"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/gohai/cpu"
 	"github.com/DataDog/datadog-agent/pkg/gohai/memory"
 	"github.com/DataDog/datadog-agent/pkg/gohai/network"
@@ -153,7 +152,6 @@ func TestGetPayload(t *testing.T) {
 		IPv6Address:                  "fe80::20c:29ff:feb6:d232",
 		MacAddress:                   "00:0c:29:b6:d2:32",
 		AgentVersion:                 version.AgentVersion,
-		AgentStartupTime:             pkgconfigsetup.StartTime.UnixNano(),
 		CloudProvider:                "some_cloud_provider",
 		CloudProviderAccountID:       "some_host_id",
 		CloudProviderSource:          "test_source",
@@ -181,7 +179,6 @@ func TestGetPayloadError(t *testing.T) {
 	p := ih.getPayload().(*Payload)
 	expected := &hostMetadata{
 		AgentVersion:                 version.AgentVersion,
-		AgentStartupTime:             pkgconfigsetup.StartTime.UnixNano(),
 		CloudProvider:                "some_cloud_provider",
 		CloudProviderAccountID:       "some_host_id",
 		CloudProviderSource:          "test_source",

--- a/releasenotes/notes/add-startup-timestamp-in-agent-metadata-payload-378e378c0e5ff6e8.yaml
+++ b/releasenotes/notes/add-startup-timestamp-in-agent-metadata-payload-378e378c0e5ff6e8.yaml
@@ -7,5 +7,5 @@
 # Each section note must be formatted as reStructuredText.
 ---
 enhancements:
-  - Add startup timestamp to the agent metadata payload.
+  - Add startup timestamp to the Agent metadata payload.
 

--- a/releasenotes/notes/add-startup-timestamp-in-agent-metadata-payload-378e378c0e5ff6e8.yaml
+++ b/releasenotes/notes/add-startup-timestamp-in-agent-metadata-payload-378e378c0e5ff6e8.yaml
@@ -7,5 +7,5 @@
 # Each section note must be formatted as reStructuredText.
 ---
 enhancements:
-  - Add startup timestamp to the host metadata payload.
+  - Add startup timestamp to the agent metadata payload.
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR will add `agent_startup_time_ms` field into `inventoryagent` metadata payload.
It reverts changes mades in the following PRs:
- #23683
- #23883
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Provide important data to track time relative issues.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Possible to print `agent_startup_time_ms` field value by running the following command: `./bin/agent/agent diagnose show-metadata inventory-agent -c ./bin/agent/dist/datadog.yaml`