### PR TITLE
Rename capture start/stop to not conflict with lifecycle hooks

### DIFF
--- a/comp/api/api/apiimpl/grpc.go
+++ b/comp/api/api/apiimpl/grpc.go
@@ -81,7 +81,7 @@ func (s *serverSecure) DogstatsdCaptureTrigger(_ context.Context, req *pb.Captur
 		return &pb.CaptureTriggerResponse{}, err
 	}
 
-	p, err := s.capture.Start(req.GetPath(), d, req.GetCompressed())
+	p, err := s.capture.StartCapture(req.GetPath(), d, req.GetCompressed())
 	if err != nil {
 		return &pb.CaptureTriggerResponse{}, err
 	}

--- a/comp/dogstatsd/replay/capture.go
+++ b/comp/dogstatsd/replay/capture.go
@@ -91,8 +91,8 @@ func (tc *trafficCapture) IsOngoing() bool {
 	return tc.writer.IsOngoing()
 }
 
-// Start starts a TrafficCapture and returns an error in the event of an issue.
-func (tc *trafficCapture) Start(p string, d time.Duration, compressed bool) (string, error) {
+// StartCapture starts a TrafficCapture and returns an error in the event of an issue.
+func (tc *trafficCapture) StartCapture(p string, d time.Duration, compressed bool) (string, error) {
 	if tc.IsOngoing() {
 		return "", fmt.Errorf("Ongoing capture in progress")
 	}
@@ -108,8 +108,8 @@ func (tc *trafficCapture) Start(p string, d time.Duration, compressed bool) (str
 
 }
 
-// Stop stops an ongoing TrafficCapture.
-func (tc *trafficCapture) Stop() {
+// StopCapture stops an ongoing TrafficCapture.
+func (tc *trafficCapture) StopCapture() {
 	tc.Lock()
 	defer tc.Unlock()
 	if tc.writer == nil {

--- a/comp/dogstatsd/replay/component.go
+++ b/comp/dogstatsd/replay/component.go
@@ -25,11 +25,11 @@ type Component interface {
 	// IsOngoing returns whether a capture is ongoing for this TrafficCapture instance.
 	IsOngoing() bool
 
-	// Start starts a TrafficCapture and returns an error in the event of an issue.
-	Start(p string, d time.Duration, compressed bool) (string, error)
+	// StartCapture starts a TrafficCapture and returns an error in the event of an issue.
+	StartCapture(p string, d time.Duration, compressed bool) (string, error)
 
-	// Stop stops an ongoing TrafficCapture.
-	Stop()
+	// StopCapture stops an ongoing TrafficCapture.
+	StopCapture()
 
 	// TODO: (components) pool manager should be injected as a component in the future.
 	// RegisterSharedPoolManager registers the shared pool manager with the TrafficCapture.

--- a/comp/dogstatsd/replay/mock.go
+++ b/comp/dogstatsd/replay/mock.go
@@ -38,8 +38,8 @@ func (tc *mockTrafficCapture) IsOngoing() bool {
 	return tc.isRunning
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (tc *mockTrafficCapture) Start(p string, d time.Duration, compressed bool) (string, error) {
+// StartCapture does nothign on the mock
+func (tc *mockTrafficCapture) StartCapture(_ string, _ time.Duration, _ bool) (string, error) {
 	tc.Lock()
 	defer tc.Unlock()
 	tc.isRunning = true
@@ -47,8 +47,8 @@ func (tc *mockTrafficCapture) Start(p string, d time.Duration, compressed bool) 
 
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (tc *mockTrafficCapture) Stop() {
+// StopCapture does nothign on the mock
+func (tc *mockTrafficCapture) StopCapture() {
 	tc.Lock()
 	defer tc.Unlock()
 	tc.isRunning = false

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -479,7 +479,7 @@ func (s *server) stop(context.Context) error {
 		s.Statistics.Stop()
 	}
 	if s.tCapture != nil {
-		s.tCapture.Stop()
+		s.tCapture.StopCapture()
 	}
 	s.health.Deregister() //nolint:errcheck
 	s.Started = false


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Rename start/stop functions in capture/replay so they don't appear similar to start/stop hooks used by FX lifecycles. 
This will ease migration and tracking of un-migrated code. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
