### PR TITLE
[CWS] fix ctime/mtime name changes

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -109,8 +109,18 @@ void __attribute__((always_inline)) fill_file(struct dentry* dentry, struct file
     bpf_probe_read(&file->metadata.uid, sizeof(file->metadata.uid), &d_inode->i_uid);
     bpf_probe_read(&file->metadata.gid, sizeof(file->metadata.gid), &d_inode->i_gid);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
     bpf_probe_read(&file->metadata.ctime, sizeof(file->metadata.ctime), &d_inode->i_ctime);
+#else
+    bpf_probe_read(&file->metadata.ctime, sizeof(file->metadata.ctime), &d_inode->__i_ctime);
+#endif
+
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0)
     bpf_probe_read(&file->metadata.mtime, sizeof(file->metadata.mtime), &d_inode->i_mtime);
+#else
+    bpf_probe_read(&file->metadata.mtime, sizeof(file->metadata.mtime), &d_inode->__i_mtime);
+#endif
 }
 
 #define get_dentry_key_path(dentry, path) (struct path_key_t) { .ino = get_dentry_ino(dentry), .mount_id = get_path_mount_id(path) }


### PR DESCRIPTION
### What does this PR do?

This PR fixes runtime compilation of ctime/mtime fields on recent kernels.

Changes introduced by:
- ctime: https://github.com/torvalds/linux/commit/13bc24457850583a2e7203ded05b7209ab4bc5ef
- mtime: https://github.com/torvalds/linux/commit/12cd44023651666bd44baa36a5c999698890debb

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
