### PR TITLE
Set 7.54.0 as current_milestone

### DIFF
--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
     "base_branch": "main",
-    "current_milestone": "7.53.0",
+    "current_milestone": "7.54.0",
     "last_stable": {
         "6": "6.52.0",
         "7": "7.52.0"


### PR DESCRIPTION
Set `current_milestone` to `7.54.0` so the automatic milestone action works properly on the main branch.