### PR TITLE
[CI Platforms] Add Build Impact Analysis extension to datadog-agent-nightly service

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -13,3 +13,6 @@ extensions:
       env:
         - name: "staging"
           ci_pipeline: "//fake_placeholder:fake_placeholder"
+  datadoghq.com/change-detection:
+    source_patterns:
+      - service.datadog.yaml


### PR DESCRIPTION
The extension `datadoghq.com/change-detection` is used by the service Build Impact Analysis to determine what files can impact a service. This information is used in our CI to optimise our ressources and gain time during the merge of a PR. 

### What does this PR do?

* Adds a necessary BIA extension to the declaration of the service `datadog-agent-nightly`
* Allows BIA to effectively analyse datadog-agent changes. If this configuration is not in place, this service will always be marked as impacted because it's defined at the root of the repository.

### Motivation

* Reduce queue time of new PRs of the datadog-agent repository.

### Additional Notes

* This PR is a follow-up of https://github.com/DataDog/datadog-agent/pull/24323

### Possible Drawbacks / Trade-offs

* N/A 

### Describe how to test/QA your changes

* After merging this PR, the queue time for new PRs should be reduced significantly.
