### PR TITLE
[ebpf-platform] small bug fix for verifier stats

### DIFF
--- a/tasks/ebpf.py
+++ b/tasks/ebpf.py
@@ -129,7 +129,7 @@ def collect_verification_stats(
     env = {"DD_SYSTEM_PROBE_BPF_DIR": "./pkg/ebpf/bytecode/build"}
 
     # ensure all files are object files
-    for f in filter_file:
+    for f in filter_file or []:
         _, ext = os.path.splitext(f)
         if ext != ".o":
             raise Exit(f"File {f} does not have the valid '.o' extension")
@@ -140,8 +140,8 @@ def collect_verification_stats(
             "-summary-output",
             os.fspath(VERIFIER_STATS),
         ]
-        + [f"-filter-file {f}" for f in filter_file]
-        + [f"-filter-prog {p}" for p in grep]
+        + [f"-filter-file {f}" for f in filter_file or []]
+        + [f"-filter-prog {p}" for p in grep or []]
     )
 
     if save_verifier_logs:


### PR DESCRIPTION

### What does this PR do?

Handle edge case when ebpf.collect_verifier_stats called without file-filter or grep filter.
we avoid iteration on the None object (default parameter value)

### Motivation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
