### PR TITLE
basic windows discarder on `create.file.{path,name}`

### DIFF
--- a/pkg/security/metrics/metrics_windows.go
+++ b/pkg/security/metrics/metrics_windows.go
@@ -59,6 +59,14 @@ var (
 	//Tags: -
 	MetricWindowsFileIDRename29 = newRuntimeMetric(".windows.file.id_rename29")
 
+	//MetricWindowsFileCreateSkippedDiscardedPaths is the metric for counting file create notifications for skipped discarded paths
+	//Tags: -
+	MetricWindowsFileCreateSkippedDiscardedPaths = newRuntimeMetric(".windows.file.create_skipped_discarded_paths")
+
+	//MetricWindowsFileCreateSkippedDiscardedBasenames is the metric for counting file create notifications for skipped discarded basenames
+	//Tags: -
+	MetricWindowsFileCreateSkippedDiscardedBasenames = newRuntimeMetric(".windows.file.create_skipped_discarded_basenames")
+
 	//MetricWindowsRegCreateKey is the metric for counting registry key create notifications
 	//Tags: -
 	MetricWindowsRegCreateKey = newRuntimeMetric(".windows.registry.create_key")

--- a/pkg/security/probe/discarders_windows.go
+++ b/pkg/security/probe/discarders_windows.go
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package probe
+
+func init() {
+	SupportedDiscarders["create.file.path"] = true
+}

--- a/pkg/security/probe/discarders_windows.go
+++ b/pkg/security/probe/discarders_windows.go
@@ -7,4 +7,5 @@ package probe
 
 func init() {
 	SupportedDiscarders["create.file.path"] = true
+	SupportedDiscarders["create.file.name"] = true
 }

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -130,7 +130,7 @@ The Parameters.Create.FileAttributes and Parameters.Create.EaLength members are 
 	by file systems and file system filter drivers. For more information, see the IRP_MJ_CREATE topic in
 	the Installable File System (IFS) documentation.
 */
-func (p *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHandleArgs, error) {
+func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHandleArgs, error) {
 	ca := &createHandleArgs{
 		DDEventHeader: e.EventHeader,
 	}
@@ -158,28 +158,28 @@ func (p *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHandl
 		return nil, fmt.Errorf("unknown version %v", e.EventHeader.EventDescriptor.Version)
 	}
 
-	p.filePathResolverLock.Lock()
-	defer p.filePathResolverLock.Unlock()
+	wp.filePathResolverLock.Lock()
+	defer wp.filePathResolverLock.Unlock()
 
-	if _, ok := p.discardedPaths.Get(ca.fileName); ok {
-		p.stats.fileCreateSkippedDiscardedPaths++
+	if _, ok := wp.discardedPaths.Get(ca.fileName); ok {
+		wp.stats.fileCreateSkippedDiscardedPaths++
 		return nil, errDiscardedPath
 	}
 
 	// not amazing to double compute the basename..
 	basename := filepath.Base(ca.fileName)
-	if _, ok := p.discardedBasenames.Get(basename); ok {
-		p.stats.fileCreateSkippedDiscardedBasenames++
+	if _, ok := wp.discardedBasenames.Get(basename); ok {
+		wp.stats.fileCreateSkippedDiscardedBasenames++
 		return nil, errDiscardedPath
 	}
 
-	p.filePathResolver[ca.fileObject] = ca.fileName
+	wp.filePathResolver[ca.fileObject] = ca.fileName
 
 	return ca, nil
 }
 
-func (p *WindowsProbe) parseCreateNewFileArgs(e *etw.DDEventRecord) (*createNewFileArgs, error) {
-	ca, err := p.parseCreateHandleArgs(e)
+func (wp *WindowsProbe) parseCreateNewFileArgs(e *etw.DDEventRecord) (*createNewFileArgs, error) {
+	ca, err := wp.parseCreateHandleArgs(e)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -158,9 +158,6 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 		return nil, fmt.Errorf("unknown version %v", e.EventHeader.EventDescriptor.Version)
 	}
 
-	wp.filePathResolverLock.Lock()
-	defer wp.filePathResolverLock.Unlock()
-
 	if _, ok := wp.discardedPaths.Get(ca.fileName); ok {
 		wp.stats.fileCreateSkippedDiscardedPaths++
 		return nil, errDiscardedPath
@@ -173,6 +170,8 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 		return nil, errDiscardedPath
 	}
 
+	wp.filePathResolverLock.Lock()
+	defer wp.filePathResolverLock.Unlock()
 	wp.filePathResolver[ca.fileObject] = ca.fileName
 
 	return ca, nil

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -162,12 +162,14 @@ func (p *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHandl
 	defer p.filePathResolverLock.Unlock()
 
 	if _, ok := p.discardedPaths.Get(ca.fileName); ok {
+		p.stats.fileCreateSkippedDiscardedPaths++
 		return nil, errDiscardedPath
 	}
 
 	// not amazing to double compute the basename..
 	basename := filepath.Base(ca.fileName)
 	if _, ok := p.discardedBasenames.Get(basename); ok {
+		p.stats.fileCreateSkippedDiscardedBasenames++
 		return nil, errDiscardedPath
 	}
 

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -9,6 +9,7 @@ package probe
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -163,6 +164,13 @@ func (p *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHandl
 	if _, ok := p.discardedPaths.Get(ca.fileName); ok {
 		return nil, errDiscardedPath
 	}
+
+	// not amazing to double compute the basename..
+	basename := filepath.Base(ca.fileName)
+	if _, ok := p.discardedBasenames.Get(basename); ok {
+		return nil, errDiscardedPath
+	}
+
 	p.filePathResolver[ca.fileObject] = ca.fileName
 
 	return ca, nil

--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -33,6 +34,11 @@ func createTestProbe() (*WindowsProbe, error) {
 	}
 	cfg.RuntimeSecurity.FIMEnabled = true
 
+	discardedPaths, err := simplelru.NewLRU[string, struct{}](1<<10, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	// probe and config are provided as null.  During the tests, it is assumed
 	// that we will not access those values.
 	wp := &WindowsProbe{
@@ -40,6 +46,7 @@ func createTestProbe() (*WindowsProbe, error) {
 		config:           cfg,
 		filePathResolver: make(map[fileObjectPointer]string, 0),
 		regPathResolver:  make(map[regObjectPointer]string, 0),
+		discardedPaths:   discardedPaths,
 	}
 	err = wp.Init()
 

--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -39,6 +39,11 @@ func createTestProbe() (*WindowsProbe, error) {
 		return nil, err
 	}
 
+	discardedBasenames, err := simplelru.NewLRU[string, struct{}](1<<10, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	// probe and config are provided as null.  During the tests, it is assumed
 	// that we will not access those values.
 	wp := &WindowsProbe{
@@ -46,7 +51,8 @@ func createTestProbe() (*WindowsProbe, error) {
 		config:           cfg,
 		filePathResolver: make(map[fileObjectPointer]string, 0),
 		regPathResolver:  make(map[regObjectPointer]string, 0),
-		discardedPaths:   discardedPaths,
+		discardedPaths:     discardedPaths,
+		discardedBasenames: discardedBasenames,
 	}
 	err = wp.Init()
 

--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
-	"github.com/hashicorp/golang-lru/v2/simplelru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -34,12 +34,12 @@ func createTestProbe() (*WindowsProbe, error) {
 	}
 	cfg.RuntimeSecurity.FIMEnabled = true
 
-	discardedPaths, err := simplelru.NewLRU[string, struct{}](1<<10, nil)
+	discardedPaths, err := lru.New[string, struct{}](1 << 10)
 	if err != nil {
 		return nil, err
 	}
 
-	discardedBasenames, err := simplelru.NewLRU[string, struct{}](1<<10, nil)
+	discardedBasenames, err := lru.New[string, struct{}](1 << 10)
 	if err != nil {
 		return nil, err
 	}
@@ -47,10 +47,10 @@ func createTestProbe() (*WindowsProbe, error) {
 	// probe and config are provided as null.  During the tests, it is assumed
 	// that we will not access those values.
 	wp := &WindowsProbe{
-		opts:             opts,
-		config:           cfg,
-		filePathResolver: make(map[fileObjectPointer]string, 0),
-		regPathResolver:  make(map[regObjectPointer]string, 0),
+		opts:               opts,
+		config:             cfg,
+		filePathResolver:   make(map[fileObjectPointer]string, 0),
+		regPathResolver:    make(map[regObjectPointer]string, 0),
 		discardedPaths:     discardedPaths,
 		discardedBasenames: discardedBasenames,
 	}

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -748,8 +748,8 @@ func (p *WindowsProbe) OnNewDiscarder(_ *rules.RuleSet, ev *model.Event, field e
 
 	fileObject := fileObjectPointer(ev.CreateNewFile.File.FileObject)
 	p.filePathResolverLock.Lock()
+	defer p.filePathResolverLock.Unlock()
 	delete(p.filePathResolver, fileObject)
-	p.filePathResolverLock.Unlock()
 }
 
 // NewModel returns a new Model

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -747,7 +747,9 @@ func (p *WindowsProbe) OnNewDiscarder(_ *rules.RuleSet, ev *model.Event, field e
 	}
 
 	fileObject := fileObjectPointer(ev.CreateNewFile.File.FileObject)
-	delete(filePathResolver, fileObject)
+	p.filePathResolverLock.Lock()
+	delete(p.filePathResolver, fileObject)
+	p.filePathResolverLock.Unlock()
 }
 
 // NewModel returns a new Model

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -723,16 +723,12 @@ func (p *WindowsProbe) FlushDiscarders() error {
 // OnNewDiscarder handles discarders
 func (p *WindowsProbe) OnNewDiscarder(_ *rules.RuleSet, ev *model.Event, field eval.Field, evalType eval.EventType) {
 	if evalType == "create" && field == "create.file.path" {
-		value, err := ev.GetFieldValue(field)
-		if err != nil {
-			seclog.Errorf("error getting field value for `%s` -> `%v`", field, err)
-			return
-		}
+		path := ev.CreateNewFile.File.PathnameStr
+		fileObject := fileObjectPointer(ev.CreateNewFile.File.FileObject)
 
-		seclog.Errorf("new discarder for `%s` -> `%v`", field, value)
-		if sval, ok := value.(string); ok {
-			p.discardedPaths.Add(sval, struct{}{})
-		}
+		seclog.Errorf("new discarder for `%s` -> `%v`", field, path)
+		p.discardedPaths.Add(path, struct{}{})
+		delete(filePathResolver, fileObject)
 	}
 }
 

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -717,6 +717,7 @@ func (p *WindowsProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetRe
 
 // FlushDiscarders invalidates all the discarders
 func (p *WindowsProbe) FlushDiscarders() error {
+	p.discardedPaths.Purge()
 	return nil
 }
 

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -32,7 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/windowsdriver/procmon"
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/cenkalti/backoff/v4"
-	"github.com/hashicorp/golang-lru/v2/simplelru"
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	"golang.org/x/sys/windows"
 )
@@ -78,8 +78,8 @@ type WindowsProbe struct {
 	// stats
 	stats stats
 	// discarders
-	discardedPaths     *simplelru.LRU[string, struct{}]
-	discardedBasenames *simplelru.LRU[string, struct{}]
+	discardedPaths     *lru.Cache[string, struct{}]
+	discardedBasenames *lru.Cache[string, struct{}]
 }
 
 type etwNotification struct {
@@ -672,12 +672,12 @@ func (p *WindowsProbe) SendStats() error {
 
 // NewWindowsProbe instantiates a new runtime security agent probe
 func NewWindowsProbe(probe *Probe, config *config.Config, opts Opts) (*WindowsProbe, error) {
-	discardedPaths, err := simplelru.NewLRU[string, struct{}](1<<10, nil)
+	discardedPaths, err := lru.New[string, struct{}](1 << 10)
 	if err != nil {
 		return nil, err
 	}
 
-	discardedBasenames, err := simplelru.NewLRU[string, struct{}](1<<10, nil)
+	discardedBasenames, err := lru.New[string, struct{}](1 << 10)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -115,8 +115,8 @@ type stats struct {
 	regSetValueKey uint64
 
 	//filePathResolver status
-	filePathNewWrites  uint64
-	filePathOverwrites uint64
+	fileCreateSkippedDiscardedPaths     uint64
+	fileCreateSkippedDiscardedBasenames uint64
 }
 
 /*
@@ -636,6 +636,13 @@ func (p *WindowsProbe) SendStats() error {
 	if err := p.statsdClient.Gauge(metrics.MetricWindowsFileIDRename29, float64(p.stats.fileidRename29), nil, 1); err != nil {
 		return err
 	}
+	if err := p.statsdClient.Gauge(metrics.MetricWindowsFileCreateSkippedDiscardedPaths, float64(p.stats.fileCreateSkippedDiscardedPaths), nil, 1); err != nil {
+		return err
+	}
+	if err := p.statsdClient.Gauge(metrics.MetricWindowsFileCreateSkippedDiscardedBasenames, float64(p.stats.fileCreateSkippedDiscardedBasenames), nil, 1); err != nil {
+		return err
+	}
+
 	if err := p.statsdClient.Gauge(metrics.MetricWindowsRegCreateKey, float64(p.stats.regCreateKey), nil, 1); err != nil {
 		return err
 	}
@@ -658,12 +665,6 @@ func (p *WindowsProbe) SendStats() error {
 		return err
 	}
 	if err := p.statsdClient.Gauge(metrics.MetricWindowsSizeOfRegistryPathResolver, float64(len(p.regPathResolver)), nil, 1); err != nil {
-		return err
-	}
-	if err := p.statsdClient.Gauge(metrics.MetricWindowsFileResolverNew, float64(p.stats.filePathNewWrites), nil, 1); err != nil {
-		return err
-	}
-	if err := p.statsdClient.Gauge(metrics.MetricWindowsFileResolverOverwrite, float64(p.stats.filePathOverwrites), nil, 1); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -493,6 +493,7 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 		ev.Type = uint32(model.CreateNewFileEventType)
 		ev.CreateNewFile = model.CreateNewFileEvent{
 			File: model.FileEvent{
+				FileObject:  uint64(arg.fileObject),
 				PathnameStr: arg.fileName,
 				BasenameStr: filepath.Base(arg.fileName),
 			},

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -44,6 +44,7 @@ type Event struct {
 
 // FileEvent is the common file event type
 type FileEvent struct {
+	FileObject  uint64 `field:"-"`                                                                                  // handle numeric value
 	PathnameStr string `field:"path,handler:ResolveFilePath,opts:length" op_override:"eval.WindowsPathCmp"`         // SECLDoc[path] Definition:`File's path` Example:`exec.file.path == "c:\cmd.bat"` Description:`Matches the execution of the file located at c:\cmd.bat`
 	BasenameStr string `field:"name,handler:ResolveFileBasename,opts:length" op_override:"eval.CaseInsensitiveCmp"` // SECLDoc[name] Definition:`File's basename` Example:`exec.file.name == "cmd.bat"` Description:`Matches the execution of any file named cmd.bat.`
 }


### PR DESCRIPTION
### What does this PR do?

This PR implements a basic discarder for paths operating on `create.file.path` and `create.file.name`.
The current implementation stores a mapping `handle -> file path`. This mapping can grow quickly in size and be filled with paths of no interest. The goal of this PR is to use discarders to:
- clean up this map of non-interesting mapping entries
- shortcut new event evaluation when the path is already known to be not interesting

The result of this PR is a big improvement in memory usage.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
