### PR TITLE
Add eventually to avoid flakiness in Windows secrets e2e tests

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/secret/secret_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/secret/secret_win_test.go
@@ -8,6 +8,7 @@ package secret
 import (
 	_ "embed"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
@@ -29,21 +30,25 @@ func TestWindowsSecretSuite(t *testing.T) {
 func (v *windowsSecretSuite) TestAgentSecretExecDoesNotExist() {
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)), awshost.WithAgentOptions(agentparams.WithAgentConfig("secret_backend_command: /does/not/exist"))))
 
-	output := v.Env().Agent.Client.Secret()
-	assert.Contains(v.T(), output, "=== Checking executable permissions ===")
-	assert.Contains(v.T(), output, "Executable path: /does/not/exist")
-	assert.Contains(v.T(), output, "Executable permissions: error: secretBackendCommand '/does/not/exist' does not exist")
-	assert.Regexp(v.T(), "Number of secrets .+: 0", output)
+	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
+		output := v.Env().Agent.Client.Secret()
+		assert.Contains(t, output, "=== Checking executable permissions ===")
+		assert.Contains(t, output, "Executable path: /does/not/exist")
+		assert.Contains(t, output, "Executable permissions: error: secretBackendCommand '/does/not/exist' does not exist")
+		assert.Regexp(t, "Number of secrets .+: 0", output)
+	}, 30*time.Second, 3*time.Second)
 }
 
 func (v *windowsSecretSuite) TestAgentSecretChecksExecutablePermissions() {
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)), awshost.WithAgentOptions(agentparams.WithAgentConfig("secret_backend_command: C:\\Windows\\system32\\cmd.exe"))))
 
-	output := v.Env().Agent.Client.Secret()
-	assert.Contains(v.T(), output, "=== Checking executable permissions ===")
-	assert.Contains(v.T(), output, "Executable path: C:\\Windows\\system32\\cmd.exe")
-	assert.Regexp(v.T(), "Executable permissions: error: invalid executable 'C:\\\\Windows\\\\system32\\\\cmd.exe': other users/groups than LOCAL_SYSTEM, .+ have rights on it", output)
-	assert.Regexp(v.T(), "Number of secrets .+: 0", output)
+	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
+		output := v.Env().Agent.Client.Secret()
+		assert.Contains(t, output, "=== Checking executable permissions ===")
+		assert.Contains(t, output, "Executable path: C:\\Windows\\system32\\cmd.exe")
+		assert.Regexp(t, "Executable permissions: error: invalid executable 'C:\\\\Windows\\\\system32\\\\cmd.exe': other users/groups than LOCAL_SYSTEM, .+ have rights on it", output)
+		assert.Regexp(t, "Number of secrets .+: 0", output)
+	}, 30*time.Second, 3*time.Second)
 }
 
 //go:embed fixtures/setup_secret.ps1
@@ -72,15 +77,17 @@ host_aliases:
 			awshost.WithAgentOptions(agentparams.WithAgentConfig(config))),
 	)
 
-	output := v.Env().Agent.Client.Secret()
-	assert.Contains(v.T(), output, "=== Checking executable permissions ===")
-	assert.Contains(v.T(), output, "Executable path: C:\\TestFolder\\secret.bat")
-	assert.Contains(v.T(), output, "Executable permissions: OK, the executable has the correct permissions")
+	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
+		output := v.Env().Agent.Client.Secret()
+		assert.Contains(t, output, "=== Checking executable permissions ===")
+		assert.Contains(t, output, "Executable path: C:\\TestFolder\\secret.bat")
+		assert.Contains(t, output, "Executable permissions: OK, the executable has the correct permissions")
 
-	ddagentRegex := `Access : .+\\ddagentuser Allow  ReadAndExecute`
-	assert.Regexp(v.T(), ddagentRegex, output)
-	assert.Regexp(v.T(), "Number of secrets .+: 1", output)
-	assert.Contains(v.T(), output, "- 'alias_secret':\r\n\tused in 'datadog.yaml' configuration in entry 'host_aliases")
-	// assert we don't output the resolved secret
-	assert.NotContains(v.T(), output, "a_super_secret_string")
+		ddagentRegex := `Access : .+\\ddagentuser Allow  ReadAndExecute`
+		assert.Regexp(t, ddagentRegex, output)
+		assert.Regexp(t, "Number of secrets .+: 1", output)
+		assert.Contains(t, output, "- 'alias_secret':\r\n\tused in 'datadog.yaml' configuration in entry 'host_aliases")
+		// assert we don't output the resolved secret
+		assert.NotContains(t, output, "a_super_secret_string")
+	}, 30*time.Second, 3*time.Second)
 }


### PR DESCRIPTION

### What does this PR do?

Try to fix a flaky tests

### Motivation

Windows secrets e2e tests have been flaky recently. It's probably due to the fact that the secret comp is initialised but not configured and so the Agent consider that the secret feature is not enabled.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
