### PR TITLE
[CWS] do not implement containers telemetry on windows

### DIFF
--- a/pkg/security/agent/telemetry_linux.go
+++ b/pkg/security/agent/telemetry_linux.go
@@ -28,7 +28,6 @@ type telemetry struct {
 	logProfiledWorkloads  bool
 }
 
-//nolint:unused // TODO(SEC) Fix unused linter
 func newTelemetry(senderManager sender.SenderManager, wmeta workloadmeta.Component, logProfiledWorkloads, ignoreDDAgentContainers bool) (*telemetry, error) {
 	runtimeSecurityClient, err := NewRuntimeSecurityClient()
 	if err != nil {

--- a/pkg/security/agent/telemetry_others.go
+++ b/pkg/security/agent/telemetry_others.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+// Package agent holds agent related files
+package agent
+
+import "context"
+
+type telemetry struct{}
+
+func (t *telemetry) registerProfiledContainer(_, _ string) {}
+
+func (t *telemetry) run(_ context.Context, _ *RuntimeSecurityAgent) {}


### PR DESCRIPTION
### What does this PR do?

This PR removes the `nolint:unused` by gating the containers telemetry code to linux only, and creating an empty shell for other OS.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
