### PR TITLE
Bump viper version from `1.13.0` to `1.13.1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.14.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.14.0
 	github.com/DataDog/sketches-go v1.4.4
-	github.com/DataDog/viper v1.13.0
+	github.com/DataDog/viper v1.13.1
 	github.com/DataDog/watermarkpodautoscaler v0.6.1
 	github.com/DataDog/zstd v1.5.5
 	github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f // indirect

--- a/go.sum
+++ b/go.sum
@@ -716,8 +716,8 @@ github.com/DataDog/sketches-go v1.4.4 h1:dF52vzXRFSPOj2IjXSWLvXq3jubL4CI69kwYjJ1
 github.com/DataDog/sketches-go v1.4.4/go.mod h1:XR0ns2RtEEF09mDKXiKZiQg+nfZStrq1ZuL1eezeZe0=
 github.com/DataDog/trivy v0.0.0-20240327150525-a3045a95060a h1:Ps5dXg7Cq0rGj+60EIGi4dEvFNhpWa/Dx/6QeveuMAI=
 github.com/DataDog/trivy v0.0.0-20240327150525-a3045a95060a/go.mod h1:xmc7xCb5KSg2mFbztyInH8ciotVbad9SOmGFClgD0cU=
-github.com/DataDog/viper v1.13.0 h1:XE5cJiXeXkyijwgspwZiH6iroWYLgAPXTOhcBnDBOMs=
-github.com/DataDog/viper v1.13.0/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
+github.com/DataDog/viper v1.13.1 h1:54lvepVPd96zMUJLsD3T2OV7usNh+Nsu9vjbeZBAp2s=
+github.com/DataDog/viper v1.13.1/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
 github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950 h1:2imDajw3V85w1iqHsuXN+hUBZQVF+r9eME8tsPq/HpA=
 github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950/go.mod h1:FU+7qU8DeQQgSZDmmThMJi93kPkLFgy0oVAcLxurjIk=
 github.com/DataDog/watermarkpodautoscaler v0.6.1 h1:KEj10Cm8wO/36lEOgqjgDfIMMpMPReY/+bDacWe7Adw=

--- a/releasenotes/notes/bump-viper-version-to-1.13.1-daf1a3e5bb933264.yaml
+++ b/releasenotes/notes/bump-viper-version-to-1.13.1-daf1a3e5bb933264.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Bumping viper version from ``1.13.0`` to ``1.13.1`` fixes a bug in where using secrets in
+    ``network_devices.snmp_traps.community_strings`` would discard defaults values in ``network_devices.snmp_traps``.


### PR DESCRIPTION
### What does this PR do?

Bump viper version from `1.13.0` to `1.13.1`

### Describe how to test/QA your changes

Set secrets in `network_devices.snmp_traps.community_strings` and check that the value for `network_devices.snmp_traps` from the configuration are still getting used (like `enabled` or `port`).
