### PR TITLE
Remove `GOPROXY=off` from tidy hook

### DIFF
--- a/tasks/git-hooks/go-mod-tidy.py
+++ b/tasks/git-hooks/go-mod-tidy.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import os
 import sys
 
 from invoke.context import Context
@@ -10,9 +9,7 @@ from ..go import tidy_all
 
 if __name__ == "__main__":
     # need to tidy all modules due to the replace directives
-    # disable module lookup so that it fails as early as possible
     # might be possible to do something smarter once https://github.com/golang/go/issues/27005 is fixed
-    os.environ["GOPROXY"] = "off"
     ctx = Context()
     try:
         tidy_all(ctx)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Remove `GOPROXY=off` from the `go mod tidy` git hook.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
I initially set `GOPROXY=off` to fail early if there are any changes, but it will also fail if it needs to download a dependency (even if that doesn't result in a change in `go.mod`).
Removing `GOPROXY=off` means the hook might take a little longer to fail but at least it won't fail if there are no changes.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
