### PR TITLE
[installer] add back centos test + fix

### DIFF
--- a/.gitlab/common/test_infra_version.yml
+++ b/.gitlab/common/test_infra_version.yml
@@ -4,4 +4,4 @@ variables:
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
   # Make sure to update test-infra-definitions version in go.mod as well
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 646121a20ef2
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: e488596ad7f3

--- a/test/new-e2e/examples/kind_test.go
+++ b/test/new-e2e/examples/kind_test.go
@@ -32,7 +32,7 @@ func TestMyKindSuite(t *testing.T) {
 		awskubernetes.Provisioner(
 			awskubernetes.WithoutFakeIntake(),
 			awskubernetes.WithWorkloadApp(func(e config.CommonEnvironment, kubeProvider *kubernetes.Provider) (*compkube.Workload, error) {
-				return nginx.K8sAppDefinition(e, kubeProvider, "nginx", nil)
+				return nginx.K8sAppDefinition(e, kubeProvider, "nginx", "", nil)
 			}),
 			awskubernetes.WithWorkloadApp(func(e config.CommonEnvironment, kubeProvider *kubernetes.Provider) (*compkube.Workload, error) {
 				return dogstatsd.K8sAppDefinition(e, kubeProvider, "dogstatsd", 8125, "/var/run/datadog/dsd.socket")

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -28,7 +28,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240405153332-646121a20ef2
+	github.com/DataDog/test-infra-definitions v0.0.0-20240409081032-e488596ad7f3
 	github.com/aws/aws-sdk-go-v2 v1.25.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.6
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.19.0 h1:Wvz/63/q39EpVwSH1T8jVyRvP
 github.com/DataDog/datadog-api-client-go/v2 v2.19.0/go.mod h1:oD5Lx8Li3oPRa/BSBenkn4i48z+91gwYORF/+6ph71g=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20240405153332-646121a20ef2 h1:VWUZgx88tLZ2DHT8Cml3PjDLfg9L1Okt7fkO8viCs/Q=
-github.com/DataDog/test-infra-definitions v0.0.0-20240405153332-646121a20ef2/go.mod h1:KNF9SeKFoqxSSucHpuXQ1QDmpi7HFS9yr5kM2h9ls3c=
+github.com/DataDog/test-infra-definitions v0.0.0-20240409081032-e488596ad7f3 h1:tMeY0/XojCupNNEdM4De04Jy/1Lgb9L/Z/DSoL6YPjQ=
+github.com/DataDog/test-infra-definitions v0.0.0-20240409081032-e488596ad7f3/go.mod h1:KNF9SeKFoqxSSucHpuXQ1QDmpi7HFS9yr5kM2h9ls3c=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/tests/updater/linux_test.go
+++ b/test/new-e2e/tests/updater/linux_test.go
@@ -51,13 +51,10 @@ func runTest(t *testing.T, pkgManager string, arch os.Architecture, distro os.De
 }
 
 func TestCentOS(t *testing.T) {
-	t.Skip()
-	t.Parallel()
 	runTest(t, "rpm", os.AMD64Arch, os.CentOSDefault)
 }
 
 func TestUbuntu(t *testing.T) {
-	t.Parallel()
 	runTest(t, "dpkg", os.ARM64Arch, os.UbuntuDefault)
 }
 
@@ -106,8 +103,9 @@ func (v *vmUpdaterSuite) TestAgentUnitsLoaded() {
 }
 
 func (v *vmUpdaterSuite) TestExperimentCrash() {
-	host := v.Env().RemoteHost
 	t := v.T()
+	t.Skip()
+	host := v.Env().RemoteHost
 	startTime := getMonotonicTimestamp(t, host)
 	host.MustExecute(fmt.Sprintf(`sudo %v/bin/updater/updater bootstrap --url "oci://us-docker.pkg.dev/datadog-sandbox/updater-dev/agent@sha256:868287768e7f224fbf210a864c3da614ab19cde23ddbd8a94e747c915d8c9ab1"`, bootUpdaterDir))
 	v.Env().RemoteHost.MustExecute(`sudo systemctl start datadog-agent-exp --no-block`)


### PR DESCRIPTION
centos test broke with rename to datadog-installer
- enabling it back
- picking the required fix from test-infra-def: https://github.com/DataDog/test-infra-definitions/pull/747
- [remove the parallel to avoid OOM on the runner](https://github.com/DataDog/datadog-agent/pull/24455#discussion_r1555994356)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
