### PR TITLE
Fix the display of `kubectl get all,nodes` at the end of TestKindSuite

### DIFF
--- a/test/new-e2e/tests/containers/dump_cluster_state.go
+++ b/test/new-e2e/tests/containers/dump_cluster_state.go
@@ -164,7 +164,7 @@ func dumpKindClusterState(ctx context.Context, name string) (ret string) {
 	}
 
 	sshClient, err := ssh.Dial("tcp", *instanceIP+":22", &ssh.ClientConfig{
-		User:            "ubuntu",
+		User:            "ec2-user",
 		Auth:            auth,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	})


### PR DESCRIPTION
### What does this PR do?

Fix the user to use to connect on Kind VM.

### Motivation

Fix the display of the output `kubectl get all,nodes` at the end of `TestKindSuite`.
It is currently broken [with the following error](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/480600700):
```
    k8s_test.go:70: The data produced and asserted by these tests can be viewed on this dashboard:
    k8s_test.go:72: https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?refresh_mode=paused&tpl_var_kube_cluster_name%5B0%5D=ci-480600700-4670-kind-cluster&tpl_var_fake_intake_task_family%5B0%5D=ci-480600700-4670-kind-cluster-fakeintake-ecs&from_ts=1712585748795&to_ts=1712586371728&live=false
    kindvm_test.go:81: Failed to dial SSH server 10.1.50.243: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
```

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Look at the [output logs of `containers` new-e2e tests for the output of `kubectl get all,nodes`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/481038810#L640).
