### PR TITLE
[e2e]: Use exponential backoff for retries, retry install script call

### DIFF
--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -8,6 +8,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -184,7 +185,7 @@ func (c *TestClient) ExecuteWithRetry(cmd string) (string, error) {
 		if err == nil {
 			ok = true
 		}
-		time.Sleep(1 * time.Second)
+		time.Sleep(time.Duration(math.Pow(2, float64(try))) * time.Second)
 	}
 
 	return output, err

--- a/test/new-e2e/tests/agent-platform/install/install.go
+++ b/test/new-e2e/tests/agent-platform/install/install.go
@@ -67,7 +67,7 @@ func Unix(t *testing.T, client *common.TestClient, options ...installparams.Opti
 		require.NoError(tt, err, "failed to download install script from %s: ", source, err)
 
 		cmd := fmt.Sprintf(`DD_API_KEY="%s" %v DD_SITE="datadoghq.eu" bash installscript.sh`, apikey, commandLine)
-		output, err := client.Host.Execute(cmd)
+		output, err := client.ExecuteWithRetry(cmd)
 		tt.Log(output)
 		require.NoError(tt, err, "agent installation should not return any error: ", err)
 	})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates our retry function to use exponential backoff, and use said retry function to invoke the install scripts. While our modern install scripts have internal retry mechanisms, the Agent 5 script does not.

Given some of these tests use the agent 5 installer to test the upgrade process, I expect this to be a source of a test flakiness.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Reduce test e2e flakes.

### Additional Notes

[BARX-303](https://datadoghq.atlassian.net/browse/BARX-303)
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->


[BARX-303]: https://datadoghq.atlassian.net/browse/BARX-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