### PR TITLE
[CWS] make MacroEvaluator use the cached fields

### DIFF
--- a/pkg/security/secl/compiler/eval/macro.go
+++ b/pkg/security/secl/compiler/eval/macro.go
@@ -169,11 +169,5 @@ func (m *Macro) GetFields() []Field {
 
 // GetFields - Returns all the Field that the MacroEvaluator handles
 func (m *MacroEvaluator) GetFields() []Field {
-	fields := make([]Field, len(m.fieldValues))
-	i := 0
-	for key := range m.fieldValues {
-		fields[i] = key
-		i++
-	}
-	return fields
+	return m.fields
 }


### PR DESCRIPTION
### What does this PR do?

We already compute the `fields` from `fieldValues` when creating the macro evaluator, no need to compute it again for each `GetFields` call. More than that `fields` was actually never used.. this PR cleans this all up.

### Motivation

Performance work

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
