### PR TITLE
[CWS] fix CWS feature e2e test

### DIFF
--- a/test/new-e2e/tests/cws/api/ddsql.go
+++ b/test/new-e2e/tests/cws/api/ddsql.go
@@ -65,8 +65,8 @@ func NewDDSQLClient(apiKey, appKey string) *DDSQLClient {
 func (c *DDSQLClient) Do(query string) (*DDSQLTableResponse, error) {
 	now := time.Now()
 	params := DDSQLTableQueryParams{
-		DefaultStart:    int(now.Add(-10 * time.Minute).Unix()),
-		DefaultEnd:      int(now.Unix()),
+		DefaultStart:    int(now.Add(-1 * time.Hour).UnixMilli()),
+		DefaultEnd:      int(now.UnixMilli()),
 		DefaultInterval: 20000,
 		Query:           query,
 		Source:          "inventories",

--- a/test/new-e2e/tests/cws/api/ddsql.go
+++ b/test/new-e2e/tests/cws/api/ddsql.go
@@ -13,13 +13,23 @@ import (
 	"time"
 )
 
+// JSONAPIPayload is a struct that represents the body of a JSON API request
+type JSONAPIPayload[Attr any] struct {
+	Data JSONAPIPayloadData[Attr] `json:"data"`
+}
+
+// JSONAPIPayloadData is a struct that represents the data field of a JSON API request
+type JSONAPIPayloadData[Attr any] struct {
+	Type      string `json:"type"`
+	Attribute Attr   `json:"attributes"`
+}
+
 // DDSQLTableQueryParams is a struct that represents a DDSQL table query
 type DDSQLTableQueryParams struct {
 	DefaultStart    int    `json:"default_start"`
 	DefaultEnd      int    `json:"default_end"`
 	DefaultInterval int    `json:"default_interval"`
 	Query           string `json:"query"`
-	Source          string `json:"source"`
 }
 
 // DDSQLTableResponse is a struct that represents a DDSQL table response
@@ -69,10 +79,15 @@ func (c *DDSQLClient) Do(query string) (*DDSQLTableResponse, error) {
 		DefaultEnd:      int(now.UnixMilli()),
 		DefaultInterval: 20000,
 		Query:           query,
-		Source:          "inventories",
+	}
+	payload := JSONAPIPayload[DDSQLTableQueryParams]{
+		Data: JSONAPIPayloadData[DDSQLTableQueryParams]{
+			Type:      "ddsql_table_request",
+			Attribute: params,
+		},
 	}
 
-	reqData, err := json.Marshal(params)
+	reqData, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
 	}

--- a/test/new-e2e/tests/cws/ec2_test.go
+++ b/test/new-e2e/tests/cws/ec2_test.go
@@ -213,7 +213,7 @@ func (a *agentSuite) Test01FeatureCWSEnabled() {
 				return
 			}
 		}
-	}, 16*time.Minute, 2*time.Minute, "cws activation test timed out for host %s", a.Env().Agent.Client.Hostname())
+	}, 20*time.Minute, 2*time.Minute, "cws activation test timed out for host %s", a.Env().Agent.Client.Hostname())
 }
 
 func (a *agentSuite) waitAgentLogs(agentName string, pattern string) error {

--- a/test/new-e2e/tests/cws/ec2_test.go
+++ b/test/new-e2e/tests/cws/ec2_test.go
@@ -213,7 +213,7 @@ func (a *agentSuite) Test01FeatureCWSEnabled() {
 				return
 			}
 		}
-	}, 20*time.Minute, 2*time.Minute, "cws activation test timed out for host %s", a.Env().Agent.Client.Hostname())
+	}, 20*time.Minute, 30*time.Second, "cws activation test timed out for host %s", a.Env().Agent.Client.Hostname())
 }
 
 func (a *agentSuite) waitAgentLogs(agentName string, pattern string) error {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the new CWS e2e test, especially the step where we check that the `feature_cws_enabled` is correct in the inventory payload.

This PR:
- increases the timeout and decreases the delay related to this check
- ensures the body of the API call follows the api/v2 expected format
- ensures the timestamp are provided as unix milliseconds

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
