### PR TITLE
[RC] fix default RC root behavior for mrf service with different site

### DIFF
--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -328,12 +328,11 @@ func NewService(cfg model.Reader, rcType, baseRawURL, hostname string, tags []st
 	if err != nil {
 		return nil, err
 	}
-	site := cfg.GetString("site")
 	configRoot := options.configRootOverride
 	directorRoot := options.directorRootOverride
 	opt := []uptane.ClientOption{
-		uptane.WithConfigRootOverride(site, configRoot),
-		uptane.WithDirectorRootOverride(site, directorRoot),
+		uptane.WithConfigRootOverride(options.site, configRoot),
+		uptane.WithDirectorRootOverride(options.site, directorRoot),
 	}
 	if authKeys.rcKeySet {
 		opt = append(opt, uptane.WithOrgIDCheck(authKeys.rcKey.OrgID))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

In a previous PRa devx nice-to-have was added where if the configured `site` was the staging dd backend URL, the staging RC roots would be loaded by the RC service. However if the main RC service and agent site are configured to be the dd staging backend URL, this means that the MRF RC service will _also_ load the staging roots. This change uses the site passed into the RC service via `options` to determine which roots to use. 
- [The MRF service uses the `multi_region_failover.site` config](https://github.com/DataDog/datadog-agent/blob/main/comp/remote-config/rcservicemrf/rcservicemrfimpl/rcservicemrf.go#L76-L77)
- [The main service uses the `site` config](https://github.com/DataDog/datadog-agent/blob/main/comp/remote-config/rcservice/rcserviceimpl/rcservice.go#L78-L79)


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Gameday 6 testing revealed that configuring `site` to staging causes the MRF roots to be loaded incorrectly. This improvement will make future Gameday testing easier.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1. Configure the agent:
```
api_key: <R1 RC API Key>
site: datad0g.com

multi_region_failover:
  enabled: true
  api_key: <R2 RC API Key>
  site: us3.datadoghq.com

remote_configuration:
  enabled: true
```
2. Ensure there are no RC errors for either the RC or MRF RC services.
3. Publish a failover config to R2
4. Ensure the MRF RC service applies the configuration
