### PR TITLE
[comp/core/tagger] Delete unused argument from List()

### DIFF
--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -26,7 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/settings"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/collectors"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -203,7 +202,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request, ac autodiscovery.Com
 
 //nolint:revive // TODO(CINT) Fix revive linter
 func getTaggerList(w http.ResponseWriter, r *http.Request) {
-	response := tagger.List(collectors.HighCardinality)
+	response := tagger.List()
 
 	jsonTags, err := json.Marshal(response)
 	if err != nil {

--- a/cmd/process-agent/api/tagger_list.go
+++ b/cmd/process-agent/api/tagger_list.go
@@ -10,13 +10,11 @@ import (
 	"net/http"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/collectors"
 )
 
 //nolint:revive // TODO(PROC) Fix revive linter
 func getTaggerList(deps APIServerDeps, w http.ResponseWriter, r *http.Request) {
-	cardinality := collectors.TagCardinality(tagger.ChecksCardinality)
-	response := tagger.List(cardinality)
+	response := tagger.List()
 
 	jsonTags, err := json.Marshal(response)
 	if err != nil {

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -38,7 +38,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/settings"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/collectors"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	dogstatsddebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
@@ -420,9 +419,7 @@ func getConfigCheck(w http.ResponseWriter, _ *http.Request, ac autodiscovery.Com
 }
 
 func getTaggerList(w http.ResponseWriter, _ *http.Request) {
-	// query at the highest cardinality between checks and dogstatsd cardinalities
-	cardinality := collectors.TagCardinality(max(int(tagger.ChecksCardinality), int(tagger.DogstatsdCardinality)))
-	response := tagger.List(cardinality)
+	response := tagger.List()
 
 	jsonTags, err := json.Marshal(response)
 	if err != nil {
@@ -573,14 +570,6 @@ func getDiagnose(w http.ResponseWriter, r *http.Request, diagnoseDeps diagnose.S
 	if err != nil {
 		setJSONError(w, log.Errorf("Unable to marshal config check response: %s", err), 500)
 	}
-}
-
-// max returns the maximum value between a and b.
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 // GetConnection returns the connection for the request

--- a/comp/core/tagger/component.go
+++ b/comp/core/tagger/component.go
@@ -25,7 +25,7 @@ type Component interface {
 	Tag(entity string, cardinality collectors.TagCardinality) ([]string, error)
 	AccumulateTagsFor(entity string, cardinality collectors.TagCardinality, tb tagset.TagsAccumulator) error
 	Standard(entity string) ([]string, error)
-	List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse
+	List() tagger_api.TaggerListResponse
 	GetEntity(entityID string) (*types.Entity, error)
 	Subscribe(cardinality collectors.TagCardinality) chan []types.EntityEvent
 	Unsubscribe(ch chan []types.EntityEvent)

--- a/comp/core/tagger/global.go
+++ b/comp/core/tagger/global.go
@@ -96,9 +96,9 @@ func GlobalTags(cardinality collectors.TagCardinality) ([]string, error) {
 }
 
 // List the content of the defaulTagger
-func List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse {
+func List() tagger_api.TaggerListResponse {
 	if globalTagger != nil {
-		return globalTagger.List(cardinality)
+		return globalTagger.List()
 	}
 	return tagger_api.TaggerListResponse{}
 }

--- a/comp/core/tagger/local/fake_tagger.go
+++ b/comp/core/tagger/local/fake_tagger.go
@@ -108,9 +108,7 @@ func (f *FakeTagger) GetEntity(entityID string) (*types.Entity, error) {
 }
 
 // List fake implementation
-//
-//nolint:revive // TODO(CINT) Fix revive linter
-func (f *FakeTagger) List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse {
+func (f *FakeTagger) List() tagger_api.TaggerListResponse {
 	return f.store.List()
 }
 

--- a/comp/core/tagger/local/tagger.go
+++ b/comp/core/tagger/local/tagger.go
@@ -113,9 +113,7 @@ func (t *Tagger) GetEntity(entityID string) (*types.Entity, error) {
 }
 
 // List the content of the tagger
-//
-//nolint:revive // TODO(CINT) Fix revive linter
-func (t *Tagger) List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse {
+func (t *Tagger) List() tagger_api.TaggerListResponse {
 	return t.tagStore.List()
 }
 

--- a/comp/core/tagger/remote/tagger.go
+++ b/comp/core/tagger/remote/tagger.go
@@ -224,9 +224,7 @@ func (t *Tagger) GetEntity(entityID string) (*types.Entity, error) {
 }
 
 // List returns all the entities currently stored by the tagger.
-//
-//nolint:revive // TODO(CINT) Fix revive linter
-func (t *Tagger) List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse {
+func (t *Tagger) List() tagger_api.TaggerListResponse {
 	entities := t.store.listEntities()
 	resp := tagger_api.TaggerListResponse{
 		Entities: make(map[string]tagger_api.TaggerListEntity),

--- a/comp/core/tagger/replay/tagger.go
+++ b/comp/core/tagger/replay/tagger.go
@@ -99,9 +99,7 @@ func (t *Tagger) Standard(entityID string) ([]string, error) {
 }
 
 // List returns all the entities currently stored by the tagger.
-//
-//nolint:revive // TODO(CINT) Fix revive linter
-func (t *Tagger) List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse {
+func (t *Tagger) List() tagger_api.TaggerListResponse {
 	return t.store.List()
 }
 

--- a/comp/core/tagger/tagger.go
+++ b/comp/core/tagger/tagger.go
@@ -340,8 +340,8 @@ func (t *TaggerClient) globalTagBuilder(cardinality collectors.TagCardinality, t
 }
 
 // List the content of the defaulTagger
-func (t *TaggerClient) List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse {
-	return t.defaultTagger.List(cardinality)
+func (t *TaggerClient) List() tagger_api.TaggerListResponse {
+	return t.defaultTagger.List()
 }
 
 // SetNewCaptureTagger sets the tagger to be used when replaying a capture


### PR DESCRIPTION
### What does this PR do?

Deletes an unused argument (`cardinality`) from the List() function defined in the Tagger interface.
None of the tagger implementations use the cardinality in List().


### Describe how to test/QA your changes

Skip.