### PR TITLE
feat(installer): Add installer in path

### DIFF
--- a/pkg/fleet/installer/service/datadog_installer.go
+++ b/pkg/fleet/installer/service/datadog_installer.go
@@ -90,6 +90,12 @@ func SetupInstaller(ctx context.Context) (err error) {
 		return fmt.Errorf("error changing owner of /var/log/datadog: %w", err)
 	}
 
+	// Create installer path symlink
+	err = os.Symlink("/opt/datadog-packages/datadog-installer/stable/bin/installer/installer", "/usr/bin/datadog-installer")
+	if err != nil {
+		return fmt.Errorf("error creating symlink to /usr/bin/datadog-installer: %w", err)
+	}
+
 	// FIXME(Arthur): enable the daemon unit by default and use the same strategy as the agent
 	if os.Getenv("DD_REMOTE_UPDATES") != "true" {
 		return nil
@@ -159,6 +165,11 @@ func RemoveInstaller(ctx context.Context) {
 		if err := removeUnit(ctx, unit); err != nil {
 			log.Warnf("Failed to stop %s: %s", unit, err)
 		}
+	}
+
+	// Remove symlink
+	if err := os.Remove("/usr/bin/datadog-installer"); err != nil {
+		log.Warnf("Failed to remove /usr/bin/datadog-installer: %s", err)
 	}
 }
 

--- a/pkg/fleet/installer/service/datadog_installer.go
+++ b/pkg/fleet/installer/service/datadog_installer.go
@@ -9,6 +9,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -92,7 +93,9 @@ func SetupInstaller(ctx context.Context) (err error) {
 
 	// Create installer path symlink
 	err = os.Symlink("/opt/datadog-packages/datadog-installer/stable/bin/installer/installer", "/usr/bin/datadog-installer")
-	if err != nil {
+	if err != nil && errors.Is(err, os.ErrExist) {
+		log.Info("Installer symlink already exists, skipping")
+	} else if err != nil {
 		return fmt.Errorf("error creating symlink to /usr/bin/datadog-installer: %w", err)
 	}
 

--- a/test/new-e2e/tests/installer/linux_test.go
+++ b/test/new-e2e/tests/installer/linux_test.go
@@ -129,6 +129,16 @@ func (v *installerSuite) TestSharedAgentDirs() {
 	}
 }
 
+func (v *installerSuite) TestInstallerInPath() {
+	host := v.Env().RemoteHost
+	v.bootstrap(false)
+	_ = host.MustExecute(`test -L /usr/bin/datadog-installer`)
+	require.Equal(v.T(), "/usr/bin/datadog-installer\n", host.MustExecute("which datadog-installer"))
+	binPath := host.MustExecute("readlink -f $(which datadog-installer)")
+	assert.True(v.T(), strings.HasPrefix(binPath, "/opt/datadog-packages/datadog-installer/7."))
+	assert.True(v.T(), strings.HasSuffix(binPath, "/bin/installer/installer\n"))
+}
+
 func (v *installerSuite) TestInstallerDirs() {
 	host := v.Env().RemoteHost
 	v.bootstrap(false)

--- a/test/new-e2e/tests/installer/linux_test.go
+++ b/test/new-e2e/tests/installer/linux_test.go
@@ -131,12 +131,19 @@ func (v *installerSuite) TestSharedAgentDirs() {
 
 func (v *installerSuite) TestInstallerInPath() {
 	host := v.Env().RemoteHost
+
+	// add
 	v.bootstrap(false)
 	_ = host.MustExecute(`test -L /usr/bin/datadog-installer`)
 	require.Equal(v.T(), "/usr/bin/datadog-installer\n", host.MustExecute("which datadog-installer"))
 	binPath := host.MustExecute("readlink -f $(which datadog-installer)")
 	assert.True(v.T(), strings.HasPrefix(binPath, "/opt/datadog-packages/datadog-installer/7."))
 	assert.True(v.T(), strings.HasSuffix(binPath, "/bin/installer/installer\n"))
+
+	// remove
+	host.MustExecute(fmt.Sprintf("sudo %v/bin/installer/installer remove datadog-installer", bootInstallerDir))
+	_, err := host.Execute(`test -L /usr/bin/datadog-installer`)
+	require.NotNil(v.T(), err)
 }
 
 func (v *installerSuite) TestInstallerDirs() {


### PR DESCRIPTION
### What does this PR do?
Tiny PR to add the installer in the path once installed

### Motivation
Being able to run installer commands on the host 

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
Install the installer and check that datadog-installer is in path