### PR TITLE
fix span names

### DIFF
--- a/cmd/installer/subcommands/bootstrap/command.go
+++ b/cmd/installer/subcommands/bootstrap/command.go
@@ -127,7 +127,7 @@ func bootstrap(ctx context.Context, params *cliParams, installScriptParams *inst
 		spanOptions = append(spanOptions, tracer.ChildOf(spanCtx))
 	}
 
-	span, ctx := tracer.StartSpanFromContext(ctx, "cmd/bootstrap", spanOptions...)
+	span, ctx := tracer.StartSpanFromContext(ctx, "cmd_bootstrap", spanOptions...)
 	defer func() { span.Finish(tracer.WithError(err)) }()
 	span.SetTag(ext.ManualKeep, true)
 	span.SetTag("params.pkg", params.pkg)

--- a/cmd/installer/subcommands/purge/command.go
+++ b/cmd/installer/subcommands/purge/command.go
@@ -66,7 +66,7 @@ func purgeFxWrapper(ctx context.Context, params *cliParams) error {
 }
 
 func purge(ctx context.Context, params *cliParams, _ log.Component, _ telemetry.Component) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "cmd/purge")
+	span, ctx := tracer.StartSpanFromContext(ctx, "cmd_purge")
 	defer func() { span.Finish(tracer.WithError(err)) }()
 
 	span.SetTag("params.pkg", params.pkg)


### PR DESCRIPTION
"/" is not supported well in operation names (which become a datadog metric) and tags