### PR TITLE
[oracle] Fix global_custom_queries bug (SDBM-901)

### DIFF
--- a/pkg/collector/corechecks/oracle/config/config.go
+++ b/pkg/collector/corechecks/oracle/config/config.go
@@ -25,7 +25,7 @@ const defaultLoader = "core"
 // InitConfig is used to deserialize integration init config.
 type InitConfig struct {
 	MinCollectionInterval int           `yaml:"min_collection_interval"`
-	CustomQueries         []CustomQuery `yaml:"custom_queries"`
+	CustomQueries         []CustomQuery `yaml:"global_custom_queries"`
 	UseInstantClient      bool          `yaml:"use_instant_client"`
 	Service               string        `yaml:"service"`
 	Loader                string        `yaml:"loader"`

--- a/releasenotes/notes/oracle-fix-global-custom-queries-83b1fe0d03e7d625.yaml
+++ b/releasenotes/notes/oracle-fix-global-custom-queries-83b1fe0d03e7d625.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix ``global_custom_queries`` bug.

--- a/releasenotes/notes/oracle-fix-global-custom-queries-83b1fe0d03e7d625.yaml
+++ b/releasenotes/notes/oracle-fix-global-custom-queries-83b1fe0d03e7d625.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix ``global_custom_queries`` bug.
+    [oracle] Fix ``global_custom_queries`` bug.


### PR DESCRIPTION
### What does this PR do?

Fix a problem with `global_custom_queries`.

### Motivation

`global_custom_queries` weren't working because the parameter in the `init_config` was falsely named `custom_queries`.

### Possible Drawbacks / Trade-offs

The program would break if someone named the parameter `custom_queries` but that would against the documentation.

### Describe how to test/QA your changes

Check if `global_custom_queries` is being picked up.