### PR TITLE
[usm] Address verifier error for GoTLS on old Kernels

### DIFF
--- a/pkg/network/usm/monitor_tls_test.go
+++ b/pkg/network/usm/monitor_tls_test.go
@@ -508,6 +508,23 @@ func (s *tlsSuite) TestJavaInjection() {
 	}
 }
 
+func TestGoTLSInitialization(t *testing.T) {
+	// This is meant to test the eBPF program loading in isolation to detect
+	// things such as verifier errors
+	modes := []ebpftest.BuildMode{ebpftest.RuntimeCompiled, ebpftest.CORE}
+	ebpftest.TestBuildModes(t, modes, "", func(t *testing.T) {
+		cfg := config.New()
+		cfg.EnableGoTLSSupport = true
+
+		if !gotlstestutil.GoTLSSupported(t, cfg) {
+			t.Skip("GoTLS not supported for this setup")
+		}
+
+		monitor := setupUSMTLSMonitor(t, cfg)
+		assert.NotNil(t, monitor)
+	})
+}
+
 func TestHTTPGoTLSAttachProbes(t *testing.T) {
 	t.Skip("skipping GoTLS tests while we investigate their flakiness")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix verifier error introduced in https://github.com/DataDog/datadog-agent/pull/24753
```
program uprobe__crypto_tls_Conn_Write__return: load program: permission denied: 969: (85) call bpf_map_update_elem#2: R3 type=map_value expected=fp (1552 line(s) omitted)
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
