### PR TITLE
cluster-agent: import cws-instrumentation from tasks instead of current dir

### DIFF
--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -16,7 +16,7 @@ from tasks.build_tags import get_build_tags, get_default_build_tags
 from tasks.cluster_agent_helpers import build_common, clean_common, refresh_assets_common, version_common
 from tasks.go import deps
 from tasks.libs.common.utils import load_release_versions
-from cws_instrumentation import BIN_PATH as CWS_INSTRUMENTATION_BIN_PATH
+from tasks.cws_instrumentation import BIN_PATH as CWS_INSTRUMENTATION_BIN_PATH
 
 # constants
 BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent")


### PR DESCRIPTION

### What does this PR do?

Old invoke versions have some issues importing files from current directory, this PR fixes the issue when trying to build cluster agent importing cws instrumentation.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
