### PR TITLE
[CWS] windows: rename `path` into `device_path`

### DIFF
--- a/pkg/security/probe/field_handlers_windows.go
+++ b/pkg/security/probe/field_handlers_windows.go
@@ -43,6 +43,16 @@ func (fh *FieldHandlers) ResolveFileBasename(_ *model.Event, f *model.FileEvent)
 	return f.BasenameStr
 }
 
+// ResolveFimFilePath resolves the inode to a full path
+func (fh *FieldHandlers) ResolveFimFilePath(_ *model.Event, f *model.FimFileEvent) string {
+	return f.PathnameStr
+}
+
+// ResolveFimFileBasename resolves the inode to a full path
+func (fh *FieldHandlers) ResolveFimFileBasename(_ *model.Event, f *model.FimFileEvent) string {
+	return f.BasenameStr
+}
+
 // ResolveProcessEnvp resolves the envp of the event as an array
 func (fh *FieldHandlers) ResolveProcessEnvp(_ *model.Event, process *model.Process) []string {
 	return fh.resolvers.ProcessResolver.GetEnvp(process)

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -552,7 +552,7 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 	case *createNewFileArgs:
 		ev.Type = uint32(model.CreateNewFileEventType)
 		ev.CreateNewFile = model.CreateNewFileEvent{
-			File: model.FileEvent{
+			File: model.FimFileEvent{
 				FileObject:  uint64(arg.fileObject),
 				PathnameStr: arg.fileName,
 				BasenameStr: filepath.Base(arg.fileName),
@@ -571,12 +571,12 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 	case *renamePath:
 		ev.Type = uint32(model.FileRenameEventType)
 		ev.RenameFile = model.RenameFileEvent{
-			Old: model.FileEvent{
+			Old: model.FimFileEvent{
 				FileObject:  p.renamePreArgs.fileObject,
 				PathnameStr: p.renamePreArgs.path,
 				BasenameStr: filepath.Base(p.renamePreArgs.path),
 			},
-			New: model.FileEvent{
+			New: model.FimFileEvent{
 				FileObject:  uint64(arg.fileObject),
 				PathnameStr: arg.filePath,
 				BasenameStr: filepath.Base(arg.filePath),
@@ -585,7 +585,7 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 	case *setDeleteArgs:
 		ev.Type = uint32(model.DeleteFileEventType)
 		ev.DeleteFile = model.DeleteFileEvent{
-			File: model.FileEvent{
+			File: model.FimFileEvent{
 				FileObject:  uint64(arg.fileObject),
 				PathnameStr: arg.fileName,
 				BasenameStr: filepath.Base(arg.fileName),
@@ -594,7 +594,7 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 	case *writeArgs:
 		ev.Type = uint32(model.WriteFileEventType)
 		ev.WriteFile = model.WriteFileEvent{
-			File: model.FileEvent{
+			File: model.FimFileEvent{
 				FileObject:  uint64(arg.fileObject),
 				PathnameStr: arg.fileName,
 				BasenameStr: filepath.Base(arg.fileName),

--- a/pkg/security/secl/model/accessors_windows.go
+++ b/pkg/security/secl/model/accessors_windows.go
@@ -63,12 +63,32 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: 9999 * eval.HandlerWeight,
 		}, nil
+	case "create.file.device_path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "create.file.device_path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	case "create.file.name":
 		return &eval.StringEvaluator{
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File)
+				return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -78,27 +98,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File))
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "create.file.path":
-		return &eval.StringEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) string {
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "create.file.path.length":
-		return &eval.IntEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) int {
-				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File))
+				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -179,12 +179,32 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "delete.file.device_path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "delete.file.device_path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	case "delete.file.name":
 		return &eval.StringEvaluator{
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File)
+				return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -194,27 +214,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File))
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "delete.file.path":
-		return &eval.StringEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) string {
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "delete.file.path.length":
-		return &eval.IntEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) int {
-				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File))
+				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1220,12 +1220,32 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "rename.file.destination.device_path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "rename.file.destination.device_path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	case "rename.file.destination.name":
 		return &eval.StringEvaluator{
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New)
+				return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1235,27 +1255,27 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New))
+				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
-	case "rename.file.destination.path":
+	case "rename.file.device_path":
 		return &eval.StringEvaluator{
 			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New)
+				return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
-	case "rename.file.destination.path.length":
+	case "rename.file.device_path.length":
 		return &eval.IntEvaluator{
 			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New))
+				return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1265,7 +1285,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old)
+				return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1275,27 +1295,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old))
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "rename.file.path":
-		return &eval.StringEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) string {
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "rename.file.path.length":
-		return &eval.IntEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) int {
-				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old))
+				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1430,12 +1430,32 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "write.file.device_path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "write.file.device_path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	case "write.file.name":
 		return &eval.StringEvaluator{
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File)
+				return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1445,27 +1465,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File))
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "write.file.path":
-		return &eval.StringEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) string {
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "write.file.path.length":
-		return &eval.IntEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) int {
-				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File))
+				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1478,10 +1478,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"container.created_at",
 		"container.id",
 		"container.tags",
