### PR TITLE
[comp/core/tagger/tagstore] Reset collector priorities after test

### DIFF
--- a/comp/core/tagger/taggerimpl/tagstore/tagstore_test.go
+++ b/comp/core/tagger/taggerimpl/tagstore/tagstore_test.go
@@ -378,19 +378,23 @@ func (s *StoreTestSuite) TestGetExpiredTags() {
 }
 
 func TestDuplicateSourceTags(t *testing.T) {
+	// Mock collector priorities
+	originalCollectorPriorities := collectors.CollectorPriorities
+	collectors.CollectorPriorities = map[string]types.CollectorPriority{
+		"sourceNodeOrchestrator":    types.NodeOrchestrator,
+		"sourceNodeRuntime":         types.NodeRuntime,
+		"sourceClusterOrchestrator": types.ClusterOrchestrator,
+	}
+	defer func() {
+		collectors.CollectorPriorities = originalCollectorPriorities
+	}()
+
 	etags := newEntityTags("deadbeef")
 
 	// Get empty tags and make sure cache is now set to valid
 	tags := etags.get(types.HighCardinality)
 	assert.Len(t, tags, 0)
 	assert.True(t, etags.cacheValid)
-
-	// Mock collector priorities
-	collectors.CollectorPriorities = map[string]types.CollectorPriority{
-		"sourceNodeOrchestrator":    types.NodeOrchestrator,
-		"sourceNodeRuntime":         types.NodeRuntime,
-		"sourceClusterOrchestrator": types.ClusterOrchestrator,
-	}
 
 	// Add tags but don't invalidate the cache, we should return empty arrays
 	etags.sourceTags["sourceNodeOrchestrator"] = sourceTags{


### PR DESCRIPTION

### What does this PR do?

Fixes an issue in one of the tests in `comp/core/tagger/taggerimpl/tagstore/tagstore_test.go`.
It's setting a global without restoring the original value. This could cause issues if other tests rely on the value.


### Describe how to test/QA your changes

Skip.
