### PR TITLE
(fleet) fix macos tests

### DIFF
--- a/pkg/updater/install_test.go
+++ b/pkg/updater/install_test.go
@@ -125,7 +125,7 @@ func TestInstallExperiment(t *testing.T) {
 	assertEqualFS(t, s.ConfigFS(fixtureSimpleV2), installer.ConfigFS(fixtureSimpleV2))
 }
 
-func TestPromoteExperiment(t *testing.T) {
+func TestInstallPromoteExperiment(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
 	installer := newTestInstaller(t)

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -99,7 +99,7 @@ func newTestUpdaterWithPaths(t *testing.T, s *testFixturesServer, rcc *testRemot
 	return u, rootPath, locksPath
 }
 
-func TestUpdaterBootstrapDefault(t *testing.T) {
+func TestBootstrapDefault(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
 	rc := newTestRemoteConfigClient()
@@ -116,7 +116,7 @@ func TestUpdaterBootstrapDefault(t *testing.T) {
 	assertEqualFS(t, s.PackageFS(fixtureSimpleV1), r.StableFS())
 }
 
-func TestUpdaterBootstrapURL(t *testing.T) {
+func TestBootstrapURL(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
 	rc := newTestRemoteConfigClient()
@@ -133,7 +133,7 @@ func TestUpdaterBootstrapURL(t *testing.T) {
 	assertEqualFS(t, s.PackageFS(fixtureSimpleV1), r.StableFS())
 }
 
-func TestUpdaterPurge(t *testing.T) {
+func TestPurge(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
 	rc := newTestRemoteConfigClient()
@@ -177,7 +177,7 @@ func assertDirExistAndEmpty(t *testing.T, path string) {
 	assert.Len(t, entry, 0)
 }
 
-func TestUpdaterBootstrapWithRC(t *testing.T) {
+func TestBootstrapWithRC(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
 	rc := newTestRemoteConfigClient()
@@ -199,7 +199,7 @@ func TestUpdaterBootstrapWithRC(t *testing.T) {
 	assertEqualFS(t, s.PackageFS(fixtureSimpleV2), r.StableFS())
 }
 
-func TestUpdaterBootstrapCatalogUpdate(t *testing.T) {
+func TestBootstrapCatalogUpdate(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
 	rc := newTestRemoteConfigClient()
@@ -213,7 +213,7 @@ func TestUpdaterBootstrapCatalogUpdate(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestUpdaterStartExperiment(t *testing.T) {
+func TestStartExperiment(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
 	rc := newTestRemoteConfigClient()
@@ -241,7 +241,7 @@ func TestUpdaterStartExperiment(t *testing.T) {
 	assertEqualFS(t, s.PackageFS(fixtureSimpleV2), r.ExperimentFS())
 }
 
-func TestUpdaterPromoteExperiment(t *testing.T) {
+func TestPromoteExperiment(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
 	rc := newTestRemoteConfigClient()
@@ -278,7 +278,7 @@ func TestUpdaterPromoteExperiment(t *testing.T) {
 	assertEqualFS(t, s.PackageFS(fixtureSimpleV2), r.StableFS())
 }
 
-func TestUpdaterStopExperiment(t *testing.T) {
+func TestStopExperiment(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
 	rc := newTestRemoteConfigClient()


### PR DESCRIPTION
https://github.com/DataDog/datadog-agent/pull/24494 broke macos tests.

This PR FiXeS it by shortening the tests name as it was leading to paths over golang's limit of 104 chars on macos:

```
could not create telemetry: listen unix /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/TestUpdaterBootstrapDefault399540277/004/telemetry.sock: bind: invalid argument
```
