### PR TITLE
[NDM] Parse Cisco SD-WAN interface speed as float

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/cedge_interface.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/cedge_interface.go
@@ -57,8 +57,8 @@ func (itf *CEdgeInterface) Index() (int, error) {
 }
 
 // GetSpeedMbps returns the interface speed
-func (itf *CEdgeInterface) GetSpeedMbps() int {
-	speed, err := strconv.Atoi(itf.SpeedMbps)
+func (itf *CEdgeInterface) GetSpeedMbps() float64 {
+	speed, err := strconv.ParseFloat(itf.SpeedMbps, 64)
 	if err != nil {
 		log.Warnf("Unable to parse cEdge interface %s speed %s", itf.Ifname, itf.SpeedMbps)
 	}

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/cedge_interface_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/cedge_interface_test.go
@@ -22,7 +22,7 @@ func TestCEdgeInterface(t *testing.T) {
 		expectedID               string
 		expectedIndex            int
 		expectedIndexError       string
-		expectedSpeed            int
+		expectedSpeed            float64
 		expectedOperStatus       devicemetadata.IfOperStatus
 		expectedAdminStatus      devicemetadata.IfAdminStatus
 		expectedMetadata         devicemetadata.InterfaceMetadata
@@ -145,7 +145,7 @@ func TestCEdgeInterface(t *testing.T) {
 				VmanageSystemIP: "10.0.0.1",
 				Ifname:          "test-interface",
 				Ifindex:         "10",
-				SpeedMbps:       "1000",
+				SpeedMbps:       "0.1",
 				IfOperStatus:    "if-oper-state-ready",
 				IfAdminStatus:   "if-state-down",
 				Description:     "Description",
@@ -155,7 +155,7 @@ func TestCEdgeInterface(t *testing.T) {
 			},
 			expectedID:          "10.0.0.1:test-interface",
 			expectedIndex:       10,
-			expectedSpeed:       1000,
+			expectedSpeed:       0.1,
 			expectedOperStatus:  devicemetadata.OperStatusUp,
 			expectedAdminStatus: devicemetadata.AdminStatusDown,
 			expectedMetadata: devicemetadata.InterfaceMetadata{

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/interfaces.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/interfaces.go
@@ -18,7 +18,7 @@ type CiscoInterface interface {
 	// Index returns the interface index
 	Index() (int, error)
 	// GetSpeedMbps returns the interface speed in megabits per second
-	GetSpeedMbps() int
+	GetSpeedMbps() float64
 	// OperStatus returns the interface oper status
 	OperStatus() devicemetadata.IfOperStatus
 	// AdminStatus returns the interface admin status

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/vedge_interface.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/vedge_interface.go
@@ -42,8 +42,8 @@ func (itf *VEdgeInterface) Index() (int, error) {
 }
 
 // GetSpeedMbps returns the interface speed
-func (itf *VEdgeInterface) GetSpeedMbps() int {
-	speed, err := strconv.Atoi(itf.SpeedMbps)
+func (itf *VEdgeInterface) GetSpeedMbps() float64 {
+	speed, err := strconv.ParseFloat(itf.SpeedMbps, 64)
 	if err != nil {
 		log.Warnf("Unable to parse vEdge interface %s speed %s", itf.Ifname, itf.SpeedMbps)
 	}

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/vedge_interface_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/vedge_interface_test.go
@@ -21,7 +21,7 @@ func TestVEdgeInterface(t *testing.T) {
 		itf                 client.InterfaceState
 		expectedID          string
 		expectedIndex       int
-		expectedSpeed       int
+		expectedSpeed       float64
 		expectedOperStatus  devicemetadata.IfOperStatus
 		expectedAdminStatus devicemetadata.IfAdminStatus
 		expectedMetadata    devicemetadata.InterfaceMetadata
@@ -139,7 +139,7 @@ func TestVEdgeInterface(t *testing.T) {
 				VmanageSystemIP: "10.0.0.1",
 				Ifname:          "test-interface",
 				Ifindex:         10,
-				SpeedMbps:       "1000",
+				SpeedMbps:       "0.1",
 				IfOperStatus:    "Up",
 				IfAdminStatus:   "Down",
 				Desc:            "Description",
@@ -148,7 +148,7 @@ func TestVEdgeInterface(t *testing.T) {
 			},
 			expectedID:          "10.0.0.1:test-interface",
 			expectedIndex:       10,
-			expectedSpeed:       1000,
+			expectedSpeed:       0.1,
 			expectedOperStatus:  devicemetadata.OperStatusUp,
 			expectedAdminStatus: devicemetadata.AdminStatusDown,
 			expectedMetadata: devicemetadata.InterfaceMetadata{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Fix parsing of interface speed, as speed can be a float

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
