### PR TITLE
omnibus: stop providing install directory through environment

### DIFF
--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -5,7 +5,6 @@
 .common_build_oci:
   script:
     - echo "About to build for $RELEASE_VERSION"
-    - export INSTALL_DIR=/opt/datadog-packages/datadog-agent/$(inv agent.version -u)-1
     - !reference [.setup_ruby_mirror_linux]
     - !reference [.setup_python_mirror_linux]
     - !reference [.retrieve_linux_go_deps]
@@ -21,7 +20,7 @@
     - chmod 0744 /tmp/system-probe/clang-bpf /tmp/system-probe/llc-bpf
     # NOTE: for now, we consider "ociru" to be a "redhat_target" in omnibus/lib/ostools.rb
     # if we ever start building on a different platform, that might need to change
-    - inv -e omnibus.build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --base-dir $OMNIBUS_BASE_DIR  ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --host-distribution=ociru --install-directory="$INSTALL_DIR"
+    - inv -e omnibus.build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --base-dir $OMNIBUS_BASE_DIR  ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --host-distribution=ociru --install-directory="/opt/datadog-packages/datadog-agent/$(inv agent.version -u)-1"
     - ls -la $OMNIBUS_PACKAGE_DIR
     - !reference [.upload_sbom_artifacts]
   variables:
@@ -142,9 +141,7 @@ installer-amd64-oci:
     DESTINATION_FILE: "datadog-updater_7-amd64-oci.tar.xz"
   before_script:
     - source /root/.bashrc
-    - export INSTALL_DIR=/opt/datadog-packages/datadog-installer/$(inv agent.version -u)-1
-    - export INSTALL_DIR_PARAM="--install-directory=$INSTALL_DIR"
-
+    - export INSTALL_DIR_PARAM="--install-directory=/opt/datadog-packages/datadog-installer/$(inv agent.version -u)-1"
 
 installer-arm64-oci:
   extends: installer-arm64
@@ -152,5 +149,4 @@ installer-arm64-oci:
     DESTINATION_FILE: "datadog-updater_7-arm64-oci.tar.xz"
   before_script:
     - source /root/.bashrc
-    - export INSTALL_DIR=/opt/datadog-packages/datadog-installer/$(inv agent.version -u)-1
-    - export INSTALL_DIR_PARAM="--install-directory=$INSTALL_DIR"
+    - export INSTALL_DIR_PARAM="--install-directory=/opt/datadog-packages/datadog-installer/$(inv agent.version -u)-1"

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -45,7 +45,7 @@ if windows_target?
   PYTHON_2_EMBEDDED_DIR = format('%s/embedded2', INSTALL_DIR)
   PYTHON_3_EMBEDDED_DIR = format('%s/embedded3', INSTALL_DIR)
 else
-  INSTALL_DIR = ENV["INSTALL_DIR"] || '/opt/datadog-agent'
+  INSTALL_DIR = Omnibus::Config.install_dir || '/opt/datadog-installer'
 end
 
 install_dir INSTALL_DIR

--- a/omnibus/config/projects/installer.rb
+++ b/omnibus/config/projects/installer.rb
@@ -13,7 +13,7 @@ third_party_licenses "../LICENSE-3rdparty.csv"
 
 homepage 'http://www.datadoghq.com'
 
-INSTALL_DIR = ENV['INSTALL_DIR'] || '/opt/datadog-installer'
+INSTALL_DIR = Omnibus::Config.install_dir || '/opt/datadog-installer'
 
 install_dir INSTALL_DIR
 

--- a/release.json
+++ b/release.json
@@ -8,7 +8,7 @@
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "master",
         "OMNIBUS_SOFTWARE_VERSION": "0566b54e725fcd66e841579a1d789dd5bb23870f",
