### PR TITLE
[CWS] fix windows discarders with recent device path renaming

### DIFF
--- a/pkg/security/probe/discarders_windows.go
+++ b/pkg/security/probe/discarders_windows.go
@@ -15,23 +15,23 @@ func init() {
 		{
 			Entries: []rules.MultiDiscarderEntry{
 				{
-					Field:     "create.file.path",
+					Field:     "create.file.device_path",
 					EventType: model.CreateNewFileEventType,
 				},
 				{
-					Field:     "rename.file.path",
+					Field:     "rename.file.device_path",
 					EventType: model.FileRenameEventType,
 				},
 				{
-					Field:     "delete.file.path",
+					Field:     "delete.file.device_path",
 					EventType: model.DeleteFileEventType,
 				},
 				{
-					Field:     "write.file.path",
+					Field:     "write.file.device_path",
 					EventType: model.WriteFileEventType,
 				},
 			},
-			FinalField:     "create.file.path",
+			FinalField:     "create.file.device_path",
 			FinalEventType: model.CreateNewFileEventType,
 		},
 		{

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -838,7 +838,7 @@ func (p *WindowsProbe) OnNewDiscarder(_ *rules.RuleSet, ev *model.Event, field e
 		return
 	}
 
-	if field == "create.file.path" {
+	if field == "create.file.device_path" {
 		path := ev.CreateNewFile.File.PathnameStr
 		seclog.Debugf("new discarder for `%s` -> `%v`", field, path)
 		p.discardedPaths.Add(path, struct{}{})

--- a/pkg/security/probe/selftests/create_file_windows.go
+++ b/pkg/security/probe/selftests/create_file_windows.go
@@ -31,7 +31,7 @@ func (o *WindowsCreateFileSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 
 	return &rules.RuleDefinition{
 		ID:         o.ruleID,
-		Expression: fmt.Sprintf(`create.file.name == "%s" && create.file.path == "%s"`, basename, o.filename),
+		Expression: fmt.Sprintf(`create.file.name == "%s" && create.file.device_path == "%s"`, basename, o.filename),
 	}
 }
 

--- a/pkg/security/seclwin/model/accessors_win.go
+++ b/pkg/security/seclwin/model/accessors_win.go
@@ -61,12 +61,32 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: 9999 * eval.HandlerWeight,
 		}, nil
+	case "create.file.device_path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "create.file.device_path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	case "create.file.name":
 		return &eval.StringEvaluator{
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File)
+				return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -76,27 +96,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File))
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "create.file.path":
-		return &eval.StringEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) string {
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "create.file.path.length":
-		return &eval.IntEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) int {
-				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File))
+				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -177,12 +177,32 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "delete.file.device_path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "delete.file.device_path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	case "delete.file.name":
 		return &eval.StringEvaluator{
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File)
+				return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -192,27 +212,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File))
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "delete.file.path":
-		return &eval.StringEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) string {
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "delete.file.path.length":
-		return &eval.IntEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) int {
-				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File))
+				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1218,12 +1218,32 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "rename.file.destination.device_path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "rename.file.destination.device_path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	case "rename.file.destination.name":
 		return &eval.StringEvaluator{
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New)
+				return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1233,27 +1253,27 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New))
+				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
-	case "rename.file.destination.path":
+	case "rename.file.device_path":
 		return &eval.StringEvaluator{
 			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New)
+				return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
-	case "rename.file.destination.path.length":
+	case "rename.file.device_path.length":
 		return &eval.IntEvaluator{
 			OpOverrides: eval.WindowsPathCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New))
