### PR TITLE
run `inv -e check-go-mod-replaces` in the CI

### DIFF
--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -236,3 +236,4 @@ go_mod_tidy_check:
     - !reference [.retrieve_linux_go_deps]
   script:
     - inv -e check-mod-tidy
+    - inv -e check-go-mod-replaces


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/24062 introduced a task to check for missing replaces in the different go.mod files. https://github.com/DataDog/datadog-agent/pull/24012 confirmed that the task correctly identified missing replaces so this PR adds the check in the `go_mod_tidy_check` CI job.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
