### PR TITLE
fix byte manips

### DIFF
--- a/pkg/fleet/installer/service/apm_inject.go
+++ b/pkg/fleet/installer/service/apm_inject.go
@@ -175,12 +175,15 @@ func (a *apmInjectorInstaller) setLDPreloadConfigContent(ldSoPreload []byte) ([]
 		return bytes.ReplaceAll(ldSoPreload, []byte(oldLDPath), []byte(launcherPreloadPath)), nil
 	}
 
+	var buf bytes.Buffer
+	buf.Write(ldSoPreload)
 	// Append the launcher preload path to the file
 	if len(ldSoPreload) > 0 && ldSoPreload[len(ldSoPreload)-1] != '\n' {
-		ldSoPreload = append(ldSoPreload, '\n')
+		buf.WriteByte('\n')
 	}
-	ldSoPreload = append(ldSoPreload, []byte(launcherPreloadPath+"\n")...)
-	return ldSoPreload, nil
+	buf.WriteString(launcherPreloadPath)
+	buf.WriteByte('\n')
+	return buf.Bytes(), nil
 }
 
 // deleteLDPreloadConfigContent deletes the content of the LD preload configuration

--- a/pkg/fleet/installer/service/apm_inject_test.go
+++ b/pkg/fleet/installer/service/apm_inject_test.go
@@ -18,20 +18,47 @@ func TestSetLDPreloadConfig(t *testing.T) {
 	a := &apmInjectorInstaller{
 		installPath: "/tmp/stable",
 	}
+	testCases := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "File doesn't exist",
+			input:    nil,
+			expected: []byte("/tmp/stable/inject/launcher.preload.so\n"),
+		},
+		{
+			name:     "Don't reuse the input buffer",
+			input:    make([]byte, 2, 1000),
+			expected: append([]byte{0x0, 0x0}, []byte("\n/tmp/stable/inject/launcher.preload.so\n")...),
+		},
+		{
+			name:     "File contains unrelated entries",
+			input:    []byte("/abc/def/preload.so\n"),
+			expected: []byte("/abc/def/preload.so\n/tmp/stable/inject/launcher.preload.so\n"),
+		},
+		{
+			name:     "File contains unrelated entries with no newline",
+			input:    []byte("/abc/def/preload.so"),
+			expected: []byte("/abc/def/preload.so\n/tmp/stable/inject/launcher.preload.so\n"),
+		},
+		{
+			name:     "File contains old preload instructions",
+			input:    []byte("banana\n/opt/datadog/apm/inject/launcher.preload.so\ntomato"),
+			expected: []byte("banana\n/tmp/stable/inject/launcher.preload.so\ntomato"),
+		},
+	}
 
-	for input, expected := range map[string]string{
-		// File doesn't exist
-		"": "/tmp/stable/inject/launcher.preload.so\n",
-		// File contains unrelated entries
-		"/abc/def/preload.so\n": "/abc/def/preload.so\n/tmp/stable/inject/launcher.preload.so\n",
-		// File contains unrelated entries with no newline
-		"/abc/def/preload.so": "/abc/def/preload.so\n/tmp/stable/inject/launcher.preload.so\n",
-		// File contains old preload instructions
-		"banana\n/opt/datadog/apm/inject/launcher.preload.so\ntomato": "banana\n/tmp/stable/inject/launcher.preload.so\ntomato",
-	} {
-		output, err := a.setLDPreloadConfigContent([]byte(input))
-		assert.Nil(t, err)
-		assert.Equal(t, expected, string(output))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := a.setLDPreloadConfigContent(tc.input)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected, output)
+			if len(tc.input) > 0 {
+				assert.False(t, &tc.input[0] == &output[0])
+			}
+		})
 	}
 }
 
@@ -72,6 +99,7 @@ func TestRemoveLDPreloadConfig(t *testing.T) {
 	output, err := a.deleteLDPreloadConfigContent([]byte(input))
 	assert.NotNil(t, err)
 	assert.Equal(t, "", string(output))
+	assert.NotEqual(t, input, string(output))
 }
 
 func TestSetAgentConfig(t *testing.T) {


### PR DESCRIPTION
Avoid reusing the byte slice

NB there's the same issue on the agent config change, but I'm removing that code in a next PR
(removing completely agent config changes)