### PR TITLE
[CWS] remove `fim_enabled` need on windows

### DIFF
--- a/cmd/system-probe/config/adjust_security.go
+++ b/cmd/system-probe/config/adjust_security.go
@@ -6,7 +6,6 @@
 package config
 
 import (
-	"runtime"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -31,11 +30,7 @@ func adjustSecurity(cfg config.Config) {
 
 	if cfg.GetBool(secNS("enabled")) {
 		// if runtime is enabled then we force fim
-
-		// except, temporarily, for Windows
-		if runtime.GOOS != "windows" {
-			cfg.Set(secNS("fim_enabled"), true, model.SourceAgentRuntime)
-		}
+		cfg.Set(secNS("fim_enabled"), true, model.SourceAgentRuntime)
 	} else {
 		// if runtime is disabled then we force disable activity dumps and security profiles
 		cfg.Set(secNS("activity_dump.enabled"), false, model.SourceAgentRuntime)


### PR DESCRIPTION
### What does this PR do?

Before 7.54 (while windows frim was in beta), we gated fim on a specific config flag `fim_enabled` to allow the process based rules to go GA with frim disabled.

Now that we are confident in windows frim we can move to the same way it's done on linux, i.e. `runtime_security_config.enabled` enables everything.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
