### PR TITLE
[CWS] Add kind-based e2e tests

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -241,6 +241,7 @@ new-e2e-cws:
     - deploy_deb_testing-a7_x64
     - qa_cws_instrumentation
     - qa_agent
+    - qa_dca
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
@@ -249,6 +250,7 @@ new-e2e-cws:
     matrix:
       - EXTRA_PARAMS: --run TestAgentSuite
       - EXTRA_PARAMS: --run TestECSFargate
+      - EXTRA_PARAMS: --run TestKindSuite
   # Temporary, remove once we made sure the recent changes have no impact on the stability of these tests
   allow_failure: true
 

--- a/test/new-e2e/tests/cws/kind_test.go
+++ b/test/new-e2e/tests/cws/kind_test.go
@@ -6,7 +6,6 @@
 package cws
 
 import (
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"testing"

--- a/test/new-e2e/tests/cws/kind_test.go
+++ b/test/new-e2e/tests/cws/kind_test.go
@@ -1,0 +1,148 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cws
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
+	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/kubernetes"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/platforms"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/cws/api"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+)
+
+const (
+	k8sHostnamePrefix = "cws-e2e-kind-node"
+	osPlatform        = "ubuntu"
+	osArch            = "x86_64"
+	osVersion         = "ubuntu-22-04"
+)
+
+// Depending on the pulumi version used to run these tests, the following values may not be properly merged with the default values defined in the test-infra-definitions repository.
+// This PR https://github.com/pulumi/pulumi-kubernetes/pull/2963 should fix this issue upstream.
+const valuesFmt = `
+datadog:
+  envDict:
+    DD_HOSTNAME: "%s"
+  securityAgent:
+    runtime:
+      enabled: true
+agents:
+  volumes:
+    - name: host-root-proc
+      hostPath:
+        path: /host/proc
+  volumeMounts:
+    - name: host-root-proc
+      mountPath: /host/root/proc
+  containers:
+    systemProbe:
+      env:
+        - name: HOST_PROC
+          value: "/host/root/proc"
+`
+
+type kindSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+	apiClient  *api.Client
+	ddHostname string
+}
+
+func TestKindSuite(t *testing.T) {
+	platformJSON := map[string]map[string]map[string]string{}
+	err := json.Unmarshal(platforms.Content, &platformJSON)
+	require.NoErrorf(t, err, "failed to umarshall platform file: %v", err)
+
+	ami := platformJSON[osPlatform][osArch][osVersion]
+	require.NotEmpty(t, ami, "No image found for %s %s %s", osPlatform, osArch, osVersion)
+	osDesc := platforms.BuildOSDescriptor(osPlatform, osArch, osVersion)
+
+	ddHostname := fmt.Sprintf("%s-%s", k8sHostnamePrefix, uuid.NewString()[:4])
+	values := fmt.Sprintf(valuesFmt, ddHostname)
+	t.Logf("Running testsuite with DD_HOSTNAME=%s", ddHostname)
+	e2e.Run[environments.Kubernetes](t, &kindSuite{ddHostname: ddHostname},
+		e2e.WithProvisioner(
+			awskubernetes.Provisioner(
+				awskubernetes.WithEC2VMOptions(
+					ec2.WithAMI(ami, osDesc, osDesc.Architecture),
+				),
+				awskubernetes.WithoutFakeIntake(),
+				awskubernetes.WithAgentOptions(
+					kubernetesagentparams.WithHelmValues(values),
+				),
+			),
+		),
+	)
+}
+
+func (s *kindSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	s.apiClient = api.NewClient()
+}
+
+func (s *kindSuite) Hostname() string {
+	return s.ddHostname
+}
+
+func (s *kindSuite) Client() *api.Client {
+	return s.apiClient
+}
+
+func (s *kindSuite) Test00RulesetLoadedDefaultFile() {
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		testRulesetLoaded(c, s, "file", "default.policy")
+	}, 1*time.Minute, 5*time.Second)
+}
+
+func (s *kindSuite) Test01RulesetLoadedDefaultRC() {
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		testRulesetLoaded(c, s, "remote-config", "default.policy")
+	}, 1*time.Minute, 5*time.Second)
+}
+
+func (s *kindSuite) Test02Selftests() {
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		testSelftestsEvent(c, s, func(event *api.SelftestsEvent) {
+			assert.Contains(c, event.SucceededTests, "datadog_agent_cws_self_test_rule_open", "missing selftest result")
+			assert.Contains(c, event.SucceededTests, "datadog_agent_cws_self_test_rule_chmod", "missing selftest result")
+			assert.Contains(c, event.SucceededTests, "datadog_agent_cws_self_test_rule_chown", "missing selftest result")
+			validateEventSchema(c, &event.Event, "self_test_schema.json")
+		})
+	}, 1*time.Minute, 5*time.Second)
+}
+
+func (s *kindSuite) Test03MetricRuntimeRunning() {
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		testMetricExists(c, s, "datadog.security_agent.runtime.running", map[string]string{"host": s.Hostname()})
+	}, 2*time.Minute, 10*time.Second)
+}
+
+func (s *kindSuite) Test04MetricContainersRunning() {
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		testMetricExists(c, s, "datadog.security_agent.runtime.containers_running", map[string]string{"host": s.Hostname()})
+	}, 2*time.Minute, 10*time.Second)
+}
+
+// test that the detection of CWS is properly working
+// this test can be quite long so run it last
+func (s *kindSuite) Test99CWSEnabled() {
+	assert.EventuallyWithTf(s.T(), func(c *assert.CollectT) {
+		testCwsEnabled(c, s)
+	}, 20*time.Minute, 30*time.Second, "cws activation test timed out for host %s", s.Hostname())
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds a new testsuite to the CWS e2e tests, testing a kind/helm based environment.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- Test coverage
- This is the final step towards removing the argo-based CWS e2e tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
