### PR TITLE
[windows][cws][wkint-485] Add collection of module loads.

### DIFF
--- a/pkg/security/metrics/metrics_windows.go
+++ b/pkg/security/metrics/metrics_windows.go
@@ -121,4 +121,11 @@ var (
 	//MetricWindowsETWTotalNotifications is the metric for counting the total number of ETW notifications
 	//Tags: -
 	MetricWindowsETWTotalNotifications = newRuntimeMetric(".windows.etw_total_notifications")
+	//MetricWindowsModuleLoad is the metric for counting module load notifications
+	//Tags: -
+	MetricWindowsModuleLoad = newRuntimeMetric(".windows.module.load")
+	//MetricWindowsProcessUntracked is the metric for counting untracked process notifications
+	//Tags: -
+	MetricWindowsProcessUntracked = newRuntimeMetric(".windows.process.untracked")
+
 )

--- a/pkg/security/probe/probe_kernel_process_windows.go
+++ b/pkg/security/probe/probe_kernel_process_windows.go
@@ -14,22 +14,22 @@ import (
 )
 
 const (
-	idProcessStart = uint16(1)
-	idProcessStop  = uint16(2)
-	idThreadStart  = uint16(3)
-	idThreadStop   = uint16(4)
-	idImageLoad    = uint16(5)
-	idImageUnload  = uint16(6)
+	idProcessStart = uint16(1) // nolint:unused,revive
+	idProcessStop  = uint16(2) // nolint:unused,revive
+	idThreadStart  = uint16(3) // nolint:unused,revive
+	idThreadStop   = uint16(4) // nolint:unused,revive
+	idImageLoad    = uint16(5) // nolint:unused,revive
+	idImageUnload  = uint16(6) // nolint:unused,revive
 
-	idCpuBasePriorityChange = uint16(7)
-	idCpuPriorityChange     = uint16(8)
-	idPagePriorityChange    = uint16(9)
-	idIoPriorityChange      = uint16(10)
-	idProcessFreezeStart    = uint16(11)
-	idProcessFreezeStop     = uint16(12)
-	idJobStart              = uint16(13)
-	idJobTerminateStop      = uint16(14)
-	idProcessRundown        = uint16(15)
+	idCpuBasePriorityChange = uint16(7)  // nolint:unused,revive
+	idCpuPriorityChange     = uint16(8)  // nolint:unused,revive
+	idPagePriorityChange    = uint16(9)  // nolint:unused,revive
+	idIoPriorityChange      = uint16(10) // nolint:unused,revive
+	idProcessFreezeStart    = uint16(11) // nolint:unused,revive
+	idProcessFreezeStop     = uint16(12) // nolint:unused,revive
+	idJobStart              = uint16(13) // nolint:unused,revive
+	idJobTerminateStop      = uint16(14) // nolint:unused,revive
+	idProcessRundown        = uint16(15) // nolint:unused,revive
 )
 
 /*

--- a/pkg/security/probe/probe_kernel_process_windows.go
+++ b/pkg/security/probe/probe_kernel_process_windows.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/comp/etw"
+	etwimpl "github.com/DataDog/datadog-agent/comp/etw/impl"
+)
+
+const (
+	idProcessStart = uint16(1)
+	idProcessStop  = uint16(2)
+	idThreadStart  = uint16(3)
+	idThreadStop   = uint16(4)
+	idImageLoad    = uint16(5)
+	idImageUnload  = uint16(6)
+
+	idCpuBasePriorityChange = uint16(7)
+	idCpuPriorityChange     = uint16(8)
+	idPagePriorityChange    = uint16(9)
+	idIoPriorityChange      = uint16(10)
+	idProcessFreezeStart    = uint16(11)
+	idProcessFreezeStop     = uint16(12)
+	idJobStart              = uint16(13)
+	idJobTerminateStop      = uint16(14)
+	idProcessRundown        = uint16(15)
+)
+
+/*
+  <template tid="ImageLoadArgs">
+      <data name="ImageBase" inType="win:Pointer"/>
+      <data name="ImageSize" inType="win:Pointer"/>
+      <data name="ProcessID" inType="win:UInt32"/>
+      <data name="ImageCheckSum" inType="win:UInt32"/>
+      <data name="TimeDateStamp" inType="win:UInt32"/>
+      <data name="DefaultBase" inType="win:Pointer"/>
+      <data name="ImageName" inType="win:UnicodeString"/>
+     </template>
+*/
+
+type imageLoadArgs struct {
+	etw.DDEventHeader
+	imageBase     fileObjectPointer
+	ImageSize     fileObjectPointer
+	processID     uint32
+	imageCheckSum uint32
+	timeDateStamp uint32
+	defaultBase   fileObjectPointer
+	imageName     string
+}
+
+func (wp *WindowsProbe) parseImageLoadArgs(e *etw.DDEventRecord) (*imageLoadArgs, error) {
+	ila := &imageLoadArgs{
+		DDEventHeader: e.EventHeader,
+	}
+	data := etwimpl.GetUserData(e)
+
+	ila.imageBase = fileObjectPointer(data.GetUint64(0))
+	ila.ImageSize = fileObjectPointer(data.GetUint64(8))
+	ila.processID = data.GetUint32(16)
+	ila.imageCheckSum = data.GetUint32(20)
+	ila.timeDateStamp = data.GetUint32(24)
+	ila.defaultBase = fileObjectPointer(data.GetUint64(28))
+	ila.imageName, _, _, _ = data.ParseUnicodeString(36)
+
+	return ila, nil
+}
+
+func (ila *imageLoadArgs) String() string {
+	var output strings.Builder
+
+	output.WriteString("Image Load: Name: " + ila.imageName + "\n")
+	return output.String()
+}

