### PR TITLE
(fleet) disable installer remote updates by default

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1334,6 +1334,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	setupHighAvailability(config)
 
 	// Updater configuration
+	config.BindEnvAndSetDefault("updater.remote_updates", false)
 	config.BindEnv("updater.registry")
 }
 

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -84,6 +84,8 @@ func newTestUpdater(t *testing.T, s *testFixturesServer, rcc *testRemoteConfigCl
 
 func newTestUpdaterWithPaths(t *testing.T, s *testFixturesServer, rcc *testRemoteConfigClient, defaultFixture fixture) (*updaterImpl, string, string) {
 	cfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	var b = true
+	cfg.Set("updater.remote_updates", &b, model.SourceDefault)
 	rc := &remoteConfig{client: rcc}
 	rootPath := t.TempDir()
 	locksPath := t.TempDir()


### PR DESCRIPTION
This PR disables remote updates in the installer by default.

As we are soon going to start releasing the installer to some customers
we want to make sure to gate the remote update feature in a robust way
behind an opt-in config option.