### PR TITLE
Fix unused linter error in pkg/security/probe/selftests/tester.go on macOS

### DIFF
--- a/pkg/security/probe/selftests/tester.go
+++ b/pkg/security/probe/selftests/tester.go
@@ -36,6 +36,7 @@ type SelfTest interface {
 type SelfTester struct {
 	sync.Mutex
 
+	//nolint:unused // config is not used at all on macOS, triggering the unused linter
 	config          *config.RuntimeSecurityConfig
 	waitingForEvent *atomic.Bool
 	eventChan       chan selfTestEvent


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Follow-up of #24358: removes unused linter error in `pkg/security/probe/selftests/tester.go`, which is due to the macOS implementation of `NewSelfTester` not using the `config` parameter of the `SelfTester` struct.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix linter error on `main`.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a
