### PR TITLE
ebpf: use ELF section name to perform source code mapping

### DIFF
--- a/pkg/ebpf/verifier/stats.go
+++ b/pkg/ebpf/verifier/stats.go
@@ -356,6 +356,11 @@ func generateLoadFunction(file string, opts *StatsOptions, stats map[string]*Sta
 						progSourceMap := sourceMap[progSpec.Name]
 						if progSourceMap == nil {
 							log.Printf("No source map found for program %s\n", progSpec.Name)
+							currSectName := strings.ReplaceAll(progSpec.SectionName, "/", "__") // match naming convention
+							progSourceMap = sourceMap[currSectName]
+							if progSourceMap == nil {
+								log.Printf("No source map found for section %s\n", currSectName)
+							}
 						}
 						compl, err := unmarshalComplexity(p.VerifierLog, progSourceMap)
 						if err != nil {

--- a/pkg/ebpf/verifier/stats.go
+++ b/pkg/ebpf/verifier/stats.go
@@ -353,14 +353,10 @@ func generateLoadFunction(file string, opts *StatsOptions, stats map[string]*Sta
 					stats[progName] = stat
 
 					if opts.DetailedComplexity {
-						progSourceMap := sourceMap[progSpec.Name]
+						convSectName := strings.ReplaceAll(progSpec.SectionName, "/", "__") // match naming convention
+						progSourceMap := sourceMap[convSectName]
 						if progSourceMap == nil {
-							log.Printf("No source map found for program %s\n", progSpec.Name)
-							currSectName := strings.ReplaceAll(progSpec.SectionName, "/", "__") // match naming convention
-							progSourceMap = sourceMap[currSectName]
-							if progSourceMap == nil {
-								log.Printf("No source map found for section %s\n", currSectName)
-							}
+							log.Printf("No source map found for program section %s\n", convSectName)
 						}
 						compl, err := unmarshalComplexity(p.VerifierLog, progSourceMap)
 						if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR makes it so that the mapping between the eBPF verifier complexity information and the eBPF source code is performed using the ELF section name rather than the eBPF program name as the two might not necessarily match.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