+		"create.file.device_path",
+		"create.file.device_path.length",
 		"create.file.name",
 		"create.file.name.length",
-		"create.file.path",
-		"create.file.path.length",
 		"create.registry.key_name",
 		"create.registry.key_name.length",
 		"create.registry.key_path",
@@ -1490,10 +1490,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"create_key.registry.key_name.length",
 		"create_key.registry.key_path",
 		"create_key.registry.key_path.length",
+		"delete.file.device_path",
+		"delete.file.device_path.length",
 		"delete.file.name",
 		"delete.file.name.length",
-		"delete.file.path",
-		"delete.file.path.length",
 		"delete.registry.key_name",
 		"delete.registry.key_name.length",
 		"delete.registry.key_path",
@@ -1581,14 +1581,14 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ppid",
 		"process.user",
 		"process.user_sid",
+		"rename.file.destination.device_path",
+		"rename.file.destination.device_path.length",
 		"rename.file.destination.name",
 		"rename.file.destination.name.length",
-		"rename.file.destination.path",
-		"rename.file.destination.path.length",
+		"rename.file.device_path",
+		"rename.file.device_path.length",
 		"rename.file.name",
 		"rename.file.name.length",
-		"rename.file.path",
-		"rename.file.path.length",
 		"set.registry.key_name",
 		"set.registry.key_name.length",
 		"set.registry.key_path",
@@ -1603,10 +1603,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"set_key_value.registry.value_name",
 		"set_key_value.registry.value_name.length",
 		"set_key_value.value_name",
+		"write.file.device_path",
+		"write.file.device_path.length",
 		"write.file.name",
 		"write.file.name.length",
-		"write.file.path",
-		"write.file.path.length",
 	}
 }
 func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
@@ -1617,14 +1617,14 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext), nil
 	case "container.tags":
 		return ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext), nil
+	case "create.file.device_path":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File), nil
+	case "create.file.device_path.length":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File), nil
 	case "create.file.name":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File), nil
 	case "create.file.name.length":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File), nil
-	case "create.file.path":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File), nil
-	case "create.file.path.length":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File), nil
 	case "create.registry.key_name":
 		return ev.CreateRegistryKey.Registry.KeyName, nil
 	case "create.registry.key_name.length":
@@ -1641,14 +1641,14 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.CreateRegistryKey.Registry.KeyPath, nil
 	case "create_key.registry.key_path.length":
 		return len(ev.CreateRegistryKey.Registry.KeyPath), nil
+	case "delete.file.device_path":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File), nil
+	case "delete.file.device_path.length":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File), nil
 	case "delete.file.name":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File), nil
 	case "delete.file.name.length":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File), nil
-	case "delete.file.path":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File), nil
-	case "delete.file.path.length":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File), nil
 	case "delete.registry.key_name":
 		return ev.DeleteRegistryKey.Registry.KeyName, nil
 	case "delete.registry.key_name.length":
@@ -1986,22 +1986,22 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.FieldHandlers.ResolveUser(ev, &ev.BaseEvent.ProcessContext.Process), nil
 	case "process.user_sid":
 		return ev.BaseEvent.ProcessContext.Process.OwnerSidString, nil
+	case "rename.file.destination.device_path":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New), nil
+	case "rename.file.destination.device_path.length":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New), nil
 	case "rename.file.destination.name":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New), nil
 	case "rename.file.destination.name.length":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New), nil
-	case "rename.file.destination.path":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New), nil
-	case "rename.file.destination.path.length":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New), nil
+	case "rename.file.device_path":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old), nil
+	case "rename.file.device_path.length":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old), nil
 	case "rename.file.name":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old), nil
 	case "rename.file.name.length":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old), nil
-	case "rename.file.path":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old), nil
-	case "rename.file.path.length":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old), nil
 	case "set.registry.key_name":
 		return ev.SetRegistryKeyValue.Registry.KeyName, nil
 	case "set.registry.key_name.length":
