### PR TITLE
[e2e] bump test-infra and self init components

### DIFF
--- a/.gitlab/common/test_infra_version.yml
+++ b/.gitlab/common/test_infra_version.yml
@@ -4,4 +4,4 @@ variables:
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
   # Make sure to update test-infra-definitions version in go.mod as well
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 3ef2a7434fd6
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 65fbab1e1eaf

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -29,7 +29,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240507072103-3ef2a7434fd6
+	github.com/DataDog/test-infra-definitions v0.0.0-20240507122412-65fbab1e1eaf
 	github.com/aws/aws-sdk-go-v2 v1.26.1
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.19.0 h1:Wvz/63/q39EpVwSH1T8jVyRvP
 github.com/DataDog/datadog-api-client-go/v2 v2.19.0/go.mod h1:oD5Lx8Li3oPRa/BSBenkn4i48z+91gwYORF/+6ph71g=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20240507072103-3ef2a7434fd6 h1:Ny8qe4OhnbiphjgM7oM7Qnyh/zK17dutAcExkZ/GhYM=
-github.com/DataDog/test-infra-definitions v0.0.0-20240507072103-3ef2a7434fd6/go.mod h1:huEtduYOHXJkka1vANykh160YalqfrZjZCC6JyEHAQM=
+github.com/DataDog/test-infra-definitions v0.0.0-20240507122412-65fbab1e1eaf h1:GWFC0LDyNJUokgkqvfzIdCk0yQP6gr5wt8THKNeD0jw=
+github.com/DataDog/test-infra-definitions v0.0.0-20240507122412-65fbab1e1eaf/go.mod h1:huEtduYOHXJkka1vANykh160YalqfrZjZCC6JyEHAQM=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/pkg/components/docker_agent.go
+++ b/test/new-e2e/pkg/components/docker_agent.go
@@ -6,7 +6,10 @@
 package components
 
 import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 )
@@ -16,5 +19,14 @@ type DockerAgent struct {
 	agent.DockerAgentOutput
 
 	// Client cannot be initialized inline as it requires other information to create client
-	Client agentclient.Agent
+	Client        agentclient.Agent
+	ClientOptions []agentclientparams.Option
+}
+
+var _ e2e.Initializable = (*DockerAgent)(nil)
+
+// Init is called by e2e test Suite after the component is provisioned.
+func (a *DockerAgent) Init(ctx e2e.Context) (err error) {
+	a.Client, err = client.NewDockerAgentClient(ctx, a.DockerAgentOutput, a.ClientOptions...)
+	return err
 }

--- a/test/new-e2e/pkg/components/remotehost_agent.go
+++ b/test/new-e2e/pkg/components/remotehost_agent.go
@@ -6,7 +6,10 @@
 package components
 
 import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 )
@@ -15,6 +18,14 @@ import (
 type RemoteHostAgent struct {
 	agent.HostAgentOutput
 
-	// Client cannot be initialized inline as it requires other information to create client
-	Client agentclient.Agent
+	Client        agentclient.Agent
+	ClientOptions []agentclientparams.Option
+}
+
+var _ e2e.Initializable = (*RemoteHostAgent)(nil)
+
+// Init is called by e2e test Suite after the component is provisioned.
+func (a *RemoteHostAgent) Init(ctx e2e.Context) (err error) {
+	a.Client, err = client.NewHostAgentClientWithParams(ctx, a.HostAgentOutput.Host, a.ClientOptions...)
+	return err
 }

--- a/test/new-e2e/pkg/components/remotehost_docker.go
+++ b/test/new-e2e/pkg/components/remotehost_docker.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package components
+
+import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/test-infra-definitions/components/docker"
+)
+
+// RemoteHostDocker represents an Agent running directly on a Host
+type RemoteHostDocker struct {
+	docker.ManagerOutput
+
+	Client *client.Docker
+}
+
+var _ e2e.Initializable = (*RemoteHostDocker)(nil)
+
+// Init is called by e2e test Suite after the component is provisioned.
+func (d *RemoteHostDocker) Init(ctx e2e.Context) (err error) {
+	d.Client, err = client.NewDocker(ctx.T(), d.ManagerOutput)
+	return err
+}

