### PR TITLE
fix(ci): Remove duplicate task not used anymore

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -97,7 +97,6 @@ ns.add_task(deps_vendored)
 ns.add_task(lint_licenses)
 ns.add_task(generate_licenses)
 ns.add_task(lint_components)
-ns.add_task(lint_go)
 ns.add_task(lint_fxutil_oneshot_test)
 ns.add_task(generate_protobuf)
 ns.add_task(reset)
@@ -122,9 +121,10 @@ ns.add_task(fuzz)
 ns.add_task(go_fix)
 ns.add_task(build_messagetable)
 ns.add_task(get_impacted_packages)
-
 ns.add_task(get_modified_packages)
 ns.add_task(send_unit_tests_stats)
+# To deprecate
+ns.add_task(lint_go)
 
 # add namespaced tasks to the root
 ns.add_collection(agent)

--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -30,7 +30,6 @@ from tasks.libs.common.color import color_message
 from tasks.libs.common.datadog_api import create_count, send_metrics
 from tasks.libs.common.junit_upload_core import enrich_junitxml, produce_junit_tar
 from tasks.libs.common.utils import clean_nested_paths, collapsed_section, get_build_flags
-from tasks.linter import _lint_go
 from tasks.modules import DEFAULT_MODULES, GoModule
 from tasks.test_core import ModuleTestResult, process_input_args, process_module_results, test_core
 from tasks.testwasher import TestWasher
@@ -954,7 +953,7 @@ def should_run_all_tests(files, trigger_files):
     return False
 
 
-@task(iterable=['flavors'])
+@task
 def lint_go(
     ctx,
     module=None,
@@ -971,21 +970,6 @@ def lint_go(
     golangci_lint_kwargs="",
     headless_mode=False,
     include_sds=False,
+    only_modified_packages=False,
 ):
-    _lint_go(
-        ctx,
-        module,
-        targets,
-        flavor,
-        build,
-        build_tags,
-        build_include,
-        build_exclude,
-        rtloader_root,
-        arch,
-        cpus,
-        timeout,
-        golangci_lint_kwargs,
-        headless_mode,
-        include_sds,
-    )
+    raise Exit("This task is deprecated, please use `inv linter.go`", 1)

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -133,45 +133,6 @@ def go(
         inv linter.go --targets=./pkg/collector/check,./pkg/aggregator
         inv linter.go --module=.
     """
-    _lint_go(
-        ctx=ctx,
-        module=module,
-        targets=targets,
-        flavor=flavor,
-        build=build,
-        build_tags=build_tags,
-        build_include=build_include,
-        build_exclude=build_exclude,
-        rtloader_root=rtloader_root,
-        arch=arch,
-        cpus=cpus,
-        timeout=timeout,
-        golangci_lint_kwargs=golangci_lint_kwargs,
-        headless_mode=headless_mode,
-        include_sds=include_sds,
-        only_modified_packages=only_modified_packages,
-    )
-
-
-# Temporary method to duplicate go linter task not to impact macos jobs.
-def _lint_go(
-    ctx,
-    module,
-    targets,
-    flavor,
-    build,
-    build_tags,
-    build_include,
-    build_exclude,
-    rtloader_root,
-    arch,
-    cpus,
-    timeout,
-    golangci_lint_kwargs,
-    headless_mode,
-    include_sds,
-    only_modified_packages=False,
-):
     if not check_tools_version(ctx, ['go', 'golangci-lint']):
         print("Warning: If you have linter errors it might be due to version mismatches.", file=sys.stderr)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Remove the old `lint-go` task that was moved to `linter.go` namespace
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We kept the task to make a non breaking change in macos-lint.
Now it's changed on macos side we can deprecate this old task

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
