### PR TITLE
Fix serverless-perf test avoid sleeping 10 seconds when fetching logs

### DIFF
--- a/test/integration/serverless_perf/compute.sh
+++ b/test/integration/serverless_perf/compute.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail
+
 STARTUP_TIME_THRESHOLD=40
 
 calculate_median() {
@@ -32,8 +34,17 @@ for i in $(seq 1 ${ITERATION_COUNT})
 do
     # create a new container to ensure cold start
     dockerId=$(docker run -d datadogci/lambda-extension)
-    sleep 10
-    numberOfMillisecs=$(docker logs "$dockerId" | grep 'ready in' | grep -Eo '[0-9]{1,4}' | tail -3 | head -1)
+
+    retries=0
+    until numberOfMillisecs=$(docker logs "$dockerId" | grep 'ready in' | grep -Eo '[0-9]{1,4}' | tail -3 | head -1);
+    do
+        sleep 1
+        retries=$((retries + 1))
+        if [ $retries -gt 10 ]; then
+            log "Failed to get startup time"
+            exit 1
+        fi
+    done
     startupTimes+=($numberOfMillisecs)
     log "Iteration=$i | Startup Time=$numberOfMillisecs"
 done


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Do not sleep 10 seconds between each iteration, use a loop to sleep only when needed.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The test is taking 55 minutes, including 50 minutes of sleep.
This PR reduces it to ~21 minutes.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
