### PR TITLE
logs/sds: in debug log level, output the std/enabled rules names.

### DIFF
--- a/pkg/logs/sds/scanner.go
+++ b/pkg/logs/sds/scanner.go
@@ -129,7 +129,10 @@ func (s *Scanner) reconfigureStandardRules(rawConfig []byte) error {
 	s.standardRules = standardRules
 	s.standardDefaults = unmarshaled.Defaults
 
-	log.Info("Reconfigured SDS standard rules.")
+	log.Info("Reconfigured", len(s.standardRules), "SDS standard rules.")
+	for _, rule := range s.standardRules {
+	    log.Debug("Std rule:", rule.Name)
+	}
 	return nil
 }
 
@@ -211,7 +214,10 @@ func (s *Scanner) reconfigureRules(rawConfig []byte) error {
 	s.rawConfig = rawConfig
 	s.configuredRules = config.Rules
 
-	log.Infof("Created an SDS scanner with %d enabled rules.", len(scanner.Rules))
+	log.Info("Created an SDS scanner with", len(scanner.Rules), "enabled rules")
+	for _, rule := range s.configuredRules {
+	    log.Debug("Configured rule:", rule.Name)
+	}
 	s.Scanner = scanner
 
 	return nil


### PR DESCRIPTION
APR-138

### What does this PR do?

In `debug` log level, output the standard rules and enabled rules names.

### Motivation

#24524 won't make it before the freeze of 7.54.0, this information would not be part of the flare.
Having it in the logs would make this information end up in a debug flare.

### Possible Drawbacks / Trade-offs

Slightly verbose output.

