### PR TITLE
[CSPM] remove unused runner when creating compliance agent

### DIFF
--- a/cmd/cluster-agent/subcommands/start/compliance.go
+++ b/cmd/cluster-agent/subcommands/start/compliance.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
-	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -88,9 +87,6 @@ func startCompliance(senderManager sender.SenderManager, wmeta workloadmeta.Comp
 	if err != nil {
 		return err
 	}
-
-	runner := runner.NewRunner(senderManager)
-	stopper.Add(runner)
 
 	reporter := compliance.NewLogReporter(hname, "compliance-agent", "compliance", runPath, endpoints, ctx)
 	agent := compliance.NewAgent(senderManager, wmeta, compliance.AgentOptions{

--- a/cmd/security-agent/subcommands/compliance/compliance.go
+++ b/cmd/security-agent/subcommands/compliance/compliance.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
-	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
@@ -70,8 +69,6 @@ func StartCompliance(log log.Component, config config.Component, sysprobeconfig 
 	}
 
 	reporter := compliance.NewLogReporter(hostname, "compliance-agent", "compliance", runPath, endpoints, context)
-	runner := runner.NewRunner(senderManager)
-	stopper.Add(runner)
 	agent := compliance.NewAgent(senderManager, wmeta, compliance.AgentOptions{
 		ResolverOptions:               resolverOptions,
 		ConfigDir:                     configDir,


### PR DESCRIPTION
### What does this PR do?

This runner variable is unused, this PR removes it.

This is in prevision for https://github.com/DataDog/datadog-agent/pull/24389 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
