### PR TITLE
Remove NewEmptyProvider from the metadata comp

### DIFF
--- a/comp/metadata/internal/util/inventory_payload.go
+++ b/comp/metadata/internal/util/inventory_payload.go
@@ -142,7 +142,7 @@ func (i *InventoryPayload) MetadataProvider() runnerimpl.Provider {
 	if i.Enabled {
 		return runnerimpl.NewProvider(i.collect)
 	}
-	return runnerimpl.NewEmptyProvider()
+	return runnerimpl.NewProvider(nil)
 }
 
 // collect is the callback expected by the metadata runner.Provider. It will send a new payload and return the next

--- a/comp/metadata/internal/util/inventory_payload_test.go
+++ b/comp/metadata/internal/util/inventory_payload_test.go
@@ -83,14 +83,10 @@ func TestMetadataProvider(t *testing.T) {
 	i := getTestInventoryPayload(t, nil)
 
 	i.Enabled = true
-	cb := i.MetadataProvider().Callback
-	_, ok := cb.Get()
-	assert.True(t, ok)
+	assert.NotNil(t, i.MetadataProvider().Callback)
 
 	i.Enabled = false
-	cb = i.MetadataProvider().Callback
-	_, ok = cb.Get()
-	assert.False(t, ok)
+	assert.Nil(t, i.MetadataProvider().Callback)
 }
 
 func TestFlareProvider(t *testing.T) {

--- a/comp/metadata/resources/resourcesimpl/resources_test.go
+++ b/comp/metadata/resources/resourcesimpl/resources_test.go
@@ -47,9 +47,8 @@ func TestConfDisabled(t *testing.T) {
 		),
 	)
 
-	// When interval is 0 the resource Provider should be an empty Optional[T]
-	_, isSet := ret.Provider.Callback.Get()
-	assert.False(t, isSet)
+	// When interval is 0 the resource Provider should be nil
+	assert.Nil(t, ret.Provider.Callback)
 }
 
 func TestConfInterval(t *testing.T) {
@@ -71,6 +70,8 @@ func TestConfInterval(t *testing.T) {
 			fx.Provide(func() serializer.MetricSerializer { return nil }),
 		),
 	)
+
+	assert.NotNil(t, ret.Provider.Callback)
 
 	assert.Equal(t, 21*time.Second, ret.Comp.(*resourcesImpl).collectInterval)
 }


### PR DESCRIPTION
### What does this PR do?

Since we now filter nil value from Fx groups, we don't need the extra code around empty providers.

### Describe how to test/QA your changes

Check that metadata are still being sent by the agent.