### PR TITLE
usm: Replace skb->len with skb_info->data_end

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/usm-context.h
+++ b/pkg/network/ebpf/c/protocols/classification/usm-context.h
@@ -56,7 +56,7 @@ static __always_inline usm_context_t* __get_usm_context(struct __sk_buff *skb) {
 static __always_inline void __init_buffer(struct __sk_buff *skb, skb_info_t *skb_info, classification_buffer_t* buffer) {
     bpf_memset(buffer->data, 0, sizeof(buffer->data));
     read_into_buffer_for_classification((char *)buffer->data, skb, skb_info->data_off);
-    const size_t payload_length = skb->len - skb_info->data_off;
+    const size_t payload_length = skb_info->data_end - skb_info->data_off;
     buffer->size = payload_length < CLASSIFICATION_MAX_BUFFER ? payload_length : CLASSIFICATION_MAX_BUFFER;
 }
 

--- a/pkg/network/ebpf/c/protocols/grpc/helpers.h
+++ b/pkg/network/ebpf/c/protocols/grpc/helpers.h
@@ -59,7 +59,7 @@ static __always_inline grpc_status_t scan_headers(struct __sk_buff *skb, skb_inf
     __u64 max_bits = 0;
     __u32 frame_end = skb_info->data_off + frame_length;
     // Check that frame_end does not go beyond the skb
-    frame_end = frame_end < skb->len + 1 ? frame_end : skb->len + 1;
+    frame_end = frame_end < skb_info->data_end + 1 ? frame_end : skb_info->data_end + 1;
 
     handle_dynamic_table_update(skb, skb_info);
 
@@ -120,7 +120,7 @@ static __always_inline grpc_status_t is_grpc(struct __sk_buff *skb, const skb_in
     // Loop through the HTTP2 frames in the packet
 #pragma unroll(GRPC_MAX_FRAMES_TO_FILTER)
     for (__u8 i = 0; i < GRPC_MAX_FRAMES_TO_FILTER; ++i) {
-        if (info.data_off + HTTP2_FRAME_HEADER_SIZE > skb->len) {
+        if (info.data_off + HTTP2_FRAME_HEADER_SIZE > skb_info->data_end) {
             break;
         }
 

--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -225,7 +225,7 @@ static __always_inline bool http_allow_packet(conn_tuple_t *tuple, struct __sk_b
         return false;
     }
 
-    bool empty_payload = skb_info->data_off == skb->len;
+    bool empty_payload = skb_info->data_off == skb_info->data_end;
     if (empty_payload || tuple->sport == HTTPS_PORT || tuple->dport == HTTPS_PORT) {
         // if the payload data is empty or encrypted packet, we only
         // process it if the packet represents a TCP termination

--- a/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
+++ b/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
@@ -188,7 +188,7 @@ static __always_inline bool kafka_allow_packet(kafka_transaction_t *kafka, struc
 
     // if payload data is empty or if this is an encrypted packet, we only
     // process it if the packet represents a TCP termination
-    bool empty_payload = skb_info->data_off == skb->len;
+    bool empty_payload = skb_info->data_off == skb_info->data_end;
     if (empty_payload) {
         return skb_info->tcp_flags&(TCPHDR_FIN|TCPHDR_RST);
     }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Replaces usages of `skb->len` with `skb_info->data_end`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

`skb-len` can contain some padding, and we forgot to migrate some codepaths in the past.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

There are 2 other locations which use `skb->len`, but both of them are being called in the `kafka` monitoring code, which generate verifier errors (mainly around instruction limit). Those locations will be treated separately to handle the verifier errors

Original PR with more context - https://github.com/DataDog/datadog-agent/pull/18951

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
