### PR TITLE
[Tooling] Remove deprecated `golangci-lint` invoke task

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -59,7 +59,6 @@ from tasks.go import (
     generate_licenses,
     generate_protobuf,
     go_fix,
-    golangci_lint,
     internal_deps_checker,
     lint_licenses,
     reset,
@@ -87,7 +86,6 @@ from tasks.windows_resources import build_messagetable
 ns = Collection()
 
 # add single tasks to the root
-ns.add_task(golangci_lint)
 ns.add_task(test)
 ns.add_task(codecov)
 ns.add_task(integration_tests)

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -75,28 +75,6 @@ def run_golangci_lint(
 
 
 @task
-def golangci_lint(
-    ctx,
-    targets,
-    rtloader_root=None,
-    build_tags=None,
-    build="test",
-    arch="x64",
-    concurrency=None,  # noqa: U100
-):
-    """
-    Run golangci-lint on targets using .golangci.yml configuration.
-
-    Example invocation:
-        inv golangci-lint --targets=./pkg/collector/check,./pkg/aggregator
-    DEPRECATED
-    Please use inv linter.go instead
-    """
-    print("WARNING: golangci-lint task is deprecated, please migrate to linter.go task")
-    raise Exit(code=1)
-
-
-@task
 def internal_deps_checker(ctx, formatFile=False):
     """
     Check that every required internal dependencies are correctly replaced


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR removes the code of the already-deprecated `golangci-lint` invoke task.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

It was deprecated 7 months ago in #19022. It's now time to remove its code.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
