### PR TITLE
[CWS] introduce user path for FRIM

### DIFF
--- a/pkg/security/probe/field_handlers_windows.go
+++ b/pkg/security/probe/field_handlers_windows.go
@@ -38,6 +38,11 @@ func (fh *FieldHandlers) ResolveFilePath(_ *model.Event, f *model.FileEvent) str
 	return f.PathnameStr
 }
 
+// ResolveFileUserPath resolves the inode to a full user path
+func (fh *FieldHandlers) ResolveFileUserPath(_ *model.Event, f *model.FimFileEvent) string {
+	return f.UserPathnameStr
+}
+
 // ResolveFileBasename resolves the inode to a full path
 func (fh *FieldHandlers) ResolveFileBasename(_ *model.Event, f *model.FileEvent) string {
 	return f.BasenameStr

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -76,7 +76,7 @@ type WindowsProbe struct {
 	regPathResolver  *lru.Cache[regObjectPointer, string]
 
 	// state tracking
-	renamePreArgs *lru.Cache[uint64, string]
+	renamePreArgs *lru.Cache[uint64, fileCache]
 
 	// stats
 	stats stats
@@ -99,7 +99,8 @@ type WindowsProbe struct {
 // filecache currently only has a filename.  But this is going to expand really soon.  so go ahead
 // and have the wrapper struct even though right now it doesn't add anything.
 type fileCache struct {
-	fileName string
+	fileName     string
+	userFileName string
 }
 
 type etwNotification struct {
@@ -592,17 +593,26 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 		ev.Type = uint32(model.CreateNewFileEventType)
 		ev.CreateNewFile = model.CreateNewFileEvent{
 			File: model.FimFileEvent{
-				FileObject:  uint64(arg.fileObject),
-				PathnameStr: arg.fileName,
-				BasenameStr: filepath.Base(arg.fileName),
+				FileObject:      uint64(arg.fileObject),
+				PathnameStr:     arg.fileName,
+				UserPathnameStr: arg.userFileName,
+				BasenameStr:     filepath.Base(arg.fileName),
 			},
 		}
 	case *renameArgs:
-		p.renamePreArgs.Add(uint64(arg.fileObject), arg.fileName)
+		fc := fileCache{
+			fileName:     arg.fileName,
+			userFileName: arg.userFileName,
+		}
+		p.renamePreArgs.Add(uint64(arg.fileObject), fc)
 	case *rename29Args:
-		p.renamePreArgs.Add(uint64(arg.fileObject), arg.fileName)
+		fc := fileCache{
+			fileName:     arg.fileName,
+			userFileName: arg.userFileName,
+		}
+		p.renamePreArgs.Add(uint64(arg.fileObject), fc)
 	case *renamePath:
-		path, found := p.renamePreArgs.Get(uint64(arg.fileObject))
+		fileCache, found := p.renamePreArgs.Get(uint64(arg.fileObject))
 		if !found {
 			log.Debugf("unable to find renamePreArgs for %d", uint64(arg.fileObject))
 			return
@@ -610,14 +620,16 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 		ev.Type = uint32(model.FileRenameEventType)
 		ev.RenameFile = model.RenameFileEvent{
 			Old: model.FimFileEvent{
-				FileObject:  uint64(arg.fileObject),
-				PathnameStr: path,
-				BasenameStr: filepath.Base(path),
+				FileObject:      uint64(arg.fileObject),
+				PathnameStr:     fileCache.fileName,
+				UserPathnameStr: fileCache.userFileName,
+				BasenameStr:     filepath.Base(fileCache.fileName),
 			},
 			New: model.FimFileEvent{
-				FileObject:  uint64(arg.fileObject),
-				PathnameStr: arg.filePath,
-				BasenameStr: filepath.Base(arg.filePath),
+				FileObject:      uint64(arg.fileObject),
+				PathnameStr:     arg.filePath,
+				UserPathnameStr: arg.userFilePath,
+				BasenameStr:     filepath.Base(arg.filePath),
 			},
 		}
 		p.renamePreArgs.Remove(uint64(arg.fileObject))
@@ -625,18 +637,20 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 		ev.Type = uint32(model.DeleteFileEventType)
 		ev.DeleteFile = model.DeleteFileEvent{
 			File: model.FimFileEvent{
-				FileObject:  uint64(arg.fileObject),
-				PathnameStr: arg.fileName,
-				BasenameStr: filepath.Base(arg.fileName),
+				FileObject:      uint64(arg.fileObject),
+				PathnameStr:     arg.fileName,
+				UserPathnameStr: arg.userFileName,
+				BasenameStr:     filepath.Base(arg.fileName),
 			},
 		}
 	case *writeArgs:
 		ev.Type = uint32(model.WriteFileEventType)
 		ev.WriteFile = model.WriteFileEvent{
 			File: model.FimFileEvent{
-				FileObject:  uint64(arg.fileObject),
-				PathnameStr: arg.fileName,
-				BasenameStr: filepath.Base(arg.fileName),
+				FileObject:      uint64(arg.fileObject),
+				PathnameStr:     arg.fileName,
+				UserPathnameStr: arg.userFileName,
+				BasenameStr:     filepath.Base(arg.fileName),
 			},
 		}
 
@@ -870,7 +884,7 @@ func NewWindowsProbe(probe *Probe, config *config.Config, opts Opts) (*WindowsPr
 		return nil, err
 	}
 
-	rnc, err := lru.New[uint64, string](5)
+	rnc, err := lru.New[uint64, fileCache](5)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/secl/model/accessors_windows.go
+++ b/pkg/security/secl/model/accessors_windows.go
@@ -103,6 +103,26 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
+	case "create.file.path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.CreateNewFile.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "create.file.path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFileUserPath(ev, &ev.CreateNewFile.File))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	case "create.registry.key_name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -215,6 +235,26 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
 				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "delete.file.path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.DeleteFile.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "delete.file.path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFileUserPath(ev, &ev.DeleteFile.File))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1260,6 +1300,26 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
+	case "rename.file.destination.path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.New)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "rename.file.destination.path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.New))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	case "rename.file.device_path":
 		return &eval.StringEvaluator{
 			OpOverrides: eval.WindowsPathCmp,
@@ -1296,6 +1356,26 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
 				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "rename.file.path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.Old)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "rename.file.path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.Old))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1470,6 +1550,26 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