@@ -2030,14 +2030,14 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return len(ev.SetRegistryKeyValue.ValueName), nil
 	case "set_key_value.value_name":
 		return ev.SetRegistryKeyValue.ValueName, nil
+	case "write.file.device_path":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File), nil
+	case "write.file.device_path.length":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File), nil
 	case "write.file.name":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File), nil
 	case "write.file.name.length":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File), nil
-	case "write.file.path":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File), nil
-	case "write.file.path.length":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File), nil
 	}
 	return nil, &eval.ErrFieldNotFound{Field: field}
 }
@@ -2049,13 +2049,13 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "container.tags":
 		return "*", nil
+	case "create.file.device_path":
+		return "create", nil
+	case "create.file.device_path.length":
+		return "create", nil
 	case "create.file.name":
 		return "create", nil
 	case "create.file.name.length":
-		return "create", nil
-	case "create.file.path":
-		return "create", nil
-	case "create.file.path.length":
 		return "create", nil
 	case "create.registry.key_name":
 		return "create_key", nil
@@ -2073,13 +2073,13 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "create_key", nil
 	case "create_key.registry.key_path.length":
 		return "create_key", nil
+	case "delete.file.device_path":
+		return "delete", nil
+	case "delete.file.device_path.length":
+		return "delete", nil
 	case "delete.file.name":
 		return "delete", nil
 	case "delete.file.name.length":
-		return "delete", nil
-	case "delete.file.path":
-		return "delete", nil
-	case "delete.file.path.length":
 		return "delete", nil
 	case "delete.registry.key_name":
 		return "delete_key", nil
@@ -2255,21 +2255,21 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "process.user_sid":
 		return "*", nil
+	case "rename.file.destination.device_path":
+		return "rename", nil
+	case "rename.file.destination.device_path.length":
+		return "rename", nil
 	case "rename.file.destination.name":
 		return "rename", nil
 	case "rename.file.destination.name.length":
 		return "rename", nil
-	case "rename.file.destination.path":
+	case "rename.file.device_path":
 		return "rename", nil
-	case "rename.file.destination.path.length":
+	case "rename.file.device_path.length":
 		return "rename", nil
 	case "rename.file.name":
 		return "rename", nil
 	case "rename.file.name.length":
-		return "rename", nil
-	case "rename.file.path":
-		return "rename", nil
-	case "rename.file.path.length":
 		return "rename", nil
 	case "set.registry.key_name":
 		return "set_key_value", nil
@@ -2299,13 +2299,13 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "set_key_value", nil
 	case "set_key_value.value_name":
 		return "set_key_value", nil
+	case "write.file.device_path":
+		return "write", nil
+	case "write.file.device_path.length":
+		return "write", nil
 	case "write.file.name":
 		return "write", nil
 	case "write.file.name.length":
-		return "write", nil
-	case "write.file.path":
-		return "write", nil
-	case "write.file.path.length":
 		return "write", nil
 	}
 	return "", &eval.ErrFieldNotFound{Field: field}
@@ -2318,13 +2318,13 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "container.tags":
 		return reflect.String, nil
+	case "create.file.device_path":
+		return reflect.String, nil
+	case "create.file.device_path.length":
+		return reflect.Int, nil
 	case "create.file.name":
 		return reflect.String, nil
 	case "create.file.name.length":
-		return reflect.Int, nil
-	case "create.file.path":
-		return reflect.String, nil
-	case "create.file.path.length":
 		return reflect.Int, nil
 	case "create.registry.key_name":
 		return reflect.String, nil
@@ -2342,13 +2342,13 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "create_key.registry.key_path.length":
 		return reflect.Int, nil
+	case "delete.file.device_path":
+		return reflect.String, nil
+	case "delete.file.device_path.length":
+		return reflect.Int, nil
 	case "delete.file.name":
 		return reflect.String, nil
 	case "delete.file.name.length":
-		return reflect.Int, nil
-	case "delete.file.path":
-		return reflect.String, nil
-	case "delete.file.path.length":
 		return reflect.Int, nil
 	case "delete.registry.key_name":
 		return reflect.String, nil
@@ -2524,21 +2524,21 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "process.user_sid":
 		return reflect.String, nil
+	case "rename.file.destination.device_path":
+		return reflect.String, nil
+	case "rename.file.destination.device_path.length":
+		return reflect.Int, nil
 	case "rename.file.destination.name":
 		return reflect.String, nil
 	case "rename.file.destination.name.length":
 		return reflect.Int, nil
