### PR TITLE
[tagger/tagstore] Add DCA implementation that reduces mem usage

### DIFF
--- a/comp/core/tagger/taggerimpl/tagstore/entity_tags.go
+++ b/comp/core/tagger/taggerimpl/tagstore/entity_tags.go
@@ -6,18 +6,55 @@
 package tagstore
 
 import (
+	"maps"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl/collectors"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
-// EntityTags holds the tag information for a given entity. It is not
-// thread-safe, so should not be shared outside of the store. Usage inside the
-// store is safe since it relies on a global lock.
-type EntityTags struct {
+// This file defines the EntityTags interface which contains the tags for a
+// tagger entity.
+//
+// There are two implementations of this interface:
+// EntityTagsWithMultipleSources and EntityTagsWithSingleSource.
+//
+// EntityTagsWithMultipleSources is used when a tagger entity can be created
+// from multiple sources. For example, when a container is reported by a node
+// runtime like containerd and a node orchestrator like the kubelet. In this
+// case, the implementation keeps the information from all sources, and it's able
+// to merge them according to the priorities defined.
+//
+// EntityTagsWithSingleSource is used when a tagger entity is created from a
+// single source. In this case, the implementation doesn't need to store the
+// source information, reducing the memory footprint. EntityTagsWithSingleSource
+// is only used in the Cluster Agent. The reason is that in the Cluster Agent
+// the data can only come from static tags or a single workloadmeta collector
+// (kubeapiserver), so an entity is never created from multiple sources.
+
+// EntityTags holds the tag information for a given entity.
+type EntityTags interface {
+	toEntity() types.Entity
+	getStandard() []string
+	getHashedTags(cardinality types.TagCardinality) tagset.HashedTags
+	tagsForSource(source string) *sourceTags
+	tagsBySource() map[string][]string
+	setTagsForSource(source string, tags sourceTags)
+	sources() []string
+	deleteSource(source string, expiryDate time.Time)
+	deleteExpired(time time.Time) bool
+	shouldRemove() bool
+}
+
+// EntityTagsWithMultipleSources holds the tag information for a given entity
+// that can be created from multiple sources. It is not thread-safe, so should
+// not be shared outside of the store. Usage inside the store is safe since it
+// relies on a global lock.
+type EntityTagsWithMultipleSources struct {
 	entityID           string
 	sourceTags         map[string]sourceTags
 	cacheValid         bool
@@ -26,38 +63,19 @@ type EntityTags struct {
 	cachedLow          tagset.HashedTags // Sub-slice of cachedAll
 }
 
-func newEntityTags(entityID string) *EntityTags {
-	return &EntityTags{
+func newEntityTags(entityID string, source string) EntityTags {
+	if flavor.GetFlavor() == flavor.ClusterAgent {
+		return newEntityTagsWithSingleSource(entityID, source)
+	}
+
+	return &EntityTagsWithMultipleSources{
 		entityID:   entityID,
 		sourceTags: make(map[string]sourceTags),
 		cacheValid: true,
 	}
 }
 
-func (e *EntityTags) getStandard() []string {
-	tags := []string{}
-	for _, t := range e.sourceTags {
-		tags = append(tags, t.standardTags...)
-	}
-	return tags
-}
-
-func (e *EntityTags) get(cardinality types.TagCardinality) []string {
-	return e.getHashedTags(cardinality).Get()
-}
-
-func (e *EntityTags) getHashedTags(cardinality types.TagCardinality) tagset.HashedTags {
-	e.computeCache()
-
-	if cardinality == types.HighCardinality {
-		return e.cachedAll
-	} else if cardinality == types.OrchestratorCardinality {
-		return e.cachedOrchestrator
-	}
-	return e.cachedLow
-}
-
-func (e *EntityTags) toEntity() types.Entity {
+func (e *EntityTagsWithMultipleSources) toEntity() types.Entity {
 	e.computeCache()
 
 	cachedAll := e.cachedAll.Get()
@@ -75,7 +93,26 @@ func (e *EntityTags) toEntity() types.Entity {
 	}
 }
 
-func (e *EntityTags) computeCache() {
+func (e *EntityTagsWithMultipleSources) getStandard() []string {
+	tags := []string{}
+	for _, t := range e.sourceTags {
+		tags = append(tags, t.standardTags...)
+	}
+	return tags
+}
+
+func (e *EntityTagsWithMultipleSources) getHashedTags(cardinality types.TagCardinality) tagset.HashedTags {
+	e.computeCache()
+
+	if cardinality == types.HighCardinality {
+		return e.cachedAll
+	} else if cardinality == types.OrchestratorCardinality {
+		return e.cachedOrchestrator
+	}
+	return e.cachedLow
+}
+
+func (e *EntityTagsWithMultipleSources) computeCache() {
 	if e.cacheValid {
 		return
 	}
@@ -138,7 +175,23 @@ func (e *EntityTags) computeCache() {
 	e.cachedOrchestrator = cached.Slice(0, lowCardTags+orchCardTags)
 }
 
-func (e *EntityTags) shouldRemove() bool {
+func (e *EntityTagsWithMultipleSources) deleteExpired(time time.Time) bool {
+	initialNumSources := len(e.sourceTags)
+
+	maps.DeleteFunc(e.sourceTags, func(_ string, tags sourceTags) bool {
+		return tags.isExpired(time)
+	})
+
+	changed := len(e.sourceTags) != initialNumSources
+
+	if changed {
+		e.cacheValid = false
+	}
+
+	return changed
+}
+
+func (e *EntityTagsWithMultipleSources) shouldRemove() bool {
 	for _, tags := range e.sourceTags {
 		if !tags.expiryDate.IsZero() || !tags.isEmpty() {
 			return false
@@ -146,4 +199,161 @@ func (e *EntityTags) shouldRemove() bool {
 	}
 
 	return true
+}
+
+func (e *EntityTagsWithMultipleSources) tagsForSource(source string) *sourceTags {
+	tags, ok := e.sourceTags[source]
+	if !ok {
+		return nil
+	}
+	return &tags
+}
+
+func (e *EntityTagsWithMultipleSources) setTagsForSource(source string, tags sourceTags) {
+	e.sourceTags[source] = tags
+	e.cacheValid = false
+}
+
+func (e *EntityTagsWithMultipleSources) tagsBySource() map[string][]string {
+	tagsBySource := make(map[string][]string)
+
+	for source, tags := range e.sourceTags {
+		allTags := append([]string{}, tags.lowCardTags...)
+		allTags = append(allTags, tags.orchestratorCardTags...)
+		allTags = append(allTags, tags.highCardTags...)
+		tagsBySource[source] = allTags
+	}
+
+	return tagsBySource
+}
+
+func (e *EntityTagsWithMultipleSources) sources() []string {
+	sources := make([]string, 0, len(e.sourceTags))
+	for source := range e.sourceTags {
+		sources = append(sources, source)
+	}
+	return sources
+}
+
+func (e *EntityTagsWithMultipleSources) deleteSource(source string, expiryDate time.Time) {
+	tags, ok := e.sourceTags[source]
+	if !ok {
+		return
+	}
+
+	tags.expiryDate = expiryDate
+	e.sourceTags[source] = tags
+}
+
+// EntityTagsWithSingleSource holds the tag information for a given entity that
+// can only be created from a single source. It is not thread-safe, so should
+// not be shared outside of the store. Usage inside the store is safe since it
+// relies on a global lock.
+type EntityTagsWithSingleSource struct {
+	entityID           string
+	source             string
+	expiryDate         time.Time
+	standardTags       []string
+	cachedAll          tagset.HashedTags // Low + orchestrator + high
+	cachedOrchestrator tagset.HashedTags // Low + orchestrator (subslice of cachedAll)
+	cachedLow          tagset.HashedTags // Sub-slice of cachedAll
+	isExpired          bool
+}
+
+func newEntityTagsWithSingleSource(entityID string, source string) *EntityTagsWithSingleSource {
+	return &EntityTagsWithSingleSource{
+		entityID: entityID,
+		source:   source,
+	}
+}
+
+func (e *EntityTagsWithSingleSource) toEntity() types.Entity {
+	cachedAll := e.cachedAll.Get()
+	cachedOrchestrator := e.cachedOrchestrator.Get()
+	cachedLow := e.cachedLow.Get()
+
+	return types.Entity{
+		ID:           e.entityID,
+		StandardTags: e.getStandard(),
+		// cachedAll contains low, orchestrator and high cardinality tags, in this order.
+		// cachedOrchestrator and cachedLow are subslices of cachedAll, starting at index 0.
+		HighCardinalityTags:         cachedAll[len(cachedOrchestrator):],
+		OrchestratorCardinalityTags: cachedOrchestrator[len(cachedLow):],
+		LowCardinalityTags:          cachedLow,
+	}
+}
+
+func (e *EntityTagsWithSingleSource) getStandard() []string {
+	return e.standardTags
+}
+
+func (e *EntityTagsWithSingleSource) getHashedTags(cardinality types.TagCardinality) tagset.HashedTags {
+	switch cardinality {
+	case types.HighCardinality:
+		return e.cachedAll
+	case types.OrchestratorCardinality:
+		return e.cachedOrchestrator
+	default:
+		return e.cachedLow
+	}
+}
+
+func (e *EntityTagsWithSingleSource) tagsForSource(source string) *sourceTags {
+	if source != e.source {
+		return nil
+	}
+
+	return &sourceTags{
+		lowCardTags:          e.cachedLow.Get(),
+		orchestratorCardTags: e.cachedAll.Slice(e.cachedLow.Len(), e.cachedOrchestrator.Len()).Get(),
+		highCardTags:         e.cachedAll.Slice(e.cachedOrchestrator.Len(), e.cachedAll.Len()).Get(),
+		standardTags:         e.standardTags,
+		expiryDate:           e.expiryDate,
+	}
+}
+
+func (e *EntityTagsWithSingleSource) tagsBySource() map[string][]string {
+	return map[string][]string{e.source: e.cachedAll.Get()}
+}
+
+func (e *EntityTagsWithSingleSource) setTagsForSource(source string, tags sourceTags) {
+	if source != e.source {
+		return
+	}
+
+	e.standardTags = tags.standardTags
+
+	all := make([]string, 0, len(tags.lowCardTags)+len(tags.orchestratorCardTags)+len(tags.highCardTags))
+	all = append(all, tags.lowCardTags...)
+	all = append(all, tags.orchestratorCardTags...)
+	all = append(all, tags.highCardTags...)
+
+	cached := tagset.NewHashedTagsFromSlice(all)
+
+	e.cachedAll = cached
+	e.cachedLow = cached.Slice(0, len(tags.lowCardTags))
+	e.cachedOrchestrator = cached.Slice(0, len(tags.lowCardTags)+len(tags.orchestratorCardTags))
+}
+
+func (e *EntityTagsWithSingleSource) sources() []string {
+	return []string{e.source}
+}
+
+func (e *EntityTagsWithSingleSource) deleteSource(source string, expiryDate time.Time) {
+	if source == e.source {
+		e.expiryDate = expiryDate
+	}
+}
+
+func (e *EntityTagsWithSingleSource) deleteExpired(time time.Time) bool {
+	if !e.expiryDate.IsZero() && e.expiryDate.Before(time) {
+		e.isExpired = true
+		return true
+	}
+
+	return false
+}
+
+func (e *EntityTagsWithSingleSource) shouldRemove() bool {
+	return e.isExpired || e.cachedAll.Len() == 0
 }

--- a/comp/core/tagger/taggerimpl/tagstore/entity_tags_test.go
+++ b/comp/core/tagger/taggerimpl/tagstore/entity_tags_test.go
@@ -172,10 +172,10 @@ func TestDeleteSource(t *testing.T) {
 		lowCardTags: []string{"l1:v1"},
 	})
 
-	entityTags.deleteSource(testSource, expiryDate)
+	entityTags.setSourceExpiration(testSource, expiryDate)
 
 	// Different source is ignored
-	entityTags.deleteSource(invalidSource, time.Now())
+	entityTags.setSourceExpiration(invalidSource, time.Now())
 
 	assert.Equal(t, expiryDate, entityTags.expiryDate)
 }
@@ -210,7 +210,7 @@ func TestDeleteExpired(t *testing.T) {
 				lowCardTags: []string{"l1:v1"},
 			})
 
-			entityTags.deleteSource(testSource, expiryDate)
+			entityTags.setSourceExpiration(testSource, expiryDate)
 			entityTags.deleteExpired(test.time)
 			assert.Equal(t, test.expectShouldRemove, entityTags.shouldRemove())
 		})

--- a/comp/core/tagger/taggerimpl/tagstore/entity_tags_test.go
+++ b/comp/core/tagger/taggerimpl/tagstore/entity_tags_test.go
@@ -1,0 +1,218 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tagstore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+)
+
+const (
+	testEntityID  = "testEntityID"
+	testSource    = "testSource"
+	invalidSource = "invalidSource"
+)
+
+func TestToEntity(t *testing.T) {
+	entityTags := newEntityTagsWithSingleSource(testEntityID, testSource)
+
+	entityTags.setTagsForSource(testSource, sourceTags{
+		lowCardTags:          []string{"l1:v1", "l2:v2", "service:s1"},
+		orchestratorCardTags: []string{"o1:v1", "o2:v2"},
+		highCardTags:         []string{"h1:v1", "h2:v2"},
+		standardTags:         []string{"service:s1"},
+	})
+
+	// Different source is ignored
+	entityTags.setTagsForSource(invalidSource, sourceTags{
+		lowCardTags: []string{"l3:v3"},
+	})
+
+	assert.Equal(
+		t,
+		types.Entity{
+			ID:                          testEntityID,
+			LowCardinalityTags:          []string{"l1:v1", "l2:v2", "service:s1"},
+			OrchestratorCardinalityTags: []string{"o1:v1", "o2:v2"},
+			HighCardinalityTags:         []string{"h1:v1", "h2:v2"},
+			StandardTags:                []string{"service:s1"},
+		},
+		entityTags.toEntity(),
+	)
+}
+
+func TestGetStandard(t *testing.T) {
+	entityTags := newEntityTagsWithSingleSource(testEntityID, testSource)
+
+	entityTags.setTagsForSource(testSource, sourceTags{
+		lowCardTags:          []string{"l1:v1", "l2:v2", "service:s1"},
+		orchestratorCardTags: []string{"o1:v1", "o2:v2"},
+		highCardTags:         []string{"h1:v1", "h2:v2"},
+		standardTags:         []string{"service:s1"},
+	})
+
+	// Different source is ignored
+	entityTags.setTagsForSource(invalidSource, sourceTags{
+		lowCardTags:  []string{"l3:v3", "service:s2"},
+		standardTags: []string{"service:s2"},
+	})
+
+	assert.Equal(t, []string{"service:s1"}, entityTags.getStandard())
+}
+
+func TestGetHashedTags(t *testing.T) {
+	entityTags := newEntityTagsWithSingleSource(testEntityID, testSource)
+
+	entityTags.setTagsForSource(testSource, sourceTags{
+		lowCardTags:          []string{"l1:v1", "l2:v2", "service:s1"},
+		orchestratorCardTags: []string{"o1:v1", "o2:v2"},
+		highCardTags:         []string{"h1:v1", "h2:v2"},
+		standardTags:         []string{"service:s1"},
+	})
+
+	// Different source is ignored
+	entityTags.setTagsForSource(invalidSource, sourceTags{
+		lowCardTags: []string{"l3:v3"},
+	})
+
+	assert.ElementsMatch(
+		t,
+		[]string{"l1:v1", "l2:v2", "service:s1"},
+		entityTags.getHashedTags(types.LowCardinality).Get(),
+	)
+
+	assert.ElementsMatch(
+		t,
+		[]string{"l1:v1", "l2:v2", "service:s1", "o1:v1", "o2:v2"},
+		entityTags.getHashedTags(types.OrchestratorCardinality).Get(),
+	)
+
+	assert.ElementsMatch(
+		t,
+		[]string{"l1:v1", "l2:v2", "service:s1", "o1:v1", "o2:v2", "h1:v1", "h2:v2"},
+		entityTags.getHashedTags(types.HighCardinality).Get(),
+	)
+}
+
+func TestTagsForSource(t *testing.T) {
+	entityTags := newEntityTagsWithSingleSource(testEntityID, testSource)
+
+	entityTags.setTagsForSource(testSource, sourceTags{
+		lowCardTags:          []string{"l1:v1", "l2:v2", "service:s1"},
+		orchestratorCardTags: []string{"o1:v1", "o2:v2"},
+		highCardTags:         []string{"h1:v1", "h2:v2"},
+		standardTags:         []string{"service:s1"},
+	})
+
+	// Compare the tags (the order does not matter)
+	tags := entityTags.tagsForSource(testSource)
+	assert.ElementsMatch(t, []string{"l1:v1", "l2:v2", "service:s1"}, tags.lowCardTags)
+	assert.ElementsMatch(t, []string{"o1:v1", "o2:v2"}, tags.orchestratorCardTags)
+	assert.ElementsMatch(t, []string{"h1:v1", "h2:v2"}, tags.highCardTags)
+	assert.ElementsMatch(t, []string{"service:s1"}, tags.standardTags)
+
+	// Different source is ignored
+	entityTags.setTagsForSource(invalidSource, sourceTags{
+		lowCardTags: []string{"l3:v3"},
+	})
+	assert.Nil(t, entityTags.tagsForSource(invalidSource))
+}
+
+func TestTagsBySource(t *testing.T) {
+	entityTags := newEntityTagsWithSingleSource(testEntityID, testSource)
+
+	entityTags.setTagsForSource(testSource, sourceTags{
+		lowCardTags:          []string{"l1:v1", "l2:v2"},
+		orchestratorCardTags: []string{"o1:v1", "o2:v2"},
+		highCardTags:         []string{"h1:v1", "h2:v2"},
+	})
+
+	// Different source is ignored
+	entityTags.setTagsForSource(invalidSource, sourceTags{
+		lowCardTags: []string{"l3:v3"},
+	})
+
+	assert.Equal(
+		t,
+		map[string][]string{
+			testSource: {"l1:v1", "l2:v2", "o1:v1", "o2:v2", "h1:v1", "h2:v2"},
+		},
+		entityTags.tagsBySource(),
+	)
+}
+
+func TestSources(t *testing.T) {
+	entityTags := newEntityTagsWithSingleSource(testEntityID, testSource)
+
+	entityTags.setTagsForSource(testSource, sourceTags{
+		lowCardTags: []string{"l1:v1"},
+	})
+
+	// Different source is ignored
+	entityTags.setTagsForSource(invalidSource, sourceTags{
+		lowCardTags: []string{"l2:v2"},
+	})
+
+	assert.ElementsMatch(t, []string{testSource}, entityTags.sources())
+}
+
+func TestDeleteSource(t *testing.T) {
+	expiryDate := time.Now().Add(time.Hour)
+
+	entityTags := newEntityTagsWithSingleSource(testEntityID, testSource)
+
+	entityTags.setTagsForSource(testSource, sourceTags{
+		lowCardTags: []string{"l1:v1"},
+	})
+
+	entityTags.deleteSource(testSource, expiryDate)
+
+	// Different source is ignored
+	entityTags.deleteSource(invalidSource, time.Now())
+
+	assert.Equal(t, expiryDate, entityTags.expiryDate)
+}
+
+func TestDeleteExpired(t *testing.T) {
+	expiryDate := time.Now()
+
+	tests := []struct {
+		name               string
+		time               time.Time
+		expectShouldRemove bool
+	}{
+		{
+			name:               "expired",
+			time:               expiryDate.Add(time.Minute),
+			expectShouldRemove: true,
+		},
+		{
+			name:               "not expired",
+			time:               expiryDate.Add(-time.Minute),
+			expectShouldRemove: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entityTags := newEntityTagsWithSingleSource(testEntityID, testSource)
+
+			// Entity tags without tags are marked for deletion so set some to
+			// make sure it's not removed for that reason
+			entityTags.setTagsForSource(testSource, sourceTags{
+				lowCardTags: []string{"l1:v1"},
+			})
+
+			entityTags.deleteSource(testSource, expiryDate)
+			entityTags.deleteExpired(test.time)
+			assert.Equal(t, test.expectShouldRemove, entityTags.shouldRemove())
+		})
+	}
+}

--- a/comp/core/tagger/taggerimpl/tagstore/tagstore.go
+++ b/comp/core/tagger/taggerimpl/tagstore/tagstore.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/benbjohnson/clock"
+
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl/subscriber"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -21,8 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"github.com/benbjohnson/clock"
 )
 
 const (
@@ -37,7 +37,7 @@ var ErrNotFound = errors.New("entity not found")
 type TagStore struct {
 	sync.RWMutex
 
-	store     map[string]*EntityTags
+	store     map[string]EntityTags
 	telemetry map[string]map[string]float64
 
 	subscriber *subscriber.Subscriber
@@ -53,7 +53,7 @@ func NewTagStore() *TagStore {
 func newTagStoreWithClock(clock clock.Clock) *TagStore {
 	return &TagStore{
 		telemetry:  make(map[string]map[string]float64),
-		store:      make(map[string]*EntityTags),
+		store:      make(map[string]EntityTags),
 		subscriber: subscriber.NewSubscriber(),
 		clock:      clock,
 	}
@@ -109,13 +109,8 @@ func (s *TagStore) ProcessTagInfo(tagInfos []*types.TagInfo) {
 
 		if info.DeleteEntity {
 			if exist {
-				st, ok := storedTags.sourceTags[info.Source]
-				if ok {
-					st.expiryDate = s.clock.Now().Add(deletedTTL)
-					storedTags.sourceTags[info.Source] = st
-				}
+				storedTags.deleteSource(info.Source, s.clock.Now().Add(deletedTTL))
 			}
-
 			continue
 		}
 
@@ -129,19 +124,18 @@ func (s *TagStore) ProcessTagInfo(tagInfos []*types.TagInfo) {
 
 		eventType := types.EventTypeModified
 		if exist {
-			st, ok := storedTags.sourceTags[info.Source]
-			if ok && reflect.DeepEqual(st, newSt) {
+			tags := storedTags.tagsForSource(info.Source)
+			if tags != nil && reflect.DeepEqual(tags, newSt) {
 				continue
 			}
 		} else {
 			eventType = types.EventTypeAdded
-			storedTags = newEntityTags(info.Entity)
+			storedTags = newEntityTags(info.Entity, info.Source)
 			s.store[info.Entity] = storedTags
 		}
 
 		telemetry.UpdatedEntities.Inc()
-		storedTags.cacheValid = false
-		storedTags.sourceTags[info.Source] = newSt
+		storedTags.setTagsForSource(info.Source, newSt)
 
 		events = append(events, types.EntityEvent{
 			EventType: eventType,
@@ -163,10 +157,10 @@ func (s *TagStore) collectTelemetry() {
 	s.Lock()
 	defer s.Unlock()
 
-	for _, entityTags := range s.store {
-		prefix, _ := containers.SplitEntityName(entityTags.entityID)
+	for entityName, entityTags := range s.store {
+		prefix, _ := containers.SplitEntityName(entityName)
 
-		for source := range entityTags.sourceTags {
+		for _, source := range entityTags.sources() {
 			if _, ok := s.telemetry[prefix]; !ok {
 				s.telemetry[prefix] = make(map[string]float64)
 			}
@@ -220,27 +214,13 @@ func (s *TagStore) Prune() {
 	events := []types.EntityEvent{}
 
 	for entity, storedTags := range s.store {
-		changed := false
+		changed := storedTags.deleteExpired(now)
 
-		// remove any sourceTags that have expired
-		for source, st := range storedTags.sourceTags {
-			if st.isExpired(now) {
-				delete(storedTags.sourceTags, source)
-				changed = true
-			}
-		}
-
-		// remove all sourceTags only if they're all empty
-		if storedTags.shouldRemove() {
-			storedTags.sourceTags = nil
-			changed = true
-		}
-
-		if !changed {
+		if !changed && !storedTags.shouldRemove() {
 			continue
 		}
 
-		if len(storedTags.sourceTags) == 0 {
+		if storedTags.shouldRemove() {
 			telemetry.PrunedEntities.Inc()
 			delete(s.store, entity)
 			events = append(events, types.EntityEvent{
@@ -248,7 +228,6 @@ func (s *TagStore) Prune() {
 				Entity:    storedTags.toEntity(),
 			})
 		} else {
-			storedTags.cacheValid = false
 			events = append(events, types.EntityEvent{
 				EventType: types.EventTypeModified,
 				Entity:    storedTags.toEntity(),
@@ -298,18 +277,9 @@ func (s *TagStore) List() types.TaggerListResponse {
 	defer s.RUnlock()
 
 	for entityID, et := range s.store {
-		entity := types.TaggerListEntity{
-			Tags: make(map[string][]string),
+		r.Entities[entityID] = types.TaggerListEntity{
+			Tags: et.tagsBySource(),
 		}
-
-		for source, sourceTags := range et.sourceTags {
-			tags := append([]string(nil), sourceTags.lowCardTags...)
-			tags = append(tags, sourceTags.orchestratorCardTags...)
-			tags = append(tags, sourceTags.highCardTags...)
-			entity.Tags[source] = tags
-		}
-
-		r.Entities[entityID] = entity
 	}
 
 	return r
@@ -326,7 +296,7 @@ func (s *TagStore) GetEntity(entityID string) (*types.Entity, error) {
 	return &entity, nil
 }
 
-func (s *TagStore) getEntityTags(entityID string) (*EntityTags, error) {
+func (s *TagStore) getEntityTags(entityID string) (EntityTags, error) {
 	s.RLock()
 	defer s.RUnlock()
 

--- a/comp/core/tagger/taggerimpl/tagstore/tagstore.go
+++ b/comp/core/tagger/taggerimpl/tagstore/tagstore.go
@@ -109,7 +109,7 @@ func (s *TagStore) ProcessTagInfo(tagInfos []*types.TagInfo) {
 
 		if info.DeleteEntity {
 			if exist {
-				storedTags.deleteSource(info.Source, s.clock.Now().Add(deletedTTL))
+				storedTags.setSourceExpiration(info.Source, s.clock.Now().Add(deletedTTL))
 			}
 			continue
 		}

--- a/comp/core/tagger/taggerimpl/tagstore/tagstore_test.go
+++ b/comp/core/tagger/taggerimpl/tagstore/tagstore_test.go
@@ -49,7 +49,7 @@ func (s *StoreTestSuite) TestIngest() {
 	})
 
 	assert.Len(s.T(), s.store.store, 1)
-	assert.Len(s.T(), s.store.store["test"].sourceTags, 2)
+	assert.Len(s.T(), s.store.store["test"].sources(), 2)
 }
 
 func (s *StoreTestSuite) TestLookup() {
@@ -324,34 +324,6 @@ func TestStoreSuite(t *testing.T) {
 	suite.Run(t, &StoreTestSuite{})
 }
 
-func TestGetEntityTags(t *testing.T) {
-	etags := newEntityTags("deadbeef")
-
-	// Get empty tags and make sure cache is now set to valid
-	tags := etags.get(types.HighCardinality)
-	assert.Len(t, tags, 0)
-	assert.True(t, etags.cacheValid)
-
-	// Add tags but don't invalidate the cache, we should return empty arrays
-	etags.sourceTags["source"] = sourceTags{
-		lowCardTags:  []string{"low1", "low2"},
-		highCardTags: []string{"high1", "high2"},
-	}
-	tags = etags.get(types.HighCardinality)
-	assert.Len(t, tags, 0)
-	assert.True(t, etags.cacheValid)
-
-	// Invalidate the cache, we should now get the tags
-	etags.cacheValid = false
-	tags = etags.get(types.HighCardinality)
-	assert.Len(t, tags, 4)
-	assert.ElementsMatch(t, tags, []string{"low1", "low2", "high1", "high2"})
-	assert.True(t, etags.cacheValid)
-	tags = etags.get(types.LowCardinality)
-	assert.Len(t, tags, 2)
-	assert.ElementsMatch(t, tags, []string{"low1", "low2"})
-}
-
 func (s *StoreTestSuite) TestGetExpiredTags() {
 	s.store.ProcessTagInfo([]*types.TagInfo{
 		{
@@ -377,7 +349,7 @@ func (s *StoreTestSuite) TestGetExpiredTags() {
 	assert.NotContains(s.T(), tagsHigh, "expired")
 }
 
-func TestDuplicateSourceTags(t *testing.T) {
+func (s *StoreTestSuite) TestDuplicateSourceTags() {
 	// Mock collector priorities
 	originalCollectorPriorities := collectors.CollectorPriorities
 	collectors.CollectorPriorities = map[string]types.CollectorPriority{
@@ -389,42 +361,55 @@ func TestDuplicateSourceTags(t *testing.T) {
 		collectors.CollectorPriorities = originalCollectorPriorities
 	}()
 
-	etags := newEntityTags("deadbeef")
+	testEntity := "testEntity"
 
-	// Get empty tags and make sure cache is now set to valid
-	tags := etags.get(types.HighCardinality)
-	assert.Len(t, tags, 0)
-	assert.True(t, etags.cacheValid)
-
-	// Add tags but don't invalidate the cache, we should return empty arrays
-	etags.sourceTags["sourceNodeOrchestrator"] = sourceTags{
-		lowCardTags:  []string{"bar", "tag1:sourceHigh", "tag2:sourceHigh"},
-		highCardTags: []string{"tag3:sourceHigh", "tag4:sourceHigh"},
+	// Mock collector priorities
+	collectors.CollectorPriorities = map[string]types.CollectorPriority{
+		"sourceNodeRuntime":         types.NodeRuntime,
+		"sourceNodeOrchestrator":    types.NodeOrchestrator,
+		"sourceClusterOrchestrator": types.ClusterOrchestrator,
 	}
 
-	etags.sourceTags["sourceNodeRuntime"] = sourceTags{
-		lowCardTags:  []string{"foo", "tag1:sourceLow", "tag2:sourceLow"},
-		highCardTags: []string{"tag3:sourceLow", "tag5:sourceLow"},
+	nodeRuntimeTags := types.TagInfo{
+		Source:       "sourceNodeRuntime",
+		Entity:       testEntity,
+		LowCardTags:  []string{"foo", "tag1:sourceLow", "tag2:sourceLow"},
+		HighCardTags: []string{"tag3:sourceLow", "tag5:sourceLow"},
 	}
 
-	etags.sourceTags["sourceClusterOrchestrator"] = sourceTags{
-		lowCardTags:  []string{"tag3:sourceClusterHigh", "tag1:sourceClusterLow"},
-		highCardTags: []string{"tag4:sourceClusterLow"},
+	nodeOrchestractorTags := types.TagInfo{
+		Source:       "sourceNodeOrchestrator",
+		Entity:       testEntity,
+		LowCardTags:  []string{"bar", "tag1:sourceHigh", "tag2:sourceHigh"},
+		HighCardTags: []string{"tag3:sourceHigh", "tag4:sourceHigh"},
 	}
 
-	tags = etags.get(types.HighCardinality)
-	assert.Len(t, tags, 0)
-	assert.True(t, etags.cacheValid)
+	clusterOrchestratorTags := types.TagInfo{
+		Source:       "sourceClusterOrchestrator",
+		Entity:       testEntity,
+		LowCardTags:  []string{"tag1:sourceClusterLow", "tag3:sourceClusterHigh"},
+		HighCardTags: []string{"tag4:sourceClusterLow"},
+	}
 
-	// Invalidate the cache, we should now get the tags
-	etags.cacheValid = false
-	tags = etags.get(types.HighCardinality)
-	assert.Len(t, tags, 7)
-	assert.ElementsMatch(t, tags, []string{"foo", "bar", "tag1:sourceClusterLow", "tag2:sourceHigh", "tag3:sourceClusterHigh", "tag4:sourceClusterLow", "tag5:sourceLow"})
-	assert.True(t, etags.cacheValid)
-	tags = etags.get(types.LowCardinality)
-	assert.Len(t, tags, 5)
-	assert.ElementsMatch(t, tags, []string{"foo", "bar", "tag1:sourceClusterLow", "tag2:sourceHigh", "tag3:sourceClusterHigh"})
+	s.store.ProcessTagInfo([]*types.TagInfo{
+		&nodeRuntimeTags,
+		&nodeOrchestractorTags,
+		&clusterOrchestratorTags,
+	})
+
+	lowCardTags := s.store.Lookup(testEntity, types.LowCardinality)
+	assert.ElementsMatch(
+		s.T(),
+		lowCardTags,
+		[]string{"foo", "bar", "tag1:sourceClusterLow", "tag2:sourceHigh", "tag3:sourceClusterHigh"},
+	)
+
+	highCardTags := s.store.Lookup(testEntity, types.HighCardinality)
+	assert.ElementsMatch(
+		s.T(),
+		highCardTags,
+		[]string{"foo", "bar", "tag1:sourceClusterLow", "tag2:sourceHigh", "tag3:sourceClusterHigh", "tag4:sourceClusterLow", "tag5:sourceLow"},
+	)
 }
 
 type entityEventExpectation struct {

--- a/releasenotes-dca/notes/cluster-tagger-mem-9932964445afeb49.yaml
+++ b/releasenotes-dca/notes/cluster-tagger-mem-9932964445afeb49.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Reduced the memory used to store the tags.


### PR DESCRIPTION
### What does this PR do?

This PR reduces the memory used by the tagger when running in the Cluster Agent.

The tagger stores the tags by source and also stores the final result of aggregating them according to the priorities defined. This is a valid use case for the node agent because a single tagger entity can be reported by multiple sources. For example, a container might be reported by containerd but also by the Kubelet. Keeping the tags by source is used to merge them applying the priorities defined. Also `agent tagger-list` and some telemetry metrics show the tag source.

The case of the Cluster Agent is a bit different because tags only come from a single workloadmeta collector (kubeapiserver). That means that a single entity is not reported by multiple sources. That's why in this case we can reduce the memory used by not storing the tags by source.

This PR achieves that goal by defining a `EntityTags` interface that is responsible for storing the tags for a tagger entity and provides two implementations, one that handles the case of multiple sources (current implementation) and another one that assumes a single source (new optimization for the DCA).

This memory optimization is important in the Cluster Agent when the option to collect Kubernetes tags is enabled (`cluster_agent.collect_kubernetes_tags`) because in large clusters  the memory used to store the pod tags can be quite high.

### Describe how to test/QA your changes

For the DCA try with the option to collect Kubernetes tags enabled (`datadog.clusterTagger.collectKubernetesTags` option in the helm chart). Check in our internal clusters using profiles that the memory used by the tagger has decreased. Do also a quick verification of `agent tagger-list`.

For the Agent, a sanity check should be enough. Deploy the agent and check with `agent tagger-list` that tags are correct.