### PR TITLE
[CWS] remove time sleep in `EBPFMonitors.SendStats`

### DIFF
--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -11,7 +11,6 @@ package probe
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/eventstream"
@@ -86,30 +85,29 @@ func (m *EBPFMonitors) GetEventStreamMonitor() *eventstream.Monitor {
 
 // SendStats sends statistics about the probe to Datadog
 func (m *EBPFMonitors) SendStats() error {
-	// delay between two send in order to reduce the statsd pool presure
-	const delay = time.Second
-	time.Sleep(delay)
-
 	if resolvers := m.ebpfProbe.Resolvers; resolvers != nil {
 		if err := resolvers.ProcessResolver.SendStats(); err != nil {
 			return fmt.Errorf("failed to send process_resolver stats: %w", err)
 		}
-		time.Sleep(delay)
 
 		if err := resolvers.DentryResolver.SendStats(); err != nil {
 			return fmt.Errorf("failed to send process_resolver stats: %w", err)
 		}
+
 		if err := resolvers.NamespaceResolver.SendStats(); err != nil {
 			return fmt.Errorf("failed to send namespace_resolver stats: %w", err)
 		}
+
 		if err := resolvers.MountResolver.SendStats(); err != nil {
 			return fmt.Errorf("failed to send mount_resolver stats: %w", err)
 		}
+
 		if resolvers.SBOMResolver != nil {
 			if err := resolvers.SBOMResolver.SendStats(); err != nil {
 				return fmt.Errorf("failed to send sbom_resolver stats: %w", err)
 			}
 		}
+
 		if resolvers.HashResolver != nil {
 			if err := resolvers.HashResolver.SendStats(); err != nil {
 				return fmt.Errorf("failed to send hash_resolver stats: %w", err)
@@ -120,7 +118,6 @@ func (m *EBPFMonitors) SendStats() error {
 	if err := m.eventStreamMonitor.SendStats(); err != nil {
 		return fmt.Errorf("failed to send events stats: %w", err)
 	}
-	time.Sleep(delay)
 
 	if m.ebpfProbe.config.Probe.RuntimeMonitor {
 		if err := m.runtimeMonitor.SendStats(); err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR removes the `time.Sleep` in `EBPFMonitors.SendStats`.  They were added 2 years go to reduce the pressure to statsd but are not needed anymore.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