+	case "write.file.path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.WriteFile.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "write.file.path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFileUserPath(ev, &ev.WriteFile.File))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	}
 	return nil, &eval.ErrFieldNotFound{Field: field}
 }
@@ -1482,6 +1582,8 @@ func (ev *Event) GetFields() []eval.Field {
 		"create.file.device_path.length",
 		"create.file.name",
 		"create.file.name.length",
+		"create.file.path",
+		"create.file.path.length",
 		"create.registry.key_name",
 		"create.registry.key_name.length",
 		"create.registry.key_path",
@@ -1494,6 +1596,8 @@ func (ev *Event) GetFields() []eval.Field {
 		"delete.file.device_path.length",
 		"delete.file.name",
 		"delete.file.name.length",
+		"delete.file.path",
+		"delete.file.path.length",
 		"delete.registry.key_name",
 		"delete.registry.key_name.length",
 		"delete.registry.key_path",
@@ -1585,10 +1689,14 @@ func (ev *Event) GetFields() []eval.Field {
 		"rename.file.destination.device_path.length",
 		"rename.file.destination.name",
 		"rename.file.destination.name.length",
+		"rename.file.destination.path",
+		"rename.file.destination.path.length",
 		"rename.file.device_path",
 		"rename.file.device_path.length",
 		"rename.file.name",
 		"rename.file.name.length",
+		"rename.file.path",
+		"rename.file.path.length",
 		"set.registry.key_name",
 		"set.registry.key_name.length",
 		"set.registry.key_path",
@@ -1607,6 +1715,8 @@ func (ev *Event) GetFields() []eval.Field {
 		"write.file.device_path.length",
 		"write.file.name",
 		"write.file.name.length",
+		"write.file.path",
+		"write.file.path.length",
 	}
 }
 func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
@@ -1625,6 +1735,10 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File), nil
 	case "create.file.name.length":
 		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File), nil
