### PR TITLE
Fix `inv agent.hacky-dev-image-build` for tagged target image

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -442,7 +442,6 @@ def hacky_dev_image_build(
     ctx,
     base_image=None,
     target_image="agent",
-    target_tag="latest",
     push=False,
     signed_pull=False,
 ):
@@ -533,14 +532,13 @@ ENV DD_SSLKEYLOGFILE=/tmp/sslkeylog.txt
         )
         dockerfile.flush()
 
-        target_image_name = f'{target_image}:{target_tag}'
         pull_env = {}
         if signed_pull:
             pull_env['DOCKER_CONTENT_TRUST'] = '1'
-        ctx.run(f'docker build -t {target_image_name} -f {dockerfile.name} .', env=pull_env)
+        ctx.run(f'docker build -t {target_image} -f {dockerfile.name} .', env=pull_env)
 
         if push:
-            ctx.run(f'docker push {target_image_name}')
+            ctx.run(f'docker push {target_image}')
 
 
 @task

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -185,7 +185,6 @@ def hacky_dev_image_build(
     ctx,
     base_image=None,
     target_image="cluster-agent",
-    target_tag="latest",
     push=False,
     signed_pull=False,
 ):
@@ -241,14 +240,13 @@ ENV DD_SSLKEYLOGFILE=/tmp/sslkeylog.txt
 '''
         )
         dockerfile.flush()
-        target_image_name = f'{target_image}:{target_tag}'
         pull_env = {}
         if signed_pull:
             pull_env['DOCKER_CONTENT_TRUST'] = '1'
-        ctx.run(f'docker build -t {target_image_name} -f {dockerfile.name} .', env=pull_env)
+        ctx.run(f'docker build -t {target_image} -f {dockerfile.name} .', env=pull_env)
 
         if push:
-            ctx.run(f'docker push {target_image_name}')
+            ctx.run(f'docker push {target_image}')
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

Fix `inv (cluster-)agent.hacky-dev-image-build` when the target image contains an explicit tag:

```
$ inv agent.hacky-dev-image-build --base-image=gcr.io/datadoghq/agent:7.54.0-rc.1 --target-image=europe-west3-docker.pkg.dev/datadog-sandbox/lenaic/agent:latest --push
[…]
invalid argument "europe-west3-docker.pkg.dev/datadog-sandbox/lenaic/agent:latest:latest" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
```

```
$ inv cluster-agent.hacky-dev-image-build --base-image=gcr.io/datadoghq/cluster-agent:7.54.0-rc.1 --target-image=europe-west3-docker.pkg.dev/datadog-sandbox/lenaic/cluster-agent:latest --push
[…]
invalid argument "europe-west3-docker.pkg.dev/datadog-sandbox/lenaic/cluster-agent:latest:latest" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
```

### Motivation

The docker image naming format `<registry>/<namespace>/<repository>:<tag>` is understood by all the tools manipulating containers like docker and kubernetes.

Because it is a well known format,
```
$ inv agent.hacky-dev-image-build \
  --base-image=gcr.io/datadoghq/agent:7.54.0-rc.1 \
  --target-image=europe-west3-docker.pkg.dev/datadog-sandbox/lenaic/agent:latest
```
looks clearer than a more verbose:
```
$ inv agent.hacky-dev-image-build \
  --base-image-registry=gcr.io \
  --base-image-namespace=datadoghq \
  --base-image-repository=agent \
  --base-image-tag=7.54.0-rc.1 \
  --target-image-registry=europe-west3-docker.pkg.dev \
  --target-image-namespace=datadog-sandbox \
  --target-image-repository=lenaic/agent \
  --target-image-tag=latest
```
and the current situation where the tag of the image is in a dedicated parameter, but not the registry and only for the target image and not for the base image, doesn’t look very consistent.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run `inv agent.hacky-dev-image-build` with an explicit tag in the `--target-image` parameter. It shouldn’t fail.
Ex.:
```
$ inv agent.hacky-dev-image-build --base-image=gcr.io/datadoghq/agent:7.54.0-rc.1 --target-image=europe-west3-docker.pkg.dev/datadog-sandbox/lenaic/agent:foo
```