+				return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1263,7 +1283,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old)
+				return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1273,27 +1293,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old))
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "rename.file.path":
-		return &eval.StringEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) string {
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "rename.file.path.length":
-		return &eval.IntEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) int {
-				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old))
+				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1428,12 +1428,32 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "write.file.device_path":
+		return &eval.StringEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) string {
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+	case "write.file.device_path.length":
+		return &eval.IntEvaluator{
+			OpOverrides: eval.WindowsPathCmp,
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return len(ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	case "write.file.name":
 		return &eval.StringEvaluator{
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File)
+				return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1443,27 +1463,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.CaseInsensitiveCmp,
 			EvalFnc: func(ctx *eval.Context) int {
 				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File))
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "write.file.path":
-		return &eval.StringEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) string {
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "write.file.path.length":
-		return &eval.IntEvaluator{
-			OpOverrides: eval.WindowsPathCmp,
-			EvalFnc: func(ctx *eval.Context) int {
-				ev := ctx.Event.(*Event)
-				return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File))
+				return len(ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1476,10 +1476,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"container.created_at",
 		"container.id",
 		"container.tags",
+		"create.file.device_path",
+		"create.file.device_path.length",
 		"create.file.name",
 		"create.file.name.length",
-		"create.file.path",
-		"create.file.path.length",
 		"create.registry.key_name",
 		"create.registry.key_name.length",
 		"create.registry.key_path",
@@ -1488,10 +1488,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"create_key.registry.key_name.length",
 		"create_key.registry.key_path",
 		"create_key.registry.key_path.length",
+		"delete.file.device_path",
+		"delete.file.device_path.length",
 		"delete.file.name",
 		"delete.file.name.length",
-		"delete.file.path",
-		"delete.file.path.length",
 		"delete.registry.key_name",
 		"delete.registry.key_name.length",
 		"delete.registry.key_path",
@@ -1579,14 +1579,14 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ppid",
 		"process.user",
 		"process.user_sid",
+		"rename.file.destination.device_path",
+		"rename.file.destination.device_path.length",
 		"rename.file.destination.name",
 		"rename.file.destination.name.length",
-		"rename.file.destination.path",
-		"rename.file.destination.path.length",
+		"rename.file.device_path",
+		"rename.file.device_path.length",
 		"rename.file.name",
 		"rename.file.name.length",
-		"rename.file.path",
-		"rename.file.path.length",
 		"set.registry.key_name",
 		"set.registry.key_name.length",
 		"set.registry.key_path",
@@ -1601,10 +1601,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"set_key_value.registry.value_name",
 		"set_key_value.registry.value_name.length",
 		"set_key_value.value_name",
+		"write.file.device_path",
+		"write.file.device_path.length",
 		"write.file.name",
 		"write.file.name.length",
-		"write.file.path",
-		"write.file.path.length",
 	}
 }
 func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
@@ -1615,14 +1615,14 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext), nil
 	case "container.tags":
 		return ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext), nil
+	case "create.file.device_path":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File), nil
+	case "create.file.device_path.length":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File), nil
 	case "create.file.name":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File), nil
 	case "create.file.name.length":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File), nil
-	case "create.file.path":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File), nil
-	case "create.file.path.length":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File), nil
 	case "create.registry.key_name":
 		return ev.CreateRegistryKey.Registry.KeyName, nil
 	case "create.registry.key_name.length":
@@ -1639,14 +1639,14 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.CreateRegistryKey.Registry.KeyPath, nil
 	case "create_key.registry.key_path.length":
 		return len(ev.CreateRegistryKey.Registry.KeyPath), nil
+	case "delete.file.device_path":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File), nil
+	case "delete.file.device_path.length":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File), nil
 	case "delete.file.name":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File), nil
 	case "delete.file.name.length":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File), nil
-	case "delete.file.path":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File), nil
-	case "delete.file.path.length":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File), nil
 	case "delete.registry.key_name":
 		return ev.DeleteRegistryKey.Registry.KeyName, nil
 	case "delete.registry.key_name.length":
@@ -1984,22 +1984,22 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.FieldHandlers.ResolveUser(ev, &ev.BaseEvent.ProcessContext.Process), nil
 	case "process.user_sid":
 		return ev.BaseEvent.ProcessContext.Process.OwnerSidString, nil
+	case "rename.file.destination.device_path":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New), nil
+	case "rename.file.destination.device_path.length":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New), nil
 	case "rename.file.destination.name":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New), nil
 	case "rename.file.destination.name.length":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New), nil
-	case "rename.file.destination.path":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New), nil
-	case "rename.file.destination.path.length":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New), nil
+	case "rename.file.device_path":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old), nil
+	case "rename.file.device_path.length":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old), nil
 	case "rename.file.name":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old), nil
 	case "rename.file.name.length":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old), nil