-	case "rename.file.destination.path":
+	case "rename.file.device_path":
 		return reflect.String, nil
-	case "rename.file.destination.path.length":
+	case "rename.file.device_path.length":
 		return reflect.Int, nil
 	case "rename.file.name":
 		return reflect.String, nil
 	case "rename.file.name.length":
-		return reflect.Int, nil
-	case "rename.file.path":
-		return reflect.String, nil
-	case "rename.file.path.length":
 		return reflect.Int, nil
 	case "set.registry.key_name":
 		return reflect.String, nil
@@ -2568,13 +2568,13 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "set_key_value.value_name":
 		return reflect.String, nil
+	case "write.file.device_path":
+		return reflect.String, nil
+	case "write.file.device_path.length":
+		return reflect.Int, nil
 	case "write.file.name":
 		return reflect.String, nil
 	case "write.file.name.length":
-		return reflect.Int, nil
-	case "write.file.path":
-		return reflect.String, nil
-	case "write.file.path.length":
 		return reflect.Int, nil
 	}
 	return reflect.Invalid, &eval.ErrFieldNotFound{Field: field}
@@ -2614,6 +2614,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ContainerContext.Tags"}
 		}
 		return nil
+	case "create.file.device_path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "CreateNewFile.File.PathnameStr"}
+		}
+		ev.CreateNewFile.File.PathnameStr = rv
+		return nil
+	case "create.file.device_path.length":
+		return &eval.ErrFieldReadOnly{Field: "create.file.device_path.length"}
 	case "create.file.name":
 		rv, ok := value.(string)
 		if !ok {
@@ -2623,15 +2632,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "create.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "create.file.name.length"}
-	case "create.file.path":
-		rv, ok := value.(string)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "CreateNewFile.File.PathnameStr"}
-		}
-		ev.CreateNewFile.File.PathnameStr = rv
-		return nil
-	case "create.file.path.length":
-		return &eval.ErrFieldReadOnly{Field: "create.file.path.length"}
 	case "create.registry.key_name":
 		rv, ok := value.(string)
 		if !ok {
@@ -2668,6 +2668,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "create_key.registry.key_path.length":
 		return &eval.ErrFieldReadOnly{Field: "create_key.registry.key_path.length"}
+	case "delete.file.device_path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "DeleteFile.File.PathnameStr"}
+		}
+		ev.DeleteFile.File.PathnameStr = rv
+		return nil
+	case "delete.file.device_path.length":
+		return &eval.ErrFieldReadOnly{Field: "delete.file.device_path.length"}
 	case "delete.file.name":
 		rv, ok := value.(string)
 		if !ok {
@@ -2677,15 +2686,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "delete.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "delete.file.name.length"}
-	case "delete.file.path":
-		rv, ok := value.(string)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "DeleteFile.File.PathnameStr"}
-		}
-		ev.DeleteFile.File.PathnameStr = rv
-		return nil
-	case "delete.file.path.length":
-		return &eval.ErrFieldReadOnly{Field: "delete.file.path.length"}
 	case "delete.registry.key_name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3508,6 +3508,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.BaseEvent.ProcessContext.Process.OwnerSidString = rv
 		return nil
+	case "rename.file.destination.device_path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RenameFile.New.PathnameStr"}
+		}
+		ev.RenameFile.New.PathnameStr = rv
+		return nil
+	case "rename.file.destination.device_path.length":
+		return &eval.ErrFieldReadOnly{Field: "rename.file.destination.device_path.length"}
 	case "rename.file.destination.name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3517,15 +3526,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "rename.file.destination.name.length":
 		return &eval.ErrFieldReadOnly{Field: "rename.file.destination.name.length"}
-	case "rename.file.destination.path":
+	case "rename.file.device_path":
 		rv, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RenameFile.New.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "RenameFile.Old.PathnameStr"}
 		}
-		ev.RenameFile.New.PathnameStr = rv
+		ev.RenameFile.Old.PathnameStr = rv
 		return nil
-	case "rename.file.destination.path.length":
-		return &eval.ErrFieldReadOnly{Field: "rename.file.destination.path.length"}
+	case "rename.file.device_path.length":
+		return &eval.ErrFieldReadOnly{Field: "rename.file.device_path.length"}
 	case "rename.file.name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3535,15 +3544,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "rename.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "rename.file.name.length"}
-	case "rename.file.path":
-		rv, ok := value.(string)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RenameFile.Old.PathnameStr"}
-		}
-		ev.RenameFile.Old.PathnameStr = rv
-		return nil
-	case "rename.file.path.length":
-		return &eval.ErrFieldReadOnly{Field: "rename.file.path.length"}
 	case "set.registry.key_name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3612,6 +3612,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.SetRegistryKeyValue.ValueName = rv
 		return nil
