### PR TITLE
fix(installer): Don't use extra fields in docker daemon.json

### DIFF
--- a/pkg/installer/service/apm_inject.go
+++ b/pkg/installer/service/apm_inject.go
@@ -14,8 +14,10 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -137,7 +139,7 @@ func (a *apmInjectorInstaller) setLDPreloadConfig(ctx context.Context) error {
 	if stat != nil {
 		perms = stat.Mode()
 	}
-	err = os.WriteFile("/tmp/ld.so.preload.tmp", newLdSoPreload, perms)
+	err = os.WriteFile(filepath.Join(setup.InstallPath, "run", "ld.so.preload.tmp"), newLdSoPreload, perms)
 	if err != nil {
 		return err
 	}
@@ -190,7 +192,7 @@ func (a *apmInjectorInstaller) deleteLDPreloadConfig(ctx context.Context) error 
 	if stat != nil {
 		perms = stat.Mode()
 	}
-	err = os.WriteFile("/tmp/ld.so.preload.tmp", newLdSoPreload, perms)
+	err = os.WriteFile(filepath.Join(setup.InstallPath, "run", "ld.so.preload.tmp"), newLdSoPreload, perms)
 	if err != nil {
 		return err
 	}

--- a/pkg/installer/service/docker.go
+++ b/pkg/installer/service/docker.go
@@ -16,13 +16,14 @@ import (
 	"os/exec"
 	"path"
 
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type dockerDaemonConfig map[string]interface{}
 
-const (
-	tmpDockerDaemonPath = "/tmp/daemon.json.tmp"
+var (
+	tmpDockerDaemonPath = path.Join(setup.InstallPath, "run", "daemon.json.tmp")
 	dockerDaemonPath    = "/etc/docker/daemon.json"
 )
 

--- a/pkg/installer/service/docker.go
+++ b/pkg/installer/service/docker.go
@@ -83,9 +83,6 @@ func (a *apmInjectorInstaller) setDockerConfigContent(previousContent []byte) ([
 		}
 	}
 
-	if _, ok := dockerConfig["default-runtime"]; ok {
-		dockerConfig["default-runtime-backup"] = dockerConfig["default-runtime"]
-	}
 	dockerConfig["default-runtime"] = "dd-shim"
 	runtimes, ok := dockerConfig["runtimes"].(map[string]interface{})
 	if !ok {
@@ -153,10 +150,7 @@ func (a *apmInjectorInstaller) deleteDockerConfigContent(previousContent []byte)
 		}
 	}
 
-	if _, ok := dockerConfig["default-runtime-backup"]; ok {
-		dockerConfig["default-runtime"] = dockerConfig["default-runtime-backup"]
-		delete(dockerConfig, "default-runtime-backup")
-	} else {
+	if defaultRuntime, ok := dockerConfig["default-runtime"].(string); ok && defaultRuntime == "dd-shim" || !ok {
 		dockerConfig["default-runtime"] = "runc"
 	}
 	runtimes, ok := dockerConfig["runtimes"].(map[string]interface{})

--- a/pkg/installer/service/docker_test.go
+++ b/pkg/installer/service/docker_test.go
@@ -53,7 +53,6 @@ func TestSetDockerConfig(t *testing.T) {
     }
 }`: `{
     "default-runtime": "dd-shim",
-    "default-runtime-backup": "containerd",
     "runtimes": {
         "containerd": {
             "path": "/usr/bin/containerd"
@@ -111,8 +110,7 @@ func TestRemoveDockerConfig(t *testing.T) {
 }`,
 		// File had already overridden the default runtime
 		`{
-    "default-runtime": "dd-shim",
-	"default-runtime-backup": "containerd",
+    "default-runtime": "containerd",
     "runtimes": {
         "containerd": {
             "path": "/usr/bin/containerd"

--- a/pkg/installer/service/helper/main.go
+++ b/pkg/installer/service/helper/main.go
@@ -134,11 +134,11 @@ func buildCommand(inputCommand privilegeCommand) (*exec.Cmd, error) {
 	case "create-docker-dir":
 		return exec.Command("mkdir", "-p", "/etc/docker"), nil
 	case "replace-docker":
-		return exec.Command("mv", "/tmp/daemon.json.tmp", "/etc/docker/daemon.json"), nil
+		return exec.Command("mv", filepath.Join(installPath, "run", "daemon.json.tmp"), "/etc/docker/daemon.json"), nil
 	case "restart-docker":
 		return exec.Command("systemctl", "restart", "docker"), nil
 	case "replace-ld-preload":
-		return exec.Command("mv", "/tmp/ld.so.preload.tmp", "/etc/ld.so.preload"), nil
+		return exec.Command("mv", filepath.Join(installPath, "run", "ld.so.preload.tmp"), "/etc/ld.so.preload"), nil
 	case "add-installer-to-agent-group":
 		return exec.Command("usermod", "-aG", "dd-agent", "dd-installer"), nil
 	default:


### PR DESCRIPTION
### What does this PR do?
Stops using extra fields in docker daemon.json when installing the injector
Also stops using /tmp in favor of /opt/datadog-installer/run

### Motivation
Some distros don't support extra fields that are not in the schema

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
If tests are green we're good
