### PR TITLE
Remove gzip from processed BTFs archive

### DIFF
--- a/.gitlab/deps_build/deps_build.yml
+++ b/.gitlab/deps_build/deps_build.yml
@@ -92,5 +92,5 @@ build_processed_btfhub_archive:
     KUBERNETES_CPU_REQUEST: 32
   script:
     - inv -e system-probe.process-btfhub-archive --branch $BTFHUB_ARCHIVE_BRANCH
-    - $S3_CP_CMD btfs-x86_64.tar.gz $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-x86_64.tar --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-    - $S3_CP_CMD btfs-arm64.tar.gz $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-arm64.tar --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    - $S3_CP_CMD btfs-x86_64.tar $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-x86_64.tar --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    - $S3_CP_CMD btfs-arm64.tar $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-arm64.tar --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers

--- a/.gitlab/deps_build/deps_build.yml
+++ b/.gitlab/deps_build/deps_build.yml
@@ -92,5 +92,5 @@ build_processed_btfhub_archive:
     KUBERNETES_CPU_REQUEST: 32
   script:
     - inv -e system-probe.process-btfhub-archive --branch $BTFHUB_ARCHIVE_BRANCH
-    - $S3_CP_CMD btfs-x86_64.tar.gz $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-x86_64.tar.gz --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-    - $S3_CP_CMD btfs-arm64.tar.gz $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-arm64.tar.gz --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    - $S3_CP_CMD btfs-x86_64.tar.gz $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-x86_64.tar --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    - $S3_CP_CMD btfs-arm64.tar.gz $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-arm64.tar --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers

--- a/.gitlab/package_deps_build/package_deps_build.yml
+++ b/.gitlab/package_deps_build/package_deps_build.yml
@@ -11,8 +11,8 @@
   tags: ["arch:amd64"]
   script:
     - cd $CI_PROJECT_DIR
-    - $S3_CP_CMD $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-$ARCH.tar.gz .
-    - tar -xf btfs-$ARCH.tar.gz
+    - $S3_CP_CMD $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-$ARCH.tar .
+    - tar -xf btfs-$ARCH.tar
     - tar -xf sysprobe-build-outputs.tar.xz
     - inv -e system-probe.generate-minimized-btfs --source-dir "$CI_PROJECT_DIR/btfs-$ARCH" --output-dir "$CI_PROJECT_DIR/minimized-btfs" --bpf-programs "$CI_PROJECT_DIR/pkg/ebpf/bytecode/build/co-re"
     - cd minimized-btfs

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1581,7 +1581,6 @@ def process_btfhub_archive(ctx, branch="main"):
             # at least one file needs to be moved for directory to exist
             if os.path.exists(btfs_dir):
                 with ctx.cd(temp_dir):
-                    # gzip ends up being much faster than xz, for roughly the same output file size
                     # include btfs-$ARCH as prefix for all paths
                     ctx.run(f"tar -cf {output_path} btfs-{arch}")
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1517,7 +1517,7 @@ def generate_minimized_btfs(ctx, source_dir, output_dir, bpf_programs):
                     },
                 )
 
-    ctx.run(f"ninja -f {ninja_file_path}")
+    ctx.run(f"ninja -f {ninja_file_path}", env={"NINJA_STATUS": "(%r running) (%c/s) (%es) [%f/%t] "})
 
 
 @task

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1577,13 +1577,13 @@ def process_btfhub_archive(ctx, branch="main"):
         # generate both tarballs
         for arch in ["x86_64", "arm64"]:
             btfs_dir = os.path.join(temp_dir, f"btfs-{arch}")
-            output_path = os.path.join(output_dir, f"btfs-{arch}.tar.gz")
+            output_path = os.path.join(output_dir, f"btfs-{arch}.tar")
             # at least one file needs to be moved for directory to exist
             if os.path.exists(btfs_dir):
                 with ctx.cd(temp_dir):
                     # gzip ends up being much faster than xz, for roughly the same output file size
                     # include btfs-$ARCH as prefix for all paths
-                    ctx.run(f"tar -czf {output_path} btfs-{arch}")
+                    ctx.run(f"tar -cf {output_path} btfs-{arch}")
 
 
 @task


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Remove gzip from processed BTFs archive

### Motivation

The gzip compression does not meaningfully reduce the final archive file size, since each file is already compressed. This saves ~2 mins of decompression time during the minimization job.

### Additional Notes

Added some timing and debug output to `NINJA_STATUS` which is output on each line.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
