### PR TITLE
[CWS][hackaton] Publishing the POC of container profiler

### DIFF
--- a/cmd/profiler/command/command.go
+++ b/cmd/profiler/command/command.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package command holds the main command factory for CWS profiler
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// SubcommandFactory is a callable that will return a slice of subcommands.
+type SubcommandFactory func() []*cobra.Command
+
+// MakeCommand makes the top-level Cobra command for this app.
+func MakeCommand(subcommandFactories []SubcommandFactory) *cobra.Command {
+	// cwsProfilerCmd is the root command
+	cwsProfilerCmd := &cobra.Command{
+		Use:   fmt.Sprintf("%s [command]", os.Args[0]),
+		Short: "Datadog Agent CWS workload profiler",
+		Long: `
+The Datadog Agent CWS workload profiler is used to learn a workload by listening from cws-instrumenatation ptracer; then it saves it as security profile.`,
+		SilenceUsage: true,
+	}
+
+	for _, sf := range subcommandFactories {
+		subcommands := sf()
+		for _, cmd := range subcommands {
+			cwsProfilerCmd.AddCommand(cmd)
+		}
+	}
+
+	return cwsProfilerCmd
+}

--- a/cmd/profiler/example/Dockerfile
+++ b/cmd/profiler/example/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+
+COPY init.sh /init.sh
+
+# REPLACE:
+# CMD /init.sh
+# BY:
+
+COPY cws-instrumentation /cws-instrumentation
+CMD /cws-instrumentation trace -- /init.sh

--- a/cmd/profiler/example/Makefile
+++ b/cmd/profiler/example/Makefile
@@ -1,0 +1,6 @@
+all:
+	cp ../../../bin/cws-instrumentation/cws-instrumentation .
+	docker build -t spi/myapp --platform linux/amd64 . -f Dockerfile
+
+run:
+	docker run --network=host --privileged spi/myapp

--- a/cmd/profiler/example/init.sh
+++ b/cmd/profiler/example/init.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/dash
+
+/usr/bin/cat /etc/hostname
+
+/usr/bin/ls -l /
+
+/usr/bin/sleep 3

--- a/cmd/profiler/main.go
+++ b/cmd/profiler/main.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package main is the main package of CWS profiler
+package main
+
+import (
+	"os"
+
+	"github.com/DataDog/datadog-agent/cmd/profiler/command"
+	"github.com/DataDog/datadog-agent/cmd/profiler/subcommands"
+
+	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
+)
+
+func main() {
+	rootCmd := command.MakeCommand(subcommands.CWSProfilerSubcommands())
+	os.Exit(runcmd.Run(rootCmd))
+}

