### PR TITLE
[CWS-1954] Add EKS Fargate configuration to the inventory agent payload  

### DIFF
--- a/comp/metadata/inventoryagent/README.md
+++ b/comp/metadata/inventoryagent/README.md
@@ -49,6 +49,7 @@ The payload is a JSON dict with the following fields
   - `config_process_dd_url` - **string**: the configuration value `process_config.process_dd_url` (scrubbed)
   - `config_proxy_http` - **string**: the configuration value `proxy.http` (scrubbed)
   - `config_proxy_https` - **string**: the configuration value `proxy.https` (scrubbed)
+  - `config_eks_fargate` - **bool**: the configuration value `eks_fargate`
   - `install_method_tool` - **string**: the name of the tool used to install the agent (ie, Chef, Ansible, ...).
   - `install_method_tool_version` - **string**: the tool version used to install the agent (ie: Chef version, Ansible
     version, ...). This defaults to `"undefined"` when not installed through a tool (like when installed with apt, source

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -225,6 +225,7 @@ func (ia *inventoryagent) fetchCoreAgentMetadata() {
 	ia.data["config_process_dd_url"] = scrub(ia.conf.GetString("process_config.process_dd_url"))
 	ia.data["config_proxy_http"] = scrub(ia.conf.GetString("proxy.http"))
 	ia.data["config_proxy_https"] = scrub(ia.conf.GetString("proxy.https"))
+	ia.data["config_eks_fargate"] = ia.conf.GetBool("eks_fargate")
 	ia.data["feature_fips_enabled"] = ia.conf.GetBool("fips.enabled")
 	ia.data["feature_logs_enabled"] = ia.conf.GetBool("logs_enabled")
 	ia.data["feature_imdsv2_enabled"] = ia.conf.GetBool("ec2_prefer_imdsv2")

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -151,6 +151,7 @@ func TestInitData(t *testing.T) {
 		"proxy.http":                       "http://name:sekrit@proxy.example.com/",
 		"proxy.https":                      "https://name:sekrit@proxy.example.com/",
 		"site":                             "test",
+		"eks_fargate":                      true,
 
 		"fips.enabled":                                true,
 		"logs_enabled":                                true,
@@ -181,6 +182,7 @@ func TestInitData(t *testing.T) {
 		"config_process_dd_url":            "http://name:********@someintake.example.com/",
 		"config_proxy_http":                "http://name:********@proxy.example.com/",
 		"config_proxy_https":               "https://name:********@proxy.example.com/",
+		"config_eks_fargate":               true,
 
 		"feature_process_language_detection_enabled": true,
 		"feature_fips_enabled":                       true,

--- a/releasenotes/notes/add-eks-fargate-to-agent-metadata-payload-3d6f2900fd328784.yaml
+++ b/releasenotes/notes/add-eks-fargate-to-agent-metadata-payload-3d6f2900fd328784.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Report EKS Fargate configuration to the Agent metadata payload.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds a new `config_eks_fargate` field to the Agent metadata payload.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Reporting this field allows distinguishing agents deployed on an EKS Fargate cluster.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- The `agent diagnose show-metadata inventory-agent` command should report the `config_eks_fargate` field.
- Deploy the agent on an EKS Fargate cluster and check this field is set to `true`.
