### PR TITLE
prepare installer

### DIFF
--- a/.gitlab/packaging/deb.yml
+++ b/.gitlab/packaging/deb.yml
@@ -3,7 +3,6 @@
   before_script:
     - source /root/.bashrc
     - export RELEASE_VERSION=$RELEASE_VERSION_7
-    - export INSTALL_DIR=/opt/datadog/updater/
   stage: packaging
   script:
     - source /root/.bashrc

--- a/.gitlab/packaging/rpm.yml
+++ b/.gitlab/packaging/rpm.yml
@@ -7,7 +7,6 @@
   before_script:
     - source /root/.bashrc
     - export RELEASE_VERSION=$RELEASE_VERSION_7
-    - export INSTALL_DIR=/opt/datadog/updater/
   script:
     - echo "About to build for $RELEASE_VERSION"
     - !reference [.setup_ruby_mirror_linux]

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	// root user is changed to dd-updater to avoid permission issues
-	rootToDDUpdater()
+	// root user is changed to dd-installer to avoid permission issues
+	rootToDDInstaller()
 	os.Exit(runcmd.Run(command.MakeCommand(subcommands.UpdaterSubcommands())))
 }

--- a/cmd/updater/user_all.go
+++ b/cmd/updater/user_all.go
@@ -15,8 +15,8 @@ import (
 	"syscall"
 )
 
