### PR TITLE
Fix flaky oracle query metrics test (DBMON-3921)

### DIFF
--- a/pkg/collector/corechecks/oracle/custom_queries_test.go
+++ b/pkg/collector/corechecks/oracle/custom_queries_test.go
@@ -86,8 +86,10 @@ func TestFloat(t *testing.T) {
       - name: value
         type: gauge
 `, "")
+	defer c.Teardown()
 	err := c.Run()
 	require.NoError(t, err)
+	assertConnectionCount(t, &c, expectedSessionsWithCustomQueries)
 	s.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	s.AssertMetricTaggedWith(t, "Gauge", "oracle.custom_query.test.value", []string{"name:TAG1"})
 	s.AssertMetric(t, "Gauge", "oracle.custom_query.test.value", 1.012345, c.dbHostname, []string{})
@@ -96,5 +98,6 @@ func TestFloat(t *testing.T) {
 func TestGlobalCustomQueries(t *testing.T) {
 	globalCustomQueries := fmt.Sprintf("global_custom_queries:\n%s", customQueryTestConfig)
 	c, s := newDefaultCheck(t, "", globalCustomQueries)
+	defer c.Teardown()
 	assertCustomQuery(t, &c, s)
 }

--- a/pkg/collector/corechecks/oracle/init_test.go
+++ b/pkg/collector/corechecks/oracle/init_test.go
@@ -18,6 +18,7 @@ func TestTags(t *testing.T) {
 	c, _ := newDefaultCheck(t, `tags:
   - foo1:bar1
   - foo2:bar2`, "")
+	defer c.Teardown()
 	err := c.Run()
 	require.NoError(t, err)
 	assert.True(t, c.initialized, "Check not initialized")

--- a/pkg/collector/corechecks/oracle/oracle_dictionary_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_dictionary_test.go
@@ -17,12 +17,13 @@ import (
 
 func TestGetFullSqlText(t *testing.T) {
 	c, _ := newDefaultCheck(t, "", "")
-	c.db = nil
+	defer c.Teardown()
 
 	c.dbmEnabled = false
 
 	err := c.Run()
 	assert.NoError(t, err, "check run")
+	assertConnectionCount(t, &c, expectedSessionsDefault)
 
 	var SQLStatement string
 	err = getFullSQLText(&c, &SQLStatement, "sql_id", "A")

--- a/pkg/collector/corechecks/oracle/sysmetrics_test.go
+++ b/pkg/collector/corechecks/oracle/sysmetrics_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestSysmetrics(t *testing.T) {
 	c, _ := newDefaultCheck(t, "dbm: true", "")
+	defer c.Teardown()
 	c.Run()
 	assert.True(t, c.dbmEnabled, "dbm should be enabled")
 	n, err := c.sysMetrics()

--- a/pkg/collector/corechecks/oracle/tablespaces_test.go
+++ b/pkg/collector/corechecks/oracle/tablespaces_test.go
@@ -24,6 +24,7 @@ import (
 
 func TestTablespaces(t *testing.T) {
 	c, s := newDefaultCheck(t, "", "")
+	defer c.Teardown()
 	err := c.Run()
 	require.NoError(t, err)
 	s.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()

--- a/pkg/collector/corechecks/oracle/test-utils/run-tests.sh
+++ b/pkg/collector/corechecks/oracle/test-utils/run-tests.sh
@@ -36,5 +36,7 @@ do
   echo "Starting tests for $f"
   . $f
   go clean -testcache
-  gotestsum --jsonfile module_test_output.json --format pkgname --packages=./pkg/collector/corechecks/oracle/... -- -mod=mod -vet=off --tags=oracle_test,oracle,test
+
+  # Tests are running sequentially for the predictability of the memory leak test
+  gotestsum --jsonfile module_test_output.json --format pkgname --packages=./pkg/collector/corechecks/oracle/... -- -mod=mod -vet=off --tags=oracle_test,oracle,test 
 done


### PR DESCRIPTION
### What does this PR do?

Fixing flaky Oracle tests.

### Additional Notes

- Fixed a bug in memory leak test
- New tests for detecting leaked connections
- Fixed the failed query metrics test when an external agent is running against the test database
