### PR TITLE
[usm] Build lookup table test programs as Go modules

### DIFF
--- a/pkg/network/go/rungo/matrix/matrix.go
+++ b/pkg/network/go/rungo/matrix/matrix.go
@@ -44,7 +44,7 @@ type Runner struct {
 	// the HOME environment variable is replaced with a synthetic value.
 	//
 	// To skip a version-architecture pair, return `nil` for this function.
-	GetCommand func(ctx context.Context, version goversion.GoVersion, arch string) *exec.Cmd
+	GetCommand func(ctx context.Context, version goversion.GoVersion, arch string, goExe string) *exec.Cmd
 }
 
 type architectureVersion struct {
@@ -202,16 +202,11 @@ func (r *Runner) installSingleVersion(ctx context.Context, version goversion.GoV
 }
 
 func (r *Runner) runSingleCommand(ctx context.Context, goExe string, version goversion.GoVersion, arch string) error {
-	command := r.GetCommand(ctx, version, arch)
+	command := r.GetCommand(ctx, version, arch, goExe)
 	if command == nil {
 		// Allow the GetCommand implementation to skip a version/arch combination
 		return nil
 	}
-
-	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "GOARCH", arch))
-	// The $HOME directory needs to be set to the Go installation directory
-	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "HOME", r.getInstallLocation()))
-	command.Path = goExe
 
 	// Dump the command
 	log.Printf("[%s-%s] %s %s %s", version, arch, strings.Join(command.Env, " "), command.Path, strings.Join(command.Args[1:], " "))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Build Go test programs used for generating the lookup tables (Go TLS monitoring).

### Motivation

Enable use of 3rd party library types.
Currently our test programs (for example `pkg/network/protocols/http/gotls/lookup/internal/program.go`) used for the purposes of binary inspection can't rely on 3rd party libraries because the `go build` command is not able to automatically resolve dependencies.
This PR addresses that by making use of go modules.

### Additional Notes

Depends on https://github.com/DataDog/datadog-agent/pull/24202
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
