### PR TITLE
[PROCS-3945] Add processchecks subcommand to core agent

### DIFF
--- a/cmd/agent/subcommands/processchecks/command.go
+++ b/cmd/agent/subcommands/processchecks/command.go
@@ -18,14 +18,14 @@ import (
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	processCommand.OneShotLogParams = logimpl.ForOneShot(string(command.LoggerName), "info", true)
-	short := "Run a specific check and print the results. Choose from: process, rtprocess, container, rtcontainer, process_discovery"
+	checkAllowlist := []string{"process", "rtprocess", "container", "rtcontainer", "process_discovery"}
 	cmd := check.MakeCommand(
 		&processCommand.GlobalParams{
 			ConfFilePath:         globalParams.ConfFilePath,
 			SysProbeConfFilePath: globalParams.SysProbeConfFilePath,
 		},
 		"processchecks",
-		short,
+		checkAllowlist,
 	)
 	return []*cobra.Command{cmd}
 }

--- a/cmd/agent/subcommands/processchecks/command.go
+++ b/cmd/agent/subcommands/processchecks/command.go
@@ -18,12 +18,14 @@ import (
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	processCommand.OneShotLogParams = logimpl.ForOneShot(string(command.LoggerName), "info", true)
+	short := "Run a specific check and print the results. Choose from: process, rtprocess, container, rtcontainer, process_discovery"
 	cmd := check.MakeCommand(
 		&processCommand.GlobalParams{
 			ConfFilePath:         globalParams.ConfFilePath,
 			SysProbeConfFilePath: globalParams.SysProbeConfFilePath,
 		},
 		"processchecks",
+		short,
 	)
 	return []*cobra.Command{cmd}
 }

--- a/cmd/agent/subcommands/processchecks/command.go
+++ b/cmd/agent/subcommands/processchecks/command.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package check implements 'agent processchecks'.
+// Package processchecks implements 'agent processchecks'.
 package processchecks
 
 import (

--- a/cmd/agent/subcommands/processchecks/command.go
+++ b/cmd/agent/subcommands/processchecks/command.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package check implements 'agent processchecks'.
+package processchecks
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	processCommand "github.com/DataDog/datadog-agent/cmd/process-agent/command"
+	app "github.com/DataDog/datadog-agent/cmd/process-agent/subcommands/check"
+)
+
+// Commands returns a slice of subcommands for the 'agent' command.
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cmd := app.MakeCommand(
+		&processCommand.GlobalParams{
+			ConfFilePath:         globalParams.ConfFilePath,
+			SysProbeConfFilePath: globalParams.SysProbeConfFilePath,
+		},
+		"processchecks",
+	)
+	return []*cobra.Command{cmd}
+}

--- a/cmd/agent/subcommands/processchecks/command.go
+++ b/cmd/agent/subcommands/processchecks/command.go
@@ -11,12 +11,14 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	processCommand "github.com/DataDog/datadog-agent/cmd/process-agent/command"
-	app "github.com/DataDog/datadog-agent/cmd/process-agent/subcommands/check"
+	"github.com/DataDog/datadog-agent/cmd/process-agent/subcommands/check"
+	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 )
 
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	cmd := app.MakeCommand(
+	processCommand.OneShotLogParams = logimpl.ForOneShot(string(command.LoggerName), "info", true)
+	cmd := check.MakeCommand(
 		&processCommand.GlobalParams{
 			ConfFilePath:         globalParams.ConfFilePath,
 			SysProbeConfFilePath: globalParams.SysProbeConfFilePath,

--- a/cmd/agent/subcommands/processchecks/command_test.go
+++ b/cmd/agent/subcommands/processchecks/command_test.go
@@ -3,19 +3,20 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package check
+package processchecks
 
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/cmd/process-agent/subcommands/check"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func TestRunCheckCmdCommand(t *testing.T) {
+func TestCommand(t *testing.T) {
 	fxutil.TestOneShotSubcommand(t,
 		Commands(&command.GlobalParams{}),
-		[]string{"check", "process"},
-		runCheckCmd,
+		[]string{"processchecks", "process"},
+		check.RunCheckCmd,
 		func() {})
 }

--- a/cmd/agent/subcommands/processchecks/command_test.go
+++ b/cmd/agent/subcommands/processchecks/command_test.go
@@ -18,5 +18,6 @@ func TestCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"processchecks", "process"},
 		check.RunCheckCmd,
-		func() {})
+		func(CliParams *check.CliParams) {},
+	)
 }

--- a/cmd/agent/subcommands/subcommands.go
+++ b/cmd/agent/subcommands/subcommands.go
@@ -24,6 +24,7 @@ import (
 	cmdintegrations "github.com/DataDog/datadog-agent/cmd/agent/subcommands/integrations"
 	cmdjmx "github.com/DataDog/datadog-agent/cmd/agent/subcommands/jmx"
 	cmdlaunchgui "github.com/DataDog/datadog-agent/cmd/agent/subcommands/launchgui"
+	cmdprocesschecks "github.com/DataDog/datadog-agent/cmd/agent/subcommands/processchecks"
 	cmdremoteconfig "github.com/DataDog/datadog-agent/cmd/agent/subcommands/remoteconfig"
 	cmdrun "github.com/DataDog/datadog-agent/cmd/agent/subcommands/run"
 	cmdsecret "github.com/DataDog/datadog-agent/cmd/agent/subcommands/secret"
@@ -70,5 +71,6 @@ func AgentSubcommands() []command.SubcommandFactory {
 		cmdintegrations.Commands,
 		cmdstop.Commands,
 		cmdcontrolsvc.Commands,
+		cmdprocesschecks.Commands,
 	}
 }

