### PR TITLE
logs/sds: delete existing scanners when an update with 0 configuration is received through RC

### DIFF
--- a/comp/logs/agent/agent.go
+++ b/comp/logs/agent/agent.go
@@ -335,7 +335,7 @@ func (a *agent) onUpdateSDSAgentConfig(updates map[string]state.RawConfig, apply
 	var err error
 
 	// We received a hit that new updates arrived, but if the list of updates
-	// is empty, it means we don't have any updates applying to thsi agent anymore
+	// is empty, it means we don't have any updates applying to this agent anymore
 	// Send a reconfiguration with an empty payload, indicating that
 	// the scanners have to be dropped.
 	if len(updates) == 0 {

--- a/comp/logs/agent/agent.go
+++ b/comp/logs/agent/agent.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"go.uber.org/atomic"
 	"go.uber.org/fx"
 
@@ -308,7 +309,7 @@ func (a *agent) onUpdateSDSRules(updates map[string]state.RawConfig, applyStateC
 	var err error
 	for _, config := range updates {
 		if rerr := a.pipelineProvider.ReconfigureSDSStandardRules(config.Config); rerr != nil {
-			err = rerr
+			err = multierror.Append(err, rerr)
 		}
 	}
 
@@ -342,7 +343,7 @@ func (a *agent) onUpdateSDSAgentConfig(updates map[string]state.RawConfig, apply
 	} else {
 		for _, config := range updates {
 			if rerr := a.pipelineProvider.ReconfigureSDSAgentConfig(config.Config); rerr != nil {
-				err = rerr
+				err = multierror.Append(err, rerr)
 			}
 		}
 	}

--- a/comp/otelcol/logsagentpipeline/go.mod
+++ b/comp/otelcol/logsagentpipeline/go.mod
@@ -109,6 +109,8 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/comp/otelcol/logsagentpipeline/go.sum
+++ b/comp/otelcol/logsagentpipeline/go.sum
@@ -191,6 +191,10 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9G
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.13.0/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
@@ -120,6 +120,8 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.sum
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.sum
@@ -191,6 +191,10 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9G
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.13.0/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/pkg/logs/pipeline/go.mod
+++ b/pkg/logs/pipeline/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/status/health v0.54.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/util/log v0.54.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/util/startstop v0.54.0-rc.2
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/atomic v1.11.0
 )
@@ -109,6 +110,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/pkg/logs/pipeline/go.sum
+++ b/pkg/logs/pipeline/go.sum
@@ -191,6 +191,10 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9G
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.13.0/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -8,6 +8,7 @@ package pipeline
 import (
 	"context"
 
+	"github.com/hashicorp/go-multierror"
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
@@ -133,7 +134,7 @@ func (p *provider) reconfigureSDS(config []byte, orderType sds.ReconfigureOrderT
 	for _, response := range responses {
 		err := <-response
 		if err != nil {
-			rerr = err
+			rerr = multierror.Append(rerr, err)
 		}
 		close(response)
 	}

--- a/pkg/logs/sds/scanner_test.go
+++ b/pkg/logs/sds/scanner_test.go
@@ -203,6 +203,77 @@ func TestCreateScanner(t *testing.T) {
 	require.Len(s.configuredRules, 0, "The group is disabled, no rules should be configured.")
 }
 
+// TestEmptyConfiguration validates that the scanner is destroyed when receiving
+// an empty configuration.
+func TestEmptyConfiguration(t *testing.T) {
+	require := require.New(t)
+
+	standardRules := []byte(`
+        {"priority":1,"is_enabled":true,"rules":[
+            {
+                "id":"zero-0",
+                "description":"zero desc",
+                "name":"zero",
+                "definitions": [{"version":1, "pattern":"zero"}]
+            },{
+                "id":"one-1",
+                "description":"one desc",
+                "name":"one",
+                "definitions": [{"version":1, "pattern":"one"}]
+            },{
+                "id":"two-2",
+                "description":"two desc",
+                "name":"two",
+                "definitions": [{"version":1, "pattern":"two"}]
+            }
+        ]}
+    `)
+	agentConfig := []byte(`
+        {"is_enabled":true,"rules":[
+            {
+                "id": "random000",
+                "name":"zero",
+                "definition":{"standard_rule_id":"zero-0"},
+                "match_action":{"type":"Redact","placeholder":"[redacted]"},
+                "is_enabled":true
+            }
+        ]}
+    `)
+
+	s := CreateScanner(0)
+
+	require.NotNil(s, "the scanner should not be nil after a creation")
+
+	err := s.Reconfigure(ReconfigureOrder{
+		Type:   StandardRules,
+		Config: standardRules,
+	})
+
+	require.NoError(err, "configuring the standard rules should not fail")
+
+	// configure with one rule
+
+	err = s.Reconfigure(ReconfigureOrder{
+		Type:   AgentConfig,
+		Config: agentConfig,
+	})
+
+	require.NoError(err, "this one should not fail since one rule is enabled")
+	require.Len(s.configuredRules, 1, "only one rules should be part of this scanner")
+	require.NotNil(s.Scanner)
+
+	// empty reconfiguration
+
+	err = s.Reconfigure(ReconfigureOrder{
+		Type:   AgentConfig,
+		Config: []byte("{}"),
+	})
+
+	require.NoError(err)
+	require.Len(s.configuredRules, 0)
+	require.Nil(s.Scanner)
+}
+
 func TestIsReady(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
APR-94

### What does this PR do?

When an Agent isn't targeted _anymore_, it is receiving an update with no configuration.
In this scenario for the SDS "agent config" configurations, we have to make sure existing scanners are dropped.

### Motivation

Fix the behaviour when an Agent isn't targeted anymore.

### Describe how to test/QA your changes

* In an org with RC & SDS enabled
* Configure a scanning group for your agent to receive a configuration through the UI
* Make sure it is reconfiguring itself
* Change the scanning group to not target this agent anymore
* Make sure the Agent is reconfiguring itself (destroying its scanners)