### PR TITLE
[process-agent] Remove noisy log about ECS Fargate Misconfiguration

### DIFF
--- a/pkg/process/checks/chunking.go
+++ b/pkg/process/checks/chunking.go
@@ -17,7 +17,7 @@ func chunkProcessesBySizeAndWeight(procs []*model.Process, ctr *model.Container,
 		// can happen in three scenarios, and we still need to report the container
 		// a) if a process is skipped (e.g. disallowlisted)
 		// b) if process <=> container mapping cannot be established (e.g. Docker on Windows).
-		// c) No non-containerized process detected (e.g. ECS Fargate)
+		// c) if no processes were collected from the container (e.g. pidMode not set to "task" on ECS Fargate)
 		appendContainerWithoutProcesses(ctr, chunker)
 		return
 	}

--- a/pkg/process/checks/chunking.go
+++ b/pkg/process/checks/chunking.go
@@ -6,12 +6,9 @@
 package checks
 
 import (
-	"os"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // chunkProcessesBySizeAndWeight chunks `model.Process` payloads by max allowed size and max allowed weight of a chunk
@@ -20,10 +17,7 @@ func chunkProcessesBySizeAndWeight(procs []*model.Process, ctr *model.Container,
 		// can happen in three scenarios, and we still need to report the container
 		// a) if a process is skipped (e.g. disallowlisted)
 		// b) if process <=> container mapping cannot be established (e.g. Docker on Windows).
-		// c) if no processes were collected from the container (e.g. pidMode not set to "task" on ECS Fargate)
-		if ecsContainerMetadataURI := os.Getenv("ECS_CONTAINER_METADATA_URI_V4"); ecsContainerMetadataURI != "" {
-			log.Warnf("No processes found for container %s, pidMode may not be configured correctly (should be set to task)", ctr.Name)
-		}
+		// c) No non-containerized process detected (e.g. ECS Fargate)
 		appendContainerWithoutProcesses(ctr, chunker)
 		return
 	}

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -429,6 +429,7 @@ func chunkProcessesAndContainers(
 
 	totalProcs := len(procsByCtr[emptyCtrID])
 
+	// we first split non-container processes in chunks
 	chunkProcessesBySizeAndWeight(procsByCtr[emptyCtrID], nil, maxChunkSize, maxChunkWeight, chunker)
 
 	totalContainers := len(containers)

--- a/releasenotes/notes/process-fargate-chunking-log-cc88bf008c7288e7.yaml
+++ b/releasenotes/notes/process-fargate-chunking-log-cc88bf008c7288e7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    Removed log that was noisy when Process Agent was running on ECS Fargate.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Removes the following log: `No processes found for container %s, pidMode may not be configured correctly (should be set to task)` as it would appear on every check run, even when configured correctly, due to the presence of `aws-fargate-pause` internal container that becomes detectable with `pidMode: "task"`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run Process Agent on ECS Fargate as described here and verify the log doesn't appear anymore:
https://github.com/DataDog/datadog-agent/pull/25100