+	case "write.file.device_path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "WriteFile.File.PathnameStr"}
+		}
+		ev.WriteFile.File.PathnameStr = rv
+		return nil
+	case "write.file.device_path.length":
+		return &eval.ErrFieldReadOnly{Field: "write.file.device_path.length"}
 	case "write.file.name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3621,15 +3630,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "write.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "write.file.name.length"}
-	case "write.file.path":
-		rv, ok := value.(string)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "WriteFile.File.PathnameStr"}
-		}
-		ev.WriteFile.File.PathnameStr = rv
-		return nil
-	case "write.file.path.length":
-		return &eval.ErrFieldReadOnly{Field: "write.file.path.length"}
 	}
 	return &eval.ErrFieldNotFound{Field: field}
 }

--- a/pkg/security/secl/model/field_accessors_windows.go
+++ b/pkg/security/secl/model/field_accessors_windows.go
@@ -37,12 +37,28 @@ func (ev *Event) GetContainerTags() []string {
 	return ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext)
 }
 
+// GetCreateFileDevicePath returns the value of the field, resolving if necessary
+func (ev *Event) GetCreateFileDevicePath() string {
+	if ev.GetEventType().String() != "create" {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File)
+}
+
+// GetCreateFileDevicePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetCreateFileDevicePathLength() int {
+	if ev.GetEventType().String() != "create" {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File))
+}
+
 // GetCreateFileName returns the value of the field, resolving if necessary
 func (ev *Event) GetCreateFileName() string {
 	if ev.GetEventType().String() != "create" {
 		return ""
 	}
-	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File)
+	return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File)
 }
 
 // GetCreateFileNameLength returns the value of the field, resolving if necessary
@@ -50,23 +66,7 @@ func (ev *Event) GetCreateFileNameLength() int {
 	if ev.GetEventType().String() != "create" {
 		return 0
 	}
-	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File))
-}
-
-// GetCreateFilePath returns the value of the field, resolving if necessary
-func (ev *Event) GetCreateFilePath() string {
-	if ev.GetEventType().String() != "create" {
-		return ""
-	}
-	return ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File)
-}
-
-// GetCreateFilePathLength returns the value of the field, resolving if necessary
-func (ev *Event) GetCreateFilePathLength() int {
-	if ev.GetEventType().String() != "create" {
-		return 0
-	}
-	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File))
+	return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File))
 }
 
 // GetCreateRegistryKeyName returns the value of the field, resolving if necessary
@@ -133,12 +133,28 @@ func (ev *Event) GetCreateKeyRegistryKeyPathLength() int {
 	return len(ev.CreateRegistryKey.Registry.KeyPath)
 }
 
+// GetDeleteFileDevicePath returns the value of the field, resolving if necessary
+func (ev *Event) GetDeleteFileDevicePath() string {
+	if ev.GetEventType().String() != "delete" {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File)
+}
+
+// GetDeleteFileDevicePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetDeleteFileDevicePathLength() int {
+	if ev.GetEventType().String() != "delete" {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File))
+}
+
 // GetDeleteFileName returns the value of the field, resolving if necessary
 func (ev *Event) GetDeleteFileName() string {
 	if ev.GetEventType().String() != "delete" {
 		return ""
 	}
-	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File)
+	return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File)
 }
 
 // GetDeleteFileNameLength returns the value of the field, resolving if necessary
@@ -146,23 +162,7 @@ func (ev *Event) GetDeleteFileNameLength() int {
 	if ev.GetEventType().String() != "delete" {
 		return 0
 	}
-	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File))
-}
-
-// GetDeleteFilePath returns the value of the field, resolving if necessary
-func (ev *Event) GetDeleteFilePath() string {
-	if ev.GetEventType().String() != "delete" {
-		return ""
-	}
-	return ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File)
-}
-
-// GetDeleteFilePathLength returns the value of the field, resolving if necessary
-func (ev *Event) GetDeleteFilePathLength() int {
-	if ev.GetEventType().String() != "delete" {
-		return 0
-	}
-	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File))
+	return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File))
 }
 
 // GetDeleteRegistryKeyName returns the value of the field, resolving if necessary
@@ -1293,12 +1293,28 @@ func (ev *Event) GetProcessUserSid() string {
 	return ev.BaseEvent.ProcessContext.Process.OwnerSidString
 }
 