-        "OMNIBUS_RUBY_VERSION": "07f5a646f298c56168e32b4c92af679eb356a846",
+        "OMNIBUS_RUBY_VERSION": "chouquette/install_dir_config",
         "JMXFETCH_VERSION": "0.49.1",
         "JMXFETCH_HASH": "6c5d4ae2f858aa57fac7f92d6615931bf95f9a99c92979090f2de9d4b3c1f0d3",
         "MACOS_BUILD_VERSION": "master",
@@ -27,7 +27,7 @@
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "master",
         "OMNIBUS_SOFTWARE_VERSION": "0566b54e725fcd66e841579a1d789dd5bb23870f",
-        "OMNIBUS_RUBY_VERSION": "07f5a646f298c56168e32b4c92af679eb356a846",
+        "OMNIBUS_RUBY_VERSION": "chouquette/install_dir_config",
         "JMXFETCH_VERSION": "0.49.1",
         "JMXFETCH_HASH": "6c5d4ae2f858aa57fac7f92d6615931bf95f9a99c92979090f2de9d4b3c1f0d3",
         "MACOS_BUILD_VERSION": "master",

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -143,9 +143,6 @@ def get_omnibus_env(
         env['DEPLOY_AGENT'] = os.environ.get('DEPLOY_AGENT')
     if 'PACKAGE_ARCH' in os.environ:
         env['PACKAGE_ARCH'] = os.environ.get('PACKAGE_ARCH')
-    if 'INSTALL_DIR' in os.environ:
-        print('Forwarding INSTALL_DIR')
-        env['INSTALL_DIR'] = os.environ.get('INSTALL_DIR')
 
     return env
 

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -25,7 +25,7 @@ def omnibus_run_task(
     omnibus_s3_cache=False,
     log_level="info",
     host_distribution=None,
-    install_dir=None,
+    install_directory=None,
 ):
     with ctx.cd("omnibus"):
         overrides_cmd = ""
@@ -33,8 +33,8 @@ def omnibus_run_task(
             overrides_cmd = f"--override=base_dir:{base_dir}"
         if host_distribution:
             overrides_cmd += f" --override=host_distribution:{host_distribution}"
-        if install_dir:
-            overrides_cmd += f" --override=install_dir:{install_dir}"
+        if install_directory:
+            overrides_cmd += f" --override=install_dir:{install_directory}"
 
         omnibus = "bundle exec omnibus"
         if sys.platform == 'win32':
@@ -288,6 +288,7 @@ def build(
             omnibus_s3_cache=omnibus_s3_cache,
             log_level=log_level,
             host_distribution=host_distribution,
+            install_directory=install_directory,
         )
 
     # Delete the temporary pip.conf file once the build is done

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -17,7 +17,15 @@ from tasks.ssm import get_pfx_pass, get_signing_cert
 
 
 def omnibus_run_task(
-    ctx, task, target_project, base_dir, env, omnibus_s3_cache=False, log_level="info", host_distribution=None
+    ctx,
+    task,
+    target_project,
+    base_dir,
+    env,
+    omnibus_s3_cache=False,
+    log_level="info",
+    host_distribution=None,
+    install_dir=None,
 ):
     with ctx.cd("omnibus"):
         overrides_cmd = ""
@@ -25,6 +33,8 @@ def omnibus_run_task(
             overrides_cmd = f"--override=base_dir:{base_dir}"
         if host_distribution:
             overrides_cmd += f" --override=host_distribution:{host_distribution}"
+        if install_dir:
+            overrides_cmd += f" --override=install_dir:{install_dir}"
 
         omnibus = "bundle exec omnibus"
         if sys.platform == 'win32':


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Stop using `INSTALL_DIR` environment variable to provide the install directory

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We need to provide an install directory for all our OCI builds, however providing it through the environment causes the omnibus cache to systematically cache miss as the install directory usually contains the pipeline ID, which will obviously differ for every pipeline.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

We *could* simply ignore `INSTALL_DIR` environment variable, but it feels like a more robust approach to stop relying on various environment variables to tweak our builds, and use a dedicated argument.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
