### PR TITLE
[NPM-3277] Disable NPM rollups if USM rollups are not enabled

### DIFF
--- a/cmd/system-probe/config/adjust_npm.go
+++ b/cmd/system-probe/config/adjust_npm.go
@@ -83,4 +83,11 @@ func adjustNetwork(cfg config.Config) {
 		log.Warn("disabling process event monitoring as it is not supported for this kernel version")
 		cfg.Set(evNS("network_process", "enabled"), false, model.SourceAgentRuntime)
 	}
+
+	// if npm connection rollups are enabled, but usm rollups are not,
+	// then disable npm rollups as well
+	if cfg.GetBool(netNS("enable_connection_rollup")) && !cfg.GetBool(smNS("enable_connection_rollup")) {
+		log.Warn("disabling NPM connection rollups since USM connection rollups are not enabled")
+		cfg.Set(netNS("enable_connection_rollup"), false, model.SourceAgentRuntime)
+	}
 }

--- a/cmd/system-probe/config/adjust_npm_test.go
+++ b/cmd/system-probe/config/adjust_npm_test.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+func TestAdjustConnectionRollup(t *testing.T) {
+	tests := []struct {
+		npmEnabled, usmEnabled   bool
+		npmAdjusted, usmAdjusted bool
+	}{
+		{false, false, false, false},
+		{true, false, false, false}, // this is the only case where the configs are "adjusted"
+		{false, true, false, true},
+		{true, true, true, true},
+	}
+
+	for _, te := range tests {
+		t.Run(fmt.Sprintf("npm_enabled_%t_usm_enabled_%t", te.npmEnabled, te.usmEnabled), func(t *testing.T) {
+			config.ResetSystemProbeConfig(t)
+			cfg := config.SystemProbe
+			cfg.Set(netNS("enable_connection_rollup"), te.npmEnabled, model.SourceUnknown)
+			cfg.Set(smNS("enable_connection_rollup"), te.usmEnabled, model.SourceUnknown)
+			Adjust(cfg)
+
+			assert.Equal(t, te.npmAdjusted, cfg.GetBool(netNS("enable_connection_rollup")), "adjusted network_config.enable_connection_rollup does not match expected value")
+			assert.Equal(t, te.usmAdjusted, cfg.GetBool(smNS("enable_connection_rollup")), "adjusted service_monitoring_config.enable_connection_rollup does not match expected value")
+		})
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Disables NPM connection rollups if USM connection rollups are disabled. This is because USM cannot match connections if NPM is rolling them up and USM is not.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
