### PR TITLE
USM: reduce number of instructions for http2_filter program 

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -414,7 +414,7 @@ static __always_inline bool get_first_frame(struct __sk_buff *skb, skb_info_t *s
 // - HEADERS frames
 // - RST_STREAM frames
 // - DATA frames with the END_STREAM flag set
-static __always_inline bool find_relevant_frames(struct __sk_buff *skb, skb_info_t *skb_info, http2_tail_call_state_t *iteration_value, http2_telemetry_t *http2_tel) {
+static __always_inline bool find_relevant_frames(struct __sk_buff *skb, skb_info_t *restrict skb_info, http2_tail_call_state_t *iteration_value, http2_telemetry_t *http2_tel) {
     bool is_headers_or_rst_frame, is_data_end_of_stream;
     http2_frame_t current_frame = {};
 


### PR DESCRIPTION
### What does this PR do?

Using a `restrict` ([ref](https://en.wikipedia.org/wiki/Restrict)) keyword to allow clang optimization on the pointer argument.
Specifically this hint allows the compiler to perform some code eliminations when emitting load operations.

See "Additional Notes" section for further details

### Motivation

reduce instruction count of the heavy ebpf programs

### Additional Notes

to check the compiler optimization report, one can use the following flags for the clang compiler:
```
    -Rpass=.*
    -Rpass-analysis=.*
    -Rpass-missed=.*
```

**Note: running that on all our ebpf programs will result in an enormous output!**

specifically the one that is interesting in this case is -Rpass-missed=gvn (more [info](https://blog.llvm.org/2009/12/introduction-to-load-elimination-in-gvn.html))

### Possible Drawbacks / Trade-offs

Need to run sanity tests to make sure the code still works as expected

### Describe how to test/QA your changes

Using the ebpf.print-verification-stats command on main and on this branch:

`inv -e ebpf.print-verification-stats --filter-file usm.o --grep http2_filter --out stats_http2_restrict.json --jsonfmt`

Before:

```
    "usm/socket__http2_filter": {
        "stack_usage": 152,
        "instruction_processed": 73581,
        "limit": 1000000,
        "verification_time": 18642,
        "max_states_per_insn": 16,
        "total_states": 5380,
        "peak_states": 4104
    },
```

After:

```
    "usm/socket__http2_filter": {
        "stack_usage": 168,
        "instruction_processed": 71247,
        "limit": 1000000,
        "verification_time": 19853,
        "max_states_per_insn": 17,
        "total_states": 4949,
        "peak_states": 4182
    }
```