-func moveToDDUpdater() error {
-	grp, err := user.LookupGroup("dd-updater")
+func moveToDDInstaller() error {
+	grp, err := user.LookupGroup("dd-installer")
 	if err != nil {
 		return err
 	}
@@ -38,7 +38,7 @@ func moveToDDUpdater() error {
 	if err := syscall.Setgroups([]int{agentGid, gid}); err != nil {
 		return err
 	}
-	usr, err := user.Lookup("dd-updater")
+	usr, err := user.Lookup("dd-installer")
 	if err != nil {
 		return err
 	}
@@ -49,14 +49,14 @@ func moveToDDUpdater() error {
 	return syscall.Setuid(uid)
 }
 
-func rootToDDUpdater() {
+func rootToDDInstaller() {
 	userID := syscall.Getuid()
 	if userID != 0 {
 		return
 	}
-	fmt.Println("Program run as root, downgrading to dd-updater user and group.")
+	fmt.Println("Program run as root, downgrading to dd-installer user and group.")
 
-	if err := moveToDDUpdater(); err != nil {
-		fmt.Printf("Failed to downgrade to dd-updater user, running as root: %v\n", err)
+	if err := moveToDDInstaller(); err != nil {
+		fmt.Printf("Failed to downgrade to dd-installer user, running as root: %v\n", err)
 	}
 }

--- a/cmd/updater/user_windows.go
+++ b/cmd/updater/user_windows.go
@@ -6,4 +6,4 @@
 // Package main implements 'updater'.
 package main
 
-func rootToDDUpdater() {}
+func rootToDDInstaller() {}

--- a/omnibus/config/projects/updater.rb
+++ b/omnibus/config/projects/updater.rb
@@ -13,7 +13,7 @@ third_party_licenses "../LICENSE-3rdparty.csv"
 
 homepage 'http://www.datadoghq.com'
 
-INSTALL_DIR = ENV['INSTALL_DIR'] || '/opt/datadog/updater'
+INSTALL_DIR = ENV['INSTALL_DIR'] || '/opt/datadog-packages/installer_boot'
 
 install_dir INSTALL_DIR
 
@@ -142,7 +142,7 @@ if linux_target?
   if debian_target?
     systemd_directory = "/lib/systemd/system"
   end
-  extra_package_file "#{systemd_directory}/datadog-updater.service"
+  extra_package_file "#{systemd_directory}/datadog-installer.service"
   extra_package_file '/etc/datadog-agent/'
   extra_package_file '/var/log/datadog/'
   extra_package_file '/var/run/datadog-packages/'

--- a/omnibus/config/software/updater.rb
+++ b/omnibus/config/software/updater.rb
@@ -59,8 +59,8 @@ build do
       mkdir "/usr/lib/systemd/system/"
       systemdPath = "/usr/lib/systemd/system/"
     end
-    erb source: "datadog-updater.service.erb",
-       dest: systemdPath + "datadog-updater.service",
+    erb source: "datadog-installer.service.erb",
+       dest: systemdPath + "datadog-installer.service",
        mode: 0644,
        vars: { install_dir: install_dir, etc_dir: etc_dir}
 
@@ -73,7 +73,7 @@ build do
       "datadog-agent-process.service.erb" => "datadog-agent-process.service",
       "datadog-agent-security.service.erb" => "datadog-agent-security.service",
       "datadog-agent-sysprobe.service.erb" => "datadog-agent-sysprobe.service",
-      "datadog-updater.service.erb" => "datadog-updater.service",
+      "datadog-installer.service.erb" => "datadog-installer.service",
     }
     templateToFile.each do |template, file|
       agent_dir = "/opt/datadog-packages/datadog-agent/stable"

--- a/omnibus/config/templates/updater/datadog-installer.service.erb
+++ b/omnibus/config/templates/updater/datadog-installer.service.erb
@@ -1,11 +1,11 @@
 [Unit]
-Description=Datadog Updater
+Description=Datadog Installer
 After=network.target
 
 [Service]
 Type=simple
 PIDFile=<%= install_dir %>/run/updater.pid
-User=dd-updater
+User=dd-installer
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
 ExecStart=<%= install_dir %>/bin/updater/updater run -p <%= install_dir %>/run/updater.pid

--- a/omnibus/package-scripts/updater-deb/postinst
+++ b/omnibus/package-scripts/updater-deb/postinst
@@ -4,9 +4,9 @@
 #
 # .deb: STEP 5 of 5
 
-readonly INSTALL_DIR=/opt/datadog/updater
-readonly UPDATER_HELPER=${INSTALL_DIR}/bin/updater/updater-helper
 readonly PACKAGES_DIR=/opt/datadog-packages
+readonly INSTALL_DIR=${PACKAGES_DIR}/installer_boot
+readonly UPDATER_HELPER=${INSTALL_DIR}/bin/updater/updater-helper
 readonly LOG_DIR=/var/log/datadog
 readonly PACKAGES_LOCK_DIR=/var/run/datadog-packages
 readonly CONFIG_DIR=/etc/datadog-agent
@@ -33,9 +33,9 @@ add_user_and_group() {
 set -e
 case "$1" in
     configure)
-        add_user_and_group 'dd-updater' $PACKAGES_DIR
+        add_user_and_group 'dd-installer' $PACKAGES_DIR
         add_user_and_group 'dd-agent' $PACKAGES_DIR/datadog-agent
-        usermod -aG dd-agent dd-updater
+        usermod -aG dd-agent dd-installer
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;
@@ -48,9 +48,8 @@ chown -R dd-agent:dd-agent ${CONFIG_DIR}
 chmod -R g+rw ${CONFIG_DIR}
 chown -R dd-agent:dd-agent ${LOG_DIR}
 chmod -R g+rw ${LOG_DIR}
-chown -R dd-updater:dd-updater ${INSTALL_DIR}
-chown -R dd-updater:dd-updater ${PACKAGES_DIR}
-chown -R dd-updater:dd-updater ${PACKAGES_LOCK_DIR}
+chown -R dd-installer:dd-installer ${PACKAGES_DIR}
+chown -R dd-installer:dd-installer ${PACKAGES_LOCK_DIR}
 
 chmod -R 755 ${PACKAGES_DIR}
 # Lock_dir is world read/write/x as any application with a tracer injected
@@ -81,10 +80,8 @@ fi
 chmod 750 ${UPDATER_HELPER}
 setcap cap_setuid+ep ${UPDATER_HELPER}
 
-$INSTALL_DIR/bin/updater/updater bootstrap -P datadog-agent
-
 # start updater
-SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-updater || true
-SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-updater || true
+SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-installer || true
+SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-installer || true
 
 exit 0

--- a/omnibus/package-scripts/updater-deb/postrm
+++ b/omnibus/package-scripts/updater-deb/postrm
@@ -4,7 +4,6 @@
 #
 # .deb: STEP 3 of 5
 
-INSTALL_DIR=/opt/datadog
 PACKAGES_DIR=/opt/datadog-packages
 LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
@@ -16,12 +15,11 @@ case "$1" in
     purge)
         echo "Deleting dd-agent user"
         deluser dd-agent --quiet
-        deluser dd-updater --quiet
+        deluser dd-installer --quiet
         echo "Deleting dd-agent group"
         (getent group dd-agent >/dev/null && delgroup dd-agent --quiet) || true
-        (getent group dd-updater >/dev/null && delgroup dd-updater --quiet) || true
-        echo "Force-deleting $INSTALL_DIR"
-        rm -rf $INSTALL_DIR
+        (getent group dd-installer >/dev/null && delgroup dd-installer --quiet) || true
+        echo "Force-deleting $PACKAGES_DIR, $LOG_DIR, $CONFIG_DIR"
         rm -rf $LOG_DIR
         rm -rf $CONFIG_DIR
         rm -rf $PACKAGES_DIR

--- a/omnibus/package-scripts/updater-deb/preinst
+++ b/omnibus/package-scripts/updater-deb/preinst
@@ -4,6 +4,6 @@
 # .deb: STEP 2 of 5
 
 
-SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
+SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-installer || true
 
 exit 0

--- a/omnibus/package-scripts/updater-deb/prerm
+++ b/omnibus/package-scripts/updater-deb/prerm
@@ -3,10 +3,11 @@
 #
 # .deb: STEP 1 of 5
 
-readonly INSTALL_DIR=/opt/datadog/updater
+readonly PACKAGES_DIR=/opt/datadog-packages
+readonly INSTALL_DIR=${PACKAGES_DIR}/installer_boot
 
-SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
-SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-updater || true
+SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-installer || true
+SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-installer || true
 
 set -e
 

--- a/omnibus/package-scripts/updater-rpm/postrm
+++ b/omnibus/package-scripts/updater-rpm/postrm
@@ -4,7 +4,6 @@
 # or during the removal of the previous version after an upgrade
 #
 
-INSTALL_DIR=/opt/datadog
 PACKAGES_DIR=/opt/datadog-packages
 LOG_DIR=/var/log/datadog
 PACKAGES_LOCK_DIR=/var/run/datadog-packages
@@ -18,12 +17,11 @@ fi
 
 echo "Deleting dd-agent user"
 userdel dd-agent
-userdel dd-updater
+userdel dd-installer
 echo "Deleting dd-agent group"
 (getent group dd-agent >/dev/null && groupdel dd-agent) || true
-(getent group dd-updater >/dev/null && groupdel dd-updater) || true
-echo "Force-deleting $INSTALL_DIR"
-rm -rf $INSTALL_DIR
+(getent group dd-installer >/dev/null && groupdel dd-installer) || true
+echo "Force-deleting $PACKAGES_DIR $LOG_DIR"
 rm -rf $LOG_DIR
 rm -rf $PACKAGES_DIR
 rm -rf $PACKAGES_LOCK_DIR

--- a/omnibus/package-scripts/updater-rpm/posttrans
+++ b/omnibus/package-scripts/updater-rpm/posttrans
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-readonly INSTALL_DIR=/opt/datadog/updater
-readonly UPDATER_HELPER=${INSTALL_DIR}/bin/updater/updater-helper
 readonly PACKAGES_DIR=/opt/datadog-packages
+readonly INSTALL_DIR=${PACKAGES_DIR}/installer_boot
+readonly UPDATER_HELPER=${INSTALL_DIR}/bin/updater/updater-helper
 readonly LOG_DIR=/var/log/datadog
 readonly PACKAGES_LOCK_DIR=/var/run/datadog-packages
 readonly CONFIG_DIR=/etc/datadog-agent
@@ -23,18 +23,17 @@ add_user_and_group() {
 }
 
 # We're in the initial install case
-add_user_and_group 'dd-updater' $PACKAGES_DIR
+add_user_and_group 'dd-installer' $PACKAGES_DIR
 add_user_and_group 'dd-agent' $PACKAGES_DIR/datadog-agent
-usermod -aG dd-agent dd-updater
+usermod -aG dd-agent dd-installer
 
 # Set proper rights to the dd-agent user
 chown -R dd-agent:dd-agent ${CONFIG_DIR}
 chmod -R g+rw ${CONFIG_DIR}
 chown -R dd-agent:dd-agent ${LOG_DIR}
 chmod -R g+rw ${LOG_DIR}
-chown -R dd-updater:dd-updater ${INSTALL_DIR}
-chown -R dd-updater:dd-updater ${PACKAGES_DIR}
-chown -R dd-updater:dd-updater ${PACKAGES_LOCK_DIR}
+chown -R dd-installer:dd-installer ${PACKAGES_DIR}
+chown -R dd-installer:dd-installer ${PACKAGES_LOCK_DIR}
 
 chmod -R 755 ${PACKAGES_DIR}
 # Lock_dir is world read/write/x as any application with a tracer injected
@@ -65,11 +64,9 @@ fi
 chmod 750 ${UPDATER_HELPER}
 setcap cap_setuid+ep ${UPDATER_HELPER}
 
-$INSTALL_DIR/bin/updater/updater bootstrap -P datadog-agent
-
 # start updater
-SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-updater || true
-SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-updater || true
+SYSTEMCTL_SKIP_SYSV=true systemctl enable datadog-installer || true
+SYSTEMCTL_SKIP_SYSV=true systemctl start datadog-installer || true
 
 exit 0
 

--- a/omnibus/package-scripts/updater-rpm/preinst
+++ b/omnibus/package-scripts/updater-rpm/preinst
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
+SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-installer || true
 
 exit 0

--- a/omnibus/package-scripts/updater-rpm/prerm
+++ b/omnibus/package-scripts/updater-rpm/prerm
@@ -2,10 +2,10 @@
 #
 # Perform necessary datadog-agent setup steps prior to remove the old package.
 
-readonly INSTALL_DIR=/opt/datadog/updater
+readonly INSTALL_DIR=/opt/datadog-packages/installer_boot
 
-SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-updater || true
-SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-updater || true
+SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-installer || true
+SYSTEMCTL_SKIP_SYSV=true systemctl disable datadog-installer || true
 
 set -e
 

--- a/pkg/updater/service/helper/main.go
+++ b/pkg/updater/service/helper/main.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package main is a package that allows dd-updater
+// Package main is a package that allows dd-installer
 // to execute a subset of priviledged commands
 package main
 
@@ -130,14 +130,14 @@ func executeCommand() error {
 		return err
 	}
 
-	// only root or dd-updater can execute this command
+	// only root or dd-installer can execute this command
 	if currentUser != 0 && enforceUID() {
-		ddUpdaterUser, err := user.Lookup("dd-updater")
+		ddUpdaterUser, err := user.Lookup("dd-installer")
 		if err != nil {
-			return fmt.Errorf("failed to lookup dd-updater user: %s", err)
+			return fmt.Errorf("failed to lookup dd-installer user: %s", err)
 		}
 		if strconv.Itoa(currentUser) != ddUpdaterUser.Uid {
-			return fmt.Errorf("only root or dd-updater can execute this command")
+			return fmt.Errorf("only root or dd-installer can execute this command")
 		}
 		if err := syscall.Setuid(0); err != nil {
 			return fmt.Errorf("failed to setuid: %s", err)

--- a/pkg/updater/service/systemd_test.go
+++ b/pkg/updater/service/systemd_test.go
@@ -45,7 +45,7 @@ func TestAssertWorkingCommands(t *testing.T) {
 	testSetup(t)
 
 	// missing permissions on test setup, e2e tests verify the successful commands
-	successErr := "error: failed to lookup dd-updater user: user: unknown user dd-updater\n"
+	successErr := "error: failed to lookup dd-installer user: user: unknown user dd-installer\n"
 
 	require.Equal(t, successErr, startUnit("datadog-agent").Error())
 	assert.Equal(t, successErr, stopUnit("datadog-agent").Error())

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -39,6 +39,7 @@ const (
 	catalogOverridePath = defaultRepositoriesPath + "/catalog.json"
 	// bootstrapVersionsOverridePath is the path to the bootstrap versions override file
 	bootstrapVersionsOverridePath = defaultRepositoriesPath + "/bootstrap.json"
+	bootUpdater                   = defaultRepositoriesPath + "/installer_boot"
 )
 
 var (
@@ -46,6 +47,11 @@ var (
 	// It is the sum of the maximum size of the extracted oci-layout and the maximum size of the datadog package
 	requiredDiskSpace = ociLayoutMaxSize + datadogPackageMaxSize
 	fsDisk            = filesystem.NewDisk()
+	avoidPurge        = map[string]struct{}{
+		catalogOverridePath:           {},
+		bootstrapVersionsOverridePath: {},
+		bootUpdater:                   {},
+	}
 )
 
 // Updater is the updater used to update packages.
@@ -107,7 +113,7 @@ func cleanDir(dir string, cleanFunc func(string) error) {
 
 	for _, entry := range entries {
 		path := filepath.Join(dir, entry.Name())
-		if path == catalogOverridePath || path == bootstrapVersionsOverridePath {
+		if _, ok := avoidPurge[path]; ok {
 			continue
 		}
 		err := cleanFunc(path)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

- rename user/group dd-updater to dd-installer
- remove installation of datadog-agent on boot
- move out install path from /opt/datadog to avoid issues with other installations in /opt/datadog
- change systemd unit to datadog-installer

NB I ran the [rpm tests from this PR](https://github.com/DataDog/datadog-agent/pull/24455) on this run: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/31585121/
Given that this will generate multiple conflicts and that the rpm test PR might take time to merge, sending this PR first

Next: 
- [package renaming comes with Hugo's work](https://github.com/DataDog/datadog-agent/commit/1771d3691013c04c87f0dbe2a80680018a58eb26)
- binaries rename
- code swap to updater -> installer (for later, will wait for next Monday morning)

