### PR TITLE
Change OTel top-level spans identification logic to opt-in instead of default

### DIFF
--- a/cmd/trace-agent/test/testsuite/otlp_test.go
+++ b/cmd/trace-agent/test/testsuite/otlp_test.go
@@ -246,6 +246,7 @@ otlp_config:
       endpoint: 0.0.0.0:5111
 apm_config:
   env: my-env
+  features: ["enable_otlp_compute_top_level_by_span_kind"]
 `, port)
 		if err := r.RunAgent([]byte(c)); err != nil {
 			t.Fatal(err)
@@ -312,7 +313,6 @@ otlp_config:
       endpoint: 0.0.0.0:5111
 apm_config:
   env: my-env
-  features: ["disable_otlp_compute_top_level_by_span_kind"]
 `, port)
 		if err := r.RunAgent([]byte(c)); err != nil {
 			t.Fatal(err)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1553,8 +1553,9 @@ api_key:
   ## @env DD_APM_COMPUTE_STATS_BY_SPAN_KIND - bool - default: false
   ## [BETA] Enables an additional stats computation check on spans to see they have an eligible `span.kind` (server, consumer, client, producer).
   ## If enabled, a span with an eligible `span.kind` will have stats computed. If disabled, only top-level and measured spans will have stats computed.
-  ## NOTE: Stats are computed by span kind for OTel traces by default.
-  ## If you are sending OTel traces and do not want stats computed by span kind, you need to disable this flag and enable the "disable_otlp_compute_top_level_by_span_kind" APM feature.
+  ## NOTE: For stats computed from OTel traces, only top-level spans are considered when this option is off.
+  ## If you are sending OTel traces and want stats on non-top-level spans, this flag will need to be enabled.
+  ## If you are sending OTel traces and do not want stats computed by span kind, you need to disable this flag and remove the "enable_otlp_compute_top_level_by_span_kind" APM feature if present.
   # compute_stats_by_span_kind: false
 
   ## @param peer_service_aggregation - bool - default: false
@@ -1587,7 +1588,7 @@ api_key:
   ## The list of items available under apm_config.features is not guaranteed to persist across versions;
   ## a feature may eventually be promoted to its own configuration option on the agent, or dropped entirely.
   #
-  # features: ["error_rare_sample_tracer_drop","table_names","component2name","sql_cache","disable_otlp_compute_top_level_by_span_kind"]
+  # features: ["error_rare_sample_tracer_drop","table_names","component2name","sql_cache","enable_otlp_compute_top_level_by_span_kind"]
 
   ## @param additional_endpoints - object - optional
   ## @env DD_APM_ADDITIONAL_ENDPOINTS - object - optional

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -557,7 +557,7 @@ func TestOTLPReceiveResourceSpans(t *testing.T) {
 		}}
 
 		t.Run("default", testAndExpect(testSpans, http.Header{}, func(p *Payload) {
-			require.True(p.ClientComputedTopLevel)
+			require.False(p.ClientComputedTopLevel)
 		}))
 
 		t.Run("header", testAndExpect(testSpans, http.Header{
@@ -566,10 +566,10 @@ func TestOTLPReceiveResourceSpans(t *testing.T) {
 			require.True(p.ClientComputedTopLevel)
 		}))
 
-		cfg.Features["disable_otlp_compute_top_level_by_span_kind"] = struct{}{}
+		cfg.Features["enable_otlp_compute_top_level_by_span_kind"] = struct{}{}
 
 		t.Run("withFeatureFlag", testAndExpect(testSpans, http.Header{}, func(p *Payload) {
-			require.False(p.ClientComputedTopLevel)
+			require.True(p.ClientComputedTopLevel)
 		}))
 
 		t.Run("headerWithFeatureFlag", testAndExpect(testSpans, http.Header{

--- a/releasenotes/notes/otel-top-level-spans-3e391e77dd7ebf83.yaml
+++ b/releasenotes/notes/otel-top-level-spans-3e391e77dd7ebf83.yaml
@@ -8,7 +8,6 @@
 ---
 features:
   - |
-    OTLP ingest now identifies top-level spans by span kind for OpenTelemetry spans by default. This is both a breaking change and a bug fix that may increase the number of spans that generate trace metrics. This new logic can be disabled if needed by adding `disable_otlp_compute_top_level_by_span_kind` in DD_APM_FEATURES.
+    OTLP ingest now has a feature flag to identify top-level spans by span kind. This new logic can be enabled by adding `enable_otlp_compute_top_level_by_span_kind` in DD_APM_FEATURES.
     - With this new logic, root spans and spans with a server or consumer `span.kind` will be marked as top-level. Additionally, spans with a client or producer `span.kind` will have stats computed.
-    - If `disable_otlp_compute_top_level_by_span_kind` is enabled, this new logic will be disabled and OpenTelemetry spans may be misidentified as top-level.
-    - To disable computing stats by span kind for OTel traces, enable `disable_otlp_compute_top_level_by_span_kind` and disable `apm_config.compute_stats_by_span_kind`.
+    - Enabling this feature flag may increase the number of spans that generate trace metrics, and may change which spans appear as top-level in Datadog.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Changes new OTel top-level spans identification logic from https://github.com/DataDog/datadog-agent/pull/22163 to opt-in instead of default.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The OTel top-level spans identification changes have been delayed until we have a new policy for releasing breaking changes for OTel customers. Changing this feature to opt-in prevents breaking changes.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Add APM feature flag "enable_otlp_compute_top_level_by_span_kind". Send OTLP spans of varying span kinds and verify that root spans and server/consumer spans are marked as top-level in Datadog. Also verify that client/producer spans are marked as measured and have stats computed, and internal spans are not marked as top-level or measured.
