### PR TITLE
[RC] fix misleading log statement

### DIFF
--- a/comp/remote-config/rcserviceha/rcservicehaimpl/rcserviceha.go
+++ b/comp/remote-config/rcserviceha/rcservicehaimpl/rcserviceha.go
@@ -81,7 +81,7 @@ func newHaRemoteConfigService(deps dependencies) (rcserviceha.Component, error) 
 		options = append(options, remoteconfig.WithRefreshInterval(deps.Cfg.GetDuration("ha.remote_configuration.refresh_interval"), "ha.remote_configuration.refresh_interval"))
 	}
 	if deps.Cfg.IsSet("ha.remote_configuration.max_backoff_interval") {
-		options = append(options, remoteconfig.WithMaxBackoffInterval(deps.Cfg.GetDuration("ha.remote_configuration.max_backoff_interval"), "remote_configuration.max_backoff_time"))
+		options = append(options, remoteconfig.WithMaxBackoffInterval(deps.Cfg.GetDuration("ha.remote_configuration.max_backoff_interval"), "ha.remote_configuration.max_backoff_time"))
 	}
 	if deps.Cfg.IsSet("ha.remote_configuration.clients.ttl_seconds") {
 		options = append(options, remoteconfig.WithClientTTL(deps.Cfg.GetDuration("ha.remote_configuration.clients.ttl_seconds"), "ha.remote_configuration.clients.ttl_seconds"))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Updates a misleading log statement that describes that the wrong configuration is out of the expected range. This configuration is not in use yet.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

start up the agent with remote configuration enabled and HA enabled. Configure `ha.remote_configuration.max_backoff_interval` to be `1s`. Ensure the following log statement appears:
`ha.remote_configuration.max_backoff_interval is set to 1s which is below the minimum of 2m0s - setting value to 2m0s` (note the `ha.` prefix that was previously missing from the log statement).

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
