### PR TITLE
[CWS] fix windows selftests

### DIFF
--- a/pkg/security/module/server_windows.go
+++ b/pkg/security/module/server_windows.go
@@ -81,7 +81,7 @@ func (a *APIServer) RunSelfTest(_ context.Context, _ *api.RunSelfTestParams) (*a
 		}, nil
 	}
 
-	if _, err := a.cwsConsumer.RunSelfTest(false); err != nil {
+	if _, err := a.cwsConsumer.RunSelfTest(true); err != nil {
 		return &api.SecuritySelfTestResultMessage{
 			Ok:    false,
 			Error: err.Error(),

--- a/pkg/security/probe/selftests/create_file_windows.go
+++ b/pkg/security/probe/selftests/create_file_windows.go
@@ -28,10 +28,16 @@ func (o *WindowsCreateFileSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 	o.ruleID = fmt.Sprintf("%s_windows_create_file", ruleIDPrefix)
 
 	basename := filepath.Base(o.filename)
+	devicePath := o.filename
+	volumeName := filepath.VolumeName(o.filename)
+	// replace volume name with glob matching the device name
+	if volumeName != "" {
+		devicePath = "/Device/*" + o.filename[len(volumeName):]
+	}
 
 	return &rules.RuleDefinition{
 		ID:         o.ruleID,
-		Expression: fmt.Sprintf(`create.file.name == "%s" && create.file.device_path == "%s"`, basename, o.filename),
+		Expression: fmt.Sprintf(`create.file.name == "%s" && create.file.device_path =~ "%s" && process.pid == %d`, basename, filepath.ToSlash(devicePath), os.Getpid()),
 	}
 }
 

--- a/pkg/security/probe/selftests/create_file_windows.go
+++ b/pkg/security/probe/selftests/create_file_windows.go
@@ -50,8 +50,7 @@ func (o *WindowsCreateFileSelfTest) GenerateEvent() error {
 		log.Debugf("error creating file: %v", err)
 		return err
 	}
-	defer file.Close()
-	return nil
+	return file.Close()
 }
 
 // HandleEvent handles self test events

--- a/pkg/security/probe/selftests/open_registry_key_windows.go
+++ b/pkg/security/probe/selftests/open_registry_key_windows.go
@@ -10,6 +10,7 @@ package selftests
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -32,7 +33,7 @@ func (o *WindowsOpenRegistryKeyTest) GetRuleDefinition() *rules.RuleDefinition {
 
 	return &rules.RuleDefinition{
 		ID:         o.ruleID,
-		Expression: fmt.Sprintf(`open.registry.key_name == "%s"`, filepath.Base(o.keyPath)),
+		Expression: fmt.Sprintf(`open.registry.key_name == "%s" && process.pid == %d`, filepath.Base(o.keyPath), os.Getpid()),
 	}
 }
 

--- a/pkg/security/probe/selftests/tester_windows.go
+++ b/pkg/security/probe/selftests/tester_windows.go
@@ -8,6 +8,7 @@ package selftests
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"go.uber.org/atomic"
@@ -39,7 +40,7 @@ func NewSelfTester(cfg *config.RuntimeSecurityConfig, probe *probe.Probe) (*Self
 		return nil, err
 	}
 	selfTests = []SelfTest{
-		&WindowsCreateFileSelfTest{filename: fmt.Sprintf("%s/%s", dir, fileToCreate)},
+		&WindowsCreateFileSelfTest{filename: filepath.Join(dir, fileToCreate)},
 		&WindowsOpenRegistryKeyTest{keyPath: keyPath},
 	}
 

--- a/pkg/security/probe/selftests/tester_windows.go
+++ b/pkg/security/probe/selftests/tester_windows.go
@@ -45,7 +45,7 @@ func NewSelfTester(cfg *config.RuntimeSecurityConfig, probe *probe.Probe) (*Self
 	}
 
 	s := &SelfTester{
-		waitingForEvent: atomic.NewBool(cfg.EBPFLessEnabled),
+		waitingForEvent: atomic.NewBool(false),
 		eventChan:       make(chan selfTestEvent, 10),
 		selfTestRunning: make(chan time.Duration, 10),
 		probe:           probe,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

- This PR fixes the create file Windows selftest by using glob matching on the file path field
- It also prevents processes other than system-probe from triggering the selftest rules (as the open registry one was triggered by the security-agent, causing selftest events to be triggered outside of an actual selftest run)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
