### PR TITLE
[workloadmeta] Add kubernetes namespace information to workloadmeta

### DIFF
--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -136,8 +136,6 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 				tagInfos = append(tagInfos, c.handleKubePod(ev)...)
 			case workloadmeta.KindKubernetesNode:
 				tagInfos = append(tagInfos, c.handleKubeNode(ev)...)
-			case workloadmeta.KindKubernetesNamespace:
-				tagInfos = append(tagInfos, c.handleKubeNamespace(ev)...)
 			case workloadmeta.KindECSTask:
 				tagInfos = append(tagInfos, c.handleECSTask(ev)...)
 			case workloadmeta.KindContainerImageMetadata:
@@ -437,28 +435,6 @@ func (c *WorkloadMetaCollector) handleKubeNode(ev workloadmeta.Event) []*types.T
 	return tagInfos
 }
 
-func (c *WorkloadMetaCollector) handleKubeNamespace(ev workloadmeta.Event) []*types.TagInfo {
-	namespace := ev.Entity.(*workloadmeta.KubernetesNamespace)
-
-	tags := utils.NewTagList()
-
-	// Add tags for namespace here
-
-	low, orch, high, standard := tags.Compute()
-	tagInfos := []*types.TagInfo{
-		{
-			Source:               nodeSource,
-			Entity:               buildTaggerEntityID(namespace.EntityID),
-			HighCardTags:         high,
-			OrchestratorCardTags: orch,
-			LowCardTags:          low,
-			StandardTags:         standard,
-		},
-	}
-
-	return tagInfos
-}
-
 func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.TagInfo {
 	task := ev.Entity.(*workloadmeta.ECSTask)
 
@@ -740,8 +716,6 @@ func buildTaggerEntityID(entityID workloadmeta.EntityID) string {
 		return kubelet.PodUIDToTaggerEntityName(entityID.ID)
 	case workloadmeta.KindKubernetesNode:
 		return kubelet.NodeUIDToTaggerEntityName(entityID.ID)
-	case workloadmeta.KindKubernetesNamespace:
-		return fmt.Sprintf("namespace://%s", entityID.ID)
 	case workloadmeta.KindECSTask:
 		return fmt.Sprintf("ecs_task://%s", entityID.ID)
 	case workloadmeta.KindContainerImageMetadata:

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -136,6 +136,8 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 				tagInfos = append(tagInfos, c.handleKubePod(ev)...)
 			case workloadmeta.KindKubernetesNode:
 				tagInfos = append(tagInfos, c.handleKubeNode(ev)...)
+			case workloadmeta.KindKubernetesNamespace:
+				// tagInfos = append(tagInfos, c.handleKubeNamespace(ev)...) No tags for now
 			case workloadmeta.KindECSTask:
 				tagInfos = append(tagInfos, c.handleECSTask(ev)...)
 			case workloadmeta.KindContainerImageMetadata:
@@ -716,6 +718,8 @@ func buildTaggerEntityID(entityID workloadmeta.EntityID) string {
 		return kubelet.PodUIDToTaggerEntityName(entityID.ID)
 	case workloadmeta.KindKubernetesNode:
 		return kubelet.NodeUIDToTaggerEntityName(entityID.ID)
+	case workloadmeta.KindKubernetesNamespace:
+		return fmt.Sprintf("namespace://%s", entityID.ID)
 	case workloadmeta.KindECSTask:
 		return fmt.Sprintf("ecs_task://%s", entityID.ID)
 	case workloadmeta.KindContainerImageMetadata:

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -136,6 +136,8 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 				tagInfos = append(tagInfos, c.handleKubePod(ev)...)
 			case workloadmeta.KindKubernetesNode:
 				tagInfos = append(tagInfos, c.handleKubeNode(ev)...)
+			case workloadmeta.KindKubernetesNamespace:
+				tagInfos = append(tagInfos, c.handleKubeNamespace(ev)...)
 			case workloadmeta.KindECSTask:
 				tagInfos = append(tagInfos, c.handleECSTask(ev)...)
 			case workloadmeta.KindContainerImageMetadata:
@@ -435,6 +437,28 @@ func (c *WorkloadMetaCollector) handleKubeNode(ev workloadmeta.Event) []*types.T
 	return tagInfos
 }
 
+func (c *WorkloadMetaCollector) handleKubeNamespace(ev workloadmeta.Event) []*types.TagInfo {
+	namespace := ev.Entity.(*workloadmeta.KubernetesNamespace)
+
+	tags := utils.NewTagList()
+
+	// Add tags for namespace here
+
+	low, orch, high, standard := tags.Compute()
+	tagInfos := []*types.TagInfo{
+		{
+			Source:               nodeSource,
+			Entity:               buildTaggerEntityID(namespace.EntityID),
+			HighCardTags:         high,
+			OrchestratorCardTags: orch,
+			LowCardTags:          low,
+			StandardTags:         standard,
+		},
+	}
+
+	return tagInfos
+}
+
 func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.TagInfo {
 	task := ev.Entity.(*workloadmeta.ECSTask)
 
@@ -716,6 +740,8 @@ func buildTaggerEntityID(entityID workloadmeta.EntityID) string {
 		return kubelet.PodUIDToTaggerEntityName(entityID.ID)
 	case workloadmeta.KindKubernetesNode:
 		return kubelet.NodeUIDToTaggerEntityName(entityID.ID)
+	case workloadmeta.KindKubernetesNamespace:
+		return fmt.Sprintf("namespace://%s", entityID.ID)
 	case workloadmeta.KindECSTask:
 		return fmt.Sprintf("ecs_task://%s", entityID.ID)
 	case workloadmeta.KindContainerImageMetadata:

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -43,6 +43,10 @@ func storeGenerators(cfg config.Reader) []storeGenerator {
 		generators = append(generators, newDeploymentStore)
 	}
 
+	if true {
+		generators = append(generators, newNamespaceStore)
+	}
+
 	return generators
 }
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -43,7 +43,7 @@ func storeGenerators(cfg config.Reader) []storeGenerator {
 		generators = append(generators, newDeploymentStore)
 	}
 
-	if true {
+	if cfg.GetBool("kubernetes_namespace_collection_enabled") {
 		generators = append(generators, newNamespaceStore)
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -69,6 +69,13 @@ func TestStoreGenerators(t *testing.T) {
 			expectedStoresGenerator: []storeGenerator{newNodeStore},
 		},
 		{
+			name: "Kube namespace collection enabled",
+			cfg: map[string]bool{
+				"kubernetes_namespace_collection_enabled": true,
+			},
+			expectedStoresGenerator: []storeGenerator{newNodeStore, newNamespaceStore},
+		},
+		{
 			name: "All configurations enabled",
 			cfg: map[string]bool{
 				"cluster_agent.collect_kubernetes_tags": true,

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/namespaces.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/namespaces.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package kubeapiserver contains the collector that collects data metadata from the API server.
+package kubeapiserver
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func newNamespaceStore(ctx context.Context, wlm workloadmeta.Component, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
+	namespaceListerWatcher := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().Namespaces().List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().Namespaces().Watch(ctx, options)
+		},
+	}
+
+	namespaceStore := newNamespaceReflectorStore(wlm)
+	namespaceReflector := cache.NewNamedReflector(
+		componentName,
+		namespaceListerWatcher,
+		&corev1.Namespace{},
+		namespaceStore,
+		noResync,
+	)
+	log.Debug("namespace reflector enabled")
+	return namespaceReflector, namespaceStore
+}
+
+func newNamespaceReflectorStore(wlmetaStore workloadmeta.Component) *reflectorStore {
+	store := &reflectorStore{
+		wlmetaStore: wlmetaStore,
+		seen:        make(map[string]workloadmeta.EntityID),
+		parser:      newNamespaceParser(),
+	}
+
+	return store
+}
+
+type namespaceParser struct{}
+
+func newNamespaceParser() objectParser {
+	return namespaceParser{}
+}
+
+func (p namespaceParser) Parse(obj interface{}) workloadmeta.Entity {
+	namespace := obj.(*corev1.Namespace)
+
+	wlmNamespace := &workloadmeta.KubernetesNamespace{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesNamespace,
+			ID:   namespace.Name,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:        namespace.Name,
+			Annotations: namespace.Annotations,
+			Labels:      namespace.Labels,
+		},
+	}
+	return wlmNamespace
+}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/namespaces_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/namespaces_test.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build kubeapiserver && test
+
+package kubeapiserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+)
+
+func TestNamespaceParser_Parse(t *testing.T) {
+	parser := newNamespaceParser()
+	expected := &workloadmeta.KubernetesNamespace{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesNamespace,
+			ID:   "test-namespace",
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:   "test-namespace",
+			Labels: map[string]string{"test-label": "test-value"},
+		},
+	}
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   expected.ID,
+			Labels: expected.Labels,
+		},
+	}
+	entity := parser.Parse(namespace)
+	storedNamespace, ok := entity.(*workloadmeta.KubernetesNamespace)
+	require.True(t, ok)
+	assert.Equal(t, expected, storedNamespace)
+}
+
+func Test_NamespaceFakeKubernetesClient(t *testing.T) {
+	objectMeta := metav1.ObjectMeta{
+		Name:   "test-namespace",
+		Labels: map[string]string{"test-label": "test-value"},
+	}
+
+	createResource := func(cl *fake.Clientset) error {
+		_, err := cl.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{ObjectMeta: objectMeta}, metav1.CreateOptions{})
+		return err
+	}
+	expected := workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.KubernetesNamespace{
+					EntityID: workloadmeta.EntityID{
+						ID:   objectMeta.Name,
+						Kind: workloadmeta.KindKubernetesNamespace,
+					},
+					EntityMeta: workloadmeta.EntityMeta{
+						Name:   objectMeta.Name,
+						Labels: objectMeta.Labels,
+					},
+				},
+			},
+		},
+	}
+	testCollectEvent(t, createResource, newNamespaceStore, expected)
+}

