### PR TITLE
(fleet) fix agent version in OCI metadata, add installer check to catch this type of issues

### DIFF
--- a/.gitlab/packaging/oci.yml
+++ b/.gitlab/packaging/oci.yml
@@ -7,8 +7,8 @@
   tags: ["arch:amd64"]
   before_script:
     - source /root/.bashrc
-    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version 7)
-    - export INSTALL_DIR=/opt/datadog-packages/${OCI_PRODUCT}/${PACKAGE_VERSION}-1
+    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version 7)-1
+    - export INSTALL_DIR=/opt/datadog-packages/${OCI_PRODUCT}/${PACKAGE_VERSION}
   variables:
     KUBERNETES_CPU_REQUEST: 16
     KUBERNETES_MEMORY_REQUEST: "32Gi"
@@ -58,23 +58,14 @@
     paths:
       - ${OMNIBUS_PACKAGE_DIR}
 
-
 agent_oci:
   extends: .package_oci
-  needs:
-    [
-      "datadog-agent-oci-x64-a7",
-      "datadog-agent-oci-arm64-a7",
-    ]
+  needs: ["datadog-agent-oci-x64-a7", "datadog-agent-oci-arm64-a7"]
   variables:
     OCI_PRODUCT: "datadog-agent"
 
 installer_oci:
   extends: .package_oci
-  needs:
-    [
-      "installer-arm64-oci",
-      "installer-amd64-oci",
-    ]
+  needs: ["installer-arm64-oci", "installer-amd64-oci"]
   variables:
     OCI_PRODUCT: "datadog-installer"

--- a/pkg/updater/download_test.go
+++ b/pkg/updater/download_test.go
@@ -230,6 +230,17 @@ func TestDownloadInvalidHash(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDownloadInvalidVersion(t *testing.T) {
+	s := newTestFixturesServer(t)
+	defer s.Close()
+	d := s.Downloader()
+
+	pkg := s.Package(fixtureSimpleV1)
+	pkg.Version = "v1-1"
+	_, err := d.Download(context.Background(), t.TempDir(), pkg)
+	assert.Error(t, err)
+}
+
 func TestDownloadPlatformNotAvailable(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()


### PR DESCRIPTION
This PR does two things:
- Fixes the agent OCI package by making sure the version in the OCI is aligned with the version in the catalog/install path
- Prevents the installation of packages where the catalog name/version don't match the OCI image metadata name/version