### PR TITLE
Fix missing autodiscovery component in agent diagnose command (#24604)

### DIFF
--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -100,9 +100,10 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					}
 				}),
 				fx.Supply(optional.NewNoneOption[collector.Component]()),
-				workloadmeta.OptionalModule(),
-				tagger.OptionalModule(),
-				autodiscoveryimpl.OptionalModule(),
+				workloadmeta.Module(),
+				tagger.Module(),
+				fx.Provide(func(config config.Component) tagger.Params { return tagger.NewTaggerParamsForCoreAgent(config) }),
+				autodiscoveryimpl.Module(),
 				diagnosesendermanagerimpl.Module(),
 			)
 		},
@@ -234,8 +235,7 @@ This command print the package-signing metadata payload. This payload is used by
 func cmdDiagnose(cliParams *cliParams,
 	senderManager diagnosesendermanager.Component,
 	wmeta optional.Option[workloadmeta.Component],
-	_ optional.Option[tagger.Component],
-	ac optional.Option[autodiscovery.Component],
+	ac autodiscovery.Component,
 	collector optional.Option[collector.Component],
 	secretResolver secrets.Component) error {
 	diagCfg := diagnosis.Config{
@@ -245,7 +245,7 @@ func cmdDiagnose(cliParams *cliParams,
 		Exclude:  cliParams.exclude,
 	}
 
-	diagnoseDeps := diagnose.NewSuitesDeps(senderManager, collector, secretResolver, wmeta, ac)
+	diagnoseDeps := diagnose.NewSuitesDeps(senderManager, collector, secretResolver, wmeta, optional.NewOption(ac))
 	// Is it List command
 	if cliParams.listSuites {
 		diagnose.ListStdOut(color.Output, diagCfg, diagnoseDeps)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds the missing autodiscovery component in `agent diagnose` command
```
==============
Suite: check-datadog
1. --------------
  UNEXPECTED ERROR Collector or AutoDiscovery not found
  Diagnosis: Collector or AutoDiscovery not found
  Error: Collector or AutoDiscovery not found
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Describe how to test/QA your changes
Run `agent diagnose` when no agent is running and makes sure the following error is not displayed.
```
==============
Suite: check-datadog
1. --------------
  UNEXPECTED ERROR Collector or AutoDiscovery not found
  Diagnosis: Collector or AutoDiscovery not found
  Error: Collector or AutoDiscovery not found
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
