### PR TITLE
pkg/trace/api: ensure connection semaphore is released on conn errors

### DIFF
--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -111,10 +111,9 @@ func (ln *measuredListener) Accept() (net.Conn, error) {
 		}
 		<-ln.sem
 		return nil, err
-	} else {
-		ln.accepted.Inc()
-		log.Tracef("Accepted connection named %q.", ln.name)
 	}
+	ln.accepted.Inc()
+	log.Tracef("Accepted connection named %q.", ln.name)
 	conn = OnCloseConn(conn, func() {
 		<-ln.sem
 	})

--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -109,6 +109,8 @@ func (ln *measuredListener) Accept() (net.Conn, error) {
 		} else {
 			ln.errored.Inc()
 		}
+		<-ln.sem
+		return nil, err
 	} else {
 		ln.accepted.Inc()
 		log.Tracef("Accepted connection named %q.", ln.name)

--- a/releasenotes/notes/apm-fix-accept-failure-9ef20bb0ef3689f7.yaml
+++ b/releasenotes/notes/apm-fix-accept-failure-9ef20bb0ef3689f7.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix potential connection issues by ensuring connection semaphore release
+    during errors.


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR releases the connection semaphore when there is an Accept() error.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
It is possible that errors occur during an Accept(). In this case, we must ensure that the live connection semaphore is released.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
