### PR TITLE
[CWS] replace `seclog.Debugf` with `fmt.Errorf` for error de-duplication

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1358,19 +1358,16 @@ func (p *EBPFProbe) handleNewMount(ev *model.Event, m *model.Mount) error {
 
 	// Resolve mount point
 	if err := p.Resolvers.PathResolver.SetMountPoint(ev, m); err != nil {
-		seclog.Debugf("failed to set mount point: %v", err)
-		return err
+		return fmt.Errorf("failed to set mount point: %w", err)
 	}
 	// Resolve root
 	if err := p.Resolvers.PathResolver.SetMountRoot(ev, m); err != nil {
-		seclog.Debugf("failed to set mount root: %v", err)
-		return err
+		return fmt.Errorf("failed to set mount root: %w", err)
 	}
 
 	// Insert new mount point in cache, passing it a copy of the mount that we got from the event
 	if err := p.Resolvers.MountResolver.Insert(*m, 0); err != nil {
-		seclog.Errorf("failed to insert mount event: %v", err)
-		return err
+		return fmt.Errorf("failed to insert mount event: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
### What does this PR do?

When `handleNewMount` fails we `Debugf` the error first in the function itself, then in the calling function as well resulting in doubled logs (especially an issue in e2e tests where the log level is set to trace).

```
[36margo-datadog-agent-cp6mq-log-system-probe-3817659234: 2024-04-05 10:45:50 UTC | SYS-PROBE | DEBUG | (pkg/security/probe/probe_ebpf.go:607 in handleEvent) | failed to handle new mount from unshare mnt ns event: non critical path resolution error: dentry path key not found 4047/162[0m
[36margo-datadog-agent-cp6mq-log-system-probe-3817659234: 2024-04-05 10:45:50 UTC | SYS-PROBE | DEBUG | (pkg/security/probe/probe_ebpf.go:1361 in handleNewMount) | failed to set mount point: non critical path resolution error: dentry path key not found 4047/175[0m
[36margo-datadog-agent-cp6mq-log-system-probe-3817659234: 2024-04-05 10:45:50 UTC | SYS-PROBE | DEBUG | (pkg/security/probe/probe_ebpf.go:607 in handleEvent) | failed to handle new mount from unshare mnt ns event: non critical path resolution error: dentry path key not found 4047/175[0m
[36margo-datadog-agent-cp6mq-log-system-probe-3817659234: 2024-04-05 10:45:50 UTC | SYS-PROBE | DEBUG | (pkg/security/probe/probe_ebpf.go:1361 in handleNewMount) | failed to set mount point: non critical path resolution error: dentry path key not found 4047/182[0m
[36margo-datadog-agent-cp6mq-log-system-probe-3817659234: 2024-04-05 10:45:50 UTC | SYS-PROBE | DEBUG | (pkg/security/probe/probe_ebpf.go:607 in handleEvent) | failed to handle new mount from unshare mnt ns event: non critical path resolution error: dentry path key not found 4047/182[0m
```

This PR cleans this up by only keeping the calling debugf, and wrapping the error to keep the context.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
