### PR TITLE
Replace deb/rpm injection path

### DIFF
--- a/pkg/fleet/installer/service/apm_inject_test.go
+++ b/pkg/fleet/installer/service/apm_inject_test.go
@@ -26,6 +26,8 @@ func TestSetLDPreloadConfig(t *testing.T) {
 		"/abc/def/preload.so\n": "/abc/def/preload.so\n/tmp/stable/inject/launcher.preload.so\n",
 		// File contains unrelated entries with no newline
 		"/abc/def/preload.so": "/abc/def/preload.so\n/tmp/stable/inject/launcher.preload.so\n",
+		// File contains old preload instructions
+		"banana\n/opt/datadog/apm/inject/launcher.preload.so\ntomato": "banana\n/tmp/stable/inject/launcher.preload.so\ntomato",
 	} {
 		output, err := a.setLDPreloadConfigContent([]byte(input))
 		assert.Nil(t, err)

--- a/pkg/fleet/installer/service/docker_test.go
+++ b/pkg/fleet/installer/service/docker_test.go
@@ -74,26 +74,37 @@ func TestRemoveDockerConfig(t *testing.T) {
 		installPath: "/tmp/stable",
 	}
 
-	for input, expected := range map[string]string{
-		// Empty file, shouldn't happen but still tested
-		"": `{
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:  "EmptyFile",
+			input: "",
+			expected: `{
     "default-runtime": "runc",
     "runtimes": {}
 }`,
-		// File only contains the injected content
-		`{
-			"default-runtime": "dd-shim",
-			"runtimes": {
-				"dd-shim": {
-					"path": "/tmp/stable/inject/auto_inject_runc"
-				}
-			}
-		}`: `{
+		},
+		{
+			name: "FileOnlyWithInjectedContent",
+			input: `{
+    "default-runtime": "dd-shim",
+    "runtimes": {
+        "dd-shim": {
+            "path": "/tmp/stable/inject/auto_inject_runc"
+        }
+    }
+}`,
+			expected: `{
     "default-runtime": "runc",
     "runtimes": {}
 }`,
-		// File contained unrelated entries
-		`{
+		},
+		{
+			name: "FileWithUnrelatedEntries",
+			input: `{
     "cgroup-parent": "abc",
     "default-runtime": "dd-shim",
     "raw-logs": false,
@@ -102,14 +113,17 @@ func TestRemoveDockerConfig(t *testing.T) {
             "path": "/tmp/stable/inject/auto_inject_runc"
         }
     }
-}`: `{
+}`,
+			expected: `{
     "cgroup-parent": "abc",
     "default-runtime": "runc",
     "raw-logs": false,
     "runtimes": {}
 }`,
-		// File had already overridden the default runtime
-		`{
+		},
+		{
+			name: "FileWithOverriddenDefaultRuntime",
+			input: `{
     "default-runtime": "containerd",
     "runtimes": {
         "containerd": {
@@ -119,7 +133,8 @@ func TestRemoveDockerConfig(t *testing.T) {
             "path": "/tmp/stable/inject/auto_inject_runc"
         }
     }
-}`: `{
+}`,
+			expected: `{
     "default-runtime": "containerd",
     "runtimes": {
         "containerd": {
@@ -127,9 +142,35 @@ func TestRemoveDockerConfig(t *testing.T) {
         }
     }
 }`,
-	} {
-		output, err := a.deleteDockerConfigContent([]byte(input))
-		assert.Nil(t, err)
-		assert.Equal(t, expected, string(output))
+		},
+		{
+			name: "ReplaceOldInjectedContent",
+			input: `{
+    "default-runtime": "containerd",
+    "runtimes": {
+        "containerd": {
+            "path": "/usr/bin/containerd"
+        },
+        "dd-shim": {
+            "path": "/tmp/stable/inject/auto_inject_runc"
+        }
+    }
+}`,
+			expected: `{
+    "default-runtime": "containerd",
+    "runtimes": {
+        "containerd": {
+            "path": "/usr/bin/containerd"
+        }
+    }
+}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := a.deleteDockerConfigContent([]byte(tc.input))
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected, string(output))
+		})
 	}
 }


### PR DESCRIPTION
If deb/rpm apm-inject is installed, overwrite the injector paths on datadog-installer installs injection
- docker: did not nothing but add a test as it already replaced
- ldpreload: swap the path + tests

Other change, if the socket is defined in env vars, don't instrument datadog config

