### PR TITLE
(fleet) remove all changes to the datadog-agent user/folders in the installer deb

### DIFF
--- a/omnibus/package-scripts/installer-deb/postinst
+++ b/omnibus/package-scripts/installer-deb/postinst
@@ -11,7 +11,7 @@ readonly STABLE_INSTALLER=${PACKAGES_DIR}/datadog-installer/stable/bin/installer
 readonly PACKAGES_LOCK_DIR=/var/run/datadog-packages
 
 bootstrap() {
-    $BOOTSTRAP_INSTALLER bootstrap --package "datadog-installer"
+    $BOOTSTRAP_INSTALLER bootstrap --package "datadog-installer" && \
     $STABLE_INSTALLER bootstrap
 }
 
@@ -55,9 +55,9 @@ chown -R dd-installer:dd-installer ${INSTALL_DIR}
 chmod 777 ${PACKAGES_LOCK_DIR}
 
 # we currently allow failures to install the installer
-exit_code=(bootstrap)
-if [ $exit_code -ne 0 ]; then
-    echo "Failed to bootstrap the installer: $exit_code" >&2
+(bootstrap) || exit_code=$?
+if [ -n "$exit_code" ]; then
+    echo "Failed to bootstrap the installer: $exit_code"
 fi
 
 exit 0

--- a/omnibus/package-scripts/installer-deb/postinst
+++ b/omnibus/package-scripts/installer-deb/postinst
@@ -55,6 +55,9 @@ chown -R dd-installer:dd-installer ${INSTALL_DIR}
 chmod 777 ${PACKAGES_LOCK_DIR}
 
 # we currently allow failures to install the installer
-(bootstrap) || true
+exit_code=(bootstrap)
+if [ $exit_code -ne 0 ]; then
+    echo "Failed to bootstrap the installer: $exit_code" >&2
+fi
 
 exit 0

--- a/omnibus/package-scripts/installer-deb/postinst
+++ b/omnibus/package-scripts/installer-deb/postinst
@@ -10,6 +10,11 @@ readonly BOOTSTRAP_INSTALLER=${INSTALL_DIR}/bin/installer/installer
 readonly STABLE_INSTALLER=${PACKAGES_DIR}/datadog-installer/stable/bin/installer/installer
 readonly PACKAGES_LOCK_DIR=/var/run/datadog-packages
 
