### PR TITLE
[CWS] ensure directory provider lock is not held while propagating profile to manager

### DIFF
--- a/pkg/security/security_profile/profile/profile_dir.go
+++ b/pkg/security/security_profile/profile/profile_dir.go
@@ -237,10 +237,14 @@ func (dp *DirectoryProvider) loadProfile(profilePath string) error {
 
 	// lock selectors and profiles mapping
 	dp.Lock()
-	defer dp.Unlock()
+	selectors := make([]cgroupModel.WorkloadSelector, len(dp.selectors))
+	copy(selectors, dp.selectors)
+	profileMapping := maps.Clone(dp.profileMapping)
+	propagateCb := dp.onNewProfileCallback
+	dp.Unlock()
 
 	// prioritize a persited profile over activity dumps
-	if existingProfile, ok := dp.profileMapping[profileManagerSelector]; ok {
+	if existingProfile, ok := profileMapping[profileManagerSelector]; ok {
 		if existingProfile.selector.Tag == "*" && profile.Selector.GetImageTag() != "*" {
 			seclog.Debugf("ignoring %s: a persisted profile already exists for workload %s", profilePath, profileManagerSelector.String())
 			return nil
@@ -255,14 +259,14 @@ func (dp *DirectoryProvider) loadProfile(profilePath string) error {
 
 	seclog.Debugf("security profile %s loaded from file system", workloadSelector)
 
-	if dp.onNewProfileCallback == nil {
+	if propagateCb == nil {
 		return nil
 	}
 
 	// check if this profile matches a workload selector
-	for _, selector := range dp.selectors {
+	for _, selector := range selectors {
 		if workloadSelector.Match(selector) {
-			dp.onNewProfileCallback(workloadSelector, profile)
+			propagateCb(workloadSelector, profile)
 		}
 	}
 	return nil


### PR DESCRIPTION
### What does this PR do?

When the directory provider `onNewProfileDebouncerCallback` is called:
- DirectoryProvider is locked
- ... callback..
- `profilesLock` is locked (inside the security profiles manager)

When the process EBPFResolver deletes an entry:
- cgroup resolver removes an entry
- `OnCGroupDeletedEvent` via the LRU entry removed callback
- `ShouldDeleteProfile` is called locking `profilesLock`
- `propagateWorkloadSelectorsToProviders`
- `DirectoryProvider.UpdateWorkloadSelectors` locking the Directory Provider

This means we have one goroutine locking the dir provider, then the profiles. And another locking the profiles then the directory provider. This is clearly an issue.

This PR fixes the issue by ensuring the directory provider is not kept locked when propagating the new profile to the manager, ensuring profilesLock is not locked while keeping the provider locked as well.

This PR will need a big follow up work to sanitize all those locks and ensure this does not happen again.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
