### PR TITLE
Remove install-fail kitchen test

### DIFF
--- a/test/kitchen/test-definitions/windows-install-test.yml
+++ b/test/kitchen/test-definitions/windows-install-test.yml
@@ -22,28 +22,3 @@ suites:
           APM_ENABLED=true
       dd-agent-rspec:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
-
-  - name: win-install-fail
-    run_list:
-      - "recipe[dd-agent-install::_install_windows_base]"
-    attributes:
-      datadog:
-        <% dd_agent_config.each do |key, value| %>
-        <%= key %>: "<%= value %>"
-        <% end %>
-      dd-agent-install:
-        <% if ENV['AGENT_VERSION'] %>
-        windows_version: "<%= ENV['AGENT_VERSION'] %>"
-        <% end %>
-        windows_agent_url: <%= windows_agent_url %>
-        <% if ENV['WINDOWS_AGENT_FILE'] %>
-        windows_agent_filename: "<%= ENV['WINDOWS_AGENT_FILE'] %>"
-        <% end %>
-        agent_install_options: >
-          APIKEY=<%= api_key %>
-          LOGS_ENABLED=false
-          PROCESS_ENABLED=true
-          APM_ENABLED=true
-          WIXFAILWHENDEFERRED=1
-      dd-agent-rspec:
-        skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>

--- a/test/new-e2e/tests/windows/install-test/assert.go
+++ b/test/new-e2e/tests/windows/install-test/assert.go
@@ -130,6 +130,8 @@ func getExpectedConfigFiles() []string {
 		`system-probe.yaml`,
 		`security-agent.yaml`,
 		`runtime-security.d\default.policy`,
+		`conf.d\win32_event_log.d\profiles\dd_security_events_high.yaml`,
+		`conf.d\win32_event_log.d\profiles\dd_security_events_low.yaml`,
 	}
 }
 

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -218,6 +218,9 @@ func (t *Tester) TestUninstallExpectations(tt *testing.T) {
 		assert.ErrorIs(tt, err, fs.ErrNotExist, "uninstall should remove %s example config files", examplePath)
 	}
 
+	_, err = t.host.Lstat(filepath.Join(t.expectedConfigRoot, "auth_token"))
+	assert.ErrorIs(tt, err, fs.ErrNotExist, "uninstall should remove auth_token")
+
 	_, err = windows.GetSIDForUser(t.host,
 		windows.MakeDownLevelLogonName(t.expectedUserDomain, t.expectedUserName),
 	)

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -221,6 +221,9 @@ func (t *Tester) TestUninstallExpectations(tt *testing.T) {
 	_, err = t.host.Lstat(filepath.Join(t.expectedConfigRoot, "auth_token"))
 	assert.ErrorIs(tt, err, fs.ErrNotExist, "uninstall should remove auth_token")
 
+	_, err = t.host.Lstat(filepath.Join(t.expectedConfigRoot, "checks.d"))
+	assert.ErrorIs(tt, err, fs.ErrNotExist, "uninstall should remove checks.d")
+
 	_, err = windows.GetSIDForUser(t.host,
 		windows.MakeDownLevelLogonName(t.expectedUserDomain, t.expectedUserName),
 	)

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
@@ -17,9 +17,7 @@ namespace Datadog.CustomActions
                 Path.Combine(projectLocation, "embedded2"),
                 Path.Combine(projectLocation, "embedded3"),
                 Path.Combine(applicationDataLocation, "install_info"),
-                Path.Combine(applicationDataLocation, "auth_token"),
-                Path.Combine(applicationDataLocation, "conf.d", "win32_event_log.d", "profiles", "dd_security_events_high.yaml"),
-                Path.Combine(applicationDataLocation, "conf.d", "win32_event_log.d", "profiles", "dd_security_events_low.yaml"),
+                Path.Combine(applicationDataLocation, "auth_token")
             };
             foreach (var path in toDelete)
             {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add new config files from https://github.com/DataDog/datadog-agent/pull/24360 to E2E tests

Remove kitchen test that is now handled by an E2E test
 - added assertions for removal of `auth_token` and `checks.d`

Revert temporary CI fix https://github.com/DataDog/datadog-agent/pull/25257

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
install-fail kitchen test started failing because it wasn't updated to be aware of the new config files added in https://github.com/DataDog/datadog-agent/pull/24360

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