+// GetRenameFileDestinationDevicePath returns the value of the field, resolving if necessary
+func (ev *Event) GetRenameFileDestinationDevicePath() string {
+	if ev.GetEventType().String() != "rename" {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New)
+}
+
+// GetRenameFileDestinationDevicePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetRenameFileDestinationDevicePathLength() int {
+	if ev.GetEventType().String() != "rename" {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New))
+}
+
 // GetRenameFileDestinationName returns the value of the field, resolving if necessary
 func (ev *Event) GetRenameFileDestinationName() string {
 	if ev.GetEventType().String() != "rename" {
 		return ""
 	}
-	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New)
+	return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New)
 }
 
 // GetRenameFileDestinationNameLength returns the value of the field, resolving if necessary
@@ -1306,23 +1322,23 @@ func (ev *Event) GetRenameFileDestinationNameLength() int {
 	if ev.GetEventType().String() != "rename" {
 		return 0
 	}
-	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New))
+	return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New))
 }
 
-// GetRenameFileDestinationPath returns the value of the field, resolving if necessary
-func (ev *Event) GetRenameFileDestinationPath() string {
+// GetRenameFileDevicePath returns the value of the field, resolving if necessary
+func (ev *Event) GetRenameFileDevicePath() string {
 	if ev.GetEventType().String() != "rename" {
 		return ""
 	}
-	return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New)
+	return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old)
 }
 
-// GetRenameFileDestinationPathLength returns the value of the field, resolving if necessary
-func (ev *Event) GetRenameFileDestinationPathLength() int {
+// GetRenameFileDevicePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetRenameFileDevicePathLength() int {
 	if ev.GetEventType().String() != "rename" {
 		return 0
 	}
-	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New))
+	return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old))
 }
 
 // GetRenameFileName returns the value of the field, resolving if necessary
@@ -1330,7 +1346,7 @@ func (ev *Event) GetRenameFileName() string {
 	if ev.GetEventType().String() != "rename" {
 		return ""
 	}
-	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old)
+	return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old)
 }
 
 // GetRenameFileNameLength returns the value of the field, resolving if necessary
@@ -1338,23 +1354,7 @@ func (ev *Event) GetRenameFileNameLength() int {
 	if ev.GetEventType().String() != "rename" {
 		return 0
 	}
-	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old))
-}
-
-// GetRenameFilePath returns the value of the field, resolving if necessary
-func (ev *Event) GetRenameFilePath() string {
-	if ev.GetEventType().String() != "rename" {
-		return ""
-	}
-	return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old)
-}
-
-// GetRenameFilePathLength returns the value of the field, resolving if necessary
-func (ev *Event) GetRenameFilePathLength() int {
-	if ev.GetEventType().String() != "rename" {
-		return 0
-	}
-	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old))
+	return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old))
 }
 
 // GetSetRegistryKeyName returns the value of the field, resolving if necessary
@@ -1474,12 +1474,28 @@ func (ev *Event) GetTimestamp() time.Time {
 	return ev.FieldHandlers.ResolveEventTime(ev, &ev.BaseEvent)
 }
 
+// GetWriteFileDevicePath returns the value of the field, resolving if necessary
+func (ev *Event) GetWriteFileDevicePath() string {
+	if ev.GetEventType().String() != "write" {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File)
+}
+
+// GetWriteFileDevicePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetWriteFileDevicePathLength() int {
+	if ev.GetEventType().String() != "write" {
+		return 0
+	}
+	return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File))
+}
+
 // GetWriteFileName returns the value of the field, resolving if necessary
 func (ev *Event) GetWriteFileName() string {
 	if ev.GetEventType().String() != "write" {
 		return ""
 	}
-	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File)
+	return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File)
 }
 
 // GetWriteFileNameLength returns the value of the field, resolving if necessary
@@ -1487,21 +1503,5 @@ func (ev *Event) GetWriteFileNameLength() int {
 	if ev.GetEventType().String() != "write" {
 		return 0
 	}
-	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File))
-}
-
-// GetWriteFilePath returns the value of the field, resolving if necessary
-func (ev *Event) GetWriteFilePath() string {
-	if ev.GetEventType().String() != "write" {
-		return ""
-	}
-	return ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File)
-}
-
-// GetWriteFilePathLength returns the value of the field, resolving if necessary
-func (ev *Event) GetWriteFilePathLength() int {
-	if ev.GetEventType().String() != "write" {
-		return 0
-	}
-	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File))
+	return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File))
 }

