### PR TITLE
[ASCII-1512] Truncate output body of diagnose command when too long

### DIFF
--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -201,7 +201,7 @@ func verifyEndpointResponse(diagCfg diagnosis.Config, statusCode int, responseBo
 
 	scrubbedResponseBody := scrubber.ScrubLine(string(responseBody))
 	if !diagCfg.Verbose && len(scrubbedResponseBody) > 500 {
-		scrubbedResponseBody = fmt.Sprint(len(scrubbedResponseBody) > 500, scrubbedResponseBody[:500]+"...")
+		scrubbedResponseBody = scrubbedResponseBody[:500]+"..."
 		scrubbedResponseBody += "\nBody is too long to display. To display the whole body, please add \"--verbose\" or \"-v\" flag to the command."
 	}
 

--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -203,8 +203,8 @@ func verifyEndpointResponse(diagCfg diagnosis.Config, statusCode int, responseBo
 
 	scrubbedResponseBody := scrubber.ScrubLine(string(responseBody))
 	if !diagCfg.Verbose && len(scrubbedResponseBody) > limitSize {
-		scrubbedResponseBody = scrubbedResponseBody[:limitSize] + "..."
-		scrubbedResponseBody += fmt.Sprintf("\nResponse body is %v bytes long, truncated at %v\n", len(responseBody), limitSize)
+		scrubbedResponseBody = scrubbedResponseBody[:limitSize] + "...\n"
+		scrubbedResponseBody += fmt.Sprintf("Response body is %v bytes long, truncated at %v\n", len(responseBody), limitSize)
 		scrubbedResponseBody += "To display the whole body use the \"--verbose\" flag."
 	}
 

--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -201,8 +201,9 @@ func verifyEndpointResponse(diagCfg diagnosis.Config, statusCode int, responseBo
 
 	scrubbedResponseBody := scrubber.ScrubLine(string(responseBody))
 	if !diagCfg.Verbose && len(scrubbedResponseBody) > 500 {
-		scrubbedResponseBody = scrubbedResponseBody[:500]+"..."
-		scrubbedResponseBody += "\nBody is too long to display. To display the whole body, please add \"--verbose\" or \"-v\" flag to the command."
+		scrubbedResponseBody = scrubbedResponseBody[:500] + "..."
+		scrubbedResponseBody += fmt.Sprintf("\nResponse body is %v bytes long, truncated at 500", len(responseBody))
+		scrubbedResponseBody += "\nTo display the whole body, please add \"--verbose\" or \"-v\" flag to the command."
 	}
 
 	if statusCode >= 400 {

--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -204,8 +204,8 @@ func verifyEndpointResponse(diagCfg diagnosis.Config, statusCode int, responseBo
 	scrubbedResponseBody := scrubber.ScrubLine(string(responseBody))
 	if !diagCfg.Verbose && len(scrubbedResponseBody) > limitSize {
 		scrubbedResponseBody = scrubbedResponseBody[:limitSize] + "..."
-		scrubbedResponseBody += fmt.Sprintf("\nResponse body is %v bytes long, truncated at %v", len(responseBody), limitSize)
-		scrubbedResponseBody += "\nTo display the whole body, please add \"--verbose\" or \"-v\" flag to the command."
+		scrubbedResponseBody += fmt.Sprintf("\nResponse body is %v bytes long, truncated at %v\n", len(responseBody), limitSize)
+		scrubbedResponseBody += "To display the whole body use the \"--verbose\" flag."
 	}
 
 	if statusCode >= 400 {

--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -202,7 +202,7 @@ func verifyEndpointResponse(diagCfg diagnosis.Config, statusCode int, responseBo
 	scrubbedResponseBody := scrubber.ScrubLine(string(responseBody))
 	if !diagCfg.Verbose && len(scrubbedResponseBody) > 500 {
 		scrubbedResponseBody = fmt.Sprint(len(scrubbedResponseBody) > 500, scrubbedResponseBody[:500]+"...")
-		scrubbedResponseBody += "\nBody is too long to display. If you want to display the whole body, please add \"--verbose\" flag to the command."
+		scrubbedResponseBody += "\nBody is too long to display. To display the whole body, please add \"--verbose\" flag to the command."
 	}
 
 	if statusCode >= 400 {

--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -199,12 +199,12 @@ func verifyEndpointResponse(diagCfg diagnosis.Config, statusCode int, responseBo
 	var verifyReport string
 	var newErr error
 
-	fiveHundred := 500
+	limitSize := 500
 
 	scrubbedResponseBody := scrubber.ScrubLine(string(responseBody))
-	if !diagCfg.Verbose && len(scrubbedResponseBody) > fiveHundred {
-		scrubbedResponseBody = scrubbedResponseBody[:fiveHundred] + "..."
-		scrubbedResponseBody += fmt.Sprintf("\nResponse body is %v bytes long, truncated at %v", len(responseBody), fiveHundred)
+	if !diagCfg.Verbose && len(scrubbedResponseBody) > limitSize {
+		scrubbedResponseBody = scrubbedResponseBody[:limitSize] + "..."
+		scrubbedResponseBody += fmt.Sprintf("\nResponse body is %v bytes long, truncated at %v", len(responseBody), limitSize)
 		scrubbedResponseBody += "\nTo display the whole body, please add \"--verbose\" or \"-v\" flag to the command."
 	}
 

--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -202,7 +202,7 @@ func verifyEndpointResponse(diagCfg diagnosis.Config, statusCode int, responseBo
 	scrubbedResponseBody := scrubber.ScrubLine(string(responseBody))
 	if !diagCfg.Verbose && len(scrubbedResponseBody) > 500 {
 		scrubbedResponseBody = fmt.Sprint(len(scrubbedResponseBody) > 500, scrubbedResponseBody[:500]+"...")
-		scrubbedResponseBody += "\nBody is too long to display. To display the whole body, please add \"--verbose\" flag to the command."
+		scrubbedResponseBody += "\nBody is too long to display. To display the whole body, please add \"--verbose\" or \"-v\" flag to the command."
 	}
 
 	if statusCode >= 400 {

--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -164,7 +164,7 @@ func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain 
 	// Add tracing and send the request
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("DD-API-KEY", apiKey+"cc")
+	req.Header.Set("DD-API-KEY", apiKey)
 
 	resp, err := client.Do(req)
 

--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -164,7 +164,7 @@ func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain 
 	// Add tracing and send the request
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("DD-API-KEY", apiKey)
+	req.Header.Set("DD-API-KEY", apiKey+"cc")
 
 	resp, err := client.Do(req)
 
@@ -199,10 +199,12 @@ func verifyEndpointResponse(diagCfg diagnosis.Config, statusCode int, responseBo
 	var verifyReport string
 	var newErr error
 
+	fiveHundred := 500
+
 	scrubbedResponseBody := scrubber.ScrubLine(string(responseBody))
-	if !diagCfg.Verbose && len(scrubbedResponseBody) > 500 {
-		scrubbedResponseBody = scrubbedResponseBody[:500] + "..."
-		scrubbedResponseBody += fmt.Sprintf("\nResponse body is %v bytes long, truncated at 500", len(responseBody))
+	if !diagCfg.Verbose && len(scrubbedResponseBody) > fiveHundred {
+		scrubbedResponseBody = scrubbedResponseBody[:fiveHundred] + "..."
+		scrubbedResponseBody += fmt.Sprintf("\nResponse body is %v bytes long, truncated at %v", len(responseBody), fiveHundred)
 		scrubbedResponseBody += "\nTo display the whole body, please add \"--verbose\" or \"-v\" flag to the command."
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Truncate output body of diagnose command when too long

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

https://datadoghq.atlassian.net/browse/ASCII-325 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Put a wrong API key
run `datadog-agent diagnose` you should see a truncated html body with this message: `Body is too long to display. To display the whole body, please add "--verbose" or "-v" flag to the command.`
Then
run `datadog-agent diagnose -v` you should see a full html body
