### PR TITLE
[cluster-agent] Fix CWS Instrumentation metrics

### DIFF
--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -70,11 +70,19 @@ var (
 	LibInjectionErrors = telemetry.NewCounterWithOpts("admission_webhooks", "library_injection_errors",
 		[]string{"language", "auto_detected", "injection_type"}, "Number of library injection failures by language and injection type",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
-	CWSExecInstrumentationAttempts = telemetry.NewCounterWithOpts("admission_webhooks", "cws_exec_instrumentation_attempts",
-		[]string{"mode", "injected", "reason"}, "Number of exec requests instrumentation attempts by CWS Instrumentation mode",
+	CWSExecInstrumentationAttempts = telemetry.NewHistogramWithOpts(
+		"admission_webhooks",
+		"cws_exec_instrumentation_attempts",
+		[]string{"mode", "injected", "reason"},
+		"Distribution of exec requests instrumentation attempts by CWS Instrumentation mode",
+		prometheus.LinearBuckets(0, 1, 1),
 		telemetry.Options{NoDoubleUnderscoreSep: true})
-	CWSPodInstrumentationAttempts = telemetry.NewCounterWithOpts("admission_webhooks", "cws_pod_instrumentation_attempts",
-		[]string{"mode", "injected", "reason"}, "Number of pod requests instrumentation attempts by CWS Instrumentation mode",
+	CWSPodInstrumentationAttempts = telemetry.NewHistogramWithOpts(
+		"admission_webhooks",
+		"cws_pod_instrumentation_attempts",
+		[]string{"mode", "injected", "reason"},
+		"Distribution of pod requests instrumentation attempts by CWS Instrumentation mode",
+		prometheus.LinearBuckets(0, 1, 1),
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	RemoteConfigs = telemetry.NewGaugeWithOpts("admission_webhooks", "rc_provider_configs",
 		[]string{}, "Number of valid remote configurations.",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes the metrics generated for CWS Instrumentation. Instead of using a counter that will grow forever, a distribution will better fit our monitoring use case.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This fixes our visibility on the `kubectl cp` instrumentation feature added in [this PR](https://github.com/DataDog/datadog-agent/pull/24175).