--- a/cmd/profiler/subcommands/startcmd/grpc.go
+++ b/cmd/profiler/subcommands/startcmd/grpc.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package startcmd holds the start command of CWS injector
+package startcmd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	activitytree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+)
+
+// SendSyscallMsg handles gRPC messages
+func (p *ProfilerContext) SendSyscallMsg(_ context.Context, syscallMsg *ebpfless.SyscallMsg) (*ebpfless.Response, error) {
+	event := model.NewDefaultEvent() // field handlers not set
+
+	switch syscallMsg.Type {
+	case ebpfless.SyscallType_Exec:
+		entry := p.processResolver.AddExecEntry(syscallMsg.PID, syscallMsg.Exec.Filename, syscallMsg.Exec.Args, syscallMsg.Exec.Envs, syscallMsg.ContainerContext.ID)
+		event.Type = uint32(model.ExecEventType)
+		event.Exec.Process = &entry.Process
+		// DEBUG
+		fmt.Printf("EXEC: %v %v %v %v\n", syscallMsg.PID, syscallMsg.Exec.Filename, syscallMsg.Exec.Args, syscallMsg.ContainerContext.ID)
+		ancestor := entry.ProcessContext.Ancestor
+		for ancestor != nil {
+			fmt.Printf("  - from: %v %v %v\n", ancestor.Pid, ancestor.FileEvent.PathnameStr, ancestor.Argv)
+			ancestor = ancestor.ProcessContext.Ancestor
+		}
+	case ebpfless.SyscallType_Fork:
+		fmt.Printf("FORK: %v -> %v\n", syscallMsg.Fork.PPID, syscallMsg.PID)
+		p.processResolver.AddForkEntry(syscallMsg.PID, syscallMsg.Fork.PPID)
+		event.Type = uint32(model.ForkEventType)
+	case ebpfless.SyscallType_Open:
+		fmt.Printf("OPEN: %v\n", syscallMsg.Open.Filename)
+		event.Type = uint32(model.FileOpenEventType)
+		event.Open.File.PathnameStr = syscallMsg.Open.Filename
+		event.Open.File.BasenameStr = filepath.Base(syscallMsg.Open.Filename)
+		event.Open.Flags = syscallMsg.Open.Flags
+		event.Open.Mode = syscallMsg.Open.Mode
+	default:
+		return &ebpfless.Response{}, nil
+	}
+
+	// container context
+	event.ContainerContext.ID = syscallMsg.ContainerContext.ID
+	event.ContainerContext.CreatedAt = syscallMsg.ContainerContext.CreatedAt
+	imageName := syscallMsg.ContainerContext.Name
+	if imageName == "" {
+		imageName = "host"
+	}
+	imageTag := syscallMsg.ContainerContext.Tag
+	if imageTag == "" {
+		imageTag = "latest"
+	}
+	event.ContainerContext.Tags = []string{
+		"image_name:" + imageName,
+		"image_tag:" + imageTag,
+	}
+
+	// use ProcessCacheEntry process context as process context
+	event.ProcessCacheEntry = p.processResolver.Resolve(syscallMsg.PID)
+	if event.ProcessCacheEntry == nil {
+		event.ProcessCacheEntry = model.NewPlaceholderProcessCacheEntry(syscallMsg.PID, syscallMsg.PID, false)
+	}
+	event.ProcessContext = &event.ProcessCacheEntry.ProcessContext
+
+	_, err := p.dump.ActivityTree.Insert(event, true /*insertMissingProcesses*/, activitytree.Runtime, nil /*resolvers*/)
+	if err != nil {
+		fmt.Printf("dump insertion failed: %v\n", err)
+	}
+	return &ebpfless.Response{}, nil
+}

--- a/cmd/profiler/subcommands/startcmd/start.go
+++ b/cmd/profiler/subcommands/startcmd/start.go
@@ -1,0 +1,153 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package startcmd holds the start command of CWS injector
+package startcmd
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	activitytree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
+	"github.com/DataDog/datadog-agent/pkg/security/tests/statsdclient"
+)
+
+const (
+	gRPCAddr          = "grpc-addr"
+	gRPCAddrDefault   = "localhost:5678"
+	outputfile        = "output-file"
+	outputfileDefault = "my-workload"
+)
+
+type profileCliParams struct {
+	GRPCAddr   string
+	OutputFile string
+}
+
+// Command returns the commands for the profile subcommand
+func Command() []*cobra.Command {
+	var params profileCliParams
+
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "start learning a workload from the ptracer and generate a profile when finished",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return Start(args, params.GRPCAddr, params.OutputFile)
+		},
+	}
+
+	startCmd.Flags().StringVar(&params.GRPCAddr, gRPCAddr, gRPCAddrDefault, "ptracer GRPC addr")
+	startCmd.Flags().StringVar(&params.OutputFile, outputfile, outputfileDefault, "enable verbose output")
+
+	return []*cobra.Command{startCmd}
+}
+
+type ProfilerContext struct {
+	ebpfless.UnimplementedSyscallMsgStreamServer
+	server          *grpc.Server
+	seqNum          uint64
+	processResolver *process.EBPFLessResolver
+	dump            *dump.ActivityDump
+}
+
+func Start(args []string, gRPCAddr string, outputFile string) error {
+	fmt.Printf("Starting to learn a new workload\n")
+
+	// init sig handler for ^-C
+	done := make(chan bool, 1)
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		done <- true
+	}()
+
+	// init process resolver
+	processResolver, err := process.NewEBPFLessResolver(nil /*config*/, statsdclient.NewStatsdClient(), nil /*scrubber*/, &process.ResolverOpts{})
+	if err != nil {
+		return err
+	}
+
+	// init activity tree
+	dump := dump.NewEmptyActivityDump(activitytree.NewPathsReducer())
+	dump.LoadConfig = &model.ActivityDumpLoadConfig{
+		TracedEventTypes: []model.EventType{
+			model.ExecEventType,
+			model.FileOpenEventType,
+		},
+	}
+
+	// init and launch server
+	lis, err := net.Listen("tcp", gRPCAddr)
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	var grpcOpts []grpc.ServerOption
+	ctx := &ProfilerContext{
+		server:          grpc.NewServer(grpcOpts...),
+		processResolver: processResolver,
+		dump:            dump,
+	}
+	ebpfless.RegisterSyscallMsgStreamServer(ctx.server, ctx)
+
+	go ctx.server.Serve(lis)
+
+	<-done
+
+	if len(dump.ActivityTree.ProcessNodes) == 0 {
+		fmt.Printf("\nThe profile is empty, exiting.\n")
+		return nil
+	}
+
+	fmt.Printf("\nEncoding the dump to profile\n")
+	buf, err := dump.Encode(config.Profile)
+	if err != nil {
+		return err
+	}
+	file, err := os.Create(outputFile + ".profile")
+	if err != nil {
+		return fmt.Errorf("couldn't persist to file: %w", err)
+	}
+	defer file.Close()
+	if _, err = file.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("couldn't write to file: %w", err)
+	}
+
+	fmt.Printf("Encoding the dump to dot\n")
+	buf, err = dump.Encode(config.Dot)
+	if err != nil {
+		return err
+	}
+	file, err = os.Create(outputFile + ".dot")
+	if err != nil {
+		return fmt.Errorf("couldn't persist to file: %w", err)
+	}
+	defer file.Close()
+	if _, err = file.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("couldn't write to file: %w", err)
+	}
+
+	cmd := exec.Command("sh", "-c", "dot -Tsvg "+outputFile+".dot > "+outputFile+".svg")
+	_, err = cmd.Output()
+	if err != nil {
+		fmt.Println("could not run command: ", err)
+	}
+	return nil
+}

