### PR TITLE
[CWS] allow providing a base branch to target for the btfhub sync PR

### DIFF
--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -2,6 +2,12 @@ name: "CWS BTFHub constants sync"
 
 on:
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch to target'
+        required: false
+        default: 'main'
+        type: string
   schedule:
     - cron: '30 4 * * 5' # at 4:30 UTC on Friday
 
@@ -16,6 +22,8 @@ jobs:
 
       - name: Checkout datadog-agent repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_branch || 'main' }}
 
       - name: Checkout btfhub-archive repository
         uses: actions/checkout@v4
@@ -69,7 +77,7 @@ jobs:
               owner,
               repo,
               head: '${{ steps.branch-name.outputs.BRANCH_NAME }}',
-              base: 'main',
+              base: '${{ inputs.base_branch || 'main' }}',
               body: [
                 '### What does this PR do?',
                 'This PR syncs the BTFHub constants used by CWS',

--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: 'main'
         type: string
+      force_refresh:
+        description: 'Force refresh of the constants'
+        required: false
+        default: 'false'
+        type: boolean
   schedule:
     - cron: '30 4 * * 5' # at 4:30 UTC on Friday
 
@@ -55,7 +60,7 @@ jobs:
 
       - name: Sync constants
         run: |
-          inv -e security-agent.generate-btfhub-constants --archive-path=./dev/dist/archive
+          inv -e security-agent.generate-btfhub-constants --archive-path=./dev/dist/archive ${{ inputs.force_refresh && '--force-refresh' || '' }}
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         id: commit-creator


### PR DESCRIPTION
### What does this PR do?

This PR allows to specify the target branch for the BTFHub PRs when running them manually, this will allow dev to update the constants in their PR (when adding new ones) easily.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
