### PR TITLE
strip installer binary

### DIFF
--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -46,7 +46,7 @@ def build(
     go_build_tags = " ".join(build_tags)
     updater_bin = os.path.join(BIN_PATH, bin_name("installer"))
     cmd = f"go build -mod={go_mod} {race_opt} {build_type} -tags \"{go_build_tags}\" "
-    cmd += f"-o {updater_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/installer"
+    cmd += f"-o {updater_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags} -w -s\" {REPO_PATH}/cmd/installer"
 
     ctx.run(cmd, env=env)
 


### PR DESCRIPTION
reduce binary size by 20% by stripping dwarf debug symbols: from 44MiB to 34 on Macos
```
❯ du -h bin/installer
 44M	bin/installer
❯ git checkout -
Switched to branch 'raphael/strip_binary'
❯ invoke installer.build
❯ du -h bin/installer
 34M	bin/installer
```