### PR TITLE
Implement caching for ruby dependencies used in Omnibus

### DIFF
--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -46,7 +46,10 @@
     key:
       files:
         - omnibus/Gemfile
-      prefix: omnibus-deps-$CI_JOB_NAME-$OMNIBUS_SOFTWARE_VERSION-$OMNIBUS_RUBY_VERSION
+        # This is coarser than needed, but there's no more convenient way
+        # to get a hold of OMNIBUS_RUBY_VERSION and OMNIBUS_SOFTWARE version
+        - release.json
+      prefix: omnibus-deps-$CI_JOB_NAME
     paths:
       - omnibus/vendor/bundle
 

--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -35,6 +35,21 @@
   - *get_artifactory_token_win
   - if (($Env:USE_CACHING_PROXY_PYTHON -eq "true") -and ($Env:ARTIFACTORY_BYPASS -eq "false")) { $PIP_INDEX_URL="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_PYPI_PATH}" }
 
+# Sets up a cache for gems used by Omnibus
+# Usage:
+# !reference [.cache_omnibus_ruby_deps, setup] somewhere ahead of invoking bundlex
+# !reference [.cache_omnibus_ruby_deps, cache] under `cache` for the same job
+.cache_omnibus_ruby_deps:
+  setup:
+    - (cd omnibus; bundle config set --local path 'vendor/bundle')
+  cache:
+    key:
+      files:
+        - omnibus/Gemfile
+      prefix: omnibus-deps-$CI_JOB_NAME-$OMNIBUS_SOFTWARE_VERSION-$OMNIBUS_RUBY_VERSION
+    paths:
+      - omnibus/vendor/bundle
+
 .setup_deb_signing_key: &setup_deb_signing_key
   - set +x
   - DEB_GPG_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $DEB_GPG_KEY_SSM_NAME)

--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -37,7 +37,7 @@
 
 # Sets up a cache for gems used by Omnibus
 # Usage:
-# !reference [.cache_omnibus_ruby_deps, setup] somewhere ahead of invoking bundlex
+# !reference [.cache_omnibus_ruby_deps, setup] somewhere ahead of invoking bundle
 # !reference [.cache_omnibus_ruby_deps, cache] under `cache` for the same job
 .cache_omnibus_ruby_deps:
   setup:

--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -41,7 +41,7 @@
 # !reference [.cache_omnibus_ruby_deps, cache] under `cache` for the same job
 .cache_omnibus_ruby_deps:
   setup:
-    - (cd omnibus; bundle config set --local path 'vendor/bundle')
+    - pushd omnibus && bundle config set --local path 'vendor/bundle' && popd
   cache:
     key:
       files:

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -5,6 +5,7 @@
     - !reference [.setup_ruby_mirror_linux]
     - !reference [.setup_python_mirror_linux]
     - !reference [.retrieve_linux_go_deps]
+    - !reference [.cache_omnibus_ruby_deps, setup]
     - echo "About to build for $RELEASE_VERSION"
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
@@ -31,6 +32,8 @@
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
+  cache:
+    - !reference [.cache_omnibus_ruby_deps, cache]
 
 agent_deb-x64-a6:
   extends: .agent_build_common_deb

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -9,6 +9,7 @@
     - !reference [.setup_ruby_mirror_linux]
     - !reference [.setup_python_mirror_linux]
     - !reference [.retrieve_linux_go_deps]
+    - !reference [.cache_omnibus_ruby_deps, setup]
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
@@ -32,6 +33,8 @@
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
+  cache:
+    - !reference [.cache_omnibus_ruby_deps, cache]
 
 datadog-agent-oci-x64-a7:
   extends: .common_build_oci

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -5,6 +5,7 @@
     - !reference [.setup_ruby_mirror_linux]
     - !reference [.setup_python_mirror_linux]
     - !reference [.retrieve_linux_go_deps]
+    - !reference [.cache_omnibus_ruby_deps, setup]
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
@@ -30,6 +31,8 @@
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
+  cache:
+    - !reference [.cache_omnibus_ruby_deps, cache]
 
 # build Agent package for rpm-x64
 agent_rpm-x64-a6:

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -5,6 +5,7 @@
     - !reference [.setup_ruby_mirror_linux]
     - !reference [.setup_python_mirror_linux]
     - !reference [.retrieve_linux_go_deps]
+    - !reference [.cache_omnibus_ruby_deps, setup]
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR_SUSE/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
@@ -33,6 +34,8 @@
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR_SUSE
+  cache:
+    - !reference [.cache_omnibus_ruby_deps, cache]
 
 # build Agent package for suse-x64
 agent_suse-x64-a6:

--- a/.gitlab/packaging/deb.yml
+++ b/.gitlab/packaging/deb.yml
@@ -7,6 +7,7 @@
   script:
     - source /root/.bashrc
     - !reference [.setup_ruby_mirror_linux]
+    - !reference [.cache_omnibus_ruby_deps, setup]
     - echo "About to package for $RELEASE_VERSION"
     - export OMNIBUS_PACKAGE_ARTIFACT="$(ls ${OMNIBUS_PACKAGE_DIR}/*.tar.xz | head -n 1)"
     - echo "Packaging artifact ${OMNIBUS_PACKAGE_ARTIFACT} to .deb"
@@ -18,6 +19,8 @@
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
+  cache:
+    - !reference [.cache_omnibus_ruby_deps, cache]
 
 installer_deb-amd64:
   extends: .installer_package_deb_common

--- a/.gitlab/packaging/rpm.yml
+++ b/.gitlab/packaging/rpm.yml
@@ -10,6 +10,7 @@
   script:
     - echo "About to build for $RELEASE_VERSION"
     - !reference [.setup_ruby_mirror_linux]
+    - !reference [.cache_omnibus_ruby_deps, setup]
     # remove artifacts from previous pipelines that may come from the cache
     - export OMNIBUS_PACKAGE_ARTIFACT="$(ls ${OMNIBUS_PACKAGE_DIR}/*.tar.xz | head -n 1)"
     - echo "Packaging artifact ${OMNIBUS_PACKAGE_ARTIFACT} to .rpm"
@@ -26,6 +27,8 @@
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
+  cache:
+    - !reference [.cache_omnibus_ruby_deps, cache]
 
 installer_rpm-amd64:
   extends: .installer_package_rpm_common


### PR DESCRIPTION
### What does this PR do?

Implement caching for ruby dependencies used on Omnibus (for Linux), reducing the reliance on rubygems or the caching mirror.

### Motivation

Eventually drop the caching mirror (part of [BARX-332](https://datadoghq.atlassian.net/browse/BARX-332)).

### Additional Notes

Windows and MacOS invoke omnibus somewhat differently and may be addressed in follow up work.

Example of cache hit: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/498116809#L109

### Possible Drawbacks / Trade-offs

Using `$CI_JOB_NAME` might be over-conservative (technically the platform would be the only thing that really matters), but it's used in this first implementation because it's simplest and safest.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->


[BARX-332]: https://datadoghq.atlassian.net/browse/BARX-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