### PR TITLE
[CWS] Always snapshot mmaped files in activity dumps

### DIFF
--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -50,7 +50,9 @@ func (pn *ProcessNode) snapshot(owner Owner, stats *Stats, newEvent func() *mode
 
 	// snapshot files
 	if owner.IsEventTypeValid(model.FileOpenEventType) {
-		pn.snapshotFiles(p, stats, newEvent, reducer)
+		pn.snapshotAllFiles(p, stats, newEvent, reducer)
+	} else {
+		pn.snapshotMemoryMappedFiles(p, stats, newEvent, reducer)
 	}
 
 	// snapshot sockets
@@ -63,7 +65,7 @@ func (pn *ProcessNode) snapshot(owner Owner, stats *Stats, newEvent func() *mode
 // this value was selected because it represents the default upper bound for the number of FDs a linux process can have
 const maxFDsPerProcessSnapshot = 1024
 
-func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent func() *model.Event, reducer *PathsReducer) {
+func (pn *ProcessNode) snapshotAllFiles(p *process.Process, stats *Stats, newEvent func() *model.Event, reducer *PathsReducer) {
 	// list the files opened by the process
 	fileFDs, err := p.OpenFiles()
 	if err != nil {
@@ -95,37 +97,49 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent 
 	}
 
 	// list the mmaped files of the process
-	mmapedFiles, err := snapshotMemoryMappedFiles(p.Pid, pn.Process.FileEvent.PathnameStr)
+	mmapedFiles, err := getMemoryMappedFiles(p.Pid, pn.Process.FileEvent.PathnameStr)
 	if err != nil {
 		seclog.Warnf("error while listing memory maps (pid: %v): %s", p.Pid, err)
 	}
-	// often the mmaped files are already nearly sorted, so we take the quick win and de-duplicate without sorting
-	mmapedFiles = slices.Compact(mmapedFiles)
 
 	files = append(files, mmapedFiles...)
 	if len(files) == 0 {
 		return
 	}
 
+	pn.addFiles(files, stats, newEvent, reducer)
+}
+
+func (pn *ProcessNode) snapshotMemoryMappedFiles(p *process.Process, stats *Stats, newEvent func() *model.Event, reducer *PathsReducer) {
+	// list the mmaped files of the process
+	mmapedFiles, err := getMemoryMappedFiles(p.Pid, pn.Process.FileEvent.PathnameStr)
+	if err != nil {
+		seclog.Warnf("error while listing memory maps (pid: %v): %s", p.Pid, err)
+	}
+
+	pn.addFiles(mmapedFiles, stats, newEvent, reducer)
+}
+
+func (pn *ProcessNode) addFiles(files []string, stats *Stats, newEvent func() *model.Event, reducer *PathsReducer) {
+	// list the mmaped files of the process
 	slices.Sort(files)
 	files = slices.Compact(files)
 
 	// insert files
-	var fileinfo os.FileInfo
-	var resolvedPath string
+	var (
+		err          error
+		resolvedPath string
+	)
 	for _, f := range files {
 		if len(f) == 0 {
 			continue
 		}
 
-		// fetch the file user, group and mode
 		fullPath := filepath.Join(utils.ProcRootPath(pn.Process.Pid), f)
-		fileinfo, err = os.Stat(fullPath)
-		if err != nil {
-			continue
-		}
-		stat, ok := fileinfo.Sys().(*syscall.Stat_t)
-		if !ok {
+
+		var fileStats unix.Statx_t
+		if err := unix.Statx(unix.AT_FDCWD, fullPath, 0, unix.STATX_ALL, &fileStats); err != nil {
+			seclog.Tracef("unable to stat mapped file %s", fullPath)
 			continue
 		}
 
@@ -139,14 +153,22 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent 
 			evt.Open.File.SetPathnameStr(f)
 		}
 		evt.Open.File.SetBasenameStr(path.Base(evt.Open.File.PathnameStr))
-		evt.Open.File.FileFields.Mode = uint16(stat.Mode)
-		evt.Open.File.FileFields.Inode = stat.Ino
-		evt.Open.File.FileFields.UID = stat.Uid
-		evt.Open.File.FileFields.GID = stat.Gid
+		evt.Open.File.FileFields.Mode = uint16(fileStats.Mode)
+		evt.Open.File.FileFields.Inode = fileStats.Ino
+		evt.Open.File.FileFields.UID = fileStats.Uid
+		evt.Open.File.FileFields.GID = fileStats.Gid
+
+		evt.Open.File.CTime = uint64(time.Unix(fileStats.Ctime.Sec, int64(fileStats.Ctime.Nsec)).Nanosecond())
+		evt.Open.File.MTime = uint64(time.Unix(fileStats.Mtime.Sec, int64(fileStats.Mtime.Nsec)).Nanosecond())
+		evt.Open.File.Mode = fileStats.Mode
+		evt.Open.File.Inode = fileStats.Ino
+		evt.Open.File.Device = fileStats.Dev_major<<20 | fileStats.Dev_minor
+		evt.Open.File.NLink = fileStats.Nlink
+		evt.Open.File.MountID = uint32(fileStats.Mnt_id)
 
 		evt.Open.File.Mode = evt.Open.File.FileFields.Mode
 
-		if fileinfo.Mode().IsRegular() {
+		if (fileStats.Mode & syscall.S_IFREG) != 0 {
 			evt.FieldHandlers.ResolveHashes(model.FileOpenEventType, &pn.Process, &evt.Open.File)
 		}
 
@@ -159,7 +181,7 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent 
 // MaxMmapedFiles defines the max mmaped files
 const MaxMmapedFiles = 128
 
-func snapshotMemoryMappedFiles(pid int32, processEventPath string) ([]string, error) {
+func getMemoryMappedFiles(pid int32, processEventPath string) (files []string, _ error) {
 	smapsPath := kernel.HostProc(strconv.Itoa(int(pid)), "smaps")
 	smapsFile, err := os.Open(smapsPath)
 	if err != nil {
@@ -167,7 +189,7 @@ func snapshotMemoryMappedFiles(pid int32, processEventPath string) ([]string, er
 	}
 	defer smapsFile.Close()
 
-	files := make([]string, 0, MaxMmapedFiles)
+	files = make([]string, 0, MaxMmapedFiles)
 	scanner := bufio.NewScanner(smapsFile)
 
 	for scanner.Scan() && len(files) < MaxMmapedFiles {

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
@@ -41,7 +41,7 @@ func TestSnapshotMemoryMappedFiles(t *testing.T) {
 	}
 
 	// hand-made version
-	ownImplemFiles, err := snapshotMemoryMappedFiles(int32(pid), "")
+	ownImplemFiles, err := getMemoryMappedFiles(int32(pid), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/activity_dumps_loadcontroller_test.go
+++ b/pkg/security/tests/activity_dumps_loadcontroller_test.go
@@ -11,6 +11,7 @@ package tests
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -164,7 +165,15 @@ func TestActivityDumpsLoadControllerEventTypes(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !isEventTypesStringSlicesEqual(activeEventTypes, presentEventTypes) {
+			activeTypes := make([]model.EventType, len(activeEventTypes))
+			for i, eventType := range activeEventTypes {
+				activeTypes[i] = eventType
+			}
+			if !slices.Contains(activeTypes, model.FileOpenEventType) {
+				// add open to the list of expected event types because mmaped files being present in the dump
+				activeTypes = append(activeTypes, model.FileOpenEventType)
+			}
+			if !isEventTypesStringSlicesEqual(activeTypes, presentEventTypes) {
 				t.Fatalf("Dump's event types are different as expected (%v) vs (%v)", activeEventTypes, presentEventTypes)
 			}
 			dump = nextDump


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add the mmaped files to the activity dumps even when the 'open' even type
is not enabled.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This gives activity dumps a more accurate view of the workload,
in particular for the mapped shared libraries.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