+	case "create.file.path":
+		return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.CreateNewFile.File), nil
+	case "create.file.path.length":
+		return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.CreateNewFile.File), nil
 	case "create.registry.key_name":
 		return ev.CreateRegistryKey.Registry.KeyName, nil
 	case "create.registry.key_name.length":
@@ -1649,6 +1763,10 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File), nil
 	case "delete.file.name.length":
 		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File), nil
+	case "delete.file.path":
+		return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.DeleteFile.File), nil
+	case "delete.file.path.length":
+		return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.DeleteFile.File), nil
 	case "delete.registry.key_name":
 		return ev.DeleteRegistryKey.Registry.KeyName, nil
 	case "delete.registry.key_name.length":
@@ -1994,6 +2112,10 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New), nil
 	case "rename.file.destination.name.length":
 		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New), nil
+	case "rename.file.destination.path":
+		return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.New), nil
+	case "rename.file.destination.path.length":
+		return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.New), nil
 	case "rename.file.device_path":
 		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old), nil
 	case "rename.file.device_path.length":
@@ -2002,6 +2124,10 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old), nil
 	case "rename.file.name.length":
 		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old), nil
+	case "rename.file.path":
+		return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.Old), nil
+	case "rename.file.path.length":
+		return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.Old), nil
 	case "set.registry.key_name":
 		return ev.SetRegistryKeyValue.Registry.KeyName, nil
 	case "set.registry.key_name.length":
@@ -2038,6 +2164,10 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File), nil
 	case "write.file.name.length":
 		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File), nil
+	case "write.file.path":
+		return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.WriteFile.File), nil
+	case "write.file.path.length":
+		return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.WriteFile.File), nil
 	}
 	return nil, &eval.ErrFieldNotFound{Field: field}
 }
@@ -2056,6 +2186,10 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "create.file.name":
 		return "create", nil
 	case "create.file.name.length":
+		return "create", nil
+	case "create.file.path":
+		return "create", nil
+	case "create.file.path.length":
 		return "create", nil
 	case "create.registry.key_name":
 		return "create_key", nil
@@ -2080,6 +2214,10 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "delete.file.name":
 		return "delete", nil
 	case "delete.file.name.length":
+		return "delete", nil
+	case "delete.file.path":
+		return "delete", nil
+	case "delete.file.path.length":
 		return "delete", nil
 	case "delete.registry.key_name":
 		return "delete_key", nil
@@ -2263,6 +2401,10 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rename", nil
 	case "rename.file.destination.name.length":
 		return "rename", nil
+	case "rename.file.destination.path":
+		return "rename", nil
+	case "rename.file.destination.path.length":
+		return "rename", nil
 	case "rename.file.device_path":
 		return "rename", nil
 	case "rename.file.device_path.length":
@@ -2270,6 +2412,10 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.file.name":
 		return "rename", nil
 	case "rename.file.name.length":
+		return "rename", nil
+	case "rename.file.path":
+		return "rename", nil
+	case "rename.file.path.length":
 		return "rename", nil
 	case "set.registry.key_name":
 		return "set_key_value", nil
@@ -2306,6 +2452,10 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "write.file.name":
 		return "write", nil
 	case "write.file.name.length":
+		return "write", nil
+	case "write.file.path":
+		return "write", nil
+	case "write.file.path.length":
 		return "write", nil
 	}
 	return "", &eval.ErrFieldNotFound{Field: field}
@@ -2326,6 +2476,10 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "create.file.name.length":
 		return reflect.Int, nil
+	case "create.file.path":
+		return reflect.String, nil
+	case "create.file.path.length":
+		return reflect.Int, nil
 	case "create.registry.key_name":
 		return reflect.String, nil
 	case "create.registry.key_name.length":
@@ -2349,6 +2503,10 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "delete.file.name":
 		return reflect.String, nil
 	case "delete.file.name.length":
+		return reflect.Int, nil
+	case "delete.file.path":
+		return reflect.String, nil
+	case "delete.file.path.length":
 		return reflect.Int, nil
 	case "delete.registry.key_name":
 		return reflect.String, nil
@@ -2532,6 +2690,10 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "rename.file.destination.name.length":
 		return reflect.Int, nil
+	case "rename.file.destination.path":
+		return reflect.String, nil
+	case "rename.file.destination.path.length":
+		return reflect.Int, nil
 	case "rename.file.device_path":
 		return reflect.String, nil
 	case "rename.file.device_path.length":
