### PR TITLE
[e2e] remove functional agent tests from e2e_pre_test

### DIFF
--- a/test/new-e2e/test-infra-definition/agent_test.go
+++ b/test/new-e2e/test-infra-definition/agent_test.go
@@ -6,16 +6,11 @@
 package testinfradefinition
 
 import (
-	"regexp"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,65 +24,8 @@ func TestAgentSuite(t *testing.T) {
 }
 
 func (v *agentSuite) TestAgentCommandNoArg() {
-	version := v.Env().Agent.Client.Version()
-
-	match, err := regexp.MatchString("^Agent .* - Commit: .* - Serialization version: .* - Go version: .*$", strings.TrimSuffix(version, "\n"))
-	assert.NoError(v.T(), err)
-	assert.True(v.T(), match)
-}
-
-func (v *agentSuite) TestAgentCommandWithArg() {
-	status := v.Env().Agent.Client.Status(agentclient.WithArgs([]string{"-h", "-n"}))
-	assert.Contains(v.T(), status.Content, "Use \"datadog-agent status [command] --help\" for more information about a command.")
-}
-
-func (v *agentSuite) TestWithAgentConfig() {
-	for _, param := range []struct {
-		useConfig      bool
-		config         string
-		expectedConfig string
-	}{
-		{true, "log_level: debug", "log_level: debug\n"},
-		{true, "", "log_level: info\n"},
-		{true, "log_level: warn", "log_level: warn\n"},
-		{true, "log_level: debug", "log_level: debug\n"},
-		{false, "", "log_level: info\n"},
-	} {
-		var agentParams []agentparams.Option
-		if param.useConfig {
-			agentParams = append(agentParams, agentparams.WithAgentConfig(param.config))
-		}
-		v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentParams...)))
-		config := v.Env().Agent.Client.Config()
-		re := regexp.MustCompile(`.*log_level:(.*)\n`)
-		matches := re.FindStringSubmatch(config)
-		require.NotEmpty(v.T(), matches)
-		require.Equal(v.T(), param.expectedConfig, matches[0])
-	}
-}
-
-func (v *agentSuite) TestWithTelemetry() {
-	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithTelemetry())))
-
-	require.EventuallyWithT(v.T(), func(collect *assert.CollectT) {
-		status := v.Env().Agent.Client.Status()
-		if !assert.Contains(v.T(), status.Content, "go_expvar") {
-			v.T().Log("not yet")
-		}
-	}, 5*time.Minute, 10*time.Second)
-
-	require.EventuallyWithT(v.T(), func(collect *assert.CollectT) {
-		v.UpdateEnv(awshost.ProvisionerNoFakeIntake())
-		status := v.Env().Agent.Client.Status()
-		assert.NotContains(v.T(), status.Content, "go_expvar")
-	}, 5*time.Minute, 10*time.Second)
-}
-
-func (v *agentSuite) TestWithLogs() {
-	config := v.Env().Agent.Client.Config()
-	require.Contains(v.T(), config, "logs_enabled: false")
-
-	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithLogs())))
-	config = v.Env().Agent.Client.Config()
-	require.Contains(v.T(), config, "logs_enabled: true")
+	status, err := v.Env().Agent.Client.StatusWithError()
+	require.NoError(v.T(), err)
+	assert.NotNil(v.T(), status)
+	assert.NotEmpty(v.T(), status.Content)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Keep only bare minimum test on agent environment in `e2e_pre_test`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`e2e_pre_test` use the latest stable version of the agent and are meant to test the e2e framework rather than the agent behaviour. This test recently broke because the agent  `status` command changed the behaviour, later breaking the test. 

We need to ensure that the framework correctly installs the agent, and that the agent correctly runs, so testing against `agent status` is enough

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
