### PR TITLE
Revert "What if we used zstd in our trace writers"

### DIFF
--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.5.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.14.0
 	github.com/DataDog/sketches-go v1.4.2
-	github.com/DataDog/zstd v1.5.5
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/davecgh/go-spew v1.1.1

--- a/pkg/trace/go.sum
+++ b/pkg/trace/go.sum
@@ -10,8 +10,6 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.14.0 h1:10TPq
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.14.0/go.mod h1:dvIWN9pA2zWNTw5rhDWZgzZnhcfpH++d+8d1SWW6xkY=
 github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjvVA/o=
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
-github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
-github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -8,7 +8,6 @@ package writer
 import (
 	"compress/gzip"
 	"errors"
-	"io"
 	"runtime"
 	"strings"
 	"sync"
@@ -22,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/timing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/DataDog/zstd"
 )
 
 // pathTraces is the target host API path for delivering traces.
@@ -71,7 +69,7 @@ type TraceWriter struct {
 	senders      []*sender
 	stop         chan struct{}
 	stats        *info.TraceWriterInfo
-	wg           sync.WaitGroup // waits for compressors
+	wg           sync.WaitGroup // waits for gzippers
 	tick         time.Duration  // flush frequency
 	agentVersion string
 
@@ -87,7 +85,6 @@ type TraceWriter struct {
 	easylog *log.ThrottledLogger
 	statsd  statsd.ClientInterface
 	timing  timing.Reporter
-	useZstd bool
 }
 
 // NewTraceWriter returns a new TraceWriter. It is created for the given agent configuration and
@@ -118,7 +115,6 @@ func NewTraceWriter(
 		telemetryCollector: telemetryCollector,
 		statsd:             statsd,
 		timing:             timing,
-		useZstd:            cfg.HasFeature("zstd-encoding"),
 	}
 	climit := cfg.TraceWriter.ConnectionLimit
 	if climit == 0 {
@@ -286,43 +282,25 @@ func (w *TraceWriter) serializer() {
 			}
 
 			w.stats.BytesUncompressed.Add(int64(len(b)))
-			var p *payload
-			var writer io.WriteCloser
-
-			if w.useZstd {
-				p = newPayload(map[string]string{
-					"Content-Type":     "application/x-protobuf",
-					"Content-Encoding": "zstd",
-					headerLanguages:    strings.Join(info.Languages(), "|"),
-				})
-
-				p.body.Grow(len(b) / 2)
-				writer = zstd.NewWriterLevel(p.body, zstd.BestSpeed)
-
-			} else {
-				p = newPayload(map[string]string{
-					"Content-Type":     "application/x-protobuf",
-					"Content-Encoding": "gzip",
-					headerLanguages:    strings.Join(info.Languages(), "|"),
-				})
-				p.body.Grow(len(b) / 2)
-
-				writer, err = gzip.NewWriterLevel(p.body, gzip.BestSpeed)
-				if err != nil {
-					// it will never happen, unless an invalid compression is chosen;
-					// we know gzip.BestSpeed is valid.
-					log.Errorf("Failed to compress trace paylod: %s", err)
-					return
-				}
+			p := newPayload(map[string]string{
+				"Content-Type":     "application/x-protobuf",
+				"Content-Encoding": "gzip",
+				headerLanguages:    strings.Join(info.Languages(), "|"),
+			})
+			p.body.Grow(len(b) / 2)
+			gzipw, err := gzip.NewWriterLevel(p.body, gzip.BestSpeed)
+			if err != nil {
+				// it will never happen, unless an invalid compression is chosen;
+				// we know gzip.BestSpeed is valid.
+				log.Errorf("gzip.NewWriterLevel: %d", err)
+				return
 			}
-
-			if _, err := writer.Write(b); err != nil {
-				log.Errorf("Error compressing trace payload: %v", err)
+			if _, err := gzipw.Write(b); err != nil {
+				log.Errorf("Error gzipping trace payload: %v", err)
 			}
-			if err := writer.Close(); err != nil {
-				log.Errorf("Error closing compressed stream when writing trace payload: %v", err)
+			if err := gzipw.Close(); err != nil {
+				log.Errorf("Error closing gzip stream when writing trace payload: %v", err)
 			}
-
 			sendPayloads(w.senders, p, w.syncMode)
 		}()
 	}


### PR DESCRIPTION
Reverts DataDog/datadog-agent#23806

Unfortunately the trace agent module is imported by the otel collector which disables CGO. This PR breaks that build and prevents upgrading to newer trace agent versions. To unblock them we will revert this change, but I will add a task for us to internally refactor this area so that we can use ZSTD in the trace-agent without the otel collector needing to import it directly.