### PR TITLE
[CWS] read more lines from k8s when fetching pod logs in e2e tests

### DIFF
--- a/test/e2e/cws-tests/tests/lib/kubernetes.py
+++ b/test/e2e/cws-tests/tests/lib/kubernetes.py
@@ -29,7 +29,7 @@ class KubernetesHelper(LogGetter):
 
     def get_log(self, agent_name):
         log = self.api_client.read_namespaced_pod_log(
-            name=self.pod_name, namespace=self.namespace, container=agent_name, follow=False, tail_lines=5000
+            name=self.pod_name, namespace=self.namespace, container=agent_name, follow=False, tail_lines=10000
         )
 
         return log.splitlines()


### PR DESCRIPTION
### What does this PR do?

In some cases (when we are getting spammed of logs), we can miss some important logs (like the "runtime security started" log) and fail the legacy e2e test. This PR improves on the issue by reading more logs.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
