### PR TITLE
[CWS] remove ptr from sync.Mutex in ActivityDump

### DIFF
--- a/cmd/security-agent/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/subcommands/runtime/activity_dump.go
@@ -11,7 +11,6 @@ package runtime
 import (
 	"fmt"
 	"os"
-	"sync"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -400,7 +399,6 @@ NEXT2:
 
 func computeActivityDumpDiff(p1, p2 *dump.ActivityDump, states map[string]bool) *dump.ActivityDump {
 	return &dump.ActivityDump{
-		Mutex: new(sync.Mutex),
 		ActivityTree: &activity_tree.ActivityTree{
 			ProcessNodes: diffADSubtree(p1.ActivityTree.ProcessNodes, p2.ActivityTree.ProcessNodes, states),
 		},

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -68,7 +68,7 @@ const (
 // is used to generate the activity dump metadata sent to the event platform.
 // easyjson:json
 type ActivityDump struct {
-	*sync.Mutex
+	sync.Mutex
 	state    ActivityDumpStatus
 	adm      *ActivityDumpManager
 	selector *cgroupModel.WorkloadSelector
@@ -116,7 +116,6 @@ func NewActivityDumpLoadConfig(evt []model.EventType, timeout time.Duration, wai
 // NewEmptyActivityDump returns a new zero-like instance of an ActivityDump
 func NewEmptyActivityDump(pathsReducer *activity_tree.PathsReducer) *ActivityDump {
 	ad := &ActivityDump{
-		Mutex:           &sync.Mutex{},
 		StorageRequests: make(map[config.StorageFormat][]config.StorageRequest),
 		DNSNames:        utils.NewStringKeys(nil),
 	}

--- a/pkg/security/security_profile/dump/activity_dump_easyjson.go
+++ b/pkg/security/security_profile/dump/activity_dump_easyjson.go
@@ -11,7 +11,6 @@ import (
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
-	sync "sync"
 )
 
 // suppress unused package warning
@@ -31,7 +30,6 @@ func easyjson9a9a4de6DecodeGithubComDataDogDatadogAgentPkgSecuritySecurityProfil
 		in.Skip()
 		return
 	}
-	out.Mutex = new(sync.Mutex)
 	in.Delim('{')
 	for !in.IsDelim('}') {
 		key := in.UnsafeFieldName(false)

--- a/pkg/security/security_profile/dump/manager_test.go
+++ b/pkg/security/security_profile/dump/manager_test.go
@@ -9,7 +9,6 @@
 package dump
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -223,7 +222,7 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"one_dump/one_overweight_dump",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 2},
 					}},
 				},
@@ -239,7 +238,7 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"one_dump/no_overweight_dump",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
 				},
@@ -253,19 +252,19 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"5_dumps/no_overweight_dump",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
 				},
@@ -293,19 +292,19 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"5_dumps/5_overweight_dumps",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 2},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 3},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 2},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 3},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 2},
 					}},
 				},
@@ -333,19 +332,19 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"5_dumps/2_expired_dumps",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 3},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 2},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
 				},
@@ -374,19 +373,19 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"5_dumps/2_expired_dumps_at_the_start",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 3},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 2},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
 				},
@@ -415,19 +414,19 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"5_dumps/2_expired_dumps_at_the_end",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 3},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+					{Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.Stats{ProcessNodes: 2},
 					}},
 				},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR converts the `*sync.Mutex` to `sync.Mutex` in activity dump. This allows to take advantage of default value of `sync.Mutex` in a lot of places. 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
