### PR TITLE
[CWS] fix missing set on `GlobCaseInsensitive` when doing glob + case insensitive matches

### DIFF
--- a/pkg/security/secl/compiler/eval/oo_case_insensitive.go
+++ b/pkg/security/secl/compiler/eval/oo_case_insensitive.go
@@ -12,9 +12,11 @@ var (
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
+				a.StringCmpOpts.GlobCaseInsensitive = true
 			} else if b.Field != "" {
 				b.StringCmpOpts.ScalarCaseInsensitive = true
 				b.StringCmpOpts.PatternCaseInsensitive = true
+				b.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
 			return StringEquals(a, b, state)
@@ -23,6 +25,7 @@ var (
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
+				a.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
 			return StringValuesContains(a, b, state)
@@ -31,9 +34,11 @@ var (
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
+				a.StringCmpOpts.GlobCaseInsensitive = true
 			} else if b.Field != "" {
 				b.StringCmpOpts.ScalarCaseInsensitive = true
 				b.StringCmpOpts.PatternCaseInsensitive = true
+				b.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
 			return StringArrayContains(a, b, state)
@@ -42,6 +47,7 @@ var (
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
+				a.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
 			return StringArrayMatches(a, b, state)
@@ -54,9 +60,11 @@ var (
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
+				a.StringCmpOpts.GlobCaseInsensitive = true
 			} else if b.Field != "" {
 				b.StringCmpOpts.ScalarCaseInsensitive = true
 				b.StringCmpOpts.PatternCaseInsensitive = true
+				b.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
 			return GlobCmp.StringEquals(a, b, state)
@@ -65,6 +73,7 @@ var (
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
+				a.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
 			return GlobCmp.StringValuesContains(a, b, state)
@@ -73,9 +82,11 @@ var (
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
+				a.StringCmpOpts.GlobCaseInsensitive = true
 			} else if b.Field != "" {
 				b.StringCmpOpts.ScalarCaseInsensitive = true
 				b.StringCmpOpts.PatternCaseInsensitive = true
+				b.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
 			return GlobCmp.StringArrayContains(a, b, state)
@@ -84,6 +95,7 @@ var (
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
+				a.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
 			return GlobCmp.StringArrayMatches(a, b, state)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR fixes some missing set of `GlobCaseInsensitive` when using case insensitive operator overrides.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