+bootstrap() {
+    $BOOTSTRAP_INSTALLER bootstrap --package "datadog-installer"
+    $STABLE_INSTALLER bootstrap
+}
+
 add_user_and_group() {
     # Only create group and/or user if they don't already exist
     NAME=$1
@@ -49,7 +54,7 @@ chown -R dd-installer:dd-installer ${INSTALL_DIR}
 # needs to write PID files
 chmod 777 ${PACKAGES_LOCK_DIR}
 
-$BOOTSTRAP_INSTALLER bootstrap --package "datadog-installer"
-$STABLE_INSTALLER bootstrap
+# we currently allow failures to install the installer
+(bootstrap) || true
 
 exit 0

--- a/omnibus/package-scripts/installer-deb/postinst
+++ b/omnibus/package-scripts/installer-deb/postinst
@@ -8,10 +8,7 @@ readonly PACKAGES_DIR=/opt/datadog-packages
 readonly INSTALL_DIR=/opt/datadog-installer
 readonly BOOTSTRAP_INSTALLER=${INSTALL_DIR}/bin/installer/installer
 readonly STABLE_INSTALLER=${PACKAGES_DIR}/datadog-installer/stable/bin/installer/installer
-readonly HELPER=${INSTALL_DIR}/bin/installer/helper
-readonly LOG_DIR=/var/log/datadog
 readonly PACKAGES_LOCK_DIR=/var/run/datadog-packages
-readonly CONFIG_DIR=/etc/datadog-agent
 
 add_user_and_group() {
     # Only create group and/or user if they don't already exist
@@ -36,8 +33,6 @@ set -e
 case "$1" in
     configure)
         add_user_and_group 'dd-installer' $PACKAGES_DIR
-        add_user_and_group 'dd-agent' $PACKAGES_DIR/datadog-agent
-        usermod -aG dd-agent dd-installer
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;
@@ -45,42 +40,15 @@ case "$1" in
     ;;
 esac
 
-# Set proper rights to the dd-agent user
-chown -R dd-agent:dd-agent ${CONFIG_DIR}
-chmod -R g+rw ${CONFIG_DIR}
-chown -R dd-agent:dd-agent ${LOG_DIR}
-chmod -R g+rw ${LOG_DIR}
+# Set proper rights to the dd-installer user
 chown -R dd-installer:dd-installer ${PACKAGES_DIR}
 chown -R dd-installer:dd-installer ${PACKAGES_LOCK_DIR}
 chown -R dd-installer:dd-installer ${INSTALL_DIR}
 
-chmod -R 755 ${PACKAGES_DIR}
 # Lock_dir is world read/write/x as any application with a tracer injected
 # needs to write PID files
 chmod -R 777 ${PACKAGES_LOCK_DIR}
-
-# Make system-probe configs read-only
-chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true
-if [ -f "$CONFIG_DIR/system-probe.yaml" ]; then
-    chmod 0440 ${CONFIG_DIR}/system-probe.yaml || true
-fi
-
-# Make security-agent config read-only
-chmod 0440 ${CONFIG_DIR}/security-agent.yaml.example || true
-if [ -f "$CONFIG_DIR/security-agent.yaml" ]; then
-    chmod 0440 ${CONFIG_DIR}/security-agent.yaml || true
-fi
-
-if [ -d "$CONFIG_DIR/compliance.d" ]; then
-    chown -R root:root ${CONFIG_DIR}/compliance.d || true
-fi
-
-if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
-    chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
-fi
-
-# Set helper rights
-chmod 750 ${HELPER}
+chmod -R 755 ${PACKAGES_DIR}
 
 $BOOTSTRAP_INSTALLER bootstrap --package "datadog-installer"
 $STABLE_INSTALLER bootstrap

--- a/omnibus/package-scripts/installer-deb/postinst
+++ b/omnibus/package-scripts/installer-deb/postinst
@@ -47,8 +47,7 @@ chown -R dd-installer:dd-installer ${INSTALL_DIR}
 
 # Lock_dir is world read/write/x as any application with a tracer injected
 # needs to write PID files
-chmod -R 777 ${PACKAGES_LOCK_DIR}
-chmod -R 755 ${PACKAGES_DIR}
+chmod 777 ${PACKAGES_LOCK_DIR}
 
 $BOOTSTRAP_INSTALLER bootstrap --package "datadog-installer"
 $STABLE_INSTALLER bootstrap

--- a/omnibus/package-scripts/installer-deb/postrm
+++ b/omnibus/package-scripts/installer-deb/postrm
@@ -12,13 +12,11 @@ set -e
 
 case "$1" in
     purge)
-        echo "Deleting dd-agent user"
-        deluser dd-agent --quiet
+        echo "Deleting dd-installer user"
         deluser dd-installer --quiet
-        echo "Deleting dd-agent group"
-        (getent group dd-agent >/dev/null && delgroup dd-agent --quiet) || true
+        echo "Deleting dd-installer group"
         (getent group dd-installer >/dev/null && delgroup dd-installer --quiet) || true
-        echo "Force-deleting $INSTALL_DIR, $PACKAGES_DIR"
+        echo "Force-deleting $INSTALL_DIR, $PACKAGES_DIR, $PACKAGES_LOCK_DIR"
         rm -rf $INSTALL_DIR
         rm -rf $PACKAGES_DIR
         rm -rf $PACKAGES_LOCK_DIR

--- a/omnibus/package-scripts/installer-deb/preinst
+++ b/omnibus/package-scripts/installer-deb/preinst
@@ -3,7 +3,4 @@
 #
 # .deb: STEP 2 of 5
 
-
-SYSTEMCTL_SKIP_SYSV=true systemctl stop datadog-installer || true
-
 exit 0


### PR DESCRIPTION
This PR removes all changes to datadog-agent user/folders that were previously made by the installer. Since we are currently not installing the agent those conflict with the agent deb scripts that do the same.