### PR TITLE
allow KMT jobs to have full names in messages

### DIFF
--- a/tasks/libs/pipeline/data.py
+++ b/tasks/libs/pipeline/data.py
@@ -129,7 +129,15 @@ def get_job_failure_context(job_log):
     return FailedJobType.JOB_FAILURE, FailedJobReason.FAILED_JOB_SCRIPT
 
 
+# These jobs are allowed to have their full name in the data.
+# They are often matrix/parallel jobs where the dimension values are important.
+jobs_allowed_to_have_full_names = [re.compile(r'kmt_run_.+_tests_.*')]
+
+
 def truncate_job_name(job_name, max_char_per_job=48):
+    if any(pattern.fullmatch(job_name) for pattern in jobs_allowed_to_have_full_names):
+        return job_name
+
     # Job header should be before the colon, if there is no colon this won't change job_name
     truncated_job_name = job_name.split(":")[0]
     # We also want to avoid it being too long


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Does not truncate job names that are present in the allow list.

### Motivation

Parallel/matrix jobs have additional dimensions and the job name contains the values of those dimensions. It is helpful for some jobs to have that within the Slack notification, rather than forcing a click through each time.

### Additional Notes

https://datadoghq.atlassian.net/browse/ACIX-249

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
