### PR TITLE
print 'could not reach agent...' only in case of network error

### DIFF
--- a/pkg/api/util/ipc_endpoint.go
+++ b/pkg/api/util/ipc_endpoint.go
@@ -59,8 +59,11 @@ func (end *IPCEndpoint) DoGet(options ...GetOption) ([]byte, error) {
 		if errStr, found := errMap["error"]; found {
 			return nil, errors.New(errStr)
 		}
-
-		return nil, fmt.Errorf("could not reach agent: %v\nMake sure the agent is running before requesting the runtime configuration and contact support if you continue having issues", err)
+		netErr := new(net.OpError)
+		if errors.As(err, &netErr) {
+			return nil, fmt.Errorf("could not reach agent: %v\nMake sure the agent is running before requesting the runtime configuration and contact support if you continue having issues", err)
+		}
+		return nil, err
 	}
 	return res, err
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR modify the returned error from `IPCEndpoint.doGet()` function for a more relevant one. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Currently the `IPCEndpoint.doGet()` function used to make send request from the CLI to the daemon is returning the error
```
could not reach agent: [error]
Make sure the agent is running before requesting the runtime configuration and contact support if you continue having issues
```
even if the CLI was able to reach the Agent, but it returned an HTTP error for whatever reason.

I think this error should be returned only when the Agent is truly unreachable (Agent is not running, network error, ...).

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Build an agent and run it. Then run the agent `status` command, which would continue to work correctly.
Stop the Agent, and rerun the `status` command, it should print the `could not reach agent` error.