### PR TITLE
USM: reduce number of instructions for socket__http2_headers_parser

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-common.h
@@ -68,7 +68,7 @@ static __always_inline __u64 *get_dynamic_counter(conn_tuple_t *tup) {
 }
 
 // parse_field_indexed parses fully-indexed headers.
-static __always_inline void parse_field_indexed(dynamic_table_index_t *dynamic_index, http2_header_t *headers_to_process, __u8 index, __u64 global_dynamic_counter, __u8 *interesting_headers_counter) {
+static __always_inline void parse_field_indexed(dynamic_table_index_t *dynamic_index, http2_header_t *restrict headers_to_process, __u8 index, __u64 global_dynamic_counter, __u8 *interesting_headers_counter) {
     if (headers_to_process == NULL) {
         return;
     }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -79,7 +79,7 @@ end:
 // that are relevant for us, to be processed later on.
 // The return value is the number of relevant headers that were found and inserted
 // in the `headers_to_process` table.
-static __always_inline __u8 filter_relevant_headers(struct __sk_buff *skb, skb_info_t *skb_info, conn_tuple_t *tup, dynamic_table_index_t *dynamic_index, http2_header_t *headers_to_process, __u32 frame_length, http2_telemetry_t *http2_tel) {
+static __always_inline __u8 filter_relevant_headers(struct __sk_buff *skb, skb_info_t *restrict skb_info, conn_tuple_t *tup, dynamic_table_index_t *dynamic_index, http2_header_t *headers_to_process, __u32 frame_length, http2_telemetry_t *http2_tel) {
     __u8 current_ch;
     __u8 interesting_headers = 0;
     http2_header_t *current_header;
@@ -272,7 +272,7 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
     }
 }
 
-static __always_inline void process_headers_frame(struct __sk_buff *skb, http2_stream_t *current_stream, skb_info_t *skb_info, conn_tuple_t *tup, dynamic_table_index_t *dynamic_index, http2_frame_t *current_frame_header, http2_telemetry_t *http2_tel) {
+static __always_inline void process_headers_frame(struct __sk_buff *skb, http2_stream_t *current_stream, skb_info_t *restrict skb_info, conn_tuple_t *tup, dynamic_table_index_t *dynamic_index, http2_frame_t *current_frame_header, http2_telemetry_t *http2_tel) {
     const __u32 zero = 0;
 
     // Allocating an array of headers, to hold all interesting headers from the frame.

--- a/pkg/network/ebpf/c/protocols/http2/skb-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/skb-common.h
@@ -82,7 +82,7 @@ static __always_inline bool process_and_skip_literal_headers(struct __sk_buff *s
 }
 
 // handle_dynamic_table_update handles the dynamic table size update.
-static __always_inline void handle_dynamic_table_update(struct __sk_buff *skb, skb_info_t *skb_info){
+static __always_inline void handle_dynamic_table_update(struct __sk_buff *skb, skb_info_t *restrict skb_info){
     // To determine the size of the dynamic table update, we read an integer representation byte by byte.
     // We continue reading bytes until we encounter a byte without the Most Significant Bit (MSB) set,
     // indicating that we've consumed the complete integer. While in the context of the dynamic table


### PR DESCRIPTION
### What does this PR do?

Using a restrict ([ref](https://en.wikipedia.org/wiki/Restrict)) keyword to allow clang optimization on the pointer argument.
Specifically this hint allows the compiler to perform some code eliminations when emitting load operations.

similar to https://github.com/DataDog/datadog-agent/pull/24788 

### Motivation

reduce instruction count of the heavy ebpf programs

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Using the ebpf.print-verification-stats command on main and on this branch:

inv -e ebpf.print-verification-stats --filter-file usm.o --grep http2_filter --out stats_http2_restrict.json --jsonfmt

Before:

```
    "usm/socket__http2_headers_parser": {
        "instruction_processed": 756020,
        "limit": 1000000,
        "max_states_per_insn": 29,
        "peak_states": 11662,
        "stack_usage": 496,
        "total_states": 31261
    }
```

After

```
    "usm/socket__http2_headers_parser": {
        "instruction_processed": 733138,
        "limit": 1000000,
        "max_states_per_insn": 32,
        "peak_states": 11475,
        "stack_usage": 496,
        "total_states": 31175
    }
```
