### PR TITLE
feat(ci): Add a new metric to compute duration of required jobs

### DIFF
--- a/tasks/libs/pipeline/stats.py
+++ b/tasks/libs/pipeline/stats.py
@@ -1,7 +1,99 @@
+import os
+import traceback
 from collections import Counter
+from datetime import datetime
 
+from invoke import Exit
+
+from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
+from tasks.libs.common.datadog_api import create_count, create_gauge
 from tasks.libs.pipeline.data import get_failed_jobs
 from tasks.libs.types.types import FailedJobType
+
+REQUIRED_JOBS = [
+    "go_mod_tidy_check",
+    "tests_deb-x64-py3",
+    "tests_deb-arm64-py3",
+    "tests_rpm-x64-py3",
+    "tests_rpm-arm64-py3",
+    "slack_teams_channels_check",
+    "lint_windows-x64",
+    "lint_linux-x64",
+    "lint_linux-arm64",
+    "lint_flavor_iot_linux-x64",
+    "lint_flavor_dogstatsd_linux-x64",
+    "tests_ebpf_arm64",
+    "tests_ebpf_x64",
+    "do-not-merge",
+    "agent_deb-x64-a7",
+    "agent_rpm-x64-a7",
+    "agent_suse-x64-a7",
+    "deploy_deb_testing-a7_x64",
+    "deploy_suse_rpm_testing_x64-a7",
+    "new-e2e-agent-platform-install-script-debian-a7-x86_64",
+    "new-e2e-agent-platform-install-script-suse-a7-x86_64",
+    "new-e2e-agent-platform-install-script-ubuntu-a7-x86_64",
+    "new-e2e-agent-platform-install-script-debian-iot-agent-a7-x86_64",
+    "agent_heroku_deb-x64-a7",
+    "iot_agent_deb-x64",
+    "dogstatsd_deb-x64",
+    "iot_agent_rpm-x64",
+    "dogstatsd_rpm-x64",
+    "security_go_generate_check",
+    "lint_python",
+]
+
+
+def compute_failed_jobs_series(project_name: str):
+    try:
+        global_failure_reason, job_failure_stats = get_failed_jobs_stats(project_name, os.getenv("CI_PIPELINE_ID"))
+    except Exception as e:
+        print("Found exception when generating statistics:")
+        print(e)
+        traceback.print_exc(limit=-1)
+        raise Exit(code=1)
+
+    timestamp = int(datetime.now().timestamp())
+    series = []
+
+    for failure_tags, count in job_failure_stats.items():
+        # This allows getting stats on the number of jobs that fail due to infrastructure
+        # issues vs. other failures, and have a per-pipeline ratio of infrastructure failures.
+        series.append(
+            create_count(
+                metric_name="datadog.ci.job_failures",
+                timestamp=timestamp,
+                value=count,
+                tags=list(failure_tags)
+                + [
+                    "repository:datadog-agent",
+                    f"git_ref:{os.getenv('CI_COMMIT_REF_NAME')}",
+                ],
+            )
+        )
+
+    if job_failure_stats:  # At least one job failed
+        pipeline_state = "failed"
+    else:
+        pipeline_state = "succeeded"
+
+    pipeline_tags = [
+        "repository:datadog-agent",
+        f"git_ref:{os.getenv('CI_COMMIT_REF_NAME')}",
+        f"status:{pipeline_state}",
+    ]
+    if global_failure_reason:  # Only set the reason if the pipeline fails
+        pipeline_tags.append(f"reason:{global_failure_reason}")
+
+    series.append(
+        create_count(
+            metric_name="datadog.ci.pipelines",
+            timestamp=timestamp,
+            value=1,
+            tags=pipeline_tags,
+        )
+    )
+    return series
 
 
 def get_failed_jobs_stats(project_name, pipeline_id):
@@ -38,3 +130,41 @@ def get_failed_jobs_stats(project_name, pipeline_id):
         job_failure_stats[key] += 1
 
     return global_failure_reason, job_failure_stats
