### PR TITLE
fix `inv -e security-agent.sync-secl-win-pkg` on macOS

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -945,5 +945,8 @@ def sync_secl_win_pkg(ctx):
             fto = ffrom
 
         ctx.run(f"cp pkg/security/secl/model/{ffrom} pkg/security/seclwin/model/{fto}")
-        ctx.run(f"sed -i '/^\\/\\/go:build/d' pkg/security/seclwin/model/{fto}")
+        if sys.platform == "darwin":
+            ctx.run(f"sed -i '' '/^\\/\\/go:build/d' pkg/security/seclwin/model/{fto}")
+        else:
+            ctx.run(f"sed -i '/^\\/\\/go:build/d' pkg/security/seclwin/model/{fto}")
         ctx.run(f"gofmt -s -w pkg/security/seclwin/model/{fto}")


### PR DESCRIPTION
### What does this PR do?

`sed` on linux is GNU sed, and `sed` on macOS/darwin is BSD sed. Obviously they do a similar job but with enough difference to be a pain.

This PR fixes the `sync-secl-win-pkg` to work both on linux and darwin.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
