### PR TITLE
[e2e]: pass --no-refresh to zypper install commands to reduce step-by-step test flakiness

### DIFF
--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -282,6 +282,6 @@ func (is *stepByStepSuite) StepByStepSuseTest(VMclient *common.TestClient) {
 		ExecuteWithoutError(t, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public")
 		ExecuteWithoutError(t, VMclient, "sudo rpm --import /tmp/DATADOG_RPM_KEY_E09422B3.public")
 		ExecuteWithoutError(t, VMclient, "sudo zypper --non-interactive --no-gpg-checks refresh datadog")
-		ExecuteWithoutError(t, VMclient, "sudo zypper --non-interactive install %s", *flavorName)
+		ExecuteWithoutError(t, VMclient, "sudo zypper --non-interactive --no-refresh install %s", *flavorName)
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Prevent flakey failures due to autorefresh failing. Global options for zypper can be found [here](https://en.opensuse.org/SDB:Zypper_manual#GLOBAL_OPTIONS).

### Motivation

[BARX-312](https://datadoghq.atlassian.net/browse/BARX-312) resolve flakey test.

### Additional Notes

[Reused change implemented in the install script](https://github.com/DataDog/agent-linux-install-script/pull/176).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->


[BARX-312]: https://datadoghq.atlassian.net/browse/BARX-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