### PR TITLE
CODEOWNERS: SDS build files are owned by agent-processing-and-routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -231,6 +231,7 @@
 /omnibus/config/software/datadog-agent-integrations-*.rb  @DataDog/agent-integrations
 /omnibus/config/software/datadog-security-agent*.rb       @Datadog/agent-security @DataDog/agent-build-and-releases
 /omnibus/config/software/openscap.rb                      @DataDog/agent-cspm
+/omnibus/config/software/sds.rb                           @DataDog/agent-processing-and-routing
 /omnibus/config/software/snmp-traps.rb                    @DataDog/network-device-monitoring
 /omnibus/resources/*/msi/                                 @DataDog/windows-agent
 
@@ -517,6 +518,7 @@
 /tasks/trace_agent.py                   @DataDog/agent-apm
 /tasks/rtloader.py                      @DataDog/agent-metrics-logs
 /tasks/security_agent.py                @DataDog/agent-security
+/tasks/sds.py                           @DataDog/agent-processing-and-routing
 /tasks/systray.py                       @DataDog/windows-agent
 /tasks/winbuildscripts/                 @DataDog/windows-agent
 /tasks/windows_resources.py             @DataDog/windows-agent


### PR DESCRIPTION
### What does this PR do?

These build files are owned by @DataDog/agent-processing-and-routing.