### PR TITLE
[PROCS-3944] Add process component check output to flare

### DIFF
--- a/comp/process/agent/flare.go
+++ b/comp/process/agent/flare.go
@@ -41,7 +41,7 @@ func (fh *FlareHelper) FillFlare(fb flaretypes.FlareBuilder) error {
 		fb.AddFileFromFunc(filename, func() ([]byte, error) {
 			checkOutput, ok := checks.GetCheckOutput(checkName)
 			if !ok {
-				return []byte(checkName+" check is not running or has not been scheduled yet\n"), nil
+				return []byte(checkName + " check is not running or has not been scheduled yet\n"), nil
 			}
 			checkJSON, err := json.MarshalIndent(checkOutput, "", "  ")
 			if err != nil {

--- a/comp/process/agent/flare.go
+++ b/comp/process/agent/flare.go
@@ -32,8 +32,6 @@ func (fh *FlareHelper) FillFlare(fb flaretypes.FlareBuilder) error {
 	fh.m.Lock()
 	defer fh.m.Unlock()
 
-	fmt.Fprintln(color.Output, color.BlueString("Hi"))
-
 	for _, check := range fh.Checks {
 		checkName := check.Name()
 		filename := fmt.Sprintf("%s_check_output.json", checkName)

--- a/comp/process/agent/flare.go
+++ b/comp/process/agent/flare.go
@@ -9,28 +9,23 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"sync"
 
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 )
 
-// FlareHelper
+// FlareHelper is a helper struct to fill the flare with check output.
 type FlareHelper struct {
-	m      sync.Mutex
 	Checks []checks.Check
 }
 
-// NewNewFlareHelper
+// NewNewFlareHelper creates a new FlareHelper to be provided by the process agent component.
 func NewFlareHelper(checks []checks.Check) *FlareHelper {
 	return &FlareHelper{Checks: checks}
 }
 
 // FillFlare is the callback function for the flare.
 func (fh *FlareHelper) FillFlare(fb flaretypes.FlareBuilder) error {
-	fh.m.Lock()
-	defer fh.m.Unlock()
-
 	for _, check := range fh.Checks {
 		if check.Realtime() {
 			continue

--- a/comp/process/agent/flare.go
+++ b/comp/process/agent/flare.go
@@ -32,6 +32,10 @@ func (fh *FlareHelper) FillFlare(fb flaretypes.FlareBuilder) error {
 	defer fh.m.Unlock()
 
 	for _, check := range fh.Checks {
+		if check.Realtime() {
+			continue
+		}
+
 		checkName := check.Name()
 		filename := fmt.Sprintf("%s_check_output.json", checkName)
 		fb.AddFileFromFunc(filename, func() ([]byte, error) {

--- a/comp/process/agent/flare.go
+++ b/comp/process/agent/flare.go
@@ -13,7 +13,6 @@ import (
 
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
-	"github.com/fatih/color"
 )
 
 // FlareHelper

--- a/comp/process/agent/flare.go
+++ b/comp/process/agent/flare.go
@@ -39,16 +39,13 @@ func (fh *FlareHelper) FillFlare(fb flaretypes.FlareBuilder) error {
 		checkName := check.Name()
 		filename := fmt.Sprintf("%s_check_output.json", checkName)
 		fb.AddFileFromFunc(filename, func() ([]byte, error) {
-			var out []byte
 			checkOutput, ok := checks.GetCheckOutput(checkName)
 			if !ok {
-				out = append(out, []byte(checkName+" check is not running or has not been scheduled yet\n")...)
-				return out, nil
+				return []byte(checkName+" check is not running or has not been scheduled yet\n"), nil
 			}
 			checkJSON, err := json.MarshalIndent(checkOutput, "", "  ")
 			if err != nil {
-				out = append(out, []byte(fmt.Sprintf("error: %v", err.Error()))...)
-				return out, err
+				return []byte(fmt.Sprintf("error: %s", err.Error())), err
 			}
 			return checkJSON, nil
 		})

--- a/comp/process/agent/flare.go
+++ b/comp/process/agent/flare.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//nolint:revive
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
+	"github.com/DataDog/datadog-agent/pkg/process/checks"
+	"github.com/fatih/color"
+)
+
+// FlareHelper
+type FlareHelper struct {
+	m      sync.Mutex
+	Checks []checks.Check
+}
+
+// NewNewFlareHelper
+func NewFlareHelper(checks []checks.Check) *FlareHelper {
+	return &FlareHelper{Checks: checks}
+}
+
+// FillFlare is the callback function for the flare.
+func (fh *FlareHelper) FillFlare(fb flaretypes.FlareBuilder) error {
+	fh.m.Lock()
+	defer fh.m.Unlock()
+
+	fmt.Fprintln(color.Output, color.BlueString("Hi"))
+
+	for _, check := range fh.Checks {
+		checkName := check.Name()
+		filename := fmt.Sprintf("%s_check_output.json", checkName)
+		fb.AddFileFromFunc(filename, func() ([]byte, error) {
+			var out []byte
+			checkOutput, ok := checks.GetCheckOutput(checkName)
+			if !ok {
+				out = append(out, []byte(checkName+" check is not running or has not been scheduled yet\n")...)
+				return out, nil
+			}
+			checkJSON, err := json.MarshalIndent(checkOutput, "", "  ")
+			if err != nil {
+				out = append(out, []byte(fmt.Sprintf("error: %v", err.Error()))...)
+				return out, err
+			}
+			return checkJSON, nil
+		})
+	}
+
+	return nil
+}

--- a/comp/process/agent/flare_test.go
+++ b/comp/process/agent/flare_test.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	"github.com/DataDog/datadog-agent/pkg/process/checks"
+	checkMocks "github.com/DataDog/datadog-agent/pkg/process/checks/mocks"
+)
+
+func TestFillFlare(t *testing.T) {
+	f := helpers.NewFlareBuilderMock(t, false)
+
+	check := &checkMocks.Check{}
+	check.On("Name").Return("process")
+
+	fc := NewFlareHelper([]checks.Check{check})
+
+	fc.FillFlare(f.Fb)
+	f.AssertFileExists("process_check_output.json")
+}

--- a/comp/process/agent/flare_test.go
+++ b/comp/process/agent/flare_test.go
@@ -18,6 +18,7 @@ func TestFillFlare(t *testing.T) {
 
 	check := &checkMocks.Check{}
 	check.On("Name").Return("process")
+	check.On("Realtime").Return(false)
 
 	fc := NewFlareHelper([]checks.Check{check})
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -62,8 +62,9 @@ func CompleteFlare(fb flaretypes.FlareBuilder, diagnoseDeps diagnose.SuitesDeps)
 		fb.AddFileFromFunc("tagger-list.json", getAgentTaggerList)
 		fb.AddFileFromFunc("workload-list.log", getAgentWorkloadList)
 		fb.AddFileFromFunc("process-agent_tagger-list.json", getProcessAgentTaggerList)
-
-		getProcessChecks(fb, config.GetProcessAPIAddressPort)
+		if !config.Datadog.GetBool("process_config.run_in_core_agent.enabled") {
+			getProcessChecksFromProcessAgent(fb, config.GetProcessAPIAddressPort)
+		}
 	}
 
 	fb.RegisterFilePerm(security.GetAuthTokenFilepath(config.Datadog))
@@ -239,7 +240,7 @@ func getConfigFiles(fb flaretypes.FlareBuilder, confSearchPaths map[string]strin
 	}
 }
 
-func getProcessChecks(fb flaretypes.FlareBuilder, getAddressPort func() (url string, err error)) {
+func getProcessChecksFromProcessAgent(fb flaretypes.FlareBuilder, getAddressPort func() (url string, err error)) {
 	addressPort, err := getAddressPort()
 	if err != nil {
 		log.Errorf("Could not zip process agent checks: wrong configuration to connect to process-agent: %s", err.Error())

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -63,7 +63,7 @@ func CompleteFlare(fb flaretypes.FlareBuilder, diagnoseDeps diagnose.SuitesDeps)
 		fb.AddFileFromFunc("workload-list.log", getAgentWorkloadList)
 		fb.AddFileFromFunc("process-agent_tagger-list.json", getProcessAgentTaggerList)
 		if !config.Datadog.GetBool("process_config.run_in_core_agent.enabled") {
-			getProcessChecksFromProcessAgent(fb, config.GetProcessAPIAddressPort)
+			getChecksFromProcessAgent(fb, config.GetProcessAPIAddressPort)
 		}
 	}
 
@@ -240,7 +240,7 @@ func getConfigFiles(fb flaretypes.FlareBuilder, confSearchPaths map[string]strin
 	}
 }
 
-func getProcessChecksFromProcessAgent(fb flaretypes.FlareBuilder, getAddressPort func() (url string, err error)) {
+func getChecksFromProcessAgent(fb flaretypes.FlareBuilder, getAddressPort func() (url string, err error)) {
 	addressPort, err := getAddressPort()
 	if err != nil {
 		log.Errorf("Could not zip process agent checks: wrong configuration to connect to process-agent: %s", err.Error())

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -269,7 +269,7 @@ func TestProcessAgentChecks(t *testing.T) {
 
 	t.Run("without process-agent running", func(t *testing.T) {
 		mock := flarehelpers.NewFlareBuilderMock(t, false)
-		getProcessChecksFromProcessAgent(mock.Fb, func() (string, error) { return "fake:1337", nil })
+		getChecksFromProcessAgent(mock.Fb, func() (string, error) { return "fake:1337", nil })
 
 		mock.AssertFileContentMatch("error: process-agent is not running or is unreachable: error collecting data for 'process_discovery_check_output.json': .*", "process_check_output.json")
 	})
@@ -300,7 +300,7 @@ func TestProcessAgentChecks(t *testing.T) {
 		setupIPCAddress(t, srv.URL)
 
 		mock := flarehelpers.NewFlareBuilderMock(t, false)
-		getProcessChecksFromProcessAgent(mock.Fb, config.GetProcessAPIAddressPort)
+		getChecksFromProcessAgent(mock.Fb, config.GetProcessAPIAddressPort)
 
 		mock.AssertFileContent(string(expectedProcessesJSON), "process_check_output.json")
 		mock.AssertFileContent(string(expectedContainersJSON), "container_check_output.json")

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -269,7 +269,7 @@ func TestProcessAgentChecks(t *testing.T) {
 
 	t.Run("without process-agent running", func(t *testing.T) {
 		mock := flarehelpers.NewFlareBuilderMock(t, false)
-		getProcessChecks(mock.Fb, func() (string, error) { return "fake:1337", nil })
+		getProcessChecksFromProcessAgent(mock.Fb, func() (string, error) { return "fake:1337", nil })
 
 		mock.AssertFileContentMatch("error: process-agent is not running or is unreachable: error collecting data for 'process_discovery_check_output.json': .*", "process_check_output.json")
 	})
@@ -300,7 +300,7 @@ func TestProcessAgentChecks(t *testing.T) {
 		setupIPCAddress(t, srv.URL)
 
 		mock := flarehelpers.NewFlareBuilderMock(t, false)
-		getProcessChecks(mock.Fb, config.GetProcessAPIAddressPort)
+		getProcessChecksFromProcessAgent(mock.Fb, config.GetProcessAPIAddressPort)
 
 		mock.AssertFileContent(string(expectedProcessesJSON), "process_check_output.json")
 		mock.AssertFileContent(string(expectedContainersJSON), "container_check_output.json")

--- a/releasenotes/notes/process-component-check-flare-output-c0377a2aa2860c3f.yaml
+++ b/releasenotes/notes/process-component-check-flare-output-c0377a2aa2860c3f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    check output from the Process Agent component are added to the flare when used in the core agent.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds the output for any non-realtime checks run by process agent component to the agent flare when its running in the core agent. Essentially,`$CHECKNAME_output.json` is added the to the flare for each running check. This file is generated by the `FlareProvider` provided by the process agent component.

### Motivation

PROCS-3944

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Run the process checks on the core agent:
```
// datadog.yaml
process_config:
  process_collection:
    enabled: true
  run_in_core_agent:
    enabled: true
```
2. Create flare:
```
$ datadog-agent flare
```
3. Verify archive has `process_check_output.json` with actual output.
