### PR TITLE
[core-agent] Invokes 'SetMaxProcs' even earlier in the component lifecycle

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -161,6 +161,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		// TODO: once the agent is represented as a component, and not a function (run),
 		// this will use `fxutil.Run` instead of `fxutil.OneShot`.
 		return fxutil.OneShot(run,
+			fx.Invoke(func(_ log.Component) {
+				ddruntime.SetMaxProcs()
+			}),
 			fx.Supply(core.BundleParams{
 				ConfigParams:         config.NewAgentParams(globalParams.ConfFilePath),
 				SecretParams:         secrets.NewEnabledParams(),
@@ -304,15 +307,6 @@ func run(log log.Component,
 
 func getSharedFxOption() fx.Option {
 	return fx.Options(
-		fx.Invoke(func(lc fx.Lifecycle) {
-			lc.Append(fx.Hook{
-				OnStart: func(_ context.Context) error {
-					// prepare go runtime
-					ddruntime.SetMaxProcs()
-					return nil
-				},
-			})
-		}),
 		fx.Supply(flare.NewParams(
 			path.GetDistPath(),
 			path.PyChecksPath,


### PR DESCRIPTION
### What does this PR do?

Follow-up to #25021 , this calls `SetMaxProcs` earlier in the component init lifecycle to avoid confusing behavior.

### Motivation

@ogaca-dd pointed out in the original PR that this will not run before other components' constructors and `OnStart` hooks, only before their `run` invocations.

This init is required before components can safely read `GOMAXPROCS`, so that presented a tricky, implicit contract for components to follow (can read `gomaxprocs` in `run`, but not `new`).

This strategy makes it safe for all non-logger components to use `gomaxprocs` freely.

### Additional Notes



### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes


