### PR TITLE
[CWS] change windows self test to use `create.file.path`

### DIFF
--- a/pkg/security/probe/selftests/create_file_windows.go
+++ b/pkg/security/probe/selftests/create_file_windows.go
@@ -9,7 +9,6 @@ package selftests
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -29,7 +28,7 @@ func (o *WindowsCreateFileSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 
 	return &rules.RuleDefinition{
 		ID:         o.ruleID,
-		Expression: fmt.Sprintf(`create.file.name == "%s"`, filepath.Base(o.filename)),
+		Expression: fmt.Sprintf(`create.file.path == "%s"`, o.filename),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

With the goal of having a discarder on `create.file.path`, we need the self test to use the path otherwise discarder will not be generated because this field is not used in the rule. This PR fixes this by using the path field (similarly to what is done with open events on linux).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
