### PR TITLE
chore(tagger): remove liveness probe for Replay Tagger

### DIFF
--- a/comp/core/tagger/replay/tagger.go
+++ b/comp/core/tagger/replay/tagger.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
-	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	pbutils "github.com/DataDog/datadog-agent/pkg/util/proto"
@@ -29,7 +28,6 @@ type Tagger struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	health          *health.Handle
 	telemetryTicker *time.Ticker
 }
 
@@ -44,7 +42,6 @@ func NewTagger() *Tagger {
 // Start starts the connection to the replay tagger and starts watching for
 // events.
 func (t *Tagger) Start(ctx context.Context) error {
-	t.health = health.RegisterLiveness("tagger")
 	t.telemetryTicker = time.NewTicker(1 * time.Minute)
 
 	t.ctx, t.cancel = context.WithCancel(ctx)
@@ -57,10 +54,6 @@ func (t *Tagger) Stop() error {
 	t.cancel()
 
 	t.telemetryTicker.Stop()
-	err := t.health.Deregister()
-	if err != nil {
-		return err
-	}
 
 	log.Info("replay tagger stopped successfully")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Removed the Liveness probe from the Replay Tagger.

Relates to https://github.com/DataDog/datadog-agent/pull/8193

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The Replay Tagger is only used for debug/bench purposes. While it is not used normally by the Agent, it should not have a Liveness probe that could have an impact on Agent deployments in case of misconfiguration.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

`dogstatsd-capture` is not working correctly as of now so we are skipping QA. An issue has been opened (AMLII-1652).
