### PR TITLE
[APR-121] Add user-agent to logs forwarder requests

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -288,6 +288,8 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	}
 	req.Header.Set("DD-API-KEY", d.endpoint.GetAPIKey())
 	req.Header.Set("Content-Type", d.contentType)
+	req.Header.Set("User-Agent", fmt.Sprintf("datadog-agent/%s", version.AgentVersion))
+
 	if payload.Encoding != "" {
 		req.Header.Set("Content-Encoding", payload.Encoding)
 	}

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -7,6 +7,7 @@ package http
 
 import (
 	"errors"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -207,6 +208,16 @@ func TestDestinationSendsTimestampHeaders(t *testing.T) {
 	ddCurrentTimestamp, err := strconv.ParseInt(server.request.Header.Get("dd-current-timestamp"), 10, 64)
 	assert.Nil(t, err)
 	assert.GreaterOrEqual(t, ddCurrentTimestamp, currentTimestamp)
+}
+
+func TestDestinationSendsUserAgent(t *testing.T) {
+	cfg := getNewConfig()
+	server := NewTestServer(200, cfg)
+	defer server.httpServer.Close()
+
+	err := server.Destination.unconditionalSend(&message.Payload{Encoded: []byte("payload")})
+	assert.Nil(t, err)
+	assert.Regexp(t, regexp.MustCompile("datadog-agent/.*"), server.request.Header.Values("user-agent"))
 }
 
 func TestDestinationConcurrentSends(t *testing.T) {

--- a/releasenotes/notes/logs-api-user-agent-17d71d00a0411b49.yaml
+++ b/releasenotes/notes/logs-api-user-agent-17d71d00a0411b49.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    The `User-Agent` header is now set to `datadog-agent/<version>` for logs
+    forwarding requests to `/api/v2/logs` and `/intake`. Previously it was set
+    to `Go-http-client/1.1`.


### PR DESCRIPTION
### What does this PR do?

Sets the user-agent HTTP header for requests to `/api/v2/logs` to `datadog-agent/<version>`. This matches the behavior of the default forwarder.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

I noticed this was missing compared to the default forwarder when investigating a separate issue around the `/api/v1/events` endpoints. Without it the user-agent is set as `Go-http-client/1.1`.

### Additional Notes

None.

### Possible Drawbacks / Trade-offs

None.

### Describe how to test/QA your changes

I tested this by configuring a local Agent to forward requests through a local instance of [mitmproxy](https://mitmproxy.org/) to record the in-flight requests. 