### PR TITLE
[CWS] merge `{Scalar,Pattern,Glob,Regexp}CaseInsensitive` in `StringCmpOpts`

### DIFF
--- a/pkg/security/secl/compiler/eval/oo_case_insensitive.go
+++ b/pkg/security/secl/compiler/eval/oo_case_insensitive.go
@@ -10,44 +10,32 @@ var (
 	CaseInsensitiveCmp = &OpOverrides{
 		StringEquals: func(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.PatternCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.CaseInsensitive = true
 			} else if b.Field != "" {
-				b.StringCmpOpts.ScalarCaseInsensitive = true
-				b.StringCmpOpts.PatternCaseInsensitive = true
-				b.StringCmpOpts.GlobCaseInsensitive = true
+				b.StringCmpOpts.CaseInsensitive = true
 			}
 
 			return StringEquals(a, b, state)
 		},
 		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.PatternCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.CaseInsensitive = true
 			}
 
 			return StringValuesContains(a, b, state)
 		},
 		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.PatternCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.CaseInsensitive = true
 			} else if b.Field != "" {
-				b.StringCmpOpts.ScalarCaseInsensitive = true
-				b.StringCmpOpts.PatternCaseInsensitive = true
-				b.StringCmpOpts.GlobCaseInsensitive = true
+				b.StringCmpOpts.CaseInsensitive = true
 			}
 
 			return StringArrayContains(a, b, state)
 		},
 		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.PatternCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.CaseInsensitive = true
 			}
 
 			return StringArrayMatches(a, b, state)
@@ -58,14 +46,10 @@ var (
 	WindowsPathCmp = &OpOverrides{
 		StringEquals: func(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.PatternCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.CaseInsensitive = true
 				a.StringCmpOpts.PathSeparatorNormalize = true
 			} else if b.Field != "" {
-				b.StringCmpOpts.ScalarCaseInsensitive = true
-				b.StringCmpOpts.PatternCaseInsensitive = true
-				b.StringCmpOpts.GlobCaseInsensitive = true
+				b.StringCmpOpts.CaseInsensitive = true
 				b.StringCmpOpts.PathSeparatorNormalize = true
 			}
 
@@ -73,9 +57,7 @@ var (
 		},
 		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.PatternCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.CaseInsensitive = true
 				a.StringCmpOpts.PathSeparatorNormalize = true
 			}
 
@@ -83,14 +65,10 @@ var (
 		},
 		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.PatternCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.CaseInsensitive = true
 				a.StringCmpOpts.PathSeparatorNormalize = true
 			} else if b.Field != "" {
-				b.StringCmpOpts.ScalarCaseInsensitive = true
-				b.StringCmpOpts.PatternCaseInsensitive = true
-				b.StringCmpOpts.GlobCaseInsensitive = true
+				b.StringCmpOpts.CaseInsensitive = true
 				b.StringCmpOpts.PathSeparatorNormalize = true
 			}
 
@@ -98,9 +76,7 @@ var (
 		},
 		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.PatternCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.CaseInsensitive = true
 				a.StringCmpOpts.PathSeparatorNormalize = true
 			}
 

--- a/pkg/security/secl/compiler/eval/oo_case_insensitive_test.go
+++ b/pkg/security/secl/compiler/eval/oo_case_insensitive_test.go
@@ -106,11 +106,11 @@ func TestLowerCaseEquals(t *testing.T) {
 
 		e, err := CaseInsensitiveCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
-		assert.False(t, e.Eval(&ctx).(bool))
+		assert.True(t, e.Eval(&ctx).(bool))
 
 		e, err = CaseInsensitiveCmp.StringEquals(b, a, state)
 		assert.Empty(t, err)
-		assert.False(t, e.Eval(&ctx).(bool))
+		assert.True(t, e.Eval(&ctx).(bool))
 	})
 }
 
