### PR TITLE
[CWS] prevent reading of already deleted profiles

### DIFF
--- a/pkg/security/security_profile/profile/profile_dir.go
+++ b/pkg/security/security_profile/profile/profile_dir.go
@@ -393,6 +393,9 @@ func (dp *DirectoryProvider) watch(ctx context.Context) {
 
 							// delete profile
 							dp.deleteProfile(selector)
+							dp.newFilesLock.Lock()
+							delete(dp.newFiles, profile.path)
+							dp.newFilesLock.Unlock()
 
 							seclog.Debugf("security profile %s removed from profile mapping", selector)
 						}

--- a/pkg/security/security_profile/profile/profile_dir.go
+++ b/pkg/security/security_profile/profile/profile_dir.go
@@ -364,14 +364,14 @@ func (dp *DirectoryProvider) watch(ctx context.Context) {
 					return
 				}
 
-				if event.Op&(fsnotify.Create|fsnotify.Remove) > 0 {
+				if event.Has(fsnotify.Create | fsnotify.Remove) {
 					files, err := dp.listProfiles()
 					if err != nil {
 						seclog.Errorf("couldn't list profiles: %v", err)
 						continue
 					}
 
-					if event.Op&fsnotify.Create > 0 {
+					if event.Has(fsnotify.Create) {
 						// look for the new profile
 						for _, file := range files {
 							if _, ok = dp.findProfile(file); ok {
@@ -384,7 +384,7 @@ func (dp *DirectoryProvider) watch(ctx context.Context) {
 							dp.newFilesLock.Unlock()
 							dp.newFilesDebouncer.Call()
 						}
-					} else if event.Op&fsnotify.Remove > 0 {
+					} else if event.Has(fsnotify.Remove) {
 						// look for the deleted profile
 						for selector, profile := range dp.getProfiles() {
 							if slices.Contains(files, profile.path) {
@@ -401,7 +401,7 @@ func (dp *DirectoryProvider) watch(ctx context.Context) {
 						}
 					}
 
-				} else if event.Op&fsnotify.Write > 0 && filepath.Ext(event.Name) == profileExtension {
+				} else if event.Has(fsnotify.Write) && filepath.Ext(event.Name) == profileExtension {
 					// add file in the list of new files
 					dp.newFilesLock.Lock()
 					dp.newFiles[event.Name] = true


### PR DESCRIPTION
### What does this PR do?

In some cases we get a create and then a remove notification. This means that the file ends up in `newFile` and we will try to open it even though it has been removed. This PR removes from `newFiles` when we get a removed notification

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