-	case "rename.file.path":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old), nil
-	case "rename.file.path.length":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old), nil
 	case "set.registry.key_name":
 		return ev.SetRegistryKeyValue.Registry.KeyName, nil
 	case "set.registry.key_name.length":
@@ -2028,14 +2028,14 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return len(ev.SetRegistryKeyValue.ValueName), nil
 	case "set_key_value.value_name":
 		return ev.SetRegistryKeyValue.ValueName, nil
+	case "write.file.device_path":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File), nil
+	case "write.file.device_path.length":
+		return ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File), nil
 	case "write.file.name":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File), nil
 	case "write.file.name.length":
-		return ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File), nil
-	case "write.file.path":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File), nil
-	case "write.file.path.length":
-		return ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File), nil
+		return ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File), nil
 	}
 	return nil, &eval.ErrFieldNotFound{Field: field}
 }
@@ -2047,13 +2047,13 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "container.tags":
 		return "*", nil
+	case "create.file.device_path":
+		return "create", nil
+	case "create.file.device_path.length":
+		return "create", nil
 	case "create.file.name":
 		return "create", nil
 	case "create.file.name.length":
-		return "create", nil
-	case "create.file.path":
-		return "create", nil
-	case "create.file.path.length":
 		return "create", nil
 	case "create.registry.key_name":
 		return "create_key", nil
@@ -2071,13 +2071,13 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "create_key", nil
 	case "create_key.registry.key_path.length":
 		return "create_key", nil
+	case "delete.file.device_path":
+		return "delete", nil
+	case "delete.file.device_path.length":
+		return "delete", nil
 	case "delete.file.name":
 		return "delete", nil
 	case "delete.file.name.length":
-		return "delete", nil
-	case "delete.file.path":
-		return "delete", nil
-	case "delete.file.path.length":
 		return "delete", nil
 	case "delete.registry.key_name":
 		return "delete_key", nil
@@ -2253,21 +2253,21 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "process.user_sid":
 		return "*", nil
+	case "rename.file.destination.device_path":
+		return "rename", nil
+	case "rename.file.destination.device_path.length":
+		return "rename", nil
 	case "rename.file.destination.name":
 		return "rename", nil
 	case "rename.file.destination.name.length":
 		return "rename", nil
-	case "rename.file.destination.path":
+	case "rename.file.device_path":
 		return "rename", nil
-	case "rename.file.destination.path.length":
+	case "rename.file.device_path.length":
 		return "rename", nil
 	case "rename.file.name":
 		return "rename", nil
 	case "rename.file.name.length":
-		return "rename", nil
-	case "rename.file.path":
-		return "rename", nil
-	case "rename.file.path.length":
 		return "rename", nil
 	case "set.registry.key_name":
 		return "set_key_value", nil
@@ -2297,13 +2297,13 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "set_key_value", nil
 	case "set_key_value.value_name":
 		return "set_key_value", nil
+	case "write.file.device_path":
+		return "write", nil
+	case "write.file.device_path.length":
+		return "write", nil
 	case "write.file.name":
 		return "write", nil
 	case "write.file.name.length":
-		return "write", nil
-	case "write.file.path":
-		return "write", nil
-	case "write.file.path.length":
 		return "write", nil
 	}
 	return "", &eval.ErrFieldNotFound{Field: field}
@@ -2316,13 +2316,13 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "container.tags":
 		return reflect.String, nil
+	case "create.file.device_path":
+		return reflect.String, nil
+	case "create.file.device_path.length":
+		return reflect.Int, nil
 	case "create.file.name":
 		return reflect.String, nil
 	case "create.file.name.length":
-		return reflect.Int, nil
-	case "create.file.path":
-		return reflect.String, nil
-	case "create.file.path.length":
 		return reflect.Int, nil
 	case "create.registry.key_name":
 		return reflect.String, nil
@@ -2340,13 +2340,13 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "create_key.registry.key_path.length":
 		return reflect.Int, nil
