### PR TITLE
[CWS] split constant generation into cones, and combine them in one final step

### DIFF
--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -17,13 +17,37 @@ on:
     - cron: '30 4 * * 5' # at 4:30 UTC on Friday
 
 jobs:
-  sync:
+  generate:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cone:
+          - amzn
+          - centos
+          - debian
+          - fedora
+          - ol/7/arm64
+          - ol/7/x86_64
+          - ol/8/arm64
+          - ol/8/x86_64
+          - opensuse-leap
+          - rhel
+          - sles
+          - ubuntu/16.04/x86_64
+          - ubuntu/18.04/arm64
+          - ubuntu/18.04/x86_64
+          - ubuntu/20.04/arm64
+          - ubuntu/20.04/x86_64
     steps:
       - name: Cleanup runner
         run: |
           sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
           docker rmi $(docker image ls -aq) >/dev/null 2>&1
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          df -h
 
       - name: Checkout datadog-agent repository
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -35,6 +59,7 @@ jobs:
         with:
           repository: DataDog/btfhub-archive
           path: dev/dist/archive
+          sparse-checkout: ${{ matrix.cone }}
 
       - name: Install python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
@@ -48,18 +73,57 @@ jobs:
         with:
           go-version-file: '.go-version'
 
-      - name: Install go deps
+      - name: Compute name
+        id: artifact-name
         run: |
-          inv -e deps
+          echo "ARTIFACT_NAME=constants-${{ matrix.cone }}" | tr '/' '-' >> $GITHUB_OUTPUT
+
+      - name: Sync constants
+        run: |
+          inv -e security-agent.generate-btfhub-constants --archive-path=./dev/dist/archive --output-path=./${{ steps.artifact-name.outputs.ARTIFACT_NAME }}.json ${{ inputs.force_refresh && '--force-refresh' || '' }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.artifact-name.outputs.ARTIFACT_NAME }}
+          path: ./${{ steps.artifact-name.outputs.ARTIFACT_NAME }}.json
+
+  combine:
+    needs: generate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout datadog-agent repository
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          ref: ${{ inputs.base_branch || 'main' }}
+
+      - name: Install python
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+
+      - name: Install go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: '.go-version'
+
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./dev/dist/constants
+          pattern: constants-*
+          merge-multiple: true
+
+      - name: Combine constants
+        run: |
+          inv -e security-agent.combine-btfhub-constants --archive-path=./dev/dist/constants
 
       - name: Compute branch name
         id: branch-name
         run: |
           echo "BRANCH_NAME=cws/constants-sync-$(date +%s)" >> $GITHUB_OUTPUT
-
-      - name: Sync constants
-        run: |
-          inv -e security-agent.generate-btfhub-constants --archive-path=./dev/dist/archive ${{ inputs.force_refresh && '--force-refresh' || '' }}
 
       - uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5.0.1
         id: commit-creator

--- a/pkg/security/probe/constantfetch/btfhub/main.go
+++ b/pkg/security/probe/constantfetch/btfhub/main.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"runtime/pprof"
 	"strings"
 
 	"github.com/smira/go-xz"
