### PR TITLE
Add a `only-modified-packages` option to the `linter.go` task

### DIFF
--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -345,7 +345,7 @@ def test(
     """
     sanitize_env_vars()
 
-    modules, flavor = process_input_args(module, targets, flavor)
+    modules, flavor = process_input_args(ctx, module, targets, flavor)
 
     unit_tests_tags = compute_build_tags_for_flavor(
         flavor=flavor,
@@ -476,7 +476,7 @@ def codecov(
     targets=None,
     flavor=None,
 ):
-    modules, flavor = process_input_args(module, targets, flavor)
+    modules, flavor = process_input_args(ctx, module, targets, flavor)
 
     codecov_flavor(ctx, flavor, modules)
 

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -107,6 +107,7 @@ def go(
     golangci_lint_kwargs="",
     headless_mode=False,
     include_sds=False,
+    only_modified_packages=False,
 ):
     """
     Run go linters on the given module and targets.
@@ -141,6 +142,7 @@ def go(
         golangci_lint_kwargs=golangci_lint_kwargs,
         headless_mode=headless_mode,
         include_sds=include_sds,
+        only_modified_packages=only_modified_packages,
     )
 
 
@@ -161,11 +163,20 @@ def _lint_go(
     golangci_lint_kwargs,
     headless_mode,
     include_sds,
+    only_modified_packages=False,
 ):
     if not check_tools_version(ctx, ['go', 'golangci-lint']):
         print("Warning: If you have linter errors it might be due to version mismatches.", file=sys.stderr)
 
-    modules, flavor = process_input_args(module, targets, flavor, headless_mode)
+    modules, flavor = process_input_args(
+        ctx,
+        module,
+        targets,
+        flavor,
+        headless_mode,
+        build_tags=build_tags,
+        only_modified_packages=only_modified_packages,
+    )
 
     lint_results = run_lint_go(
         ctx=ctx,

--- a/tasks/test_core.py
+++ b/tasks/test_core.py
@@ -147,12 +147,21 @@ def test_core(
     return modules_results
 
 
-def process_input_args(input_module, input_targets, input_flavor, headless_mode=False):
+def process_input_args(
+    ctx, input_module, input_targets, input_flavor, headless_mode=False, only_modified_packages=False, build_tags=None
+):
     """
     Takes the input module, targets and flavor arguments from inv test and inv codecov,
     sets default values for them & casts them to the expected types.
     """
-    if isinstance(input_module, str):
+    if only_modified_packages:
+        from tasks import get_modified_packages
+
+        if not build_tags:
+            build_tags = []
+
+        modules = get_modified_packages(ctx, build_tags)
+    elif isinstance(input_module, str):
         # when this function is called from the command line, targets are passed
         # as comma separated tokens in a string
         if isinstance(input_targets, str):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add a `only-modified-packages` option to the `linter.go` task, so we can now run: 

```
❯ inv linter.go --only-modified-packages
```

This works exactly the same way `inv test --only-modified-packages` works

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We would like to be able to run linters in a pre-commit hook, but there's no need to run linters on everything. This is the first step and we will add the hook once merged.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
