### PR TITLE
force `IdentitiesOnly=yes` when using key files in KMT

### DIFF
--- a/tasks/kernel_matrix_testing/infra.py
+++ b/tasks/kernel_matrix_testing/infra.py
@@ -64,7 +64,7 @@ class LocalCommandRunner:
 class RemoteCommandRunner:
     @staticmethod
     def run_cmd(ctx: Context, instance: HostInstance, cmd: str, allow_fail: bool, verbose: bool):
-        ssh_key_arg = f"-i {instance.ssh_key_path}" if instance.ssh_key_path is not None else ""
+        ssh_key_arg = f"-o IdentitiesOnly=yes -i {instance.ssh_key_path}" if instance.ssh_key_path is not None else ""
         res = ctx.run(
             cmd.format(
                 proxy_cmd=f"-o ProxyCommand='ssh {ssh_options_command()} {ssh_key_arg} -W %h:%p ubuntu@{instance.ip}'"
@@ -91,7 +91,7 @@ class RemoteCommandRunner:
             full_target = os.path.join(get_kmt_os().shared_dir, subdir)
             RemoteCommandRunner.run_cmd(ctx, instance, f"mkdir -p {full_target}", False, False)
 
-        ssh_key_arg = f"-i {instance.ssh_key_path}" if instance.ssh_key_path is not None else ""
+        ssh_key_arg = f"-o IdentitiesOnly=yes -i {instance.ssh_key_path}" if instance.ssh_key_path is not None else ""
         ctx.run(
             f"rsync -e \"ssh {ssh_options_command()} {ssh_key_arg}\" -p -rt --exclude='.git*' --filter=':- .gitignore' {source} ubuntu@{instance.ip}:{full_target}"
         )
@@ -134,7 +134,7 @@ class LibvirtDomain:
         else:
             extra_opts = None
 
-        run = f"ssh {ssh_options_command(extra_opts)} -i {self.ssh_key} root@{self.ip} {{proxy_cmd}} '{cmd}'"
+        run = f"ssh {ssh_options_command(extra_opts)} -o IdentitiesOnly=yes -i {self.ssh_key} root@{self.ip} {{proxy_cmd}} '{cmd}'"
         return self.instance.runner.run_cmd(ctx, self.instance, run, allow_fail, verbose)
 
     def copy(self, ctx: Context, source: PathOrStr, target: PathOrStr):

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -562,6 +562,7 @@ def prepare(
         info("[+] Dependencies already present in VMs")
         packages_with_ebpf = packages.split(",")
         packages_with_ebpf.append("./pkg/ebpf/bytecode")
+        packages_with_ebpf.append("./pkg/ebpf/bytecode/runtime")
         constrain_pkgs = f"--packages={','.join(set(packages_with_ebpf))}"
     else:
         warn("[!] Dependencies need to be rebuilt")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

- force `IdentitiesOnly=yes` when using key files
- add runtime directory to default packages

### Motivation

Better interaction with ssh agents

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-478

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
