### PR TITLE
[NDM][Cisco SD-WAN] Set default lookback interval to 10 mins

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client.go
@@ -24,7 +24,7 @@ const (
 	defaultMaxAttempts = 3
 	defaultMaxPages    = 100
 	defaultMaxCount    = "2000"
-	defaultLookback    = 20 * time.Minute
+	defaultLookback    = 10 * time.Minute
 	defaultHTTPTimeout = 10
 	defaultHTTPScheme  = "https"
 )

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client_test.go
@@ -273,7 +273,7 @@ func TestGetInterfacesMetrics(t *testing.T) {
 
 		require.Equal(t, "2000", count)
 		require.Equal(t, "UTC", timeZone)
-		require.Equal(t, "1999-12-31T23:40:00", startDate)
+		require.Equal(t, "1999-12-31T23:50:00", startDate)
 		require.Equal(t, "2000-01-01T00:00:00", endDate)
 
 		w.WriteHeader(http.StatusOK)
@@ -322,7 +322,7 @@ func TestGetDeviceHardwareMetrics(t *testing.T) {
 
 		require.Equal(t, "2000", count)
 		require.Equal(t, "UTC", timeZone)
-		require.Equal(t, "1999-12-31T23:40:00", startDate)
+		require.Equal(t, "1999-12-31T23:50:00", startDate)
 		require.Equal(t, "2000-01-01T00:00:00", endDate)
 
 		w.WriteHeader(http.StatusOK)
@@ -365,7 +365,7 @@ func TestGetApplicationAwareRoutingMetrics(t *testing.T) {
 
 		require.Equal(t, "2000", count)
 		require.Equal(t, "UTC", timeZone)
-		require.Equal(t, "1999-12-31T23:40:00", startDate)
+		require.Equal(t, "1999-12-31T23:50:00", startDate)
 		require.Equal(t, "2000-01-01T00:00:00", endDate)
 
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
At each check run, we query the Cisco SD-WAN API for metrics received by the vManage instance between `now` and `now - lookback`.
 Default lookback interval was set to 20mins. Setting it to 10mins will poll less data at each check run, and since previously sent metrics are not re-sent, it will not change the integration behavior (default check interval is 1min). 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
