### PR TITLE
Fix the cluster-agent status output

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -72,7 +72,6 @@ import (
 	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 	hostnameStatus "github.com/DataDog/datadog-agent/pkg/status/clusteragent/hostname"
-	collectorStatus "github.com/DataDog/datadog-agent/pkg/status/collector"
 	endpointsStatus "github.com/DataDog/datadog-agent/pkg/status/endpoints"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -158,7 +157,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					status.Params{
 						PythonVersionGetFunc: python.GetPythonVersion,
 					},
-					status.NewInformationProvider(collectorStatus.Provider{}),
 					status.NewInformationProvider(leaderelection.Provider{}),
 					status.NewInformationProvider(clusteragentMetricsStatus.Provider{}),
 					status.NewInformationProvider(admissionpkg.Provider{}),


### PR DESCRIPTION
### What does this PR do?

Fix the `datadog-cluster-agent status` output where the `Running Checks` section was appearing twice:
```
$ kubectl --context gke_datadog-sandbox_europe-west3-c_gke-lenaic --namespace datadog-agent-helm exec pod/datadog-agent-linux-cluster-agent-8559497f-6ghqd -c cluster-agent -- datadog-cluster-agent status

[…]
=========
Collector
=========


  Running Checks
  ==============
    
    kubernetes_apiserver
    --------------------
      Instance ID: kubernetes_apiserver [OK]
[…]
      Last Successful Execution Date : 2024-05-02 12:56:33 UTC (1714654593000)
      


  Running Checks
  ==============
    
    kubernetes_apiserver
    --------------------
      Instance ID: kubernetes_apiserver [OK]
[…]
      Last Successful Execution Date : 2024-05-02 12:56:33 UTC (1714654593000)
      

====================
Admission Controller
====================
```

### Motivation

Fix the output of `datadog-cluster-agent status`.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run `datadog-cluster-agent status` and check that the `Running Checks` sections appears exactly once:
```
$ kubectl --context gke_datadog-sandbox_europe-west3-c_gke-lenaic --namespace datadog-agent-helm exec pod/datadog-agent-linux-cluster-agent-67dbc9b7dd-85kxn -c cluster-agent -- datadog-cluster-agent status

[…]
=========
Collector
=========


  Running Checks
  ==============
    
    kubernetes_apiserver
    --------------------
      Instance ID: kubernetes_apiserver [OK]
[…]
      Last Successful Execution Date : 2024-05-02 12:46:11 UTC (1714653971000)
      

====================
Admission Controller
====================
[…]
```