### PR TITLE
[CWS] remove `time.Sleep` in activity dump snapshot

### DIFF
--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -15,7 +15,6 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
@@ -766,8 +765,6 @@ func (at *ActivityTree) FindMatchingRootNodes(arg0 string) []*ProcessNode {
 func (at *ActivityTree) Snapshot(newEvent func() *model.Event) {
 	for _, pn := range at.ProcessNodes {
 		pn.snapshot(at.validator, at.Stats, newEvent, at.pathsReducer)
-		// iterate slowly
-		time.Sleep(50 * time.Millisecond)
 	}
 }
 

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -37,8 +37,6 @@ func (pn *ProcessNode) snapshot(owner Owner, stats *Stats, newEvent func() *mode
 	// call snapshot for all the children of the current node
 	for _, child := range pn.Children {
 		child.snapshot(owner, stats, newEvent, reducer)
-		// iterate slowly
-		time.Sleep(50 * time.Millisecond)
 	}
 
 	// snapshot the current process


### PR DESCRIPTION
### What does this PR do?

This PR removes the `time.Sleep` in activity dump snapshot because they are done with the activity dump lock held, which can cause issue in the rest of the event pipeline.
They were added in order to reduce CPU spikes when snapshotting, profiling has shown that it's not really an issue anymore.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
