### PR TITLE
[windows][testing] Fix test flake for concurrent map writes.

### DIFF
--- a/pkg/network/protocols/http/etw_interface_test.go
+++ b/pkg/network/protocols/http/etw_interface_test.go
@@ -173,7 +173,7 @@ func executeRequestForTest(t *testing.T, etw *EtwInterface, test testDef) ([]Win
 	var txns []WinHttpTransaction
 	responsecount := make(map[int]int)
 	var ok bool
-
+	var maplock sync.Mutex
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -214,11 +214,13 @@ func executeRequestForTest(t *testing.T, etw *EtwInterface, test testDef) ([]Win
 			// track how many successes & errors so we can match to the transactions
 			// returned below.
 			code := resp.StatusCode
+			maplock.Lock()
 			if v, ok := responsecount[code]; ok {
 				responsecount[code] = v + 1
 			} else {
 				responsecount[code] = 1
 			}
+			maplock.Unlock()
 			err = resp.Body.Close()
 			require.NoError(t, err)
 		}()


### PR DESCRIPTION
In previous PR, added a "flood test" that made tests concurrent. However, tracking the responses then wrote to a map, which was failing intermittently due to concurrent map writes.

Lock the map accesses.

