### PR TITLE
[CWS] windows: normalize filenames before going through glob

### DIFF
--- a/pkg/security/probe/discarders_linux.go
+++ b/pkg/security/probe/discarders_linux.go
@@ -296,7 +296,7 @@ func (id *inodeDiscarders) getParentDiscarderFnc(rs *rules.RuleSet, eventType mo
 		if values := rule.GetFieldValues(field); len(values) > 0 {
 			for _, value := range values {
 				if value.Type == eval.GlobValueType {
-					glob, err := eval.NewGlob(value.Value.(string), false)
+					glob, err := eval.NewGlob(value.Value.(string), false, false)
 					if err != nil {
 						return nil, fmt.Errorf("unexpected glob `%v`: %w", value.Value, err)
 					}

--- a/pkg/security/secl/compiler/eval/glob.go
+++ b/pkg/security/secl/compiler/eval/glob.go
@@ -17,6 +17,7 @@ type Glob struct {
 	elements        []string
 	isScalar        bool
 	caseInsensitive bool
+	normalizePaths  bool
 }
 
 func (g *Glob) contains(filename string) bool {
@@ -112,11 +113,21 @@ func (g *Glob) matches(filename string) bool {
 
 // Contains returns whether the glob pattern matches the beginning of the filename
 func (g *Glob) Contains(filename string) bool {
+	if g.normalizePaths {
+		// normalize to linux-like paths
+		filename = strings.ReplaceAll(filename, "\\", "/")
+	}
+
 	return g.contains(filename)
 }
 
 // Matches the given filename
 func (g *Glob) Matches(filename string) bool {
+	if g.normalizePaths {
+		// normalize to linux-like paths
+		filename = strings.ReplaceAll(filename, "\\", "/")
+	}
+
 	if g.isScalar {
 		if g.caseInsensitive {
 			return strings.EqualFold(g.pattern, filename)
@@ -127,7 +138,12 @@ func (g *Glob) Matches(filename string) bool {
 }
 
 // NewGlob returns a new glob object from the given pattern
-func NewGlob(pattern string, caseInsensitive bool) (*Glob, error) {
+func NewGlob(pattern string, caseInsensitive bool, normalizePaths bool) (*Glob, error) {
+	if normalizePaths {
+		// normalize to linux-like paths
+		pattern = strings.ReplaceAll(pattern, "\\", "/")
+	}
+
 	els := strings.Split(pattern, "/")
 	for i, el := range els {
 		if el == "**" && i+1 != len(els) || strings.Contains(el, "**") && len(el) != len("**") {
@@ -140,5 +156,6 @@ func NewGlob(pattern string, caseInsensitive bool) (*Glob, error) {
 		elements:        els,
 		isScalar:        !strings.Contains(pattern, "*"),
 		caseInsensitive: caseInsensitive,
+		normalizePaths:  normalizePaths,
 	}, nil
 }

--- a/pkg/security/secl/compiler/eval/glob_test.go
+++ b/pkg/security/secl/compiler/eval/glob_test.go
@@ -11,219 +11,219 @@ import (
 )
 
 func TestGlobPattern(t *testing.T) {
-	if _, err := NewGlob("**/conf.d", false); err == nil {
+	if _, err := NewGlob("**/conf.d", false, false); err == nil {
 		t.Error("should return an error")
 	}
 
-	if _, err := NewGlob("/etc/conf.d/**", false); err != nil {
+	if _, err := NewGlob("/etc/conf.d/**", false, false); err != nil {
 		t.Error("shouldn't return an error")
 	}
 
-	if _, err := NewGlob("/etc/**/*.conf", false); err == nil {
+	if _, err := NewGlob("/etc/**/*.conf", false, false); err == nil {
 		t.Error("should return an error")
 	}
 
-	if _, err := NewGlob("/etc/**.conf", false); err == nil {
+	if _, err := NewGlob("/etc/**.conf", false, false); err == nil {
 		t.Error("should return an error")
 	}
 }
 
 func TestGlobContains(t *testing.T) {
-	if glob, _ := NewGlob("/", false); !glob.Contains("/var/log") {
+	if glob, _ := NewGlob("/", false, false); !glob.Contains("/var/log") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/log/*", false); !glob.Contains("/var/log") {
+	if glob, _ := NewGlob("/var/log/*", false, false); !glob.Contains("/var/log") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/log/*", false); !glob.Contains("/var/log/httpd") {
+	if glob, _ := NewGlob("/var/log/*", false, false); !glob.Contains("/var/log/httpd") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("*/log/httpd", false); !glob.Contains("/var/log/httpd") {
+	if glob, _ := NewGlob("*/log/httpd", false, false); !glob.Contains("/var/log/httpd") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("*/log", false); !glob.Contains("/var/log/httpd") {
+	if glob, _ := NewGlob("*/log", false, false); !glob.Contains("/var/log/httpd") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("*/http*", false); glob.Contains("/var/log/httpd") {
+	if glob, _ := NewGlob("*/http*", false, false); glob.Contains("/var/log/httpd") {
 		t.Error("shouldn't contain the filename")
 	}
 
-	if glob, _ := NewGlob("*/*/http*", false); !glob.Contains("/var/log/httpd") {
+	if glob, _ := NewGlob("*/*/http*", false, false); !glob.Contains("/var/log/httpd") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/*/httpd", false); !glob.Contains("/var/log/httpd") {
+	if glob, _ := NewGlob("/var/*/httpd", false, false); !glob.Contains("/var/log/httpd") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/*/httpd", false); glob.Contains("/var/log/nginx") {
+	if glob, _ := NewGlob("/var/*/httpd", false, false); glob.Contains("/var/log/nginx") {
 		t.Error("shouldn't contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/**", false); !glob.Contains("/var/log/nginx") {
+	if glob, _ := NewGlob("/var/**", false, false); !glob.Contains("/var/log/nginx") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/*", false); !glob.Contains("/var/log/nginx") {
+	if glob, _ := NewGlob("/var/*", false, false); !glob.Contains("/var/log/nginx") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/log/ng*", false); !glob.Contains("/var/log/nginx") {
+	if glob, _ := NewGlob("/var/log/ng*", false, false); !glob.Contains("/var/log/nginx") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/*o*/nginx", false); !glob.Contains("/var/log/nginx") {
+	if glob, _ := NewGlob("/var/*o*/nginx", false, false); !glob.Contains("/var/log/nginx") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/**", false); !glob.Contains("/var/log/nginx") {
+	if glob, _ := NewGlob("/var/**", false, false); !glob.Contains("/var/log/nginx") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/log/**", false); !glob.Contains("/var/log/nginx") {
+	if glob, _ := NewGlob("/var/log/**", false, false); !glob.Contains("/var/log/nginx") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/etc/conf.d/ab*", false); !glob.Contains("/etc/conf.d/") {
+	if glob, _ := NewGlob("/etc/conf.d/ab*", false, false); !glob.Contains("/etc/conf.d/") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/*", false); !glob.Contains("/var/log/nginx") {
+	if glob, _ := NewGlob("/var/*", false, false); !glob.Contains("/var/log/nginx") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/log", false); !glob.Contains("/var/log") {
+	if glob, _ := NewGlob("/var/log", false, false); !glob.Contains("/var/log") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/etc/conf.d/*", false); glob.Contains("/etc/sys.d/nginx.conf") {
+	if glob, _ := NewGlob("/etc/conf.d/*", false, false); glob.Contains("/etc/sys.d/nginx.conf") {
 		t.Error("shouldn't contain the filename")
 	}
 
-	if glob, _ := NewGlob("/var/log", false); !glob.Contains("/var/log/httpd") {
+	if glob, _ := NewGlob("/var/log", false, false); !glob.Contains("/var/log/httpd") {
 		t.Error("should contain the filename")
 	}
 }
 
 func TestGlobMatches(t *testing.T) {
-	if glob, _ := NewGlob("/tmp/test/test789", false); !glob.Matches("/tmp/test/test789") {
+	if glob, _ := NewGlob("/tmp/test/test789", false, false); !glob.Matches("/tmp/test/test789") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("*/abc/*", false); !glob.Matches("/1/abc/2") {
+	if glob, _ := NewGlob("*/abc/*", false, false); !glob.Matches("/1/abc/2") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/tmp/test/test789*", false); !glob.Matches("/tmp/test/test7890") {
+	if glob, _ := NewGlob("/tmp/test/test789*", false, false); !glob.Matches("/tmp/test/test7890") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/tmp/test/test789*", false); glob.Matches("/tmp/test") {
+	if glob, _ := NewGlob("/tmp/test/test789*", false, false); glob.Matches("/tmp/test") {
 		t.Error("shouldn't contain the filename")
 	}
 
-	if glob, _ := NewGlob("/tmp/test/*st*", false); glob.Matches("/tmp/test") {
+	if glob, _ := NewGlob("/tmp/test/*st*", false, false); glob.Matches("/tmp/test") {
 		t.Error("shouldn't contain the filename")
 	}
 
-	if glob, _ := NewGlob("/tmp/test/*st*", false); !glob.Matches("/tmp/test/ast") {
+	if glob, _ := NewGlob("/tmp/test/*st*", false, false); !glob.Matches("/tmp/test/ast") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/tmp/*/test789", false); !glob.Matches("/tmp/test/test789") {
+	if glob, _ := NewGlob("/tmp/*/test789", false, false); !glob.Matches("/tmp/test/test789") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/tmp/*/test789", false); glob.Matches("/tmp/test/test") {
+	if glob, _ := NewGlob("/tmp/*/test789", false, false); glob.Matches("/tmp/test/test") {
 		t.Error("shouldn't contain the filename")
 	}
 
-	if glob, _ := NewGlob("/tmp/**", false); !glob.Matches("/tmp/test/ast") {
+	if glob, _ := NewGlob("/tmp/**", false, false); !glob.Matches("/tmp/test/ast") {
 		t.Error("should the filename")
 	}
 
-	if glob, _ := NewGlob("/tmp/*", false); glob.Matches("/tmp/test/ast") {
+	if glob, _ := NewGlob("/tmp/*", false, false); glob.Matches("/tmp/test/ast") {
 		t.Error("shouldn't the filename")
 	}
 
-	if glob, _ := NewGlob("*", false); glob.Matches("/tmp/test/ast") {
+	if glob, _ := NewGlob("*", false, false); glob.Matches("/tmp/test/ast") {
 		t.Error("shouldn't the filename")
 	}
 
-	if glob, _ := NewGlob("**", false); !glob.Matches("/tmp/test/ast") {
+	if glob, _ := NewGlob("**", false, false); !glob.Matches("/tmp/test/ast") {
 		t.Error("should the filename")
 	}
 
-	if glob, _ := NewGlob("/var/log/*", false); !glob.Matches("/var/log/httpd") {
+	if glob, _ := NewGlob("/var/log/*", false, false); !glob.Matches("/var/log/httpd") {
 		t.Error("should match the filename")
 	}
 
-	if glob, _ := NewGlob("/var/**", false); !glob.Matches("/var/log/nginx") {
+	if glob, _ := NewGlob("/var/**", false, false); !glob.Matches("/var/log/nginx") {
 		t.Error("should match the filename")
 	}
 
-	if glob, _ := NewGlob("/var/*", false); glob.Matches("/var/log/nginx") {
+	if glob, _ := NewGlob("/var/*", false, false); glob.Matches("/var/log/nginx") {
 		t.Error("shouldn't match the filename")
 	}
 
-	if glob, _ := NewGlob("/var/log", false); !glob.Matches("/var/log") {
+	if glob, _ := NewGlob("/var/log", false, false); !glob.Matches("/var/log") {
 		t.Error("should match the filename")
 	}
 
-	if glob, _ := NewGlob("/var/run", false); glob.Matches("/var/log") {
+	if glob, _ := NewGlob("/var/run", false, false); glob.Matches("/var/log") {
 		t.Error("shouldn't match the filename")
 	}
 
-	if glob, _ := NewGlob("/var/run", false); glob.Matches("/var/run/httpd") {
+	if glob, _ := NewGlob("/var/run", false, false); glob.Matches("/var/run/httpd") {
 		t.Error("shouldn't match the filename")
 	}
 
-	if glob, _ := NewGlob("/var/run/*", false); glob.Matches("abc") {
+	if glob, _ := NewGlob("/var/run/*", false, false); glob.Matches("abc") {
 		t.Error("shouldn't match the filename")
 	}
 
-	if glob, _ := NewGlob("ab*", false); !glob.Matches("abc") {
+	if glob, _ := NewGlob("ab*", false, false); !glob.Matches("abc") {
 		t.Error("should match the filename")
 	}
 
-	if glob, _ := NewGlob("*b*", false); !glob.Matches("abc") {
+	if glob, _ := NewGlob("*b*", false, false); !glob.Matches("abc") {
 		t.Error("should match the filename")
 	}
 
-	if glob, _ := NewGlob("*d*", false); glob.Matches("abc") {
+	if glob, _ := NewGlob("*d*", false, false); glob.Matches("abc") {
 		t.Error("shouldn't match the filename")
 	}
 
-	if glob, _ := NewGlob("*/*/httpd", false); !glob.Matches("/var/log/httpd") {
+	if glob, _ := NewGlob("*/*/httpd", false, false); !glob.Matches("/var/log/httpd") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("*/*/http*", false); !glob.Matches("/var/log/httpd") {
+	if glob, _ := NewGlob("*/*/http*", false, false); !glob.Matches("/var/log/httpd") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("httpd", false); !glob.Matches("httpd") {
+	if glob, _ := NewGlob("httpd", false, false); !glob.Matches("httpd") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("mysqld", false); glob.Matches("httpd") {
+	if glob, _ := NewGlob("mysqld", false, false); glob.Matches("httpd") {
 		t.Error("shouldn't contain the filename")
 	}
 
-	if glob, _ := NewGlob("/", false); glob.Matches("/httpd") {
+	if glob, _ := NewGlob("/", false, false); glob.Matches("/httpd") {
 		t.Error("shouldn't contain the filename")
 	}
 
-	if glob, _ := NewGlob("/*", false); !glob.Matches("/httpd") {
+	if glob, _ := NewGlob("/*", false, false); !glob.Matches("/httpd") {
 		t.Error("should contain the filename")
 	}
 
-	if glob, _ := NewGlob("/sys/fs/cgroup/*", false); !glob.Matches("/sys/fs/cgroup/") {
+	if glob, _ := NewGlob("/sys/fs/cgroup/*", false, false); !glob.Matches("/sys/fs/cgroup/") {
 		t.Error("should contain the filename")
 	}
 }

--- a/pkg/security/secl/compiler/eval/oo_case_insensitive.go
+++ b/pkg/security/secl/compiler/eval/oo_case_insensitive.go
@@ -61,10 +61,12 @@ var (
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
 				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.PathSeparatorNormalize = true
 			} else if b.Field != "" {
 				b.StringCmpOpts.ScalarCaseInsensitive = true
 				b.StringCmpOpts.PatternCaseInsensitive = true
 				b.StringCmpOpts.GlobCaseInsensitive = true
+				b.StringCmpOpts.PathSeparatorNormalize = true
 			}
 
 			return GlobCmp.StringEquals(a, b, state)
@@ -74,6 +76,7 @@ var (
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
 				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.PathSeparatorNormalize = true
 			}
 
 			return GlobCmp.StringValuesContains(a, b, state)
@@ -83,10 +86,12 @@ var (
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
 				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.PathSeparatorNormalize = true
 			} else if b.Field != "" {
 				b.StringCmpOpts.ScalarCaseInsensitive = true
 				b.StringCmpOpts.PatternCaseInsensitive = true
 				b.StringCmpOpts.GlobCaseInsensitive = true
+				b.StringCmpOpts.PathSeparatorNormalize = true
 			}
 
 			return GlobCmp.StringArrayContains(a, b, state)
@@ -96,6 +101,7 @@ var (
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
 				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.PathSeparatorNormalize = true
 			}
 
 			return GlobCmp.StringArrayMatches(a, b, state)

--- a/pkg/security/secl/compiler/eval/oo_case_insensitive.go
+++ b/pkg/security/secl/compiler/eval/oo_case_insensitive.go
@@ -54,8 +54,8 @@ var (
 		},
 	}
 
-	// CaseInsensitiveGlobCmp lower case values before comparing, and converts patterns to globs. Important : this operator override doesn't support approvers
-	CaseInsensitiveGlobCmp = &OpOverrides{
+	// WindowsPathCmp lower case values before comparing, converts patterns to globs, and normalizes path separators. Important : this operator override doesn't support approvers
+	WindowsPathCmp = &OpOverrides{
 		StringEquals: func(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true

--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -20,6 +20,7 @@ type StringCmpOpts struct {
 	PatternCaseInsensitive bool
 	GlobCaseInsensitive    bool
 	RegexpCaseInsensitive  bool
+	PathSeparatorNormalize bool
 }
 
 // DefaultStringCmpOpts defines the default comparison options
@@ -122,7 +123,6 @@ func (s *StringValues) Matches(value string) bool {
 
 // StringMatcher defines a pattern matcher
 type StringMatcher interface {
-	Compile(pattern string, caseInsensitive bool) error
 	Matches(value string) bool
 }
 
@@ -179,12 +179,12 @@ type GlobStringMatcher struct {
 }
 
 // Compile a simple pattern
-func (g *GlobStringMatcher) Compile(pattern string, caseInsensitive bool) error {
+func (g *GlobStringMatcher) Compile(pattern string, caseInsensitive bool, normalizePath bool) error {
 	if g.glob != nil {
 		return nil
 	}
 
-	glob, err := NewGlob(pattern, caseInsensitive)
+	glob, err := NewGlob(pattern, caseInsensitive, normalizePath)
 	if err != nil {
 		return err
 	}
@@ -258,7 +258,7 @@ func NewStringMatcher(kind FieldValueType, pattern string, opts StringCmpOpts) (
 		return &matcher, nil
 	case GlobValueType:
 		var matcher GlobStringMatcher
-		if err := matcher.Compile(pattern, opts.GlobCaseInsensitive); err != nil {
+		if err := matcher.Compile(pattern, opts.GlobCaseInsensitive, opts.PathSeparatorNormalize); err != nil {
 			return nil, fmt.Errorf("invalid glob `%s`: %s", pattern, err)
 		}
 		return &matcher, nil

--- a/pkg/security/secl/model/accessors_windows.go
+++ b/pkg/security/secl/model/accessors_windows.go
@@ -82,7 +82,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "create.file.path":
 		return &eval.StringEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File)
@@ -92,7 +92,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "create.file.path.length":
 		return &eval.IntEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
 				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File))
@@ -356,7 +356,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "exec.file.path":
 		return &eval.StringEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent)
@@ -366,7 +366,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "exec.file.path.length":
 		return &eval.IntEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
 				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent))
@@ -496,7 +496,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "exit.file.path":
 		return &eval.StringEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent)
@@ -506,7 +506,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "exit.file.path.length":
 		return &eval.IntEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
 				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent))
@@ -777,7 +777,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "process.ancestors.file.path":
 		return &eval.StringArrayEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
 				if result, ok := ctx.StringCache[field]; ok {
@@ -799,7 +799,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "process.ancestors.file.path.length":
 		return &eval.IntArrayEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
 				if result, ok := ctx.IntCache[field]; ok {
@@ -968,7 +968,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "process.file.path":
 		return &eval.StringEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
@@ -978,7 +978,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "process.file.path.length":
 		return &eval.IntEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
 				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent))
@@ -1072,7 +1072,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "process.parent.file.path":
 		return &eval.StringEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
 				if !ev.BaseEvent.ProcessContext.HasParent() {
@@ -1085,7 +1085,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 	case "process.parent.file.path.length":
 		return &eval.IntEvaluator{
-			OpOverrides: eval.CaseInsensitiveGlobCmp,
+			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
 				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent))

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -44,7 +44,7 @@ type Event struct {
 
 // FileEvent is the common file event type
 type FileEvent struct {
-	PathnameStr string `field:"path,handler:ResolveFilePath,opts:length" op_override:"eval.CaseInsensitiveGlobCmp"` // SECLDoc[path] Definition:`File's path` Example:`exec.file.path == "c:\cmd.bat"` Description:`Matches the execution of the file located at c:\cmd.bat`
+	PathnameStr string `field:"path,handler:ResolveFilePath,opts:length" op_override:"eval.WindowsPathCmp"`         // SECLDoc[path] Definition:`File's path` Example:`exec.file.path == "c:\cmd.bat"` Description:`Matches the execution of the file located at c:\cmd.bat`
 	BasenameStr string `field:"name,handler:ResolveFileBasename,opts:length" op_override:"eval.CaseInsensitiveCmp"` // SECLDoc[name] Definition:`File's basename` Example:`exec.file.name == "cmd.bat"` Description:`Matches the execution of any file named cmd.bat.`
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The current glob implementation hardcodes path separator to `/`. This is causing issues on windows where path can be mixed between `/` and `\`. This PR adds a normalization layer to convert everything to `/` before doing the glob operation.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
