### PR TITLE
(fleet) default to US1 for the telemetry website when DD_SITE isn't set

### DIFF
--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -125,8 +125,11 @@ func newBootstraperCmd(operation string) *bootstraperCmd {
 func newTelemetry() *telemetry.Telemetry {
 	apiKey := os.Getenv(envAPIKey)
 	site := os.Getenv(envSite)
-	if apiKey == "" || site == "" {
-		fmt.Printf("telemetry disabled: missing DD_API_KEY or DD_SITE\n")
+	if site == "" {
+		site = "datadoghq.com"
+	}
+	if apiKey == "" {
+		fmt.Printf("telemetry disabled: missing DD_API_KEY\n")
 		return nil
 	}
 	t, err := telemetry.NewTelemetry(apiKey, site, "datadog-installer")


### PR DESCRIPTION
Telemetry is currently broken if a customer does not set DD_SITE in the install script.