### PR TITLE
[Network Path] Create extended timeout client

### DIFF
--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -29,8 +29,7 @@ const (
 	DefaultMinTTL       = 1
 	DefaultMaxTTL       = 30
 	DefaultDelay        = 50 //msec
-	DefaultWaitTime     = 3 * time.Second
-	DefaultReadTimeout  = 3 * time.Second
+	DefaultReadTimeout  = 10 * time.Second
 	DefaultOutputFormat = "json"
 )
 
@@ -59,22 +58,12 @@ func RunTraceroute(cfg Config) (NetworkPath, error) {
 		maxTTL = DefaultMaxTTL
 	}
 
-	var waitTime time.Duration
-	if cfg.WaitTimeMs == 0 {
-		waitTime = DefaultWaitTime
+	var timeout time.Duration
+	if cfg.TimeoutMs == 0 {
+		timeout = DefaultReadTimeout
 	} else {
-		waitTime = time.Duration(cfg.WaitTimeMs) * time.Millisecond
+		timeout = time.Duration(cfg.TimeoutMs) * time.Millisecond
 	}
-
-	// TODO: create a full traceroute timeout wrapper
-	// though at least for linux, the sysprobe call will
-	// take care of it
-	// var timeout time.Duration
-	// if cfg.TimeoutMs == 0 {
-	// 	timeout = DefaultReadTimeout
-	// } else {
-	// 	timeout = time.Duration(cfg.TimeoutMs) * time.Millisecond
-	// }
 
 	dt := &probev4.UDPv4{
 		Target:     dest,
@@ -85,7 +74,7 @@ func RunTraceroute(cfg Config) (NetworkPath, error) {
 		MinTTL:     uint8(DefaultMinTTL), // TODO: what's a good value?
 		MaxTTL:     maxTTL,
 		Delay:      time.Duration(DefaultDelay) * time.Millisecond, // TODO: what's a good value?
-		Timeout:    waitTime,                                       // TODO: what's a good value?
+		Timeout:    timeout,                                        // TODO: what's a good value?
 		BrokenNAT:  false,
 	}
 

--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -29,6 +29,7 @@ const (
 	DefaultMinTTL       = 1
 	DefaultMaxTTL       = 30
 	DefaultDelay        = 50 //msec
+	DefaultWaitTime     = 3 * time.Second
 	DefaultReadTimeout  = 3 * time.Second
 	DefaultOutputFormat = "json"
 )
@@ -58,12 +59,22 @@ func RunTraceroute(cfg Config) (NetworkPath, error) {
 		maxTTL = DefaultMaxTTL
 	}
 
-	var timeout time.Duration
-	if cfg.TimeoutMs == 0 {
-		timeout = DefaultReadTimeout
+	var waitTime time.Duration
+	if cfg.WaitTimeMs == 0 {
+		waitTime = DefaultWaitTime
 	} else {
-		timeout = time.Duration(cfg.TimeoutMs) * time.Millisecond
+		waitTime = time.Duration(cfg.WaitTimeMs) * time.Millisecond
 	}
+
+	// TODO: create a full traceroute timeout wrapper
+	// though at least for linux, the sysprobe call will
+	// take care of it
+	// var timeout time.Duration
+	// if cfg.TimeoutMs == 0 {
+	// 	timeout = DefaultReadTimeout
+	// } else {
+	// 	timeout = time.Duration(cfg.TimeoutMs) * time.Millisecond
+	// }
 
 	dt := &probev4.UDPv4{
 		Target:     dest,
@@ -74,7 +85,7 @@ func RunTraceroute(cfg Config) (NetworkPath, error) {
 		MinTTL:     uint8(DefaultMinTTL), // TODO: what's a good value?
 		MaxTTL:     maxTTL,
 		Delay:      time.Duration(DefaultDelay) * time.Millisecond, // TODO: what's a good value?
-		Timeout:    timeout,                                        // TODO: what's a good value?
+		Timeout:    waitTime,                                       // TODO: what's a good value?
 		BrokenNAT:  false,
 	}
 

--- a/pkg/networkpath/traceroute/traceroute.go
+++ b/pkg/networkpath/traceroute/traceroute.go
@@ -11,10 +11,16 @@ type (
 	// of Traceroute
 	Config struct {
 		// TODO: add common configuration
+		// Destination Hostname
 		DestHostname string
-		DestPort     uint16
-		MaxTTL       uint8
-		TimeoutMs    uint
+		// Destination Port number
+		DestPort uint16
+		// Max number of hops to try
+		MaxTTL uint8
+		// Wait time per request
+		WaitTimeMs uint
+		// Total timeout for traceroute
+		TimeoutMs uint
 	}
 
 	// Traceroute defines an interface for running

--- a/pkg/networkpath/traceroute/traceroute.go
+++ b/pkg/networkpath/traceroute/traceroute.go
@@ -17,9 +17,7 @@ type (
 		DestPort uint16
 		// Max number of hops to try
 		MaxTTL uint8
-		// Wait time per request
-		WaitTimeMs uint
-		// Total timeout for traceroute
+		// TODO: do we want to expose this?
 		TimeoutMs uint
 	}
 

--- a/pkg/networkpath/traceroute/traceroute_linux.go
+++ b/pkg/networkpath/traceroute/traceroute_linux.go
@@ -8,9 +8,7 @@
 package traceroute
 
 import (
-	"context"
 	"encoding/json"
-	"time"
 
 	dd_config "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
@@ -45,13 +43,7 @@ func (l *LinuxTraceroute) Run() (NetworkPath, error) {
 		return NetworkPath{}, err
 	}
 
-	var cancel context.CancelFunc
-	ctx := context.Background()
-	if l.cfg.TimeoutMs > 0 {
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(l.cfg.TimeoutMs)*time.Millisecond)
-		defer cancel()
-	}
-	resp, err := tu.GetTraceroute(ctx, clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.MaxTTL, l.cfg.TimeoutMs)
+	resp, err := tu.GetTraceroute(clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.MaxTTL, l.cfg.TimeoutMs)
 	if err != nil {
 		return NetworkPath{}, err
 	}

--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -196,8 +196,8 @@ func (r *RemoteSysProbeUtil) GetPing(clientID string, host string, count int, in
 }
 
 // GetTraceroute returns the results of a traceroute to a host
-func (r *RemoteSysProbeUtil) GetTraceroute(ctx context.Context, clientID string, host string, port uint16, maxTTL uint8, timeout uint) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d", tracerouteURL, host, clientID, port, maxTTL, timeout), nil)
+func (r *RemoteSysProbeUtil) GetTraceroute(clientID string, host string, port uint16, maxTTL uint8, timeout uint) ([]byte, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d", tracerouteURL, host, clientID, port, maxTTL, timeout), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -294,15 +294,15 @@ func newSystemProbe(path string) *RemoteSysProbeUtil {
 			},
 		},
 		extendedTimeoutClient: http.Client{
-			Timeout: 120 * time.Second,
+			Timeout: 25 * time.Second,
 			Transport: &http.Transport{
 				MaxIdleConns:    2,
-				IdleConnTimeout: 100 * time.Second,
+				IdleConnTimeout: 30 * time.Second,
 				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 					return net.Dial(netType, path)
 				},
 				TLSHandshakeTimeout:   1 * time.Second,
-				ResponseHeaderTimeout: 100 * time.Second,
+				ResponseHeaderTimeout: 20 * time.Second,
 				ExpectContinueTimeout: 50 * time.Millisecond,
 			},
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Creates an HTTP client for connecting to system-probe with extended timeouts compared to the regular endpoints. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
When running traceroutes through the system probe, we were previously having the traces get cut off due to the read header timeout of the HTTP client. The extended timeout client allows us to work around this without effecting other modules.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Having two HTTP clients isn't ideal, but the trade off is we don't have to maintain state in the system probe for gathering traceroute infomation.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
