### PR TITLE
Handle early subscriber channel closure in tagger server

### DIFF
--- a/comp/core/tagger/server/server.go
+++ b/comp/core/tagger/server/server.go
@@ -60,7 +60,12 @@ func (s *Server) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.AgentSecu
 	defer ticker.Stop()
 	for {
 		select {
-		case events := <-eventCh:
+		case events, ok := <-eventCh:
+			if !ok {
+				log.Warnf("subscriber channel closed, client will reconnect")
+				return fmt.Errorf("subscriber channel closed")
+			}
+
 			ticker.Reset(streamKeepAliveInterval)
 
 			responseEvents := make([]*pb.StreamTagsEvent, 0, len(events))

--- a/comp/core/tagger/subscriber/subscriber.go
+++ b/comp/core/tagger/subscriber/subscriber.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const bufferSize = 100
+const bufferSize = 1000
 
 // Subscriber allows processes to subscribe to entity events generated from a
 // tagger.

--- a/releasenotes/notes/fix-tagger-race-condition-d8fe3104ad6f9a30.yaml
+++ b/releasenotes/notes/fix-tagger-race-condition-d8fe3104ad6f9a30.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug where the tagger server did not properly handle a closed channel.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Handles early subscriber channel closure in the tagger server. Previously, if the subscriber channel was closed (due to being full), then the main tagger server logic would go into a tight loop and re-send empty events, since it didn't check for the channel closure. This causes a CPU regression. Now, if the internal subscription logic closes the channel, the server exits the loop, and the client will eventually reconnect.

This condition triggers when 1) A large number of events/tags exist and 2) a client connects, and then there a Notify call occurring very shortly after subscription. Even with this fix, a client could theoretically enter a bad state of constantly getting its channel closed and needing to reconnect. However, the longer the agents runs, the rarer Notify events become. So, it may take 1-2 tries, but a client should eventually be able to process all events before the next Notify call, even if the buffer is full.

This PR also bumps the channel size to reduce the likelihood of the client needing to reconnect, even if this is now handled properly.

Another option to make this more robust would be to allow the Notify call to block for some small amount of time, rather than just immediately close the connection. This would give the client some time to process events, but it would mean that the Notify callers can now block, which could have larger upstream implications.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/CONTINT-4019

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

The larger buffer size means that the core agent might use slightly more RAM during the first few seconds after initialization (or if a client slows down). However, even 1000 elements in the channel is quite small and the impact will be negligible.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
This needs to be deployed in staging, since the trigger condition is fairly rare.
