### PR TITLE
[windows][cws] Improve performance of CWS ETW handling

### DIFF
--- a/comp/etw/component.go
+++ b/comp/etw/component.go
@@ -166,6 +166,21 @@ type SessionConfiguration struct {
 	MaxBuffers uint32
 }
 
+// SessionStatistics contains statistics about the session
+type SessionStatistics struct {
+	// NumberOfBuffers is the number of buffers allocated for the session
+	NumberOfBuffers uint32
+	// FreeBuffers is the number of buffers that are free
+	FreeBuffers uint32
+	// EventsLost is the number of events not recorded
+	EventsLost uint32
+	// BuffersWritten is the number of buffers written
+	BuffersWritten uint32
+	// LogBuffersLost is the number of log buffers lost
+	LogBuffersLost uint32
+	// RealTimeBuffersLost is the number of real-time buffers lost
+	RealTimeBuffersLost uint32
+}
 // SessionConfigurationFunc is a function used to configure a session
 type SessionConfigurationFunc func(cfg *SessionConfiguration)
 
@@ -189,6 +204,9 @@ type Session interface {
 	// StopTracing stops all tracing activities.
 	// It's not possible to use the session anymore after a call to StopTracing.
 	StopTracing() error
+
+	// GetSessionStatistics returns statistics about the session
+	GetSessionStatistics() (SessionStatistics, error)
 }
 
 // Component offers a way to create ETW tracing sessions with a given name.

