### PR TITLE
[CONTINT-4143] Mark `TestCPU` as flaky

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	"github.com/DataDog/agent-payload/v5/sbom"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"gopkg.in/zorkian/go-datadog-api.v2"
@@ -447,6 +448,9 @@ func (suite *k8sSuite) TestRedis() {
 }
 
 func (suite *k8sSuite) TestCPU() {
+	// TODO: https://datadoghq.atlassian.net/browse/CONTINT-4143
+	flake.Mark(suite.T())
+
 	// Test CPU metrics
 	suite.testMetric(&testMetricArgs{
 		Filter: testMetricFilterArgs{


### PR DESCRIPTION
### What does this PR do?

Mark `Test(EKS|Kind)Suite/TestCPU` as flaky.

### Motivation

Something happened on Feb 28th between 14:00 and 17:30 that made `container.cpu.usage{kube_deployment:stress-ng,kube_namespace:workload-cpustress}` become very “shaky”. The values are sometimes above the expectation, sometimes below.

![image](https://github.com/DataDog/datadog-agent/assets/1437785/9a24167c-bd44-4145-92c2-463a038428e8)

### Additional Notes

Investigation notebook: https://dddev.datadoghq.com/notebook/7907118/l%C3%A9na%C3%AFc-apr-15-2024-13-17

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
