### PR TITLE
usm: protocols: Exclude unused maps

### DIFF
--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -437,12 +437,7 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 	// Add excluded functions from disabled protocols
 	for _, p := range notSupported {
 		for _, m := range p.Maps {
-			// Unused maps still need to have a non-zero size
-			options.MapSpecEditors[m.Name] = manager.MapSpecEditor{
-				MaxEntries: uint32(1),
-				EditorFlag: manager.EditMaxEntries,
-			}
-
+			options.ExcludedMaps = append(options.ExcludedMaps, m.Name)
 			log.Debugf("disabled map: %v", m.Name)
 		}
 


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Instead of editing unused maps to have only 1 entry, we use the ExcludeMap option, which does not create the map at all.
A nice side effect, since each map allocates at least 1 page, it should spare up to 120KB (30 maps, each is 4KB when disabled) from the RSS of the agent.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This is a preliminary change that is required for the purpose of making USM protocols runtime dynamic
Without the change, it will be impossible for us to enable a protocol at runtime, as its size was already
determined during the startup phase.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