+	case "delete.file.device_path":
+		return reflect.String, nil
+	case "delete.file.device_path.length":
+		return reflect.Int, nil
 	case "delete.file.name":
 		return reflect.String, nil
 	case "delete.file.name.length":
-		return reflect.Int, nil
-	case "delete.file.path":
-		return reflect.String, nil
-	case "delete.file.path.length":
 		return reflect.Int, nil
 	case "delete.registry.key_name":
 		return reflect.String, nil
@@ -2522,21 +2522,21 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "process.user_sid":
 		return reflect.String, nil
+	case "rename.file.destination.device_path":
+		return reflect.String, nil
+	case "rename.file.destination.device_path.length":
+		return reflect.Int, nil
 	case "rename.file.destination.name":
 		return reflect.String, nil
 	case "rename.file.destination.name.length":
 		return reflect.Int, nil
-	case "rename.file.destination.path":
+	case "rename.file.device_path":
 		return reflect.String, nil
-	case "rename.file.destination.path.length":
+	case "rename.file.device_path.length":
 		return reflect.Int, nil
 	case "rename.file.name":
 		return reflect.String, nil
 	case "rename.file.name.length":
-		return reflect.Int, nil
-	case "rename.file.path":
-		return reflect.String, nil
-	case "rename.file.path.length":
 		return reflect.Int, nil
 	case "set.registry.key_name":
 		return reflect.String, nil
@@ -2566,13 +2566,13 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "set_key_value.value_name":
 		return reflect.String, nil
+	case "write.file.device_path":
+		return reflect.String, nil
+	case "write.file.device_path.length":
+		return reflect.Int, nil
 	case "write.file.name":
 		return reflect.String, nil
 	case "write.file.name.length":
-		return reflect.Int, nil
-	case "write.file.path":
-		return reflect.String, nil
-	case "write.file.path.length":
 		return reflect.Int, nil
 	}
 	return reflect.Invalid, &eval.ErrFieldNotFound{Field: field}
@@ -2612,6 +2612,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "BaseEvent.ContainerContext.Tags"}
 		}
 		return nil
+	case "create.file.device_path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "CreateNewFile.File.PathnameStr"}
+		}
+		ev.CreateNewFile.File.PathnameStr = rv
+		return nil
+	case "create.file.device_path.length":
+		return &eval.ErrFieldReadOnly{Field: "create.file.device_path.length"}
 	case "create.file.name":
 		rv, ok := value.(string)
 		if !ok {
@@ -2621,15 +2630,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "create.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "create.file.name.length"}
-	case "create.file.path":
-		rv, ok := value.(string)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "CreateNewFile.File.PathnameStr"}
-		}
-		ev.CreateNewFile.File.PathnameStr = rv
-		return nil
-	case "create.file.path.length":
-		return &eval.ErrFieldReadOnly{Field: "create.file.path.length"}
 	case "create.registry.key_name":
 		rv, ok := value.(string)
 		if !ok {
@@ -2666,6 +2666,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "create_key.registry.key_path.length":
 		return &eval.ErrFieldReadOnly{Field: "create_key.registry.key_path.length"}
+	case "delete.file.device_path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "DeleteFile.File.PathnameStr"}
+		}
+		ev.DeleteFile.File.PathnameStr = rv
+		return nil
+	case "delete.file.device_path.length":
+		return &eval.ErrFieldReadOnly{Field: "delete.file.device_path.length"}
 	case "delete.file.name":
 		rv, ok := value.(string)
 		if !ok {
@@ -2675,15 +2684,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "delete.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "delete.file.name.length"}
-	case "delete.file.path":
-		rv, ok := value.(string)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "DeleteFile.File.PathnameStr"}
-		}
-		ev.DeleteFile.File.PathnameStr = rv
-		return nil
-	case "delete.file.path.length":
-		return &eval.ErrFieldReadOnly{Field: "delete.file.path.length"}
 	case "delete.registry.key_name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3506,6 +3506,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.BaseEvent.ProcessContext.Process.OwnerSidString = rv
 		return nil
