### PR TITLE
Fixed legacy mode service check (DBMON-3933)

### DIFF
--- a/pkg/collector/corechecks/oracle/oracle_integration_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_integration_test.go
@@ -321,8 +321,9 @@ func TestLegacyMode(t *testing.T) {
 		err := c.Run()
 		assert.NoError(t, err)
 		expectedServerTag := fmt.Sprintf("server:%s", c.config.InstanceConfig.Server)
-		s.AssertServiceCheck(t, canConnectServiceCheckName, servicecheck.ServiceCheckOK, "", []string{expectedServerTag}, "")
-		s.AssertServiceCheck(t, serviceCheckName, servicecheck.ServiceCheckOK, "", []string{expectedServerTag}, "")
+		host := c.dbHostname
+		s.AssertServiceCheck(t, canConnectServiceCheckName, servicecheck.ServiceCheckOK, host, []string{expectedServerTag}, "")
+		s.AssertServiceCheck(t, serviceCheckName, servicecheck.ServiceCheckOK, host, []string{expectedServerTag}, "")
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix legacy mode service check.

### Additional Notes

Added the host name in the assertion.