@@ -2539,6 +2701,10 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.file.name":
 		return reflect.String, nil
 	case "rename.file.name.length":
+		return reflect.Int, nil
+	case "rename.file.path":
+		return reflect.String, nil
+	case "rename.file.path.length":
 		return reflect.Int, nil
 	case "set.registry.key_name":
 		return reflect.String, nil
@@ -2575,6 +2741,10 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "write.file.name":
 		return reflect.String, nil
 	case "write.file.name.length":
+		return reflect.Int, nil
+	case "write.file.path":
+		return reflect.String, nil
+	case "write.file.path.length":
 		return reflect.Int, nil
 	}
 	return reflect.Invalid, &eval.ErrFieldNotFound{Field: field}
@@ -2632,6 +2802,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "create.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "create.file.name.length"}
+	case "create.file.path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "CreateNewFile.File.UserPathnameStr"}
+		}
+		ev.CreateNewFile.File.UserPathnameStr = rv
+		return nil
+	case "create.file.path.length":
+		return &eval.ErrFieldReadOnly{Field: "create.file.path.length"}
 	case "create.registry.key_name":
 		rv, ok := value.(string)
 		if !ok {
@@ -2686,6 +2865,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "delete.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "delete.file.name.length"}
+	case "delete.file.path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "DeleteFile.File.UserPathnameStr"}
+		}
+		ev.DeleteFile.File.UserPathnameStr = rv
+		return nil
+	case "delete.file.path.length":
+		return &eval.ErrFieldReadOnly{Field: "delete.file.path.length"}
 	case "delete.registry.key_name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3526,6 +3714,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "rename.file.destination.name.length":
 		return &eval.ErrFieldReadOnly{Field: "rename.file.destination.name.length"}
+	case "rename.file.destination.path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RenameFile.New.UserPathnameStr"}
+		}
+		ev.RenameFile.New.UserPathnameStr = rv
+		return nil
+	case "rename.file.destination.path.length":
+		return &eval.ErrFieldReadOnly{Field: "rename.file.destination.path.length"}
 	case "rename.file.device_path":
 		rv, ok := value.(string)
 		if !ok {
@@ -3544,6 +3741,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "rename.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "rename.file.name.length"}
+	case "rename.file.path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RenameFile.Old.UserPathnameStr"}
+		}
+		ev.RenameFile.Old.UserPathnameStr = rv
+		return nil
+	case "rename.file.path.length":
+		return &eval.ErrFieldReadOnly{Field: "rename.file.path.length"}
 	case "set.registry.key_name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3630,6 +3836,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "write.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "write.file.name.length"}
+	case "write.file.path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "WriteFile.File.UserPathnameStr"}
+		}
+		ev.WriteFile.File.UserPathnameStr = rv
+		return nil
+	case "write.file.path.length":
+		return &eval.ErrFieldReadOnly{Field: "write.file.path.length"}
 	}
 	return &eval.ErrFieldNotFound{Field: field}
 }

--- a/pkg/security/secl/model/field_accessors_windows.go
+++ b/pkg/security/secl/model/field_accessors_windows.go
@@ -69,6 +69,22 @@ func (ev *Event) GetCreateFileNameLength() int {
 	return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File))
 }
 
+// GetCreateFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetCreateFilePath() string {
+	if ev.GetEventType().String() != "create" {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.CreateNewFile.File)
+}
+
+// GetCreateFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetCreateFilePathLength() int {
+	if ev.GetEventType().String() != "create" {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFileUserPath(ev, &ev.CreateNewFile.File))
+}
+
 // GetCreateRegistryKeyName returns the value of the field, resolving if necessary
 func (ev *Event) GetCreateRegistryKeyName() string {
 	if ev.GetEventType().String() != "create_key" {
@@ -163,6 +179,22 @@ func (ev *Event) GetDeleteFileNameLength() int {
 		return 0
 	}
 	return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File))
+}
+
+// GetDeleteFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetDeleteFilePath() string {
+	if ev.GetEventType().String() != "delete" {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.DeleteFile.File)
+}
+
+// GetDeleteFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetDeleteFilePathLength() int {
+	if ev.GetEventType().String() != "delete" {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFileUserPath(ev, &ev.DeleteFile.File))
 }
 
 // GetDeleteRegistryKeyName returns the value of the field, resolving if necessary