--- a/pkg/security/secl/model/field_handlers_windows.go
+++ b/pkg/security/secl/model/field_handlers_windows.go
@@ -61,12 +61,12 @@ func (ev *Event) resolveFields(forADs bool) {
 	// resolve event specific fields
 	switch ev.GetEventType().String() {
 	case "create":
-		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File)
-		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File)
+		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File)
+		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File)
 	case "create_key":
 	case "delete":
-		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File)
-		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File)
+		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File)
+		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File)
 	case "delete_key":
 	case "exec":
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent)
@@ -88,14 +88,14 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exit.Process)
 	case "open_key":
 	case "rename":
-		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old)
-		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old)
-		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New)
-		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New)
+		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old)
+		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old)
+		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New)
+		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New)
 	case "set_key_value":
 	case "write":
-		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File)
-		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File)
+		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File)
+		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File)
 	}
 }
 
@@ -107,6 +107,8 @@ type FieldHandlers interface {
 	ResolveEventTimestamp(ev *Event, e *BaseEvent) int
 	ResolveFileBasename(ev *Event, e *FileEvent) string
 	ResolveFilePath(ev *Event, e *FileEvent) string
+	ResolveFimFileBasename(ev *Event, e *FimFileEvent) string
+	ResolveFimFilePath(ev *Event, e *FimFileEvent) string
 	ResolveProcessCmdLine(ev *Event, e *Process) string
 	ResolveProcessCmdLineScrubbed(ev *Event, e *Process) string
 	ResolveProcessCreatedAt(ev *Event, e *Process) int
@@ -133,7 +135,13 @@ func (dfh *FakeFieldHandlers) ResolveEventTimestamp(ev *Event, e *BaseEvent) int
 func (dfh *FakeFieldHandlers) ResolveFileBasename(ev *Event, e *FileEvent) string {
 	return e.BasenameStr
 }
-func (dfh *FakeFieldHandlers) ResolveFilePath(ev *Event, e *FileEvent) string     { return e.PathnameStr }
+func (dfh *FakeFieldHandlers) ResolveFilePath(ev *Event, e *FileEvent) string { return e.PathnameStr }
+func (dfh *FakeFieldHandlers) ResolveFimFileBasename(ev *Event, e *FimFileEvent) string {
+	return e.BasenameStr
+}
+func (dfh *FakeFieldHandlers) ResolveFimFilePath(ev *Event, e *FimFileEvent) string {
+	return e.PathnameStr
+}
 func (dfh *FakeFieldHandlers) ResolveProcessCmdLine(ev *Event, e *Process) string { return e.CmdLine }
 func (dfh *FakeFieldHandlers) ResolveProcessCmdLineScrubbed(ev *Event, e *Process) string {
 	return e.CmdLineScrubbed

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -52,6 +52,13 @@ type FileEvent struct {
 	BasenameStr string `field:"name,handler:ResolveFileBasename,opts:length" op_override:"eval.CaseInsensitiveCmp"` // SECLDoc[name] Definition:`File's basename` Example:`exec.file.name == "cmd.bat"` Description:`Matches the execution of any file named cmd.bat.`
 }
 
+// FimFileEvent is the common file event type
+type FimFileEvent struct {
+	FileObject  uint64 `field:"-"`                                                                                     // handle numeric value
+	PathnameStr string `field:"device_path,handler:ResolveFimFilePath,opts:length" op_override:"eval.WindowsPathCmp"`  // SECLDoc[device_path] Definition:`File's path` Example:`create.file.device_path == "\device\harddisk1\cmd.bat"` Description:`Matches the creation of the file located at c:\cmd.bat`
+	BasenameStr string `field:"name,handler:ResolveFimFileBasename,opts:length" op_override:"eval.CaseInsensitiveCmp"` // SECLDoc[name] Definition:`File's basename` Example:`create.file.name == "cmd.bat"` Description:`Matches the creation of any file named cmd.bat.`
+}
+
 // RegistryEvent is the common registry event type
 type RegistryEvent struct {
 	KeyName string `field:"key_name,opts:length"`                                       // SECLDoc[key_name] Definition:`Registry's name`
@@ -112,23 +119,23 @@ type ExtraFieldHandlers interface {
 
 // CreateNewFileEvent defines file creation
 type CreateNewFileEvent struct {
-	File FileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
+	File FimFileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
 }
 
 // RenameFileEvent defines file renaming
 type RenameFileEvent struct {
-	Old FileEvent `field:"file"`             // SECLDoc[file] Definition:`File Event`
-	New FileEvent `field:"file.destination"` // SECLDoc[file] Definition:`File Event`
+	Old FimFileEvent `field:"file"`             // SECLDoc[file] Definition:`File Event`
+	New FimFileEvent `field:"file.destination"` // SECLDoc[file] Definition:`File Event`
 }
 
 // DeleteFileEvent represents an unlink event
 type DeleteFileEvent struct {
-	File FileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
+	File FimFileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
 }
 
 // WriteFileEvent represents a write event
 type WriteFileEvent struct {
-	File FileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
+	File FimFileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
 }
 
 // Registries

--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -91,6 +91,13 @@ func newFileSerializer(fe *model.FileEvent, e *model.Event, _ ...uint64) *FileSe
 	}
 }
 
+func newFimFileSerializer(fe *model.FimFileEvent, e *model.Event, _ ...uint64) *FileSerializer {
+	return &FileSerializer{
+		Path: e.FieldHandlers.ResolveFimFilePath(e, fe),
+		Name: e.FieldHandlers.ResolveFimFileBasename(e, fe),
+	}
+}
+
 func newUserContextSerializer(e *model.Event) *UserContextSerializer {
 	if e.ProcessContext == nil || e.ProcessContext.Pid == 0 || e == nil {
 		return nil
@@ -195,20 +202,20 @@ func NewEventSerializer(event *model.Event, opts *eval.Opts) *EventSerializer {
 	switch eventType {
 	case model.CreateNewFileEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.CreateNewFile.File, event),
+			FileSerializer: *newFimFileSerializer(&event.CreateNewFile.File, event),
 		}
 	case model.FileRenameEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.RenameFile.Old, event),
-			Destination:    newFileSerializer(&event.RenameFile.New, event),
+			FileSerializer: *newFimFileSerializer(&event.RenameFile.Old, event),
+			Destination:    newFimFileSerializer(&event.RenameFile.New, event),
 		}
 	case model.DeleteFileEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.DeleteFile.File, event),
+			FileSerializer: *newFimFileSerializer(&event.DeleteFile.File, event),
 		}
 	case model.WriteFileEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.WriteFile.File, event),
