### PR TITLE
[windows] etw: add support for well-known event providers

### DIFF
--- a/comp/etw/component.go
+++ b/comp/etw/component.go
@@ -185,6 +185,7 @@ type Session interface {
 // Component offers a way to create ETW tracing sessions with a given name.
 type Component interface {
 	NewSession(sessionName string) (Session, error)
+	NewWellKnownSession(sessionName string) (Session, error)
 }
 
 // UserData offers a wrapper around the UserData field of an ETW event.

--- a/comp/etw/impl/etwImpl.go
+++ b/comp/etw/impl/etwImpl.go
@@ -35,3 +35,11 @@ func (s *etwImpl) NewSession(sessionName string) (etw.Session, error) {
 	}
 	return session, nil
 }
+
+func (s *etwImpl) NewWellKnownSession(sessionName string) (etw.Session, error) {
+	session, err := createWellKnownEtwSession(sessionName)
+	if err != nil {
+		return nil, err
+	}
+	return session, nil
+}

--- a/comp/etw/impl/etwSession.go
+++ b/comp/etw/impl/etwSession.go
@@ -44,9 +44,9 @@ func (e *etwSession) ConfigureProvider(providerGUID windows.GUID, configurations
 }
 
 func (e *etwSession) EnableProvider(providerGUID windows.GUID) error {
-	// could also thrown an error here for improper api usage.
+	
 	if e.wellKnown {
-		return nil
+		return fmt.Errorf("cannot enable provider on well-known session")
 	}
 	if _, ok := e.providers[providerGUID]; !ok {
 		// ConfigureProvider was not called prior, set the default configuration

--- a/comp/etw/impl/etwSession.go
+++ b/comp/etw/impl/etwSession.go
@@ -25,12 +25,17 @@ import "C"
 type etwSession struct {
 	Name          string
 	hSession      C.TRACEHANDLE
+	hTraceHandle  C.TRACEHANDLE
+	wellKnown     bool
 	propertiesBuf []byte
 	providers     map[windows.GUID]etw.ProviderConfiguration
 	utf16name     []uint16
 }
 
 func (e *etwSession) ConfigureProvider(providerGUID windows.GUID, configurations ...etw.ProviderConfigurationFunc) {
+	if e.wellKnown {
+		return
+	}
 	cfg := etw.ProviderConfiguration{}
 	for _, configuration := range configurations {
 		configuration(&cfg)
@@ -39,6 +44,10 @@ func (e *etwSession) ConfigureProvider(providerGUID windows.GUID, configurations
 }
 
 func (e *etwSession) EnableProvider(providerGUID windows.GUID) error {
+	// could also thrown an error here for improper api usage.
+	if e.wellKnown {
+		return nil
+	}
 	if _, ok := e.providers[providerGUID]; !ok {
 		// ConfigureProvider was not called prior, set the default configuration
 		e.ConfigureProvider(providerGUID, nil)
@@ -110,6 +119,7 @@ func (e *etwSession) StartTracing(callback etw.EventCallback) error {
 		return fmt.Errorf("failed to start tracing: %v", windows.GetLastError())
 	}
 
+	e.hTraceHandle = traceHandle
 	ret := windows.Errno(C.ProcessTrace(
 		C.PTRACEHANDLE(&traceHandle),
 		1,
@@ -128,11 +138,11 @@ func (e *etwSession) StopTracing() error {
 		// nil errors are discarded
 		globalError = errors.Join(globalError, e.DisableProvider(guid))
 	}
-
+	ptp := (C.PEVENT_TRACE_PROPERTIES)(unsafe.Pointer(&e.propertiesBuf[0]))
 	ret := windows.Errno(C.ControlTraceW(
 		e.hSession,
 		nil,
-		(C.PEVENT_TRACE_PROPERTIES)(unsafe.Pointer(&e.propertiesBuf[0])),
+		ptp,
 		C.EVENT_TRACE_CONTROL_STOP))
 	if !(ret == windows.ERROR_MORE_DATA ||
 		ret == windows.ERROR_SUCCESS) {
@@ -175,6 +185,7 @@ func createEtwSession(name string) (*etwSession, error) {
 	utf16SessionName, err := windows.UTF16FromString(name)
 	s := &etwSession{
 		Name:      name,
+		wellKnown: false,
 		utf16name: utf16SessionName,
 		providers: make(map[windows.GUID]etw.ProviderConfiguration),
 	}
@@ -210,4 +221,29 @@ func createEtwSession(name string) (*etwSession, error) {
 	}
 
 	return nil, fmt.Errorf("StartTraceW failed; %w", err)
+}
+
+func createWellKnownEtwSession(name string) (*etwSession, error) {
+	utf16SessionName, err := windows.UTF16FromString(name)
+	if err != nil {
+		return nil, fmt.Errorf("incorrect session name; %w", err)
+	}
+
+	s := &etwSession{
+		Name:      name,
+		utf16name: utf16SessionName,
+		wellKnown: true,
+	}
+	sessionNameSize := (len(utf16SessionName) * int(unsafe.Sizeof(utf16SessionName[0])))
+	bufSize := int(unsafe.Sizeof(C.EVENT_TRACE_PROPERTIES{})) + sessionNameSize
+	propertiesBuf := make([]byte, bufSize)
+
+	pProperties := (C.PEVENT_TRACE_PROPERTIES)(unsafe.Pointer(&propertiesBuf[0]))
+	pProperties.Wnode.BufferSize = C.ulong(bufSize)
+	pProperties.Wnode.ClientContext = 1
+	pProperties.Wnode.Flags = C.WNODE_FLAG_TRACED_GUID
+
+	pProperties.LogFileMode = C.EVENT_TRACE_REAL_TIME_MODE
+	s.propertiesBuf = propertiesBuf
+	return s, nil
 }

--- a/comp/etw/impl/etwSession.go
+++ b/comp/etw/impl/etwSession.go
@@ -44,7 +44,7 @@ func (e *etwSession) ConfigureProvider(providerGUID windows.GUID, configurations
 }
 
 func (e *etwSession) EnableProvider(providerGUID windows.GUID) error {
-	
+
 	if e.wellKnown {
 		return fmt.Errorf("cannot enable provider on well-known session")
 	}


### PR DESCRIPTION
This change adds support for well-known event providers in the ETW component.  Allows for tracing ETW specifically for audit events.

Note that the audit provider can only be subscribed when running as LOCAL_SYSTEM; making testing difficult.

### What does this PR do?

### Motivation

This is an enabling PR for the continued development of CWS.

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

As mentioned above, testing in isolation is problematic because it can only be done as `LOCAL_SYSTEM`.  Feature testing will be included in the consuming PR for CWS.