--- a/comp/etw/component.go
+++ b/comp/etw/component.go
@@ -160,6 +160,15 @@ type ProviderConfiguration struct {
 // ProviderConfigurationFunc is a function used to configure a provider
 type ProviderConfigurationFunc func(cfg *ProviderConfiguration)
 
+// SessionConfiguration is a structure containing all the configuration options for an ETW session
+type SessionConfiguration struct {
+	//MaxBuffers is the maximum number of buffers for ETW to allocate.  The default is 0
+	MaxBuffers uint32
+}
+
+// SessionConfigurationFunc is a function used to configure a session
+type SessionConfigurationFunc func(cfg *SessionConfiguration)
+
 // Session represents an ETW session. A session can have multiple tracing providers enabled.
 type Session interface {
 	// ConfigureProvider configures a particular ETW provider identified by its GUID for this session.
@@ -184,7 +193,7 @@ type Session interface {
 
 // Component offers a way to create ETW tracing sessions with a given name.
 type Component interface {
-	NewSession(sessionName string) (Session, error)
+	NewSession(sessionName string, f SessionConfigurationFunc) (Session, error)
 	NewWellKnownSession(sessionName string) (Session, error)
 }
 

--- a/comp/etw/impl/etwImpl.go
+++ b/comp/etw/impl/etwImpl.go
@@ -28,8 +28,8 @@ func NewEtw() (etw.Component, error) {
 type etwImpl struct {
 }
 
-func (s *etwImpl) NewSession(sessionName string) (etw.Session, error) {
-	session, err := createEtwSession(sessionName)
+func (s *etwImpl) NewSession(sessionName string, f etw.SessionConfigurationFunc) (etw.Session, error) {
+	session, err := createEtwSession(sessionName, f)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/trace/etwtracer/etwtracerimpl/etwtracerimpl.go
+++ b/comp/trace/etwtracer/etwtracerimpl/etwtracerimpl.go
@@ -275,7 +275,7 @@ func (a *etwtracerimpl) start(_ context.Context) error {
 	a.log.Infof("Starting Datadog APM ETW tracer component")
 	var err error
 	etwSessionName := "Datadog APM ETW tracer"
-	a.session, err = a.etw.NewSession(etwSessionName)
+	a.session, err = a.etw.NewSession(etwSessionName, func(cfg *etw.SessionConfiguration) {})
 	if err != nil {
 		a.log.Errorf("Failed to create the ETW session '%s': %v", etwSessionName, err)
 		// Don't fail the Agent startup

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -42,6 +42,8 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.SetDefault("runtime_security_config.etw_events_channel_size", 0)
 	cfg.SetDefault("runtime_security_config.etw_events_max_buffers", 0)
 	cfg.SetDefault("runtime_security_config.windows_probe_block_on_channel_send", true)
+	cfg.SetDefault("runtime_security_config.windows_filename_cache_max", 16384)
+	cfg.SetDefault("runtime_security_config.windows_registry_cache_max", 4096)
 
 	// CWS - activity dump
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.enabled", true)

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -39,9 +39,9 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.compliance_module.enabled", false)
 
 	// windows specific channel size for etw events
-	cfg.SetDefault("runtime_security_config.etw_events_channel_size", 2048)
+	cfg.SetDefault("runtime_security_config.etw_events_channel_size", 0)
 	cfg.SetDefault("runtime_security_config.etw_events_max_buffers", 0)
-	cfg.SetDefault("runtime_security_config.windows_probe_channel_unbuffered", true)
+	cfg.SetDefault("runtime_security_config.windows_probe_block_on_channel_send", true)
 
 	// CWS - activity dump
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.enabled", true)

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -38,6 +38,9 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.use_secruntime_track", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.compliance_module.enabled", false)
 
+	// windows specific channel size for etw events
+	cfg.SetDefault("runtime_security_config.etw_events_channel_size", 2048)
+
 	// CWS - activity dump
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.cleanup_period", "30s")

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -41,6 +41,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// windows specific channel size for etw events
 	cfg.SetDefault("runtime_security_config.etw_events_channel_size", 2048)
 	cfg.SetDefault("runtime_security_config.etw_events_max_buffers", 0)
+	cfg.SetDefault("runtime_security_config.windows_probe_channel_unbuffered", true)
 
 	// CWS - activity dump
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.enabled", true)

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -40,6 +40,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	// windows specific channel size for etw events
 	cfg.SetDefault("runtime_security_config.etw_events_channel_size", 2048)
+	cfg.SetDefault("runtime_security_config.etw_events_max_buffers", 0)
 
 	// CWS - activity dump
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.enabled", true)

--- a/pkg/network/protocols/http/etw_interface.go
+++ b/pkg/network/protocols/http/etw_interface.go
@@ -50,7 +50,7 @@ func NewEtwInterface(c *config.Config) (*EtwInterface, error) {
 		return nil, err
 	}
 
-	ei.session, err = etwcomp.NewSession(etwSessionName)
+	ei.session, err = etwcomp.NewSession(etwSessionName, func(cfg *etw.SessionConfiguration) {} )
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -232,7 +232,7 @@ type RuntimeSecurityConfig struct {
 	ETWEventsMaxBuffers int
 
 	// WindowsProbeChannelUnbuffered defines if the windows probe channel should be unbuffered
-	WindowsProbeChannelUnbuffered bool
+	WindowsProbeBlockOnChannelSend bool
 }
 
 // Config defines a security config
@@ -286,11 +286,11 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 	}
 
 	rsConfig := &RuntimeSecurityConfig{
-		RuntimeEnabled:       coreconfig.SystemProbe.GetBool("runtime_security_config.enabled"),
-		FIMEnabled:           coreconfig.SystemProbe.GetBool("runtime_security_config.fim_enabled"),
-		ETWEventsChannelSize: coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_channel_size"),
-		ETWEventsMaxBuffers:  coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_max_buffers"),
-		WindowsProbeChannelUnbuffered: coreconfig.SystemProbe.GetBool("runtime_security_config.windows_probe_channel_unbuffered"),
+		RuntimeEnabled:                 coreconfig.SystemProbe.GetBool("runtime_security_config.enabled"),
+		FIMEnabled:                     coreconfig.SystemProbe.GetBool("runtime_security_config.fim_enabled"),
+		ETWEventsChannelSize:           coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_channel_size"),
+		ETWEventsMaxBuffers:            coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_max_buffers"),
+		WindowsProbeBlockOnChannelSend: coreconfig.SystemProbe.GetBool("runtime_security_config.windows_probe_block_on_channel_send"),
 
 		SocketPath:           coreconfig.SystemProbe.GetString("runtime_security_config.socket"),
 		EventServerBurst:     coreconfig.SystemProbe.GetInt("runtime_security_config.event_server.burst"),

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -233,6 +233,12 @@ type RuntimeSecurityConfig struct {
 
 	// WindowsProbeChannelUnbuffered defines if the windows probe channel should be unbuffered
 	WindowsProbeBlockOnChannelSend bool
+
+	//WindowsFilenameCacheSize is the max number of filenames to cache
+	WindowsFilenameCacheSize int
+
+	//WindowsRegistryCacheSize is the max number of registry paths to cache
+	WindowsRegistryCacheSize int
 }
 
 // Config defines a security config
@@ -291,6 +297,8 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		ETWEventsChannelSize:           coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_channel_size"),
 		ETWEventsMaxBuffers:            coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_max_buffers"),
 		WindowsProbeBlockOnChannelSend: coreconfig.SystemProbe.GetBool("runtime_security_config.windows_probe_block_on_channel_send"),
+		WindowsFilenameCacheSize:       coreconfig.SystemProbe.GetInt("runtime_security_config.windows_filename_cache_max"),
+		WindowsRegistryCacheSize:       coreconfig.SystemProbe.GetInt("runtime_security_config.windows_registry_cache_max"),
 
 		SocketPath:           coreconfig.SystemProbe.GetString("runtime_security_config.socket"),
 		EventServerBurst:     coreconfig.SystemProbe.GetInt("runtime_security_config.event_server.burst"),

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -227,6 +227,9 @@ type RuntimeSecurityConfig struct {
 
 	// ETWEventsChannelSize windows specific ETW channel buffer size
 	ETWEventsChannelSize int
+
+	//ETWEventsMaxBuffers sets the maximumbuffers aregument to ETW
+	ETWEventsMaxBuffers int
 }
 
 // Config defines a security config
@@ -283,6 +286,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		RuntimeEnabled:       coreconfig.SystemProbe.GetBool("runtime_security_config.enabled"),
 		FIMEnabled:           coreconfig.SystemProbe.GetBool("runtime_security_config.fim_enabled"),
 		ETWEventsChannelSize: coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_channel_size"),
+		ETWEventsMaxBuffers:  coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_max_buffers"),
 
 		SocketPath:           coreconfig.SystemProbe.GetString("runtime_security_config.socket"),
 		EventServerBurst:     coreconfig.SystemProbe.GetInt("runtime_security_config.event_server.burst"),

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -230,6 +230,9 @@ type RuntimeSecurityConfig struct {
 
 	//ETWEventsMaxBuffers sets the maximumbuffers aregument to ETW
 	ETWEventsMaxBuffers int
+
+	// WindowsProbeChannelUnbuffered defines if the windows probe channel should be unbuffered
+	WindowsProbeChannelUnbuffered bool
 }
 
 // Config defines a security config
@@ -287,6 +290,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		FIMEnabled:           coreconfig.SystemProbe.GetBool("runtime_security_config.fim_enabled"),
 		ETWEventsChannelSize: coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_channel_size"),
 		ETWEventsMaxBuffers:  coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_max_buffers"),
+		WindowsProbeChannelUnbuffered: coreconfig.SystemProbe.GetBool("runtime_security_config.windows_probe_channel_unbuffered"),
 
 		SocketPath:           coreconfig.SystemProbe.GetString("runtime_security_config.socket"),
 		EventServerBurst:     coreconfig.SystemProbe.GetInt("runtime_security_config.event_server.burst"),

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -224,6 +224,9 @@ type RuntimeSecurityConfig struct {
 
 	// Enforcement capabilities
 	EnforcementEnabled bool
+
+	// ETWEventsChannelSize windows specific ETW channel buffer size
+	ETWEventsChannelSize int
 }
 
 // Config defines a security config
@@ -277,8 +280,9 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 	}
 
 	rsConfig := &RuntimeSecurityConfig{
-		RuntimeEnabled: coreconfig.SystemProbe.GetBool("runtime_security_config.enabled"),
-		FIMEnabled:     coreconfig.SystemProbe.GetBool("runtime_security_config.fim_enabled"),
+		RuntimeEnabled:       coreconfig.SystemProbe.GetBool("runtime_security_config.enabled"),
+		FIMEnabled:           coreconfig.SystemProbe.GetBool("runtime_security_config.fim_enabled"),
+		ETWEventsChannelSize: coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_channel_size"),
 
 		SocketPath:           coreconfig.SystemProbe.GetString("runtime_security_config.socket"),
 		EventServerBurst:     coreconfig.SystemProbe.GetInt("runtime_security_config.event_server.burst"),

--- a/pkg/security/metrics/metrics_windows.go
+++ b/pkg/security/metrics/metrics_windows.go
@@ -94,4 +94,22 @@ var (
 	//MetricWindowsETWChannelBlockedCount is the metric for counting the number of blocked ETW channels
 	//Tags: -
 	MetricWindowsETWChannelBlockedCount = newRuntimeMetric(".windows.etw_channel_blocked_count")
+	//MetricWindowsETWNumberOfBuffers is the metric for counting the number of ETW buffers
+	//Tags: -
+	MetricWindowsETWNumberOfBuffers = newRuntimeMetric(".windows.etw_number_of_buffers")
+	//MetricWindowsETWFreeBuffers is the metric for counting the number of free ETW buffers
+	//Tags: -
+	MetricWindowsETWFreeBuffers = newRuntimeMetric(".windows.etw_free_buffers")
+	//MetricWindowsETWEventsLost is the metric for counting the number of ETW events lost
+	//Tags: -
+	MetricWindowsETWEventsLost = newRuntimeMetric(".windows.etw_events_lost")
+	//MetricWindowsETWBuffersWritten is the metric for counting the number of ETW buffers written
+	//Tags: -
+	MetricWindowsETWBuffersWritten = newRuntimeMetric(".windows.etw_buffers_written")
+	//MetricWindowsETWLogBuffersLost is the metric for counting the number of ETW log buffers lost
+	//Tags: -
+	MetricWindowsETWLogBuffersLost = newRuntimeMetric(".windows.etw_log_buffers_lost")
+	//MetricWindowsETWRealTimeBuffersLost is the metric for counting the number of ETW real-time buffers lost
+	//Tags: -
+	MetricWindowsETWRealTimeBuffersLost = newRuntimeMetric(".windows.etw_real_time_buffers_lost")
 )

--- a/pkg/security/metrics/metrics_windows.go
+++ b/pkg/security/metrics/metrics_windows.go
@@ -91,4 +91,7 @@ var (
 	//MetricWindowsSizeOfRegistryPathResolver is the metric for counting the size of the registry cache
 	//Tags: -
 	MetricWindowsSizeOfRegistryPathResolver = newRuntimeMetric(".windows.registry_resolver.size")
+	//MetricWindowsETWChannelBlockedCount is the metric for counting the number of blocked ETW channels
+	//Tags: -
+	MetricWindowsETWChannelBlockedCount = newRuntimeMetric(".windows.etw_channel_blocked_count")
 )

--- a/pkg/security/metrics/metrics_windows.go
+++ b/pkg/security/metrics/metrics_windows.go
@@ -112,4 +112,7 @@ var (
 	//MetricWindowsETWRealTimeBuffersLost is the metric for counting the number of ETW real-time buffers lost
 	//Tags: -
 	MetricWindowsETWRealTimeBuffersLost = newRuntimeMetric(".windows.etw_real_time_buffers_lost")
+	//MetricWindowsETWTotalNotifications is the metric for counting the total number of ETW notifications
+	//Tags: -
+	MetricWindowsETWTotalNotifications = newRuntimeMetric(".windows.etw_total_notifications")
 )

--- a/pkg/security/metrics/metrics_windows.go
+++ b/pkg/security/metrics/metrics_windows.go
@@ -36,6 +36,12 @@ var (
 	//MetricWindowsFileFlush is the metric for counting file flush notifications
 	//Tags: -
 	MetricWindowsFileFlush = newRuntimeMetric(".windows.file.flush")
+	//MetricWindowsFileWrite is the metric for counting file write notifications
+	//Tags: -
+	MetricWindowsFileWrite = newRuntimeMetric(".windows.file.write")
+	//MetricWindowsFileWriteProcessed is the metric for counting file write notifications
+	//Tags: -
+	MetricWindowsFileWriteProcessed = newRuntimeMetric(".windows.file.write_processed")
 
 	//MetricWindowsFileSetInformation is the metric for counting file set information notifications
 	//Tags: -

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -172,9 +172,7 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 
 	wp.filePathResolverLock.Lock()
 	defer wp.filePathResolverLock.Unlock()
-	wp.filePathResolver[ca.fileObject] = fileCache{
-		fileName: ca.fileName,
-	}
+	wp.filePathResolver.Add(ca.fileObject, fileCache{fileName: ca.fileName})
 
 	return ca, nil
 }
@@ -271,7 +269,7 @@ func (wp *WindowsProbe) parseInformationArgs(e *etw.DDEventRecord) (*setInformat
 
 	wp.filePathResolverLock.Lock()
 	defer wp.filePathResolverLock.Unlock()
-	if s, ok := wp.filePathResolver[fileObjectPointer(sia.fileObject)]; ok {
+	if s, ok := wp.filePathResolver.Get(fileObjectPointer(sia.fileObject)); ok {
 		sia.fileName = s.fileName
 	}
 
@@ -406,7 +404,7 @@ func (wp *WindowsProbe) parseCleanupArgs(e *etw.DDEventRecord) (*cleanupArgs, er
 
 	wp.filePathResolverLock.Lock()
 	defer wp.filePathResolverLock.Unlock()
-	if s, ok := wp.filePathResolver[ca.fileObject]; ok {
+	if s, ok := wp.filePathResolver.Get(fileObjectPointer(ca.fileObject)); ok {
 		ca.fileName = s.fileName
 	}
 
@@ -501,7 +499,7 @@ func (wp *WindowsProbe) parseReadArgs(e *etw.DDEventRecord) (*readArgs, error) {
 	}
 	wp.filePathResolverLock.Lock()
 	defer wp.filePathResolverLock.Unlock()
-	if s, ok := wp.filePathResolver[fileObjectPointer(ra.fileObject)]; ok {
+	if s, ok := wp.filePathResolver.Get(fileObjectPointer(ra.fileObject)); ok {
 		if isread {
 			if s.readProcessed {
 				return nil, errDiscardedPath
@@ -611,7 +609,7 @@ func (wp *WindowsProbe) parseDeletePathArgs(e *etw.DDEventRecord) (*deletePathAr
 
 	wp.filePathResolverLock.Lock()
 	defer wp.filePathResolverLock.Unlock()
-	if s, ok := wp.filePathResolver[fileObjectPointer(dpa.fileObject)]; ok {
+	if s, ok := wp.filePathResolver.Get(fileObjectPointer(dpa.fileObject)); ok {
 		dpa.oldPath = s.fileName
 		// question, should we reset the filePathResolver here?
 	}

--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -46,14 +46,22 @@ func createTestProbe() (*WindowsProbe, error) {
 	if err != nil {
 		return nil, err
 	}
+	fc, err := lru.New[fileObjectPointer, fileCache](1024)
+	if err != nil {
+		return nil, err
+	}
+	rc, err := lru.New[regObjectPointer, string](1024)
+	if err != nil {
+		return nil, err
+	}
 
 	// probe and config are provided as null.  During the tests, it is assumed
 	// that we will not access those values.
 	wp := &WindowsProbe{
 		opts:               opts,
 		config:             cfg,
-		filePathResolver:   make(map[fileObjectPointer]string, 0),
-		regPathResolver:    make(map[regObjectPointer]string, 0),
+		filePathResolver:   fc,
+		regPathResolver:    rc,
 		discardedPaths:     discardedPaths,
 		discardedBasenames: discardedBasenames,
 	}

--- a/pkg/security/probe/probe_kernel_reg_windows.go
+++ b/pkg/security/probe/probe_kernel_reg_windows.go
@@ -161,10 +161,10 @@ func (wp *WindowsProbe) computeFullPath(cka *createKeyArgs) {
 	if strings.HasPrefix(cka.relativeName, regprefix) {
 		cka.translateBasePaths()
 		cka.computedFullPath = cka.relativeName
-		wp.regPathResolver[cka.keyObject] = cka.relativeName
+		wp.regPathResolver.Add(cka.keyObject, cka.relativeName)
 		return
 	}
-	if s, ok := wp.regPathResolver[cka.keyObject]; ok {
+	if s, ok := wp.regPathResolver.Get(cka.keyObject); ok {
 		cka.computedFullPath = s
 	}
 	var outstr string
@@ -175,13 +175,13 @@ func (wp *WindowsProbe) computeFullPath(cka *createKeyArgs) {
 		outstr += cka.relativeName
 	} else {
 
-		if s, ok := wp.regPathResolver[cka.baseObject]; ok {
+		if s, ok := wp.regPathResolver.Get(cka.keyObject); ok {
 			outstr = s + "\\" + cka.relativeName
 		} else {
 			outstr = cka.relativeName
 		}
 	}
-	wp.regPathResolver[cka.keyObject] = outstr
+	wp.regPathResolver.Add(cka.keyObject, outstr)
 	cka.computedFullPath = outstr
 }
 func (cka *createKeyArgs) String() string {
@@ -213,7 +213,7 @@ func (wp *WindowsProbe) parseDeleteRegistryKey(e *etw.DDEventRecord) (*deleteKey
 	dka.keyObject = regObjectPointer(data.GetUint64(0))
 	dka.status = data.GetUint32(8)
 	dka.keyName, _, _, _ = data.ParseUnicodeString(12)
-	if s, ok := wp.regPathResolver[dka.keyObject]; ok {
+	if s, ok := wp.regPathResolver.Get(dka.keyObject); ok {
 		dka.computedFullPath = s
 	}
 
@@ -329,7 +329,7 @@ func (wp *WindowsProbe) parseSetValueKey(e *etw.DDEventRecord) (*setValueKeyArgs
 
 	sv.previousData = data.Bytes(nextOffset, int(sv.previousDataSize))
 
-	if s, ok := wp.regPathResolver[sv.keyObject]; ok {
+	if s, ok := wp.regPathResolver.Get(sv.keyObject); ok {
 		sv.computedFullPath = s
 	}
 

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -282,79 +282,87 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 		switch e.EventHeader.ProviderID {
 		case etw.DDGUID(p.fileguid):
 			switch e.EventHeader.EventDescriptor.ID {
-			case idNameCreate:
-				if ca, err := p.parseNameCreateArgs(e); err == nil {
-					log.Tracef("Received nameCreate event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
-					ecb(ca, e.EventHeader.ProcessID)
-				}
-
-			case idNameDelete:
-				if ca, err := p.parseNameDeleteArgs(e); err == nil {
-					log.Tracef("Received nameDelete event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
-					ecb(ca, e.EventHeader.ProcessID)
-				}
-
+			/*
+				case idNameCreate:
+					if ca, err := p.parseNameCreateArgs(e); err == nil {
+						log.Tracef("Received nameCreate event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
+						ecb(ca, e.EventHeader.ProcessID)
+					}
+			*/
+			/*
+				case idNameDelete:
+					if ca, err := p.parseNameDeleteArgs(e); err == nil {
+						log.Tracef("Received nameDelete event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
+						ecb(ca, e.EventHeader.ProcessID)
+					}
+			*/
 			case idCreate:
 				if ca, err := p.parseCreateHandleArgs(e); err == nil {
-					log.Tracef("Received idCreate event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
+					//log.Tracef("Received idCreate event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
 					ecb(ca, e.EventHeader.ProcessID)
 				}
 				p.stats.fileCreate++
 			case idCreateNewFile:
 				if ca, err := p.parseCreateNewFileArgs(e); err == nil {
-					log.Tracef("Received idCreateNewFile event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
+					//log.Tracef("Received idCreateNewFile event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
 					ecb(ca, e.EventHeader.ProcessID)
 				}
 				p.stats.fileCreateNew++
 			case idCleanup:
-				if ca, err := p.parseCleanupArgs(e); err == nil {
-					log.Tracef("Received cleanup event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
-					ecb(ca, e.EventHeader.ProcessID)
-				}
+				/*
+					if ca, err := p.parseCleanupArgs(e); err == nil {
+						log.Tracef("Received cleanup event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
+						ecb(ca, e.EventHeader.ProcessID)
+					}
+				*/
 				p.stats.fileCleanup++
 			case idClose:
 				if ca, err := p.parseCloseArgs(e); err == nil {
-					log.Tracef("Received Close event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
+					//log.Tracef("Received Close event %d %s\n", e.EventHeader.EventDescriptor.ID, ca)
 					ecb(ca, e.EventHeader.ProcessID)
-					if e.EventHeader.EventDescriptor.ID == idClose {
-						p.filePathResolverLock.Lock()
-						delete(p.filePathResolver, ca.fileObject)
-						p.filePathResolverLock.Unlock()
-					}
+					p.filePathResolverLock.Lock()
+					delete(p.filePathResolver, ca.fileObject)
+					p.filePathResolverLock.Unlock()
 				}
 				p.stats.fileClose++
 			case idFlush:
-				if fa, err := p.parseFlushArgs(e); err == nil {
-					ecb(fa, e.EventHeader.ProcessID)
-				}
+				/*
+					if fa, err := p.parseFlushArgs(e); err == nil {
+						ecb(fa, e.EventHeader.ProcessID)
+					}
+				*/
 				p.stats.fileFlush++
 
 			case idWrite:
 				if wa, err := p.parseWriteArgs(e); err == nil {
 					//fmt.Printf("Received Write event %d %s\n", e.EventHeader.EventDescriptor.ID, wa)
-					log.Tracef("Received Write event %d %s\n", e.EventHeader.EventDescriptor.ID, wa)
+					//log.Tracef("Received Write event %d %s\n", e.EventHeader.EventDescriptor.ID, wa)
 					ecb(wa, e.EventHeader.ProcessID)
 				}
 
-			case idSetInformation:
-				if si, err := p.parseInformationArgs(e); err == nil {
-					log.Tracef("Received SetInformation event %d %s\n", e.EventHeader.EventDescriptor.ID, si)
-					ecb(si, e.EventHeader.ProcessID)
-				}
+				/*
+					case idSetInformation:
+						if si, err := p.parseInformationArgs(e); err == nil {
+							log.Tracef("Received SetInformation event %d %s\n", e.EventHeader.EventDescriptor.ID, si)
+							ecb(si, e.EventHeader.ProcessID)
+						}
+				*/
 				p.stats.fileSetInformation++
 
 			case idSetDelete:
 				if sd, err := p.parseSetDeleteArgs(e); err == nil {
-					log.Tracef("Received SetDelete event %d %s\n", e.EventHeader.EventDescriptor.ID, sd)
+					//log.Tracef("Received SetDelete event %d %s\n", e.EventHeader.EventDescriptor.ID, sd)
 					ecb(sd, e.EventHeader.ProcessID)
 				}
 				p.stats.fileSetDelete++
 
-			case idDeletePath:
-				if dp, err := p.parseDeletePathArgs(e); err == nil {
-					log.Tracef("Received DeletePath event %d %s\n", e.EventHeader.EventDescriptor.ID, dp)
-					ecb(dp, e.EventHeader.ProcessID)
-				}
+				/*
+					case idDeletePath:
+						if dp, err := p.parseDeletePathArgs(e); err == nil {
+							log.Tracef("Received DeletePath event %d %s\n", e.EventHeader.EventDescriptor.ID, dp)
+							ecb(dp, e.EventHeader.ProcessID)
+						}
+				*/
 
 			case idRename:
 				if rn, err := p.parseRenameArgs(e); err == nil {
@@ -371,15 +379,17 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 			case idQueryInformation:
 				p.stats.fileidQueryInformation++
 			case idFSCTL:
-				if fs, err := p.parseFsctlArgs(e); err == nil {
-					log.Tracef("Received FSCTL event %d %s\n", e.EventHeader.EventDescriptor.ID, fs)
-					ecb(fs, e.EventHeader.ProcessID)
-				}
+				/*
+					if fs, err := p.parseFsctlArgs(e); err == nil {
+						log.Tracef("Received FSCTL event %d %s\n", e.EventHeader.EventDescriptor.ID, fs)
+						ecb(fs, e.EventHeader.ProcessID)
+					}
+				*/
 				p.stats.fileidFSCTL++
 
 			case idRename29:
 				if rn, err := p.parseRename29Args(e); err == nil {
-					log.Tracef("Received Rename29 event %d %s\n", e.EventHeader.EventDescriptor.ID, rn)
+					//log.Tracef("Received Rename29 event %d %s\n", e.EventHeader.EventDescriptor.ID, rn)
 					ecb(rn, e.EventHeader.ProcessID)
 				}
 				p.stats.fileidRename29++
@@ -389,44 +399,51 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 			switch e.EventHeader.EventDescriptor.ID {
 			case idRegCreateKey:
 				if cka, err := p.parseCreateRegistryKey(e); err == nil {
-					log.Tracef("Got idRegCreateKey %s", cka)
+					//log.Tracef("Got idRegCreateKey %s", cka)
 					ecb(cka, e.EventHeader.ProcessID)
 				}
 				p.stats.regCreateKey++
 			case idRegOpenKey:
 				if cka, err := p.parseOpenRegistryKey(e); err == nil {
-					log.Tracef("Got idRegOpenKey %s", cka)
+					//log.Tracef("Got idRegOpenKey %s", cka)
 					ecb(cka, e.EventHeader.ProcessID)
 				}
 				p.stats.regOpenKey++
 			case idRegDeleteKey:
 				if dka, err := p.parseDeleteRegistryKey(e); err == nil {
-					log.Tracef("Got idRegDeleteKey %v", dka)
+					//log.Tracef("Got idRegDeleteKey %v", dka)
 					ecb(dka, e.EventHeader.ProcessID)
 				}
 				p.stats.regDeleteKey++
+
 			case idRegFlushKey:
-				if dka, err := p.parseFlushKey(e); err == nil {
-					log.Tracef("Got idRegFlushKey %v", dka)
-				}
+				/*
+					if dka, err := p.parseFlushKey(e); err == nil {
+						log.Tracef("Got idRegFlushKey %v", dka)
+					}
+				*/
 				p.stats.regFlushKey++
 			case idRegCloseKey:
 				if dka, err := p.parseCloseKeyArgs(e); err == nil {
-					log.Tracef("Got idRegCloseKey %s", dka)
+					//log.Tracef("Got idRegCloseKey %s", dka)
 					delete(p.regPathResolver, dka.keyObject)
 				}
 				p.stats.regCloseKey++
-			case idQuerySecurityKey:
-				if dka, err := p.parseQuerySecurityKeyArgs(e); err == nil {
-					log.Tracef("Got idQuerySecurityKey %v", dka.keyName)
-				}
-			case idSetSecurityKey:
-				if dka, err := p.parseSetSecurityKeyArgs(e); err == nil {
-					log.Tracef("Got idSetSecurityKey %v", dka.keyName)
-				}
+				/*
+					case idQuerySecurityKey:
+						if dka, err := p.parseQuerySecurityKeyArgs(e); err == nil {
+							log.Tracef("Got idQuerySecurityKey %v", dka.keyName)
+						}
+				*/
+				/*
+					case idSetSecurityKey:
+						if dka, err := p.parseSetSecurityKeyArgs(e); err == nil {
+							log.Tracef("Got idSetSecurityKey %v", dka.keyName)
+						}
+				*/
 			case idRegSetValueKey:
 				if svk, err := p.parseSetValueKey(e); err == nil {
-					log.Tracef("Got idRegSetValueKey %s", svk)
+					//log.Tracef("Got idRegSetValueKey %s", svk)
 					ecb(svk, e.EventHeader.ProcessID)
 
 				}

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -169,10 +169,10 @@ func (p *WindowsProbe) initEtwFIM() error {
 		return err
 	}
 	p.fimSession, err = etwcomp.NewSession(etwSessionName, func(cfg *etw.SessionConfiguration) {
-		// commented out for isolated checking
-		//if p.config.RuntimeSecurity.ETWEventsMaxBuffers > 0 {
-		//	cfg.MaxBuffers = uint32(p.config.RuntimeSecurity.ETWEventsMaxBuffers)
-		//}
+		if p.config.RuntimeSecurity.ETWEventsMaxBuffers > 0 {
+			log.Infof("Setting ETW Max buffers to %d", p.config.RuntimeSecurity.ETWEventsMaxBuffers)
+			cfg.MaxBuffers = uint32(p.config.RuntimeSecurity.ETWEventsMaxBuffers)
+		}
 	})
 
 	if err != nil {

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -168,7 +168,13 @@ func (p *WindowsProbe) initEtwFIM() error {
 	if err != nil {
 		return err
 	}
-	p.fimSession, err = etwcomp.NewSession(etwSessionName)
+	p.fimSession, err = etwcomp.NewSession(etwSessionName, func(cfg *etw.SessionConfiguration) {
+		// commented out for isolated checking
+		//if p.config.RuntimeSecurity.ETWEventsMaxBuffers > 0 {
+		//	cfg.MaxBuffers = uint32(p.config.RuntimeSecurity.ETWEventsMaxBuffers)
+		//}
+	})
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Work In Progress

### What does this PR do?

PR changes channel used to deliver ETW notifications to non-blocking, and drops notifications if channel is full.
Is being used for now to test theory that the underlying cause of the memory leak is due to close notifications being missed due to ETW backpressure.

### Motivation

The memory leak is understood in the sense that we know what allocations are growing without bound.  What is not clear is _why_, as there should be a 1:1 correspondence between opens and closes.  This PR, as of first checkin, is to test the theory.


### Possible Drawbacks / Trade-offs

As written, since the ETW notifications will just be dropped (and counted) if the channel receiver is not readly, we're liable to miss _lots_ of events we're interested in.

### Describe how to test/QA your changes
