### PR TITLE
fix(installer): When unpacking use tmp dir in the installer's install path

### DIFF
--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -19,7 +19,6 @@ import (
 	oci "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 
-	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/installer/repository"
 	"github.com/DataDog/datadog-agent/pkg/installer/service"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -47,7 +46,7 @@ func newPackageManager(repositories *repository.Repositories) *packageManager {
 	return &packageManager{
 		repositories: repositories,
 		configsDir:   defaultConfigsDir,
-		tmpDirPath:   filepath.Join(setup.InstallPath, "run"),
+		tmpDirPath:   defaultRepositoriesPath,
 	}
 }
 

--- a/pkg/installer/install_test.go
+++ b/pkg/installer/install_test.go
@@ -79,12 +79,13 @@ type testPackageManager struct {
 	packageManager
 }
 
-func newTestPackageManager(t *testing.T) *testPackageManager {
-	repositories := repository.NewRepositories(t.TempDir(), t.TempDir())
+func newTestPackageManager(t *testing.T, rootPath string, locksPath string) *testPackageManager {
+	repositories := repository.NewRepositories(rootPath, locksPath)
 	return &testPackageManager{
 		packageManager{
 			repositories: repositories,
 			configsDir:   t.TempDir(),
+			tmpDirPath:   t.TempDir(),
 		},
 	}
 }
@@ -96,7 +97,7 @@ func (i *testPackageManager) ConfigFS(f fixture) fs.FS {
 func TestInstallStable(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
-	installer := newTestPackageManager(t)
+	installer := newTestPackageManager(t, t.TempDir(), t.TempDir())
 
 	err := installer.installStable(testCtx, fixtureSimpleV1.pkg, fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
 	assert.NoError(t, err)
@@ -112,7 +113,7 @@ func TestInstallStable(t *testing.T) {
 func TestInstallExperiment(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
-	installer := newTestPackageManager(t)
+	installer := newTestPackageManager(t, t.TempDir(), t.TempDir())
 
 	err := installer.installStable(testCtx, fixtureSimpleV1.pkg, fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
 	assert.NoError(t, err)
@@ -131,7 +132,7 @@ func TestInstallExperiment(t *testing.T) {
 func TestInstallPromoteExperiment(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
-	installer := newTestPackageManager(t)
+	installer := newTestPackageManager(t, t.TempDir(), t.TempDir())
 
 	err := installer.installStable(testCtx, fixtureSimpleV1.pkg, fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
 	assert.NoError(t, err)
@@ -151,7 +152,7 @@ func TestInstallPromoteExperiment(t *testing.T) {
 func TestUninstallExperiment(t *testing.T) {
 	s := newTestFixturesServer(t)
 	defer s.Close()
-	installer := newTestPackageManager(t)
+	installer := newTestPackageManager(t, t.TempDir(), t.TempDir())
 
 	err := installer.installStable(testCtx, fixtureSimpleV1.pkg, fixtureSimpleV1.version, s.Image(fixtureSimpleV1))
 	assert.NoError(t, err)

--- a/pkg/installer/install_test.go
+++ b/pkg/installer/install_test.go
@@ -85,7 +85,7 @@ func newTestPackageManager(t *testing.T, rootPath string, locksPath string) *tes
 		packageManager{
 			repositories: repositories,
 			configsDir:   t.TempDir(),
-			tmpDirPath:   t.TempDir(),
+			tmpDirPath:   rootPath,
 		},
 	}
 }

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -339,7 +339,7 @@ func (i *installerImpl) BootstrapURL(ctx context.Context, url string) (err error
 
 func (i *installerImpl) bootstrapPackage(ctx context.Context, url string, expectedPackage string, expectedVersion string) error {
 	// both tmp and repository paths are checked for available disk space in case they are on different partitions
-	err := checkAvailableDiskSpace(fsDisk, defaultRepositoriesPath, os.TempDir())
+	err := checkAvailableDiskSpace(fsDisk, defaultRepositoriesPath)
 	if err != nil {
 		return fmt.Errorf("not enough disk space to install package: %w", err)
 	}
@@ -372,7 +372,7 @@ func (i *installerImpl) StartExperiment(ctx context.Context, pkg string, version
 
 	log.Infof("Installer: Starting experiment for package %s version %s", pkg, version)
 	// both tmp and repository paths are checked for available disk space in case they are on different partitions
-	err = checkAvailableDiskSpace(fsDisk, defaultRepositoriesPath, os.TempDir())
+	err = checkAvailableDiskSpace(fsDisk, defaultRepositoriesPath)
 	if err != nil {
 		return fmt.Errorf("not enough disk space to install package: %w", err)
 	}

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -91,6 +91,7 @@ func newTestInstallerWithPaths(t *testing.T, s *testFixturesServer, rcc *testRem
 	rootPath := t.TempDir()
 	locksPath := t.TempDir()
 	u, err := newInstaller(rc, rootPath, locksPath, cfg)
+	u.packageManager = &newTestPackageManager(t, rootPath, locksPath).packageManager
 	assert.NoError(t, err)
 	u.packageManager.configsDir = t.TempDir()
 	assert.Nil(t, service.BuildHelperForTests(rootPath, t.TempDir(), true))


### PR DESCRIPTION
### What does this PR do?
Don't use `/tmp` to extract OCI packages. As it may not be in the same partition as `/opt/datadog-packages` this can cause issues when moving the extracted packages (can't move between partitions, and copying / deleting is hard as we need to handle symlinks, hardlinks, ownerships & permissions).

Thus in this PR we extract in a temp dir in `/opt/datadog-packages`.

### Motivation
Working on all setups

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
Size at extract could be an issue, but we have mitigations in place to check size beforehand

### Describe how to test/QA your changes
A test will be added in system tests, so no need for manual QA.