+	case "rename.file.destination.device_path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RenameFile.New.PathnameStr"}
+		}
+		ev.RenameFile.New.PathnameStr = rv
+		return nil
+	case "rename.file.destination.device_path.length":
+		return &eval.ErrFieldReadOnly{Field: "rename.file.destination.device_path.length"}
 	case "rename.file.destination.name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3515,15 +3524,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "rename.file.destination.name.length":
 		return &eval.ErrFieldReadOnly{Field: "rename.file.destination.name.length"}
-	case "rename.file.destination.path":
+	case "rename.file.device_path":
 		rv, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RenameFile.New.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "RenameFile.Old.PathnameStr"}
 		}
-		ev.RenameFile.New.PathnameStr = rv
+		ev.RenameFile.Old.PathnameStr = rv
 		return nil
-	case "rename.file.destination.path.length":
-		return &eval.ErrFieldReadOnly{Field: "rename.file.destination.path.length"}
+	case "rename.file.device_path.length":
+		return &eval.ErrFieldReadOnly{Field: "rename.file.device_path.length"}
 	case "rename.file.name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3533,15 +3542,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "rename.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "rename.file.name.length"}
-	case "rename.file.path":
-		rv, ok := value.(string)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RenameFile.Old.PathnameStr"}
-		}
-		ev.RenameFile.Old.PathnameStr = rv
-		return nil
-	case "rename.file.path.length":
-		return &eval.ErrFieldReadOnly{Field: "rename.file.path.length"}
 	case "set.registry.key_name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3610,6 +3610,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.SetRegistryKeyValue.ValueName = rv
 		return nil
+	case "write.file.device_path":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "WriteFile.File.PathnameStr"}
+		}
+		ev.WriteFile.File.PathnameStr = rv
+		return nil
+	case "write.file.device_path.length":
+		return &eval.ErrFieldReadOnly{Field: "write.file.device_path.length"}
 	case "write.file.name":
 		rv, ok := value.(string)
 		if !ok {
@@ -3619,15 +3628,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 	case "write.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "write.file.name.length"}
-	case "write.file.path":
-		rv, ok := value.(string)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "WriteFile.File.PathnameStr"}
-		}
-		ev.WriteFile.File.PathnameStr = rv
-		return nil
-	case "write.file.path.length":
-		return &eval.ErrFieldReadOnly{Field: "write.file.path.length"}
 	}
 	return &eval.ErrFieldNotFound{Field: field}
 }

--- a/pkg/security/seclwin/model/field_handlers_win.go
+++ b/pkg/security/seclwin/model/field_handlers_win.go
@@ -59,12 +59,12 @@ func (ev *Event) resolveFields(forADs bool) {
 	// resolve event specific fields
 	switch ev.GetEventType().String() {
 	case "create":
-		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.CreateNewFile.File)
-		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.CreateNewFile.File)
+		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.CreateNewFile.File)
+		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.CreateNewFile.File)
 	case "create_key":
 	case "delete":
-		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.DeleteFile.File)
-		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.DeleteFile.File)
+		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.DeleteFile.File)
+		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.DeleteFile.File)
 	case "delete_key":
 	case "exec":
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent)
@@ -86,14 +86,14 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exit.Process)
 	case "open_key":
 	case "rename":
-		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.Old)
-		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.Old)
-		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.RenameFile.New)
-		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.RenameFile.New)
+		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.Old)
+		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.Old)
+		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.RenameFile.New)
+		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.RenameFile.New)
 	case "set_key_value":
 	case "write":
-		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.WriteFile.File)
-		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.WriteFile.File)
+		_ = ev.FieldHandlers.ResolveFimFilePath(ev, &ev.WriteFile.File)
+		_ = ev.FieldHandlers.ResolveFimFileBasename(ev, &ev.WriteFile.File)
 	}
 }
 