@@ -37,12 +38,27 @@ func main() {
 	var constantOutputPath string
 	var forceRefresh bool
 	var combineConstants bool
+	var cpuPprofPath string
 
 	flag.StringVar(&archiveRootPath, "archive-root", "", "Root path of BTFHub archive")
 	flag.StringVar(&constantOutputPath, "output", "", "Output path for JSON constants")
 	flag.BoolVar(&forceRefresh, "force-refresh", false, "Force refresh of the constants")
 	flag.BoolVar(&combineConstants, "combine", false, "Don't read btf files, but read constants")
+	flag.StringVar(&cpuPprofPath, "cpu-prof", "", "Path to the CPU profile to generate")
 	flag.Parse()
+
+	if cpuPprofPath != "" {
+		f, err := os.Create(cpuPprofPath)
+		if err != nil {
+			panic(err)
+		}
+		defer f.Close()
+
+		if err := pprof.StartCPUProfile(f); err != nil {
+			panic(err)
+		}
+		defer pprof.StopCPUProfile()
+	}
 
 	if combineConstants {
 		combined, err := combineConstantFiles(archiveRootPath)

--- a/pkg/security/probe/constantfetch/btfhub/main.go
+++ b/pkg/security/probe/constantfetch/btfhub/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"archive/tar"
 	"bytes"
+	"cmp"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -24,7 +25,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime/pprof"
+	"slices"
 	"strings"
+	"sync"
 
 	"github.com/smira/go-xz"
 
@@ -94,9 +97,23 @@ func main() {
 
 	twCollector := newTreeWalkCollector(preAllocHint)
 
+	var wg sync.WaitGroup
+	// github actions runner have only 2 cores
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := twCollector.extractor(); err != nil {
+				panic(err)
+			}
+		}()
+	}
+
 	if err := filepath.WalkDir(archiveRootPath, twCollector.treeWalkerBuilder(archiveRootPath)); err != nil {
 		panic(err)
 	}
+
+	wg.Wait()
 
 	export := twCollector.finish()
 
@@ -205,18 +222,28 @@ func getCommitSha(cwd string) (string, error) {
 }
 
 type treeWalkCollector struct {
-	counter int
-	results []extractionResult
+	sync.Mutex
+
+	counter   int
+	results   []extractionResult
+	cache     map[string]map[string]uint64
+	queryChan chan extractionQuery
 }
 
 func newTreeWalkCollector(preAllocHint int) *treeWalkCollector {
 	return &treeWalkCollector{
-		counter: 0,
-		results: make([]extractionResult, 0, preAllocHint),
+		counter:   0,
+		results:   make([]extractionResult, 0, preAllocHint),
+		cache:     make(map[string]map[string]uint64),
+		queryChan: make(chan extractionQuery),
 	}
 }
 
 func (c *treeWalkCollector) finish() constantfetch.BTFHubConstants {
+	slices.SortFunc(c.results, func(a extractionResult, b extractionResult) int {
+		return cmp.Compare(a.counter, b.counter)
+	})
+
 	constants := make([]map[string]uint64, 0)
 	kernels := make([]constantfetch.BTFHubKernel, 0)
 
@@ -274,28 +301,56 @@ func (c *treeWalkCollector) treeWalkerBuilder(prefix string) fs.WalkDirFunc {
 		arch := btfParts[len(btfParts)-2]
 		unameRelease := strings.TrimSuffix(btfParts[len(btfParts)-1], ".btf.tar.xz")
 
-		fmt.Println(c.counter, path)
-		c.counter++
-
-		constants, err := extractConstantsFromBTF(path, distribution, distribVersion)
-		if err != nil {
-			return fmt.Errorf("failed to extract constants from `%s`: %v", path, err)
-		}
-
-		res := extractionResult{
+		c.queryChan <- extractionQuery{
+			counter:        c.counter,
+			path:           path,
 			distribution:   distribution,
 			distribVersion: distribVersion,
 			arch:           arch,
 			unameRelease:   unameRelease,
-			constants:      constants,
 		}
 
-		c.results = append(c.results, res)
+		c.counter++
 		return nil
 	}
 }
 
+func (c *treeWalkCollector) extractor() error {
+	for query := range c.queryChan {
+		fmt.Println(query.counter, query.path)
+
+		constants, err := c.extractConstantsFromBTF(query.path, query.distribution, query.distribVersion)
+		if err != nil {
+			return fmt.Errorf("failed to extract constants from `%s`: %v", query.path, err)
+		}
+
+		res := extractionResult{
+			counter:        query.counter,
+			distribution:   query.distribution,
+			distribVersion: query.distribVersion,
+			arch:           query.arch,
+			unameRelease:   query.unameRelease,
+			constants:      constants,
+		}
+
+		c.Lock()
+		c.results = append(c.results, res)
+		c.Unlock()
+	}
+	return nil
+}
+
+type extractionQuery struct {
+	counter        int
+	path           string
+	distribution   string
+	distribVersion string
+	arch           string
+	unameRelease   string
+}
+
 type extractionResult struct {
+	counter        int
 	distribution   string
 	distribVersion string
 	arch           string
@@ -303,16 +358,21 @@ type extractionResult struct {
 	constants      map[string]uint64
 }
 
-var cache = map[string]map[string]uint64{}
+func (c *treeWalkCollector) getCacheEntry(cacheKey string) (map[string]uint64, bool) {
+	c.Lock()
+	defer c.Unlock()
+	val, ok := c.cache[cacheKey]
+	return val, ok
+}
 
-func extractConstantsFromBTF(archivePath, distribution, distribVersion string) (map[string]uint64, error) {
+func (c *treeWalkCollector) extractConstantsFromBTF(archivePath, distribution, distribVersion string) (map[string]uint64, error) {
 	btfContent, err := createBTFReaderFromTarball(archivePath)
 	if err != nil {
 		return nil, err
 	}
 
 	cacheKey := computeCacheKey(btfContent)
-	if constants, ok := cache[cacheKey]; ok {
+	if constants, ok := c.getCacheEntry(cacheKey); ok {
 		return constants, nil
 	}
 
@@ -346,7 +406,9 @@ func extractConstantsFromBTF(archivePath, distribution, distribVersion string) (
 		return nil, err
 	}
 
-	cache[cacheKey] = constants
+	c.Lock()
+	c.cache[cacheKey] = constants
+	c.Unlock()
 	return constants, nil
 }
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -741,12 +741,21 @@ def generate_syscall_table(ctx):
     )
 
 
+DEFAULT_BTFHUB_CONSTANTS_PATH = "./pkg/security/probe/constantfetch/btfhub/constants.json"
+
+
 @task
-def generate_btfhub_constants(ctx, archive_path, force_refresh=False):
-    output_path = "./pkg/security/probe/constantfetch/btfhub/constants.json"
+def generate_btfhub_constants(ctx, archive_path, force_refresh=False, output_path=DEFAULT_BTFHUB_CONSTANTS_PATH):
     force_refresh_opt = "-force-refresh" if force_refresh else ""
     ctx.run(
         f"go run -tags linux_bpf,btfhubsync ./pkg/security/probe/constantfetch/btfhub/ -archive-root {archive_path} -output {output_path} {force_refresh_opt}",
+    )
+
+
+@task
+def combine_btfhub_constants(ctx, archive_path, output_path=DEFAULT_BTFHUB_CONSTANTS_PATH):
+    ctx.run(
+        f"go run -tags linux_bpf,btfhubsync ./pkg/security/probe/constantfetch/btfhub/ -combine -archive-root {archive_path} -output {output_path}",
     )
 
 


### PR DESCRIPTION
### What does this PR do?

The github action step BTFHub sync is not able anymore to clone the btfhub archive repo with the given disk space, the script is also not able anymore to compute the constants with the available memory because of the archive size. To fix both of those issues this PR splits this generation into multiple parallel steps, one for each subfolders in the archive (we call them cones because we do a git sparse cone checkout).

One final step takes all those constant files and combine them into one big result.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
