### PR TITLE
APM: Always set trace chunk tags to non-nil to prevent panic

### DIFF
--- a/cmd/trace-agent/test/testsuite/traces_test.go
+++ b/cmd/trace-agent/test/testsuite/traces_test.go
@@ -183,6 +183,24 @@ func TestTraces(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("probabilistic", func(t *testing.T) {
+		if err := r.RunAgent([]byte("apm_config:\r\n  probabilistic_sampler:\r\n    enabled: true\r\n    sampling_percentage: 100\r\n")); err != nil {
+			t.Fatal(err)
+		}
+		defer r.KillAgent()
+
+		p := testutil.GeneratePayload(10, &testutil.TraceConfig{
+			MinSpans: 10,
+			Keep:     true,
+		}, nil)
+		if err := r.Post(p); err != nil {
+			t.Fatal(err)
+		}
+		waitForTrace(t, &r, func(v *pb.AgentPayload) {
+			payloadsEqual(t, p, v)
+		})
+	})
 }
 
 // payloadsEqual validates that the traces in from are the same as the ones in to.

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -41,9 +41,10 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 func NewTestAgent(ctx context.Context, conf *config.AgentConfig, telemetryCollector telemetry.TelemetryCollector) *Agent {
@@ -530,7 +531,7 @@ func TestProcess(t *testing.T) {
 }
 
 func spansToChunk(spans ...*pb.Span) *pb.TraceChunk {
-	return &pb.TraceChunk{Spans: spans}
+	return &pb.TraceChunk{Spans: spans, Tags: make(map[string]string)}
 }
 
 func dropped(c *pb.TraceChunk) *pb.TraceChunk {

--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -200,9 +200,6 @@ func setChunkAttributes(chunk *pb.TraceChunk, root *pb.Span) {
 		var set bool
 		for _, span := range chunk.Spans {
 			if dm, ok := span.Meta[tagDecisionMaker]; !set && ok {
-				if chunk.Tags == nil {
-					chunk.Tags = make(map[string]string)
-				}
 				chunk.Tags[tagDecisionMaker] = dm
 				set = true
 			}

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -758,6 +758,7 @@ func traceChunksFromSpans(spans []*pb.Span) []*pb.TraceChunk {
 		traceChunks = append(traceChunks, &pb.TraceChunk{
 			Priority: int32(sampler.PriorityNone),
 			Spans:    t,
+			Tags:     make(map[string]string),
 		})
 	}
 	return traceChunks
@@ -769,6 +770,7 @@ func traceChunksFromTraces(traces pb.Traces) []*pb.TraceChunk {
 		traceChunks = append(traceChunks, &pb.TraceChunk{
 			Priority: int32(sampler.PriorityNone),
 			Spans:    trace,
+			Tags:     make(map[string]string),
 		})
 	}
 

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -581,6 +581,7 @@ func TestDecodeV05(t *testing.T) {
 		TracerVersion:   "1.2.3",
 		Chunks: []*pb.TraceChunk{
 			{
+				Tags:     make(map[string]string),
 				Priority: int32(sampler.PriorityNone),
 				Spans: []*pb.Span{
 					{

--- a/pkg/trace/sampler/probabilistic.go
+++ b/pkg/trace/sampler/probabilistic.go
@@ -18,8 +18,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 
-	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.uber.org/atomic"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 const (


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Always set trace chunk level tags to be non-nil
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
There is a subtle bug where the probabilistic sampler tries to write to the trace level chunk and the map may be nil (causing a panic). This only occurs when the trace-agent receives a chunk without a pre-existing "decision maker" (_dd.p.dm tag), which explains why none of the existing unit or end to end tests caught this behavior as _dd.p.dm is nearly always included. I was only able to catch this while manually testing the probabilistic sampler with a mixed setup where the trace began with an OTEL tracer before having the context passed to a datadog tracer.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Maybe it's better to just be more defensive throughout the code where we write to this map, but this approach seems sufficient to me for now?
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
I've added an integration test that verifies this fix so no manual QA should be required here.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
