### PR TITLE
fix jmx and check command to have a valid settings component

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -43,6 +43,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
+	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
@@ -141,6 +142,10 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			workloadmeta.Module(),
 			apiimpl.Module(),
 			authtokenimpl.Module(),
+			// The jmx command do not have settings that change are runtime
+			// still, we need to pass it to ensure the API server is proprely initialized
+			settingsimpl.Module(),
+			fx.Supply(settings.Settings{}),
 			// TODO(components): this is a temporary hack as the StartServer() method of the API package was previously called with nil arguments
 			// This highlights the fact that the API Server created by JMX (through ExecJmx... function) should be different from the ones created
 			// in others commands such as run.
@@ -153,7 +158,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			fx.Provide(func() inventoryagent.Component { return nil }),
 			fx.Provide(func() inventoryhost.Component { return nil }),
 			fx.Provide(func() demultiplexer.Component { return nil }),
-			fx.Provide(func() settings.Component { return nil }),
 			fx.Provide(func() inventorychecks.Component { return nil }),
 			fx.Provide(func() packagesigning.Component { return nil }),
 			fx.Provide(func() optional.Option[rcservice.Component] { return optional.NewNoneOption[rcservice.Component]() }),

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -44,6 +44,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
+	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/status/statusimpl"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
@@ -208,7 +209,10 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 					},
 				),
 				statusimpl.Module(),
-
+				// The check command do not have settings that change are runtime
+				// still, we need to pass it to ensure the API server is proprely initialized
+				settingsimpl.Module(),
+				fx.Supply(settings.Settings{}),
 				// TODO(components): this is a temporary hack as the StartServer() method of the API package was previously called with nil arguments
 				// This highlights the fact that the API Server created by JMX (through ExecJmx... function) should be different from the ones created
 				// in others commands such as run.
@@ -217,7 +221,6 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				fx.Provide(func() replay.Component { return nil }),
 				fx.Provide(func() pidmap.Component { return nil }),
 				fx.Provide(func() serverdebug.Component { return nil }),
-				fx.Provide(func() settings.Component { return nil }),
 				fx.Provide(func() host.Component { return nil }),
 				fx.Provide(func() inventoryagent.Component { return nil }),
 				fx.Provide(func() inventoryhost.Component { return nil }),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fix an issue with `jmx check` created on this PR https://github.com/DataDog/datadog-agent/pull/24435

```
2024-04-12 10:21:17 UTC | CORE | INFO | (pkg/api/security/security.go:74 in GenerateRootCert) | [/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/api/api/apiimpl/security.go:50] Generating root certificate for hosts 127.0.0.1, localhost, ::1, localhost:0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x2b95330]

goroutine 1 [running]:
github.com/DataDog/datadog-agent/comp/api/api/apiimpl/internal/agent.SetupHandlers(0xeba2d27704f730a8?, {0x0?, 0x0}, {0x0, _}, {_, _}, {_, _}, {{_, ...}, ...}, ...)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/api/api/apiimpl/internal/agent/agent.go:109 +0x630
github.com/DataDog/datadog-agent/comp/api/api/apiimpl.startCMDServer({_, _}, _, _, {{_, _}, _}, {{_, _}, _}, ...)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/api/api/apiimpl/server_cmd.go:154 +0xb3c
github.com/DataDog/datadog-agent/comp/api/api/apiimpl.StartServers({{_, _}, _}, {{_, _}, _}, {_, _}, {_, _}, ...)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/api/api/apiimpl/server.go:120 +0x438
github.com/DataDog/datadog-agent/comp/api/api/apiimpl.(*apiServer).StartServer(0x4001f10418?, {0x6746ea8?, 0x40009400b0?}, {0x6721540?, 0x4000f34190?}, {0x673d8a8, 0x4000f309c0}, {{0x0?, 0x0?}, 0xb8?}, ...)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/api/api/apiimpl/api.go:131 +0x24c
github.com/DataDog/datadog-agent/pkg/cli/standalone.execJmxCommand({0x520c123, 0x7}, {0xa782e80, 0x0, 0x0}, {0x520bfa2, 0x7}, 0x4001f3de18, {0x5205249, 0x5}, ...)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/cli/standalone/jmx.go:75 +0xa0
github.com/DataDog/datadog-agent/pkg/cli/standalone.ExecJMXCommandConsole(...)
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
