### PR TITLE
feat(dogstatsd): implement unified origin detection

### DIFF
--- a/comp/core/tagger/tagger.go
+++ b/comp/core/tagger/tagger.go
@@ -75,6 +75,7 @@ type tagger interface {
 type datadogConfig struct {
 	dogstatsdEntityIDPrecedenceEnabled bool
 	dogstatsdOptOutEnabled             bool
+	dogstatsdUnifiedEnabled            bool
 }
 
 // TaggerClient is a component that contains two tagger component: capturetagger and defaulttagger
@@ -165,6 +166,7 @@ func newTaggerClient(deps dependencies) Component {
 	}
 
 	taggerClient.datadogConfig.dogstatsdEntityIDPrecedenceEnabled = deps.Config.GetBool("dogstatsd_entity_id_precedence")
+	taggerClient.datadogConfig.dogstatsdUnifiedEnabled = deps.Config.GetBool("dogstatsd_origin_detection_unified")
 	taggerClient.datadogConfig.dogstatsdOptOutEnabled = deps.Config.GetBool("dogstatsd_origin_optout_enabled")
 
 	deps.Log.Info("TaggerClient is created, defaultTagger type: ", reflect.TypeOf(taggerClient.defaultTagger))
@@ -365,8 +367,14 @@ func (t *TaggerClient) ResetCaptureTagger() {
 func (t *TaggerClient) EnrichTags(tb tagset.TagsAccumulator, originInfo taggertypes.OriginInfo) {
 	cardinality := taggerCardinality(originInfo.Cardinality)
 
+	// If dogstatsdUnifiedEnabled is disabled, we use DogStatsD's Legacy Origin Detection.
+	// TODO: remove this when dogstatsd_origin_detection_unified is enabled by default
+	if !t.datadogConfig.dogstatsdUnifiedEnabled {
+		originInfo.ProductOrigin = taggertypes.ProductOriginDogStatsDLegacy
+	}
+
 	switch originInfo.ProductOrigin {
-	case taggertypes.ProductOriginDogStatsD:
+	case taggertypes.ProductOriginDogStatsDLegacy:
 		// The following was moved from the dogstatsd package
 		// originFromUDS is the origin discovered via UDS origin detection (container ID).
 		// originFromTag is the origin sent by the client via the dd.internal.entity_id tag (non-prefixed pod uid).

--- a/comp/core/tagger/tagger.go
+++ b/comp/core/tagger/tagger.go
@@ -367,13 +367,14 @@ func (t *TaggerClient) ResetCaptureTagger() {
 func (t *TaggerClient) EnrichTags(tb tagset.TagsAccumulator, originInfo taggertypes.OriginInfo) {
 	cardinality := taggerCardinality(originInfo.Cardinality)
 
-	// If dogstatsdUnifiedEnabled is disabled, we use DogStatsD's Legacy Origin Detection.
-	// TODO: remove this when dogstatsd_origin_detection_unified is enabled by default
-	if !t.datadogConfig.originDetectionUnifiedEnabled {
-		originInfo.ProductOrigin = taggertypes.ProductOriginDogStatsDLegacy
+	productOrigin := originInfo.ProductOrigin
+	// If origin_detection_unified is disabled, we use DogStatsD's Legacy Origin Detection.
+	// TODO: remove this when origin_detection_unified is enabled by default
+	if !t.datadogConfig.originDetectionUnifiedEnabled && productOrigin == taggertypes.ProductOriginDogStatsD {
+		productOrigin = taggertypes.ProductOriginDogStatsDLegacy
 	}
 
-	switch originInfo.ProductOrigin {
+	switch productOrigin {
 	case taggertypes.ProductOriginDogStatsDLegacy:
 		// The following was moved from the dogstatsd package
 		// originFromUDS is the origin discovered via UDS origin detection (container ID).

--- a/comp/core/tagger/tagger.go
+++ b/comp/core/tagger/tagger.go
@@ -75,7 +75,7 @@ type tagger interface {
 type datadogConfig struct {
 	dogstatsdEntityIDPrecedenceEnabled bool
 	dogstatsdOptOutEnabled             bool
-	dogstatsdUnifiedEnabled            bool
+	originDetectionUnifiedEnabled      bool
 }
 
 // TaggerClient is a component that contains two tagger component: capturetagger and defaulttagger
@@ -166,7 +166,7 @@ func newTaggerClient(deps dependencies) Component {
 	}
 
 	taggerClient.datadogConfig.dogstatsdEntityIDPrecedenceEnabled = deps.Config.GetBool("dogstatsd_entity_id_precedence")
-	taggerClient.datadogConfig.dogstatsdUnifiedEnabled = deps.Config.GetBool("dogstatsd_origin_detection_unified")
+	taggerClient.datadogConfig.originDetectionUnifiedEnabled = deps.Config.GetBool("origin_detection_unified")
 	taggerClient.datadogConfig.dogstatsdOptOutEnabled = deps.Config.GetBool("dogstatsd_origin_optout_enabled")
 
 	deps.Log.Info("TaggerClient is created, defaultTagger type: ", reflect.TypeOf(taggerClient.defaultTagger))
@@ -369,7 +369,7 @@ func (t *TaggerClient) EnrichTags(tb tagset.TagsAccumulator, originInfo taggerty
 
 	// If dogstatsdUnifiedEnabled is disabled, we use DogStatsD's Legacy Origin Detection.
 	// TODO: remove this when dogstatsd_origin_detection_unified is enabled by default
-	if !t.datadogConfig.dogstatsdUnifiedEnabled {
+	if !t.datadogConfig.originDetectionUnifiedEnabled {
 		originInfo.ProductOrigin = taggertypes.ProductOriginDogStatsDLegacy
 	}
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -528,7 +528,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection_client", false)
 	// If enabled, all origin detection mechanisms will be unified to use the same logic.
-	config.BindEnvAndSetDefault("origin_detection_unified", true)
+	config.BindEnvAndSetDefault("origin_detection_unified", false)
 	config.BindEnvAndSetDefault("dogstatsd_origin_optout_enabled", true)
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -527,8 +527,8 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("dogstatsd_context_expiry_seconds", 20)
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection_client", false)
-	// If enabled, DogStatsD origin detection will use the same logic as other origin detection mechanisms.
-	config.BindEnvAndSetDefault("dogstatsd_origin_detection_unified", true)
+	// If enabled, all origin detection mechanisms will be unified to use the same logic.
+	config.BindEnvAndSetDefault("origin_detection_unified", true)
 	config.BindEnvAndSetDefault("dogstatsd_origin_optout_enabled", true)
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -215,6 +215,9 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("hostname_file", "")
 	config.BindEnvAndSetDefault("tags", []string{})
 	config.BindEnvAndSetDefault("extra_tags", []string{})
+	// If enabled, all origin detection mechanisms will be unified to use the same logic.
+	// Will override all other origin detection settings in favor of the unified one.
+	config.BindEnvAndSetDefault("origin_detection_unified", false)
 	config.BindEnv("env")
 	config.BindEnvAndSetDefault("tag_value_split_separator", map[string]string{})
 	config.BindEnvAndSetDefault("conf_path", ".")
@@ -527,8 +530,6 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("dogstatsd_context_expiry_seconds", 20)
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection_client", false)
-	// If enabled, all origin detection mechanisms will be unified to use the same logic.
-	config.BindEnvAndSetDefault("origin_detection_unified", false)
 	config.BindEnvAndSetDefault("dogstatsd_origin_optout_enabled", true)
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -527,6 +527,8 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("dogstatsd_context_expiry_seconds", 20)
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection_client", false)
+	// If enabled, DogStatsD origin detection will use the same logic as other origin detection mechanisms.
+	config.BindEnvAndSetDefault("dogstatsd_origin_detection_unified", true)
 	config.BindEnvAndSetDefault("dogstatsd_origin_optout_enabled", true)
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)

--- a/pkg/tagger/types/types.go
+++ b/pkg/tagger/types/types.go
@@ -10,6 +10,9 @@ package types
 type ProductOrigin int
 
 const (
+	// ProductOriginDogStatsDLegacy is the ProductOrigin for DogStatsD in Legacy mode.
+	// TODO: remove this when dogstatsd_origin_detection_unified is enabled by default
+	ProductOriginDogStatsDLegacy ProductOrigin = iota
 	// ProductOriginDogStatsD is the ProductOrigin for DogStatsD.
 	ProductOriginDogStatsD ProductOrigin = iota
 	// ProductOriginAPM is the ProductOrigin for APM.

--- a/releasenotes/notes/dogstatsd-origin-detected-unified-98897086225b0783.yaml
+++ b/releasenotes/notes/dogstatsd-origin-detected-unified-98897086225b0783.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    dogstatsd: Implement unified origin detection
+

--- a/releasenotes/notes/dogstatsd-origin-detected-unified-98897086225b0783.yaml
+++ b/releasenotes/notes/dogstatsd-origin-detected-unified-98897086225b0783.yaml
@@ -8,5 +8,6 @@
 ---
 enhancements:
   - |
-    dogstatsd: Implement unified origin detection
-
+    dogstatsd: Implement new config option `origin_detection_unified`.
+    This new option will allow users to configure the origin detection behavior for DogStatsD.
+    When enabled, the DogStatsD server will use the default Origin Detection logic.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Implements `origin_detection_unified` setting that will discard all specific Origin Detection mechanisms (E.G. DogStatsD) in favor of the default one.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This is done to start unifying Origin Detection across products.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Note that we activated the `dogstatsd_entity_id_precedence` setting. This setting will now be ignored and you should get container instead of just pod tags.

```
dogstatsd_entity_id_precedence: true
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Deploy the following charts on an ARM Kubernetes (Local Minikube or Kind) cluster.
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  override:
    nodeAgent:
      image:
        name: agent
        tag: latest
        pullPolicy: Always
      volumes:
      - hostPath:
          path: /var/run/datadog/
        name: dogstatsd-socket
      containers:
        agent:
          volumeMounts:
          - mountPath: /var/run/datadog
            name: dogstatsd-socket
          env:
          - name: "DD_ORIGIN_DETECTION_UNIFIED"
            value: "true"
          - name: "DD_DOGSTATSD_ENTITY_ID_PRECEDENCE"
            value: "true"
    clusterAgent:
      image:
        tag: latest
        pullPolicy: Always
    clusterChecksRunner:
      image:
        tag: latest
        pullPolicy: Always
  global:
    clusterName: "unified-od-qa"
    registry: "docker.io/wdhifdatadog"
    kubelet:
      tlsVerify: false
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
  features:
    admissionController:
      enabled: true
    dogstatsd:
      originDetectionEnabled: true
      tagCardinality: "high"
      hostPortConfig:
        enabled: true
```

Note that the `DD_DOGSTATSD_ENTITY_ID_PRECEDENCE` is set to verify that it is discarded.

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-dogstatsd-udp-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dummy-dogstatsd-udp-app
  template:
    metadata:
      labels:
        app: dummy-dogstatsd-udp-app
    spec:
      containers:
      - name: dummy-dogstatsd-udp-app
        image: wdhifdatadog/dummy_dogstatsd_udp
        imagePullPolicy: Always
        env:
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-dogstatsd-uds-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dummy-dogstatsd-uds-app
  template:
    metadata:
      labels:
        app: dummy-dogstatsd-uds-app
    spec:
      containers:
      - name: dummy-dogstatsd-uds-app
        image: wdhifdatadog/dummy_dogstatsd_uds
        imagePullPolicy: Always
        env:
        - name: DD_DOGSTATSD_URL
          value: /var/run/datadog/dsd.socket
        volumeMounts:
        - mountPath: /var/run/datadog
          name: dogstatsd-socket
      volumes:
      - name: dogstatsd-socket
        hostPath:
          path: /var/run/datadog/
```

Make sure that you are getting high cardinality tags (like `container_id`) for the following metrics:

* `dummy_dsd_uds_python.increment`
* `dummy_dsd_uds_python.decrement`
* `dummy_dsd_udp_python.increment`
* `dummy_dsd_udp_python.decrement`

You can use queries like this:
```
avg:dummy_dsd_uds_python.increment{kube_cluster_name:dogstatsdunifiedtest} by {container_id}.as_count()
```