### PR TITLE
[CWS] add toggle in module tester to disable trace pipe logging

### DIFF
--- a/pkg/security/tests/main_linux.go
+++ b/pkg/security/tests/main_linux.go
@@ -136,6 +136,7 @@ var (
 	logStatusMetrics bool
 	withProfile      bool
 	trace            bool
+	disableTracePipe bool
 )
 
 var testSuitePid uint32
@@ -145,6 +146,7 @@ func init() {
 	flag.BoolVar(&logStatusMetrics, "status-metrics", false, "display status metrics")
 	flag.BoolVar(&withProfile, "with-profile", false, "enable profile per test")
 	flag.BoolVar(&trace, "trace", false, "wrap the test suite with the ptracer")
+	flag.BoolVar(&disableTracePipe, "no-trace-pipe", false, "disable the trace pipe log")
 
 	testSuitePid = utils.Getpid()
 }

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -656,7 +656,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		testMod.t = t
 		testMod.opts.dynamicOpts = opts.dynamicOpts
 
-		if !ebpfLessEnabled {
+		if !disableTracePipe && !ebpfLessEnabled {
 			if testMod.tracePipe, err = testMod.startTracing(); err != nil {
 				return testMod, err
 			}
@@ -768,7 +768,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		opts.staticOpts.preStartCallback(testMod)
 	}
 
-	if !ebpfLessEnabled {
+	if !disableTracePipe && !ebpfLessEnabled {
 		if testMod.tracePipe, err = testMod.startTracing(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### What does this PR do?

The trace pipe logger is an interesting feature, especially in CI, but it can cause issue when developing locally and you just want the trace pipe on one terminal and your testsuite on the other (because you cannot open a trace pipe if another one is already in use). This PR adds a flag to disable the automatic trace pipe logger giving you freedom to do it manually if needed. This toggle is disabled by default so everything stays the same unless explicitly specified.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