@@ -1325,6 +1357,22 @@ func (ev *Event) GetRenameFileDestinationNameLength() int {
 	return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New))
 }
 
+// GetRenameFileDestinationPath returns the value of the field, resolving if necessary
+func (ev *Event) GetRenameFileDestinationPath() string {
+	if ev.GetEventType().String() != "rename" {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.New)
+}
+
+// GetRenameFileDestinationPathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetRenameFileDestinationPathLength() int {
+	if ev.GetEventType().String() != "rename" {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.New))
+}
+
 // GetRenameFileDevicePath returns the value of the field, resolving if necessary
 func (ev *Event) GetRenameFileDevicePath() string {
 	if ev.GetEventType().String() != "rename" {
@@ -1355,6 +1403,22 @@ func (ev *Event) GetRenameFileNameLength() int {
 		return 0
 	}
 	return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old))
+}
+
+// GetRenameFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetRenameFilePath() string {
+	if ev.GetEventType().String() != "rename" {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.Old)
+}
+
+// GetRenameFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetRenameFilePathLength() int {
+	if ev.GetEventType().String() != "rename" {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.Old))
 }
 
 // GetSetRegistryKeyName returns the value of the field, resolving if necessary
@@ -1504,4 +1568,20 @@ func (ev *Event) GetWriteFileNameLength() int {
 		return 0
 	}
 	return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File))
+}
+
+// GetWriteFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetWriteFilePath() string {
+	if ev.GetEventType().String() != "write" {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFileUserPath(ev, &ev.WriteFile.File)
+}
+
+// GetWriteFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetWriteFilePathLength() int {
+	if ev.GetEventType().String() != "write" {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFileUserPath(ev, &ev.WriteFile.File))
 }

--- a/pkg/security/secl/model/field_handlers_windows.go
+++ b/pkg/security/secl/model/field_handlers_windows.go
@@ -62,10 +62,12 @@ func (ev *Event) resolveFields(forADs bool) {
 	switch ev.GetEventType().String() {
 	case "create":
 		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File)
+		_ = ev.FieldHandlers.ResolveFileUserPath(ev, &ev.CreateNewFile.File)
 		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File)
 	case "create_key":
 	case "delete":
 		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File)
+		_ = ev.FieldHandlers.ResolveFileUserPath(ev, &ev.DeleteFile.File)
 		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File)
 	case "delete_key":
 	case "exec":
@@ -87,12 +89,15 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "open_key":
 	case "rename":
 		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old)
+		_ = ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.Old)
 		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old)
 		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New)
+		_ = ev.FieldHandlers.ResolveFileUserPath(ev, &ev.RenameFile.New)
 		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New)
 	case "set_key_value":
 	case "write":
 		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File)
+		_ = ev.FieldHandlers.ResolveFileUserPath(ev, &ev.WriteFile.File)
 		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File)
 	}
 }
@@ -105,6 +110,7 @@ type FieldHandlers interface {
 	ResolveEventTimestamp(ev *Event, e *BaseEvent) int
 	ResolveFileBasename(ev *Event, e *FileEvent) string
 	ResolveFilePath(ev *Event, e *FileEvent) string
+	ResolveFileUserPath(ev *Event, e *FimFileEvent) string
 	ResolveFimFileBasename(ev *Event, e *FimFileEvent) string
 	ResolveFimFilePath(ev *Event, e *FimFileEvent) string
 	ResolveProcessCmdLine(ev *Event, e *Process) string
@@ -134,6 +140,9 @@ func (dfh *FakeFieldHandlers) ResolveFileBasename(ev *Event, e *FileEvent) strin
 	return e.BasenameStr
 }
 func (dfh *FakeFieldHandlers) ResolveFilePath(ev *Event, e *FileEvent) string { return e.PathnameStr }
