### PR TITLE
[ASCII-1543] Update GUI path concatenation fonctions

### DIFF
--- a/comp/core/gui/guiimpl/checks.go
+++ b/comp/core/gui/guiimpl/checks.go
@@ -247,8 +247,16 @@ func setCheckConfigFile(w http.ResponseWriter, r *http.Request) {
 	var checkConfFolderPath, defaultCheckConfFolderPath string
 
 	if checkFolder != "" {
-		checkConfFolderPath = filepath.Join(config.Datadog.GetString("confd_path"), checkFolder)
-		defaultCheckConfFolderPath = filepath.Join(path.GetDistPath(), "conf.d", checkFolder)
+		checkConfFolderPath, err = securejoin.SecureJoin(config.Datadog.GetString("confd_path"), checkFolder)
+		if err != nil {
+			log.Errorf("Error: Unable to join provided \"confd_path\" setting path with checkFolder: %s", fileName)
+			return
+		}
+		defaultCheckConfFolderPath, err = securejoin.SecureJoin(filepath.Join(path.GetDistPath(), "conf.d"), checkFolder)
+		if err != nil {
+			log.Errorf("Error: Unable to join conf folder path with checkFolder: %s", fileName)
+			return
+		}
 	} else {
 		checkConfFolderPath = config.Datadog.GetString("confd_path")
 		defaultCheckConfFolderPath = filepath.Join(path.GetDistPath(), "conf.d")

--- a/comp/core/gui/guiimpl/checks.go
+++ b/comp/core/gui/guiimpl/checks.go
@@ -249,12 +249,14 @@ func setCheckConfigFile(w http.ResponseWriter, r *http.Request) {
 	if checkFolder != "" {
 		checkConfFolderPath, err = securejoin.SecureJoin(config.Datadog.GetString("confd_path"), checkFolder)
 		if err != nil {
-			log.Errorf("Error: Unable to join provided \"confd_path\" setting path with checkFolder: %s", fileName)
+			http.Error(w, "invalid checkFolder path", http.StatusBadRequest)
+			log.Errorf("Error: Unable to join provided \"confd_path\" setting path with checkFolder: %s", err.Error())
 			return
 		}
 		defaultCheckConfFolderPath, err = securejoin.SecureJoin(filepath.Join(path.GetDistPath(), "conf.d"), checkFolder)
 		if err != nil {
-			log.Errorf("Error: Unable to join conf folder path with checkFolder: %s", fileName)
+			http.Error(w, "invalid checkFolder path", http.StatusBadRequest)
+			log.Errorf("Error: Unable to join conf folder path with checkFolder: %s", err.Error())
 			return
 		}
 	} else {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR replace `path.Join()` functions call by `securejoin.SecureJoin()`.

### Describe how to test/QA your changes
#### Prerequisite
build the Agent
run a daemon Agent
#### Tests
1. run command `datadog-agent launch-gui`
2. on the GUI
    1. go to page `Checks` -> `Manage Checks`
    2. on the left select in the input `Add a Check`
    3. choose one (for example `activemq`)
    4. click on the button `Add Check` on the right
    5. restart the agent
    6. go back to `Edit Enabled Checks`
    7. verify that the check you had exist

The behaviour should be the same before and after this PR.