### PR TITLE
fix(ci): Remove unsupported extension for releasenote-check

### DIFF
--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt -r tasks/requirements.txt
       - name: Remove unsupported git config
-        # Triggers dulwich.repo.UnsupportedExtension: b'worktreeConfig' 
+        # Triggers dulwich.repo.UnsupportedExtension: b'worktreeConfig' see https://github.com/GitTools/actions/issues/1115 
         run: git config --unset-all extensions.worktreeconfig
       - name: Check release note
         env:

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -46,6 +46,9 @@ jobs:
           cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
         run: pip install -r requirements.txt -r tasks/requirements.txt
+      - name: Remove unsupported git config
+        # Triggers dulwich.repo.UnsupportedExtension: b'worktreeConfig' 
+        run: git config --unset-all extensions.worktreeconfig
       - name: Check release note
         env:
           BRANCH_NAME: ${{ github.head_ref }}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Remove an unsupported extension from git config

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The releasenote check recently started to [fail](https://github.com/DataDog/datadog-agent/actions/runs/8787442267/job/24112650113)
[Validated](https://github.com/DataDog/datadog-agent/actions/runs/8790023858/job/24121115082?pr=24934) on the [failing PR](https://github.com/DataDog/datadog-agent/pull/24927) by addition of the last commit [here](https://github.com/DataDog/datadog-agent/pull/24934/commits)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
[Reported upstream ](https://github.com/GitTools/actions/issues/1115#issuecomment-2070736857)as well

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