+
+
+def compute_required_jobs_max_duration(project_name: str):
+    timestamp = int(datetime.now().timestamp())
+    series = []
+    max_duration, status = get_max_duration(project_name=project_name)
+    pipeline_tags = [
+        "repository:datadog-agent",
+        f"git_ref:{os.getenv('CI_COMMIT_REF_NAME')}",
+        f"status:{status}",
+    ]
+    series.append(
+        create_gauge(
+            metric_name="datadog.ci.required_duration",
+            timestamp=timestamp,
+            value=max_duration,
+            tags=pipeline_tags,
+        )
+    )
+
+    return series
+
+
+def get_max_duration(project_name: str):
+    datadog_agent = get_gitlab_repo(repo=project_name)
+    pipeline = datadog_agent.pipelines.get(os.getenv("CI_PIPELINE_ID"))
+    start = datetime.fromisoformat(pipeline.created_at[:-1])
+    max = start
+    status = "success"
+    jobs = pipeline.jobs.list(per_page=100, all=True)
+    for job in jobs:
+        if job.name in REQUIRED_JOBS:
+            finished = datetime.fromisoformat(job.finished_at[:-1])
+            if finished > max:
+                max = finished
+            if job.status != "success":
+                status = job.status
+    return (max - start).seconds, status

--- a/tasks/libs/pipeline/stats.py
+++ b/tasks/libs/pipeline/stats.py
@@ -72,10 +72,8 @@ def compute_failed_jobs_series(project_name: str):
             )
         )
 
-    if job_failure_stats:  # At least one job failed
-        pipeline_state = "failed"
-    else:
-        pipeline_state = "succeeded"
+    # Consider the pipeline state as failed if at least one job failed
+    pipeline_state = "failed" if job_failure_stats else "succeeded"
 
     pipeline_tags = [
         "repository:datadog-agent",
@@ -143,7 +141,7 @@ def compute_required_jobs_max_duration(project_name: str):
     ]
     series.append(
         create_gauge(
-            metric_name="datadog.ci.required_duration",
+            metric_name="datadog.ci.required_job.duration",
             timestamp=timestamp,
             value=max_duration,
             tags=pipeline_tags,

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -23,7 +23,7 @@ from tasks.libs.pipeline.notifications import (
     get_git_author,
     send_slack_message,
 )
-from tasks.libs.pipeline.stats import get_failed_jobs_stats
+from tasks.libs.pipeline.stats import compute_failed_jobs_series, compute_required_jobs_max_duration
 from tasks.libs.types.types import FailedJobs, SlackMessage, TeamMessage
 
 UNKNOWN_OWNER_TEMPLATE = """The owner `{owner}` is not mapped to any slack channel.
@@ -57,8 +57,8 @@ def send_message(ctx, notification_type="merge", print_to_stdout=False):
     Use the --print-to-stdout option to test this locally, without sending
     real slack messages.
     """
-    default_branch = os.getenv('CI_DEFAULT_BRANCH')
-    git_ref = os.getenv('CI_COMMIT_REF_NAME')
+    default_branch = os.getenv("CI_DEFAULT_BRANCH")
+    git_ref = os.getenv("CI_COMMIT_REF_NAME")
 
     try:
         failed_jobs = get_failed_jobs(PROJECT_NAME, os.getenv("CI_PIPELINE_ID"))
@@ -109,7 +109,7 @@ def send_message(ctx, notification_type="merge", print_to_stdout=False):
         if print_to_stdout:
             print(f"Would send to {channel}:\n{str(message)}")
         else:
-            all_teams = channel == '#datadog-agent-pipelines'
+            all_teams = channel == "#datadog-agent-pipelines"
             post_channel = _should_send_message_to_channel(git_ref, default_branch) or all_teams
             send_dm = not _should_send_message_to_channel(git_ref, default_branch) and all_teams
 
@@ -125,7 +125,7 @@ def send_message(ctx, notification_type="merge", print_to_stdout=False):
                             "repository:datadog-agent",
                             f"git_ref:{git_ref}",
                         ],
-                        unit='notification',
+                        unit="notification",
                         value=1,
                     )
                 )
