### PR TITLE
Add Windows Installer failure E2E test

### DIFF
--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -43,6 +43,7 @@
       - E2E_MSI_TEST: TestSubServicesOpts/all-subservices
       - E2E_MSI_TEST: TestSubServicesOpts/no-subservices
       - E2E_MSI_TEST: TestInstallAltDir
+      - E2E_MSI_TEST: TestInstallFail
 
 # Agent 6
 .new-e2e_windows_a6_x86_64:

--- a/test/new-e2e/tests/windows/common/registry.go
+++ b/test/new-e2e/tests/windows/common/registry.go
@@ -21,3 +21,13 @@ func GetRegistryValue(host *components.RemoteHost, path string, value string) (s
 	}
 	return strings.TrimSpace(out), nil
 }
+
+// RegistryKeyExists returns true if the registry key exists on the remote host
+func RegistryKeyExists(host *components.RemoteHost, path string) (bool, error) {
+	cmd := fmt.Sprintf("Test-Path -Path '%s'", path)
+	out, err := host.Execute(cmd)
+	if err != nil {
+		return false, err
+	}
+	return strings.EqualFold(strings.TrimSpace(out), "True"), nil
+}

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -228,7 +228,12 @@ func (t *Tester) TestUninstallExpectations(tt *testing.T) {
 	assert.NoError(tt, err, "uninstall should not remove agent user")
 
 	for _, serviceName := range servicetest.ExpectedInstalledServices() {
-		_, err := windows.GetServiceConfig(t.host, serviceName)
+		conf, err := windows.GetServiceConfig(t.host, serviceName)
+		if err == nil && windows.IsKernelModeServiceType(conf.ServiceType) {
+			// TODO WKINT-410: kernel mode services are not removed on install rollback
+			tt.Logf("WKINT-410: Skipping known failure, kernel mode service not removed: %s", serviceName)
+			continue
+		}
 		assert.Errorf(tt, err, "uninstall should remove service %s", serviceName)
 	}
 

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -231,6 +231,10 @@ func (t *Tester) TestUninstallExpectations(tt *testing.T) {
 		_, err := windows.GetServiceConfig(t.host, serviceName)
 		assert.Errorf(tt, err, "uninstall should remove service %s", serviceName)
 	}
+
+	registryKeyExists, err := windows.RegistryKeyExists(t.host, windowsAgent.RegistryKeyPath)
+	assert.NoError(tt, err, "should check registry key exists")
+	assert.False(tt, registryKeyExists, "uninstall should remove registry key")
 }
 
 // Only do some basic checks on the agent since it's a previous version


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Adds a test for expected behavior when the installer fails to install the Agnet

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-507

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Skipping part of the test due to a bug adding this test caught
https://datadoghq.atlassian.net/browse/WKINT-410

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
