### PR TITLE
mark /comp/README.md as un-owned

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -237,6 +237,7 @@
 # The following is managed by `inv lint-components` -- DO NOT EDIT
 # BEGIN COMPONENTS
 /comp @DataDog/agent-shared-components
+/comp/README.md # do not notify anyone
 /comp/agent @DataDog/agent-shared-components
 /comp/aggregator @DataDog/agent-metrics-logs
 /comp/api @DataDog/agent-shared-components

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -222,6 +222,7 @@ def make_codeowners(codeowners_lines, bundles, components_without_bundle):
     # less-specific (bundles).  We include only components with a team different from their bundle, to
     # keep the file short.
     yield '/comp @DataDog/agent-shared-components'
+    yield '/comp/README.md # do not notify anyone'
     different_components = []
     for b in bundles:
         if b.team:


### PR DESCRIPTION
Currently all new comps implicitely need a review from ASC, even if created in existing domains owned by other teams. 
This comes from the requirement to edit `/comp/README.md` which is owned by ASC. 

This PR proposes to mark that specifc file as un-owned to avoid that bottleneck. If this is intended and desirable it's also fine to reject it.