@@ -105,6 +105,8 @@ type FieldHandlers interface {
 	ResolveEventTimestamp(ev *Event, e *BaseEvent) int
 	ResolveFileBasename(ev *Event, e *FileEvent) string
 	ResolveFilePath(ev *Event, e *FileEvent) string
+	ResolveFimFileBasename(ev *Event, e *FimFileEvent) string
+	ResolveFimFilePath(ev *Event, e *FimFileEvent) string
 	ResolveProcessCmdLine(ev *Event, e *Process) string
 	ResolveProcessCmdLineScrubbed(ev *Event, e *Process) string
 	ResolveProcessCreatedAt(ev *Event, e *Process) int
@@ -131,7 +133,13 @@ func (dfh *FakeFieldHandlers) ResolveEventTimestamp(ev *Event, e *BaseEvent) int
 func (dfh *FakeFieldHandlers) ResolveFileBasename(ev *Event, e *FileEvent) string {
 	return e.BasenameStr
 }
-func (dfh *FakeFieldHandlers) ResolveFilePath(ev *Event, e *FileEvent) string     { return e.PathnameStr }
+func (dfh *FakeFieldHandlers) ResolveFilePath(ev *Event, e *FileEvent) string { return e.PathnameStr }
+func (dfh *FakeFieldHandlers) ResolveFimFileBasename(ev *Event, e *FimFileEvent) string {
+	return e.BasenameStr
+}
+func (dfh *FakeFieldHandlers) ResolveFimFilePath(ev *Event, e *FimFileEvent) string {
+	return e.PathnameStr
+}
 func (dfh *FakeFieldHandlers) ResolveProcessCmdLine(ev *Event, e *Process) string { return e.CmdLine }
 func (dfh *FakeFieldHandlers) ResolveProcessCmdLineScrubbed(ev *Event, e *Process) string {
 	return e.CmdLineScrubbed

--- a/pkg/security/seclwin/model/model_win.go
+++ b/pkg/security/seclwin/model/model_win.go
@@ -52,6 +52,13 @@ type FileEvent struct {
 	BasenameStr string `field:"name,handler:ResolveFileBasename,opts:length" op_override:"eval.CaseInsensitiveCmp"` // SECLDoc[name] Definition:`File's basename` Example:`exec.file.name == "cmd.bat"` Description:`Matches the execution of any file named cmd.bat.`
 }
 
+// FimFileEvent is the common file event type
+type FimFileEvent struct {
+	FileObject  uint64 `field:"-"`                                                                                     // handle numeric value
+	PathnameStr string `field:"device_path,handler:ResolveFimFilePath,opts:length" op_override:"eval.WindowsPathCmp"`  // SECLDoc[device_path] Definition:`File's path` Example:`create.file.device_path == "\device\harddisk1\cmd.bat"` Description:`Matches the creation of the file located at c:\cmd.bat`
+	BasenameStr string `field:"name,handler:ResolveFimFileBasename,opts:length" op_override:"eval.CaseInsensitiveCmp"` // SECLDoc[name] Definition:`File's basename` Example:`create.file.name == "cmd.bat"` Description:`Matches the creation of any file named cmd.bat.`
+}
+
 // RegistryEvent is the common registry event type
 type RegistryEvent struct {
 	KeyName string `field:"key_name,opts:length"`                                       // SECLDoc[key_name] Definition:`Registry's name`
@@ -112,23 +119,23 @@ type ExtraFieldHandlers interface {
 
 // CreateNewFileEvent defines file creation
 type CreateNewFileEvent struct {
-	File FileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
+	File FimFileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
 }
 
 // RenameFileEvent defines file renaming
 type RenameFileEvent struct {
-	Old FileEvent `field:"file"`             // SECLDoc[file] Definition:`File Event`
-	New FileEvent `field:"file.destination"` // SECLDoc[file] Definition:`File Event`
+	Old FimFileEvent `field:"file"`             // SECLDoc[file] Definition:`File Event`
+	New FimFileEvent `field:"file.destination"` // SECLDoc[file] Definition:`File Event`
 }
 
 // DeleteFileEvent represents an unlink event
 type DeleteFileEvent struct {
-	File FileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
+	File FimFileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
 }
 
 // WriteFileEvent represents a write event
 type WriteFileEvent struct {
-	File FileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
+	File FimFileEvent `field:"file"` // SECLDoc[file] Definition:`File Event`
 }
 
 // Registries


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/25309 renamed `path` into `device_path` for FRIM events, but without updating the discarders registration, effectively disabling them. This PR fixes this.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
