### PR TITLE
[usm] Get socket information from all namespaces

### DIFF
--- a/pkg/network/usm/tuple_maps.go
+++ b/pkg/network/usm/tuple_maps.go
@@ -31,6 +31,14 @@ func initializeTupleMaps(m *ddebpf.Manager) {
 
 	connections := procnet.GetTCPConnections()
 	for _, c := range connections {
+		if !c.Laddr.IsValid() || !c.Raddr.IsValid() {
+			// This is a safeguard against calling As4() or As6() on a
+			// zero netip.Addr value. Note that a zero netip.Addr value is not a
+			// valid IP address and it's not the same thing as "0.0.0.0" or "::"
+			// which are both valid.
+			continue
+		}
+
 		ll, lh := util.ToLowHighIP(c.Laddr)
 		rl, rh := util.ToLowHighIP(c.Raddr)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Extends https://github.com/DataDog/datadog-agent/pull/24642 to support all network namespaces as opposed to just the root network namespace.

### Motivation

https://github.com/DataDog/datadog-agent/pull/24642 was aimed at fixing the issue with agent "cold-starts" in the context of GoTLS monitoring, which means our monitoring capabilities for TLS connections that happen *before* system-probe startup.

The issue with the previous PR is that we wrongly assumed that all connections from all network namespaces would be present in the `/proc/net/tcp` and `/proc/net/tcp6` files, but that file only contains connections belonging the namespace of the process reading it.

In this PR we take a slightly different approach and rely on parsing multiple `/proc/net/<pid>/tcp` files instead, to get the a list of all connections from all namespaces. It's important to note that we only read/parse one file *per namespace*, which is why we keep a list of "seen namespaces".

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
