### PR TITLE
[CWS] use `assert.NoError` instead of `assert.Nil` where possible

### DIFF
--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -30,7 +30,7 @@ func testCacheSize(t *testing.T, resolver *EBPFResolver) {
 			return fmt.Errorf("cache size error: %d", resolver.cacheSize.Load())
 		},
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFork1st(t *testing.T) {

--- a/pkg/security/secl/model/process_cache_entry_unix_test.go
+++ b/pkg/security/secl/model/process_cache_entry_unix_test.go
@@ -42,7 +42,7 @@ func TestHasValidLineage(t *testing.T) {
 
 		isValid, err := child2.HasValidLineage()
 		assert.True(t, isValid)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("pid1-missing", func(t *testing.T) {

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -472,10 +472,10 @@ func TestRuleAgentConstraint(t *testing.T) {
 	}
 
 	agentVersion, err := semver.NewVersion("7.38")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	agentVersionFilter, err := NewAgentVersionFilter(agentVersion)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	policyOpts := PolicyLoaderOpts{
 		MacroFilters: []MacroFilter{

--- a/pkg/security/secl/rules/rule_filters_test.go
+++ b/pkg/security/secl/rules/rule_filters_test.go
@@ -9,8 +9,9 @@
 package rules
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRuleIDFilter(t *testing.T) {

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -128,7 +128,7 @@ func TestActionKill(t *testing.T) {
 
 			return nil
 		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("kill-action-kill", func(t *testing.T) {
@@ -183,6 +183,6 @@ func TestActionKill(t *testing.T) {
 
 			return nil
 		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 }

--- a/pkg/security/tests/dentry_test.go
+++ b/pkg/security/tests/dentry_test.go
@@ -72,12 +72,12 @@ func TestDentryPathERPC(t *testing.T) {
 		basename := path.Base(testFile)
 
 		res, err := p.Resolvers.DentryResolver.Resolve(event.Open.File.PathKey, true)
-		assert.Nil(test.t, err)
+		assert.NoError(test.t, err)
 		assert.Equal(test.t, basename, path.Base(res))
 
 		// check that the path is now available from the cache
 		res, err = p.Resolvers.DentryResolver.ResolveFromCache(event.Open.File.PathKey)
-		assert.Nil(test.t, err)
+		assert.NoError(test.t, err)
 		assert.Equal(test.t, basename, path.Base(res))
 
 		// check stats
@@ -139,12 +139,12 @@ func TestDentryPathMap(t *testing.T) {
 		basename := path.Base(testFile)
 
 		res, err := p.Resolvers.DentryResolver.Resolve(event.Open.File.PathKey, true)
-		assert.Nil(test.t, err)
+		assert.NoError(test.t, err)
 		assert.Equal(test.t, basename, path.Base(res))
 
 		// check that the path is now available from the cache
 		res, err = p.Resolvers.DentryResolver.ResolveFromCache(event.Open.File.PathKey)
-		assert.Nil(test.t, err)
+		assert.NoError(test.t, err)
 		assert.Equal(test.t, basename, path.Base(res))
 
 		// check stats
@@ -211,7 +211,7 @@ func TestDentryName(t *testing.T) {
 
 		// check that the path is now available from the cache
 		res, err = p.Resolvers.DentryResolver.ResolveNameFromCache(event.Open.File.PathKey)
-		assert.Nil(test.t, err)
+		assert.NoError(test.t, err)
 		assert.Equal(test.t, basename, path.Base(res))
 	})
 }

--- a/pkg/security/tests/eventmonitor_test.go
+++ b/pkg/security/tests/eventmonitor_test.go
@@ -127,7 +127,7 @@ func TestEventMonitor(t *testing.T) {
 
 			return errors.New("event not received")
 		}, retry.Delay(200*time.Millisecond), retry.Attempts(10), retry.DelayType(retry.FixedDelay))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("exec-exit", func(t *testing.T) {
@@ -145,6 +145,6 @@ func TestEventMonitor(t *testing.T) {
 
 			return errors.New("event not received")
 		}, retry.Delay(200*time.Millisecond), retry.Attempts(10), retry.DelayType(retry.FixedDelay))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 }

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -115,7 +115,7 @@ func TestProcessEBPFLess(t *testing.T) {
 			}
 			return nil
 		}, retry.Delay(200*time.Millisecond), retry.Attempts(10))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR converts all the `assert.Nil(t, err)` where `err` is an error (not a `*multierr.Error` sadly) to `assert.NoError(t, err)` allowing an improved debugging experience because testify will print the error message and not a simple `%v`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
