### PR TITLE
[CWS] fix error log when reading profile was not possible

### DIFF
--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -196,7 +196,7 @@ func LoadProtoFromFile(filepath string) (*proto.SecurityProfile, error) {
 
 	raw, err := io.ReadAll(f)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't open profile: %w", err)
+		return nil, fmt.Errorf("couldn't read profile: %w", err)
 	}
 
 	pp := &proto.SecurityProfile{}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR fixes the issue where "failed to open" and "fail to read" had the same message. 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
