### PR TITLE
Allow OMNIBUS_RUBY_VERSION to be overriden from the environment

### DIFF
--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -100,7 +100,7 @@ def get_omnibus_env(
     if int(major_version) > 6:
         env['OMNIBUS_OPENSSL_SOFTWARE'] = 'openssl3'
 
-    env_override = ['INTEGRATIONS_CORE_VERSION', 'OMNIBUS_SOFTWARE_VERSION']
+    env_override = ['INTEGRATIONS_CORE_VERSION', 'OMNIBUS_RUBY_VERSION', 'OMNIBUS_SOFTWARE_VERSION']
     for key in env_override:
         value = os.environ.get(key)
         # Only overrides the env var if the value is a non-empty string.


### PR DESCRIPTION
### What does this PR do?

Adds `OMNIBUS_RUBY_VERSION` to the list of variables we allow overriding before launching Omnibus.

### Motivation

We set up a [trigger on the omnibus-ruby](https://github.com/DataDog/omnibus-ruby/blob/78573b961ef3400787a7069526d91795c1a34238/.gitlab-ci.yml#L28) to make it more convenient to test omnibus-ruby changes against the Agent repo; we realized it wasn't picking up the right version.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
