### PR TITLE
[CWS] Add hashing for ebpfless

### DIFF
--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -221,11 +221,6 @@ func (fh *EBPFLessFieldHandlers) ResolveFileFilesystem(_ *model.Event, e *model.
 	return e.Filesystem
 }
 
-// ResolveHashesFromEvent resolves the hashes of the requested event
-func (fh *EBPFLessFieldHandlers) ResolveHashesFromEvent(_ *model.Event, e *model.FileEvent) []string {
-	return e.Hashes
-}
-
 // ResolveK8SGroups resolves the k8s groups of the event
 func (fh *EBPFLessFieldHandlers) ResolveK8SGroups(_ *model.Event, e *model.UserSessionContext) []string {
 	return e.K8SGroups
@@ -337,8 +332,13 @@ func (fh *EBPFLessFieldHandlers) ResolveXAttrNamespace(_ *model.Event, e *model.
 }
 
 // ResolveHashes resolves the hash of the provided file
-func (fh *EBPFLessFieldHandlers) ResolveHashes(_ model.EventType, _ *model.Process, _ *model.FileEvent) []string {
-	return nil
+func (fh *EBPFLessFieldHandlers) ResolveHashes(eventType model.EventType, process *model.Process, file *model.FileEvent) []string {
+	return fh.resolvers.HashResolver.ComputeHashes(eventType, process, file)
+}
+
+// ResolveHashesFromEvent resolves the hashes of the requested event
+func (fh *EBPFLessFieldHandlers) ResolveHashesFromEvent(ev *model.Event, f *model.FileEvent) []string {
+	return fh.resolvers.HashResolver.ComputeHashesFromEvent(ev, f)
 }
 
 // ResolveUserSessionContext resolves and updates the provided user session context

--- a/pkg/security/probe/model_ebpfless.go
+++ b/pkg/security/probe/model_ebpfless.go
@@ -43,6 +43,7 @@ func NewEBPFLessModel() *model.Model {
 				!strings.HasPrefix(field, "load_module.") &&
 				!strings.HasPrefix(field, "unload_module.") &&
 				!strings.HasPrefix(field, "container.") &&
+				!strings.HasPrefix(field, "hash.") &&
 				!strings.HasPrefix(field, "event.") {
 				return rules.ErrEventTypeNotEnabled
 			}

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -117,6 +117,7 @@ func copyFileAttributes(src *ebpfless.FileSyscallMsg, dst *model.FileEvent) {
 	dst.CTime = src.CTime
 	dst.MTime = src.MTime
 	dst.Mode = uint16(src.Mode)
+	dst.Inode = src.Inode
 	if src.Credentials != nil {
 		dst.UID = src.Credentials.UID
 		dst.User = src.Credentials.User

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -107,13 +107,12 @@ func (p *EBPFLessProbe) handleClientMsg(cl *client, msg *ebpfless.Message) {
 
 func copyFileAttributes(src *ebpfless.FileSyscallMsg, dst *model.FileEvent) {
 	if strings.HasPrefix(src.Filename, "memfd:") {
-		dst.PathnameStr = ""
-		dst.BasenameStr = src.Filename
+		dst.SetPathnameStr("")
+		dst.SetBasenameStr(src.Filename)
 	} else {
-		dst.PathnameStr = src.Filename
-		dst.BasenameStr = filepath.Base(src.Filename)
+		dst.SetPathnameStr(src.Filename)
+		dst.SetBasenameStr(filepath.Base(src.Filename))
 	}
-	dst.IsPathnameStrResolved = true
 	dst.CTime = src.CTime
 	dst.MTime = src.MTime
 	dst.Mode = uint16(src.Mode)
@@ -304,7 +303,6 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 		p.processKiller.HandleProcessExited(event)
 	}
 
-	event.ResolveFields()
 	p.DispatchEvent(event)
 
 	// flush pending kill actions

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -113,6 +113,7 @@ func copyFileAttributes(src *ebpfless.FileSyscallMsg, dst *model.FileEvent) {
 		dst.PathnameStr = src.Filename
 		dst.BasenameStr = filepath.Base(src.Filename)
 	}
+	dst.IsPathnameStrResolved = true
 	dst.CTime = src.CTime
 	dst.MTime = src.MTime
 	dst.Mode = uint16(src.Mode)
@@ -302,6 +303,7 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 		p.processKiller.HandleProcessExited(event)
 	}
 
+	event.ResolveFields()
 	p.DispatchEvent(event)
 
 	// flush pending kill actions

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -129,6 +129,7 @@ type FileSyscallMsg struct {
 	CTime       uint64
 	MTime       uint64
 	Mode        uint32
+	Inode       uint64
 	Credentials *Credentials
 }
 

--- a/pkg/security/ptracer/utils.go
+++ b/pkg/security/ptracer/utils.go
@@ -305,6 +305,7 @@ func fillFileMetadata(tracer *Tracer, filepath string, fileMsg *ebpfless.FileSys
 	stat := fileInfo.Sys().(*syscall.Stat_t)
 	fileMsg.MTime = uint64(stat.Mtim.Nano())
 	fileMsg.CTime = uint64(stat.Ctim.Nano())
+	fileMsg.Inode = stat.Ino
 	fileMsg.Credentials = &ebpfless.Credentials{
 		UID:   stat.Uid,
 		User:  getUserFromUID(tracer, int32(stat.Uid)),

--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -233,6 +233,10 @@ func (resolver *Resolver) hash(eventType model.EventType, process *model.Process
 			rootPIDs = w.GetPIDs()
 		}
 	}
+	if process.ContainerID == "" {
+		// try also to open directly the file on the filesystem in case the process was a short lived one
+		rootPIDs = append(rootPIDs, 1)
+	}
 
 	// open the target file
 	var lastErr error

--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -237,10 +237,6 @@ func (resolver *Resolver) hash(eventType model.EventType, process *model.Process
 			rootPIDs = w.GetPIDs()
 		}
 	}
-	if process.ContainerID == "" {
-		// try also to open directly the file on the filesystem in case the process was a short lived one
-		rootPIDs = append(rootPIDs, 1)
-	}
 
 	// open the target file
 	var lastErr error

--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -74,6 +74,12 @@ type ResolverOpts struct {
 	EventTypes []model.EventType
 }
 
+// LRUCacheKey is the structure used to access cached hashes
+type LRUCacheKey struct {
+	path        string
+	containerID string
+}
+
 // LRUCacheEntry is the structure used to cache hashes
 type LRUCacheEntry struct {
 	state  model.HashState
@@ -87,7 +93,7 @@ type Resolver struct {
 	limiter        *rate.Limiter
 	cgroupResolver *cgroup.Resolver
 
-	cache *lru.Cache[model.PathKey, *LRUCacheEntry]
+	cache *lru.Cache[LRUCacheKey, *LRUCacheEntry]
 
 	// stats
 	hashCount    map[model.EventType]map[model.HashAlgorithm]*atomic.Uint64
@@ -105,10 +111,10 @@ func NewResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.ClientInte
 		}, nil
 	}
 
-	var cache *lru.Cache[model.PathKey, *LRUCacheEntry]
+	var cache *lru.Cache[LRUCacheKey, *LRUCacheEntry]
 	if c.HashResolverCacheSize > 0 {
 		var err error
-		cache, err = lru.New[model.PathKey, *LRUCacheEntry](c.HashResolverCacheSize)
+		cache, err = lru.New[LRUCacheKey, *LRUCacheEntry](c.HashResolverCacheSize)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't create hash resolver cache: %w", err)
 		}
@@ -206,8 +212,12 @@ func (resolver *Resolver) hash(eventType model.EventType, process *model.Process
 	}
 
 	// check if the hash(es) of this file is in cache
+	fileKey := LRUCacheKey{
+		path:        file.PathnameStr,
+		containerID: process.ContainerID,
+	}
 	if resolver.cache != nil {
-		cacheEntry, ok := resolver.cache.Get(file.PathKey)
+		cacheEntry, ok := resolver.cache.Get(fileKey)
 		if ok {
 			file.HashState = cacheEntry.state
 			file.Hashes = cacheEntry.hashes
@@ -341,7 +351,7 @@ func (resolver *Resolver) hash(eventType model.EventType, process *model.Process
 			hashes: make([]string, len(file.Hashes)),
 		}
 		copy(cacheEntry.hashes, file.Hashes)
-		resolver.cache.Add(file.PathKey, cacheEntry)
+		resolver.cache.Add(fileKey, cacheEntry)
 	}
 }
 

--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -78,6 +78,7 @@ type ResolverOpts struct {
 type LRUCacheKey struct {
 	path        string
 	containerID string
+	inode       uint64
 }
 
 // LRUCacheEntry is the structure used to cache hashes
@@ -215,6 +216,7 @@ func (resolver *Resolver) hash(eventType model.EventType, process *model.Process
 	fileKey := LRUCacheKey{
 		path:        file.PathnameStr,
 		containerID: process.ContainerID,
+		inode:       file.Inode,
 	}
 	if resolver.cache != nil {
 		cacheEntry, ok := resolver.cache.Get(fileKey)

--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -79,6 +79,7 @@ type LRUCacheKey struct {
 	path        string
 	containerID string
 	inode       uint64
+	pathID      uint32
 }
 
 // LRUCacheEntry is the structure used to cache hashes
@@ -217,6 +218,7 @@ func (resolver *Resolver) hash(eventType model.EventType, process *model.Process
 		path:        file.PathnameStr,
 		containerID: process.ContainerID,
 		inode:       file.Inode,
+		pathID:      file.PathKey.PathID,
 	}
 	if resolver.cache != nil {
 		cacheEntry, ok := resolver.cache.Get(fileKey)

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -173,6 +173,8 @@ runtime_security_config:
   {{end}}
   ebpfless:
     enabled: {{.EBPFLessEnabled}}
+  hash_resolver:
+    enabled: false
 `
 
 const testPolicy = `---


### PR DESCRIPTION
### What does this PR do?

This PR adds the hashing capability for ebpfless, using the existing hash resolver.

It will take into account the same params, so by default it will be enabled for execs and opens

### Motivation

This is a prerequisite to be able to bring malware on ebpfless

### Additional Notes

As in ebpfless we don't have inodeID, mountID and pathID, I've added another implementation to use instead the path/inode/containerID as cache key.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
