### PR TITLE
Rework cleanup_conn logic to fix debian 9 verifier bug

### DIFF
--- a/pkg/network/ebpf/c/tracer/events.h
+++ b/pkg/network/ebpf/c/tracer/events.h
@@ -73,15 +73,15 @@ static __always_inline void cleanup_conn(void *ctx, conn_tuple_t *tup, struct so
     }
 
     cst = bpf_map_lookup_elem(&conn_stats, &(conn.tup));
-    if (is_udp && !cst) {
-        increment_telemetry_count(udp_dropped_conns);
-        return; // nothing to report
-    }
 
     if (cst) {
         conn.conn_stats = *cst;
         bpf_map_delete_elem(&conn_stats, &(conn.tup));
     } else {
+        if (is_udp) {
+            increment_telemetry_count(udp_dropped_conns);
+            return; // nothing to report
+        }
         // we don't have any stats for the connection,
         // so cookie is not set, set it here
         conn.conn_stats.cookie = get_sk_cookie(sk);


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

For whatever reason the debian 9 verifier "forgets" about the value type in r0. this PR moves the usage of r0 (the assignment `conn.conn_stats = *cst`) closer to the bpf_map_lookup.

This will eventually be tested by https://datadoghq.atlassian.net/browse/EBPF-456, but I'd like to get this change into the 7.54 release so it can be used by a customer that would be helped by it. There is really no downside to this change otherwise as it's functionally the same logic. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