@@ -156,58 +156,12 @@ def send_stats(_, print_to_stdout=False):
     Use the --print-to-stdout option to test this locally, without sending
     data points to Datadog.
     """
-    try:
-        global_failure_reason, job_failure_stats = get_failed_jobs_stats(PROJECT_NAME, os.getenv("CI_PIPELINE_ID"))
-    except Exception as e:
-        print("Found exception when generating statistics:")
-        print(e)
-        traceback.print_exc(limit=-1)
-        raise Exit(code=1)
-
     if not (print_to_stdout or os.environ.get("DD_API_KEY")):
         print("DD_API_KEY environment variable not set, cannot send pipeline metrics to the backend")
         raise Exit(code=1)
 
-    timestamp = int(datetime.now().timestamp())
-    series = []
-
-    for failure_tags, count in job_failure_stats.items():
-        # This allows getting stats on the number of jobs that fail due to infrastructure
-        # issues vs. other failures, and have a per-pipeline ratio of infrastructure failures.
-        series.append(
-            create_count(
-                metric_name="datadog.ci.job_failures",
-                timestamp=timestamp,
-                value=count,
-                tags=list(failure_tags)
-                + [
-                    "repository:datadog-agent",
-                    f"git_ref:{os.getenv('CI_COMMIT_REF_NAME')}",
-                ],
-            )
-        )
-
-    if job_failure_stats:  # At least one job failed
-        pipeline_state = "failed"
-    else:
-        pipeline_state = "succeeded"
-
-    pipeline_tags = [
-        "repository:datadog-agent",
-        f"git_ref:{os.getenv('CI_COMMIT_REF_NAME')}",
-        f"status:{pipeline_state}",
-    ]
-    if global_failure_reason:  # Only set the reason if the pipeline fails
-        pipeline_tags.append(f"reason:{global_failure_reason}")
-
-    series.append(
-        create_count(
-            metric_name="datadog.ci.pipelines",
-            timestamp=timestamp,
-            value=1,
-            tags=pipeline_tags,
-        )
-    )
+    series = compute_failed_jobs_series(PROJECT_NAME)
+    series.extend(compute_required_jobs_max_duration(PROJECT_NAME))
 
     if not print_to_stdout:
         send_metrics(series)
@@ -276,7 +230,10 @@ def check_consistent_failures(ctx, job_failures_file="job_executions.json"):
     # Upload document
     with open(job_failures_file, "w") as f:
         json.dump(job_executions, f)
-    ctx.run(f"{AWS_S3_CP_CMD} {job_failures_file} {S3_CI_BUCKET_URL}/{job_failures_file} ", hide="stdout")
+    ctx.run(
+        f"{AWS_S3_CP_CMD} {job_failures_file} {S3_CI_BUCKET_URL}/{job_failures_file} ",
+        hide="stdout",
+    )
 
 
 def retrieve_job_executions(ctx, job_failures_file):
@@ -284,7 +241,10 @@ def retrieve_job_executions(ctx, job_failures_file):
     Retrieve the stored document in aws s3, or create it
     """
     try:
-        ctx.run(f"{AWS_S3_CP_CMD}  {S3_CI_BUCKET_URL}/{job_failures_file} {job_failures_file}", hide=True)
+        ctx.run(
+            f"{AWS_S3_CP_CMD}  {S3_CI_BUCKET_URL}/{job_failures_file} {job_failures_file}",
+            hide=True,
+        )
         with open(job_failures_file) as f:
             job_executions = json.load(f)
     except UnexpectedExit as e:
@@ -311,7 +271,10 @@ def update_statistics(job_executions):
     # Insert data for newly failing jobs
     new_failed_jobs = failed_set - current_set
     for job in new_failed_jobs:
-        job_executions["jobs"][job] = {"consecutive_failures": 1, "cumulative_failures": [1]}
+        job_executions["jobs"][job] = {
+            "consecutive_failures": 1,
+            "cumulative_failures": [1],
+        }
     # Reset information for no-more failing jobs
     solved_jobs = current_set - failed_set
     for job in solved_jobs:
