### PR TITLE
feat(ci): Always build agent 6 & 7 together

### DIFF
--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -1,6 +1,7 @@
 import os
 import pprint
 import re
+import sys
 import time
 from datetime import datetime, timedelta
 
@@ -215,7 +216,7 @@ def run(
     git_ref=None,
     here=False,
     use_release_entries=False,
-    major_versions='6,7',
+    major_versions=None,
     repo_branch="dev",
     deploy=False,
     all_builds=True,
@@ -277,11 +278,11 @@ def run(
         release_version_6 = nightly_entry_for(6)
         release_version_7 = nightly_entry_for(7)
 
-    major_versions = major_versions.split(',')
-    if '6' not in major_versions:
-        release_version_6 = ""
-    if '7' not in major_versions:
-        release_version_7 = ""
+    if major_versions:
+        print(
+            "[WARNING] --major-versions option will be deprecated soon. Both Agent 6 & 7 will be run everytime.",
+            file=sys.stderr,
+        )
 
     if here:
         git_ref = ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Remove the possibility to build agent 6 xor agent 7. Replace the modification by a warning to be compatible with current calls for a while
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Simplification of gitlab configuration
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Behaviour before:
```
inv pipeline.run --major-versions 6 --git-ref nschweitzer/test_main
There are already 1 pipeline(s) running on the target git ref.
For each of them, you'll be asked whether you want to cancel them or not.
If you don't need these pipelines, please cancel them to save CI resources.
They are ordered from the newest one to the oldest one.

Pipeline 31121538 (https://gitlab.ddbuild.io/DataDog/datadog-agent/pipelines/31121538)
Started at Fri Mar 29 17:40:22 2024 (2024-03-29T16:40:22.173Z)
Commit: Nschweitzer/acix 87/merge a6a7 (#24219) (a813e319) by Nicolas Schweitzer
Do you want to cancel this pipeline? [Y/n] Y
Pipeline 31121538 has been cancelled.

Creating pipeline for datadog-agent on branch/tag nschweitzer/test_main with args:
  - RUN_ALL_BUILDS: true
  - RUN_E2E_TESTS: on
  - RELEASE_VERSION_6: nightly
  - RELEASE_VERSION_7: 
  - BUCKET_BRANCH: dev
```
and after
```
[WARNING] Running only Agent 6 is no more supported. We will run both Agent 6 and Agent 7.
There are already 1 pipeline(s) running on the target git ref.
For each of them, you'll be asked whether you want to cancel them or not.
If you don't need these pipelines, please cancel them to save CI resources.
They are ordered from the newest one to the oldest one.

Pipeline 31123299 (https://gitlab.ddbuild.io/DataDog/datadog-agent/pipelines/31123299)
Started at Fri Mar 29 18:03:06 2024 (2024-03-29T17:03:06.022Z)
Commit: feat(ci): Always build agent 6 & 7 together (3d5037d9) by Nicolas Schweitzer
Do you want to cancel this pipeline? [Y/n] Y
Pipeline 31123299 has been cancelled.

Creating pipeline for datadog-agent on branch/tag nschweitzer/acix-87/warning with args:
  - RUN_ALL_BUILDS: true
  - RUN_E2E_TESTS: on
  - RELEASE_VERSION_6: nightly
  - RELEASE_VERSION_7: nightly-a7
  - BUCKET_BRANCH: dev
```

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
