### PR TITLE
usm: tests: grpc: Reduce flakiness of TestLargeBodiesGRPCScenarios

### DIFF
--- a/pkg/network/usm/usm_grpc_monitor_test.go
+++ b/pkg/network/usm/usm_grpc_monitor_test.go
@@ -467,7 +467,7 @@ func (s *usmGRPCSuite) TestLargeBodiesGRPCScenarios() {
 					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: {
-					// We have a wide range here as the test is flaky due to TCP out of order packets.
+					// incident-27158: We have a wide range here as the test is flaky due to TCP out of order packets.
 					lower: 3,
 					upper: 7,
 				},
@@ -504,7 +504,7 @@ func (s *usmGRPCSuite) TestLargeBodiesGRPCScenarios() {
 		},
 	}
 	for _, tt := range tests {
-		// Currently patching the number of clients we test, to reduce the number of runs we have of the test as
+		// incident-27158: Currently patching the number of clients we test, to reduce the number of runs we have of the test as
 		// the test is flaky (due to TCP out of order packets).
 		for _, clientCount := range []int{1} {
 			testNameSuffix := fmt.Sprintf("-different clients - %v", clientCount)

--- a/pkg/network/usm/usm_grpc_monitor_test.go
+++ b/pkg/network/usm/usm_grpc_monitor_test.go
@@ -437,9 +437,9 @@ func (s *usmGRPCSuite) TestLargeBodiesGRPCScenarios() {
 	t.Cleanup(cancel)
 	defaultCtx := context.Background()
 
-	// Random string generation is an heavy operation, and it's proportional for the length (30MB)
+	// Random string generation is an heavy operation, and it's proportional for the length (15MB)
 	// Instead of generating the same long string (long name) for every test, we're generating it only once.
-	longRandomString := randStringRunes(30 * 1024 * 1024)
+	longRandomString := randStringRunes(15 * 1024 * 1024)
 	shortRandomString := longRandomString[:5*1024*1024]
 
 	// c is a stream endpoint
@@ -450,12 +450,14 @@ func (s *usmGRPCSuite) TestLargeBodiesGRPCScenarios() {
 		expectedEndpoints map[http.Key]captureRange
 	}{
 		{
+			// Although we changed the side of the payload, we keep the test name as it is for consistency and to allow
+			// tracking flakiness rate and its history.
 			name: "request with large body (30MB)",
 			runClients: func(t *testing.T, clientsCount int) {
 				clients, cleanup := getGRPCClientsArray(t, clientsCount, s.isTLS)
 				defer cleanup()
 				longRandomString[0] = '0' + rune(clientsCount)
-				for i := 0; i < 5; i++ {
+				for i := 0; i < 7; i++ {
 					longRandomString[1] = 'a' + rune(i)
 					require.NoError(t, clients[getClientsIndex(i, clientsCount)].HandleUnary(defaultCtx, string(longRandomString)))
 				}
@@ -465,8 +467,9 @@ func (s *usmGRPCSuite) TestLargeBodiesGRPCScenarios() {
 					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: {
-					lower: 4,
-					upper: 5,
+					// We have a wide range here as the test is flaky due to TCP out of order packets.
+					lower: 3,
+					upper: 7,
 				},
 			},
 		},
@@ -501,7 +504,9 @@ func (s *usmGRPCSuite) TestLargeBodiesGRPCScenarios() {
 		},
 	}
 	for _, tt := range tests {
-		for _, clientCount := range []int{1, 2, 5} {
+		// Currently patching the number of clients we test, to reduce the number of runs we have of the test as
+		// the test is flaky (due to TCP out of order packets).
+		for _, clientCount := range []int{1} {
 			testNameSuffix := fmt.Sprintf("-different clients - %v", clientCount)
 			t.Run(tt.name+testNameSuffix, func(t *testing.T) {
 				s.testGRPCScenarios(t, srv.Process.Pid, tt.runClients, tt.expectedEndpoints, clientCount)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

To reduce the number of runs and failures we -
1. Run the test only for a single client, instead of for a 1, 2, and 5 clients
2. Loosen the number of requests we're looking for capture (3 out of 7, instead 4 out of 5)
3. Change the side of the random payload from 30MB to 15MB to reduce number of packets sent
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This is the most flaky of USM, as the test triggers tcp-out-of-order issue.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
