### PR TITLE
[CWS] skip octogon constants test if in-kernel BTF is available

### DIFF
--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -56,6 +56,10 @@ var BTFVsFallbackPossiblyMissingConstants = []string{
 func TestOctogonConstants(t *testing.T) {
 	SkipIfNotAvailable(t)
 
+	if _, err := constantfetch.NewBTFConstantFetcherFromCurrentKernel(); err == nil {
+		t.Skipf("this kernel has BTF data available, skipping octogon")
+	}
+
 	if err := initLogger(); err != nil {
 		t.Fatal(err)
 	}
@@ -117,17 +121,6 @@ func TestOctogonConstants(t *testing.T) {
 		fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
 
 		assertConstantsEqual(t, btfhubFetcher, fallbackFetcher, kv, BTFHubVsFallbackPossiblyMissingConstants)
-	})
-
-	t.Run("btf-vs-fallback", func(t *testing.T) {
-		btfFetcher, err := constantfetch.NewBTFConstantFetcherFromCurrentKernel()
-		if err != nil {
-			t.Skipf("btf constant fetcher is not available: %v", err)
-		}
-
-		fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
-
-		assertConstantContains(t, btfFetcher, fallbackFetcher, kv, BTFVsFallbackPossiblyMissingConstants)
 	})
 
 	t.Run("guesser-vs-rc", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

The octogon constants tests are important for old kernels where the fallback might actually be exercised (because of kernel updates without btfhub, or failure of kernel header download). Recent kernels with BTF will never exercice the fallback code path, as such it's mostly a burden to maintain it without real gain. This PR skips the octogon tests if BTF is available.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
