### PR TITLE
[CWS] ensure string literals are quoted like patterns

### DIFF
--- a/pkg/security/secl/compiler/ast/secl.go
+++ b/pkg/security/secl/compiler/ast/secl.go
@@ -56,7 +56,7 @@ func buildParser(obj interface{}, lexer lexer.Definition) *participle.Parser {
 	parser, err := participle.Build(obj,
 		participle.Lexer(lexer),
 		participle.Elide("Whitespace", "Comment"),
-		participle.Unquote("String"),
+		participle.Map(unquoteLiteral, "String"),
 		participle.Map(parseDuration, "Duration"),
 		participle.Map(unquotePattern, "Pattern", "Regexp"),
 	)
@@ -64,6 +64,13 @@ func buildParser(obj interface{}, lexer lexer.Definition) *participle.Parser {
 		panic(err)
 	}
 	return parser
+}
+
+func unquoteLiteral(t lexer.Token) (lexer.Token, error) {
+	unquoted := strings.TrimSpace(t.Value)
+	unquoted = unquoted[1 : len(unquoted)-1]
+	t.Value = unquoted
+	return t, nil
 }
 
 func unquotePattern(t lexer.Token) (lexer.Token, error) {

--- a/pkg/security/tests/file_windows_test.go
+++ b/pkg/security/tests/file_windows_test.go
@@ -25,7 +25,7 @@ func TestBasicFileTest(t *testing.T) {
 	//ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_create_file",
-		Expression: `create.file.name =~ "test.bad" && create.file.path =~ "\\Device\\*\\Temp\\**"`,
+		Expression: `create.file.name =~ "test.bad" && create.file.path =~ "\Device\*\Temp\**"`,
 	}
 	opts := testOpts{
 		enableFIM: true,

--- a/pkg/security/tests/registry_windows_test.go
+++ b/pkg/security/tests/registry_windows_test.go
@@ -30,11 +30,11 @@ import (
 func TestBasicRegistryTestPowershell(t *testing.T) {
 	openDef := &rules.RuleDefinition{
 		ID:         "test_open_rule",
-		Expression: `open.registry.key_path == "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"`,
+		Expression: `open.registry.key_path == "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run"`,
 	}
 	createDef := &rules.RuleDefinition{
 		ID:         "test_create_rule",
-		Expression: `create.registry.key_path == "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"`,
+		Expression: `create.registry.key_path == "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run"`,
 	}
 
 	opts := testOpts{
@@ -77,11 +77,11 @@ func TestBasicRegistryTestPowershell(t *testing.T) {
 func TestBasicRegistryTestRegExe(t *testing.T) {
 	openDef := &rules.RuleDefinition{
 		ID:         "test_open_rule",
-		Expression: `open.registry.key_path == "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"`,
+		Expression: `open.registry.key_path == "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run"`,
 	}
 	createDef := &rules.RuleDefinition{
 		ID:         "test_create_rule",
-		Expression: `create.registry.key_path == "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"`,
+		Expression: `create.registry.key_path == "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run"`,
 	}
 
 	opts := testOpts{
@@ -125,11 +125,11 @@ func TestBasicRegistryTestRegExe(t *testing.T) {
 func TestBasicRegistryTestAPI(t *testing.T) {
 	openDef := &rules.RuleDefinition{
 		ID:         "test_open_rule",
-		Expression: `open.registry.key_path == "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"`,
+		Expression: `open.registry.key_path == "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run"`,
 	}
 	createDef := &rules.RuleDefinition{
 		ID:         "test_create_rule",
-		Expression: `create.registry.key_path == "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"`,
+		Expression: `create.registry.key_path == "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run"`,
 	}
 
 	opts := testOpts{


### PR DESCRIPTION
### What does this PR do?

Currently non-pattern string literals are unquoted using `participle.Unquote` which actually tries to interpret `\` in the string. Patterns on the other hand are simply trimmed of `"`. This PR migrates everything to the pattern way of doing things. This is especially important for windows paths with `\`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