@@ -208,7 +208,7 @@ func TestLowerCaseContains(t *testing.T) {
 
 		e, err := CaseInsensitiveCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
-		assert.False(t, e.Eval(&ctx).(bool))
+		assert.True(t, e.Eval(&ctx).(bool))
 
 		values.AppendFieldValue(FieldValue{Value: "[Ff][Oo].*", Type: RegexpValueType})
 

--- a/pkg/security/secl/compiler/eval/oo_case_insensitive_test.go
+++ b/pkg/security/secl/compiler/eval/oo_case_insensitive_test.go
@@ -234,8 +234,7 @@ func TestLowerCaseContains(t *testing.T) {
 		values.AppendFieldValue(FieldValue{Value: "fo*", Type: PatternValueType})
 
 		opts := StringCmpOpts{
-			ScalarCaseInsensitive:  true,
-			PatternCaseInsensitive: true,
+			CaseInsensitive: true,
 		}
 
 		if err := values.Compile(opts); err != nil {

--- a/pkg/security/secl/compiler/eval/operators.go
+++ b/pkg/security/secl/compiler/eval/operators.go
@@ -306,7 +306,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEv
 	}
 
 	if a.Field != "" && b.Field != "" {
-		if a.StringCmpOpts.ScalarCaseInsensitive || b.StringCmpOpts.ScalarCaseInsensitive {
+		if a.StringCmpOpts.CaseInsensitive || b.StringCmpOpts.CaseInsensitive {
 			op = strings.EqualFold
 		}
 	} else if a.Field != "" {
@@ -470,10 +470,10 @@ func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, state *Sta
 	}
 
 	if a.Field != "" && b.Field != "" {
-		if a.StringCmpOpts.ScalarCaseInsensitive || b.StringCmpOpts.ScalarCaseInsensitive {
+		if a.StringCmpOpts.CaseInsensitive || b.StringCmpOpts.CaseInsensitive {
 			cmp = strings.EqualFold
 		}
-	} else if a.Field != "" && a.StringCmpOpts.ScalarCaseInsensitive {
+	} else if a.Field != "" && a.StringCmpOpts.CaseInsensitive {
 		cmp = strings.EqualFold
 	} else if b.Field != "" {
 		matcher, err := a.ToStringMatcher(b.StringCmpOpts)

--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -16,10 +16,7 @@ import (
 
 // StringCmpOpts defines options to apply during string comparison
 type StringCmpOpts struct {
-	ScalarCaseInsensitive  bool
-	PatternCaseInsensitive bool
-	GlobCaseInsensitive    bool
-	RegexpCaseInsensitive  bool
+	CaseInsensitive        bool
 	PathSeparatorNormalize bool
 }
 
@@ -252,25 +249,25 @@ func NewStringMatcher(kind FieldValueType, pattern string, opts StringCmpOpts) (
 	switch kind {
 	case PatternValueType:
 		var matcher PatternStringMatcher
-		if err := matcher.Compile(pattern, opts.PatternCaseInsensitive); err != nil {
+		if err := matcher.Compile(pattern, opts.CaseInsensitive); err != nil {
 			return nil, fmt.Errorf("invalid pattern `%s`: %s", pattern, err)
 		}
 		return &matcher, nil
 	case GlobValueType:
 		var matcher GlobStringMatcher
-		if err := matcher.Compile(pattern, opts.GlobCaseInsensitive, opts.PathSeparatorNormalize); err != nil {
+		if err := matcher.Compile(pattern, opts.CaseInsensitive, opts.PathSeparatorNormalize); err != nil {
 			return nil, fmt.Errorf("invalid glob `%s`: %s", pattern, err)
 		}
 		return &matcher, nil
 	case RegexpValueType:
 		var matcher RegexpStringMatcher
-		if err := matcher.Compile(pattern, opts.RegexpCaseInsensitive); err != nil {
+		if err := matcher.Compile(pattern, opts.CaseInsensitive); err != nil {
 			return nil, fmt.Errorf("invalid regexp `%s`: %s", pattern, err)
 		}
 		return &matcher, nil
 	case ScalarValueType:
 		var matcher ScalarStringMatcher
-		if err := matcher.Compile(pattern, opts.ScalarCaseInsensitive); err != nil {
+		if err := matcher.Compile(pattern, opts.CaseInsensitive); err != nil {
 			return nil, fmt.Errorf("invalid regexp `%s`: %s", pattern, err)
 		}
 		return &matcher, nil

--- a/pkg/security/secl/compiler/eval/strings_test.go
+++ b/pkg/security/secl/compiler/eval/strings_test.go
@@ -33,7 +33,7 @@ func TestStringValues(t *testing.T) {
 		var values StringValues
 		values.AppendScalarValue("test123")
 
-		if err := values.Compile(StringCmpOpts{ScalarCaseInsensitive: true}); err != nil {
+		if err := values.Compile(StringCmpOpts{CaseInsensitive: true}); err != nil {
 			t.Error(err)
 		}
 
@@ -64,7 +64,7 @@ func TestScalar(t *testing.T) {
 	})
 
 	t.Run("insensitive-case", func(t *testing.T) {
-		matcher, err := NewStringMatcher(ScalarValueType, "test123", StringCmpOpts{ScalarCaseInsensitive: true})
+		matcher, err := NewStringMatcher(ScalarValueType, "test123", StringCmpOpts{CaseInsensitive: true})
 		if err != nil {
 			t.Error(err)
 		}
@@ -96,7 +96,7 @@ func TestPattern(t *testing.T) {
 	})
 
 	t.Run("insensitive-case", func(t *testing.T) {
-		matcher, err := NewStringMatcher(PatternValueType, "http://TEst*", StringCmpOpts{PatternCaseInsensitive: true})
+		matcher, err := NewStringMatcher(PatternValueType, "http://TEst*", StringCmpOpts{CaseInsensitive: true})
 		if err != nil {
 			t.Error(err)
 		}
@@ -126,7 +126,7 @@ func TestPattern(t *testing.T) {
 	})
 
 	t.Run("insensitive-case-scalar", func(t *testing.T) {
-		matcher, err := NewStringMatcher(PatternValueType, "http://test123", StringCmpOpts{PatternCaseInsensitive: true})
+		matcher, err := NewStringMatcher(PatternValueType, "http://test123", StringCmpOpts{CaseInsensitive: true})
 		if err != nil {
 			t.Error(err)
 		}
@@ -158,7 +158,7 @@ func TestGlob(t *testing.T) {
 	})
 
 	t.Run("insensitive-case", func(t *testing.T) {
-		matcher, err := NewStringMatcher(GlobValueType, "/etc/TEst*", StringCmpOpts{GlobCaseInsensitive: true})
+		matcher, err := NewStringMatcher(GlobValueType, "/etc/TEst*", StringCmpOpts{CaseInsensitive: true})
 		if err != nil {
 			t.Error(err)
 		}
@@ -188,7 +188,7 @@ func TestGlob(t *testing.T) {
 	})
 
 	t.Run("insensitive-case-scalar", func(t *testing.T) {
-		matcher, err := NewStringMatcher(GlobValueType, "/etc/test123", StringCmpOpts{GlobCaseInsensitive: true})
+		matcher, err := NewStringMatcher(GlobValueType, "/etc/test123", StringCmpOpts{CaseInsensitive: true})
 		if err != nil {
 			t.Error(err)
 		}
@@ -220,7 +220,7 @@ func TestRegexp(t *testing.T) {
 	})
 
 	t.Run("insensitive-case", func(t *testing.T) {
-		matcher, err := NewStringMatcher(RegexpValueType, "test.*", StringCmpOpts{RegexpCaseInsensitive: true})
+		matcher, err := NewStringMatcher(RegexpValueType, "test.*", StringCmpOpts{CaseInsensitive: true})
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
### What does this PR do?

Those fields are all used differently, but shouldn't really have different values. This PR cleans this up by just using a simple `CaseInsensitive`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
