### PR TITLE
[EBPF] Fix default vmconfig path

### DIFF
--- a/test/new-e2e/scenarios/system-probe/main.go
+++ b/test/new-e2e/scenarios/system-probe/main.go
@@ -18,7 +18,7 @@ import (
 	systemProbe "github.com/DataDog/datadog-agent/test/new-e2e/system-probe"
 )
 
-var defaultVMConfigPath = filepath.Join(".", "system-probe", "config", "vmconfig.json")
+var defaultVMConfigPath = filepath.Join(".", "system-probe", "config", "vmconfig-system-probe.json")
 
 func run(envName, x86InstanceType, armInstanceType string, destroy bool, opts *systemProbe.EnvOpts) error {
 	if destroy {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix the default path for vmconfig files

### Motivation

This fixes `system-probe.start-microvms` task when invoked without a specific vmconfig file. This change was missed when changing to having multiple `vmconfig` files per each component.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Tested locally.