### PR TITLE
[CWS] introduce `ClonedADs` to fix ad/adm deadlock

### DIFF
--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -681,10 +681,9 @@ func (adm *ActivityDumpManager) ProcessEvent(event *model.Event) {
 		return
 	}
 
-	adm.Lock()
-	defer adm.Unlock()
+	activeDumps := adm.ClonedADs()
 
-	for _, d := range adm.activeDumps {
+	for _, d := range activeDumps {
 		d.Insert(event)
 	}
 }

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -654,10 +654,9 @@ func (adm *ActivityDumpManager) HasActiveActivityDump(event *model.Event) bool {
 		return false
 	}
 
-	adm.Lock()
-	defer adm.Unlock()
+	activeDumps := adm.ClonedADs()
 
-	for _, d := range adm.activeDumps {
+	for _, d := range activeDumps {
 		d.Lock()
 		matches := d.MatchesSelector(event.ProcessCacheEntry)
 		state := d.state


### PR DESCRIPTION
### What does this PR do?

Here is what is happening:
```
adm.resolveTagsPerAd locks ad
and calls adm.RemoveDump which locks adm

adm.SendStats locks adm
and then calls ad.SendStats which locks ad
```

this different order of locking can mean that we end up with a deadlock on ad, and thus we block the whole event goroutine which is catastrophic.

This PR fixes this by introducing `ClonedADs` which locks, copies the ADs, unlock and returns the copied slice. This allows to operate on a slice of ADs while unlocking the adm.

This PR also exposes a bug `StopDumpsWithSelector` which is always operating on an empty slice. This bug will be fixed in another, non-backported PR.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
