### PR TITLE
[usm] Add `/proc/net/tcp` scanner

### DIFF
--- a/pkg/network/usm/procnet/parser.go
+++ b/pkg/network/usm/procnet/parser.go
@@ -113,7 +113,7 @@ func newEntry(line, buffer []byte) entry {
 	e.laddr = iter.nextField()
 	e.raddr = iter.nextField()
 	e.state = iter.nextField()
-	iter.skip(5)
+	iter.skip(5) // skips queue (tx + rx), tr, tm->when, retrnsmt ....
 	e.inode = iter.nextField()
 
 	return e

--- a/pkg/network/usm/procnet/parser.go
+++ b/pkg/network/usm/procnet/parser.go
@@ -104,7 +104,7 @@ type entry struct {
 	buffer []byte
 }
 
-func newEntry(line []byte, buffer []byte) entry {
+func newEntry(line, buffer []byte) entry {
 	e := entry{buffer: buffer}
 	iter := fieldIterator{line}
 

--- a/pkg/network/usm/procnet/parser.go
+++ b/pkg/network/usm/procnet/parser.go
@@ -216,6 +216,7 @@ func (iter *fieldIterator) nextField() []byte {
 	return result
 }
 
+// skip results in advancing the iterator in `n` fields (columns)
 func (iter *fieldIterator) skip(n int) {
 	for i := 0; i < n; i++ {
 		_ = iter.nextField()

--- a/pkg/network/usm/procnet/parser.go
+++ b/pkg/network/usm/procnet/parser.go
@@ -1,0 +1,223 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procnet
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"net/netip"
+	"os"
+	"slices"
+	"strconv"
+)
+
+// This file contains the code that does the parsing of /proc/net/{tcp,tcp6} files.
+//
+// The format of these files is the following:
+//
+//    46: 010310AC:9C4C 030310AC:1770 01
+//    |      |      |      |      |   |--> connection state
+//    |      |      |      |      |------> remote TCP port number
+//    |      |      |      |-------------> remote IPv4 address
+//    |      |      |--------------------> local TCP port number
+//    |      |---------------------------> local IPv4 address
+//    |----------------------------------> number of entry
+//
+//    00000150:00000000 01:00000019 00000000
+//       |        |     |     |       |--> number of unrecovered RTO timeouts
+//       |        |     |     |----------> number of jiffies until timer expires
+//       |        |     |----------------> timer_active (see below)
+//       |        |----------------------> receive-queue
+//       |-------------------------------> transmit-queue
+//
+//    1000        0 54165785 4 cd1e6040 25 4 27 3 -1
+//     |          |    |     |    |     |  | |  | |--> slow start size threshold,
+//     |          |    |     |    |     |  | |  |      or -1 if the threshold
+//     |          |    |     |    |     |  | |  |      is >= 0xFFFF
+//     |          |    |     |    |     |  | |  |----> sending congestion window
+//     |          |    |     |    |     |  | |-------> (ack.quick<<1)|ack.pingpong
+//     |          |    |     |    |     |  |---------> Predicted tick of soft clock
+//     |          |    |     |    |     |              (delayed ACK control data)
+//     |          |    |     |    |     |------------> retransmit timeout
+//     |          |    |     |    |------------------> location of socket in memory
+//     |          |    |     |-----------------------> socket reference count
+//     |          |    |-----------------------------> inode
+//     |          |----------------------------------> unanswered 0-window probes
+//     |---------------------------------------------> uid
+//
+// Source: https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt
+
+type scanner struct {
+	file   *os.File
+	reader *bufio.Reader
+
+	hexDecodingBuffer []byte
+}
+
+func newScanner(filepath string) (*scanner, error) {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := bufio.NewReader(f)
+
+	// Skip header line
+	_, _ = reader.ReadBytes('\n')
+
+	return &scanner{
+		file:              f,
+		reader:            reader,
+		hexDecodingBuffer: make([]byte, 16),
+	}, nil
+
+}
+
+func (s *scanner) Next() (entry, bool) {
+	b, err := s.reader.ReadBytes('\n')
+	if err != nil {
+		return entry{}, false
+	}
+
+	return newEntry(b, s.hexDecodingBuffer), true
+}
+
+func (s *scanner) Close() {
+	s.file.Close()
+}
+
+// entry represents one line in the /proc/net file
+type entry struct {
+	laddr []byte
+	raddr []byte
+	state []byte
+	inode []byte
+
+	// used for the purposes of decoding hex numbers
+	buffer []byte
+}
+
+func newEntry(line []byte, buffer []byte) entry {
+	e := entry{buffer: buffer}
+	iter := fieldIterator{line}
+
+	// refer to the diagram above for the line format
+	iter.skip(1)
+	e.laddr = iter.nextField()
+	e.raddr = iter.nextField()
+	e.state = iter.nextField()
+	iter.skip(5)
+	e.inode = iter.nextField()
+
+	return e
+}
+
+func (e entry) LocalAddress() (netip.Addr, uint16) {
+	return e.parseAddress(e.laddr)
+}
+
+func (e entry) RemoteAddress() (netip.Addr, uint16) {
+	return e.parseAddress(e.raddr)
+}
+
+func (e entry) Inode() int {
+	return e.atoi(e.inode)
+}
+
+func (e entry) ConnectionState() int {
+	n, err := hex.Decode(e.buffer, e.state)
+	if err != nil || n != 1 {
+		return -1
+	}
+
+	return int(e.buffer[0])
+}
+
+func (e entry) atoi(number []byte) int {
+	// note: looks like the Go compiler is smart enough to not allocate the
+	// string from the given byte slice. There is a benchmark in parser_net.go
+	// covering this.
+	i, err := strconv.Atoi(string(number))
+	if err != nil {
+		return -1
+	}
+
+	return i
+}
+
+// parseAddress converts a textual address representation of the form
+// 010310AC:9C4C into a (netip.Addr, uint16) pair.
+func (e entry) parseAddress(rawAddress []byte) (netip.Addr, uint16) {
+	i := bytes.IndexByte(rawAddress, ':')
+	if i == -1 {
+		return netip.Addr{}, 0
+	}
+
+	rawIP := rawAddress[:i]
+	rawPort := rawAddress[i+1:]
+
+	// Parse port number
+	n, err := hex.Decode(e.buffer, rawPort)
+	if err != nil {
+		return netip.Addr{}, 0
+	}
+	parsedPort := binary.BigEndian.Uint16(e.buffer[:n])
+
+	// Parse IP address (IPv4 or IPv6)
+	n, err = hex.Decode(e.buffer, rawIP)
+	if err != nil || (n != 4 && n != 16) {
+		return netip.Addr{}, 0
+	}
+	// Byte ordering is reversed (big endian) than `netip` expects
+	slices.Reverse(e.buffer[:n])
+
+	if n == 4 {
+		var ipv4 [4]byte
+		copy(ipv4[:], e.buffer[:n])
+		return netip.AddrFrom4(ipv4), parsedPort
+	}
+
+	var ipv6 [16]byte
+	copy(ipv6[:], e.buffer[:n])
+	return netip.AddrFrom16(ipv6), parsedPort
+}
+
+// copied from pkg/network/proc_net.go
+type fieldIterator struct {
+	data []byte
+}
+
+func (iter *fieldIterator) nextField() []byte {
+	// skip any leading whitespace
+	for i, b := range iter.data {
+		if b != ' ' {
+			iter.data = iter.data[i:]
+			break
+		}
+	}
+
+	// read field up until the first whitespace char
+	var result []byte
+	for i, b := range iter.data {
+		if b == ' ' {
+			result = iter.data[:i]
+			iter.data = iter.data[i:]
+			break
+		}
+	}
+
+	return result
+}
+
+func (iter *fieldIterator) skip(n int) {
+	for i := 0; i < n; i++ {
+		_ = iter.nextField()
+	}
+}

--- a/pkg/network/usm/procnet/parser.go
+++ b/pkg/network/usm/procnet/parser.go
@@ -109,7 +109,7 @@ func newEntry(line, buffer []byte) entry {
 	iter := fieldIterator{line}
 
 	// refer to the diagram above for the line format
-	iter.skip(1)
+	iter.skip(1) // skips the number of the entry
 	e.laddr = iter.nextField()
 	e.raddr = iter.nextField()
 	e.state = iter.nextField()

--- a/pkg/network/usm/procnet/parser_test.go
+++ b/pkg/network/usm/procnet/parser_test.go
@@ -1,0 +1,175 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procnet
+
+import (
+	"net/netip"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcNetParsing(t *testing.T) {
+	// The example below contains the following connections:
+	//
+	// 0: 1.1.1.1:8080->1.1.1.1:59836
+	// 1: 1.1.1.1:59836->1.1.1.1:8080
+	// 2: 10.211.55.6:57434->34.233.170.129:80
+	procNetFile := createTempFile(t, `sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+  0: 01010101:1F90 01010101:E9BC 01 00000000:00000000 00:00000000 00000000  1000        0 347102 1 0000000000000000 20 0 0 10 -1
+  1: 01010101:E9BC 01010101:1F90 01 00000000:00000000 00:00000000 00000000  1000        0 348600 1 0000000000000000 20 0 0 10 -1
+  2: 0637D30A:E05A 81AAE922:0050 06 00000000:00000000 03:00001721 00000000     0        0 0 3 0000000000000000
+`)
+
+	scanner, err := newScanner(procNetFile)
+	assert.NoError(t, err)
+	defer scanner.Close()
+
+	// Entry 0
+	entry, ok := scanner.Next()
+	assert.True(t, ok)
+	laddr, lport := entry.LocalAddress()
+	assert.Equal(t, "1.1.1.1", laddr.String())
+	assert.Equal(t, uint16(8080), lport)
+	raddr, rport := entry.RemoteAddress()
+	assert.Equal(t, "1.1.1.1", raddr.String())
+	assert.Equal(t, uint16(59836), rport)
+	assert.Equal(t, 347102, entry.Inode())
+
+	// Entry 1
+	entry, ok = scanner.Next()
+	assert.True(t, ok)
+	laddr, lport = entry.LocalAddress()
+	assert.Equal(t, "1.1.1.1", laddr.String())
+	assert.Equal(t, uint16(59836), lport)
+	raddr, rport = entry.RemoteAddress()
+	assert.Equal(t, "1.1.1.1", raddr.String())
+	assert.Equal(t, uint16(8080), rport)
+	assert.Equal(t, 348600, entry.Inode())
+
+	// Entry 2
+	entry, ok = scanner.Next()
+	assert.True(t, ok)
+	laddr, lport = entry.LocalAddress()
+	assert.Equal(t, "10.211.55.6", laddr.String())
+	assert.Equal(t, uint16(57434), lport)
+	raddr, rport = entry.RemoteAddress()
+	assert.Equal(t, "34.233.170.129", raddr.String())
+	assert.Equal(t, uint16(80), rport)
+	assert.Equal(t, 0, entry.Inode())
+
+	_, ok = scanner.Next()
+	assert.False(t, ok)
+}
+
+func BenchmarkScanner(b *testing.B) {
+	procNetContents := `sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 01010101:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 347101 1 0000000000000000 100 0 0 10 0
+   1: 3500007F:0035 00000000:0000 0A 00000000:00000000 00:00000000 00000000   102        0 19914 1 0000000000000000 100 0 0 10 5
+   2: 00000000:0016 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 21564 1 0000000000000000 100 0 0 10 0
+   3: 01010101:1F90 01010101:E9BC 01 00000000:00000000 00:00000000 00000000  1000        0 347102 1 0000000000000000 20 0 0 10 -1
+   4: 01010101:E9BC 01010101:1F90 01 00000000:00000000 00:00000000 00000000  1000        0 348600 1 0000000000000000 20 0 0 10 -1
+   5: 0637D30A:0016 0237D30A:E5A8 01 00000000:00000000 02:000A8D2D 00000000     0        0 349974 2 0000000000000000 20 9 27 10 -1
+   6: 0637D30A:E05A 81AAE922:0050 06 00000000:00000000 03:00001721 00000000     0        0 0 3 0000000000000000
+   7: 0637D30A:0016 0237D30A:E5E9 01 00000000:00000000 02:000AF78A 00000000     0        0 350034 4 0000000000000000 20 4 31 10 -1
+   8: 0637D30A:0016 0237D30A:E2A7 01 00000000:00000000 02:0004DAA7 00000000     0        0 296943 2 0000000000000000 20 4 30 7 7
+   9: 0637D30A:0016 0237D30A:C3B3 01 00000000:00000000 02:0001DAA7 00000000     0        0 215210 2 0000000000000000 20 4 30 10 60
+  10: 0637D30A:0016 0237D30A:E446 01 00000000:00000000 02:0007BB1F 00000000     0        0 348601 2 0000000000000000 20 4 25 10 -1
+  11: 0637D30A:DDE8 31C26597:01BB 01 00000000:00000000 00:00000000 00000000   112        0 154366 1 0000000000000000 61 4 32 10 -1
+`
+	f, _ := os.CreateTemp(b.TempDir(), "")
+	f.WriteString(procNetContents)
+	filePath := f.Name()
+	f.Close()
+
+	scanner, _ := newScanner(filePath)
+	defer scanner.Close()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	// The purpose of this benchmark is to ensure there are no allocations when *scanning*
+	// the file. Note that when we reach the end of the file we're rewinding to offset 0
+	// to ensure that the Go benchmarking will collect enough samples.
+	for i := 0; i < b.N; i++ {
+		_, ok := scanner.Next()
+		if !ok {
+			scanner.file.Seek(0, 0)
+		}
+	}
+}
+
+func BenchmarkAddressParsing(b *testing.B) {
+	const (
+		expectedIP   = "1.1.1.1"
+		expectedPort = uint16(8080)
+	)
+
+	// Local Address (01010101:1F90) represents "1.1.1.1:8080"
+	procNetEntry := []byte("0: 01010101:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000" +
+		"0 347101 1 0000000000000000 100 0 0 10 0")
+
+	buffer := make([]byte, 16)
+	entry := newEntry(procNetEntry, buffer)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var (
+		laddr netip.Addr
+		lport uint16
+	)
+
+	for i := 0; i < b.N; i++ {
+		laddr, lport = entry.LocalAddress()
+	}
+	b.StopTimer()
+
+	// Use previous results from the last method calls to ensure they won't be optimized away
+	if laddr.String() != expectedIP || lport != expectedPort {
+		b.Fatalf("benchmark didn't produced the expected values. expected=%s:%d got=%s:%d",
+			expectedIP,
+			expectedPort,
+			laddr.String(),
+			lport,
+		)
+	}
+}
+
+func BenchmarkInodeParsing(b *testing.B) {
+	// The inode of the entry below is 347102
+	procNetEntry := []byte("0: 01010101:1F90 01010101:E9BC 01 00000000:00000000 00:00000000 00000000 1000 0 347102 1 0000000000000000 20 0 0 10 -1")
+	const expectedInode = 347102
+
+	buffer := make([]byte, 16)
+	entry := newEntry(procNetEntry, buffer)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var inode int
+	for i := 0; i < b.N; i++ {
+		inode = entry.Inode()
+	}
+	b.StopTimer()
+
+	// Use previous results from the last method calls to ensure they won't be optimized away
+	if inode != expectedInode {
+		b.Fatalf("benchmark didn't produced the expected values. expected=%d got=%d",
+			expectedInode,
+			inode,
+		)
+	}
+}
+
+func createTempFile(t *testing.T, contents string) string {
+	f, err := os.CreateTemp(t.TempDir(), "")
+	assert.NoError(t, err)
+	defer f.Close()
+	_, err = f.WriteString(contents)
+	assert.NoError(t, err)
+	return f.Name()
+}

--- a/pkg/network/usm/procnet/procnet.go
+++ b/pkg/network/usm/procnet/procnet.go
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package procnet is responsible for scraping procFS and returning a list of
+// all existing sockets, including information such as their local/remote
+// addresses, PIDs and file descriptor numbers.
+//
+// The main motivation is to provide a way to fetch socket information for
+// connections that were created prior system-probe startup, so we can use this
+// data to "pre-populate" some of our eBPF maps.
+package procnet
+
+import (
+	"fmt"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+)
+
+// TCPConnection encapsulates information for a TCP connection.
+// This information is obtained from the /proc/net/{tcp,tcp6} files
+// along with /proc/<PID>/fds directories.
+type TCPConnection struct {
+	// Sourced from /proc/net/{tcp,tcp6}
+	Laddr netip.Addr
+	Raddr netip.Addr
+	Lport uint16
+	Rport uint16
+	State int
+
+	// Sourced from /proc/<PID>/fd
+	PID uint32
+	FD  uint32
+}
+
+// GetTCPConnections returns a list of all existing TCP connections
+func GetTCPConnections() []TCPConnection {
+	procRoot := kernel.ProcFSRoot()
+
+	connByInode := make(map[int]TCPConnection)
+	populateIndex(connByInode, filepath.Join(procRoot, "net", "tcp"))
+	populateIndex(connByInode, filepath.Join(procRoot, "net", "tcp6"))
+
+	result := make([]TCPConnection, 0, len(connByInode))
+	_ = kernel.WithAllProcs(procRoot, func(pid int) error {
+		result = matchFDWithSocket(procRoot, pid, connByInode, result)
+		return nil
+	})
+
+	return result
+}
+
+// populateIndex builds an index of TCP connection data by inode by
+// reading /proc/net/{tcp,tcp6} files
+func populateIndex(connByInode map[int]TCPConnection, file string) {
+	scanner, err := newScanner(file)
+	if err != nil {
+		return
+	}
+	defer scanner.Close()
+
+	for {
+		entry, ok := scanner.Next()
+		if !ok {
+			break
+		}
+
+		laddr, lport := entry.LocalAddress()
+		raddr, rport := entry.RemoteAddress()
+		connByInode[entry.Inode()] = TCPConnection{
+			Laddr: laddr,
+			Raddr: raddr,
+			Lport: lport,
+			Rport: rport,
+			State: entry.ConnectionState(),
+		}
+	}
+}
+
+// matchFDWithSocket checks every file descriptor of a given PID and try to
+// match it against socket data using the inode number.
+// In case there is a match, we augument TCPConnection data with PID and FD
+// information and add that to the `conns` slice.
+// Note that the resulting `conns` slice can actually be bigger than the
+// original `connsByInode` map size because one TCP socket can potentially "map"
+// to multiple (PID, FD) pairs (eg. forked processes etc).
+func matchFDWithSocket(procRoot string, pid int, connByInode map[int]TCPConnection, conns []TCPConnection) []TCPConnection {
+	fdsDir := filepath.Join(procRoot, fmt.Sprintf("%d", pid), "fd")
+	fds, err := os.ReadDir(fdsDir)
+	if err != nil {
+		return conns
+	}
+
+	for _, fd := range fds {
+		info, err := os.Stat(filepath.Join(fdsDir, fd.Name()))
+		if err != nil {
+			continue
+		}
+
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			continue
+		}
+
+		conn, ok := connByInode[int(stat.Ino)]
+		if !ok {
+			continue
+		}
+
+		fdNum, err := strconv.Atoi(fd.Name())
+		if err != nil {
+			continue
+		}
+
+		conn.PID = uint32(pid)
+		conn.FD = uint32(fdNum)
+		conns = append(conns, conn)
+	}
+
+	return conns
+}

--- a/pkg/network/usm/procnet/procnet.go
+++ b/pkg/network/usm/procnet/procnet.go
@@ -39,6 +39,8 @@ type TCPConnection struct {
 	// Sourced from /proc/<PID>/fd
 	PID uint32
 	FD  uint32
+	// Sourced from /proc/<PID>/ns
+	NetNS uint32
 }
 
 // GetTCPConnections returns a list of all existing TCP connections
@@ -99,6 +101,11 @@ func matchFDWithSocket(procRoot string, pid int, connByInode map[int]TCPConnecti
 		return conns
 	}
 
+	netNS, err := kernel.GetNetNsInoFromPid(procRoot, pid)
+	if err != nil {
+		return conns
+	}
+
 	for _, fd := range fds {
 		info, err := os.Stat(filepath.Join(fdsDir, fd.Name()))
 		if err != nil {
@@ -122,6 +129,7 @@ func matchFDWithSocket(procRoot string, pid int, connByInode map[int]TCPConnecti
 
 		conn.PID = uint32(pid)
 		conn.FD = uint32(fdNum)
+		conn.NetNS = netNS
 		conns = append(conns, conn)
 	}
 

--- a/pkg/network/usm/procnet/procnet.go
+++ b/pkg/network/usm/procnet/procnet.go
@@ -89,7 +89,7 @@ func populateIndex(connByInode map[int]TCPConnection, file string) {
 
 // matchFDWithSocket checks every file descriptor of a given PID and try to
 // match it against socket data using the inode number.
-// In case there is a match, we augument TCPConnection data with PID and FD
+// In case there is a match, we augment TCPConnection data with PID and FD
 // information and add that to the `conns` slice.
 // Note that the resulting `conns` slice can actually be bigger than the
 // original `connsByInode` map size because one TCP socket can potentially "map"

--- a/pkg/network/usm/procnet/procnet_test.go
+++ b/pkg/network/usm/procnet/procnet_test.go
@@ -14,8 +14,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 )
 
 func TestGetTCPConnections(t *testing.T) {

--- a/pkg/network/usm/procnet/procnet_test.go
+++ b/pkg/network/usm/procnet/procnet_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procnet
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTCPConnections(t *testing.T) {
+	const srvAddress = "127.0.0.1:8080"
+
+	// Create TCP server
+	srv := testutil.NewTCPServer(srvAddress, func(c net.Conn) { time.Sleep(time.Minute) }, false)
+	done := make(chan struct{})
+	srv.Run(done)
+	t.Cleanup(func() { close(done) })
+
+	// Connect to it
+	clientConn, err := net.Dial("tcp4", srvAddress)
+	assert.NoError(t, err)
+
+	// Now let's "manually" obtain the FD and PID of this connection so we can
+	// use it later in our test assertions
+	connPID := uint32(os.Getpid())
+	rawConn, err := clientConn.(*net.TCPConn).SyscallConn()
+	assert.NoError(t, err)
+	var connFD uint32
+	rawConn.Control(func(fd uintptr) {
+		connFD = uint32(fd)
+	})
+
+	matches := func(c TCPConnection, expected net.Conn) bool {
+		return c.FD == connFD &&
+			c.PID == connPID &&
+			fmt.Sprintf("%s:%d", c.Laddr, c.Lport) == expected.LocalAddr().String() &&
+			fmt.Sprintf("%s:%d", c.Raddr, c.Rport) == expected.RemoteAddr().String()
+	}
+
+	// Finally, fetch all connections by calling GetTCPConnections() and
+	// ensure we can see the connection we created with the proper addresses,
+	// and process information (PID & FD)
+	connections := GetTCPConnections()
+	assert.Condition(t, func() bool {
+		for _, c := range connections {
+			if matches(c, clientConn) {
+				return true
+			}
+		}
+		return false
+	})
+}

--- a/pkg/network/usm/procnet/procnet_test.go
+++ b/pkg/network/usm/procnet/procnet_test.go
@@ -61,3 +61,13 @@ func TestGetTCPConnections(t *testing.T) {
 		return false
 	})
 }
+
+// This benchmark is mostly intended to be executed as a source of pprof data:
+// go test -tags=linux_bpf -bench=BenchmarkGetTCPConnections -benchmem -cpuprofile cpu.prof -memprofile mem.prof
+func BenchmarkGetTCPConnections(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		GetTCPConnections()
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add utility for obtaining connection information from `procfs` data.

### Motivation

We'll be using this information to pre-populate some of our eBPF maps that associate PID, FD and socket data.
These maps are used in the context of OpenSSL and Go TLS monitoring and currentl lack information about connections that are _created prior to system-probe startup_.

### Additional Notes

The actual use of the `procnet` package will be added in a follow-up PR.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
