### PR TITLE
Update linux_test.go

### DIFF
--- a/test/new-e2e/tests/updater/linux_test.go
+++ b/test/new-e2e/tests/updater/linux_test.go
@@ -70,7 +70,7 @@ func TestUbuntuARM(t *testing.T) {
 
 func TestDebianX86(t *testing.T) {
 	t.Parallel()
-	runTest(t, "dpkg", os.AMD64Arch, os.UbuntuDefault)
+	runTest(t, "dpkg", os.AMD64Arch, os.DebianDefault)
 }
 
 func (v *vmUpdaterSuite) TestUserGroupsCreation() {


### PR DESCRIPTION
Fixed distro, also ubuntu x86 is the most likely to hit docker rate limits