--- a/cmd/profiler/subcommands/subcommands.go
+++ b/cmd/profiler/subcommands/subcommands.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package subcommands is used to list the subcommands of CWS profiler
+package subcommands
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/profiler/command"
+	"github.com/DataDog/datadog-agent/cmd/profiler/subcommands/startcmd"
+)
+
+// CWSProfilerSubcommands returns SubcommandFactories for the subcommands supported
+// with the current build flags.
+func CWSProfilerSubcommands() []command.SubcommandFactory {
+	return []command.SubcommandFactory{
+		startcmd.Command,
+	}
+}

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -560,5 +560,12 @@ func StartCWSPtracer(args []string, grpcAddr string, verbose bool) error {
 
 	<-traceChan
 
-	return tracer.Trace(cb)
+	if err := tracer.Trace(cb); err != nil {
+		return err
+	}
+
+	// let a few queued message being send
+	time.Sleep(time.Second)
+
+	return nil
 }

--- a/pkg/security/ptracer/ptracer.go
+++ b/pkg/security/ptracer/ptracer.go
@@ -201,11 +201,8 @@ func (t *Tracer) Trace(cb func(cbType CallbackType, nr int, pid int, ppid int, r
 			if signal := waitStatus.StopSignal(); signal != syscall.SIGTRAP {
 				if signal < Nsig {
 					_ = syscall.PtraceCont(pid, int(signal))
-
-				} else {
-					_ = syscall.PtraceCont(pid, 0)
+					continue
 				}
-				continue
 			}
 
 			if err := syscall.PtraceGetRegs(pid, &regs); err != nil {

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -372,9 +372,10 @@ func GetNextAncestorBinaryOrArgv0(entry *model.ProcessContext) *model.ProcessCac
 	current := entry
 	ancestor := entry.Ancestor
 	for ancestor != nil {
-		if ancestor.FileEvent.Inode == 0 {
-			return nil
-		}
+		// HACK: we did not retrieve inodes yet
+		// if ancestor.FileEvent.Inode == 0 {
+		// 	return nil
+		// }
 		if current.FileEvent.PathnameStr != ancestor.FileEvent.PathnameStr {
 			return ancestor
 		}
@@ -437,14 +438,15 @@ func (at *ActivityTree) buildBranchAndLookupCookies(entry *model.ProcessCacheEnt
 		return nil, nil, nil
 	}
 
-	// make sure the branch has a valid root node
-	for i := len(branch) - 1; i >= 0; i-- {
-		if isValidRootNode(&branch[i].ProcessContext) {
-			return branch[:i+1], nil, nil
-		}
-	}
-
-	return branch, nil, ErrNotValidRootNode
+	// HACK: we don't have valid root node
+	// // make sure the branch has a valid root node
+	// for i := len(branch) - 1; i >= 0; i-- {
+	// 	if isValidRootNode(&branch[i].ProcessContext) {
+	// 		return branch[:i+1], nil, nil
+	// 	}
+	// }
+	// return branch, nil, ErrNotValidRootNode
+	return branch, nil, nil
 }
 
 // CreateProcessNode looks up or inserts the provided entry in the tree
@@ -453,13 +455,14 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, genera
 		return nil, false, nil
 	}
 
-	if _, err := entry.HasValidLineage(); err != nil {
-		// check if the node belongs to the container
-		var mn *model.ErrProcessMissingParentNode
-		if !errors.As(err, &mn) {
-			return nil, false, ErrBrokenLineage
-		}
-	}
+	// HACK: disable because with ptracer we'll won't have pid 1 lineage
+	// if _, err := entry.HasValidLineage(); err != nil {
+	// 	// check if the node belongs to the container
+	// 	var mn *model.ErrProcessMissingParentNode
+	// 	if !errors.As(err, &mn) {
+	// 		return nil, false, ErrBrokenLineage
+	// 	}
+	// }
 
 	// Check if entry or one of its parents cookies are in CookieToProcessNode while building the branch we're trying to
 	// insert.

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -24,6 +24,7 @@ from . import (
     package,
     pipeline,
     process_agent,
+    profiler,
     release,
     rtloader,
     security_agent,
@@ -145,6 +146,7 @@ ns.add_collection(system_probe)
 ns.add_collection(process_agent)
 ns.add_collection(security_agent)
 ns.add_collection(cws_instrumentation)
+ns.add_collection(profiler)
 ns.add_collection(vscode)
 ns.add_collection(new_e2e_tests)
 ns.add_collection(kmt)

--- a/tasks/profiler.py
+++ b/tasks/profiler.py
@@ -1,0 +1,73 @@
+import datetime
+import glob
+import os
+import platform
+import shutil
+
+from invoke import task
+from invoke.exceptions import Exit
+
+from .build_tags import get_default_build_tags
+from .system_probe import CURRENT_ARCH
+from .utils import (
+    REPO_PATH,
+    bin_name,
+    get_build_flags,
+    get_git_branch_name,
+    get_git_commit,
+    get_go_version,
+    get_version,
+)
+
+BIN_DIR = os.path.join(".", "bin")
+BIN_PATH = os.path.join(BIN_DIR, "profiler", bin_name("profiler"))
+CONTAINER_PLATFORM_MAPPING = {"aarch64": "arm64", "amd64": "amd64", "x86_64": "amd64"}
+
+
+@task(iterable=["build_tags"])
+def build(
+    ctx,
+    build_tags,
+    race=False,
+    incremental_build=True,
+    major_version='7',
+    # arch is never used here; we keep it to have a
+    # consistent CLI on the build task for all agents.
+    arch=CURRENT_ARCH,  # noqa: U100
+    go_mod="mod",
+    static=False,
+):
+    """
+    Build profiler
+    """
+    ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version, python_runtimes='3', static=static)
+
+    # TODO use pkg/version for this
+    main = "main."
+    ld_vars = {
+        "Version": get_version(ctx, major_version=major_version),
+        "GoVersion": get_go_version(),
+        "GitBranch": get_git_branch_name(),
+        "GitCommit": get_git_commit(),
+        "BuildDate": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+
+    ldflags += ' '.join([f"-X '{main + key}={value}'" for key, value in ld_vars.items()])
+    build_tags += get_default_build_tags(
+        build="profiler"
+    )  # TODO/FIXME: Arch not passed to preserve build tags. Should this be fixed?
+    build_tags.append("netgo")
+    build_tags.append("osusergo")
+
+    race_opt = "-race" if race else ""
+    build_type = "" if incremental_build else "-a"
+    go_build_tags = " ".join(build_tags)
+    agent_bin = BIN_PATH
+
+    cmd = (
+        f'go build -mod={go_mod} {race_opt} {build_type} -tags "{go_build_tags}" '
+        f'-o {agent_bin} -gcflags="{gcflags}" -ldflags="{ldflags} -s -w" {REPO_PATH}/cmd/profiler'
+    )
+
+    ctx.run(cmd, env=env)
+


### PR DESCRIPTION
### What does this PR do?

It adds a "profiler" tool, listening from ptracer GRPC intel to produce a security profile

### Motivation

* Try another approach to solve the "learning period" issue, where a customer won't be "protected" until a workload is learnt. Here, we can automatically learn a workload during a CI job, produce the related profile, and embed it directly into the docker image (which could be loaded by the datadog-agent directly, instead of trying to "learn" a new workload).
* Investigate the gap to build profiles out of the ebpfless implementation for fargate.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
