### PR TITLE
[CWS] remove unused components from security-agent

### DIFF
--- a/cmd/cluster-agent/subcommands/start/compliance.go
+++ b/cmd/cluster-agent/subcommands/start/compliance.go
@@ -88,7 +88,12 @@ func startCompliance(senderManager sender.SenderManager, wmeta workloadmeta.Comp
 	}
 
 	reporter := compliance.NewLogReporter(hname, "compliance-agent", "compliance", endpoints, ctx)
-	agent := compliance.NewAgent(senderManager, wmeta, compliance.AgentOptions{
+	statsdClient, err := simpleTelemetrySenderFromSenderManager(senderManager)
+	if err != nil {
+		return err
+	}
+
+	agent := compliance.NewAgent(statsdClient, wmeta, compliance.AgentOptions{
 		ConfigDir:     configDir,
 		Reporter:      reporter,
 		CheckInterval: checkInterval,

--- a/cmd/cluster-agent/subcommands/start/statsdsender.go
+++ b/cmd/cluster-agent/subcommands/start/statsdsender.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows && kubeapiserver
+
+package start
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/security/telemetry"
+)
+
+func simpleTelemetrySenderFromSenderManager(senderManager sender.SenderManager) (telemetry.SimpleTelemetrySender, error) {
+	s, err := senderManager.GetDefaultSender()
+	if err != nil {
+		return nil, err
+	}
+	return &statsdFromSender{sender: s}, nil
+}
+
+type statsdFromSender struct {
+	sender sender.Sender
+}
+
+// Gauge implements telemetry.SimpleTelemetrySender.
+func (s *statsdFromSender) Gauge(name string, value float64, tags []string) {
+	s.sender.Gauge(name, value, "", tags)
+}
+
+// Commit implements telemetry.SimpleTelemetrySender.
+func (s *statsdFromSender) Commit() {
+	s.sender.Commit()
+}

--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -22,8 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/runtime"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/start"
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -41,13 +39,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
-	"github.com/DataDog/datadog-agent/comp/forwarder"
-	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
-	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
-	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
-	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl"
-	"github.com/DataDog/datadog-agent/comp/serializer/compression/compressionimpl"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -92,11 +84,11 @@ func (s *service) Run(svcctx context.Context) error {
 	params := &cliParams{}
 	err := fxutil.OneShot(
 		func(log log.Component, config config.Component, _ secrets.Component, statsd statsd.Component, sysprobeconfig sysprobeconfig.Component,
-			telemetry telemetry.Component, _ workloadmeta.Component, params *cliParams, demultiplexer demultiplexer.Component, statusComponent status.Component) error {
+			telemetry telemetry.Component, _ workloadmeta.Component, params *cliParams, statusComponent status.Component) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer start.StopAgent(cancel, log)
 
-			err := start.RunAgent(ctx, log, config, telemetry, demultiplexer, statusComponent)
+			err := start.RunAgent(ctx, log, config, telemetry, statusComponent)
 			if err != nil {
 				return err
 			}
@@ -116,16 +108,6 @@ func (s *service) Run(svcctx context.Context) error {
 		}),
 		core.Bundle(),
 		dogstatsd.ClientBundle,
-		forwarder.Bundle(),
-		fx.Provide(defaultforwarder.NewParamsWithResolvers),
-		compressionimpl.Module(),
-		demultiplexerimpl.Module(),
-		orchestratorForwarderImpl.Module(),
-		fx.Supply(orchestratorForwarderImpl.NewDisabledParams()),
-		eventplatformimpl.Module(),
-		fx.Supply(eventplatformimpl.NewDisabledParams()),
-		eventplatformreceiverimpl.Module(),
-		fx.Supply(demultiplexerimpl.NewDefaultParams()),
 
 		// workloadmeta setup
 		collectors.GetCatalog(),
@@ -142,7 +124,7 @@ func (s *service) Run(svcctx context.Context) error {
 				AgentType: catalog,
 			}
 		}),
-		fx.Provide(func(log log.Component, config config.Component, statsd statsd.Component, demultiplexer demultiplexer.Component, wmeta workloadmeta.Component) (status.InformationProvider, *agent.RuntimeSecurityAgent, error) {
+		fx.Provide(func(log log.Component, config config.Component, statsd statsd.Component, wmeta workloadmeta.Component) (status.InformationProvider, *agent.RuntimeSecurityAgent, error) {
 			stopper := startstop.NewSerialStopper()
 
 			statsdClient, err := statsd.CreateForHostPort(setup.GetBindHost(config), config.GetInt("dogstatsd_port"))
@@ -156,7 +138,7 @@ func (s *service) Run(svcctx context.Context) error {
 				return status.NewInformationProvider(nil), nil, err
 			}
 
-			runtimeAgent, err := runtime.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, demultiplexer, wmeta)
+			runtimeAgent, err := runtime.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, wmeta)
 			if err != nil {
 				return status.NewInformationProvider(nil), nil, err
 			}

--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -34,7 +34,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/k8sconfig"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -111,7 +110,7 @@ func commandsWrapped(bundleParamsFactory func() core.BundleParams) []*cobra.Comm
 }
 
 // RunCheck runs a check
-func RunCheck(log log.Component, config config.Component, _ secrets.Component, statsd statsd.Component, checkArgs *CliParams) error {
+func RunCheck(log log.Component, config config.Component, _ secrets.Component, statsdComp statsd.Component, checkArgs *CliParams) error {
 	hname, err := hostname.Get(context.TODO())
 	if err != nil {
 		return err
@@ -120,7 +119,7 @@ func RunCheck(log log.Component, config config.Component, _ secrets.Component, s
 	var statsdClient ddgostatsd.ClientInterface
 	metricsEnabled := config.GetBool("compliance_config.metrics.enabled")
 	if metricsEnabled {
-		cl, err := statsd.CreateForHostPort(pkgconfig.GetBindHost(), config.GetInt("dogstatsd_port"))
+		cl, err := statsdComp.Get()
 		if err != nil {
 			log.Warnf("Error creating statsd Client: %s", err)
 		} else {

--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -30,7 +30,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
@@ -627,7 +626,7 @@ func reloadRuntimePolicies(_ log.Component, _ config.Component, _ secrets.Compon
 }
 
 // StartRuntimeSecurity starts runtime security
-func StartRuntimeSecurity(log log.Component, config config.Component, hostname string, stopper startstop.Stopper, _ ddgostatsd.ClientInterface, senderManager sender.SenderManager, wmeta workloadmeta.Component) (*secagent.RuntimeSecurityAgent, error) {
+func StartRuntimeSecurity(log log.Component, config config.Component, hostname string, stopper startstop.Stopper, statsdClient ddgostatsd.ClientInterface, wmeta workloadmeta.Component) (*secagent.RuntimeSecurityAgent, error) {
 	enabled := config.GetBool("runtime_security_config.enabled")
 	if !enabled {
 		log.Info("Datadog runtime security agent disabled by config")
@@ -636,7 +635,7 @@ func StartRuntimeSecurity(log log.Component, config config.Component, hostname s
 
 	// start/stop order is important, agent need to be stopped first and started after all the others
 	// components
-	agent, err := secagent.NewRuntimeSecurityAgent(senderManager, hostname, secagent.RSAOptions{
+	agent, err := secagent.NewRuntimeSecurityAgent(statsdClient, hostname, secagent.RSAOptions{
 		LogProfiledWorkloads:    config.GetBool("runtime_security_config.log_profiled_workloads"),
 		IgnoreDDAgentContainers: config.GetBool("runtime_security_config.telemetry.ignore_dd_agent_containers"),
 	}, wmeta)

--- a/cmd/security-agent/subcommands/runtime/command_unsupported.go
+++ b/cmd/security-agent/subcommands/runtime/command_unsupported.go
@@ -17,10 +17,9 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
-	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 // Commands returns the runtime security commands
@@ -29,12 +28,12 @@ func Commands(*command.GlobalParams) []*cobra.Command {
 }
 
 // StartRuntimeSecurity starts runtime security
-func StartRuntimeSecurity(log log.Component, config config.Component, _ string, _ startstop.Stopper, _ ddgostatsd.ClientInterface, _ sender.SenderManager, _ workloadmeta.Component) (*secagent.RuntimeSecurityAgent, error) {
+func StartRuntimeSecurity(log log.Component, config config.Component, _ string, _ startstop.Stopper, _ statsd.ClientInterface, _ workloadmeta.Component) (*secagent.RuntimeSecurityAgent, error) {
 	enabled := config.GetBool("runtime_security_config.enabled")
 	if !enabled {
 		log.Info("Datadog runtime security agent disabled by config")
 		return nil, nil
 	}
 
-	return nil, errors.New("Datadog runtime security agent is only supported on Linux")
+	return nil, errors.New("Datadog runtime security agent is only supported on Linux and Windows")
 }

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -28,8 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/compliance"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/runtime"
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -50,13 +48,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
-	"github.com/DataDog/datadog-agent/comp/forwarder"
-	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
-	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
-	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
-	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl"
-	"github.com/DataDog/datadog-agent/comp/serializer/compression/compressionimpl"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	pkgCompliance "github.com/DataDog/datadog-agent/pkg/compliance"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -105,27 +97,14 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				core.Bundle(),
 				dogstatsd.ClientBundle,
-				forwarder.Bundle(),
-				fx.Provide(defaultforwarder.NewParamsWithResolvers),
-				compressionimpl.Module(),
-				demultiplexerimpl.Module(),
-				orchestratorForwarderImpl.Module(),
-				fx.Supply(orchestratorForwarderImpl.NewDisabledParams()),
-				eventplatformimpl.Module(),
-				fx.Supply(eventplatformimpl.NewDisabledParams()),
-				eventplatformreceiverimpl.Module(),
-				fx.Supply(demultiplexerimpl.NewDefaultParams()),
 				// workloadmeta setup
 				collectors.GetCatalog(),
 				workloadmeta.Module(),
 				fx.Provide(func(config config.Component) workloadmeta.Params {
-
 					catalog := workloadmeta.NodeAgent
-
 					if config.GetBool("security_agent.remote_workloadmeta") {
 						catalog = workloadmeta.Remote
 					}
-
 					return workloadmeta.Params{
 						AgentType: catalog,
 					}
@@ -143,13 +122,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Provide(func(config config.Component, statsd statsd.Component) (ddgostatsd.ClientInterface, error) {
 					return statsd.CreateForHostPort(setup.GetBindHost(config), config.GetInt("dogstatsd_port"))
 				}),
-				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, demultiplexer demultiplexer.Component, wmeta workloadmeta.Component) (status.InformationProvider, *agent.RuntimeSecurityAgent, error) {
+				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, wmeta workloadmeta.Component) (status.InformationProvider, *agent.RuntimeSecurityAgent, error) {
 					hostnameDetected, err := utils.GetHostnameWithContextAndFallback(context.TODO())
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
 					}
 
-					runtimeAgent, err := runtime.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, demultiplexer, wmeta)
+					runtimeAgent, err := runtime.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, wmeta)
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
 					}
@@ -161,14 +140,14 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					// TODO - components: Do not remove runtimeAgent ref until "github.com/DataDog/datadog-agent/pkg/security/agent" is a component so they're not GCed
 					return status.NewInformationProvider(runtimeAgent.StatusProvider()), runtimeAgent, nil
 				}),
-				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, demultiplexer demultiplexer.Component, sysprobeconfig sysprobeconfig.Component, wmeta workloadmeta.Component) (status.InformationProvider, *pkgCompliance.Agent, error) {
+				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, sysprobeconfig sysprobeconfig.Component, wmeta workloadmeta.Component) (status.InformationProvider, *pkgCompliance.Agent, error) {
 					hostnameDetected, err := utils.GetHostnameWithContextAndFallback(context.TODO())
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
 					}
 
 					// start compliance security agent
-					complianceAgent, err := compliance.StartCompliance(log, config, sysprobeconfig, hostnameDetected, stopper, statsdClient, demultiplexer, wmeta)
+					complianceAgent, err := compliance.StartCompliance(log, config, sysprobeconfig, hostnameDetected, stopper, statsdClient, wmeta)
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
 					}
@@ -210,11 +189,11 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 // TODO(components): note how workloadmeta is passed anonymously, it is still required as it is used
 // as a global. This should eventually be fixed and all workloadmeta interactions should be via the
 // injected instance.
-func start(log log.Component, config config.Component, _ secrets.Component, _ statsd.Component, _ sysprobeconfig.Component, telemetry telemetry.Component, demultiplexer demultiplexer.Component, statusComponent status.Component, _ pid.Component) error {
+func start(log log.Component, config config.Component, _ secrets.Component, _ statsd.Component, _ sysprobeconfig.Component, telemetry telemetry.Component, statusComponent status.Component, _ pid.Component) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer StopAgent(cancel, log)
 
-	err := RunAgent(ctx, log, config, telemetry, demultiplexer, statusComponent)
+	err := RunAgent(ctx, log, config, telemetry, statusComponent)
 	if errors.Is(err, errAllComponentsDisabled) || errors.Is(err, errNoAPIKeyConfigured) {
 		return nil
 	}
@@ -265,7 +244,7 @@ var errAllComponentsDisabled = errors.New("all security-agent component are disa
 var errNoAPIKeyConfigured = errors.New("no API key configured")
 
 // RunAgent initialized resources and starts API server
-func RunAgent(ctx context.Context, log log.Component, config config.Component, telemetry telemetry.Component, demultiplexer demultiplexer.Component, statusComponent status.Component) (err error) {
+func RunAgent(ctx context.Context, log log.Component, config config.Component, telemetry telemetry.Component, statusComponent status.Component) (err error) {
 	if err := util.SetupCoreDump(config); err != nil {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
@@ -313,8 +292,6 @@ func RunAgent(ctx context.Context, log log.Component, config config.Component, t
 			log.Errorf("Error creating expvar server on port %v: %v", port, err)
 		}
 	}()
-
-	demultiplexer.AddAgentStartupTelemetry(fmt.Sprintf("%s - Datadog Security Agent", version.AgentVersion))
 
 	if err = initRuntimeSettings(); err != nil {
 		return err

--- a/pkg/security/agent/agent_nix.go
+++ b/pkg/security/agent/agent_nix.go
@@ -13,24 +13,24 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 // NewRuntimeSecurityAgent instantiates a new RuntimeSecurityAgent
-func NewRuntimeSecurityAgent(senderManager sender.SenderManager, hostname string, opts RSAOptions, wmeta workloadmeta.Component) (*RuntimeSecurityAgent, error) {
+func NewRuntimeSecurityAgent(statsdClient statsd.ClientInterface, hostname string, opts RSAOptions, wmeta workloadmeta.Component) (*RuntimeSecurityAgent, error) {
 	client, err := NewRuntimeSecurityClient()
 	if err != nil {
 		return nil, err
 	}
 
 	// on windows do no telemetry
-	telemetry, err := newTelemetry(senderManager, wmeta, opts.LogProfiledWorkloads, opts.IgnoreDDAgentContainers)
+	telemetry, err := newTelemetry(statsdClient, wmeta, opts.LogProfiledWorkloads, opts.IgnoreDDAgentContainers)
 	if err != nil {
 		return nil, errors.New("failed to initialize the telemetry reporter")
 	}
 	// on windows do no storage manager
-	storage, err := dump.NewSecurityAgentStorageManager(senderManager)
+	storage, err := dump.NewSecurityAgentStorageManager()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/agent/agent_windows.go
+++ b/pkg/security/agent/agent_windows.go
@@ -9,11 +9,11 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 // NewRuntimeSecurityAgent instantiates a new RuntimeSecurityAgent
-func NewRuntimeSecurityAgent(_ sender.SenderManager, hostname string, _ RSAOptions, _ workloadmeta.Component) (*RuntimeSecurityAgent, error) {
+func NewRuntimeSecurityAgent(_ statsd.ClientInterface, hostname string, _ RSAOptions, _ workloadmeta.Component) (*RuntimeSecurityAgent, error) {
 	client, err := NewRuntimeSecurityClient()
 	if err != nil {
 		return nil, err

--- a/pkg/security/security_profile/dump/local_storage.go
+++ b/pkg/security/security_profile/dump/local_storage.go
@@ -22,10 +22,10 @@ import (
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"go.uber.org/atomic"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 type dumpFiles struct {
@@ -212,17 +212,17 @@ func (storage *ActivityDumpLocalStorage) Persist(request config.StorageRequest, 
 }
 
 // SendTelemetry sends telemetry for the current storage
-func (storage *ActivityDumpLocalStorage) SendTelemetry(sender sender.Sender) {
+func (storage *ActivityDumpLocalStorage) SendTelemetry(sender statsd.ClientInterface) {
 	storage.Lock()
 	defer storage.Unlock()
 
 	// send the count of dumps stored locally
 	if count := storage.localDumps.Len(); count > 0 {
-		sender.Gauge(metrics.MetricActivityDumpLocalStorageCount, float64(count), "", []string{})
+		_ = sender.Gauge(metrics.MetricActivityDumpLocalStorageCount, float64(count), nil, 1.0)
 	}
 
 	// send the count of recently deleted dumps
 	if count := storage.deletedCount.Swap(0); count > 0 {
-		sender.Count(metrics.MetricActivityDumpLocalStorageDeleted, float64(count), "", []string{})
+		_ = sender.Count(metrics.MetricActivityDumpLocalStorageDeleted, int64(count), nil, 1.0)
 	}
 }

--- a/pkg/security/security_profile/dump/remote_storage_forwarder.go
+++ b/pkg/security/security_profile/dump/remote_storage_forwarder.go
@@ -11,10 +11,10 @@ package dump
 import (
 	"bytes"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 // ActivityDumpRemoteStorageForwarder is a remote storage that forwards dumps to the security-agent
@@ -57,4 +57,4 @@ func (storage *ActivityDumpRemoteStorageForwarder) Persist(request config.Storag
 }
 
 // SendTelemetry sends telemetry for the current storage
-func (storage *ActivityDumpRemoteStorageForwarder) SendTelemetry(_ sender.Sender) {}
+func (storage *ActivityDumpRemoteStorageForwarder) SendTelemetry(_ statsd.ClientInterface) {}

--- a/pkg/security/telemetry/telemetry.go
+++ b/pkg/security/telemetry/telemetry.go
@@ -10,28 +10,22 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 // ContainersTelemetry represents the objects necessary to send metrics listing containers
 type ContainersTelemetry struct {
-	Sender        sender.Sender
-	MetadataStore workloadmeta.Component
-	IgnoreDDAgent bool
+	TelemetrySender SimpleTelemetrySender
+	MetadataStore   workloadmeta.Component
+	IgnoreDDAgent   bool
 }
 
 // NewContainersTelemetry returns a new ContainersTelemetry based on default/global objects
-func NewContainersTelemetry(senderManager sender.SenderManager, wmeta workloadmeta.Component) (*ContainersTelemetry, error) {
-	sender, err := senderManager.GetDefaultSender()
-	if err != nil {
-		return nil, err
-	}
-
+func NewContainersTelemetry(telemetrySender SimpleTelemetrySender, wmeta workloadmeta.Component) (*ContainersTelemetry, error) {
 	return &ContainersTelemetry{
-		Sender: sender,
-		// TODO(components): stop using globals and rely on injected workloadmeta component
-		MetadataStore: wmeta,
+		TelemetrySender: telemetrySender,
+		MetadataStore:   wmeta,
 	}, nil
 }
 
@@ -55,8 +49,33 @@ func (c *ContainersTelemetry) ReportContainers(metricName string) {
 			}
 		}
 
-		c.Sender.Gauge(metricName, 1.0, "", []string{"container_id:" + container.ID})
+		c.TelemetrySender.Gauge(metricName, 1.0, []string{"container_id:" + container.ID})
 	}
+	c.TelemetrySender.Commit()
+}
 
-	c.Sender.Commit()
+// SimpleTelemetrySender is an abstraction over what is needed for the container telemetry
+// the main goal is to be able to use it with a dogstatsd client or a SenderManager's default sender
+type SimpleTelemetrySender interface {
+	Gauge(name string, value float64, tags []string)
+	Commit()
+}
+
+type statsdSTS struct {
+	sci statsd.ClientInterface
+}
+
+func (s *statsdSTS) Gauge(name string, value float64, tags []string) {
+	_ = s.sci.Gauge(name, value, tags, 1.0)
+}
+
+func (s *statsdSTS) Commit() {
+	// nothing to do here
+}
+
+// NewSimpleTelemetrySenderFromStatsd returns a new SimpleTelemetrySender from a statsd client
+func NewSimpleTelemetrySenderFromStatsd(sci statsd.ClientInterface) SimpleTelemetrySender {
+	return &statsdSTS{
+		sci: sci,
+	}
 }

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -165,8 +165,6 @@ class TestE2EDocker(unittest.TestCase):
                 f"Sending event message for rule `{agent_rule_name}`",
             )
 
-            wait_agent_log("security-agent", self.docker_helper, "Successfully posted payload to")
-
         with Step(msg="check app event", emoji=":chart_increasing_with_yen:"):
             event = self.app.wait_app_log(f"rule_id:{agent_rule_name}")
             attributes = event["data"][0]["attributes"]

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -186,12 +186,6 @@ class TestE2EKubernetes(unittest.TestCase):
                 f"Sending event message for rule `{agent_rule_name}`",
             )
 
-            wait_agent_log(
-                "security-agent",
-                self.kubernetes_helper,
-                "Successfully posted payload to",
-            )
-
         with Step(msg="check app event", emoji=":chart_increasing_with_yen:"):
             event = self.app.wait_app_log(f"rule_id:{agent_rule_name}")
             attributes = event["data"][0]["attributes"]

--- a/test/new-e2e/tests/cws/ec2_test.go
+++ b/test/new-e2e/tests/cws/ec2_test.go
@@ -141,10 +141,6 @@ func (a *agentSuite) Test00OpenSignal() {
 	// Trigger agent event
 	a.Env().RemoteHost.MustExecute(fmt.Sprintf("touch %s", filename))
 
-	// Check agent event
-	err = a.waitAgentLogs("security-agent", "Successfully posted payload to")
-	require.NoError(a.T(), err, "could not send payload")
-
 	// Check app signal
 	signal, err := api.WaitAppSignal(apiClient, fmt.Sprintf("host:%s @workflow.rule.id:%s", a.Env().Agent.Client.Hostname(), signalRuleID))
 	require.NoError(a.T(), err)


### PR DESCRIPTION
### What does this PR do?

This PR removes all unused components from the security agents, especially around "multiplexer/orchestrator/forwarder" components.
To do this, we converts all usages of `Sender` to use regular statsd client (as already done by the compliance part).

For the containers telemetry we use a small interface that can be plugged through either statsd (for security agent) or `Sender` (when used from the cluster agent that has no statsd client).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- CWS: this should basically be a no-op, the main goal is to check that metrics are still reported correctly (especially the container metric), and are correctly dual-shipped as expected
- CSPM: basically the same thing, check that metrics are emitted correctly

And also that the product still works and does not directly crash in some kind of fx-inflicted fire at boot
