### PR TITLE
Emit metrics for failed jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -198,7 +198,7 @@ variables:
   # They must be defined as environment variables in the GitLab CI/CD settings, to ease rotation if needed
   AGENT_QA_PROFILE_SSM_NAME: ci.datadog-agent.agent-qa-profile  # agent-ci-experience
   API_KEY_ORG2_SSM_NAME: ci.datadog-agent.datadog_api_key_org2  # agent-ci-experience
-  API_KEY_SSM_NAME: ci.datadog-agent.datadog_api_key  # agent-ci-experience
+  API_KEY_DDDEV_SSM_NAME: ci.datadog-agent.datadog_api_key  # agent-ci-experience
   APP_KEY_ORG2_SSM_NAME: ci.datadog-agent.datadog_app_key_org2  # agent-ci-experience
   ARTIFACTORY_TOKEN_SSM_NAME: ci.datadog-agent.artifactory_token  # agent-ci-experience
   ARTIFACTORY_BYPASS_SSM_NAME: ci.datadog-agent.artifactory_bypass  # agent-ci-experience

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -12,7 +12,7 @@
   before_script:
     - export DOCKER_REGISTRY_LOGIN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $DOCKER_REGISTRY_LOGIN_SSM_KEY)
     - export DOCKER_REGISTRY_PWD=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $DOCKER_REGISTRY_PWD_SSM_KEY)
-    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_SSM_NAME)
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_DDDEV_SSM_NAME)
 
 .k8s-e2e-cws-cspm-init:
   - set +x

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -26,8 +26,9 @@ notify:
   timeout: 15 minutes # Added to prevent a stuck job blocking the resource_group defined above
   script:
     - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $GITLAB_READ_API_TOKEN_SSM_NAME)
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_ORG2_SSM_NAME)
     - !reference [.setup_python_mirror_linux]
-    - python3 -m pip install -r tasks/libs/requirements-notifications.txt
+    - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-notifications.txt -r tasks/libs/requirements-datadog.txt
     - |
       # Do not send notifications if this is a child pipeline of another repo
       # The triggering repo should already have its own notification system

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -18,8 +18,7 @@ github_rate_limit_info:
     - when: on_success
   script:
     - source /root/.bashrc
-    - python3 -m pip install -r tasks/libs/requirements-github.txt
-    - python3 -m pip install datadog_api_client
+    - python3 -m pip install -r tasks/libs/requirements-github.txt -r tasks/libs/requirements-datadog.txt
     # Send stats for app 1
     - export GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $MACOS_GITHUB_KEY_SSM_NAME)
     - export GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $MACOS_GITHUB_APP_ID_SSM_NAME)

--- a/tasks/libs/common/datadog_api.py
+++ b/tasks/libs/common/datadog_api.py
@@ -48,7 +48,7 @@ def send_metrics(series):
         response = api_instance.submit_metrics(body=MetricPayload(series=series))
 
         if response["errors"]:
-            print(f"Error(s) while sending pipeline metrics to the Datadog backend: {response['errors']}")
+            print(f"Error(s) while sending pipeline metrics to the Datadog backend: {response['errors']}", file=sys.stderr)
             raise Exit(code=1)
 
         return response

--- a/tasks/libs/common/datadog_api.py
+++ b/tasks/libs/common/datadog_api.py
@@ -1,3 +1,5 @@
+import sys
+
 from invoke.exceptions import Exit
 
 
@@ -48,7 +50,9 @@ def send_metrics(series):
         response = api_instance.submit_metrics(body=MetricPayload(series=series))
 
         if response["errors"]:
-            print(f"Error(s) while sending pipeline metrics to the Datadog backend: {response['errors']}", file=sys.stderr)
+            print(
+                f"Error(s) while sending pipeline metrics to the Datadog backend: {response['errors']}", file=sys.stderr
+            )
             raise Exit(code=1)
 
         return response

--- a/tasks/libs/requirements-datadog.txt
+++ b/tasks/libs/requirements-datadog.txt
@@ -1,0 +1,1 @@
+datadog-api-client~=2.23.0

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -98,7 +98,7 @@ def send_message(ctx, notification_type="merge", print_to_stdout=False):
 
     # Send messages
     metrics = []
-    timestamp = int(datetime.now().timestamp())
+    timestamp = int(datetime.now(timezone.utc).timestamp())
     for owner, message in messages_to_send.items():
         channel = GITHUB_SLACK_MAP.get(owner.lower(), None)
         message.base_message = base

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -5,7 +5,7 @@ import re
 import tempfile
 import traceback
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict
 
 from invoke import task

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -97,6 +97,8 @@ def send_message(ctx, notification_type="merge", print_to_stdout=False):
     base = base_message(header, state)
 
     # Send messages
+    metrics = []
+    timestamp = int(datetime.now().timestamp())
     for owner, message in messages_to_send.items():
         channel = GITHUB_SLACK_MAP.get(owner.lower(), None)
         message.base_message = base
@@ -114,12 +116,28 @@ def send_message(ctx, notification_type="merge", print_to_stdout=False):
             if post_channel:
                 recipient = channel
                 send_slack_message(recipient, str(message))
+                metrics.append(
+                    create_count(
+                        metric_name="datadog.ci.failed_job_notifications",
+                        timestamp=timestamp,
+                        tags=[
+                            f"team:{owner}",
+                            "repository:datadog-agent",
+                            f"git_ref:{git_ref}",
+                        ],
+                        unit='notification',
+                        value=1,
+                    )
+                )
 
             # DM author
             if send_dm:
                 author_email = get_git_author(email=True)
                 recipient = email_to_slackid(ctx, author_email)
                 send_slack_message(recipient, str(message))
+
+    if metrics:
+        send_metrics(metrics)
 
 
 def _should_send_message_to_channel(git_ref: str, default_branch: str) -> bool:
@@ -192,10 +210,7 @@ def send_stats(_, print_to_stdout=False):
     )
 
     if not print_to_stdout:
-        response = send_metrics(series)
-        if response["errors"]:
-            print(f"Error(s) while sending pipeline metrics to the Datadog backend: {response['errors']}")
-            raise Exit(code=1)
+        send_metrics(series)
         print(f"Sent pipeline metrics: {series}")
     else:
         print(f"Would send: {series}")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

When the CI sends slack notifications for each team, now it sends additional metrics to datadog to see which teams receive more messages.

[details](https://datadoghq.atlassian.net/browse/ACIX-25)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- Here is [an example of metric](https://dddev.datadoghq.com/metric/summary?metric=datadog.ci.failed_job_notifications).
- Some refactoring has been made such that we are aware when sending metrics fails
- Renamed dddev api key (was misleading)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
