### PR TITLE
[CWS] allow `fim_enabled` to explicitly be set to false

### DIFF
--- a/cmd/system-probe/config/adjust_security.go
+++ b/cmd/system-probe/config/adjust_security.go
@@ -29,8 +29,10 @@ func adjustSecurity(cfg config.Config) {
 	)
 
 	if cfg.GetBool(secNS("enabled")) {
-		// if runtime is enabled then we force fim
-		cfg.Set(secNS("fim_enabled"), true, model.SourceAgentRuntime)
+		// if runtime is enabled then we enable fim as well (except if force disabled)
+		if !cfg.IsSet(secNS("fim_enabled")) {
+			cfg.Set(secNS("fim_enabled"), true, model.SourceAgentRuntime)
+		}
 	} else {
 		// if runtime is disabled then we force disable activity dumps and security profiles
 		cfg.Set(secNS("activity_dump.enabled"), false, model.SourceAgentRuntime)

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -19,7 +19,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	// CWS - general config
 	cfg.BindEnvAndSetDefault("runtime_security_config.enabled", false)
-	cfg.BindEnvAndSetDefault("runtime_security_config.fim_enabled", false)
+	cfg.BindEnv("runtime_security_config.fim_enabled")
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.watch_dir", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.monitor.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.monitor.per_rule_enabled", false)


### PR DESCRIPTION
### What does this PR do?

Currently you can enable CWS using either `enabled` or `fim_enabled`. For windows especially we would like to be able to enable runtime, but keeping the option to disable fim in case of issue. This PR allows this by turning `fim_enabled` into a tri-state, that we set to true if unset and CWS is enabled. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
