### PR TITLE
Use eventuallyWithT to try to fix flaky health e2e tests

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
@@ -42,10 +42,6 @@ func (v *linuxHealthSuite) TestDefaultInstallUnhealthy() {
 	// agent should be unhealthy because the key is invalid
 	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
 		_, err := v.Env().Agent.Client.Health()
-		if err == nil {
-			assert.Fail(t, "agent expected to be unhealthy, but no error found!")
-			return
-		}
-		assert.Contains(t, err.Error(), "Agent health: FAIL")
+		assert.ErrorContains(t, err, "Agent health: FAIL")
 	}, 1*time.Minute, 10*time.Second)
 }

--- a/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
@@ -7,6 +7,7 @@ package health
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -39,10 +40,12 @@ func (v *linuxHealthSuite) TestDefaultInstallUnhealthy() {
 	))
 
 	// agent should be unhealthy because the key is invalid
-	_, err := v.Env().Agent.Client.Health()
-	if err == nil {
-		assert.Fail(v.T(), "agent expected to be unhealthy, but no error found!")
-		return
-	}
-	assert.Contains(v.T(), err.Error(), "Agent health: FAIL")
+	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
+		_, err := v.Env().Agent.Client.Health()
+		if err == nil {
+			assert.Fail(t, "agent expected to be unhealthy, but no error found!")
+			return
+		}
+		assert.Contains(t, err.Error(), "Agent health: FAIL")
+	}, 1*time.Minute, 10*time.Second)
 }

--- a/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
@@ -7,6 +7,7 @@ package health
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -39,10 +40,9 @@ func (v *windowsHealthSuite) TestDefaultInstallUnhealthy() {
 		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\n"))))
 
 	// agent should be unhealthy because the key is invalid
-	_, err := v.Env().Agent.Client.Health()
-	if err == nil {
-		assert.Fail(v.T(), "agent expected to be unhealthy, but no error found!")
-		return
-	}
-	assert.Contains(v.T(), err.Error(), "Agent health: FAIL")
+
+	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
+		_, err := v.Env().Agent.Client.Health()
+		assert.ErrorContains(t, err, "Agent health: FAIL")
+	}, 1*time.Minute, 10*time.Second)
 }


### PR DESCRIPTION

### What does this PR do?

Fix flaky tests

### Motivation

Test is flaky so we should wait a bit to make sure the forwarder has time to do request and set himself as unhealthy

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
