### PR TITLE
Add pympler python package back

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -223,6 +223,9 @@ if with_python_runtime? "3"
   dependency 'datadog-agent-integrations-py3'
 end
 
+# Used for memory profiling with the `status py` agent subcommand
+dependency 'pympler'
+
 if linux_target?
   dependency 'datadog-security-agent-policies'
 end

--- a/omnibus/config/software/pympler.rb
+++ b/omnibus/config/software/pympler.rb
@@ -1,0 +1,42 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https:#www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+# Even though this is a dependency that we install with `pip`, it makes sense to keep it
+# separate from the integrations-related definitions since it's not defined anywhere as
+# a dependency for integrations.
+name 'pympler'
+default_version "0.7"
+
+if with_python_runtime? "3"
+  dependency 'pip3'
+  dependency 'setuptools3'
+end
+
+if with_python_runtime? "3"
+  dependency 'pip2'
+end
+
+pympler_requirement = "pympler==#{default_version}"
+
+build do
+  if with_python_runtime? "3"
+    if windows_target?
+      python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
+    else
+      python = "#{install_dir}/embedded/bin/python3"
+    end
+    command "#{python} -m pip install #{pympler_requirement}"
+  end
+
+  if with_python_runtime? "2"
+    if windows_target?
+      python = "#{windows_safe_path(python_2_embedded)}\\python.exe"
+    else
+      python = "#{install_dir}/embedded/bin/python2"
+    end
+    command "#{python} -m pip install #{pympler_requirement}"
+  end
+
+end


### PR DESCRIPTION
### What does this PR do?

Adds `pympler` back. This is hit by the `status py` subcommand (on [this file](https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/utils/py_mem.py)).

### Motivation

This got lost in the big changes to how we build dependencies (#23094).

The way the code is organized, as it is right now, this is technically not a dependency linked to integrations, and therefore I've decided to create a separate definition for it to remind ourselves that we may want to do something to avoid this kind of stray dependency.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Confirmed that the command no longer complains of the missing library.
