### PR TITLE
[oracle] Fix missing query metrics (DBMON-4021)

### DIFF
--- a/pkg/collector/corechecks/oracle/oracle_integration_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_integration_test.go
@@ -354,3 +354,22 @@ func buildConnectionString(connectionConfig config.ConnectionConfig) string {
 	}
 	return connStr
 }
+
+func TestLargeUint64Binding(t *testing.T) {
+	largeUint64 := uint64(18446744073709551615)
+	var result uint64
+
+	var err error
+	driver := common.GoOra
+	db, err := connectToDB(driver)
+	require.NoErrorf(t, err, "connecting to db with %s driver", driver)
+
+	err = db.Get(&result, "SELECT n FROM sys.T WHERE n = :1", largeUint64)
+	assert.NoError(t, err, "running test statement with %s driver", driver)
+	assert.Equal(t, result, largeUint64, "simple uint64 binding with %s driver", driver)
+
+	err = db.Get(&result, "SELECT 18446744073709551615 FROM dual")
+	assert.NoError(t, err, "running test statement with %s driver", driver)
+	assert.Equal(t, result, largeUint64, "result set truncated with %s driver", driver)
+	db.Close()
+}

--- a/pkg/collector/corechecks/oracle/releasenotes/notes/oracle-missing-query-metrics-bug-1398cacee699e297.yaml
+++ b/pkg/collector/corechecks/oracle/releasenotes/notes/oracle-missing-query-metrics-bug-1398cacee699e297.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    [oracle] Fix missing query metrics.

--- a/pkg/collector/corechecks/oracle/releasenotes/notes/oracle-missing-query-metrics-bug-1398cacee699e297.yaml
+++ b/pkg/collector/corechecks/oracle/releasenotes/notes/oracle-missing-query-metrics-bug-1398cacee699e297.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    [oracle] Fix missing query metrics.

--- a/releasenotes/notes/oracle-fix-missing-query-metrics-f82ffbd306619033.yaml
+++ b/releasenotes/notes/oracle-fix-missing-query-metrics-f82ffbd306619033.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    [oracle] Fix missing query metrics.


### PR DESCRIPTION
### What does this PR do?

Fix missing query metrics.

### Additional Notes

The problem might appear if there are multiple queries with the same `force_matching_signature` but different `sql_id`. Any `sql_id` that was recently executed can be selected in such a case. Since `sql_id` is a part of the cache key, there won't be a match in the previous snapshot. Therefore, `sql_id` in the cache key is set to an empty value if `force_matching_signature` isn't empty.

