### PR TITLE
pkg/trace/api: use different fd acquisition method for UDS

### DIFF
--- a/pkg/trace/api/container_linux.go
+++ b/pkg/trace/api/container_linux.go
@@ -59,7 +59,7 @@ func connContext(ctx context.Context, c net.Conn) context.Context {
 		ucred, cerr = syscall.GetsockoptUcred(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERCRED)
 	})
 	if err != nil {
-		log.Debugf("Failed to read credentials from unix socket: %v", err)
+		log.Debugf("Failed to control raw unix socket: %v", err)
 		return ctx
 	}
 	if cerr != nil {


### PR DESCRIPTION



<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
We switch the UDS credential code to use SyscallConn() to get the underlying fd without duplicating the fd.

We also implement a benchmark, which shows an 11% improvement in performance reading over the socket with the new method.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

For UDS connections, we need to get the file descriptor to call the linux-specific GetsockoptUcred syscall. We had been using conn.File(), but this duplicates the file descriptor and causes performance issues (see https://github.com/golang/go/issues/22953).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Tests show that the new method works, but during QA we should run a trace agent and connect a tracer to it over UDS, ensuring that container tags still work.