+func (dfh *FakeFieldHandlers) ResolveFileUserPath(ev *Event, e *FimFileEvent) string {
+	return e.UserPathnameStr
+}
 func (dfh *FakeFieldHandlers) ResolveFimFileBasename(ev *Event, e *FimFileEvent) string {
 	return e.BasenameStr
 }

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -54,9 +54,10 @@ type FileEvent struct {
 
 // FimFileEvent is the common file event type
 type FimFileEvent struct {
-	FileObject  uint64 `field:"-"`                                                                                     // handle numeric value
-	PathnameStr string `field:"device_path,handler:ResolveFimFilePath,opts:length" op_override:"eval.WindowsPathCmp"`  // SECLDoc[device_path] Definition:`File's path` Example:`create.file.device_path == "\device\harddisk1\cmd.bat"` Description:`Matches the creation of the file located at c:\cmd.bat`
-	BasenameStr string `field:"name,handler:ResolveFimFileBasename,opts:length" op_override:"eval.CaseInsensitiveCmp"` // SECLDoc[name] Definition:`File's basename` Example:`create.file.name == "cmd.bat"` Description:`Matches the creation of any file named cmd.bat.`
+	FileObject      uint64 `field:"-"`                                                                                     // handle numeric value
+	PathnameStr     string `field:"device_path,handler:ResolveFimFilePath,opts:length" op_override:"eval.WindowsPathCmp"`  // SECLDoc[device_path] Definition:`File's path` Example:`create.file.device_path == "\device\harddisk1\cmd.bat"` Description:`Matches the creation of the file located at c:\cmd.bat`
+	UserPathnameStr string `field:"path,handler:ResolveFileUserPath,opts:length" op_override:"eval.WindowsPathCmp"`        // SECLDoc[path] Definition:`File's path` Example:`create.file.path == "c:\cmd.bat"` Description:`Matches the creation of the file located at c:\cmd.bat`
+	BasenameStr     string `field:"name,handler:ResolveFimFileBasename,opts:length" op_override:"eval.CaseInsensitiveCmp"` // SECLDoc[name] Definition:`File's basename` Example:`create.file.name == "cmd.bat"` Description:`Matches the creation of any file named cmd.bat.`
 }
 
 // RegistryEvent is the common registry event type

--- a/pkg/security/tests/file_windows_test.go
+++ b/pkg/security/tests/file_windows_test.go
@@ -25,7 +25,7 @@ func TestBasicFileTest(t *testing.T) {
 	//ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_create_file",
-		Expression: `create.file.name =~ "test.bad" && create.file.device_path =~ "\Device\*\Temp\**"`,
+		Expression: `create.file.name =~ "test.bad" && create.file.path =~ "C:\Temp\**"`,
 	}
 	opts := testOpts{
 		enableFIM: true,
@@ -68,7 +68,7 @@ func TestRenameFileEvent(t *testing.T) {
 	// ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_rename_file",
-		Expression: `rename.file.name =~ "test.bad" && rename.file.device_path =~ "\Device\*\Temp\**"`,
+		Expression: `rename.file.name =~ "test.bad" && rename.file.path =~ "C:\Temp\**"`,
 	}
 	opts := testOpts{
 		enableFIM: true,
@@ -105,7 +105,7 @@ func TestDeleteFileEvent(t *testing.T) {
 	// ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_delete_file",
-		Expression: `delete.file.name =~ "test.bad" && delete.file.device_path =~ "\Device\*\Temp\**"`,
+		Expression: `delete.file.name =~ "test.bad" && delete.file.path =~ "C:\Temp\**"`,
 	}
 	opts := testOpts{
 		enableFIM: true,
@@ -141,7 +141,7 @@ func TestWriteFileEvent(t *testing.T) {
 	// ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_write_file",
-		Expression: `write.file.name =~ "test.bad" && write.file.device_path =~ "\Device\*\Temp\**"`,
+		Expression: `write.file.name =~ "test.bad" && write.file.path =~ "C:\Temp\**"`,
 	}
 	opts := testOpts{
 		enableFIM: true,


### PR DESCRIPTION
### What does this PR do?

This PR introduces the concept of a user path (or user file name in some places, I plan to sync all this naming in a follow up PR).
```
Device path: "\Device\HarddiskXX\a\b\c"
User path: "C:\a\b\c"
```

The user path is computed as soon as possible using the path resolver, and then provided to the user as a `.path` field, in addition to the `.device_path` already available.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