--- a/test/new-e2e/pkg/environments/aws/docker/host.go
+++ b/test/new-e2e/pkg/environments/aws/docker/host.go
@@ -151,6 +151,10 @@ func Run(ctx *pulumi.Context, env *environments.DockerHost, params *ProvisionerP
 	if err != nil {
 		return err
 	}
+	err = manager.Export(ctx, &env.Docker.ManagerOutput)
+	if err != nil {
+		return err
+	}
 
 	// Create FakeIntake if required
 	if params.fakeintakeOptions != nil {

--- a/test/new-e2e/pkg/environments/aws/docker/host.go
+++ b/test/new-e2e/pkg/environments/aws/docker/host.go
@@ -147,7 +147,7 @@ func Run(ctx *pulumi.Context, env *environments.DockerHost, params *ProvisionerP
 		return err
 	}
 
-	manager, _, err := docker.NewManager(&awsEnv, host, utils.PulumiDependsOn(installEcrCredsHelperCmd))
+	manager, err := docker.NewManager(&awsEnv, host, utils.PulumiDependsOn(installEcrCredsHelperCmd))
 	if err != nil {
 		return err
 	}

--- a/test/new-e2e/pkg/environments/aws/host/host.go
+++ b/test/new-e2e/pkg/environments/aws/host/host.go
@@ -191,7 +191,7 @@ func Run(ctx *pulumi.Context, env *environments.Host, params *ProvisionerParams)
 	}
 
 	if params.installDocker {
-		_, dockerRes, err := docker.NewManager(&awsEnv, host)
+		dockerManager, err := docker.NewManager(&awsEnv, host)
 		if err != nil {
 			return err
 		}
@@ -202,7 +202,7 @@ func Run(ctx *pulumi.Context, env *environments.Host, params *ProvisionerParams)
 			// at the same time.
 			params.agentOptions = append(params.agentOptions,
 				agentparams.WithPulumiResourceOptions(
-					utils.PulumiDependsOn(dockerRes)))
+					utils.PulumiDependsOn(dockerManager)))
 		}
 	}
 

--- a/test/new-e2e/pkg/environments/aws/host/host.go
+++ b/test/new-e2e/pkg/environments/aws/host/host.go
@@ -255,12 +255,12 @@ func Run(ctx *pulumi.Context, env *environments.Host, params *ProvisionerParams)
 		if err != nil {
 			return err
 		}
+
+		env.Agent.ClientOptions = params.agentClientOptions
 	} else {
 		// Suite inits all fields by default, so we need to explicitly set it to nil
 		env.Agent = nil
 	}
-
-	env.AgentClientOptions = params.agentClientOptions
 
 	return nil
 }

--- a/test/new-e2e/pkg/environments/aws/host/windows/host.go
+++ b/test/new-e2e/pkg/environments/aws/host/windows/host.go
@@ -198,11 +198,10 @@ func Run(ctx *pulumi.Context, env *environments.WindowsHost, params *Provisioner
 		if err != nil {
 			return err
 		}
+		env.Agent.ClientOptions = params.agentClientOptions
 	} else {
 		env.Agent = nil
 	}
-
-	env.AgentClientOptions = params.agentClientOptions
 
 	return nil
 }

--- a/test/new-e2e/pkg/environments/dockerhost.go
+++ b/test/new-e2e/pkg/environments/dockerhost.go
@@ -8,7 +8,6 @@ package environments
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 )
 
@@ -26,13 +25,5 @@ var _ e2e.Initializable = &DockerHost{}
 
 // Init initializes the environment
 func (e *DockerHost) Init(ctx e2e.Context) error {
-	if e.Agent != nil {
-		agent, err := client.NewDockerAgentClient(ctx.T(), e.Docker.Client, e.Agent.ContainerName, true)
-		if err != nil {
-			return err
-		}
-		e.Agent.Client = agent
-	}
-
 	return nil
 }

