### PR TITLE
[serverless] serverless cold start perf: enlarge sample & print

### DIFF
--- a/test/integration/serverless_perf/compute.sh
+++ b/test/integration/serverless_perf/compute.sh
@@ -28,7 +28,7 @@ startupTimes=()
 # counts are useful for exploiting large-sample-size statistics.
 ITERATION_COUNT=301
 
-for i in {1..${ITERATION_COUNT}}
+for i in $(seq 1 ${ITERATION_COUNT})
 do
     # create a new container to ensure cold start
     dockerId=$(docker run -d datadogci/lambda-extension)

--- a/test/integration/serverless_perf/compute.sh
+++ b/test/integration/serverless_perf/compute.sh
@@ -42,9 +42,8 @@ medianMs=$(calculate_median "${startupTimes[@]}")
 
 log "Median=$medianMs | Threshold=$STARTUP_TIME_THRESHOLD"
 
-# Log raw startup time data in a CSV-like format for plotting a histogram
-# & exploratory data analysis.
-IFS=$',' log "RawData=${startupTimes[*]}"
+# Log raw startup time data to a single line for exploratory data analysis
+log "RawData=${startupTimes[*]}"
 
 # check whether or not the median duration exceeds the threshold
 if (( medianMs > STARTUP_TIME_THRESHOLD )); then

--- a/test/integration/serverless_perf/compute.sh
+++ b/test/integration/serverless_perf/compute.sh
@@ -23,8 +23,12 @@ log() {
 
 startupTimes=()
 
-# loop 10 times to incur no false positive/negative alarms
-for i in {1..10}
+# Cold start container enough times to get a reasonable histogram in <= 1 hour.
+# Pick an odd number to avoid having to average two elements. Larger iteration
+# counts are useful for exploiting large-sample-size statistics.
+ITERATION_COUNT=301
+
+for i in {1..${ITERATION_COUNT}}
 do
     # create a new container to ensure cold start
     dockerId=$(docker run -d datadogci/lambda-extension)
@@ -37,6 +41,10 @@ done
 medianMs=$(calculate_median "${startupTimes[@]}")
 
 log "Median=$medianMs | Threshold=$STARTUP_TIME_THRESHOLD"
+
+# Log raw startup time data in a CSV-like format for plotting a histogram
+# & exploratory data analysis.
+IFS=$',' log "RawData=${startupTimes[*]}"
 
 # check whether or not the median duration exceeds the threshold
 if (( medianMs > STARTUP_TIME_THRESHOLD )); then


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Given the importance of cold start latency to Serverless Agent performance, gathering a larger data set would enable us to better estimate quantile statistics, as well as estimate the accuracy of those estimates (e.g., using a confidence interval).

This pull request increases the iteration count of the cold start container loop from 10 to 301 so that:

- this test still runs in an hour or less (hopefully)

- we can plot a histogram of the raw data to better understand the distribution of cold start times

- the data set is large enough to use bootstrapping methods to construct confidence intervals on the median

In addition, this pull request should print the raw cold start data in a ~~CSV-like~~ space-delimited format on a single line so it's easy to import into a `numpy` array for exploratory data analysis.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Improve understanding of how PRs affect cold starts in practice. Explore potentially incorporating uncertainty in the estimated median cold start time into the serverless cold start performance test.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Larger data sets (like 1,000+) would be better, resources permitting. Under some mild assumptions[^1], as the sample size approaches infinity, the distribution of the sample median approaches a normal distribution[^2], which can be used to compute confidence intervals[^3].

[^1]: Assuming the cold start latency could be modeled as an absolutely continuous random variable, and samples are independently and identically distributed.

[^2]: Google "asymptotic normality median", or see chapter 21 of A. W. van der Vaart, *Asymptotic Statistics*, Cambridge University Press, 1998.

[^3]: In practice, one would use bootstrapping to approximate the distribution of medians, which is sort of like computing a correction to this asymptotic result. T. Hesterberg, "What teachers should know about the bootstrap: resampling in the undergraduate statistics curriculum", [arXiv:1411.5279](https://arxiv.org/abs/1411.5279) is a nice introduction to why this approach is useful. Rigorous mathematical justification for this argument can be found in Chapter 3 of P. Hall, *The Bootstrap and Edgeworth Expansion*, Springer, 1992. The "correction" I allude to is the second (and sometimes third) term in an Edgeworth expansion about a normal distribution.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Increasing the sample size used to compute median cold start time means that the serverless perf test will run longer. Given that other functional tests (e.g., the regression detector tests) have an SLO of around an hour, I used that SLO as a guideline when increasing that sample size.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Look at the CI output for this test.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
