### PR TITLE
[e2e]: break out of retry loop, instead of waiting again

### DIFF
--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -174,15 +174,13 @@ func (c *TestClient) GetAgentVersion() (string, error) {
 
 // ExecuteWithRetry execute the command with retry
 func (c *TestClient) ExecuteWithRetry(cmd string) (string, error) {
-	ok := false
-
 	var err error
 	var output string
 
-	for try := 0; try < 5 && !ok; try++ {
+	for try := 0; try < 5; try++ {
 		output, err = c.Host.Execute(cmd)
 		if err == nil {
-			ok = true
+			break
 		}
 		time.Sleep(1 * time.Second)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The original retry mechanism would continue to wait one more iteration after succeeding, this exits the loop early. Credit to @chouquette 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
