### PR TITLE
[CWS] fix parent and child pid collection from tracepoint on rhel9

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -162,8 +162,11 @@ int hook__do_fork(ctx_t *ctx) {
 
 SEC("tracepoint/sched/sched_process_fork")
 int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
+    u64 sched_process_fork_child_pid_offset;
+    LOAD_CONSTANT("sched_process_fork_child_pid_offset", sched_process_fork_child_pid_offset);
+
     u32 pid = 0, parent_pid = 0;
-    bpf_probe_read(&pid, sizeof(pid), &args->child_pid);
+    bpf_probe_read(&pid, sizeof(pid), (void *)args + sched_process_fork_child_pid_offset);
     bpf_probe_read(&parent_pid, sizeof(parent_pid), &args->parent_pid);
     // ignore the rest if kworker
     struct syscall_cache_t *syscall = peek_syscall(EVENT_FORK);

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -162,12 +162,14 @@ int hook__do_fork(ctx_t *ctx) {
 
 SEC("tracepoint/sched/sched_process_fork")
 int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
+    u64 sched_process_fork_parent_pid_offset;
+    LOAD_CONSTANT("sched_process_fork_parent_pid_offset", sched_process_fork_parent_pid_offset);
     u64 sched_process_fork_child_pid_offset;
     LOAD_CONSTANT("sched_process_fork_child_pid_offset", sched_process_fork_child_pid_offset);
 
     u32 pid = 0, parent_pid = 0;
     bpf_probe_read(&pid, sizeof(pid), (void *)args + sched_process_fork_child_pid_offset);
-    bpf_probe_read(&parent_pid, sizeof(parent_pid), &args->parent_pid);
+    bpf_probe_read(&parent_pid, sizeof(parent_pid), (void *)args + sched_process_fork_parent_pid_offset);
     // ignore the rest if kworker
     struct syscall_cache_t *syscall = peek_syscall(EVENT_FORK);
     if (!syscall || syscall->fork.is_kthread || parent_pid == 2) {

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -235,6 +235,11 @@ func (k *Version) IsRH9Kernel() bool {
 	return k.OsRelease["PLATFORM_ID"] == "platform:el9"
 }
 
+// IsRH9_3Kernel returns whether the kernel is a rh9.3 kernel
+func (k *Version) IsRH9_3Kernel() bool {
+	return k.IsRH9Kernel() && strings.HasPrefix(k.OsRelease["VERSION_ID"], "9.3")
+}
+
 // IsSuseKernel returns whether the kernel is a suse kernel
 func (k *Version) IsSuseKernel() bool {
 	return k.IsSLESKernel() || k.OsRelease["ID"] == "opensuse-leap"

--- a/pkg/security/probe/constantfetch/available_unsupported.go
+++ b/pkg/security/probe/constantfetch/available_unsupported.go
@@ -9,6 +9,8 @@
 package constantfetch
 
 import (
+	"errors"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
@@ -31,4 +33,9 @@ func GetAvailableConstantFetchers(_ *config.Config, kv *kernel.Version, _ statsd
 	fetchers = append(fetchers, fallbackConstantFetcher)
 
 	return fetchers
+}
+
+// GetHasUsernamespaceFirstArgWithBtf uses BTF to check if the security_inode_setattr function has a user namespace as its first argument
+func GetHasUsernamespaceFirstArgWithBtf() (bool, error) {
+	return false, errors.New("unsupported BTF request")
 }

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -28,6 +28,8 @@ const (
 	OffsetNameKernelCloneArgsExitSignal = "kernel_clone_args_exit_signal_offset"
 	OffsetNameFileFinode                = "file_f_inode_offset"
 	OffsetNameFileFpath                 = "file_f_path_offset"
+	OffsetNameSchedProcessForkParentPid = "sched_process_fork_parent_pid_offset"
+	OffsetNameSchedProcessForkChildPid  = "sched_process_fork_child_pid_offset"
 
 	// bpf offsets
 	OffsetNameBPFMapStructID                  = "bpf_map_id_offset"

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -137,6 +137,10 @@ func (f *FallbackConstantFetcher) appendRequest(id string) {
 		value = getFileFinodeOffset(f.kernelVersion)
 	case OffsetNameFileFpath:
 		value = getFileFpathOffset(f.kernelVersion)
+	case OffsetNameSchedProcessForkChildPid:
+		value = getSchedProcessForkChildPidOffset(f.kernelVersion)
+	case OffsetNameSchedProcessForkParentPid:
+		value = getSchedProcessForkParentPidOffset(f.kernelVersion)
 	}
 	f.res[id] = value
 }
@@ -993,4 +997,20 @@ func getFileFpathOffset(kv *kernel.Version) uint64 {
 	default:
 		return 16
 	}
+}
+
+func getSchedProcessForkParentPidOffset(kv *kernel.Version) uint64 {
+	if kv.IsInRangeCloseOpen(kernel.Kernel5_14, kernel.Kernel5_15) && kv.IsRH9_3Kernel() {
+		return 28
+	}
+
+	return 24 // for regular kernels
+}
+
+func getSchedProcessForkChildPidOffset(kv *kernel.Version) uint64 {
+	if kv.IsInRangeCloseOpen(kernel.Kernel5_14, kernel.Kernel5_15) && kv.IsRH9_3Kernel() {
+		return 48
+	}
+
+	return 44 // for regular kernels
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1776,6 +1776,13 @@ func getDoForkInput(kernelVersion *kernel.Version) uint64 {
 }
 
 func getHasUsernamespaceFirstArg(kernelVersion *kernel.Version) uint64 {
+	if val, err := constantfetch.GetHasUsernamespaceFirstArgWithBtf(); err == nil {
+		if val {
+			return 1
+		}
+		return 0
+	}
+
 	switch {
 	case kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel6_0:
 		return 1

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1562,6 +1562,10 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts, wmeta optional
 			Value: getDoForkInput(p.kernelVersion),
 		},
 		manager.ConstantEditor{
+			Name:  "sched_process_fork_parent_pid_offset",
+			Value: getSchedProcessForkParentPidOffset(p.kernelVersion),
+		},
+		manager.ConstantEditor{
 			Name:  "sched_process_fork_child_pid_offset",
 			Value: getSchedProcessForkChildPidOffset(p.kernelVersion),
 		},
@@ -1777,6 +1781,14 @@ func getDoForkInput(kernelVersion *kernel.Version) uint64 {
 		return doForkStructInput
 	}
 	return doForkListInput
+}
+
+func getSchedProcessForkParentPidOffset(kernelVersion *kernel.Version) uint64 {
+	if kernelVersion.IsInRangeCloseOpen(kernel.Kernel5_14, kernel.Kernel5_15) && kernelVersion.IsRH9Kernel() {
+		return 28
+	}
+
+	return 24 // for regular kernels
 }
 
 func getSchedProcessForkChildPidOffset(kernelVersion *kernel.Version) uint64 {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1800,10 +1800,14 @@ func getSchedProcessForkChildPidOffset(kernelVersion *kernel.Version) uint64 {
 }
 
 func getHasUsernamespaceFirstArg(kernelVersion *kernel.Version) uint64 {
-	if kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel6_0 {
+	switch {
+	case kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel6_0:
 		return 1
+	case kernelVersion.IsInRangeCloseOpen(kernel.Kernel5_14, kernel.Kernel5_15) && kernelVersion.IsRH9Kernel():
+		return 1
+	default:
+		return 0
 	}
-	return 0
 }
 
 func getOvlPathInOvlInode(kernelVersion *kernel.Version) uint64 {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1779,7 +1779,7 @@ func getHasUsernamespaceFirstArg(kernelVersion *kernel.Version) uint64 {
 	switch {
 	case kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel6_0:
 		return 1
-	case kernelVersion.IsInRangeCloseOpen(kernel.Kernel5_14, kernel.Kernel5_15) && kernelVersion.IsRH9Kernel():
+	case kernelVersion.IsInRangeCloseOpen(kernel.Kernel5_14, kernel.Kernel5_15) && kernelVersion.IsRH9_3Kernel():
 		return 1
 	default:
 		return 0

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1562,14 +1562,6 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts, wmeta optional
 			Value: getDoForkInput(p.kernelVersion),
 		},
 		manager.ConstantEditor{
-			Name:  "sched_process_fork_parent_pid_offset",
-			Value: getSchedProcessForkParentPidOffset(p.kernelVersion),
-		},
-		manager.ConstantEditor{
-			Name:  "sched_process_fork_child_pid_offset",
-			Value: getSchedProcessForkChildPidOffset(p.kernelVersion),
-		},
-		manager.ConstantEditor{
 			Name:  "has_usernamespace_first_arg",
 			Value: getHasUsernamespaceFirstArg(p.kernelVersion),
 		},
@@ -1783,22 +1775,6 @@ func getDoForkInput(kernelVersion *kernel.Version) uint64 {
 	return doForkListInput
 }
 
-func getSchedProcessForkParentPidOffset(kernelVersion *kernel.Version) uint64 {
-	if kernelVersion.IsInRangeCloseOpen(kernel.Kernel5_14, kernel.Kernel5_15) && kernelVersion.IsRH9Kernel() {
-		return 28
-	}
-
-	return 24 // for regular kernels
-}
-
-func getSchedProcessForkChildPidOffset(kernelVersion *kernel.Version) uint64 {
-	if kernelVersion.IsInRangeCloseOpen(kernel.Kernel5_14, kernel.Kernel5_15) && kernelVersion.IsRH9Kernel() {
-		return 48
-	}
-
-	return 44 // for regular kernels
-}
-
 func getHasUsernamespaceFirstArg(kernelVersion *kernel.Version) uint64 {
 	switch {
 	case kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel6_0:
@@ -1886,6 +1862,8 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameVMAreaStructFlags, "struct vm_area_struct", "vm_flags", "linux/mm_types.h")
 	constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameFileFinode, "struct file", "f_inode", "linux/fs.h")
 	constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameFileFpath, "struct file", "f_path", "linux/fs.h")
+	constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameSchedProcessForkChildPid, "trace_event_raw_sched_process_fork", "child_pid", "")
+	constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameSchedProcessForkParentPid, "trace_event_raw_sched_process_fork", "parent_pid", "")
 	if kv.Code >= kernel.Kernel5_3 {
 		constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameKernelCloneArgsExitSignal, "struct kernel_clone_args", "exit_signal", "linux/sched/task.h")
 	}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1562,6 +1562,10 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts, wmeta optional
 			Value: getDoForkInput(p.kernelVersion),
 		},
 		manager.ConstantEditor{
+			Name:  "sched_process_fork_child_pid_offset",
+			Value: getSchedProcessForkChildPidOffset(p.kernelVersion),
+		},
+		manager.ConstantEditor{
 			Name:  "has_usernamespace_first_arg",
 			Value: getHasUsernamespaceFirstArg(p.kernelVersion),
 		},
@@ -1773,6 +1777,14 @@ func getDoForkInput(kernelVersion *kernel.Version) uint64 {
 		return doForkStructInput
 	}
 	return doForkListInput
+}
+
+func getSchedProcessForkChildPidOffset(kernelVersion *kernel.Version) uint64 {
+	if kernelVersion.IsInRangeCloseOpen(kernel.Kernel5_14, kernel.Kernel5_15) && kernelVersion.IsRH9Kernel() {
+		return 48
+	}
+
+	return 44 // for regular kernels
 }
 
 func getHasUsernamespaceFirstArg(kernelVersion *kernel.Version) uint64 {

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -22,6 +22,8 @@ import (
 var BTFHubVsRcPossiblyMissingConstants = []string{
 	constantfetch.OffsetNameNFConnStructCTNet,
 	constantfetch.OffsetNameIoKiocbStructCtx,
+	constantfetch.OffsetNameSchedProcessForkChildPid,
+	constantfetch.OffsetNameSchedProcessForkParentPid,
 }
 
 var RCVsFallbackPossiblyMissingConstants = []string{
@@ -29,6 +31,8 @@ var RCVsFallbackPossiblyMissingConstants = []string{
 	constantfetch.OffsetNameTaskStructPID,
 	constantfetch.OffsetNameTaskStructPIDLink,
 	constantfetch.OffsetNameDeviceStructNdNet,
+	constantfetch.OffsetNameSchedProcessForkChildPid,
+	constantfetch.OffsetNameSchedProcessForkParentPid,
 }
 
 var BTFHubVsFallbackPossiblyMissingConstants = []string{
@@ -36,6 +40,8 @@ var BTFHubVsFallbackPossiblyMissingConstants = []string{
 	constantfetch.OffsetNameTaskStructPID,
 	constantfetch.OffsetNameTaskStructPIDLink,
 	constantfetch.OffsetNameDeviceStructNdNet,
+	constantfetch.OffsetNameSchedProcessForkChildPid,
+	constantfetch.OffsetNameSchedProcessForkParentPid,
 }
 
 var BTFVsFallbackPossiblyMissingConstants = []string{
@@ -43,6 +49,8 @@ var BTFVsFallbackPossiblyMissingConstants = []string{
 	constantfetch.OffsetNameTaskStructPID,
 	constantfetch.OffsetNameTaskStructPIDLink,
 	constantfetch.OffsetNameDeviceStructNdNet,
+	constantfetch.OffsetNameSchedProcessForkChildPid,
+	constantfetch.OffsetNameSchedProcessForkParentPid,
 }
 
 func TestOctogonConstants(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

On rhel 9.3 kernel the parent pid and child pid are slightly offset in the tracepoint format resulting in incorrect pid context in events.

This PR fixes this by using CO-RE/BTF to compute the {child,parent}_pid offset.

This PR also fixes an issue where "has_usernamespace_first_arg" was not correctly computed for kernels where the upstream commit was backported. The fix extracts the value from BTF which is much more stable.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
