### PR TITLE
[PROCS-3838] Add handling for ECS Fargate misconfiguration during chunking

### DIFF
--- a/pkg/process/checks/chunking.go
+++ b/pkg/process/checks/chunking.go
@@ -22,7 +22,7 @@ func chunkProcessesBySizeAndWeight(procs []*model.Process, ctr *model.Container,
 		// b) if process <=> container mapping cannot be established (e.g. Docker on Windows).
 		// c) if no processes were collected from the container (e.g. pidMode not set to "task" on ECS Fargate)
 		if ecsContainerMetadataURI := os.Getenv("ECS_CONTAINER_METADATA_URI_V4"); ecsContainerMetadataURI != "" {
-			log.Warnf("No processes found for container %s, pidMode may not be configured correctly (set to task)", ctr.Name)
+			log.Warnf("No processes found for container %s, pidMode may not be configured correctly (should be set to task)", ctr.Name)
 		}
 		appendContainerWithoutProcesses(ctr, chunker)
 		return

--- a/pkg/process/checks/chunking.go
+++ b/pkg/process/checks/chunking.go
@@ -20,7 +20,7 @@ func chunkProcessesBySizeAndWeight(procs []*model.Process, ctr *model.Container,
 		// can happen in three scenarios, and we still need to report the container
 		// a) if a process is skipped (e.g. disallowlisted)
 		// b) if process <=> container mapping cannot be established (e.g. Docker on Windows).
-		// c) pidMode not set to "task" on ECS Fargate
+		// c) if no processes were collected from the container (e.g. pidMode not set to "task" on ECS Fargate)
 		if ecsContainerMetadataURI := os.Getenv("ECS_CONTAINER_METADATA_URI_V4"); ecsContainerMetadataURI != "" {
 			log.Warnf("No processes found for container %s, pidMode may not be configured correctly (set to task)", ctr.Name)
 		}

--- a/pkg/process/checks/chunking.go
+++ b/pkg/process/checks/chunking.go
@@ -17,7 +17,7 @@ import (
 // chunkProcessesBySizeAndWeight chunks `model.Process` payloads by max allowed size and max allowed weight of a chunk
 func chunkProcessesBySizeAndWeight(procs []*model.Process, ctr *model.Container, maxChunkSize, maxChunkWeight int, chunker *util.ChunkAllocator[model.CollectorProc, *model.Process]) {
 	if ctr != nil && len(procs) == 0 {
-		// can happen in two scenarios, and we still need to report the container
+		// can happen in three scenarios, and we still need to report the container
 		// a) if a process is skipped (e.g. disallowlisted)
 		// b) if process <=> container mapping cannot be established (e.g. Docker on Windows).
 		// c) pidMode not set to "task" on ECS Fargate

--- a/pkg/process/checks/chunking_test.go
+++ b/pkg/process/checks/chunking_test.go
@@ -227,6 +227,31 @@ func TestChunkProcessesBySizeAndWeight(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "first container with no processes",
+			containers: []*model.Container{
+				ctr("qux"),
+				ctr("foo"),
+			},
+			procsByCtr: map[string][]*model.Process{
+				"foo": {
+					proc(2, "foo", strings.Repeat("-", 970)),
+				},
+			},
+			maxChunkSize:   3,
+			maxChunkWeight: 1000,
+			expectedChunks: []model.CollectorProc{
+				{
+					Containers: []*model.Container{
+						ctr("qux"),
+						ctr("foo"),
+					},
+					Processes: []*model.Process{
+						proc(2, "foo", strings.Repeat("-", 970)),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/releasenotes/notes/process-fargate-chunking-pidMode-0144d9e0833cb19b.yaml
+++ b/releasenotes/notes/process-fargate-chunking-pidMode-0144d9e0833cb19b.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    The Process Agent will no longer crash when pidMode is misconfigured on ECS Fargate and a warning will be logged instead.
+    The Process Agent no longer crashes when pidMode is misconfigured on ECS Fargate. A warning is logged instead.

--- a/releasenotes/notes/process-fargate-chunking-pidMode-0144d9e0833cb19b.yaml
+++ b/releasenotes/notes/process-fargate-chunking-pidMode-0144d9e0833cb19b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The Process Agent will no longer crash when pidMode is misconfigured on ECS Fargate and a warning will be logged instead.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR handles the issue described in https://github.com/DataDog/datadog-agent/issues/22940. Previously, when on ECS Fargate with a misconfigured pidMode setting, the process agent can fails to maintain the relationship between `chunks` and `props` in the ChunkAllocator when calling `appendContainerWithoutProcesses` causing a panic when `props` is accessed during `ChunkAllocator.Accept`. Now, `ChunkAllocator.Accept` is used directly in the function to that `props` and `chunks` remain equal in length.

### Motivation

PROCS-3838

### Additional Notes

The added unit test confirmed the behavior as it results in a panic on `main` but passes with this PR's changes.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the agent as a sidecar container with container on ECS Fargate without pidMode set. Verify the panic no longer occurs and the log warning appears. Also check that process/container data is available on Datadog.

Sample task definition to create service from:
```
{
    "containerDefinitions": [
            {
                "name": "redis",
                "image": "redis:latest",
                "cpu": 0,
                "portMappings": [],
                "essential": true,
                "environment": [],
                "mountPoints": [],
                "volumesFrom": [],
                "dockerLabels": {
                    "com.datadoghq.ad.check_names": "[\"redisdb\"]",
                    "com.datadoghq.ad.init_configs": "[{}]",
                    "com.datadoghq.ad.instances": "[{\"host\": \"%%host%%\", \"port\": 6379}]"
                },
                "systemControls": []
            },
            {
                "name": "datadog-agent",
                "image": "public.ecr.aws/datadog/agent:latest",
                "cpu": 0,
                "portMappings": [],
                "essential": true,
                "environment": [
                    {
                        "name": "ECS_FARGATE",
                        "value": "true"
                    },
                    {
                        "name": "DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED",
                        "value": "true"
                    }
                ],
                "mountPoints": [],
                "volumesFrom": [],
                "secrets": [
                    {
                        "name": "DD_API_KEY",
                        "valueFrom": "<secret>"
                    }
                ],
               ...
            }
        ],
}
```
Log:
```
2024-04-25 20:06:47 UTC | PROCESS | WARN | (pkg/process/checks/chunking.go:25 in chunkProcessesBySizeAndWeight) | No processes found for container , pidMode may not be configured correctly (set to task)	
```