### PR TITLE
[EBPF] Improve tasks around KMT CI

### DIFF
--- a/tasks/kernel_matrix_testing/README.md
+++ b/tasks/kernel_matrix_testing/README.md
@@ -365,3 +365,25 @@ This is only relevant for VMs running in the local environment. This has no effe
 ### Resuming the stack
 
 This resumes a previously paused stack. This is only applicable for VMs running locally.
+
+## Interacting with the CI
+
+KMT has some tasks whose purpose is to make it easier to interact with the CI. They are described below.
+
+### Creating a stack from a failed CI pipeline
+
+To avoid having to copy and paste all the data from the CI to generate a list of VMs, you can use the `--from-ci-pipeline` flag to automatically generate a configuration file that replicates the jobs that failed in a CI pipeline. See the [Configuring stack from a failed CI pipeline](#configuring-stack-from-a-failed-ci-pipeline) section for more details.
+
+### Summary of failed tests in a CI pipeline
+
+To get a summary of the tests that were run in a CI pipeline, you can use the following command:
+
+```bash
+inv -e kmt.explain-ci-failure <pipeline-id>
+```
+
+This will show several tables, skipping the cases where all jobs/tests passed to avoid polluting the output.
+
+- For each component (security-agent or system-probe) and vmset (e.g., in system-probe we have `only_tracersuite` and `no_tracersuite` test sets) it will show the jobs that failed and why (e.g., if the job failed due to an infra or a test failure).
+- Again, for each component and vmset, it will show which tests failed in a table showing in which distros/archs they failed (tests and distros that did not have any failures will not be shown).
+- For each job that failed due to infra reasons, it will show a summary with quick detection of possible boot causes (e.g., it will show if the VM did not reach the login prompt, or if it didn't get an IP address, etc).

--- a/tasks/kernel_matrix_testing/ci.py
+++ b/tasks/kernel_matrix_testing/ci.py
@@ -8,7 +8,7 @@ import tarfile
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, overload
 
-from tasks.libs.common.gitlab import Gitlab, get_gitlab_token
+from tasks.libs.ciproviders.gitlab import Gitlab, get_gitlab_token
 
 if TYPE_CHECKING:
     from typing_extensions import Literal

--- a/tasks/kernel_matrix_testing/ci.py
+++ b/tasks/kernel_matrix_testing/ci.py
@@ -27,6 +27,9 @@ class KMTJob:
         self.gitlab = get_gitlab()
         self.job_data = job_data
 
+    def __str__(self):
+        return f"<KMTJob: {self.name}>"
+
     @property
     def id(self) -> int:
         return self.job_data["id"]

--- a/tasks/kernel_matrix_testing/ci.py
+++ b/tasks/kernel_matrix_testing/ci.py
@@ -106,6 +106,7 @@ class KMTSetupEnvJob(KMTJob):
 
     def __init__(self, job_data: Dict[str, Any]):
         super().__init__(job_data)
+        self.associated_test_jobs: List[KMTTestRunJob] = []
 
     @property
     def stack_output(self) -> StackOutput:
@@ -240,6 +241,7 @@ def get_all_jobs_for_pipeline(pipeline_id: Union[int, str]) -> Tuple[List[KMTSet
         for setup_job in setup_jobs:
             if job.arch == setup_job.arch and job.component == setup_job.component:
                 job.setup_job = setup_job
+                setup_job.associated_test_jobs.append(job)
                 break
 
     return setup_jobs, test_jobs

--- a/tasks/kernel_matrix_testing/ci.py
+++ b/tasks/kernel_matrix_testing/ci.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, overload
+
+from tasks.kernel_matrix_testing.types import VMConfig
+from tasks.libs.common.gitlab import Gitlab, get_gitlab_token
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
+
+    from tasks.kernel_matrix_testing.types import Arch, Component, StackOutput
+
+
+def get_gitlab() -> Gitlab:
+    return Gitlab("DataDog/datadog-agent", str(get_gitlab_token()))
+
+
+class KMTJob:
+    def __init__(self, job_data: Dict[str, Any]):
+        self.gitlab = get_gitlab()
+        self.job_data = job_data
+
+    @property
+    def id(self) -> int:
+        return self.job_data["id"]
+
+    @property
+    def pipeline_id(self) -> int:
+        return self.job_data["pipeline"]["id"]
+
+    @property
+    def name(self) -> str:
+        return self.job_data.get("name", "")
+
+    @property
+    def arch(self) -> Arch:
+        return "x86_64" if "x64" in self.name else "arm64"
+
+    @property
+    def component(self) -> Component:
+        return "system-probe" if "sysprobe" in self.name else "security-agent"
+
+    @property
+    def status(self) -> Literal['success', 'failed']:
+        return self.job_data['status']
+
+    @property
+    def failure_reason(self) -> str:
+        return self.job_data["failure_reason"]
+
+    @overload
+    def artifact_file(self, file: str, ignore_not_found: Literal[True]) -> Optional[str]:  # noqa: U100
+        ...
+
+    @overload
+    def artifact_file(self, file: str, ignore_not_found: Literal[False] = False) -> str:  # noqa: U100
+        ...
+
+    def artifact_file(self, file: str, ignore_not_found: bool = False) -> Optional[str]:
+        try:
+            res = self.gitlab.artifact(self.id, file, ignore_not_found=ignore_not_found)
+            if res is None:
+                if not ignore_not_found:
+                    raise RuntimeError("Invalid return value from gitlab.artifact")
+                else:
+                    return None
+            res.raise_for_status()
+        except Exception as e:
+            raise RuntimeError(f"Could not retrieve artifact {file}") from e
+        return res.content.decode('utf-8')
+
+
+class KMTSetupEnvJob(KMTJob):
+    def __init__(self, job_data: Dict[str, Any]):
+        super().__init__(job_data)
+
+    @property
+    def stack_output(self) -> StackOutput:
+        return json.loads(self.artifact_file("stack.output"))
+
+    @property
+    def vmconfig(self) -> VMConfig:
+        return json.loads(self.artifact_file(f"vmconfig-{self.pipeline_id}-{self.arch}.json"))
+
+    @property
+    def seen_ips(self) -> Set[str]:
+        ips: Set[str] = set()
+
+        for iface in [0, 1, 2, 3]:
+            virbr_status = self.artifact_file(f"libvirt/dnsmasq/virbr{iface}.status", ignore_not_found=True)
+            if virbr_status is None or len(virbr_status.strip()) == 0:
+                continue
+
+            for entry in json.loads(virbr_status):
+                ip = entry.get('ip-address')
+                if ip is not None:
+                    ips.add(ip)
+
+        return ips
+
+    def get_vm(self, distro: str, vmset: str) -> Optional[Tuple[str, str]]:
+        """Return the VM ID and IP that matches a given distro and vmset in this environment job
+
+        Returns None if they're not found
+        """
+        for _, vmmap in self.stack_output.items():
+            for microvm in vmmap['microvms']:
+                if microvm['tag'] == distro and vmset in microvm['vmset-tags']:
+                    return microvm['id'], microvm['ip']
+        return None
+
+    def get_vm_boot_log(self, distro: str, vmset: str) -> Optional[str]:
+        """Return the boot log for a given distro and vmset in this setup-env job"""
+        vmdata = self.get_vm(distro, vmset)
+        if vmdata is None:
+            return None
+        vmid, _ = vmdata
+
+        dd_repo_id = 4670
+        vm_log_name = f"ddvm-ci-{self.id}-{dd_repo_id}-kernel-matrix-testing-{self.component}-{self.arch.replace('_', '-')}-{self.pipeline_id}-{vmid}.log"
+        vm_log_path = f"libvirt/log/{vm_log_name}"
+
+        return self.artifact_file(vm_log_path)
+
+
+class KMTTestRunJob(KMTJob):
+    def __init__(self, job_data: Dict[str, Any]):
+        super().__init__(job_data)
+        self.setup_job: Optional[KMTSetupEnvJob] = None
+
+    @property
+    def vars(self) -> List[str]:
+        match = re.search(r"\[([^\]]+)\]", self.name)
+        if match is None:
+            raise RuntimeError(f"Invalid job name {self.name}")
+        return [x.strip() for x in match.group(1).split(",")]
+
+    @property
+    def distro(self) -> str:
+        return self.vars[0]
+
+    @property
+    def vmset(self) -> str:
+        return self.vars[1]
+
+
+def get_all_jobs_for_pipeline(pipeline_id: Union[int, str]) -> Tuple[List[KMTSetupEnvJob], List[KMTTestRunJob]]:
+    """Gets all KMT jobs for a given pipeline, separated between setup jobs and test run jobs.
+
+    Also links the corresponding setup jobs for each test run job
+    """
+    setup_jobs: List[KMTSetupEnvJob] = []
+    test_jobs: List[KMTTestRunJob] = []
+
+    gitlab = get_gitlab()
+    for job in gitlab.all_jobs(pipeline_id):
+        name = job.get("name", "")
+        if name.startswith("kmt_setup_env"):
+            setup_jobs.append(KMTSetupEnvJob(job))
+        elif name.startswith("kmt_run_"):
+            test_jobs.append(KMTTestRunJob(job))
+
+    # link setup jobs
+    for job in test_jobs:
+        for setup_job in setup_jobs:
+            if job.arch == setup_job.arch and job.component == setup_job.component:
+                job.setup_job = setup_job
+                break
+
+    return setup_jobs, test_jobs

--- a/tasks/kernel_matrix_testing/ci.py
+++ b/tasks/kernel_matrix_testing/ci.py
@@ -8,13 +8,12 @@ import tarfile
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, overload
 
-from tasks.kernel_matrix_testing.types import VMConfig
 from tasks.libs.common.gitlab import Gitlab, get_gitlab_token
 
 if TYPE_CHECKING:
     from typing_extensions import Literal
 
-    from tasks.kernel_matrix_testing.types import Arch, Component, StackOutput
+    from tasks.kernel_matrix_testing.types import Arch, Component, StackOutput, VMConfig
 
 
 def get_gitlab() -> Gitlab:

--- a/tasks/kernel_matrix_testing/ci.py
+++ b/tasks/kernel_matrix_testing/ci.py
@@ -180,12 +180,15 @@ class KMTTestRunJob(KMTJob):
     def get_test_results(self) -> Dict[str, Optional[bool]]:
         results: Dict[str, Optional[bool]] = {}
         for report in self.get_junit_reports():
-            for testcase in report.findall(".//testcase"):
-                name = testcase.get("name")
-                if name is not None:
-                    failed = len(testcase.findall(".//failure")) > 0
-                    skipped = len(testcase.findall(".//skipped")) > 0
-                    results[name] = None if skipped else not failed
+            for testsuite in report.findall(".//testsuite"):
+                pkgname = testsuite.get("name")
+
+                for testcase in report.findall(".//testcase"):
+                    name = testcase.get("name")
+                    if name is not None:
+                        failed = len(testcase.findall(".//failure")) > 0
+                        skipped = len(testcase.findall(".//skipped")) > 0
+                        results[f"{pkgname}:{name}"] = None if skipped else not failed
 
         return results
 

--- a/tasks/kernel_matrix_testing/infra.py
+++ b/tasks/kernel_matrix_testing/infra.py
@@ -11,7 +11,7 @@ from tasks.kernel_matrix_testing.kmt_os import get_kmt_os
 from tasks.kernel_matrix_testing.tool import Exit, ask, error
 
 if TYPE_CHECKING:
-    from tasks.kernel_matrix_testing.types import ArchOrLocal, PathOrStr
+    from tasks.kernel_matrix_testing.types import ArchOrLocal, PathOrStr, StackOutput
 
 # Common SSH options for all SSH commands
 SSH_OPTIONS = {
@@ -171,7 +171,7 @@ def build_infrastructure(stack: str, remote_ssh_key: Optional[str] = None):
 
     with open(stack_output, 'r') as f:
         try:
-            infra_map = json.load(f)
+            infra_map: StackOutput = json.load(f)
         except json.decoder.JSONDecodeError:
             raise Exit(f"{stack_output} file is not a valid json file")
 

--- a/tasks/kernel_matrix_testing/types.py
+++ b/tasks/kernel_matrix_testing/types.py
@@ -76,7 +76,8 @@ VMDef = Tuple[Recipe, str, ArchOrLocal]
 
 
 class HasName(Protocol):
-    def name(self) -> str: ...
+    def name(self) -> str:
+        ...
 
 
 TNamed = TypeVar('TNamed', bound=HasName)

--- a/tasks/kernel_matrix_testing/types.py
+++ b/tasks/kernel_matrix_testing/types.py
@@ -76,8 +76,20 @@ VMDef = Tuple[Recipe, str, ArchOrLocal]
 
 
 class HasName(Protocol):
-    def name(self) -> str:
-        ...
+    def name(self) -> str: ...
 
 
 TNamed = TypeVar('TNamed', bound=HasName)
+
+
+StackOutputMicroVM = TypedDict(
+    'StackOutputMicroVM', {'id': str, 'ip': 'str', 'ssh-key-path': str, 'tag': str, 'vmset-tags': List[str]}
+)
+
+
+class StackOutputArchData(TypedDict):
+    ip: str
+    microvms: List[StackOutputMicroVM]
+
+
+StackOutput = Dict[Arch, StackOutputArchData]

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -821,11 +821,12 @@ def status(ctx: Context, stack: Optional[str] = None, all=False, ssh_key: Option
 
 @task
 def explain_ci_failure(_, pipeline: str):
+    """Show a summary of KMT failures in the given pipeline."""
     if tabulate is None:
         raise Exit("tabulate module is not installed, please install it to continue")
 
     info(f"[+] retrieving all CI jobs for pipeline {pipeline}")
-    setup_jobs, test_jobs = get_all_jobs_for_pipeline(pipeline)
+    _, test_jobs = get_all_jobs_for_pipeline(pipeline)
 
     failed_jobs = [j for j in test_jobs if j.status == "failed"]
     failreasons: Dict[str, str] = {}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Refactors the KMT code that interacts with Gitlab, with two improvements to make it easier for developers to interact with the results of the CI:

- The `kmt.gen-config --from-ci-pipeline` task will now detect which packages failed and will print the corresponding test command to use.
- Adds a `kmt.explain-ci-failure` command that shows a summary of the KMT failures in a given pipeline, including a quick lookup into the reason of infra failures. Example output:

``` 
[+] retrieving all CI jobs for pipeline 31341042
[!] Found 8 failed jobs. Showing only distros with failures
Legend: OK ✅ | Test failure ❌ | Infra failure ⚙️

=== Job failures for security-agent - all_tests
Distro      x86_64    arm64
----------  --------  -------
rocky_9.3   ❌        ❌
rocky_8.5   ✅        ❌
oracle_9.3  ❌        ❌
oracle_8.9  ❌        ❌

=== Test failures for security-agent - all_tests (show only tests and distros with at least one fail, empty means skipped)
┌──────────────────────────────────────────────────────────────────────┬───────────────────┬───────────────────┬────────────────────┬────────────────────┬────────────────────┬─────────────────────┬─────────────────────┐
│ Test name                                                            │ rocky_9.3 arm64   │ rocky_8.5 arm64   │ oracle_9.3 arm64   │ oracle_8.9 arm64   │ rocky_9.3 x86_64   │ oracle_9.3 x86_64   │ oracle_8.9 x86_64   │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestActionKill                                    │ ❌                │ ✅                │ ✅                 │ ✅                 │ ❌                 │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestActionKill/kill-action-kill                   │ ❌                │ ✅                │ ✅                 │ ✅                 │ ❌                 │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestActionKill/kill-action-usr2                   │ ❌                │ ✅                │ ✅                 │ ✅                 │ ❌                 │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestBindEvent                                     │ ❌                │ ✅                │ ✅                 │ ✅                 │ ❌                 │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestBindEvent/bind-af-inet-any-success-tcp-docker │ ❌                │ ✅                │ ✅                 │ ✅                 │ ❌                 │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestBindEvent/bind-af-inet-any-success-tcp-std    │ ❌                │ ✅                │ ✅                 │ ✅                 │ ❌                 │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestBindEvent/bind-af-inet-any-success-udp-docker │ ❌                │ ✅                │ ✅                 │ ✅                 │ ❌                 │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestBindEvent/bind-af-inet-any-success-udp-std    │ ❌                │ ✅                │ ✅                 │ ✅                 │ ❌                 │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestBindEvent/bind-af-inet6-any-success-docker    │ ❌                │ ✅                │ ✅                 │ ✅                 │ ❌                 │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestBindEvent/bind-af-inet6-any-success-std       │ ❌                │ ✅                │ ✅                 │ ✅                 │                    │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestBindEvent/bind-af-unknown-unix-docker         │ ❌                │ ✅                │ ✅                 │ ✅                 │                    │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestBindEvent/bind-af-unknown-unix-std            │ ❌                │ ✅                │ ✅                 │ ✅                 │                    │ ✅                  │ ✅                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestOctogonConstants                              │                   │ ✅                │ ❌                 │ ❌                 │                    │ ❌                  │ ❌                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestOctogonConstants/btf-vs-fallback              │                   │ ✅                │ ❌                 │ ❌                 │                    │ ❌                  │ ❌                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestOctogonConstants/rc-vs-fallback               │                   │ ✅                │ ❌                 │ ❌                 │                    │ ❌                  │ ❌                  │
├──────────────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┼────────────────────┼────────────────────┼─────────────────────┼─────────────────────┤
│ pkg/security/tests:TestPTraceEvent                                   │                   │ ❌                │ ✅                 │ ✅                 │                    │ ✅                  │ ✅                  │
└──────────────────────────────────────────────────────────────────────┴───────────────────┴───────────────────┴────────────────────┴────────────────────┴────────────────────┴─────────────────────┴─────────────────────┘

=== Job failures for system-probe - no_tracersuite
Distro    x86_64    arm64
--------  --------  -------
centos_8  ⚙️        ✅

[+] Analyzing system-probe x86_64 infra failures...
Distro    Login prompt found    setup-ddvm ok    Assigned IP    Downloaded boot log
--------  --------------------  ---------------  -------------  ---------------------------------------------------------------------------------------------------------------------------
centos_8  ✅                    ❌               ✅             /var/folders/sf/lxvsk3cs7_53cz4p1h3g8zgh0000gp/T/kmt-pipeline-31341042/x86_64-system-probe-centos_8-no_tracersuite.boot.log
```

### Motivation

Make it easier to interact with the result of pipelines without having to go through all the CI jobs.

### Additional Notes

Based on this it wouldn't be difficult to add the same results as an automated Github comment.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
