### PR TITLE
|SBOM] Use in-memory overlayfs to scan container images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1136,6 +1136,7 @@ replace k8s.io/cri-api => k8s.io/cri-api v0.25.5
 // Use custom Trivy fork to reduce binary size
 // Pull in replacements needed by upstream Trivy
 replace (
+	// Maps to Trivy fork https://github.com/DataDog/trivy/commits/lebauce/use-fs-main-dd/
 	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20240425145011-1883c1659654
 	github.com/saracen/walker => github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950
 	// testcontainers-go has a bug with versions v0.25.0 and v0.26.0

--- a/go.mod
+++ b/go.mod
@@ -1136,7 +1136,7 @@ replace k8s.io/cri-api => k8s.io/cri-api v0.25.5
 // Use custom Trivy fork to reduce binary size
 // Pull in replacements needed by upstream Trivy
 replace (
-	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20240425083949-2c901525e688
+	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20240425145011-1883c1659654
 	github.com/saracen/walker => github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950
 	// testcontainers-go has a bug with versions v0.25.0 and v0.26.0
 	// ref: https://github.com/testcontainers/testcontainers-go/issues/1782

--- a/go.mod
+++ b/go.mod
@@ -1136,7 +1136,7 @@ replace k8s.io/cri-api => k8s.io/cri-api v0.25.5
 // Use custom Trivy fork to reduce binary size
 // Pull in replacements needed by upstream Trivy
 replace (
-	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20240327150525-a3045a95060a
+	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20240425083949-2c901525e688
 	github.com/saracen/walker => github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950
 	// testcontainers-go has a bug with versions v0.25.0 and v0.26.0
 	// ref: https://github.com/testcontainers/testcontainers-go/issues/1782

--- a/go.mod
+++ b/go.mod
@@ -1137,7 +1137,7 @@ replace k8s.io/cri-api => k8s.io/cri-api v0.25.5
 // Pull in replacements needed by upstream Trivy
 replace (
 	// Maps to Trivy fork https://github.com/DataDog/trivy/commits/lebauce/use-fs-main-dd/
-	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20240425145011-1883c1659654
+	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20240426155824-6c986dae34c1
 	github.com/saracen/walker => github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950
 	// testcontainers-go has a bug with versions v0.25.0 and v0.26.0
 	// ref: https://github.com/testcontainers/testcontainers-go/issues/1782

--- a/go.sum
+++ b/go.sum
@@ -786,8 +786,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.14.0 h1:QHx6B/VUx3rZ
 github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.14.0/go.mod h1:q4c7zbmdnIdSJNZuBsveTk5ZeRkSkS2g6b8zzFF1mE4=
 github.com/DataDog/sketches-go v1.4.4 h1:dF52vzXRFSPOj2IjXSWLvXq3jubL4CI69kwYjJ1w5Z8=
 github.com/DataDog/sketches-go v1.4.4/go.mod h1:XR0ns2RtEEF09mDKXiKZiQg+nfZStrq1ZuL1eezeZe0=
-github.com/DataDog/trivy v0.0.0-20240327150525-a3045a95060a h1:Ps5dXg7Cq0rGj+60EIGi4dEvFNhpWa/Dx/6QeveuMAI=
-github.com/DataDog/trivy v0.0.0-20240327150525-a3045a95060a/go.mod h1:xmc7xCb5KSg2mFbztyInH8ciotVbad9SOmGFClgD0cU=
+github.com/DataDog/trivy v0.0.0-20240425083949-2c901525e688 h1:iCExVzcILHdleMz4ULPj9ACT/juLBbSQUSNmhBpnGjE=
+github.com/DataDog/trivy v0.0.0-20240425083949-2c901525e688/go.mod h1:xmc7xCb5KSg2mFbztyInH8ciotVbad9SOmGFClgD0cU=
 github.com/DataDog/viper v1.13.2 h1:GrYzwGiaEoliIXA4wPkx8MHIRY5sNi8frV1Fsv7VCJU=
 github.com/DataDog/viper v1.13.2/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
 github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950 h1:2imDajw3V85w1iqHsuXN+hUBZQVF+r9eME8tsPq/HpA=

--- a/go.sum
+++ b/go.sum
@@ -786,8 +786,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.14.0 h1:QHx6B/VUx3rZ
 github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.14.0/go.mod h1:q4c7zbmdnIdSJNZuBsveTk5ZeRkSkS2g6b8zzFF1mE4=
 github.com/DataDog/sketches-go v1.4.4 h1:dF52vzXRFSPOj2IjXSWLvXq3jubL4CI69kwYjJ1w5Z8=
 github.com/DataDog/sketches-go v1.4.4/go.mod h1:XR0ns2RtEEF09mDKXiKZiQg+nfZStrq1ZuL1eezeZe0=
-github.com/DataDog/trivy v0.0.0-20240425145011-1883c1659654 h1:tMlN1vN/p3x6Gp0PN04yUn70cplZg6rQyH3QGZL/UoM=
-github.com/DataDog/trivy v0.0.0-20240425145011-1883c1659654/go.mod h1:xmc7xCb5KSg2mFbztyInH8ciotVbad9SOmGFClgD0cU=
+github.com/DataDog/trivy v0.0.0-20240426155824-6c986dae34c1 h1:0iL9+kxw9y4OJeI4pZAwxZ76ah0Sj6AEuv7mh3Vp0N0=
+github.com/DataDog/trivy v0.0.0-20240426155824-6c986dae34c1/go.mod h1:xmc7xCb5KSg2mFbztyInH8ciotVbad9SOmGFClgD0cU=
 github.com/DataDog/viper v1.13.2 h1:GrYzwGiaEoliIXA4wPkx8MHIRY5sNi8frV1Fsv7VCJU=
 github.com/DataDog/viper v1.13.2/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
 github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950 h1:2imDajw3V85w1iqHsuXN+hUBZQVF+r9eME8tsPq/HpA=

--- a/go.sum
+++ b/go.sum
@@ -786,8 +786,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.14.0 h1:QHx6B/VUx3rZ
 github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.14.0/go.mod h1:q4c7zbmdnIdSJNZuBsveTk5ZeRkSkS2g6b8zzFF1mE4=
 github.com/DataDog/sketches-go v1.4.4 h1:dF52vzXRFSPOj2IjXSWLvXq3jubL4CI69kwYjJ1w5Z8=
 github.com/DataDog/sketches-go v1.4.4/go.mod h1:XR0ns2RtEEF09mDKXiKZiQg+nfZStrq1ZuL1eezeZe0=
-github.com/DataDog/trivy v0.0.0-20240425083949-2c901525e688 h1:iCExVzcILHdleMz4ULPj9ACT/juLBbSQUSNmhBpnGjE=
-github.com/DataDog/trivy v0.0.0-20240425083949-2c901525e688/go.mod h1:xmc7xCb5KSg2mFbztyInH8ciotVbad9SOmGFClgD0cU=
+github.com/DataDog/trivy v0.0.0-20240425145011-1883c1659654 h1:tMlN1vN/p3x6Gp0PN04yUn70cplZg6rQyH3QGZL/UoM=
+github.com/DataDog/trivy v0.0.0-20240425145011-1883c1659654/go.mod h1:xmc7xCb5KSg2mFbztyInH8ciotVbad9SOmGFClgD0cU=
 github.com/DataDog/viper v1.13.2 h1:GrYzwGiaEoliIXA4wPkx8MHIRY5sNi8frV1Fsv7VCJU=
 github.com/DataDog/viper v1.13.2/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
 github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950 h1:2imDajw3V85w1iqHsuXN+hUBZQVF+r9eME8tsPq/HpA=

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -10,7 +10,9 @@ package sbom
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -219,16 +221,39 @@ func (p *processor) processHostScanResult(result sbom.ScanResult) {
 	p.queue <- sbom
 }
 
+type relFS struct {
+	root string
+	fs   fs.FS
+}
+
+func newFS(root string) fs.FS {
+	fs := os.DirFS(root)
+	return &relFS{root: "/", fs: fs}
+}
+
+func (f *relFS) Open(name string) (fs.File, error) {
+	if filepath.IsAbs(name) {
+		var err error
+		name, err = filepath.Rel(f.root, name)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return f.fs.Open(name)
+}
+
 func (p *processor) triggerHostScan() {
 	if !p.hostSBOM {
 		return
 	}
 	log.Debugf("Triggering host SBOM refresh")
 
-	scanRequest := host.NewScanRequest("/")
+	scanPath := "/"
 	if hostRoot := os.Getenv("HOST_ROOT"); ddConfig.IsContainerized() && hostRoot != "" {
-		scanRequest = host.NewScanRequest(hostRoot)
+		scanPath = hostRoot
 	}
+	scanRequest := host.NewScanRequest(scanPath, newFS("/"))
 
 	if err := p.sbomScanner.Scan(scanRequest); err != nil {
 		log.Errorf("Failed to trigger SBOM generation for host: %s", err)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1230,7 +1230,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("sbom.container_image.analyzers", []string{"os"})
 	config.BindEnvAndSetDefault("sbom.container_image.check_disk_usage", true)
 	config.BindEnvAndSetDefault("sbom.container_image.min_available_disk", "1Gb")
-	config.BindEnvAndSetDefault("sbom.container_image.overlayfs_direct_scan", true)
+	config.BindEnvAndSetDefault("sbom.container_image.overlayfs_direct_scan", false)
 
 	// Host SBOM configuration
 	config.BindEnvAndSetDefault("sbom.host.enabled", false)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1230,6 +1230,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("sbom.container_image.analyzers", []string{"os"})
 	config.BindEnvAndSetDefault("sbom.container_image.check_disk_usage", true)
 	config.BindEnvAndSetDefault("sbom.container_image.min_available_disk", "1Gb")
+	config.BindEnvAndSetDefault("sbom.container_image.overlayfs_direct_scan", true)
 
 	// Host SBOM configuration
 	config.BindEnvAndSetDefault("sbom.host.enabled", false)

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -28,30 +28,30 @@ import (
 // not trigger multiple scans at the same time unlike for container-images.
 const channelSize = 1
 
-// ScanRequest defines a scan request. This struct should be
+// scanRequest defines a scan request. This struct should be
 // hashable to be pushed in the work queue for processing.
-type ScanRequest struct {
+type scanRequest struct {
 	Path string
 	FS   fs.FS
 }
 
 // NewScanRequest creates a new scan request
 func NewScanRequest(path string, fs fs.FS) sbom.ScanRequest {
-	return ScanRequest{Path: path, FS: fs}
+	return scanRequest{Path: path, FS: fs}
 }
 
 // Collector returns the collector name
-func (r ScanRequest) Collector() string {
+func (r scanRequest) Collector() string {
 	return collectors.HostCollector
 }
 
 // Type returns the scan request type
-func (r ScanRequest) Type(sbom.ScanOptions) string {
+func (r scanRequest) Type(sbom.ScanOptions) string {
 	return sbom.ScanFilesystemType
 }
 
 // ID returns the scan request ID
-func (r ScanRequest) ID() string {
+func (r scanRequest) ID() string {
 	return r.Path
 }
 
@@ -86,7 +86,7 @@ func (c *Collector) Init(cfg config.Component, wmeta optional.Option[workloadmet
 
 // Scan performs a scan
 func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.ScanResult {
-	hostScanRequest, ok := request.(ScanRequest)
+	hostScanRequest, ok := request.(scanRequest)
 	if !ok {
 		return sbom.ScanResult{Error: fmt.Errorf("invalid request type '%s' for collector '%s'", reflect.TypeOf(request), collectors.HostCollector)}
 	}

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -86,7 +86,7 @@ func (c *Collector) Init(cfg config.Component, wmeta optional.Option[workloadmet
 
 // Scan performs a scan
 func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.ScanResult {
-	hostScanRequest, ok := request.(*ScanRequest)
+	hostScanRequest, ok := request.(ScanRequest)
 	if !ok {
 		return sbom.ScanResult{Error: fmt.Errorf("invalid request type '%s' for collector '%s'", reflect.TypeOf(request), collectors.HostCollector)}
 	}

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -218,7 +218,7 @@ func (r *Resolver) generateSBOM(root string, sbom *SBOM) error {
 	seclog.Infof("Generating SBOM for %s", root)
 	r.sbomGenerations.Inc()
 
-	scanRequest := host.NewScanRequest(root)
+	scanRequest := host.NewScanRequest(root, os.DirFS("/"))
 	ch := collectors.GetHostScanner().Channel()
 	if ch == nil {
 		return fmt.Errorf("couldn't retrieve global host scanner result channel")

--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images/archive"
@@ -74,7 +73,7 @@ func imageWriter(client *containerd.Client, img containerd.Image) imageSave {
 }
 
 // Custom code based on https://github.com/aquasecurity/trivy/blob/2206e008ea6e5f4e5c1aa7bc8fc77dae7041de6a/pkg/fanal/image/daemon/containerd.go `ContainerdImage`
-func convertContainerdImage(ctx context.Context, client *containerd.Client, imgMeta *workloadmeta.ContainerImageMetadata, img containerd.Image) (types.Image, func(), error) {
+func convertContainerdImage(ctx context.Context, client *containerd.Client, imgMeta *workloadmeta.ContainerImageMetadata, img containerd.Image) (*image, func(), error) {
 	ctx = namespaces.WithNamespace(ctx, imgMeta.Namespace)
 	cleanup := func() {}
 

--- a/pkg/util/trivy/docker.go
+++ b/pkg/util/trivy/docker.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 
-	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/docker/docker/client"
 	"golang.org/x/xerrors"
 )
@@ -22,7 +21,7 @@ import (
 const DockerCollector = "docker"
 
 // Custom code based on https://github.com/aquasecurity/trivy/blob/2206e008ea6e5f4e5c1aa7bc8fc77dae7041de6a/pkg/fanal/image/daemon/docker.go `DockerImage`
-func convertDockerImage(ctx context.Context, client client.ImageAPIClient, imgMeta *workloadmeta.ContainerImageMetadata) (types.Image, func(), error) {
+func convertDockerImage(ctx context.Context, client client.ImageAPIClient, imgMeta *workloadmeta.ContainerImageMetadata) (*image, func(), error) {
 	cleanup := func() {}
 
 	// <image_name>:<tag> pattern like "alpine:3.15"

--- a/pkg/util/trivy/overlayfs.go
+++ b/pkg/util/trivy/overlayfs.go
@@ -1,0 +1,242 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package trivy implement a simple overlayfs like filesystem to be able to
+// scan through layered filesystems.
+package trivy
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"sort"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// whiteoutCharDev is defined as zero and is not const only for testing as it
+// is not allowed to mknod a 0/0 char dev in userns.
+var whiteoutCharDev uint64 = 0 //nolint:revive
+
+var whiteout *fs.DirEntry
+
+type filesystem struct {
+	layers []string
+}
+
+type file struct {
+	*os.File
+	ofs  filesystem
+	fi   fs.FileInfo
+	name string
+}
+
+// NewFS returns a fs.ReadDirFS consisting of merging the given layer paths.
+func NewFS(layers []string) interface {
+	fs.FS
+	fs.ReadDirFS
+	fs.StatFS
+} {
+	return &filesystem{layers[:]}
+}
+
+// Open implements fs.StatFS.
+func (ofs filesystem) Stat(name string) (fs.FileInfo, error) {
+	name = path.Join("/", name)[1:]
+	if name == "" {
+		name = "."
+	}
+	_, fi, err := ofs.stat(name)
+	return fi, err
+}
+
+// Open implements fs.FS.
+func (ofs filesystem) Open(name string) (fs.File, error) {
+	name = path.Join("/", name)[1:]
+	layerIndex, fi, err := ofs.stat(name)
+	if err != nil {
+		err.(*os.PathError).Op = "open"
+		return nil, err
+	}
+	f, err := os.Open(ofs.path(layerIndex, name))
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: name, Err: err}
+	}
+	return &file{File: f, ofs: ofs, fi: fi, name: name}, nil
+}
+
+func (ofs filesystem) path(layerIndex int, name string) string {
+	if !fs.ValidPath(name) {
+		panic(fmt.Errorf("unexpected invalid path name %q", name))
+	}
+	return path.Join(ofs.layers[layerIndex], name)
+}
+
+func (ofs filesystem) stat(name string) (int, fs.FileInfo, error) {
+	var errf error
+	for layerIndex := range ofs.layers {
+		fi, err := os.Stat(ofs.path(layerIndex, name))
+		if errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.ENOTDIR) {
+			// When path does not exist, overlayfs does not verify that a
+			// whiteout file has been created as one of the parent dir in the
+			// current layer. Meaning you can open file from lower dirs even
+			// if a whiteout or opaque directory has been created on an upper
+			// layer.
+			continue
+		}
+		if err != nil {
+			errf = err
+			break
+		}
+		if isWhiteout(fi) {
+			break
+		}
+		return layerIndex, fi, nil
+	}
+	if errf == nil {
+		errf = syscall.ENOENT
+	}
+	return 0, nil, &os.PathError{Op: "stat", Path: name, Err: errf}
+}
+
+// ReadDir implements fs.ReadDirFS.
+func (ofs filesystem) ReadDir(name string) ([]fs.DirEntry, error) {
+	return ofs.readDirN(name, -1)
+}
+
+func (ofs filesystem) readDirN(name string, n int) ([]fs.DirEntry, error) {
+	name = path.Join("/", name)[1:]
+	if name == "" {
+		name = "."
+	}
+
+	var entriesMap map[string]*fs.DirEntry
+	var err error
+	var ok bool
+	for layerIndex := range ofs.layers {
+		if ok, err = ofs.readDirLayer(layerIndex, name, n, &entriesMap); ok {
+			break
+		}
+	}
+	if err == nil && entriesMap == nil {
+		err = syscall.ENOENT
+	}
+	if err != nil {
+		return []fs.DirEntry{}, &os.PathError{Op: "readdirent", Path: name, Err: err}
+	}
+
+	entries := make([]fs.DirEntry, 0, len(entriesMap))
+	for _, entry := range entriesMap {
+		if entry != whiteout {
+			entries = append(entries, *entry)
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+	if n > 0 && len(entries) > n {
+		entries = entries[:n]
+	}
+	return entries, nil
+}
+
+func (ofs filesystem) readDirLayer(layerIndex int, name string, n int, entriesMap *map[string]*fs.DirEntry) (bool, error) {
+	fullname := ofs.path(layerIndex, name)
+
+	di, err := os.Stat(fullname)
+	if errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.ENOTDIR) {
+		return false, nil
+	}
+	if err != nil {
+		return true, err
+	}
+	if isWhiteout(di) {
+		return true, syscall.ENOENT
+	}
+	if !di.IsDir() {
+		return true, syscall.ENOTDIR
+	}
+
+	d, err := os.Open(fullname)
+	if err != nil {
+		return true, err
+	}
+
+	entries, err := d.ReadDir(n)
+	if err != nil {
+		return true, err
+	}
+	if *entriesMap == nil {
+		*entriesMap = make(map[string]*fs.DirEntry)
+	}
+	for entryIndex, entry := range entries {
+		entryName := entry.Name()
+		if _, exists := (*entriesMap)[entryName]; !exists {
+			entryPtr := &entries[entryIndex]
+			if entry.Type().IsRegular() {
+				(*entriesMap)[entryName] = entryPtr
+			} else {
+				ei, err := entry.Info()
+				if err != nil {
+					return true, err
+				}
+				if isWhiteout(ei) {
+					(*entriesMap)[entryName] = whiteout
+				} else {
+					(*entriesMap)[entryName] = entryPtr
+				}
+			}
+		}
+	}
+
+	return isOpaqueDir(d), nil
+}
+
+// ReadDir implements fs.ReadDirFile.
+func (f *file) ReadDir(n int) ([]fs.DirEntry, error) {
+	if !f.fi.IsDir() {
+		return nil, &os.PathError{Op: "readdirent", Path: f.name, Err: syscall.ENOTDIR}
+	}
+	return f.ofs.readDirN(f.name, n)
+}
+
+// Read implements fs.File.
+func (f *file) Read(b []byte) (int, error) {
+	return f.File.Read(b)
+}
+
+// Stat implements fs.File.
+func (f *file) Stat() (fs.FileInfo, error) {
+	return f.fi, nil
+}
+
+// Close implements fs.File.
+func (f *file) Close() error {
+	return f.File.Close()
+}
+
+var _ fs.ReadDirFile = &file{}
+
+func isWhiteout(fm fs.FileInfo) bool {
+	return fm.Mode()&fs.ModeCharDevice != 0 && uint64(fm.Sys().(*syscall.Stat_t).Rdev) == whiteoutCharDev
+}
+
+func isOpaqueDir(d *os.File) bool {
+	var data [1]byte
+	var sz int
+	var err error
+	for {
+		sz, err = unix.Fgetxattr(int(d.Fd()), "trusted.overlay.opaque", data[:])
+		if err != unix.EINTR {
+			break
+		}
+	}
+	return sz == 1 && data[0] == 'y'
+}

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -249,13 +249,13 @@ func (c *Collector) ScanDockerImage(ctx context.Context, imgMeta *workloadmeta.C
 	}
 
 	if c.config.overlayFSSupport && fanalImage.inspect.GraphDriver.Name == "overlay2" {
-		return c.scanOverlayFS(ctx, fanalImage, scanOptions)
+		return c.scanOverlayFS(ctx, fanalImage, imgMeta, scanOptions)
 	}
 
 	return c.scanImage(ctx, fanalImage, imgMeta, scanOptions)
 }
 
-func (c *Collector) scanOverlayFS(ctx context.Context, fanalImage *image, scanOptions sbom.ScanOptions) (sbom.Report, error) {
+func (c *Collector) scanOverlayFS(ctx context.Context, fanalImage *image, imgMeta *workloadmeta.ContainerImageMetadata, scanOptions sbom.ScanOptions) (sbom.Report, error) {
 	var layers []string
 	if layerDirs, ok := fanalImage.inspect.GraphDriver.Data["LowerDir"]; ok {
 		layers = append(layers, strings.Split(layerDirs, ":")...)
@@ -266,7 +266,7 @@ func (c *Collector) scanOverlayFS(ctx context.Context, fanalImage *image, scanOp
 	}
 
 	fs := NewFS(layers)
-	report, err := c.scanFilesystem(ctx, fs, ".", nil, scanOptions)
+	report, err := c.scanFilesystem(ctx, fs, ".", imgMeta, scanOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (c *Collector) ScanContainerdImage(ctx context.Context, imgMeta *workloadme
 	}
 
 	if c.config.overlayFSSupport && fanalImage.inspect.GraphDriver.Name == "overlay2" {
-		return c.scanOverlayFS(ctx, fanalImage, scanOptions)
+		return c.scanOverlayFS(ctx, fanalImage, imgMeta, scanOptions)
 	}
 
 	return c.scanImage(ctx, fanalImage, imgMeta, scanOptions)

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -348,12 +348,12 @@ func (c *Collector) scanFilesystem(ctx context.Context, fsys fs.FS, path string,
 		return nil, fmt.Errorf("unable to marshal report to sbom format, err: %w", err)
 	}
 
-	log.Infof("Found OS: %+v", trivyReport.Metadata.OS)
+	log.Debugf("Found OS: %+v", trivyReport.Metadata.OS)
 	pkgCount := 0
 	for _, results := range trivyReport.Results {
 		pkgCount += len(results.Packages)
 	}
-	log.Infof("Found %d packages", pkgCount)
+	log.Debugf("Found %d packages", pkgCount)
 
 	return &Report{
 		Report:    trivyReport,

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -256,10 +256,6 @@ func (c *Collector) ScanDockerImage(ctx context.Context, imgMeta *workloadmeta.C
 }
 
 func (c *Collector) scanOverlayFS(ctx context.Context, fanalImage *image, scanOptions sbom.ScanOptions) (sbom.Report, error) {
-	if !c.config.overlayFSSupport || fanalImage.inspect.GraphDriver.Name != "overlay2" {
-		return nil, fmt.Errorf("failed to scan overlayfs for %s", fanalImage.inspect.ID)
-	}
-
 	var layers []string
 	if layerDirs, ok := fanalImage.inspect.GraphDriver.Data["LowerDir"]; ok {
 		layers = append(layers, strings.Split(layerDirs, ":")...)

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -275,10 +275,6 @@ func (c *Collector) scanOverlayFS(ctx context.Context, fanalImage *image, scanOp
 		return nil, err
 	}
 
-	if report, ok := report.(*Report); ok {
-		report.Report.Metadata.ImageID, _ = fanalImage.ID()
-	}
-
 	return report, nil
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

When the container runtime is using overlayfs as filesystem, use a virtual
in memory overlayfs to scan the image instead of relying on the snapshotter.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Using the snapshotter requires having the CAP_SYS_ADMIN capability while this method
"only" needs
 uid 0.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
