### PR TITLE
Publish the beta builds CNAB workflows individually instead of as one

### DIFF
--- a/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -29,7 +29,7 @@ internal_kubernetes_deploy_experimental:
     OPTION_AUTOMATIC_ROLLOUT: "true"
     OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging ${CI_COMMIT_REF_SLUG}-jmx-${CI_COMMIT_SHORT_SHA} ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}"
     SKIP_PLAN_CHECK: "true"
-    EXPLICIT_WORKFLOWS: "//workflows:beta_builds.agents_nightly.publish"
+    EXPLICIT_WORKFLOWS: "//workflows:beta_builds.agents_nightly.staging-deploy.publish,//workflows:beta_builds.agents_nightly.staging-validate.publish,//workflows:beta_builds.agents_nightly.prod-wait-business-hours.publish,//workflows:beta_builds.agents_nightly.prod-deploy.publish,//workflows:beta_builds.agents_nightly.prod-validate.publish,//workflows:beta_builds.agents_nightly.publish-image-confirmation.publish"
     BUNDLE_VERSION_OVERRIDE: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   script:
     - source /root/.bashrc


### PR DESCRIPTION
### What does this PR do?

This PR publishes the now split up beta builds CNAB workflows individually, instead of relying on the one main one

### Motivation

Better visibility into the status of the pipeline via SDP and slack

### Additional Notes

See [related PR here](https://github.com/DataDog/k8s-datadog-agent-ops/pull/3344) with more details on change

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
