### PR TITLE
Sets gomaxprocs in core agent before components initialize

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -237,9 +237,6 @@ func run(log log.Component,
 		stopAgent(agentAPI)
 	}()
 
-	// prepare go runtime
-	ddruntime.SetMaxProcs()
-
 	// Setup a channel to catch OS signals
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
@@ -307,6 +304,15 @@ func run(log log.Component,
 
 func getSharedFxOption() fx.Option {
 	return fx.Options(
+		fx.Invoke(func(lc fx.Lifecycle) {
+			lc.Append(fx.Hook{
+				OnStart: func(_ context.Context) error {
+					// prepare go runtime
+					ddruntime.SetMaxProcs()
+					return nil
+				},
+			})
+		}),
 		fx.Supply(flare.NewParams(
 			path.GetDistPath(),
 			path.PyChecksPath,

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -139,7 +139,7 @@ func sendIterableSeries(serializer serializer.MetricSerializer, start time.Time,
 // for the DogStatsD workers and how many DogStatsD pipeline should be running.
 func GetDogStatsDWorkerAndPipelineCount() (int, int) {
 	work, pipe := getDogStatsDWorkerAndPipelineCount(agentruntime.NumVCPU())
-	log.Infof("Decided to run %d workers and %d pipelines", work, pipe)
+	log.Infof("Dogstatsd configured to run with %d workers and %d pipelines", work, pipe)
 	return work, pipe
 }
 

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -138,7 +138,9 @@ func sendIterableSeries(serializer serializer.MetricSerializer, start time.Time,
 // GetDogStatsDWorkerAndPipelineCount returns how many routines should be spawned
 // for the DogStatsD workers and how many DogStatsD pipeline should be running.
 func GetDogStatsDWorkerAndPipelineCount() (int, int) {
-	return getDogStatsDWorkerAndPipelineCount(agentruntime.NumVCPU())
+	work, pipe := getDogStatsDWorkerAndPipelineCount(agentruntime.NumVCPU())
+	log.Infof("Decided to run %d workers and %d pipelines", work, pipe)
+	return work, pipe
 }
 
 func getDogStatsDWorkerAndPipelineCount(vCPUs int) (int, int) {


### PR DESCRIPTION

### What does this PR do?
This reorders the core agent startup so that the custom logic we have for setting `GOMAXPROCS` will always finish before any other component initializes.

### Motivation
Components can and do (see dogstatsd) use the value of `GOMAXPROCS` to make decisions about how many of a certain component to run.

If the `GOMAXPROCS` env var is set using a millicore suffix as is supported by the Agent, this currently races against component initialization (and loses in practice).

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes
QA Done locally, confirmed that GOMAXPROCS is set correctly and core agent runs properly.
