### PR TITLE
[CWS] fix the retrieval of spans after a fork

### DIFF
--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -429,6 +429,7 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, opts Opts) 
 				if flags := tracer.ReadArgUint64(regs, 0); flags&uint64(unix.SIGCHLD) == 0 {
 					pc.SetAsThreadOf(process, ppid)
 				} else if parent := pc.Get(ppid); parent != nil {
+					pc.HeritSpan(ppid, process.Tgid)
 					sendSyscallMsg(&ebpfless.SyscallMsg{
 						Type: ebpfless.SyscallTypeFork,
 						Fork: &ebpfless.ForkSyscallMsg{
@@ -444,6 +445,7 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, opts Opts) 
 				if flags := binary.NativeEndian.Uint64(data); flags&uint64(unix.SIGCHLD) == 0 {
 					pc.SetAsThreadOf(process, ppid)
 				} else if parent := pc.Get(ppid); parent != nil {
+					pc.HeritSpan(ppid, process.Tgid)
 					sendSyscallMsg(&ebpfless.SyscallMsg{
 						Type: ebpfless.SyscallTypeFork,
 						Fork: &ebpfless.ForkSyscallMsg{
@@ -453,6 +455,7 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, opts Opts) 
 				}
 			case ForkNr, VforkNr:
 				if parent := pc.Get(ppid); parent != nil {
+					pc.HeritSpan(ppid, process.Tgid)
 					sendSyscallMsg(&ebpfless.SyscallMsg{
 						Type: ebpfless.SyscallTypeFork,
 						Fork: &ebpfless.ForkSyscallMsg{

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -316,6 +316,7 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, opts Opts) 
 		process := pc.Get(pid)
 		if process == nil {
 			process = NewProcess(pid)
+			fmt.Printf("DEBUG: new process %d -> %d\n", ppid, pid)
 			pc.Add(pid, process)
 		}
 
@@ -353,6 +354,12 @@ func StartCWSPtracer(args []string, envs []string, probeAddr string, opts Opts) 
 
 			// if available, gather span
 			syscallMsg.SpanContext = fillSpanContext(tracer, process.Tgid, pid, pc.GetSpan(process.Tgid))
+			// span := pc.GetSpan(process.Tgid)
+			// syscallMsg.SpanContext = fillSpanContext(tracer, process.Tgid, pid, span)
+			// // special case fallback
+			// if (nr == ExecveNr || nr == ExecveatNr) && span != nil && syscallMsg.SpanContext == nil {
+			// 	syscallMsg.SpanContext = fallbackFillSpanContext(tracer, span)
+			// }
 
 			/* internal special cases */
 			switch nr {

--- a/pkg/security/ptracer/process.go
+++ b/pkg/security/ptracer/process.go
@@ -137,3 +137,8 @@ func (tc *ProcessCache) SetSpan(tgid int, span *SpanTLS) {
 func (tc *ProcessCache) UnsetSpan(tgid int) {
 	delete(tc.tgid2Span, tgid)
 }
+
+// HeritSpan will copy the TLS section from the parent to the child if any
+func (tc *ProcessCache) HeritSpan(ppid, pid int) {
+	tc.SetSpan(pid, tc.GetSpan(ppid))
+}

--- a/pkg/security/ptracer/span.go
+++ b/pkg/security/ptracer/span.go
@@ -10,6 +10,7 @@ package ptracer
 
 import (
 	"encoding/binary"
+	"fmt"
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
@@ -27,6 +28,7 @@ type SpanTLS struct {
 	format     uint64 // present but not used
 	maxThreads uint64
 	base       uintptr
+	ppid       int
 }
 
 func registerSpanHandlers(handlers map[int]syscallHandler) []string {
@@ -61,6 +63,8 @@ func handleIoctl(tracer *Tracer, process *Process, regs syscall.PtraceRegs) *Spa
 		return nil
 	}
 
+	fmt.Printf("DEBUG: handleIoctl register span %d\n", process.Tgid)
+
 	return &SpanTLS{
 		format:     binary.NativeEndian.Uint64(pRequests[1:9]),
 		maxThreads: binary.NativeEndian.Uint64(pRequests[9:17]),
@@ -68,19 +72,81 @@ func handleIoctl(tracer *Tracer, process *Process, regs syscall.PtraceRegs) *Spa
 	}
 }
 
+// func fillSpanContext(tracer *Tracer, pid int, tid int, span *SpanTLS) *ebpfless.SpanContext {
+// 	if span == nil {
+// 		return nil
+// 	}
+// 	offset := uint64((tid % int(span.maxThreads)) * 2 * 8)
+
+// 	pSpan, err := tracer.readData(pid, uint64(span.base)+offset, 16 /*sizeof uint64 x2*/)
+// 	if err != nil {
+// 		return nil
+// 	}
+
+// 	return &ebpfless.SpanContext{
+// 		SpanID:  binary.NativeEndian.Uint64(pSpan[0:8]),
+// 		TraceID: binary.NativeEndian.Uint64(pSpan[8:16]),
+// 	}
+// }
+
 func fillSpanContext(tracer *Tracer, pid int, tid int, span *SpanTLS) *ebpfless.SpanContext {
 	if span == nil {
 		return nil
 	}
 	offset := uint64((tid % int(span.maxThreads)) * 2 * 8)
 
-	pSpan, err := tracer.readData(pid, uint64(span.base)+offset, 16 /*sizeof uint64 x2*/)
+	pSpan, err := tracer.readData(pid, uint64(span.base), uint(16*span.maxThreads))
 	if err != nil {
 		return nil
 	}
 
-	return &ebpfless.SpanContext{
-		SpanID:  binary.NativeEndian.Uint64(pSpan[0:8]),
-		TraceID: binary.NativeEndian.Uint64(pSpan[8:16]),
+	for i := uint64(0); i < span.maxThreads; i++ {
+		of := i * 16
+		span := binary.NativeEndian.Uint64(pSpan[of : of+8])
+		trace := binary.NativeEndian.Uint64(pSpan[of+8 : of+16])
+		if span != 0 || trace != 0 {
+			fmt.Printf("DEBUG: %d fillSpanContext offset %d vs wanted %d : %d/%d\n", pid, of, offset, span, trace)
+			if offset == of {
+				return &ebpfless.SpanContext{
+					SpanID:  span,
+					TraceID: trace,
+				}
+			}
+		}
 	}
+	return &ebpfless.SpanContext{}
 }
+
+// func fallbackFillSpanContext(tracer *Tracer, span *SpanTLS) *ebpfless.SpanContext {
+// 	fmt.Printf("DEBUG: fallbackFillSpanContext\n")
+// 	if span == nil {
+// 		fmt.Printf("DEBUG: NO SPAN\n")
+// 		return nil
+// 	} else if span.ppid == 0 {
+// 		fmt.Printf("DEBUG: NO PPID\n")
+// 		return nil
+// 	}
+// 	pid := span.ppid
+// 	offset := uint64((pid % int(span.maxThreads)) * 2 * 8)
+
+// 	pSpan, err := tracer.readData(pid, uint64(span.base), uint(16*span.maxThreads))
+// 	if err != nil {
+// 		return nil
+// 	}
+
+// 	for i := uint64(0); i < span.maxThreads; i++ {
+// 		of := i * 16
+// 		span := binary.NativeEndian.Uint64(pSpan[of : of+8])
+// 		trace := binary.NativeEndian.Uint64(pSpan[of+8 : of+16])
+// 		if span != 0 || trace != 0 {
+// 			fmt.Printf("DEBUG: %d FALLBACK fillSpanContext offset %d vs wanted %d : %d/%d\n", pid, of, offset, span, trace)
+// 			if offset == of {
+// 				return &ebpfless.SpanContext{
+// 					SpanID:  span,
+// 					TraceID: trace,
+// 				}
+// 			}
+// 		}
+// 	}
+// 	return &ebpfless.SpanContext{}
+// }

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -104,16 +104,20 @@ int span_exec(int argc, char **argv) {
         return EXIT_FAILURE;
     }
 
-    struct thread_opts opts = {
-        .argv = argv,
-        .tls = tls,
-    };
-
-    pthread_t thread;
-    if (pthread_create(&thread, NULL, thread_span_exec, &opts) < 0) {
-        return EXIT_FAILURE;
+    int child = fork();
+    if (child == 0) {
+        struct thread_opts opts = {
+            .argv = argv,
+            .tls = tls,
+        };
+        pthread_t thread;
+        if (pthread_create(&thread, NULL, thread_span_exec, &opts) < 0) {
+            return EXIT_FAILURE;
+        }
+        pthread_join(thread, NULL);
+    } else {
+        wait(NULL);
     }
-    pthread_join(thread, NULL);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
### What does this PR do?

We discovered that the span retrieval for an exec after a fork was not working as expected.
This PR:
* modify the span exec test by adding a fork after doing the TLS register, and before doing the exec
* fix the eBPFless implementation by inheriting the TLS (if any) on forks
* TODO: do the same for eBPF

### Motivation



### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
