### PR TITLE
[ASCII-1551][ASCII-1552] Fix flare tests with system probe on Darwin

### DIFF
--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -9,6 +9,7 @@ package flare
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -165,17 +166,6 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 		}
 	}
 
-	probeUtil, probeUtilErr := net.GetRemoteSystemProbeUtil(pkgconfig.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
-	sysProbeGet := func() pprofGetter {
-		return func(path string) ([]byte, error) {
-			if probeUtilErr != nil {
-				return nil, probeUtilErr
-			}
-
-			return probeUtil.GetPprof(path)
-		}
-	}
-
 	serviceProfileCollector := func(get func(url string) ([]byte, error), seconds int) agentProfileCollector {
 		return func(service string) error {
 			fmt.Fprintln(color.Output, color.BlueString("Getting a %ds profile snapshot from %s.", seconds, service))
@@ -242,7 +232,21 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 	}
 
 	if pkgconfig.SystemProbe.GetBool("system_probe_config.enabled") {
-		agentCollectors["system-probe"] = serviceProfileCollector(sysProbeGet(), seconds)
+		probeUtil, probeUtilErr := net.GetRemoteSystemProbeUtil(pkgconfig.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
+
+		if !errors.Is(probeUtilErr, net.ErrNotImplemented) {
+			sysProbeGet := func() pprofGetter {
+				return func(path string) ([]byte, error) {
+					if probeUtilErr != nil {
+						return nil, probeUtilErr
+					}
+
+					return probeUtil.GetPprof(path)
+				}
+			}
+
+			agentCollectors["system-probe"] = serviceProfileCollector(sysProbeGet(), seconds)
+		}
 	}
 
 	var errs error

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -6,6 +6,7 @@
 package flare
 
 import (
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -59,9 +60,6 @@ func getPprofTestServer(t *testing.T) (tcpServer *httptest.Server, unixServer *h
 }
 
 func TestReadProfileData(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("FIXME: Failing test on macOS - #incident-26991")
-	}
 	ts, uts := getPprofTestServer(t)
 	t.Cleanup(func() {
 		ts.Close()
@@ -112,11 +110,15 @@ func TestReadProfileData(t *testing.T) {
 		"trace-block.pprof":             []byte("block"),
 		"trace-cpu.pprof":               []byte("10_sec_cpu_pprof"),
 		"trace-mutex.pprof":             []byte("mutex"),
-		"system-probe-1st-heap.pprof":   []byte("heap_profile"),
-		"system-probe-2nd-heap.pprof":   []byte("heap_profile"),
-		"system-probe-block.pprof":      []byte("block"),
-		"system-probe-cpu.pprof":        []byte("10_sec_cpu_pprof"),
-		"system-probe-mutex.pprof":      []byte("mutex"),
+	}
+	if runtime.GOOS != "darwin" {
+		maps.Copy(expected, flare.ProfileData{
+			"system-probe-1st-heap.pprof": []byte("heap_profile"),
+			"system-probe-2nd-heap.pprof": []byte("heap_profile"),
+			"system-probe-block.pprof":    []byte("block"),
+			"system-probe-cpu.pprof":      []byte("10_sec_cpu_pprof"),
+			"system-probe-mutex.pprof":    []byte("mutex"),
+		})
 	}
 
 	require.Len(t, data, len(expected), "expected pprof data has more or less profiles than expected")
@@ -126,9 +128,6 @@ func TestReadProfileData(t *testing.T) {
 }
 
 func TestReadProfileDataNoTraceAgent(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("FIXME: Failing test on macOS - #incident-26991")
-	}
 	ts, uts := getPprofTestServer(t)
 	t.Cleanup(func() {
 		ts.Close()
@@ -175,11 +174,15 @@ func TestReadProfileDataNoTraceAgent(t *testing.T) {
 		"security-agent-block.pprof":    []byte("block"),
 		"security-agent-cpu.pprof":      []byte("10_sec_cpu_pprof"),
 		"security-agent-mutex.pprof":    []byte("mutex"),
-		"system-probe-1st-heap.pprof":   []byte("heap_profile"),
-		"system-probe-2nd-heap.pprof":   []byte("heap_profile"),
-		"system-probe-block.pprof":      []byte("block"),
-		"system-probe-cpu.pprof":        []byte("10_sec_cpu_pprof"),
-		"system-probe-mutex.pprof":      []byte("mutex"),
+	}
+	if runtime.GOOS != "darwin" {
+		maps.Copy(expected, flare.ProfileData{
+			"system-probe-1st-heap.pprof": []byte("heap_profile"),
+			"system-probe-2nd-heap.pprof": []byte("heap_profile"),
+			"system-probe-block.pprof":    []byte("block"),
+			"system-probe-cpu.pprof":      []byte("10_sec_cpu_pprof"),
+			"system-probe-mutex.pprof":    []byte("mutex"),
+		})
 	}
 
 	require.Len(t, data, len(expected), "expected pprof data has more or less profiles than expected")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix flare unit tests on MacOS.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Tests were broken on MacOS by https://github.com/DataDog/datadog-agent/pull/25037 due to the system-probe code returning an error (`"system-probe unsupported"`) on Darwin.

Gating the system probe specific parts of the tests on Darwin fixed the issue.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
QA covered by https://github.com/DataDog/datadog-agent/pull/25037 and CI.
