### PR TITLE
[CWS] allow `security-agent runtime policy check` on windows model

### DIFF
--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -42,6 +43,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	winmodel "github.com/DataDog/datadog-agent/pkg/security/seclwin/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
@@ -54,6 +56,7 @@ type checkPoliciesCliParams struct {
 
 	dir                      string
 	evaluateAllPolicySources bool
+	windowsModel             bool
 }
 
 func commonPolicyCommands(globalParams *command.GlobalParams) []*cobra.Command {
@@ -131,6 +134,9 @@ func commonCheckPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Co
 
 	commonCheckPoliciesCmd.Flags().StringVar(&cliParams.dir, "policies-dir", pkgconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
 	commonCheckPoliciesCmd.Flags().BoolVar(&cliParams.evaluateAllPolicySources, "loaded-policies", false, "Evaluate loaded policies")
+	if runtime.GOOS == "linux" {
+		commonCheckPoliciesCmd.Flags().BoolVar(&cliParams.windowsModel, "windows-model", false, "Evaluate policies using the Windows model")
+	}
 
 	return []*cobra.Command{commonCheckPoliciesCmd}
 }
@@ -365,6 +371,10 @@ func newAgentVersionFilter() (*rules.AgentVersionFilter, error) {
 
 func checkPolicies(_ log.Component, _ config.Component, args *checkPoliciesCliParams) error {
 	if args.evaluateAllPolicySources {
+		if args.windowsModel {
+			return errors.New("unable to evaluator loaded policies using the windows model")
+		}
+
 		client, err := secagent.NewRuntimeSecurityClient()
 		if err != nil {
 			return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -398,6 +408,10 @@ func checkPoliciesLoaded(client secagent.SecurityModuleClientWrapper, writer io.
 
 func newFakeEvent() eval.Event {
 	return model.NewFakeEvent()
+}
+
+func newFakeWindowsEvent() eval.Event {
+	return winmodel.NewFakeEvent()
 }
 
 func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
@@ -436,7 +450,12 @@ func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
 
 	loader := rules.NewPolicyLoader(provider)
 
-	ruleSet := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
+	var ruleSet *rules.RuleSet
+	if args.windowsModel {
+		ruleSet = rules.NewRuleSet(&winmodel.Model{}, newFakeWindowsEvent, ruleOpts, evalOpts)
+	} else {
+		ruleSet = rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
+	}
 	evaluationSet, err := rules.NewEvaluationSet([]*rules.RuleSet{ruleSet})
 	if err != nil {
 		return err
@@ -445,15 +464,17 @@ func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
 		return err
 	}
 
-	report, err := kfilters.NewApplyRuleSetReport(cfg, ruleSet)
-	if err != nil {
-		return err
-	}
+	if !args.windowsModel {
+		report, err := kfilters.NewApplyRuleSetReport(cfg, ruleSet)
+		if err != nil {
+			return err
+		}
 
-	content, _ := json.MarshalIndent(report, "", "\t")
-	_, err = fmt.Fprintf(writer, "%s\n", string(content))
-	if err != nil {
-		return fmt.Errorf("unable to write out report: %w", err)
+		content, _ := json.MarshalIndent(report, "", "\t")
+		_, err = fmt.Fprintf(writer, "%s\n", string(content))
+		if err != nil {
+			return fmt.Errorf("unable to write out report: %w", err)
+		}
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -643,6 +643,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.53.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/process/util/api v0.53.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/proto v0.53.0-rc.2
+	github.com/DataDog/datadog-agent/pkg/security/seclwin v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/serializer v0.53.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/status/health v0.53.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/tagger/types v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
### What does this PR do?

This PR allows the security agent running on linux to validate rules using the windows model. This will be useful for the `security-monitoring` CI.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
