### PR TITLE
[CWS] add `inv security-agent.freeze-friday` task

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -950,3 +950,9 @@ def sync_secl_win_pkg(ctx):
         else:
             ctx.run(f"sed -i '/^\\/\\/go:build/d' pkg/security/seclwin/model/{fto}")
         ctx.run(f"gofmt -s -w pkg/security/seclwin/model/{fto}")
+
+
+@task
+def freeze_friday(ctx):
+    # sync seclwin package
+    sync_secl_win_pkg(ctx)


### PR DESCRIPTION
### What does this PR do?

This PR adds a new CWS specific task, collecting all tasks that need to be done before an agent freeze. Currently it includes:
- sync-ing the seclwin package
In the future, it will include:
- sync-ing the embedded default policy with security-agent-policies

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
