### PR TITLE
[ASCII-1440] Use auth token mock to avoid trying to read the file

### DIFF
--- a/comp/core/configsync/configsyncimpl/test_common.go
+++ b/comp/core/configsync/configsyncimpl/test_common.go
@@ -27,7 +27,7 @@ import (
 func makeDeps(t *testing.T) dependencies {
 	return fxutil.Test[dependencies](t, fx.Options(
 		core.MockBundle(),
-		fetchonlyimpl.Module(),
+		fetchonlyimpl.MockModule(), // use the mock to avoid trying to read the file
 	))
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Update the `configsync` package tests to use the auth token mock component, which avoids trying to read the actual auth token file.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Some test failed on MacOS, I suspect this is due to the runner being slow, and I noticed that the test actually tried to read the auth token file because it is using the "real" component.
Using the mock instead returns a dummy token and should be much faster.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
