### PR TITLE
[NDM][Cisco SD-WAN] Send interface traffic as bits per second

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
@@ -106,8 +106,8 @@ func (ms *SDWanSender) SendInterfaceMetrics(interfaceStats []client.InterfaceSta
 
 		ms.countWithTimestamp(ciscoSDWANMetricPrefix+"interface.tx_bits", entry.TxOctets*8, tags, ts)
 		ms.countWithTimestamp(ciscoSDWANMetricPrefix+"interface.rx_bits", entry.RxOctets*8, tags, ts)
-		ms.gaugeWithTimestamp(ciscoSDWANMetricPrefix+"interface.rx_kbps", entry.RxKbps, tags, ts)
-		ms.gaugeWithTimestamp(ciscoSDWANMetricPrefix+"interface.tx_kbps", entry.TxKbps, tags, ts)
+		ms.gaugeWithTimestamp(ciscoSDWANMetricPrefix+"interface.rx_bps", entry.RxKbps*1000, tags, ts)
+		ms.gaugeWithTimestamp(ciscoSDWANMetricPrefix+"interface.tx_bps", entry.TxKbps*1000, tags, ts)
 		ms.gaugeWithTimestamp(ciscoSDWANMetricPrefix+"interface.rx_bandwidth_usage", entry.DownCapacityPercentage, tags, ts)
 		ms.gaugeWithTimestamp(ciscoSDWANMetricPrefix+"interface.tx_bandwidth_usage", entry.UpCapacityPercentage, tags, ts)
 		ms.countWithTimestamp(ciscoSDWANMetricPrefix+"interface.rx_errors", entry.RxErrors, tags, ts)

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics_test.go
@@ -158,8 +158,8 @@ func TestSendInterfaceMetrics(t *testing.T) {
 
 	mockSender.AssertMetricWithTimestamp(t, "CountWithTimestamp", ciscoSDWANMetricPrefix+"interface.rx_bits", 20*8, "", expectedTags, 10)
 	mockSender.AssertMetricWithTimestamp(t, "CountWithTimestamp", ciscoSDWANMetricPrefix+"interface.tx_bits", 10*8, "", expectedTags, 10)
-	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"interface.rx_kbps", 13, "", expectedTags, 10)
-	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"interface.tx_kbps", 250, "", expectedTags, 10)
+	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"interface.rx_bps", 13*1000, "", expectedTags, 10)
+	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"interface.tx_bps", 250*1000, "", expectedTags, 10)
 	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"interface.rx_bandwidth_usage", 12, "", expectedTags, 10)
 	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"interface.tx_bandwidth_usage", 1, "", expectedTags, 10)
 	mockSender.AssertMetricWithTimestamp(t, "CountWithTimestamp", ciscoSDWANMetricPrefix+"interface.rx_errors", 0, "", expectedTags, 10)

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
@@ -102,8 +102,8 @@ min_collection_interval: 180
 
 	sender.AssertMetricWithTimestamp(t, "CountWithTimestamp", "cisco_sdwan.interface.tx_bits", 32, "", tags, ts)
 	sender.AssertMetricWithTimestamp(t, "CountWithTimestamp", "cisco_sdwan.interface.rx_bits", 184, "", tags, ts)
-	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.interface.rx_kbps", 10.4, "", tags, ts)
-	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.interface.tx_kbps", 9.8, "", tags, ts)
+	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.interface.rx_bps", 10400, "", tags, ts)
+	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.interface.tx_bps", 9800, "", tags, ts)
 	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.interface.rx_bandwidth_usage", 0, "", tags, ts)
 	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.interface.tx_bandwidth_usage", 0.8, "", tags, ts)
 	sender.AssertMetricWithTimestamp(t, "CountWithTimestamp", "cisco_sdwan.interface.rx_errors", 2, "", tags, ts)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Send interface traffic metrics as bits per second, as Kilobit/s is not a supported type

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
