### PR TITLE
[CWS] Add missing span unregister memory on execs

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -726,6 +726,9 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
     // send the entry to maintain userspace cache
     send_event_ptr(ctx, EVENT_EXEC, event);
 
+    // as previously registered memory will become unreachable, we'll have to unregister the TLS
+    unregister_span_memory();
+
     return 0;
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a missing span unregister on execs to avoid running into trying to fetch spans on old unreachable memory after an exec

### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

