### PR TITLE
omnibus cache: only enable for agent builds

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -30,6 +30,11 @@ else
   COMPRESSION_LEVEL = 5
 end
 
+if ENV.has_key?("OMNIBUS_GIT_CACHE_DIR")
+  Omnibus::Config.use_git_caching true
+  Omnibus::Config.git_cache_dir ENV["OMNIBUS_GIT_CACHE_DIR"]
+end
+
 BUILD_OCIRU = Omnibus::Config.host_distribution == "ociru"
 
 if windows_target?

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -38,9 +38,5 @@ if ENV["S3_OMNIBUS_CACHE_BUCKET"]
   end
 end
 
-if not ENV.has_key?("OMNIBUS_GIT_CACHE_DIR")
-  use_git_caching false
-else
-  use_git_caching true
-  git_cache_dir ENV["OMNIBUS_GIT_CACHE_DIR"]
-end
+use_git_caching false
+

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -38,5 +38,6 @@ if ENV["S3_OMNIBUS_CACHE_BUCKET"]
   end
 end
 
+# This setting can be overriden per-project (which is the case for the agent builds)
 use_git_caching false
 

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -105,6 +105,7 @@ def _get_environment_for_cache() -> dict:
             "HOME",
             "HOSTNAME",
             "HOST_IP",
+            "INFOPATH",
             "INSTALL_SCRIPT_API_KEY_SSM_NAME",
             "INTEGRATION_WHEELS_CACHE_BUCKET",
             "IRBRC",

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -200,6 +200,7 @@ def omnibus_compute_cache_key(ctx):
     for k, v in environment.items():
         print(f'\tUsing environment variable {k} to compute cache key')
         h.update(str.encode(f'{k}={v}'))
+        print(f'Current hash value: {h.hexdigest()}')
     cache_key = h.hexdigest()
     print(f'Cache key: {cache_key}')
     return cache_key

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -231,7 +231,7 @@ def build(
         bundle_install_omnibus(ctx, gem_path, env)
 
     omnibus_cache_dir = os.environ.get('OMNIBUS_GIT_CACHE_DIR')
-    use_omnibus_git_cache = omnibus_cache_dir is not None
+    use_omnibus_git_cache = omnibus_cache_dir is not None and target_project == "agent"
     if use_omnibus_git_cache:
         # The cache will be written in the provided cache dir (see omnibus.rb) but
         # the git repository itself will be located in a subfolder that replicates


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR disables omnibus cache for any other build than the agent.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The cache doesn't improve the build times for those jobs since they do not build 3rd party dependencies.
However we still upload a cache for every build, which serves no purpose but still bears a storage cost.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

This PR also sprinkles a bit of additional debug and adds an ignored environment variable when computing the cache key.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
