### PR TITLE
[e2e] use ci job id to name stacks

### DIFF
--- a/test/new-e2e/pkg/runner/ci_profile.go
+++ b/test/new-e2e/pkg/runner/ci_profile.go
@@ -38,13 +38,14 @@ func NewCIProfile() (Profile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to get pulumi state password, err: %w", err)
 	}
+	// TODO move to job script
 	os.Setenv("PULUMI_CONFIG_PASSPHRASE", passVal)
 
 	// Building name prefix
-	pipelineID := os.Getenv("CI_PIPELINE_ID")
+	jobID := os.Getenv("CI_JOB_ID")
 	projectID := os.Getenv("CI_PROJECT_ID")
-	if pipelineID == "" || projectID == "" {
-		return nil, fmt.Errorf("unable to compute name prefix, missing variables pipeline id: %s, project id: %s", pipelineID, projectID)
+	if jobID == "" || projectID == "" {
+		return nil, fmt.Errorf("unable to compute name prefix, missing variables job id: %s, project id: %s", jobID, projectID)
 	}
 
 	store := parameters.NewEnvStore(EnvPrefix)
@@ -68,7 +69,7 @@ func NewCIProfile() (Profile, error) {
 
 	return ciProfile{
 		baseProfile: newProfile("e2eci", ciEnvironments, store, &secretStore, outputRoot),
-		ciUniqueID:  "ci-" + pipelineID + "-" + projectID,
+		ciUniqueID:  "ci-" + jobID + "-" + projectID,
 	}, nil
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Use job id instead of pipeline id to name pulumi stacks on the CI

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Limit collisions on stacks across jobs running on the same pipeline. We currently ask to ensure each concurrent job has one stack with one unique name, this change would allow to run the same test suite with different flavours on the same pipeline

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
