### PR TITLE
[CWS] scope the option to force disable `fim_enabled` to windows only

### DIFF
--- a/cmd/system-probe/config/adjust_security.go
+++ b/cmd/system-probe/config/adjust_security.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"runtime"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -30,7 +31,7 @@ func adjustSecurity(cfg config.Config) {
 
 	if cfg.GetBool(secNS("enabled")) {
 		// if runtime is enabled then we enable fim as well (except if force disabled)
-		if !cfg.IsSet(secNS("fim_enabled")) {
+		if runtime.GOOS != "windows" || !cfg.IsSet(secNS("fim_enabled")) {
 			cfg.Set(secNS("fim_enabled"), true, model.SourceAgentRuntime)
 		}
 	} else {


### PR DESCRIPTION
### What does this PR do?

Giving the option to force disable fim on linux causes issue with the helm chart that always sets this fim enabled value. Meaning that the helm chart currently disables fim.. To fix this we scope the option to disable fim to windows only.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
