### PR TITLE
[CWS] prevent selftests channel from blocking messages goroutine

### DIFF
--- a/pkg/security/probe/selftests/ebpfless.go
+++ b/pkg/security/probe/selftests/ebpfless.go
@@ -29,7 +29,7 @@ func (o *EBPFLessSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 
 	return &rules.RuleDefinition{
 		ID:         o.ruleID,
-		Expression: `exec.file.path != "" && process.parent.pid == 0`,
+		Expression: `exec.file.path != "" && process.parent.pid == 0 && process.ppid == 0`,
 		Every:      time.Duration(math.MaxInt64),
 	}
 }

--- a/pkg/security/probe/selftests/tester.go
+++ b/pkg/security/probe/selftests/tester.go
@@ -214,7 +214,12 @@ func (t *SelfTester) IsExpectedEvent(rule *rules.Rule, event eval.Event, _ *prob
 			Event:  s,
 		}
 
-		t.eventChan <- selfTestEvent
+		select {
+		case t.eventChan <- selfTestEvent:
+		default:
+			log.Errorf("self test channel is full, discarding event.\n")
+		}
+
 		return true
 	}
 	return false


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR prevents the goroutine processing the ebpfless messages from being blocked by trying to send on a full selftest events channel.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
