### PR TITLE
[backport 7.52.x] openscap: fix implicit declaration of INT_MIN/INT_MAX (#25070)

### DIFF
--- a/omnibus/config/patches/openscap/int-min-max.patch
+++ b/omnibus/config/patches/openscap/int-min-max.patch
@@ -1,0 +1,21 @@
+From 21ff59e5b85d3c2498bd3126321eaebe92b42ab5 Mon Sep 17 00:00:00 2001
+From: Michal Ambroz <723625+xambroz@users.noreply.github.com>
+Date: Mon, 27 Nov 2023 06:24:56 +0100
+Subject: [PATCH] fix implicit declaration of INT_MIN/INT_MAX
+
+---
+ src/OVAL/results/oval_cmp_evr_string.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/OVAL/results/oval_cmp_evr_string.c b/src/OVAL/results/oval_cmp_evr_string.c
+index 1c440bb569..f41b00e749 100644
+--- a/src/OVAL/results/oval_cmp_evr_string.c
++++ b/src/OVAL/results/oval_cmp_evr_string.c
+@@ -30,6 +30,7 @@
+ #include <math.h>
+ #include <string.h>
+ #include <ctype.h>
++#include <limits.h>
+ #include "oval_cmp_evr_string_impl.h"
+ #include "oval_definitions.h"
+ #include "oval_types.h"

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -64,6 +64,8 @@ build do
 
   patch source: "oscap-io.patch", env: env # add new oscap-io tool
 
+  patch source: "int-min-max.patch", env: env # fix implicit declaration of INT_MIN/INT_MAX
+
   env["CC"] = "/opt/gcc-#{ENV['GCC_VERSION']}/bin/gcc"
   env["CXX"] = "/opt/gcc-#{ENV['GCC_VERSION']}/bin/g++"
   env["CXXFLAGS"] += " -static-libstdc++ -std=c++11 -DDPKG_DATADIR=/usr/share/dpkg"


### PR DESCRIPTION
(cherry picked from commit fac6122b32618f9488436f08c3727c0bc9f0a4af)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