@@ -386,7 +349,7 @@ def unit_tests(ctx, pipeline_id, pipeline_url, branch_name):
 
 
 def create_msg(pipeline_id, pipeline_url, job_list):
-    msg = f'''
+    msg = f"""
 [Fast Unit Tests Report]
 
 On pipeline [{pipeline_id}]({pipeline_url}) ([CI Visibility](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Apipeline%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40ci.pipeline.id%3A{pipeline_id}&fromUser=false&index=cipipeline)). The following jobs did not run any unit tests:
@@ -394,7 +357,7 @@ On pipeline [{pipeline_id}]({pipeline_url}) ([CI Visibility](https://app.datadog
 <details>
 <summary>Jobs:</summary>
 
-'''
+"""
     for job in job_list:
         msg += f"  - {job}\n"
     msg += "</details>\n"

--- a/tasks/unit-tests/notify_tests.py
+++ b/tasks/unit-tests/notify_tests.py
@@ -220,7 +220,7 @@ class TestSendStats(unittest.TestCase):
         pipeline_mock = repo_mock.pipelines.get
 
         trace_mock.return_value = b"E2E INTERNAL ERROR"
-        attrs={"jobs.list.return_value": get_fake_jobs(), "created_at": "2024-03-12T10:00:00.000Z"}
+        attrs = {"jobs.list.return_value": get_fake_jobs(), "created_at": "2024-03-12T10:00:00.000Z"}
         pipeline_mock.return_value = MagicMock(**attrs)
 
         notify.send_stats(MockContext(), print_to_stdout=True)

--- a/tasks/unit-tests/stats_tests.py
+++ b/tasks/unit-tests/stats_tests.py
@@ -1,32 +1,36 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from tasks.libs.pipeline.stats import get_max_duration
 from gitlab.v4.objects import ProjectJob
+
+from tasks.libs.pipeline.stats import get_max_duration
 
 
 class TestGetMaxDuration(unittest.TestCase):
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     def test_required_success(self, api_mock):
-        job_list =  [
-                {
-                    "name": "go_mod_tidy_check",
-                    "finished_at": "2024-03-12T10:10:00.000Z",
-                    "status": "success",
-                },
-                {
-                    "name": "tests_deb-x64-py3",
-                    "finished_at": "2024-03-12T10:20:00.000Z",
-                    "status": "success",
-                },
-                {
-                    "name": "tests_rpm-x64-py3",
-                    "finished_at": "2024-03-12T10:30:00.000Z",
-                    "status": "success",
-                },
-            ]
+        job_list = [
+            {
+                "name": "go_mod_tidy_check",
+                "finished_at": "2024-03-12T10:10:00.000Z",
+                "status": "success",
+            },
+            {
+                "name": "tests_deb-x64-py3",
+                "finished_at": "2024-03-12T10:20:00.000Z",
+                "status": "success",
+            },
+            {
+                "name": "tests_rpm-x64-py3",
+                "finished_at": "2024-03-12T10:30:00.000Z",
+                "status": "success",
+            },
+        ]
         # We must use a ProjectJob (and not a simple Mock) because we cannot override a MagicMock().name attribute
-        pipeline = {"jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list], "created_at": "2024-03-12T10:00:00.000Z"}
+        pipeline = {
+            "jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list],
+            "created_at": "2024-03-12T10:00:00.000Z",
+        }
         repo_mock = api_mock.return_value.projects.get.return_value
         pipeline_mock = repo_mock.pipelines.get
         pipeline_mock.return_value = MagicMock(**pipeline)
@@ -37,24 +41,27 @@ class TestGetMaxDuration(unittest.TestCase):
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     def test_required_success_reversed_max(self, api_mock):
         job_list = [
-                {
-                    "name": "go_mod_tidy_check",
-                    "finished_at": "2024-03-12T10:40:00.000Z",
-                    "status": "success",
-                },
-                {
-                    "name": "tests_deb-x64-py3",
-                    "finished_at": "2024-03-12T10:20:00.000Z",
-                    "status": "success",
-                },
-                {
-                    "name": "tests_rpm-x64-py3",
-                    "finished_at": "2024-03-12T10:10:00.000Z",
-                    "status": "success",
-                },
-            ]
+            {
+                "name": "go_mod_tidy_check",
+                "finished_at": "2024-03-12T10:40:00.000Z",
+                "status": "success",
+            },
+            {
+                "name": "tests_deb-x64-py3",
+                "finished_at": "2024-03-12T10:20:00.000Z",
+                "status": "success",
+            },
+            {
+                "name": "tests_rpm-x64-py3",
+                "finished_at": "2024-03-12T10:10:00.000Z",
+                "status": "success",
+            },
+        ]
         # We must use a ProjectJob (and not a simple Mock) because we cannot override a MagicMock().name attribute
-        pipeline = {"jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list], "created_at": "2024-03-12T10:00:00.000Z"}
+        pipeline = {
+            "jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list],
+            "created_at": "2024-03-12T10:00:00.000Z",
+        }
         repo_mock = api_mock.return_value.projects.get.return_value
         pipeline_mock = repo_mock.pipelines.get
         pipeline_mock.return_value = MagicMock(**pipeline)
@@ -65,24 +72,27 @@ class TestGetMaxDuration(unittest.TestCase):
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     def test_required_failed(self, api_mock):
         job_list = [
-                {
-                    "name": "go_mod_tidy_check",
-                    "finished_at": "2024-03-12T10:10:00.000Z",
-                    "status": "success",
-                },
-                {
-                    "name": "tests_deb-x64-py3",
-                    "finished_at": "2024-03-12T10:20:00.000Z",
-                    "status": "failed",
-                },
-                {
-                    "name": "tests_rpm-x64-py3",
-                    "finished_at": "2024-03-12T10:30:00.000Z",
-                    "status": "success",
-                },
-            ]
+            {
+                "name": "go_mod_tidy_check",
+                "finished_at": "2024-03-12T10:10:00.000Z",
+                "status": "success",
+            },
+            {
+                "name": "tests_deb-x64-py3",
+                "finished_at": "2024-03-12T10:20:00.000Z",
+                "status": "failed",
+            },
+            {
+                "name": "tests_rpm-x64-py3",
+                "finished_at": "2024-03-12T10:30:00.000Z",
+                "status": "success",
+            },
+        ]
         # We must use a ProjectJob (and not a simple Mock) because we cannot override a MagicMock().name attribute
-        pipeline = {"jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list], "created_at": "2024-03-12T10:00:00.000Z"}
+        pipeline = {
+            "jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list],
+            "created_at": "2024-03-12T10:00:00.000Z",
+        }
         repo_mock = api_mock.return_value.projects.get.return_value
         pipeline_mock = repo_mock.pipelines.get
         pipeline_mock.return_value = MagicMock(**pipeline)
@@ -92,24 +102,27 @@ class TestGetMaxDuration(unittest.TestCase):
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     def test_required_skipped(self, api_mock):
         job_list = [
-                {
-                    "name": "go_mod_tidy_check",
-                    "finished_at": "2024-03-12T10:10:00.000Z",
-                    "status": "success",
-                },
-                {
-                    "name": "tests_deb-x64-py3",
-                    "finished_at": "2024-03-12T10:20:00.000Z",
-                    "status": "failed",
-                },
-                {
-                    "name": "tests_rpm-x64-py3",
-                    "finished_at": "2024-03-12T10:30:00.000Z",
-                    "status": "skipped",
-                },
-            ]
+            {
+                "name": "go_mod_tidy_check",
+                "finished_at": "2024-03-12T10:10:00.000Z",
+                "status": "success",
+            },
+            {
+                "name": "tests_deb-x64-py3",
+                "finished_at": "2024-03-12T10:20:00.000Z",
+                "status": "failed",
+            },
+            {
+                "name": "tests_rpm-x64-py3",
+                "finished_at": "2024-03-12T10:30:00.000Z",
+                "status": "skipped",
+            },
+        ]
         # We must use a ProjectJob (and not a simple Mock) because we cannot override a MagicMock().name attribute
-        pipeline = {"jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list], "created_at": "2024-03-12T10:00:00.000Z"}
+        pipeline = {
+            "jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list],
+            "created_at": "2024-03-12T10:00:00.000Z",
+        }
         repo_mock = api_mock.return_value.projects.get.return_value
         pipeline_mock = repo_mock.pipelines.get
         pipeline_mock.return_value = MagicMock(**pipeline)
@@ -119,24 +132,27 @@ class TestGetMaxDuration(unittest.TestCase):
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     def test_no_required(self, api_mock):
         job_list = [
-                {
-                    "name": "un",
-                    "finished_at": "2024-03-12T10:10:00.000Z",
-                    "status": "success",
-                },
-                {
-                    "name": "dos",
-                    "finished_at": "2024-03-12T10:20:00.000Z",
-                    "status": "failed",
-                },
-                {
-                    "name": "tres",
-                    "finished_at": "2024-03-12T10:30:00.000Z",
-                    "status": "success",
-                },
-            ]
+            {
+                "name": "un",
+                "finished_at": "2024-03-12T10:10:00.000Z",
+                "status": "success",
+            },
+            {
+                "name": "dos",
+                "finished_at": "2024-03-12T10:20:00.000Z",
+                "status": "failed",
+            },
+            {
+                "name": "tres",
+                "finished_at": "2024-03-12T10:30:00.000Z",
+                "status": "success",
+            },
+        ]
         # We must use a ProjectJob (and not a simple Mock) because we cannot override a MagicMock().name attribute
-        pipeline = {"jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list], "created_at": "2024-03-12T10:00:00.000Z"}
+        pipeline = {
+            "jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list],
+            "created_at": "2024-03-12T10:00:00.000Z",
+        }
         repo_mock = api_mock.return_value.projects.get.return_value
         pipeline_mock = repo_mock.pipelines.get
         pipeline_mock.return_value = MagicMock(**pipeline)

--- a/tasks/unit-tests/stats_tests.py
+++ b/tasks/unit-tests/stats_tests.py
@@ -1,0 +1,145 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tasks.libs.pipeline.stats import get_max_duration
+from gitlab.v4.objects import ProjectJob
+
+
+class TestGetMaxDuration(unittest.TestCase):
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    def test_required_success(self, api_mock):
+        job_list =  [
+                {
+                    "name": "go_mod_tidy_check",
+                    "finished_at": "2024-03-12T10:10:00.000Z",
+                    "status": "success",
+                },
+                {
+                    "name": "tests_deb-x64-py3",
+                    "finished_at": "2024-03-12T10:20:00.000Z",
+                    "status": "success",
+                },
+                {
+                    "name": "tests_rpm-x64-py3",
+                    "finished_at": "2024-03-12T10:30:00.000Z",
+                    "status": "success",
+                },
+            ]
+        # We must use a ProjectJob (and not a simple Mock) because we cannot override a MagicMock().name attribute
+        pipeline = {"jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list], "created_at": "2024-03-12T10:00:00.000Z"}
+        repo_mock = api_mock.return_value.projects.get.return_value
+        pipeline_mock = repo_mock.pipelines.get
+        pipeline_mock.return_value = MagicMock(**pipeline)
+        max_duration, status = get_max_duration("datadog-agent")
+        self.assertEqual(max_duration, 1800)
+        self.assertEqual(status, "success")
+
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    def test_required_success_reversed_max(self, api_mock):
+        job_list = [
+                {
+                    "name": "go_mod_tidy_check",
+                    "finished_at": "2024-03-12T10:40:00.000Z",
+                    "status": "success",
+                },
+                {
+                    "name": "tests_deb-x64-py3",
+                    "finished_at": "2024-03-12T10:20:00.000Z",
+                    "status": "success",
+                },
+                {
+                    "name": "tests_rpm-x64-py3",
+                    "finished_at": "2024-03-12T10:10:00.000Z",
+                    "status": "success",
+                },
+            ]
+        # We must use a ProjectJob (and not a simple Mock) because we cannot override a MagicMock().name attribute
+        pipeline = {"jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list], "created_at": "2024-03-12T10:00:00.000Z"}
+        repo_mock = api_mock.return_value.projects.get.return_value
+        pipeline_mock = repo_mock.pipelines.get
+        pipeline_mock.return_value = MagicMock(**pipeline)
+        max_duration, status = get_max_duration("datadog-agent")
+        self.assertEqual(max_duration, 2400)
+        self.assertEqual(status, "success")
+
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    def test_required_failed(self, api_mock):
+        job_list = [
+                {
+                    "name": "go_mod_tidy_check",
+                    "finished_at": "2024-03-12T10:10:00.000Z",
+                    "status": "success",
+                },
+                {
+                    "name": "tests_deb-x64-py3",
+                    "finished_at": "2024-03-12T10:20:00.000Z",
+                    "status": "failed",
+                },
+                {
+                    "name": "tests_rpm-x64-py3",
+                    "finished_at": "2024-03-12T10:30:00.000Z",
+                    "status": "success",
+                },
+            ]
+        # We must use a ProjectJob (and not a simple Mock) because we cannot override a MagicMock().name attribute
+        pipeline = {"jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list], "created_at": "2024-03-12T10:00:00.000Z"}
+        repo_mock = api_mock.return_value.projects.get.return_value
+        pipeline_mock = repo_mock.pipelines.get
+        pipeline_mock.return_value = MagicMock(**pipeline)
+        _, status = get_max_duration("datadog-agent")
+        self.assertEqual(status, "failed")
+
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    def test_required_skipped(self, api_mock):
+        job_list = [
+                {
+                    "name": "go_mod_tidy_check",
+                    "finished_at": "2024-03-12T10:10:00.000Z",
+                    "status": "success",
+                },
+                {
+                    "name": "tests_deb-x64-py3",
+                    "finished_at": "2024-03-12T10:20:00.000Z",
+                    "status": "failed",
+                },
+                {
+                    "name": "tests_rpm-x64-py3",
+                    "finished_at": "2024-03-12T10:30:00.000Z",
+                    "status": "skipped",
+                },
+            ]
+        # We must use a ProjectJob (and not a simple Mock) because we cannot override a MagicMock().name attribute
+        pipeline = {"jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list], "created_at": "2024-03-12T10:00:00.000Z"}
+        repo_mock = api_mock.return_value.projects.get.return_value
+        pipeline_mock = repo_mock.pipelines.get
+        pipeline_mock.return_value = MagicMock(**pipeline)
+        _, status = get_max_duration("datadog-agent")
+        self.assertEqual(status, "skipped")
+
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    def test_no_required(self, api_mock):
+        job_list = [
+                {
+                    "name": "un",
+                    "finished_at": "2024-03-12T10:10:00.000Z",
+                    "status": "success",
+                },
+                {
+                    "name": "dos",
+                    "finished_at": "2024-03-12T10:20:00.000Z",
+                    "status": "failed",
+                },
+                {
+                    "name": "tres",
+                    "finished_at": "2024-03-12T10:30:00.000Z",
+                    "status": "success",
+                },
+            ]
+        # We must use a ProjectJob (and not a simple Mock) because we cannot override a MagicMock().name attribute
+        pipeline = {"jobs.list.return_value": [ProjectJob(MagicMock(), attrs=job) for job in job_list], "created_at": "2024-03-12T10:00:00.000Z"}
+        repo_mock = api_mock.return_value.projects.get.return_value
+        pipeline_mock = repo_mock.pipelines.get
+        pipeline_mock.return_value = MagicMock(**pipeline)
+        max_duration, status = get_max_duration("datadog-agent")
+        self.assertEqual(max_duration, 0)
+        self.assertEqual(status, "success")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add a metric computing required jobs duration

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
It's not easy to compute this duration directly on ci-visibility (as jobs have dependency we must take into account). It will give us a precise information of the minimum CI requested time duration until further updates on the pipeline constraints

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Sorry for the formatting, shipped with the ruff update..

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
