### PR TITLE
fix(ci): remove condition that could prevent deploy of windows package

### DIFF
--- a/.gitlab/kitchen_deploy/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy/kitchen_deploy.yml
@@ -360,7 +360,6 @@ deploy_windows_testing-a7:
   rules:
     - !reference [.except_no_tests_no_deploy]
     - !reference [.except_mergequeue]
-    - !reference [.on_windows_installer_changes_or_manual]
     - when: on_success
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -5,7 +5,7 @@ import sys
 from datetime import datetime
 
 import requests
-from release import _get_release_json_value
+from tasks.release import _get_release_json_value
 
 
 def _get_build_images(ctx):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
`deploy_windows_testing-a7` has a `when: manual` default condition, which means in most of case it doesn't run automatically. I remove this condition to make it run in all cases.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This job is now required by e2e tests since [this recent change](https://github.com/DataDog/datadog-agent/pull/23871). Having the step manual made the tests to be skipped in most of the cases.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
