### PR TITLE
[CWS/CSPM][CWS-1892] send `datadog.security_agent.{runtime,compliance}.running` with none cardinality

### DIFF
--- a/cmd/security-agent/subcommands/compliance/compliance.go
+++ b/cmd/security-agent/subcommands/compliance/compliance.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/constants"
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/telemetry"
@@ -94,7 +95,10 @@ func StartCompliance(log log.Component, config config.Component, sysprobeconfig 
 // sendRunningMetrics exports a metric to distinguish between security-agent modules that are activated
 func sendRunningMetrics(statsdClient ddgostatsd.ClientInterface, moduleName string) *time.Ticker {
 	// Retrieve the agent version using a dedicated package
-	tags := []string{fmt.Sprintf("version:%s", version.AgentVersion)}
+	tags := []string{
+		fmt.Sprintf("version:%s", version.AgentVersion),
+		constants.CardinalityTagPrefix + "none",
+	}
 
 	// Send the metric regularly
 	heartbeat := time.NewTicker(15 * time.Second)

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/atomic"
 
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/constants"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
@@ -189,6 +190,7 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}, wg *
 				tags := []string{
 					fmt.Sprintf("version:%s", version.AgentVersion),
 					fmt.Sprintf("os:%s", runtime.GOOS),
+					constants.CardinalityTagPrefix + "none",
 				}
 
 				if os.Getenv("ECS_FARGATE") == "true" || os.Getenv("DD_ECS_FARGATE") == "true" {


### PR DESCRIPTION
### What does this PR do?

The `datadog.security_agent.{runtime,compliance}.running` metric is currently sent with full cardinality. This means that it ends up collecting all the tags from all sources, like auto discovery (especially `team:container-integrations`).

This PR switches those 2 metrics to be `none` cardinality. We still have the host tags, the `kube_cluster_name`, `datacenter` etc that we care about.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
