### PR TITLE
[Backport 7.53.x] [CWS] only report ebpfless selftest once

### DIFF
--- a/pkg/security/probe/selftests/tester.go
+++ b/pkg/security/probe/selftests/tester.go
@@ -11,6 +11,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"go.uber.org/atomic"
+
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
@@ -19,8 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/serializers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/hashicorp/go-multierror"
-	"go.uber.org/atomic"
 )
 
 // SelfTest represent one self test
@@ -66,12 +67,8 @@ func (t *SelfTester) RunSelfTest(timeout time.Duration) error {
 	return nil
 }
 
-// Start the self tester policy provider
-func (t *SelfTester) Start() {
-	if t.config.EBPFLessEnabled {
-		t.selfTestRunning <- DefaultTimeout
-	}
-}
+// Start implements the policy provider interface
+func (t *SelfTester) Start() {}
 
 // GetStatus returns the result of the last performed self tests
 func (t *SelfTester) GetStatus() *api.SelfTestsStatus {

--- a/pkg/security/probe/selftests/tester_others.go
+++ b/pkg/security/probe/selftests/tester_others.go
@@ -13,8 +13,9 @@ import (
 )
 
 // NewSelfTester returns a new SelfTester, enabled or not
-func NewSelfTester(_ *config.RuntimeSecurityConfig, probe *probe.Probe) (*SelfTester, error) {
+func NewSelfTester(cfg *config.RuntimeSecurityConfig, probe *probe.Probe) (*SelfTester, error) {
 	return &SelfTester{
-		probe: probe,
+		probe:  probe,
+		config: cfg,
 	}, nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR backports commit [7ec22b4](https://github.com/DataDog/datadog-agent/commit/7ec22b4a2bdc61344a7ca3b5cbafee217eeac292) from #24358 and commit [21afaa7](https://github.com/DataDog/datadog-agent/commit/21afaa7727febe7709d7e9f20a07583cdcf52472) from #24368 to the 7.53.x branch.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The goal of these backports is to fix the reporting of ebpfless selftests that were incorrectly run twice. This would cause the second run to be reported as failing. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
