### PR TITLE
[NDM][Cisco SD-WAN] Add config for BFD Session metric collection

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
@@ -44,6 +44,7 @@ type checkCfg struct {
 	CAFile                    string `yaml:"ca_file"`
 	SendNDMMetadata           *bool  `yaml:"send_ndm_metadata"`
 	MinCollectionInterval     int    `yaml:"min_collection_interval"`
+	CollectBFDSessionStatus   bool   `yaml:"collect_bfd_session_status"`
 }
 
 // CiscoSdwanCheck contains the field for the CiscoSdwanCheck
@@ -99,10 +100,6 @@ func (c *CiscoSdwanCheck) Run() error {
 	if err != nil {
 		log.Warnf("Error getting OMP peer states from Cisco SD-WAN API: %s", err)
 	}
-	bfdSessionsState, err := client.GetBFDSessionsState()
-	if err != nil {
-		log.Warnf("Error getting BFD session states from Cisco SD-WAN API: %s", err)
-	}
 	deviceCounters, err := client.GetDevicesCounters()
 	if err != nil {
 		log.Warnf("Error getting device counters from Cisco SD-WAN API: %s", err)
@@ -128,9 +125,17 @@ func (c *CiscoSdwanCheck) Run() error {
 	c.metricsSender.SendAppRouteMetrics(appRouteStats)
 	c.metricsSender.SendControlConnectionMetrics(controlConnectionsState)
 	c.metricsSender.SendOMPPeerMetrics(ompPeersState)
-	c.metricsSender.SendBFDSessionMetrics(bfdSessionsState)
 	c.metricsSender.SendDeviceCountersMetrics(deviceCounters)
 	c.metricsSender.SendDeviceStatusMetrics(deviceStatus)
+
+	// Configurable metrics
+	if c.config.CollectBFDSessionStatus {
+		bfdSessionsState, err := client.GetBFDSessionsState()
+		if err != nil {
+			log.Warnf("Error getting BFD session states from Cisco SD-WAN API: %s", err)
+		}
+		c.metricsSender.SendBFDSessionMetrics(bfdSessionsState)
+	}
 
 	// Commit
 	c.metricsSender.Commit()

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
@@ -218,5 +218,46 @@ collect_bfd_session_status: true
 	assert.NoError(t, err)
 
 	sender.AssertEventPlatformEvent(t, compactEvent.Bytes(), "network-devices-metadata")
+}
 
+func TestBFDMetricConfig(t *testing.T) {
+	payload.TimeNow = mockTimeNow
+	report.TimeNow = mockTimeNow
+
+	apiMockServer := client.SetupMockAPIServer()
+	defer apiMockServer.Close()
+
+	deps := createDeps(t)
+	chk := newCheck()
+	senderManager := deps.Demultiplexer
+
+	url := strings.TrimPrefix(apiMockServer.URL, "http://")
+
+	// language=yaml
+	rawInstanceConfig := []byte(`
+vmanage_endpoint: ` + url + `
+username: admin
+password: 'test-password'
+use_http: true
+namespace: test
+`)
+
+	// Use ID to ensure the mock sender gets registered
+	id := checkid.BuildID(CheckName, integration.FakeConfigHash, rawInstanceConfig, []byte(``))
+	sender := mocksender.NewMockSenderWithSenderManager(id, senderManager)
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("GaugeWithTimestamp", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("CountWithTimestamp", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
+
+	sender.On("Commit").Return()
+
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	require.NoError(t, err)
+
+	err = chk.Run()
+	require.NoError(t, err)
+
+	sender.AssertNotCalled(t, "Gauge", "cisco_sdwan.bfd_session.status", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
@@ -68,6 +68,7 @@ password: 'test-password'
 use_http: true
 namespace: test
 min_collection_interval: 180
+collect_bfd_session_status: true
 `)
 
 	// Use ID to ensure the mock sender gets registered


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Adds a config to send BFD Session status metrics, disabled by default.
NDMII-2680

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Polling this metric might have significant impact on check duration, and since it is redundant with the `cisco_sdwan.tunnel.status` metric, we disable it by default.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
