### PR TITLE
fix ebpf network redis protocol missing bulk strings response

### DIFF
--- a/pkg/network/ebpf/c/protocols/redis/helpers.h
+++ b/pkg/network/ebpf/c/protocols/redis/helpers.h
@@ -22,6 +22,8 @@ static __always_inline bool check_supported_ascii_and_crlf(const char* buf, __u3
             continue;
         } else if (current_char == '.' || current_char == ' ' || current_char == '-' || current_char == '_') {
             continue;
+        } else if ('0' <= current_char && current_char <= '9') {
+            continue;
         }
         return false;
     }
@@ -80,6 +82,7 @@ static __always_inline bool is_redis(const char* buf, __u32 buf_size) {
         return check_err_prefix(buf, buf_size);
     case ':':
     case '$':
+        return check_supported_ascii_and_crlf(buf, buf_size, 1);
     case '*':
         return check_integer_and_crlf(buf, buf_size, 1);
     default:


### PR DESCRIPTION
### What does this PR do?
fix ebpf network redis protocol missing bulk strings response

### Motivation
[redis-protocol-spc](https://redis.io/docs/latest/develop/reference/protocol-spec/)
RESP encodes bulk strings in the following way:
```
$<length>\r\n<data>\r\n
```
Therefore, when parsing the redis protocol, should judge the response content starting with '$'

![image](https://github.com/DataDog/datadog-agent/assets/30427474/3bac9e7c-6379-44ac-bad0-27bc6bad0c9f)


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
