### PR TITLE
fix span names

### DIFF
--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -202,7 +202,7 @@ func installExperimentCommand() *cobra.Command {
 		GroupID: "installer",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
-			i := newInstallerCmd("install-experiment")
+			i := newInstallerCmd("install_experiment")
 			defer func() { i.Stop(err) }()
 			i.span.SetTag("params.url", args[0])
 			return i.InstallExperiment(i.ctx, args[0])
@@ -218,7 +218,7 @@ func removeExperimentCommand() *cobra.Command {
 		GroupID: "installer",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
-			i := newInstallerCmd("remove-experiment")
+			i := newInstallerCmd("remove_experiment")
 			defer func() { i.Stop(err) }()
 			i.span.SetTag("params.package", args[0])
 			return i.RemoveExperiment(i.ctx, args[0])
@@ -234,7 +234,7 @@ func promoteExperimentCommand() *cobra.Command {
 		GroupID: "installer",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
-			i := newInstallerCmd("promote-experiment")
+			i := newInstallerCmd("promote_experiment")
 			defer func() { i.Stop(err) }()
 			i.span.SetTag("params.package", args[0])
 			return i.PromoteExperiment(i.ctx, args[0])
@@ -250,7 +250,7 @@ func garbageCollectCommand() *cobra.Command {
 		GroupID: "installer",
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
-			i := newInstallerCmd("garbage-collect")
+			i := newInstallerCmd("garbage_collect")
 			defer func() { i.Stop(err) }()
 			return i.GarbageCollect(i.ctx)
 		},


### PR DESCRIPTION
Since our spans don't pass through the trace-agent normalisation and until it's implemented in telemetry backend, we need to properly respect metrics/tags format

## operation names are used in metrics and should follow
- Metric names must start with a letter
- Metric names must only contain ASCII alphanumerics, underscores, and periods.
- Other characters, including spaces, are converted to underscores.
- Unicode is not supported.
- Metric names must not exceed 200 characters. Fewer than 100 is preferred from a UI perspective.

## resource (=operation name by default) are used in tags and should follow
- Tags must start with a letter and after that may contain the characters listed below:
Alphanumerics, Underscores, Minuses, Colons, Periods, Slashes
- Tags can be up to 200 characters long and support Unicode letters (which includes most character sets, including languages such as Japanese).
- Tags are converted to lowercase. Therefore, CamelCase tags are not recommended. Authentication (crawler) based integrations convert camel case tags to underscores, for example TestTag –> test_tag.
