### PR TITLE
(fleet) fix missing site override in the bootstraper

### DIFF
--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -109,6 +109,9 @@ func newBootstraperCmd(operation string) *bootstraperCmd {
 	if cmd.apiKey != "" {
 		opts = append(opts, bootstraper.WithAPIKey(cmd.apiKey))
 	}
+	if cmd.site != "" {
+		opts = append(opts, bootstraper.WithSite(cmd.site))
+	}
 	if os.Getenv(envBootstrapInstallerVersion) != "" {
 		opts = append(opts, bootstraper.WithInstallerVersion(os.Getenv(envBootstrapInstallerVersion)))
 	}

--- a/pkg/fleet/bootstraper/bootstraper.go
+++ b/pkg/fleet/bootstraper/bootstraper.go
@@ -71,6 +71,13 @@ func WithAPIKey(apiKey string) Option {
 	}
 }
 
+// WithSite sets the site.
+func WithSite(site string) Option {
+	return func(o *options) {
+		o.site = site
+	}
+}
+
 // Bootstrap installs a first version of the installer on the disk.
 //
 // The bootstrap process is composed of the following steps:


### PR DESCRIPTION
Bootstrap was not taking into account site which broke the logic redirecting to staging registries.