### PR TITLE
Fix `TestEKSSuite/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting` flaky new-e2e test

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -92,7 +92,7 @@ func (suite *k8sSuite) TearDownSuite() {
 // The 00 in Test00UpAndRunning is here to guarantee that this test, waiting for the agent pods to be ready,
 // is run first.
 func (suite *k8sSuite) Test00UpAndRunning() {
-	suite.testUpAndRunning(5 * time.Minute)
+	suite.testUpAndRunning(10 * time.Minute)
 }
 
 // An agent restart (because of a health probe failure or because of a OOM kill for ex.)


### PR DESCRIPTION
### What does this PR do?

Increase the timeout of the `TestEKSSuite/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting` new e2e test.

### Motivation

Make it less flaky because [it failed a few times recently](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.name%3A%22TestEKSSuite%2FTest00UpAndRunning%2Fagent_pods_are_ready_and_not_restarting%22&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=&fromUser=false&index=citest&mode=sliding&saved-view-id=2236559&start=1711706583689&end=1712311383689&paused=false).

### Additional Notes

The [CI complains that the Windows agent pod isn’t ready](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/478370730#L1178):
```
=== FAIL: tests/containers TestEKSSuite/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting (300.00s)
    k8s_test.go:115: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:181
        	            				/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.8.linux-amd64/src/runtime/asm_amd64.s:1650
        	Error:      	Should be true
        	Messages:   	Container agent of pod dda-windows-datadog-rv45w isn’t ready
    k8s_test.go:115: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:115
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:115
        	Error:      	Condition never satisfied
        	Test:       	TestEKSSuite/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting
        	Messages:   	Not all agents eventually became ready in time.
        --- FAIL: TestEKSSuite/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting (300.00s)
```

Yet, when showing the state of the cluster, the same [CI logs show that the Windows agent pod is up and running and hasn’t restarted](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/478370730#L1718):
```
        NAMESPACE                       NAME                                                   READY   STATUS    RESTARTS   AGE   IP            NODE                          NOMINATED NODE   READINESS GATES
        datadog                         pod/dda-windows-datadog-rv45w                          3/3     Running   0          16m   10.1.49.209   ip-10-1-48-172.ec2.internal   <none>           <none>
```

Also, we can notice that even when the `TestEKSSuite/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting` passes, it’s sometimes close to the current timeout:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/8addd8e9-45af-43ee-a691-6b9d5a3065de)

And indeed, [the data collected during the tests are showing that the Windows agent pods takes several more minutes to start than the Linux ones](https://dddev.datadoghq.com/metric/explorer?fromUser=true&start=1712250900000&end=1712252100000&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMgA1ngARjoiiJppCJ5wAHQOUJ1GGFBYwHWNTploeBoIOk6R6siZEAC0ACwA7AAcAMxrAAxrW7urAGx7S3A1Gkvjk9PaFAAEPbNRcMhQyUsAVDwP9VgPYDPOZwHidYRoNAAChEeEhAEoQDwALpUVzuOEYULhdGqTExUrxJGokBTLBoHKgeQYCkIabKKA4GBjTAaDQQTKJNCiOBOOSKZTpblQLk8pz0JjKERuDxoJH8CD2TBYPkKHIgeoYbSWFE8Pik+TchAAYSkwhgKFhkJ4QA):
![image](https://github.com/DataDog/datadog-agent/assets/1437785/cb2a35e8-76e4-41a9-8af5-c47e9edad6fb)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