--- a/cmd/process-agent/command/command.go
+++ b/cmd/process-agent/command/command.go
@@ -149,6 +149,6 @@ func GetCoreBundleParamsForOneShot(globalParams *GlobalParams) core.BundleParams
 		ConfigParams:         configComponent.NewAgentParams(globalParams.ConfFilePath),
 		SecretParams:         secrets.NewEnabledParams(),
 		SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
-		LogParams:            logComponentimpl.ForOneShot(string(LoggerName), "info", true),
+		LogParams:            OneShotLogParams,
 	}
 }

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 //nolint:revive // TODO(PROC) Fix revive linter
-package app
+package check
 
 import (
 	"encoding/json"
@@ -96,7 +96,7 @@ func MakeCommand(globalParams *command.GlobalParams, name string) *cobra.Command
 				bundleParams.LogParams = logimpl.ForOneShot(string(command.LoggerName), "off", true)
 			}
 
-			return fxutil.OneShot(runCheckCmd,
+			return fxutil.OneShot(RunCheckCmd,
 				fx.Supply(cliParams, bundleParams),
 				core.Bundle(),
 				// Provide workloadmeta module
@@ -136,7 +136,7 @@ func MakeCommand(globalParams *command.GlobalParams, name string) *cobra.Command
 	return checkCmd
 }
 
-func runCheckCmd(deps dependencies) error {
+func RunCheckCmd(deps dependencies) error {
 	command.SetHostMountEnv(deps.Log)
 
 	// Now that the logger is configured log host info

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -73,21 +74,26 @@ func nextGroupID() func() int32 {
 
 // Commands returns a slice of subcommands for the `check` command in the Process Agent
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	return []*cobra.Command{MakeCommand(globalParams, "check")}
+	desc := "Run a specific check and print the results. Choose from: process, rtprocess, container, rtcontainer, connections, process_discovery, process_events"
+	return []*cobra.Command{MakeCommand(globalParams, "check", desc)}
 }
 
-func MakeCommand(globalParams *command.GlobalParams, name string) *cobra.Command {
+func MakeCommand(globalParams *command.GlobalParams, name string, short string) *cobra.Command {
 	cliParams := &cliParams{
 		GlobalParams: globalParams,
 	}
 
 	checkCmd := &cobra.Command{
 		Use:   name,
-		Short: "Run a specific check and print the results. Choose from: process, rtprocess, container, rtcontainer, connections, process_discovery, process_events",
+		Short: short,
 
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.checkName = args[0]
+
+			if !strings.Contains(short, cliParams.checkName) {
+				return fmt.Errorf("invalid check '%s'", cliParams.checkName)
+			}
 
 			bundleParams := command.GetCoreBundleParamsForOneShot(globalParams)
 

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -73,12 +73,16 @@ func nextGroupID() func() int32 {
 
 // Commands returns a slice of subcommands for the `check` command in the Process Agent
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	return []*cobra.Command{MakeCommand(globalParams, "check")}
+}
+
+func MakeCommand(globalParams *command.GlobalParams, name string) *cobra.Command {
 	cliParams := &cliParams{
 		GlobalParams: globalParams,
 	}
 
 	checkCmd := &cobra.Command{
-		Use:   "check",
+		Use:   name,
 		Short: "Run a specific check and print the results. Choose from: process, rtprocess, container, rtcontainer, connections, process_discovery, process_events",
 
 		Args: cobra.ExactArgs(1),
@@ -129,7 +133,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	checkCmd.Flags().BoolVar(&cliParams.checkOutputJSON, "json", false, "Output check results in JSON")
 	checkCmd.Flags().DurationVarP(&cliParams.waitInterval, "wait", "w", defaultWaitInterval, "How long to wait before running the check")
 
-	return []*cobra.Command{checkCmd}
+	return checkCmd
 }
 
 func runCheckCmd(deps dependencies) error {

--- a/cmd/process-agent/subcommands/check/check_test.go
+++ b/cmd/process-agent/subcommands/check/check_test.go
@@ -17,5 +17,6 @@ func TestRunCheckCmdCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"check", "process"},
 		RunCheckCmd,
-		func() {})
+		func(CliParams *CliParams) {},
+	)
 }

--- a/cmd/process-agent/subcommands/check/check_test.go
+++ b/cmd/process-agent/subcommands/check/check_test.go
@@ -16,6 +16,6 @@ func TestRunCheckCmdCommand(t *testing.T) {
 	fxutil.TestOneShotSubcommand(t,
 		Commands(&command.GlobalParams{}),
 		[]string{"check", "process"},
-		runCheckCmd,
+		RunCheckCmd,
 		func() {})
 }

--- a/releasenotes/notes/process-checks-core-agent-subcommand-bb0228c89c58bee1.yaml
+++ b/releasenotes/notes/process-checks-core-agent-subcommand-bb0228c89c58bee1.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Allow certain Process Agent checks to be run from the core agent using the `processchecks` 
+    subcommand.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adds the `processchecks` subcommand to the core agent which can run all process-agent associated check command except for `connections` and `process_events`. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

PROCS-3945

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Run the `check` command on process agent and validate there are results
```
process-agent check process
```
2. Run the `processchecks` command on the core agent and validate there are results
```
datadog-agent processchecks process
```
