### PR TITLE
[CWS] fix windows multi-discarder on `create.file.path`

### DIFF
--- a/pkg/security/probe/discarders_windows.go
+++ b/pkg/security/probe/discarders_windows.go
@@ -5,7 +5,10 @@
 
 package probe
 
-import "github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
 
 func init() {
 	SupportedMultiDiscarder = []*rules.MultiDiscarder{
@@ -13,45 +16,45 @@ func init() {
 			Entries: []rules.MultiDiscarderEntry{
 				{
 					Field:     "create.file.path",
-					EventType: "create",
+					EventType: model.CreateNewFileEventType,
 				},
 				{
 					Field:     "rename.file.path",
-					EventType: "rename",
+					EventType: model.FileRenameEventType,
 				},
 				{
 					Field:     "delete.file.path",
-					EventType: "delete",
+					EventType: model.DeleteFileEventType,
 				},
 				{
 					Field:     "write.file.path",
-					EventType: "write",
+					EventType: model.WriteFileEventType,
 				},
 			},
 			FinalField:     "create.file.path",
-			FinalEventType: "create",
+			FinalEventType: model.CreateNewFileEventType,
 		},
 		{
 			Entries: []rules.MultiDiscarderEntry{
 				{
 					Field:     "create.file.name",
-					EventType: "create",
+					EventType: model.CreateNewFileEventType,
 				},
 				{
 					Field:     "rename.file.name",
-					EventType: "rename",
+					EventType: model.FileRenameEventType,
 				},
 				{
 					Field:     "delete.file.name",
-					EventType: "delete",
+					EventType: model.DeleteFileEventType,
 				},
 				{
 					Field:     "write.file.name",
-					EventType: "write",
+					EventType: model.WriteFileEventType,
 				},
 			},
 			FinalField:     "create.file.name",
-			FinalEventType: "create",
+			FinalEventType: model.CreateNewFileEventType,
 		},
 	}
 }

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -108,11 +108,11 @@ func NewEvalOpts(eventTypeEnabled map[eval.EventType]bool) (*Opts, *eval.Opts) {
 type MultiDiscarder struct {
 	Entries        []MultiDiscarderEntry
 	FinalField     string
-	FinalEventType string
+	FinalEventType model.EventType
 }
 
 // MultiDiscarderEntry represents a multi discarder entry (a field, and associated event type)
 type MultiDiscarderEntry struct {
 	Field     string
-	EventType string
+	EventType model.EventType
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes the multi-discarder feature by correctly setting the event type on discarder evaluation specific fake event. This allows the discarder evaluation to proceed correctly.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
