### PR TITLE
Update deb 10 AMI with fix for buster backports

### DIFF
--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -40,7 +40,7 @@
         },
         "ec2": {
             "x86_64": {
-                "debian-10": "ami-041540a5c191757a0",
+                "debian-10": "ami-081ff51562a6d21f5",
                 "debian-11": "ami-0607e701db389efe7",
                 "debian-12": "ami-07edaec601cf2b6d3"
             },

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -40,7 +40,7 @@
         },
         "ec2": {
             "x86_64": {
-                "debian-10": "ami-081ff51562a6d21f5",
+                "debian-10": "ami-0b94008ae0e4512b8",
                 "debian-11": "ami-0607e701db389efe7",
                 "debian-12": "ami-07edaec601cf2b6d3"
             },

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -45,7 +45,7 @@
                 "debian-12": "ami-07edaec601cf2b6d3"
             },
             "arm64": {
-                "debian-10": "ami-0108ade0d057c8eba",
+                "debian-10": "ami-0458baca856015b8d",
                 "debian-11": "ami-00988b9ead6afb0b1",
                 "debian-12": "ami-02aab8d5301cb8d68"
             }

--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -2,12 +2,12 @@
     "debian": {
         "x86_64": {
             "debian-9": "ami-0182559468c1975fe",
-            "debian-10": "ami-041540a5c191757a0",
+            "debian-10": "ami-081ff51562a6d21f5",
             "debian-11": "ami-0607e701db389efe7",
             "debian-12": "ami-07edaec601cf2b6d3"
         },
         "arm64": {
-            "debian-10": "ami-081ff51562a6d21f5",
+            "debian-10": "ami-0108ade0d057c8eba",
             "debian-11": "ami-00988b9ead6afb0b1",
             "debian-12": "ami-02aab8d5301cb8d68"
         }

--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -2,7 +2,7 @@
     "debian": {
         "x86_64": {
             "debian-9": "ami-0182559468c1975fe",
-            "debian-10": "ami-081ff51562a6d21f5",
+            "debian-10": "ami-0b94008ae0e4512b8",
             "debian-11": "ami-0607e701db389efe7",
             "debian-12": "ami-07edaec601cf2b6d3"
         },

--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -7,7 +7,7 @@
             "debian-12": "ami-07edaec601cf2b6d3"
         },
         "arm64": {
-            "debian-10": "ami-0108ade0d057c8eba",
+            "debian-10": "ami-081ff51562a6d21f5",
             "debian-11": "ami-00988b9ead6afb0b1",
             "debian-12": "ami-02aab8d5301cb8d68"
         }

--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -7,7 +7,7 @@
             "debian-12": "ami-07edaec601cf2b6d3"
         },
         "arm64": {
-            "debian-10": "ami-0108ade0d057c8eba",
+            "debian-10": "ami-0458baca856015b8d",
             "debian-11": "ami-00988b9ead6afb0b1",
             "debian-12": "ami-02aab8d5301cb8d68"
         }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Update deb-10 AMI because debian moved buster backports to archive
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
