### PR TITLE
Fix trace api dogstatsd unit test to pass locally

### DIFF
--- a/pkg/trace/api/dogstatsd_test.go
+++ b/pkg/trace/api/dogstatsd_test.go
@@ -37,7 +37,7 @@ func TestDogStatsDReverseProxy(t *testing.T) {
 		{
 			"bad statsd host",
 			func(cfg *config.AgentConfig) {
-				cfg.StatsdHost = "this is invalid"
+				cfg.StatsdHost = "this[is[invalid"
 			},
 			http.StatusInternalServerError,
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Change one of the tests of `pkg/trace/api/dogstatsd_test.go` to pass when running locally with AppGate running.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
When AppGate is enabled, the hostname `"this is invalid"` is properly resolved to an IP and the test fails because it shouldn't, which is annoying when testing locally.
Updating the hostname to `"this[is[invalid"` is properly not resolved and the test passes.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