--- a/comp/core/workloadmeta/component.go
+++ b/comp/core/workloadmeta/component.go
@@ -75,6 +75,10 @@ type Component interface {
 	// the entity with kind KindKubernetesDeployment and the given ID.
 	GetKubernetesDeployment(id string) (*KubernetesDeployment, error)
 
+	// GetKubernetesNamespace returns metadata about a Kubernetes namespace. It fetches
+	// the entity with kind KindKubernetesNamespace and the given ID.
+	GetKubernetesNamespace(id string) (*KubernetesNamespace, error)
+
 	// ListECSTasks returns metadata about all ECS tasks, equivalent to all
 	// entities with kind KindECSTask.
 	ListECSTasks() []*ECSTask

--- a/comp/core/workloadmeta/dump.go
+++ b/comp/core/workloadmeta/dump.go
@@ -63,6 +63,8 @@ func (w *workloadmeta) Dump(verbose bool) WorkloadDumpResponse {
 			info = e.String(verbose)
 		case *KubernetesDeployment:
 			info = e.String(verbose)
+		case *KubernetesNamespace:
+			info = e.String(verbose)
 		default:
 			return "", fmt.Errorf("unsupported type %T", e)
 		}

--- a/comp/core/workloadmeta/store.go
+++ b/comp/core/workloadmeta/store.go
@@ -338,6 +338,16 @@ func (w *workloadmeta) GetKubernetesDeployment(id string) (*KubernetesDeployment
 	return entity.(*KubernetesDeployment), nil
 }
 
+// GetKubernetesNamespace implements Store#GetKubernetesNamespace
+func (w *workloadmeta) GetKubernetesNamespace(id string) (*KubernetesNamespace, error) {
+	entity, err := w.getEntityByKind(KindKubernetesNamespace, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.(*KubernetesNamespace), nil
+}
+
 // ListECSTasks implements Store#ListECSTasks
 func (w *workloadmeta) ListECSTasks() []*ECSTask {
 	entities := w.listEntitiesByKind(KindECSTask)

--- a/comp/core/workloadmeta/store_test.go
+++ b/comp/core/workloadmeta/store_test.go
@@ -679,6 +679,49 @@ func TestGetKubernetesDeployment(t *testing.T) {
 	tassert.True(t, errors.IsNotFound(err))
 }
 
+func TestGetKubernetesNamespace(t *testing.T) {
+	deps := fxutil.Test[dependencies](t, fx.Options(
+		logimpl.MockModule(),
+		config.MockModule(),
+		fx.Supply(NewParams()),
+	))
+
+	s := newWorkloadmetaObject(deps)
+
+	namespace := &KubernetesNamespace{
+		EntityID: EntityID{
+			Kind: KindKubernetesNamespace,
+			ID:   "default",
+		},
+	}
+
+	s.handleEvents([]CollectorEvent{
+		{
+			Type:   EventTypeSet,
+			Source: fooSource,
+			Entity: namespace,
+		},
+	})
+
+	retrievedNamespace, err := s.GetKubernetesNamespace("default")
+	tassert.NoError(t, err)
+
+	if !reflect.DeepEqual(namespace, retrievedNamespace) {
+		t.Errorf("expected namespace %q to match the one in the store", retrievedNamespace.ID)
+	}
+
+	s.handleEvents([]CollectorEvent{
+		{
+			Type:   EventTypeUnset,
+			Source: fooSource,
+			Entity: namespace,
+		},
+	})
+
+	_, err = s.GetKubernetesNamespace("datadog-cluster-agent")
+	tassert.True(t, errors.IsNotFound(err))
+}
+
 func TestGetProcess(t *testing.T) {
 	deps := fxutil.Test[dependencies](t, fx.Options(
 		logimpl.MockModule(),

--- a/comp/core/workloadmeta/store_test.go
+++ b/comp/core/workloadmeta/store_test.go
@@ -710,14 +710,6 @@ func TestGetKubernetesNamespace(t *testing.T) {
 		t.Errorf("expected namespace %q to match the one in the store", retrievedNamespace.ID)
 	}
 
-	s.handleEvents([]CollectorEvent{
-		{
-			Type:   EventTypeUnset,
-			Source: fooSource,
-			Entity: namespace,
-		},
-	})
-
 	_, err = s.GetKubernetesNamespace("datadog-cluster-agent")
 	tassert.True(t, errors.IsNotFound(err))
 }

--- a/comp/core/workloadmeta/types.go
+++ b/comp/core/workloadmeta/types.go
@@ -42,6 +42,7 @@ const (
 	KindKubernetesPod          Kind = "kubernetes_pod"
 	KindKubernetesNode         Kind = "kubernetes_node"
 	KindKubernetesDeployment   Kind = "kubernetes_deployment"
+	KindKubernetesNamespace    Kind = "kubernetes_namespace"
 	KindECSTask                Kind = "ecs_task"
 	KindContainerImageMetadata Kind = "container_image_metadata"
 	KindProcess                Kind = "process"
@@ -904,6 +905,47 @@ func (d KubernetesDeployment) String(verbose bool) string {
 }
 
 var _ Entity = &KubernetesDeployment{}
+
+// KubernetesNamespace is an Entity representing a Kubernetes Namespace.
+type KubernetesNamespace struct {
+	EntityID
+	EntityMeta
+}
+
+// GetID implements Entity#GetID.
+func (n *KubernetesNamespace) GetID() EntityID {
+	return n.EntityID
+}
+
+// Merge implements Entity#Merge.
+func (n *KubernetesNamespace) Merge(e Entity) error {
+	nn, ok := e.(*KubernetesNamespace)
+	if !ok {
+		return fmt.Errorf("cannot merge KubernetesNamespace with different kind %T", e)
+	}
+
+	return merge(n, nn)
+}
+
+// DeepCopy implements Entity#DeepCopy.
+func (n KubernetesNamespace) DeepCopy() Entity {
+	cn := deepcopy.Copy(n).(KubernetesNamespace)
+	return &cn
+}
+
+// String implements Entity#String
+func (n KubernetesNamespace) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
+	_, _ = fmt.Fprintln(&sb, n.EntityID.String(verbose))
+
+	_, _ = fmt.Fprintln(&sb, "----------- Entity Meta -----------")
+	_, _ = fmt.Fprint(&sb, n.EntityMeta.String(verbose))
+
+	return sb.String()
+}
+
+var _ Entity = &KubernetesNamespace{}
 
 // ECSTaskKnownStatusStopped is the known status of an ECS task that has stopped.
 const ECSTaskKnownStatusStopped = "STOPPED"

--- a/comp/core/workloadmeta/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/workloadmeta_mock.go
@@ -198,6 +198,16 @@ func (w *workloadMetaMock) GetKubernetesDeployment(id string) (*KubernetesDeploy
 	return entity.(*KubernetesDeployment), nil
 }
 
+// GetKubernetesNamespace implements Component#GetKubernetesNamespace
+func (w *workloadMetaMock) GetKubernetesNamespace(id string) (*KubernetesNamespace, error) {
+	entity, err := w.getEntityByKind(KindKubernetesNamespace, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.(*KubernetesNamespace), nil
+}
+
 // GetECSTask returns metadata about an ECS task.
 func (w *workloadMetaMock) GetECSTask(id string) (*ECSTask, error) {
 	entity, err := w.getEntityByKind(KindECSTask, id)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -623,6 +623,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("kubernetes_node_label_as_cluster_name", "")
 	config.BindEnvAndSetDefault("kubernetes_namespace_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_cgroup_prefix", "")
+	config.BindEnvAndSetDefault("kubernetes_namespace_collection_enabled", false) // Enables collection of kubernetes namespace information
 
 	// CRI
 	config.BindEnvAndSetDefault("cri_socket_path", "")              // empty is disabled


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds a new `KubernetesNamespace` type to workloadmeta to collect and store kubernetes namespace information.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Among other features, this will be used to add `kubernetes_namespace_labels_as_tags` to kubernetes events.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Currently namespace information is only collected if the config `kubernetes_namespace_collection_enabled` is set to `true`.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1. Deploy the agent and cluster agent
2. Exec into the cluster agent and verify that you do not see any `kubernetes_namespace` entries in workloadmeta (when running `agent workload-list -v`)
3. Update the configuration to set `kubernetes_namespace_collection_enabled` = `true`
4. Redeploy and verify that you see an entry in workloadmeta for each namespace
```
root@datadog-agent-cluster-agent-695595b86f-wzp6h:/# agent workload-list -v
2024-04-30 18:04:22 UTC | CLUSTER | DEBUG | (pkg/util/log/log.go:791 in func1) | 'use_proxy_for_cloud_metadata' is enabled: adding cloud provider URL to the no_proxy list
2024-04-30 18:04:22 UTC | CLUSTER | DEBUG | (pkg/util/log/log.go:786 in func1) | FIPS mode is disabled
2024-04-30 18:04:22 UTC | CLUSTER | INFO | (pkg/util/log/log.go:831 in func1) | 2 Features detected from environment: kubernetes,kube_orchestratorexplorer

=== Entity kubernetes_node sources(merged):[kubeapiserver] id: jenn-display-name ===
----------- Entity ID -----------
Kind: kubernetes_node ID: jenn-display-name

----------- Entity Meta -----------
Name: jenn-display-name
Namespace:
Annotations: kubeadm.alpha.kubernetes.io/cri-socket:unix:///var/run/cri-dockerd.sock node.alpha.kubernetes.io/ttl:0 volumes.kubernetes.io/controller-managed-attach-detach:true
Labels: minikube.k8s.io/primary:true minikube.k8s.io/updated_at:2024_04_29T17_26_35_0700 minikube.k8s.io/version:v1.32.0 node-role.kubernetes.io/control-plane: beta.kubernetes.io/os:linux minikube.k8s.io/commit:***********************************0512d beta.kubernetes.io/arch:arm64 minikube.k8s.io/name:jenn-display-name kubernetes.io/arch:arm64 kubernetes.io/hostname:jenn-display-name kubernetes.io/os:linux node.kubernetes.io/exclude-from-external-load-balancers:
===

=== Entity kubernetes_namespace sources(merged):[kubeapiserver] id: default ===
----------- Entity ID -----------
Kind: kubernetes_namespace ID: default

----------- Entity Meta -----------
Name: default
Namespace:
Annotations:
Labels: kubernetes.io/metadata.name:default
===

=== Entity kubernetes_namespace sources(merged):[kubeapiserver] id: kube-node-lease ===
----------- Entity ID -----------
Kind: kubernetes_namespace ID: kube-node-lease

----------- Entity Meta -----------
Name: kube-node-lease
Namespace:
Annotations:
Labels: kubernetes.io/metadata.name:kube-node-lease
===

=== Entity kubernetes_namespace sources(merged):[kubeapiserver] id: kube-public ===
----------- Entity ID -----------
Kind: kubernetes_namespace ID: kube-public

----------- Entity Meta -----------
Name: kube-public
Namespace:
Annotations:
Labels: kubernetes.io/metadata.name:kube-public
===

=== Entity kubernetes_namespace sources(merged):[kubeapiserver] id: kube-system ===
----------- Entity ID -----------
Kind: kubernetes_namespace ID: kube-system

----------- Entity Meta -----------
Name: kube-system
Namespace:
Annotations:
Labels: kubernetes.io/metadata.name:kube-system
===

=== Entity kubernetes_namespace sources(merged):[kubeapiserver] id: test ===
----------- Entity ID -----------
Kind: kubernetes_namespace ID: test

----------- Entity Meta -----------
Name: test
Namespace:
Annotations:
Labels: kubernetes.io/metadata.name:test
===
```
5. Add a label to one of the namespaces and verify that this change is reflected in wlm
```
$ k label namespace test app=test

agent workload-list -v
... 
=== Entity kubernetes_namespace sources(merged):[kubeapiserver] id: test ===
----------- Entity ID -----------
Kind: kubernetes_namespace ID: test

----------- Entity Meta -----------
Name: test
Namespace:
Annotations:
Labels: kubernetes.io/metadata.name:test app:test
===
```