### PR TITLE
[CWS] fix error with `bdist_wheel` in `security_go_generate_check`

### DIFF
--- a/.gitlab/source_test/go_generate_check.yml
+++ b/.gitlab/source_test/go_generate_check.yml
@@ -9,6 +9,7 @@ security_go_generate_check:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - source /root/.bashrc
+    - pip3 install wheel
     - pip3 install -r docs/cloud-workload-security/scripts/requirements-docs.txt
     - inv -e install-tools
   script:


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue in `security_go_generate_check` where we fail to build `bdist_wheel`. This does not crash the job but can make the output confusing.

To fix the issue by installing `wheel` manually. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
