### PR TITLE
AMLII-1645 Add duration parameter to stream-logs command

### DIFF
--- a/cmd/agent/subcommands/streamlogs/command.go
+++ b/cmd/agent/subcommands/streamlogs/command.go
@@ -147,7 +147,7 @@ func streamRequest(url string, body []byte, duration time.Duration, onChunk func
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
 
-	e = DoPostChunkedWithTimeout(ctx, c, url, "application/json", bytes.NewBuffer(body), duration, onChunk)
+	e = doPostChunkedWithTimeout(ctx, c, url, "application/json", bytes.NewBuffer(body), duration, onChunk)
 
 	if e == context.DeadlineExceeded {
 		fmt.Printf("Finished streaming logs for %v\n", duration)
@@ -163,6 +163,7 @@ func streamRequest(url string, body []byte, duration time.Duration, onChunk func
 	return e
 }
 
+// openFileForWriting opens a file for writing
 func openFileForWriting(filePath string) (*os.File, *bufio.Writer, error) {
 	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -172,7 +173,8 @@ func openFileForWriting(filePath string) (*os.File, *bufio.Writer, error) {
 	return f, bufWriter, nil
 }
 
-func DoPostChunkedWithTimeout(ctx context.Context, c *http.Client, url string, contentType string, body io.Reader, duration time.Duration, onChunk func([]byte)) error {
+// doPostChunkedWithTimeout is a wrapper around requests that stream chunked data with a timeout
+func doPostChunkedWithTimeout(ctx context.Context, c *http.Client, url string, contentType string, body io.Reader, duration time.Duration, onChunk func([]byte)) error {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, duration)
 	defer cancel()

--- a/cmd/agent/subcommands/streamlogs/command.go
+++ b/cmd/agent/subcommands/streamlogs/command.go
@@ -114,12 +114,12 @@ func streamLogs(log log.Component, config config.Component, cliParams *cliParams
 		if err != nil {
 			return fmt.Errorf("error opening file %s for writing: %v", cliParams.FilePath, err)
 		}
-		defer f.Close()
 		defer func() {
 			err := bufWriter.Flush()
 			if err != nil {
 				fmt.Printf("Error flushing buffer for log stream: %v", err)
 			}
+			f.Close()
 		}()
 	}
 

--- a/cmd/agent/subcommands/streamlogs/command_test.go
+++ b/cmd/agent/subcommands/streamlogs/command_test.go
@@ -7,6 +7,7 @@ package streamlogs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -19,10 +20,12 @@ import (
 func TestCommand(t *testing.T) {
 	fxutil.TestOneShotSubcommand(t,
 		Commands(&command.GlobalParams{}),
-		[]string{"stream-logs", "--type", "foo"},
+		[]string{"stream-logs", "--type", "foo", "--duration", "10s", "--output", "~/output.log"},
 		streamLogs,
 		func(cliParams *cliParams, coreParams core.BundleParams, secretParams secrets.Params) {
 			require.Equal(t, false, secretParams.Enabled)
 			require.Equal(t, "foo", cliParams.filters.Type)
+			require.Equal(t, 10*time.Second, cliParams.Duration)
+			require.Equal(t, "~/output.log", cliParams.FilePath)
 		})
 }


### PR DESCRIPTION
### What does this PR do?
This PR introduces a new feature to the stream-logs command. It adds a duration parameter to the StreamLogParams struct, allowing users to specify how long a log stream will be written.

### Motivation
The motivation behind this change is to provide users with more flexibility when using the stream-logs command. By allowing users to specify a duration, they can set a timer on their log stream or output x amount of logs to a file combining with output parameter. This should help support team troubleshooting missing logs issue.

### Describe how to test/QA your changes
- Spin up the agent to tail some logs
- Run:
```
datad-agent stream-logs -d 10s 
```

and

```
datad-agent stream-logs -o path/to/file.log -d 10s 
```

Logs should be streaming for 10s and writing to new log file 