### PR TITLE
[gitlab] Update k8s runners CPU requests based on observed CPU usage

### DIFF
--- a/.gitlab/binary_build/cluster_agent.yml
+++ b/.gitlab/binary_build/cluster_agent.yml
@@ -11,6 +11,7 @@
   variables:
     KUBERNETES_MEMORY_REQUEST: "8Gi"
     KUBERNETES_MEMORY_LIMIT: "8Gi"
+    KUBERNETES_CPU_REQUEST: 6
 
 cluster_agent-build_amd64:
   extends: .cluster_agent-build_common

--- a/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
@@ -13,6 +13,7 @@ cluster_agent_cloudfoundry-build_amd64:
       - $OMNIBUS_PACKAGE_DIR
   variables:
     ARCH: amd64
+    KUBERNETES_CPU_REQUEST: 4
   before_script:
     - source /root/.bashrc
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -79,6 +79,8 @@ build_iot_agent-binary_x64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["lint_linux-x64", "go_deps"]
+  variables:
+    KUBERNETES_CPU_REQUEST: 4
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
@@ -95,6 +97,7 @@ build_iot_agent-binary_arm64:
   needs: ["lint_linux-arm64", "go_deps"]
   variables:
     ARCH: arm64
+    KUBERNETES_CPU_REQUEST: 4
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:

--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -19,6 +19,7 @@
   variables:
     KUBERNETES_MEMORY_REQUEST: "6Gi"
     KUBERNETES_MEMORY_LIMIT: "12Gi"
+    KUBERNETES_CPU_REQUEST: 6
   artifacts:
     expire_in: 2 weeks
     paths:

--- a/.gitlab/deps_build/deps_build.yml
+++ b/.gitlab/deps_build/deps_build.yml
@@ -6,6 +6,8 @@
   rules:
     !reference [.manual]
   stage: deps_build
+  variables:
+    KUBERNETES_CPU_REQUEST: 4
   script:
     # use tmpdir to prevent git remote capture by clang build
     - mkdir /tmp/clangbuild && cd /tmp/clangbuild

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -116,6 +116,8 @@ iot_agent_suse-x64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_mod_tidy_check", "go_deps"]
+  variables:
+    UBERNETES_CPU_REQUEST: 4
   before_script:
     - source /root/.bashrc
   script:

--- a/.gitlab/package_deps_build/package_deps_build.yml
+++ b/.gitlab/package_deps_build/package_deps_build.yml
@@ -20,6 +20,7 @@
   variables:
     KUBERNETES_MEMORY_REQUEST: "32Gi"
     KUBERNETES_MEMORY_LIMIT: "32Gi"
+    KUBERNETES_CPU_REQUEST: 24
   artifacts:
     expire_in: 2 weeks
     paths:

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -16,6 +16,7 @@
   variables:
     KUBERNETES_MEMORY_REQUEST: "16Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"
+    KUBERNETES_CPU_REQUEST: 6
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
@@ -49,6 +50,8 @@ tests_ebpf_arm64:
     - !reference [.except_mergequeue]
     - when: on_success
   needs: ["go_deps", "go_tools_deps"]
+  variables:
+    KUBERNETES_CPU_REQUEST: 4
   artifacts:
     when: always
     paths:

--- a/.gitlab/source_test/go_generate_check.yml
+++ b/.gitlab/source_test/go_generate_check.yml
@@ -5,6 +5,8 @@ security_go_generate_check:
   tags: ["arch:amd64"]
   stage: source_test
   needs: [ "go_deps", "go_tools_deps" ]
+  variables:
+    KUBERNETES_CPU_REQUEST: 4
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]

--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -9,6 +9,8 @@ golang_deps_diff:
     - !reference [ .except_main_or_release_branch ]
     - when: on_success
   needs: ["go_deps"]
+  variables:
+    KUBERNETES_CPU_REQUEST: 4
   before_script:
     - source /root/.bashrc
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -227,6 +227,8 @@ go_mod_tidy_check:
   stage: source_test
   extends: .linux_x64
   needs: ["go_deps"]
+  variables:
+    KUBERNETES_CPU_REQUEST: 4
   before_script:
     - source /root/.bashrc
     - !reference [.retrieve_linux_go_deps]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the `KUBERNETES_CPU_REQUEST` of several CI jobs, based on [observed usage](https://app.datadoghq.com/s/yB5yjZ/bv2-xn6-p63).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Being good CI citizens by requesting the resources we actually need. The default `KUBERNETES_CPU_REQUEST` value for all jobs is `1`, which is less than what these jobs use.

This may also help get our jobs placed on instances that do have the needed CPU resources to run our jobs, potentially making their durations more stable.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a