### PR TITLE
[EBPF] Fix upload of KMT ARM64 test results

### DIFF
--- a/.gitlab/junit_upload/junit_upload.yml
+++ b/.gitlab/junit_upload/junit_upload.yml
@@ -25,41 +25,8 @@ kmt_arm64_junit_upload:
   allow_failure: true
   needs:
     - job: kmt_run_sysprobe_tests_arm64
-      parallel:
-        matrix:
-          - TAG:
-            - "ubuntu_18.04"
-            - "ubuntu_20.04"
-            - "ubuntu_22.04"
-            - "ubuntu_23.10"
-            - "amzn_4.14"
-            - "amzn_5.4"
-            - "amzn_5.10"
-            - "fedora_37"
-            - "fedora_38"
-            - "debian_10"
-            - "debian_11"
-            - "debian_12"
-            - "centos_79"
-            - "centos_8"
-            TEST_SET: ["no_tracersuite", "only_tracersuite"]
       optional: true
     - job: kmt_run_secagent_tests_arm64
-      parallel:
-        matrix:
-          - TAG:
-              - "ubuntu_18.04"
-              - "ubuntu_20.04"
-              - "ubuntu_22.04"
-              - "ubuntu_23.10"
-              - "amzn_5.4"
-              - "amzn_5.10"
-              - "fedora_37"
-              - "fedora_38"
-              - "debian_10"
-              - "debian_11"
-              - "debian_12"
-            TEST_SET: ["all_tests"]
       optional: true
   script:
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "$DD_AGENT_TESTING_DIR/junit-*.tar.gz"

--- a/.gitlab/junit_upload/junit_upload.yml
+++ b/.gitlab/junit_upload/junit_upload.yml
@@ -15,6 +15,8 @@ unit_tests_arm64_windows_junit_upload:
   script:
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh
 
+# The corresponding upload for the x86 tests is in the test jobs themselves, we have to upload
+# the ARM64 test results here as we need an x86 image to run the upload.
 kmt_arm64_junit_upload:
   stage: junit_upload
   rules:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Remove the list of OSs in the `kmt_arm64_junit_upload` job, Gitlab automatically downloads artifacts for all parallel jobs by default.

### Motivation

Avoid problems when the list of OSs in the junit-upload job gets out of sync with the list in the KMT jobs. For example, the Rocky images were not included in that job and [results for those jobs were not uploaded](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40ci.job.name%3A%22kmt_run_secagent_tests_arm64%3A%20%5Brocky_8.5%2C%20all_tests%5D%22&agg_m=count&agg_m_source=base&agg_q=%40ci.job.name&agg_q_source=base&agg_t=count&eventStack=&fromUser=true&index=citest&top_n=100&top_o=top&viz=timeseries&x_missing=true&start=1712748071549&end=1714044071549&paused=false).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Tested in CI