### PR TITLE
Catch cache cloning errors and continue

### DIFF
--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from invoke import task
+from invoke.exceptions import UnexpectedExit
 
 from tasks.flavor import AgentFlavor
 from tasks.go import deps
@@ -265,9 +266,13 @@ def build(
                 with timed(quiet=True) as restore_cache:
                     # Allow failure in case the cache was evicted
                     if ctx.run(f"{aws_cmd} s3 cp --only-show-errors {git_cache_url} {bundle_path}", warn=True):
-                        print(f'Successfully restored cache {cache_key}')
-                        ctx.run(f"git clone --mirror {bundle_path} {omnibus_cache_dir}", err_stream=sys.stdout)
-                        cache_state = ctx.run(f"git -C {omnibus_cache_dir} tag -l").stdout
+                        print(f'Successfully retrieved cache {cache_key}')
+                        try:
+                            ctx.run(f"git clone --mirror {bundle_path} {omnibus_cache_dir}")
+                        except UnexpectedExit as exc:
+                            print(f"An error occurring while cloning the cache repo: {exc}")
+                        else:
+                            cache_state = ctx.run(f"git -C {omnibus_cache_dir} tag -l").stdout
                     else:
                         print(f'Failed to restore cache from key {cache_key}')
                         send_cache_miss_event(


### PR DESCRIPTION
### What does this PR do?

Continue building even if we can't clone the cache due to some sort of corruption.

### Motivation

Avoid disruption caused by errors when cloning from the cache git bundle, such as https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/504828928#L178.

### Additional Notes

The issue is probably related to what's described in https://github.com/aws/aws-sdk-go/issues/4986. I.e. when we have a lot of activity, and a download happens at the same time as an upload, the downloaded file may be subject to read skew and have a mix of versions.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
