### PR TITLE
[CWS] improve glob matching by pre-computing segments

### DIFF
--- a/pkg/security/secl/compiler/eval/glob_test.go
+++ b/pkg/security/secl/compiler/eval/glob_test.go
@@ -227,3 +227,17 @@ func TestGlobMatches(t *testing.T) {
 		t.Error("should contain the filename")
 	}
 }
+
+func BenchmarkGlob(b *testing.B) {
+	glob, err := NewGlob("*/*/http*/*b*/test/**", false, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if matches := glob.Matches("/var/log/httpd/abc/test/123"); !matches {
+			b.Fatalf("glob should match")
+		}
+	}
+}

--- a/pkg/security/secl/compiler/eval/pattern.go
+++ b/pkg/security/secl/compiler/eval/pattern.go
@@ -58,36 +58,64 @@ func hasPrefix(s, prefix string, caseInsensitive bool) bool {
 
 // PatternMatches matches a pattern against a string
 func PatternMatches(pattern string, str string, caseInsensitive bool) bool {
-	if pattern == "*" {
+	patternElem := newPatternElement(pattern)
+	return PatternMatchesWithSegments(patternElem, str, caseInsensitive)
+}
+
+// PatternMatchesWithSegments matches a pattern against a string
+func PatternMatchesWithSegments(patternElem patternElement, str string, caseInsensitive bool) bool {
+	if patternElem.pattern == "*" {
 		return true
 	}
 
-	if len(pattern) == 0 {
+	if len(patternElem.pattern) == 0 {
 		return len(str) == 0
 	}
 
-	for len(pattern) > 0 {
-		star, segment, nextIndex := nextSegment(pattern)
-		if star {
+	for _, seg := range patternElem.segments {
+		if seg.star {
 			// there is no pattern to match after the last star
-			if len(segment) == 0 {
+			if len(seg.segment) == 0 {
 				return true
 			}
 
-			index := index(str, segment, caseInsensitive)
+			index := index(str, seg.segment, caseInsensitive)
 			if index == -1 {
 				return false
 			}
-			str = str[index+len(segment):]
+			str = str[index+len(seg.segment):]
 		} else {
-			if !hasPrefix(str, segment, caseInsensitive) {
+			if !hasPrefix(str, seg.segment, caseInsensitive) {
 				return false
 			}
-			str = str[len(segment):]
+			str = str[len(seg.segment):]
 		}
-		pattern = pattern[nextIndex:]
 	}
 
 	// return false if there is still some str to match
 	return len(str) == 0
+}
+
+type patternElement struct {
+	pattern  string
+	segments []patternSegment
+}
+
+type patternSegment struct {
+	star    bool
+	segment string
+}
+
+func newPatternElement(element string) patternElement {
+	el := patternElement{
+		pattern: element,
+	}
+
+	for len(element) > 0 {
+		star, segment, nextIndex := nextSegment(element)
+		element = element[nextIndex:]
+		el.segments = append(el.segments, patternSegment{star, segment})
+	}
+
+	return el
 }

--- a/pkg/security/secl/compiler/eval/pattern.go
+++ b/pkg/security/secl/compiler/eval/pattern.go
@@ -19,7 +19,7 @@ func nextSegment(str string) (bool, string, int) {
 		star = true
 	}
 
-	for i, c := range str {
+	for i, c := range []byte(str) {
 		if c != '*' {
 			if !inSegment {
 				start = i

--- a/pkg/security/secl/compiler/eval/pattern_test.go
+++ b/pkg/security/secl/compiler/eval/pattern_test.go
@@ -107,3 +107,12 @@ func TestPatternMatches(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkNextSegment(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		star, segment, _ := nextSegment("*test*123*")
+		if !star || segment != "test" {
+			b.Fatalf("expected segment not found: %v, %v", star, segment)
+		}
+	}
+}

--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -202,7 +202,7 @@ func (g *GlobStringMatcher) Contains(value string) bool {
 
 // PatternStringMatcher defines a pattern matcher
 type PatternStringMatcher struct {
-	pattern         string
+	pattern         patternElement
 	caseInsensitive bool
 }
 
@@ -213,14 +213,14 @@ func (p *PatternStringMatcher) Compile(pattern string, caseInsensitive bool) err
 		return fmt.Errorf("`**` is not allowed in patterns")
 	}
 
-	p.pattern = pattern
+	p.pattern = newPatternElement(pattern)
 	p.caseInsensitive = caseInsensitive
 	return nil
 }
 
 // Matches returns whether the value matches
 func (p *PatternStringMatcher) Matches(value string) bool {
-	return PatternMatches(p.pattern, value, p.caseInsensitive)
+	return PatternMatchesWithSegments(p.pattern, value, p.caseInsensitive)
 }
 
 // ScalarStringMatcher defines a scalar matcher


### PR DESCRIPTION
### What does this PR do?

This PR improves the performance of the glob matching, by keeping track of the segments instead of re-computing for each match operation.
The segment computation is also sped up by skipping the utf-8 decoding

benchmark:
```
# before
BenchmarkGlob-10    	15692864	        74.17 ns/op	       0 B/op	       0 allocs/op
# after
BenchmarkGlob-10    	22775433	        52.72 ns/op	       0 B/op	       0 allocs/op

# before
BenchmarkNextSegment-10    	124941762	         9.490 ns/op	       0 B/op	       0 allocs/op
# after
BenchmarkNextSegment-10    	178843194	         6.648 ns/op	       0 B/op	       0 allocs/op
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
