### PR TITLE
Enabling BuildImpactAnalysis integration in MergeQueue

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -3,7 +3,7 @@ schema-version: v1
 kind: mergequeue
 enable: true
 merge_method: squash
-workflow_type: speculative
+workflow_type: speculative_parallel_impact
 speculative_max_depth: 5
 wait_for_check_timeout_in_minutes: 240
 gitlab_jobs_retry_enable: true


### PR DESCRIPTION
This commit will enable analysis of changed packages in the merge queue allowing it to merge pull requests impacting distinct packages in parallel rather than sequentially. This should reduce queue time significantly.

If, for any reason, this causes issues - simply revert this PR.