### PR TITLE
better error message for `inv -e check-go-mod-replaces`

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -368,7 +368,11 @@ def check_go_mod_replaces(_ctx):
                     errors_found.add(f"{mod.import_path}/go.mod is missing a replace for {err_mod}")
 
     if errors_found:
-        message = "\nErrors found:\n" + "\n".join("  - " + error for error in sorted(errors_found))
+        message = "\nErrors found:\n"
+        message += "\n".join("  - " + error for error in sorted(errors_found))
+        message += (
+            "\n\nThis task operates on go.sum files, so make sure to run `inv -e tidy-all` before re-running this task."
+        )
         raise Exit(message=message)
 
 


### PR DESCRIPTION
### What does this PR do?

The error message did not fully convey the fact that running `inv -e tidy-all` after adding the missing replaces was needed. This PR improves the error message to make it a bit clearer.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
