### PR TITLE
[process-agent] Move use of telemetry component

### DIFF
--- a/comp/process/agent/agentimpl/agent.go
+++ b/comp/process/agent/agentimpl/agent.go
@@ -14,7 +14,6 @@ import (
 	logComponent "github.com/DataDog/datadog-agent/comp/core/log"
 	statusComponent "github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
-	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/process/agent"
 	expvars "github.com/DataDog/datadog-agent/comp/process/expvars/expvarsimpl"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
@@ -53,7 +52,6 @@ type dependencies struct {
 	Submitter      submitterComp.Component
 	SysProbeConfig sysprobeconfig.Component
 	HostInfo       hostinfo.Component
-	Telemetry      telemetry.Component
 }
 
 type processAgent struct {
@@ -108,7 +106,7 @@ func newProcessAgent(deps dependencies) provides {
 	if flavor.GetFlavor() != flavor.ProcessAgent {
 		// We return a status provider when the component is used outside of the process agent
 		// as the component status is unique from the typical agent status in this case.
-		err := expvars.InitProcessStatus(deps.Config, deps.SysProbeConfig, deps.HostInfo, deps.Log, deps.Telemetry)
+		err := expvars.InitProcessStatus(deps.Config, deps.SysProbeConfig, deps.HostInfo, deps.Log)
 		if err != nil {
 			_ = deps.Log.Critical("Failed to initialize process status server:", err)
 		}

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -8,7 +8,9 @@
 package agentimpl
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -16,6 +18,8 @@ import (
 
 	configComp "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
 	"github.com/DataDog/datadog-agent/comp/process/agent"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo/hostinfoimpl"
 	"github.com/DataDog/datadog-agent/comp/process/processcheck/processcheckimpl"
@@ -195,4 +199,53 @@ func TestStatusProvider(t *testing.T) {
 			assert.IsType(t, tc.expected, provides.StatusProvider.Provider)
 		})
 	}
+}
+
+func TestTelemetryCoreAgent(t *testing.T) {
+	originalFlavor := flavor.GetFlavor()
+	defer flavor.SetFlavor(originalFlavor)
+	flavor.SetFlavor("agent")
+
+	deps := fxutil.Test[dependencies](t, fx.Options(
+		runnerimpl.Module(),
+		hostinfoimpl.MockModule(),
+		submitterimpl.MockModule(),
+		taggerimpl.MockModule(),
+		Module(),
+		fx.Replace(configComp.MockParams{Overrides: map[string]interface{}{
+			"process_config.run_in_core_agent.enabled": true,
+			"telemetry.enabled": true,
+		}}),
+		processcheckimpl.MockModule(),
+		fx.Provide(func() func(c *checkMocks.Check) {
+			return func(c *checkMocks.Check) {
+				c.On("Init", mock.Anything, mock.Anything, mock.AnythingOfType("bool")).Return(nil).Maybe()
+				c.On("Name").Return(checks.ProcessCheckName).Maybe()
+				c.On("SupportsRunOptions").Return(false).Maybe()
+				c.On("Realtime").Return(false).Maybe()
+				c.On("Cleanup").Maybe()
+				c.On("Run", mock.Anything, mock.Anything).Return(&checks.StandardRunResult{}, nil).Maybe()
+				c.On("ShouldSaveLastRun").Return(false).Maybe()
+				c.On("IsEnabled").Return(true).Maybe()
+			}
+		}),
+	))
+	_ = newProcessAgent(deps)
+
+	tel := fxutil.Test[telemetry.Mock](t, telemetryimpl.MockModule())
+	tel.Reset()
+	// Setup expvar server
+	telemetryHandler := tel.Handler()
+
+	http.Handle("/telemetry", telemetryHandler)
+
+	assert.Eventually(t, func() bool {
+		res, err := http.Get("http://localhost:5000/telemetry")
+		if err != nil {
+			return false
+		}
+		defer res.Body.Close()
+
+		return res.StatusCode == http.StatusOK
+	}, 5*time.Second, time.Second)
 }

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -241,14 +241,4 @@ func TestTelemetryCoreAgent(t *testing.T) {
 	telemetryHandler := tel.Handler()
 
 	http.Handle("/telemetry", telemetryHandler)
-
-	assert.Eventually(t, func() bool {
-		res, err := http.Get("http://localhost:5000/telemetry")
-		if err != nil {
-			return false
-		}
-		defer res.Body.Close()
-
-		return res.StatusCode == http.StatusOK
-	}, 10*time.Second, time.Second)
 }

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -10,7 +10,6 @@ package agentimpl
 import (
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -214,7 +214,7 @@ func TestTelemetryCoreAgent(t *testing.T) {
 		Module(),
 		fx.Replace(configComp.MockParams{Overrides: map[string]interface{}{
 			"process_config.run_in_core_agent.enabled": true,
-			"telemetry.enabled": true,
+			"telemetry.enabled":                        true,
 		}}),
 		processcheckimpl.MockModule(),
 		fx.Provide(func() func(c *checkMocks.Check) {

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -202,6 +202,9 @@ func TestStatusProvider(t *testing.T) {
 }
 
 func TestTelemetryCoreAgent(t *testing.T) {
+	// This test catches if there are multiple handlers for "/telemetry" endpoint
+	// registered to help avoid introducing panics.
+
 	originalFlavor := flavor.GetFlavor()
 	defer flavor.SetFlavor(originalFlavor)
 	flavor.SetFlavor("agent")
@@ -247,5 +250,5 @@ func TestTelemetryCoreAgent(t *testing.T) {
 		defer res.Body.Close()
 
 		return res.StatusCode == http.StatusOK
-	}, 5*time.Second, time.Second)
+	}, 10*time.Second, time.Second)
 }

--- a/pkg/process/status/expvars.go
+++ b/pkg/process/status/expvars.go
@@ -11,7 +11,6 @@ package status
 import (
 	"bufio"
 	"expvar"
-	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -21,7 +20,6 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 
-	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
@@ -248,7 +246,7 @@ func publishDropCheckPayloads() interface{} {
 }
 
 // InitExpvars initializes expvars
-func InitExpvars(config ddconfig.Reader, telemetry telemetry.Component, hostname string, processModuleEnabled, languageDetectionEnabled bool, eps []apicfg.Endpoint) {
+func InitExpvars(config ddconfig.Reader, hostname string, processModuleEnabled, languageDetectionEnabled bool, eps []apicfg.Endpoint) {
 	infoOnce.Do(func() {
 		processExpvars := expvar.NewMap("process_agent")
 		hostString := expvar.NewString("host")
@@ -284,9 +282,4 @@ func InitExpvars(config ddconfig.Reader, telemetry telemetry.Component, hostname
 		processExpvars.Set("workloadmeta_extractor_stale_diffs", publishInt(&infoWlmExtractorStaleDiffs))
 		processExpvars.Set("workloadmeta_extractor_diffs_dropped", publishInt(&infoWlmExtractorDiffsDropped))
 	})
-
-	// Run a profile & telemetry server.
-	if config.GetBool("telemetry.enabled") {
-		http.Handle("/telemetry", telemetry.Handler())
-	}
 }

--- a/releasenotes/notes/process-telemetry-fix-4508fe2fa39957d0.yaml
+++ b/releasenotes/notes/process-telemetry-fix-4508fe2fa39957d0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix panic when running process checks in the core Agent with telemetry enabled.


### PR DESCRIPTION
### What does this PR do?

This PR moves the use of the telemetry component from `expvars.InitExpvars` to `expvars.newExpvarServer`.

### Motivation

The current location could cause panics on startup on the core agent when the `telemetry.enabled` config is set to `true` as it would result in multiple handlers being registered for the same endpoint. This only occurs when running the process checks in the core agent.

```
panic: http: multiple registrations for /telemetry

goroutine 1 [running]:
net/http.(*ServeMux).Handle(0xbd20100, {0x72ab32a, 0xa}, {0x82029c0, 0x4001c23e60})
	/home/vagrant/.gimme/versions/go1.21.8.linux.arm64/src/net/http/server.go:2530 +0x3a4
net/http.Handle({0x72ab32a, 0xa}, {0x82029c0, 0x4001c23e60})
	/home/vagrant/.gimme/versions/go1.21.8.linux.arm64/src/net/http/server.go:2573 +0x48
github.com/DataDog/datadog-agent/cmd/agent/subcommands/run.startAgent({_, _}, {_, _}, {_, _}, {_, _}, {_, _}, ...)
	/git/datadog-agent/cmd/agent/subcommands/run/command.go:514 +0x4b0
github.com/DataDog/datadog-agent/cmd/agent/subcommands/run.run({_, _}, {_, _}, {_, _}, {_, _}, {_, _}, ...)
	/git/datadog-agent/cmd/agent/subcommands/run/command.go:279 +0x558
reflect.Value.call({0x70db3e0, 0x7a170c0, 0x13}, {0x729186b, 0x4}, {0x400127c800, 0x26, 0x26})
	/home/vagrant/.gimme/versions/go1.21.8.linux.arm64/src/reflect/value.go:596 +0x9e8
reflect.Value.Call({0x70db3e0, 0x7a170c0, 0x13}, {0x400127c800, 0x26, 0x26})
	/home/vagrant/.gimme/versions/go1.21.8.linux.arm64/src/reflect/value.go:380 +0x74
github.com/DataDog/datadog-agent/pkg/util/fxutil.(*delayedFxInvocation).call(0x4001168ac0)
	/git/datadog-agent/pkg/util/fxutil/args.go:72 +0x94
github.com/DataDog/datadog-agent/pkg/util/fxutil.OneShot({0x70db3e0, 0x7a170c0}, {0x4000fc74d0, 0x9, 0x9})
	/git/datadog-agent/pkg/util/fxutil/oneshot.go:55 +0x510
github.com/DataDog/datadog-agent/cmd/agent/subcommands/run.Commands.func1(0x4001160600, {0xc2bafe0, 0x0, 0x0})
	/git/datadog-agent/cmd/agent/subcommands/run/command.go:165 +0x5c8
github.com/spf13/cobra.(*Command).execute(0x4001160600, {0xc2bafe0, 0x0, 0x0})
	/home/vagrant/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xbd8
github.com/spf13/cobra.(*Command).ExecuteC(0x40010aaf00)
	/home/vagrant/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x7b4
github.com/spf13/cobra.(*Command).Execute(0x40010aaf00)
	/home/vagrant/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x30
github.com/DataDog/datadog-agent/cmd/internal/runcmd.Run(0x40010aaf00)
	/git/datadog-agent/cmd/internal/runcmd/runcmd.go:27 +0x34
main.main()
	/git/datadog-agent/cmd/agent/main.go:69 +0x468
```

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Verify the crash no longer occurs.

1. Use the following config:
```
telemetry:
  enabled: true

process_config:
  process_collection:
    enabled: true
  run_in_core_agent:
    enabled: true
```
2. Run the agent and make sure no crash occurs
```
$ datadog-agent run
```
3. Switch process checks to the process agent
```
 run_in_core_agent:
    enabled: false
```
4. Verify the agents still report telemetry on their servers.
```
// core agent
$ curl http://localhost:5000/telemetry
// Process Agent
$ curl http://localhost:6062/telemetry
```
