### PR TITLE
fix(installer): Use gcr.io by default instead of public.ecr.aws

### DIFF
--- a/pkg/fleet/internal/oci/download.go
+++ b/pkg/fleet/internal/oci/download.go
@@ -231,6 +231,6 @@ func PackageURL(site string, pkg string, version string) string {
 	case "datad0g.com":
 		return fmt.Sprintf("oci://docker.io/datadog/%s-package-dev:%s", strings.TrimPrefix(pkg, "datadog-"), version)
 	default:
-		return fmt.Sprintf("oci://public.ecr.aws/datadog/%s-package:%s", strings.TrimPrefix(pkg, "datadog-"), version)
+		return fmt.Sprintf("oci://gcr.io/datadoghq/%s-package:%s", strings.TrimPrefix(pkg, "datadog-"), version)
 	}
 }

--- a/pkg/fleet/internal/oci/download_test.go
+++ b/pkg/fleet/internal/oci/download_test.go
@@ -131,7 +131,7 @@ func TestPackageURL(t *testing.T) {
 
 	tests := []test{
 		{site: "datad0g.com", pkg: "datadog-agent", version: "latest", expected: "oci://docker.io/datadog/agent-package-dev:latest"},
-		{site: "datadoghq.com", pkg: "datadog-agent", version: "1.2.3", expected: "oci://public.ecr.aws/datadog/agent-package:1.2.3"},
+		{site: "datadoghq.com", pkg: "datadog-agent", version: "1.2.3", expected: "oci://gcr.io/datadoghq/agent-package:1.2.3"},
 	}
 
 	for _, tt := range tests {

--- a/test/new-e2e/tests/installer/linux_test.go
+++ b/test/new-e2e/tests/installer/linux_test.go
@@ -176,10 +176,10 @@ func (v *installerSuite) TestInstallerUnitLoaded() {
 	if v.remoteUpdatesEnabled {
 		host.MustExecute(fmt.Sprintf("sudo %v/bin/installer/installer remove datadog-installer", bootInstallerDir))
 		v.bootstrap(false)
-		host.MustExecute(fmt.Sprintf(`DD_REMOTE_UPDATES=true sudo -E %v/bin/installer/installer install "oci://public.ecr.aws/datadog/installer-package:latest"`, bootInstallerDir))
+		host.MustExecute(fmt.Sprintf(`DD_REMOTE_UPDATES=true sudo -E %v/bin/installer/installer install "oci://gcr.io/datadoghq/installer-package:latest"`, bootInstallerDir))
 		require.Equal(v.T(), "enabled\n", v.Env().RemoteHost.MustExecute(`systemctl is-enabled datadog-installer.service`))
 		host.MustExecute(fmt.Sprintf("DD_REMOTE_UPDATES=true sudo -E %v/bin/installer/installer remove datadog-installer", bootInstallerDir))
-		host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://public.ecr.aws/datadog/installer-package:latest"`, bootInstallerDir))
+		host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://gcr.io/datadoghq/installer-package:latest"`, bootInstallerDir))
 	}
 	_, err = host.Execute(`systemctl is-enabled datadog-installer.service`)
 	require.ErrorContains(t, err, "Failed to get unit file state for datadog-installer.service: No such file or directory")
@@ -196,7 +196,7 @@ func (v *installerSuite) TestAgentUnitsLoaded() {
 	}
 	host := v.Env().RemoteHost
 	v.bootstrap(false)
-	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://public.ecr.aws/datadog/agent-package@sha256:c942936609b7ae0f457ba4c3516b340f5e0bb3459af730892abe8f2f2f84d552"`, bootInstallerDir))
+	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://gcr.io/datadoghq/agent-package@sha256:c942936609b7ae0f457ba4c3516b340f5e0bb3459af730892abe8f2f2f84d552"`, bootInstallerDir))
 	for _, unit := range stableUnits {
 		require.Equal(t, "enabled\n", host.MustExecute(fmt.Sprintf(`systemctl is-enabled %s`, unit)))
 	}
@@ -206,7 +206,7 @@ func (v *installerSuite) TestExperimentCrash() {
 	t := v.T()
 	host := v.Env().RemoteHost
 	v.bootstrap(false)
-	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://public.ecr.aws/datadog/agent-package@sha256:c942936609b7ae0f457ba4c3516b340f5e0bb3459af730892abe8f2f2f84d552"`, bootInstallerDir))
+	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://gcr.io/datadoghq/agent-package@sha256:c942936609b7ae0f457ba4c3516b340f5e0bb3459af730892abe8f2f2f84d552"`, bootInstallerDir))
 	startTime := getMonotonicTimestamp(t, host)
 	v.Env().RemoteHost.MustExecute(`sudo systemctl start datadog-agent-exp --no-block`)
 	res := getJournalDOnCondition(t, host, startTime, stopCondition([]JournaldLog{
@@ -258,7 +258,7 @@ func (v *installerSuite) TestPurgeAndInstallAgent() {
 	}
 
 	// bootstrap
-	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://public.ecr.aws/datadog/agent-package@sha256:c942936609b7ae0f457ba4c3516b340f5e0bb3459af730892abe8f2f2f84d552"`, bootInstallerDir))
+	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://gcr.io/datadoghq/agent-package@sha256:c942936609b7ae0f457ba4c3516b340f5e0bb3459af730892abe8f2f2f84d552"`, bootInstallerDir))
 
 	// assert agent symlink
 	_ = host.MustExecute(`test -L /usr/bin/datadog-agent`)
@@ -336,9 +336,9 @@ func (v *installerSuite) TestPurgeAndInstallAPMInjector() {
 	// Bootstrap packages //
 	////////////////////////
 
-	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://public.ecr.aws/datadog/agent-package@sha256:c942936609b7ae0f457ba4c3516b340f5e0bb3459af730892abe8f2f2f84d552"`, bootInstallerDir))
-	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://public.ecr.aws/datadog/apm-library-java-package@sha256:d9ef5c492d19980d5bbf5105f2de71c49c39df9cc3ae57fa921fdeade8711d82"`, bootInstallerDir))
-	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://public.ecr.aws/datadog/apm-inject-package@sha256:5fc83f7127647d53d52f72b90de3f7835ec54eb5ed3760c43496e98621a6d717"`, bootInstallerDir))
+	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://gcr.io/datadoghq/agent-package@sha256:c942936609b7ae0f457ba4c3516b340f5e0bb3459af730892abe8f2f2f84d552"`, bootInstallerDir))
+	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://gcr.io/datadoghq/apm-library-java-package@sha256:d9ef5c492d19980d5bbf5105f2de71c49c39df9cc3ae57fa921fdeade8711d82"`, bootInstallerDir))
+	host.MustExecute(fmt.Sprintf(`sudo %v/bin/installer/installer install "oci://gcr.io/datadoghq/apm-inject-package@sha256:5fc83f7127647d53d52f72b90de3f7835ec54eb5ed3760c43496e98621a6d717"`, bootInstallerDir))
 
 	////////////////////////////////
 	// Check post-bootstrap state //


### PR DESCRIPTION
### What does this PR do?
Uses gcr.io by default as the AWS registry is rate limited

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
