### PR TITLE
(fleet) fix a warn log in telemetry

### DIFF
--- a/pkg/fleet/telemetry/telemetry.go
+++ b/pkg/fleet/telemetry/telemetry.go
@@ -89,7 +89,7 @@ func (t *Telemetry) Start(_ context.Context) error {
 		env = "staging"
 	}
 	tracer.Start(
-		tracer.WithServiceName(t.service),
+		tracer.WithService(t.service),
 		tracer.WithServiceVersion(version.AgentVersion),
 		tracer.WithEnv(env),
 		tracer.WithGlobalTag("site", t.site),


### PR DESCRIPTION
```
2024/05/03 08:04:57 Datadog Tracer v1.61.0 WARN: ddtrace/tracer: deprecated config WithServiceName should not be used with `WithService` or `DD_SERVICE`; integration service name will not be set.
```
