### PR TITLE
Route e2e internal failure to #agent-e2e-testing team

### DIFF
--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -199,6 +199,9 @@ def upload_junitxmls(output_dir, owners, flavor, xmlfile_name, process_env, addi
             "--tags",
             f"jira_project:{jira_project}",
         ]
+        if is_e2e_internal_failure(junit_file_path):
+            args.append("--tags")
+            args.append("e2e_internal_error:true")
         if additional_tags and "upload_option.os_version_from_name" in additional_tags:
             additional_tags.remove("upload_option.os_version_from_name")
             additional_tags.append("--tags")
@@ -215,6 +218,14 @@ def upload_junitxmls(output_dir, owners, flavor, xmlfile_name, process_env, addi
         exit_code = process.wait()
         if exit_code != 0:
             raise subprocess.CalledProcessError(exit_code, DATADOG_CI_COMMAND)
+
+
+def is_e2e_internal_failure(xml_path):
+    """
+    Check if the given JUnit XML file contains E2E INTERAL ERROR string.
+    """
+    filecontent = open(xml_path).read()
+    return "E2E INTERNAL ERROR" in filecontent
 
 
 def _update_environ(unpack_dir):

--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -19,6 +19,7 @@ from tasks.libs.pipeline.notifications import (
     GITHUB_SLACK_MAP,
 )
 
+E2E_INTERNAL_ERROR_STRING = "E2E INTERNAL ERROR"
 CODEOWNERS_ORG_PREFIX = "@DataDog/"
 REPO_NAME_PREFIX = "github.com/DataDog/datadog-agent/"
 DATADOG_CI_COMMAND = ["datadog-ci", "junit", "upload"]
@@ -225,7 +226,7 @@ def is_e2e_internal_failure(xml_path):
     Check if the given JUnit XML file contains E2E INTERAL ERROR string.
     """
     filecontent = open(xml_path).read()
-    return "E2E INTERNAL ERROR" in filecontent
+    return E2E_INTERNAL_ERROR_STRING in filecontent
 
 
 def _update_environ(unpack_dir):

--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -225,7 +225,8 @@ def is_e2e_internal_failure(xml_path):
     """
     Check if the given JUnit XML file contains E2E INTERAL ERROR string.
     """
-    filecontent = open(xml_path).read()
+    with open(xml_path) as f:
+        filecontent = f.read()
     return E2E_INTERNAL_ERROR_STRING in filecontent
 
 

--- a/tasks/libs/pipeline/data.py
+++ b/tasks/libs/pipeline/data.py
@@ -109,6 +109,11 @@ infra_failure_logs = [
         re.compile(r'Connection to [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ closed by remote host\.'),
         FailedJobReason.EC2_SPOT,
     ),
+    # End to end tests internal infrastructure failures
+    (
+        re.compile(r'E2E INTERNAL ERROR'),
+        FailedJobReason.E2E_INFRA_FAILURE,
+    ),
 ]
 
 

--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -10,7 +10,7 @@ import yaml
 
 from tasks.libs.ciproviders.gitlab import Gitlab, get_gitlab_token
 from tasks.libs.owners.parsing import read_owners
-from tasks.libs.types.types import FailedJobs, Test
+from tasks.libs.types.types import FailedJobReason, FailedJobs, Test
 
 
 def load_and_validate(file_name: str, default_placeholder: str, default_value: str) -> Dict[str, str]:
@@ -82,6 +82,11 @@ def get_failed_tests(project_name, job, owners_file=".github/CODEOWNERS"):
 def find_job_owners(failed_jobs: FailedJobs, owners_file: str = ".gitlab/JOBOWNERS") -> Dict[str, FailedJobs]:
     owners = read_owners(owners_file)
     owners_to_notify = defaultdict(FailedJobs)
+
+    # For e2e test infrastructure errors, notify the agent-e2e-testing team
+    for job in failed_jobs.mandatory_infra_job_failures:
+        if job.failure_type == FailedJobReason.E2E_INFRA_FAILURE:
+            owners_to_notify["@datadog/agent-e2e-testing"].add_failed_job(job)
 
     for job in failed_jobs.all_non_infra_failures():
         job_owners = owners.of(job["name"])

--- a/tasks/libs/types/types.py
+++ b/tasks/libs/types/types.py
@@ -50,6 +50,7 @@ class FailedJobReason(Enum):
     GITLAB = 6
     KITCHEN = 7
     EC2_SPOT = 8
+    E2E_INFRA_FAILURE = 9
 
 
 class FailedJobs:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

All the errors that are considered as E2E internal errors should be routed to agent-e2e-testing.
With this PR:
- Modify notify job to send job failure that are related to infra error to #agent-e2e-testing slack channel
- Add a tag to test failure uploaded to CI visibility

As a follow up we need to update our notification workflow to notify the agent-e2e-testing team when the CI Visibility test has the label for e2e internal failure.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
