### PR TITLE
[usm] Refactor sock maps

### DIFF
--- a/pkg/network/ebpf/c/netns.h
+++ b/pkg/network/ebpf/c/netns.h
@@ -14,7 +14,7 @@
 #endif
 
 #ifdef COMPILE_PREBUILT
-
+#include <net/sock.h>
 static __always_inline __u32 get_netns_from_sock(struct sock* sk) {
     void* skc_net = NULL;
     __u32 net_ns_inum = 0;

--- a/pkg/network/ebpf/c/protocols/sockfd.h
+++ b/pkg/network/ebpf/c/protocols/sockfd.h
@@ -13,8 +13,8 @@
 // * Value the socket FD;
 BPF_HASH_MAP(sockfd_lookup_args, __u64, __u32, 1024)
 
-BPF_HASH_MAP(sock_by_pid_fd, pid_fd_t, struct sock *, 1024)
+BPF_HASH_MAP(tuple_by_pid_fd, pid_fd_t, conn_tuple_t, 1024)
 
-BPF_HASH_MAP(pid_fd_by_sock, struct sock *, pid_fd_t, 1024)
+BPF_HASH_MAP(pid_fd_by_tuple, conn_tuple_t, pid_fd_t, 1024)
 
 #endif

--- a/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
+++ b/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
@@ -50,17 +50,12 @@ static __always_inline conn_tuple_t* conn_tup_from_tls_conn(tls_offsets_data_t* 
         .fd = fd,
     };
 
-    struct sock **sock = bpf_map_lookup_elem(&sock_by_pid_fd, &pid_fd);
-    if (sock == NULL)  {
+    conn_tuple_t *conn_tuple = bpf_map_lookup_elem(&tuple_by_pid_fd, &pid_fd);
+    if (conn_tuple == NULL)  {
         return NULL;
     }
 
-    conn_tuple_t conn_tuple = {0};
-    if (!read_conn_tuple(&conn_tuple, *sock, pid_tgid, CONN_TYPE_TCP)) {
-        return NULL;
-    }
-
-    bpf_map_update_elem(&conn_tup_by_go_tls_conn, &conn, &conn_tuple, BPF_ANY);
+    bpf_map_update_elem(&conn_tup_by_go_tls_conn, &conn, conn_tuple, BPF_ANY);
     return bpf_map_lookup_elem(&conn_tup_by_go_tls_conn, &conn);
 }
 

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -178,17 +178,12 @@ static __always_inline conn_tuple_t* tup_from_ssl_ctx(void *ssl_ctx, u64 pid_tgi
         .fd = ssl_sock->fd,
     };
 
-    struct sock **sock = bpf_map_lookup_elem(&sock_by_pid_fd, &pid_fd);
-    if (sock == NULL)  {
+    conn_tuple_t *t = bpf_map_lookup_elem(&tuple_by_pid_fd, &pid_fd);
+    if (t == NULL)  {
         return NULL;
     }
 
-    conn_tuple_t t;
-    if (!read_conn_tuple(&t, *sock, pid_tgid, CONN_TYPE_TCP)) {
-        return NULL;
-    }
-
-    bpf_memcpy(&ssl_sock->tup, &t, sizeof(conn_tuple_t));
+    bpf_memcpy(&ssl_sock->tup, t, sizeof(conn_tuple_t));
     return &ssl_sock->tup;
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Replaces `sock_by_pid_fd` and `pid_fd_by_sock` maps by `tuple_by_pid_fd`  and `pid_fd_by_tuple` respectively.
The new eBPF maps use `conn_tuple_t` types instead of `struct sock` pointers.

### Motivation

The datatypes are being migrated so that we can pre-populate these maps from userspace during system-probe startup.
From userspace we obviosuly can't know kernel memory addresses (`struct sock *`), but we're able to extract `conn_tuple_t` data by scraping proc FS data (a PoC for that is available in https://github.com/DataDog/datadog-agent/pull/24642)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