+			FileSerializer: *newFimFileSerializer(&event.WriteFile.File, event),
 		}
 	case model.CreateRegistryKeyEventType:
 		s.RegistryEventSerializer = &RegistryEventSerializer{

--- a/pkg/security/tests/file_windows_test.go
+++ b/pkg/security/tests/file_windows_test.go
@@ -25,7 +25,7 @@ func TestBasicFileTest(t *testing.T) {
 	//ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_create_file",
-		Expression: `create.file.name =~ "test.bad" && create.file.path =~ "\Device\*\Temp\**"`,
+		Expression: `create.file.name =~ "test.bad" && create.file.device_path =~ "\Device\*\Temp\**"`,
 	}
 	opts := testOpts{
 		enableFIM: true,
@@ -68,7 +68,7 @@ func TestRenameFileEvent(t *testing.T) {
 	// ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_rename_file",
-		Expression: `rename.file.name =~ "test.bad" && rename.file.path =~ "\Device\*\Temp\**"`,
+		Expression: `rename.file.name =~ "test.bad" && rename.file.device_path =~ "\Device\*\Temp\**"`,
 	}
 	opts := testOpts{
 		enableFIM: true,
@@ -105,7 +105,7 @@ func TestDeleteFileEvent(t *testing.T) {
 	// ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_delete_file",
-		Expression: `delete.file.name =~ "test.bad" && delete.file.path =~ "\Device\*\Temp\**"`,
+		Expression: `delete.file.name =~ "test.bad" && delete.file.device_path =~ "\Device\*\Temp\**"`,
 	}
 	opts := testOpts{
 		enableFIM: true,
@@ -141,7 +141,7 @@ func TestWriteFileEvent(t *testing.T) {
 	// ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_write_file",
-		Expression: `write.file.name =~ "test.bad" && write.file.path =~ "\Device\*\Temp\**"`,
+		Expression: `write.file.name =~ "test.bad" && write.file.device_path =~ "\Device\*\Temp\**"`,
 	}
 	opts := testOpts{
 		enableFIM: true,


### PR DESCRIPTION
### What does this PR do?

Currently on windows `*.file.path` returns a path that is of the form `\Device\HarddiskVolumeN\x\y\z`. This path is not very user friendly (they would expect something like `C:\x\y\z`. To fix this this PR is renaming `path` into `device_path` allowing a future PR (reserved for 7.55) to actually provide a `.path` field with a correctly mapped path.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
