### PR TITLE
[CWS] allow disabling some windows etw parsing if event type is disabled

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -64,6 +64,10 @@ func createTestProbe() (*WindowsProbe, error) {
 		regPathResolver:    rc,
 		discardedPaths:     discardedPaths,
 		discardedBasenames: discardedBasenames,
+
+		isRenameEnabled: true,
+		isWriteEnabled:  true,
+		isDeleteEnabled: true,
 	}
 	err = wp.Init()
 

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -110,7 +110,7 @@ const (
 	LastApproverEventType = SpliceEventType
 
 	// CustomLostReadEventType is the custom event used to report lost events detected in user space
-	CustomLostReadEventType = iota
+	CustomLostReadEventType EventType = iota
 	// CustomLostWriteEventType is the custom event used to report lost events detected in kernel space
 	CustomLostWriteEventType
 	// CustomRulesetLoadedEventType is the custom event used to report that a new ruleset was loaded


### PR DESCRIPTION
### What does this PR do?

This PR allows to skip ETW message parsing and callback calls for unused event types (delete/write/rename). This PR takes advantage of the `ApplyRuleset` callback to understand which kind of event types is used in a given ruleset and discard as soon as possible the events we already know we are not interested in.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
