### PR TITLE
run multiple CodeQL languages in parallel

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   CodeQL-Build:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        language: ["go", "javascript", "python", "cpp"]
 
     steps:
       - name: Checkout repository
@@ -42,7 +45,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: go, javascript, python, cpp
+          languages: ${{ matrix.language }}
           setup-python-dependencies: false
           # Defining a fixed CodeQL bundle version
           tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-20230207/codeql-bundle-linux64.tar.gz


### PR DESCRIPTION
### What does this PR do?

The CodeQL action is currently the bottleneck of merge queue branches. If we don't want to disable it there (which is another option clearly), this PR moves it to a parallel job, running multiple languages in parallel. The result is an action that runs in ~20 min, instead of 25-30 min currently.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
