### PR TITLE
Remove container-app as an owner on pkg/config/env

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -347,7 +347,7 @@
 /pkg/config/config_template.yaml        @DataDog/agent-shared-components @DataDog/documentation
 /pkg/config/setup/apm.go                @DataDog/agent-apm
 /pkg/config/autodiscovery/              @Datadog/container-integrations
-/pkg/config/env                         @DataDog/container-integrations @DataDog/container-app
+/pkg/config/env                         @DataDog/container-integrations
 /pkg/config/logs                        @Datadog/agent-shared-components
 /pkg/config/logs/internal/seelog/seelog_config.go          @Datadog/agent-shared-components
 /pkg/config/setup                            @DataDog/agent-shared-components


### PR DESCRIPTION
### What does this PR do?

Remove container-app as an owner on pkg/config/env

### Motivation

Most changes are not impacting us