--- a/pkg/security/probe/probe_kernel_process_windows_test.go
+++ b/pkg/security/probe/probe_kernel_process_windows_test.go
@@ -1,0 +1,122 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows && functionaltests
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"golang.org/x/sys/windows"
+)
+
+func processUntilLoadNotification(t *testing.T, et *etwTester) {
+
+	et.notifications = et.notifications[:0]
+	defer func() {
+		et.loopExited <- struct{}{}
+	}()
+	et.loopStarted <- struct{}{}
+
+	for {
+		select {
+		case <-et.stopLoop:
+			return
+
+		case n := <-et.notify:
+			switch n.(type) {
+			case *imageLoadArgs:
+				et.notifications = append(et.notifications, n)
+				return
+			}
+		}
+	}
+}
+
+func TestModuleLoadNotifications(t *testing.T) {
+	if true {
+		ebpftest.LogLevel(t, "info")
+	}
+	wp, err := createTestProbe()
+	require.NoError(t, err)
+
+	// teardownTestProe calls the stop function on etw, which will
+	// in turn wait on wp.fimgw
+	defer teardownTestProbe(wp)
+
+	et := createEtwTester(wp)
+
+	wp.fimwg.Add(1)
+	go func() {
+		defer wp.fimwg.Done()
+
+		var once sync.Once
+		mypid := os.Getpid()
+
+		err := et.p.setupEtw(func(n interface{}, pid uint32) {
+			once.Do(func() {
+				close(et.etwStarted)
+			})
+			if pid != uint32(mypid) {
+				return
+			}
+			select {
+			case et.notify <- n:
+				// message sent
+			default:
+			}
+		})
+		assert.NoError(t, err)
+	}()
+	// wait until we're sure that the ETW listener is up and running.
+	// as noted above, this _could_ cause an infinite deadlock if no notifications are received.
+	// but, since we're getting the notifications from the entire system, we should be getting
+	// a steady stream as soon as it's fired up.
+	<-et.etwStarted
+	t.Run("testModuleLoadOnSelf", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			processUntilLoadNotification(t, et)
+		}()
+		<-et.loopStarted
+		h, err := windows.LoadLibrary("comctl32.dll")
+		assert.NoError(t, err)
+		defer windows.FreeLibrary(h)
+		assert.Eventually(t, func() bool {
+			select {
+			case <-et.loopExited:
+				return true
+			default:
+				return false
+			}
+		}, 4*time.Second, 250*time.Millisecond, "did not get notification")
+		stopLoop(et, &wg)
+
+		assert.Equal(t, 1, len(et.notifications), "expected 1 notification, got %d", len(et.notifications))
+		if ila, ok := et.notifications[0].(*imageLoadArgs); ok {
+			// because of sxs, not sure _exactly_ where it will be loaded from.
+			// just ensure the .DLL part is right
+			base := filepath.Base(ila.imageName)
+			assert.True(t, isSameFile("comctl32.dll", base), "expected comctl32.dll, got %s", base)
+		} else {
+			t.Errorf("expected imageLoadArgs, got %T", et.notifications[0])
+		}
+
+	})
+
+}

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -305,7 +305,7 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 			case idImageLoad:
 				p.stats.moduleLoad++
 				if il, err := p.parseImageLoadArgs(e); err == nil {
-					log.Infof("Received ImageLoad event %d %s\n", e.EventHeader.EventDescriptor.ID, il)
+					log.Tracef("Received ImageLoad event %d %s\n", e.EventHeader.EventDescriptor.ID, il)
 					ecb(il, e.EventHeader.ProcessID)
 				}
 


### PR DESCRIPTION
Introduces new ETW listener on the kernel-process notifications. Collects an event when a module is loaded.

Note that filename is of the format \Device\HarddiskVolume1\Windows\System32\ntdll.dll, rather than canonical `c:\....`

PR includes automated tests.

PR does not actually implement new functionality.  Needs CWS consumer to do something with it.