### PR TITLE
 [oracle] Bug fixes for the legacy mode (DBMON-3803)

### DIFF
--- a/pkg/collector/corechecks/oracle/connectionTest.go
+++ b/pkg/collector/corechecks/oracle/connectionTest.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+func (c *Check) connectionTest() error {
+	var n float64
+	err := c.db.Get(&n, "SELECT 1 FROM dual")
+	return err
+}

--- a/pkg/collector/corechecks/oracle/init.go
+++ b/pkg/collector/corechecks/oracle/init.go
@@ -44,6 +44,8 @@ func (c *Check) init() error {
 			} else {
 				c.connectedToPdb = true
 			}
+			c.tagsWithoutDbRole = make([]string, len(tags))
+			copy(c.tagsWithoutDbRole, tags)
 			return nil
 		}
 		return fmt.Errorf("%s failed to query v$instance: %w", c.logPrompt, err)

--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -56,7 +56,6 @@ const (
 )
 
 const serviceCheckName = "oracle.can_query"
-const canConnectServiceCheckName = "oracle.can_query"
 
 type hostingCode string
 

--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -56,6 +56,7 @@ const (
 )
 
 const serviceCheckName = "oracle.can_query"
+const canConnectServiceCheckName = "oracle.can_query"
 
 type hostingCode string
 

--- a/pkg/collector/corechecks/oracle/oracle_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_test.go
@@ -321,6 +321,8 @@ func TestLegacyMode(t *testing.T) {
 	err := c.Run()
 	require.NoError(t, err)
 
+	canConnectServiceCheckName := "oracle.can_query"
+
 	s.AssertServiceCheck(t, canConnectServiceCheckName, servicecheck.ServiceCheckOK, "", []string{"server:localhost"}, "")
 	s.AssertServiceCheck(t, serviceCheckName, servicecheck.ServiceCheckOK, "", []string{"server:localhost"}, "")
 

--- a/pkg/collector/corechecks/oracle/oracle_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_test.go
@@ -15,11 +15,13 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle/common"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle/config"
+	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	_ "github.com/godror/godror"
 	"github.com/jmoiron/sqlx"
 	go_ora "github.com/sijms/go-ora/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConnectionGoOra(t *testing.T) {
@@ -312,4 +314,20 @@ func TestObfuscator(t *testing.T) {
 	sql = "select file# from dual"
 	obfuscatedStatement, err = o.ObfuscateSQLString(sql)
 	assert.Equal(t, sql, obfuscatedStatement.Query)
+}
+
+func TestLegacyMode(t *testing.T) {
+	c, s := newLegacyCheck(t, "")
+	err := c.Run()
+	require.NoError(t, err)
+
+	s.AssertServiceCheck(t, canConnectServiceCheckName, servicecheck.ServiceCheckOK, "", []string{"server:localhost"}, "")
+	s.AssertServiceCheck(t, serviceCheckName, servicecheck.ServiceCheckOK, "", []string{"server:localhost"}, "")
+
+	c, s = newLegacyCheck(t, "only_custom_queries: true")
+	err = c.Run()
+	require.NoError(t, err)
+
+	s.AssertServiceCheck(t, canConnectServiceCheckName, servicecheck.ServiceCheckOK, "", []string{"server:localhost"}, "")
+	s.AssertServiceCheck(t, serviceCheckName, servicecheck.ServiceCheckOK, "", []string{"server:localhost"}, "")
 }


### PR DESCRIPTION
### What does this PR do?

Bug fixes for the Oracle Python integration legacy mode:
- `can_connect` wasn't emitted
- `can_query` emitted without tags
- No service checks emitted when `only_custom_queries = true`
- custom query not working on non-CDB when `only_custom_queries = true`

### Additional Notes

The problems above were noticed during QA testing for the release `7.53`. The intention is to get this PR merged in `7.53`. Since the legacy mode doesn't exist in the previous agent versions, no release note update is needed for this change.

### Describe how to test/QA your changes

For the legacy mode check:
- `can_connect` and `can_query` are emitted with tags, for both values of `only_custom_queries`
- Test `only_custom_queries = true` on non-CDB
