### PR TITLE
omnibus: python3: don't generate debug symbols

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -41,6 +41,9 @@ if ohai["platform"] != "windows"
     license "Python-2.0"
 
     env = with_standard_compiler_flags(with_embedded_path)
+    # Force different defaults for the "optimization settings"
+    # This removes the debug symbol generation and doesn't enable all warnings
+    env["OPT"] = "-DNDEBUG -fwrapv"
     configure(*python_configure_options, :env => env)
     command "make -j #{workers}", :env => env
     command "make install", :env => env


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR disable debug symbols when building python

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Most of the disk used by our python artifacts are coming from debug symbols which aren't stripped by omnibus (we ship libpython as a static library and omnibus only strips shared library)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
