### PR TITLE
[EBPF-499] Remove "Verification_time" field from the verifier stats output

### DIFF
--- a/pkg/ebpf/verifier/stats.go
+++ b/pkg/ebpf/verifier/stats.go
@@ -44,7 +44,6 @@ type Statistics struct {
 	StackDepth                 stat `json:"stack_usage" kernel:"4.15"`
 	InstructionsProcessed      stat `json:"instruction_processed" kernel:"4.15"`
 	InstructionsProcessedLimit stat `json:"limit" kernel:"4.15"`
-	VerificationTime           stat `json:"verification_time" kernel:"5.2"`
 	MaxStatesPerInstruction    stat `json:"max_states_per_insn" kernel:"5.2"`
 	TotalStates                stat `json:"total_states" kernel:"5.2"`
 	PeakStates                 stat `json:"peak_states" kernel:"5.2"`
@@ -80,13 +79,12 @@ type ComplexityInfo struct {
 }
 
 var (
-	stackUsage       = regexp.MustCompile(`stack depth\s+(?P<usage>\d+).*\n`)
-	verificationTime = regexp.MustCompile(`verification time\s+(?P<time>\d+).*\n`)
-	insnProcessed    = regexp.MustCompile(`processed (?P<processed>\d+) insns`)
-	insnLimit        = regexp.MustCompile(`\(limit (?P<limit>\d+)\)`)
-	maxStates        = regexp.MustCompile(`max_states_per_insn (?P<max_states>\d+)`)
-	totalStates      = regexp.MustCompile(`total_states (?P<total_states>\d+)`)
-	peakStates       = regexp.MustCompile(`peak_states (?P<peak_states>\d+)`)
+	stackUsage    = regexp.MustCompile(`stack depth\s+(?P<usage>\d+).*\n`)
+	insnProcessed = regexp.MustCompile(`processed (?P<processed>\d+) insns`)
+	insnLimit     = regexp.MustCompile(`\(limit (?P<limit>\d+)\)`)
+	maxStates     = regexp.MustCompile(`max_states_per_insn (?P<max_states>\d+)`)
+	totalStates   = regexp.MustCompile(`total_states (?P<total_states>\d+)`)
+	peakStates    = regexp.MustCompile(`peak_states (?P<peak_states>\d+)`)
 )
 
 func isCOREAsset(path string) bool {
@@ -381,7 +379,6 @@ type structField struct {
 
 func unmarshalStatistics(output string, hostVersion kernel.Version) (*Statistics, error) {
 	v := Statistics{
-		VerificationTime:           stat{parse: verificationTime},
 		StackDepth:                 stat{parse: stackUsage},
 		InstructionsProcessed:      stat{parse: insnProcessed},
 		InstructionsProcessedLimit: stat{parse: insnLimit},

--- a/pkg/ebpf/verifier/stats_no_linux.go
+++ b/pkg/ebpf/verifier/stats_no_linux.go
@@ -17,7 +17,6 @@ import (
 // Statistics represent that statistics exposed via
 // the eBPF verifier when  LogLevelStats is enabled
 type Statistics struct {
-	VerificationTime           int `json:"verification_time"`
 	StackDepth                 int `json:"stack_usage"`
 	InstructionsProcessed      int `json:"instruction_processed"`
 	InstructionsProcessedLimit int `json:"limit"`

--- a/pkg/ebpf/verifier/stats_test.go
+++ b/pkg/ebpf/verifier/stats_test.go
@@ -125,9 +125,6 @@ func TestBuildVerifierStats(t *testing.T) {
 
 	// sanity check the values we can somehow bound
 	for _, stat := range stats {
-		if kversion >= kernel.VersionCode(5, 2, 0) {
-			assert.True(t, stat.VerificationTime.Value > 0)
-		}
 		assert.True(t, stat.StackDepth.Value >= 0 && stat.StackDepth.Value <= EBPFStackLimit)
 		assert.True(t, stat.InstructionsProcessedLimit.Value > 0 && stat.InstructionsProcessedLimit.Value <= bpfComplexity)
 		assert.True(t, stat.InstructionsProcessed.Value > 0 && stat.InstructionsProcessed.Value <= stat.InstructionsProcessedLimit.Value)

--- a/tasks/ebpf.py
+++ b/tasks/ebpf.py
@@ -157,11 +157,12 @@ def collect_verification_stats(
     ctx.run(f"{sudo} chmod a+wr -R {VERIFIER_DATA_DIR}")
     ctx.run(f"{sudo} find {VERIFIER_DATA_DIR} -type d -exec chmod a+xr {{}} +")
 
-    with open(VERIFIER_STATS) as f:
+    with open(VERIFIER_STATS, "r+") as f:
         verifier_stats = json.load(f)
         cleaned_up = format_verifier_stats(verifier_stats)
         f.seek(0)
         json.dump(cleaned_up, f, indent=4)
+        f.truncate()
 
 
 @task(

--- a/tasks/ebpf.py
+++ b/tasks/ebpf.py
@@ -31,7 +31,6 @@ headers = [
     "Stack Usage",
     "Instructions Processed",
     "Instructions Processed limit",
-    "Verification time",
     "Max States per Instruction",
     "Peak States",
     "Total States",
@@ -41,12 +40,12 @@ verifier_stat_json_keys = [
     "stack_usage",
     "instruction_processed",
     "limit",
-    "verification_time",
     "max_states_per_insn",
     "peak_states",
     "total_states",
 ]
 
+skip_stat_keys = ["Complexity","verification_time"]
 
 def tabulate_stats(stats):
     table = list()
@@ -89,14 +88,14 @@ def write_verifier_stats(verifier_stats, f, jsonfmt):
 
 # the go program return stats in the form {func_name: {stat_name: {Value: X}}}.
 # convert this to {func_name: {stat_name: X}}
-def cleanup_verifier_stats(verifier_stats):
-    cleaned = dict()
+def format_verifier_stats(verifier_stats):
+    filtered = dict()
     for func in verifier_stats:
-        cleaned[func] = dict()
+        filtered[func] = dict()
         for stat in verifier_stats[func]:
-            if stat != "Complexity":
-                cleaned[func][stat] = verifier_stats[func][stat]["Value"]
-    return cleaned
+            if stat not in skip_stat_keys:
+                filtered[func][stat] = verifier_stats[func][stat]["Value"]
+    return filtered
 
 
 @task(
@@ -160,9 +159,8 @@ def collect_verification_stats(
 
     with open(VERIFIER_STATS) as f:
         verifier_stats = json.load(f)
-
-    cleaned_up = cleanup_verifier_stats(verifier_stats)
-    with open(VERIFIER_STATS, 'w') as f:
+        cleaned_up = format_verifier_stats(verifier_stats)
+        f.seek(0)
         json.dump(cleaned_up, f, indent=4)
 
 


### PR DESCRIPTION
### What does this PR do?

Don't include in the output the verification time

### Motivation

non-deterministic value which doesn't reflect the stats about the target programs, but affecting the diff output of the task.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
