### PR TITLE
fix(ci): prevent pipelines from being in blocked state

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1232,6 +1232,7 @@ workflow:
         - test/new-e2e/tests/agent-shared-components/**/*
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
+    allow_failure: true
 
 .on_subcommands_or_e2e_changes_or_manual:
   - !reference [.on_e2e_main_release_or_rc]
@@ -1243,6 +1244,7 @@ workflow:
         - test/new-e2e/tests/agent-subcommands/**/*
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
+    allow_failure: true
 
 .on_language-detection_or_e2e_changes_or_manual:
   - !reference [.on_e2e_main_release_or_rc]

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -11,6 +11,7 @@ variables:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: always
     - when: manual
+      allow_failure: true
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
   image: $BENCHMARKS_CI_IMAGE
   needs: ["setup_agent_version"]
@@ -51,7 +52,6 @@ trace-agent-v04-2cpus-normal_load-fixed_sps:
 
 trace-agent-v04-2cpus-stress_load-fixed_sps:
   extends: .trace_agent_benchmarks
-  when: manual
   variables:
     TRACE_AGENT_ENDPOINT: v04
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-2cpus-stress_load-fixed_sps
@@ -72,7 +72,6 @@ trace-agent-v05-2cpus-normal_load-fixed_sps:
 
 trace-agent-v05-2cpus-stress_load-fixed_sps:
   extends: .trace_agent_benchmarks
-  when: manual
   variables:
     TRACE_AGENT_ENDPOINT: v05
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-2cpus-stress_load-fixed_sps

--- a/.gitlab/deploy_containers/conditions.yml
+++ b/.gitlab/deploy_containers/conditions.yml
@@ -32,6 +32,7 @@
 .on_rc:
   - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
     when: manual
+    allow_failure: true
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
@@ -80,6 +81,7 @@
 .on_internal_rc:
   - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
     when: manual
+    allow_failure: true
     variables:
       AGENT_REPOSITORY: ci/datadog-agent/agent-release
       CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
As per [documentation](https://docs.gitlab.com/ee/ci/yaml/#allow_failure:~:text=false%20for%20jobs%20that%20use%20when%3A%20manual%20inside%20rules.), `allow_failure` defaults to `false` when used with `when: manual`. So added a bunch of `allow_failure: true` to unblock PR builds

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
CI performance

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Before
![image](https://github.com/DataDog/datadog-agent/assets/24426034/36b470b6-bb10-4d53-9103-fb542d100b9a)
after
![image](https://github.com/DataDog/datadog-agent/assets/24426034/81d3e9fe-15ad-4fc9-9b79-629cf38ef5c0)


<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