--- a/test/new-e2e/pkg/environments/dockerhost.go
+++ b/test/new-e2e/pkg/environments/dockerhost.go
@@ -8,8 +8,6 @@ package environments
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 )
@@ -21,27 +19,15 @@ type DockerHost struct {
 	RemoteHost *components.RemoteHost
 	FakeIntake *components.FakeIntake
 	Agent      *components.DockerAgent
-
-	// Other clients
-	Docker *client.Docker
+	Docker     *components.RemoteHostDocker
 }
 
 var _ e2e.Initializable = &DockerHost{}
 
 // Init initializes the environment
 func (e *DockerHost) Init(ctx e2e.Context) error {
-	privateKeyPath, err := runner.GetProfile().ParamStore().GetWithDefault(parameters.PrivateKeyPath, "")
-	if err != nil {
-		return err
-	}
-
-	e.Docker, err = client.NewDocker(ctx.T(), e.RemoteHost.HostOutput, privateKeyPath)
-	if err != nil {
-		return err
-	}
-
 	if e.Agent != nil {
-		agent, err := client.NewDockerAgentClient(ctx.T(), e.Docker, e.Agent.ContainerName, true)
+		agent, err := client.NewDockerAgentClient(ctx.T(), e.Docker.Client, e.Agent.ContainerName, true)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/pkg/environments/dockerhost.go
+++ b/test/new-e2e/pkg/environments/dockerhost.go
@@ -24,6 +24,6 @@ type DockerHost struct {
 var _ e2e.Initializable = &DockerHost{}
 
 // Init initializes the environment
-func (e *DockerHost) Init(ctx e2e.Context) error {
+func (e *DockerHost) Init(_ e2e.Context) error {
 	return nil
 }

--- a/test/new-e2e/pkg/environments/host.go
+++ b/test/new-e2e/pkg/environments/host.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 )
 
 // Host is an environment that contains a Host, FakeIntake and Agent configured to talk to each other.
@@ -22,24 +20,11 @@ type Host struct {
 	FakeIntake *components.FakeIntake
 	Agent      *components.RemoteHostAgent
 	Updater    *components.RemoteHostUpdater
-
-	// WARN: do not use outside of the Init method
-	// Agent Client options are stored here as a workaround to make it easier to customize the agent client,
-	// but they should not be used for anything else as it should eventually be refactored differently
-	AgentClientOptions []agentclientparams.Option
 }
 
-var _ e2e.Initializable = &Host{}
+var _ e2e.Initializable = (*Host)(nil)
 
 // Init initializes the environment
-func (e *Host) Init(ctx e2e.Context) error {
-	if e.Agent != nil {
-		agent, err := client.NewHostAgentClientWithParams(ctx, e.RemoteHost.HostOutput, e.AgentClientOptions...)
-		if err != nil {
-			return err
-		}
-		e.Agent.Client = agent
-	}
-
+func (e *Host) Init(_ e2e.Context) error {
 	return nil
 }

--- a/test/new-e2e/pkg/environments/host_win.go
+++ b/test/new-e2e/pkg/environments/host_win.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 )
 
 // WindowsHost is an environment based on environments.Host but that is specific to Windows.
@@ -22,24 +20,11 @@ type WindowsHost struct {
 	FakeIntake      *components.FakeIntake
 	Agent           *components.RemoteHostAgent
 	ActiveDirectory *components.RemoteActiveDirectory
-
-	// WARN: do not use outside of the Init method
-	// Agent Client options are stored here as a workaround to make it easier to customize the agent client,
-	// but they should not be used for anything else as it should eventually be refactored differently
-	AgentClientOptions []agentclientparams.Option
 }
 
 var _ e2e.Initializable = &WindowsHost{}
 
 // Init initializes the environment
-func (e *WindowsHost) Init(ctx e2e.Context) error {
-	if e.Agent != nil {
-		agent, err := client.NewHostAgentClientWithParams(ctx, e.RemoteHost.HostOutput, e.AgentClientOptions...)
-		if err != nil {
-			return err
-		}
-		e.Agent.Client = agent
-	}
-
+func (e *WindowsHost) Init(_ e2e.Context) error {
 	return nil
 }

--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -6,12 +6,12 @@
 package client
 
 import (
-	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	"github.com/DataDog/test-infra-definitions/components/remote"
 )
 
@@ -52,10 +52,12 @@ func NewHostAgentClientWithParams(context e2e.Context, hostOutput remote.HostOut
 }
 
 // NewDockerAgentClient creates an Agent client for a Docker install
-func NewDockerAgentClient(t *testing.T, docker *Docker, agentContainerName string, waitForAgentReady bool) (agentclient.Agent, error) {
-	commandRunner := newAgentCommandRunner(t, newAgentDockerExecutor(docker, agentContainerName))
+func NewDockerAgentClient(context e2e.Context, dockerAgentOutput agent.DockerAgentOutput, options ...agentclientparams.Option) (agentclient.Agent, error) {
+	params := agentclientparams.NewParams(options...)
+	ae := newAgentDockerExecutor(context, dockerAgentOutput)
+	commandRunner := newAgentCommandRunner(context.T(), ae)
 
-	if waitForAgentReady {
+	if params.ShouldWaitForReady {
 		if err := commandRunner.waitForReadyTimeout(agentReadyTimeout); err != nil {
 			return nil, err
 		}

--- a/test/new-e2e/pkg/utils/e2e/client/agent_docker.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_docker.go
@@ -5,6 +5,11 @@
 
 package client
 
+import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
+)
+
 type agentDockerExecutor struct {
 	dockerClient       *Docker
 	agentContainerName string
@@ -12,10 +17,14 @@ type agentDockerExecutor struct {
 
 var _ agentCommandExecutor = &agentDockerExecutor{}
 
-func newAgentDockerExecutor(dockerClient *Docker, agentContainerName string) *agentDockerExecutor {
+func newAgentDockerExecutor(context e2e.Context, dockerAgentOutput agent.DockerAgentOutput) *agentDockerExecutor {
+	dockerClient, err := NewDocker(context.T(), dockerAgentOutput.DockerManager)
+	if err != nil {
+		panic(err)
+	}
 	return &agentDockerExecutor{
 		dockerClient:       dockerClient,
-		agentContainerName: agentContainerName,
+		agentContainerName: dockerAgentOutput.ContainerName,
 	}
 }
 

--- a/test/new-e2e/pkg/utils/e2e/client/docker.go
+++ b/test/new-e2e/pkg/utils/e2e/client/docker.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DataDog/test-infra-definitions/components/remote"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
+	"github.com/DataDog/test-infra-definitions/components/docker"
 	"github.com/docker/cli/cli/connhelper"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -29,10 +31,15 @@ type Docker struct {
 
 // NewDocker creates a new instance of Docker
 // NOTE: docker+ssh does not support password protected SSH keys.
-func NewDocker(t *testing.T, host remote.HostOutput, privateKeyPath string) (*Docker, error) {
-	deamonURL := fmt.Sprintf("ssh://%v@%v", host.Username, host.Address)
+func NewDocker(t *testing.T, dockerOutput docker.ManagerOutput) (*Docker, error) {
+	deamonURL := fmt.Sprintf("ssh://%v@%v", dockerOutput.Host.Username, dockerOutput.Host.Address)
 
 	sshOpts := []string{"-o", "StrictHostKeyChecking no"}
+
+	privateKeyPath, err := runner.GetProfile().ParamStore().GetWithDefault(parameters.PrivateKeyPath, "")
+	if err != nil {
+		return nil, err
+	}
 	if privateKeyPath != "" {
 		sshOpts = append(sshOpts, "-i", privateKeyPath)
 	}

--- a/test/new-e2e/tests/ndm/netflow/netflow_test.go
+++ b/test/new-e2e/tests/ndm/netflow/netflow_test.go
@@ -81,7 +81,7 @@ func netflowDockerProvisioner() e2e.Provisioner {
 			return err
 		}
 
-		dockerManager, _, err := docker.NewManager(&awsEnv, host, utils.PulumiDependsOn(installEcrCredsHelperCmd))
+		dockerManager, err := docker.NewManager(&awsEnv, host, utils.PulumiDependsOn(installEcrCredsHelperCmd))
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/tests/ndm/netflow/netflow_test.go
+++ b/test/new-e2e/tests/ndm/netflow/netflow_test.go
@@ -85,6 +85,10 @@ func netflowDockerProvisioner() e2e.Provisioner {
 		if err != nil {
 			return err
 		}
+		err = dockerManager.Export(ctx, &env.Docker.ManagerOutput)
+		if err != nil {
+			return err
+		}
 
 		envVars := pulumi.StringMap{"CONFIG_DIR": pulumi.String(configPath)}
 		composeDependencies := []pulumi.Resource{configCommand}

--- a/test/new-e2e/tests/ndm/snmp/snmp_test.go
+++ b/test/new-e2e/tests/ndm/snmp/snmp_test.go
@@ -98,7 +98,7 @@ func snmpDockerProvisioner() e2e.Provisioner {
 			return err
 		}
 
-		dockerManager, _, err := docker.NewManager(&awsEnv, host)
+		dockerManager, err := docker.NewManager(&awsEnv, host)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_containerized_test.go
@@ -56,7 +56,7 @@ func dockerHostHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[dockerHostNginxEnv] 
 		}
 
 		// install docker.io
-		manager, _, err := docker.NewManager(&awsEnv, nginxHost)
+		manager, err := docker.NewManager(&awsEnv, nginxHost)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -59,7 +59,7 @@ func hostDockerHttpbinEnvProvisioner(opt ...awshost.ProvisionerOption) e2e.Pulum
 		}
 
 		// install docker.io
-		manager, _, err := docker.NewManager(&awsEnv, nginxHost)
+		manager, err := docker.NewManager(&awsEnv, nginxHost)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/tests/npm/ecs_1host_test.go
+++ b/test/new-e2e/tests/npm/ecs_1host_test.go
@@ -52,7 +52,7 @@ func ecsHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[ecsHttpbinEnv] {
 		}
 
 		// install docker.io
-		manager, _, err := docker.NewManager(&awsEnv, nginxHost)
+		manager, err := docker.NewManager(&awsEnv, nginxHost)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

* bump test-infra-definitions to include changes from https://github.com/DataDog/test-infra-definitions/pull/817
* make agent component self initializable
* make docker manager component self initializable
* make docker agent component self initializable

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This PR is the door to allow having custom environments with no need for custom init functions, with out of the box components. Given most frequently used components have all their config in the exported output from pulumi, we can now init those components autonomously. 

This adds one ssh client per component: the agent on host has its own instance of an ssh client. This loosen the dependency between the agent client and the host client. If a test environment do not care about interacting with the host, it can skip its export.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Best reviewed commit per commit

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Include changes to allow nested components DataDog/test-infra-definitions#817