### PR TITLE
fix process handle leak

### DIFF
--- a/pkg/util/winutil/process.go
+++ b/pkg/util/winutil/process.go
@@ -388,6 +388,7 @@ func getProcessStartTimeAsNs(pid uint64) (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("Error opening process %v", err)
 	}
+	defer windows.Close(h)
 	var creation windows.Filetime
 	var exit windows.Filetime
 	var krn windows.Filetime

--- a/releasenotes/notes/fix-process-handle-leak-f8417f7d96b7faff.yaml
+++ b/releasenotes/notes/fix-process-handle-leak-f8417f7d96b7faff.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix a Windows process handle leak in process-agent introduced in 7.52.0 when process_collection is enabled.
+    Fix a Windows process handle leak in the Process Agent, which was introduced in 7.52.0 when `process_collection` is enabled.

--- a/releasenotes/notes/fix-process-handle-leak-f8417f7d96b7faff.yaml
+++ b/releasenotes/notes/fix-process-handle-leak-f8417f7d96b7faff.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a Windows process handle leak in process-agent introduced in 7.52.0 when process_collection is enabled.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Close the handle opened by `OpenProcess`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
fix a handle leak when `process_collection` (Live processes) is enabled

https://datadoghq.atlassian.net/browse/WINA-760

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Workaround for 7.52.x that allows Live Processes to continue to be used but disables service tagging via USM (a beta feature).
Configure in `system-probe.yaml`
```
system_probe_config:
  process_service_inference:
    use_windows_service_name: false
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Setup:
enable live processes in `datadog.yaml`
```
process_config:
  process_collection:
    enabled: true
```
Verify:
Handle count for process-agent does not increase by ~(numprocesses) every 10-15 seconds, it should remain about the same number.