### PR TITLE
Add timestamp to all e2e error messages

### DIFF
--- a/test/new-e2e/tests/containers/base_test.go
+++ b/test/new-e2e/tests/containers/base_test.go
@@ -165,18 +165,18 @@ func (suite *baseSuite) testMetric(args *testMetricArgs) {
 				fakeintake.WithMatchingTags[*aggregator.MetricSeries](regexTags),
 			)
 			// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NoErrorf(c, err, "Failed to query fake intake") {
+			if !assert.NoErrorf(c, err, "%s\tFailed to query fake intake", time.Now()) {
 				return
 			}
 			// Can be replaced by require.NoEmptyf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NotEmptyf(c, metrics, "No `%s` metrics yet", prettyMetricQuery) {
+			if !assert.NotEmptyf(c, metrics, "%s\tNo `%s` metrics yet", time.Now(), prettyMetricQuery) {
 				return
 			}
 
 			// Check tags
 			if expectedTags != nil {
 				err := assertTags(metrics[len(metrics)-1].GetTags(), expectedTags, args.Expect.AcceptUnexpectedTags)
-				assert.NoErrorf(c, err, "Tags mismatch on `%s`", prettyMetricQuery)
+				assert.NoErrorf(c, err, "%s\tTags mismatch on `%s`", time.Now(), prettyMetricQuery)
 			}
 
 			// Check value
@@ -184,7 +184,8 @@ func (suite *baseSuite) testMetric(args *testMetricArgs) {
 				assert.NotEmptyf(c, lo.Filter(metrics[len(metrics)-1].GetPoints(), func(v *gogen.MetricPayload_MetricPoint, _ int) bool {
 					return v.GetValue() >= args.Expect.Value.Min &&
 						v.GetValue() <= args.Expect.Value.Max
-				}), "No value of `%s` is in the range [%f;%f]: %v",
+				}), "%s\tNo value of `%s` is in the range [%f;%f]: %v",
+					time.Now(),
 					prettyMetricQuery,
 					args.Expect.Value.Min,
 					args.Expect.Value.Max,
@@ -193,7 +194,7 @@ func (suite *baseSuite) testMetric(args *testMetricArgs) {
 					}),
 				)
 			}
-		}, 2*time.Minute, 10*time.Second, "Failed finding `%s` with proper tags and value", prettyMetricQuery)
+		}, 2*time.Minute, 10*time.Second, "%s\tFailed finding `%s` with proper tags and value", time.Now(), prettyMetricQuery)
 	})
 }
 
@@ -294,25 +295,26 @@ func (suite *baseSuite) testLog(args *testLogArgs) {
 				fakeintake.WithMatchingTags[*aggregator.Log](regexTags),
 			)
 			// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NoErrorf(c, err, "Failed to query fake intake") {
+			if !assert.NoErrorf(c, err, "%s\tFailed to query fake intake", time.Now()) {
 				return
 			}
 			// Can be replaced by require.NoEmptyf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NotEmptyf(c, logs, "No `%s` logs yet", prettyLogQuery) {
+			if !assert.NotEmptyf(c, logs, "%s\tNo `%s` logs yet", time.Now(), prettyLogQuery) {
 				return
 			}
 
 			// Check tags
 			if expectedTags != nil {
 				err := assertTags(logs[len(logs)-1].GetTags(), expectedTags, false)
-				assert.NoErrorf(c, err, "Tags mismatch on `%s`", prettyLogQuery)
+				assert.NoErrorf(c, err, "%s\tTags mismatch on `%s`", time.Now(), prettyLogQuery)
 			}
 
 			// Check message
 			if args.Expect.Message != "" {
 				assert.NotEmptyf(c, lo.Filter(logs, func(m *aggregator.Log, _ int) bool {
 					return expectedMessage.MatchString(m.Message)
-				}), "No log of `%s` is matching %q",
+				}), "%s\tNo log of `%s` is matching %q",
+					time.Now(),
 					prettyLogQuery,
 					args.Expect.Message,
 				)

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -111,7 +111,7 @@ func (suite *ecsSuite) Test00UpAndRunning() {
 	ctx := context.Background()
 
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
-	suite.Require().NoErrorf(err, "Failed to load AWS config")
+	suite.Require().NoErrorf(err, "%s\tFailed to load AWS config", time.Now())
 
 	client := awsecs.NewFromConfig(cfg)
 
@@ -129,7 +129,7 @@ func (suite *ecsSuite) Test00UpAndRunning() {
 					NextToken:  nextToken,
 				})
 				// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-				if !assert.NoErrorf(c, err, "Failed to list ECS services") {
+				if !assert.NoErrorf(c, err, "%s\tFailed to list ECS services", time.Now()) {
 					return
 				}
 
@@ -139,12 +139,12 @@ func (suite *ecsSuite) Test00UpAndRunning() {
 					Cluster:  &suite.ecsClusterName,
 					Services: servicesList.ServiceArns,
 				})
-				if !assert.NoErrorf(c, err, "Failed to describe ECS services %v", servicesList.ServiceArns) {
+				if !assert.NoErrorf(c, err, "%s\tFailed to describe ECS services %v", time.Now(), servicesList.ServiceArns) {
 					continue
 				}
 
 				for _, serviceDescription := range servicesDescription.Services {
-					assert.NotZerof(c, serviceDescription.DesiredCount, "ECS service %s has no task", *serviceDescription.ServiceName)
+					assert.NotZerof(c, serviceDescription.DesiredCount, "%s\tECS service %s has no task", time.Now(), *serviceDescription.ServiceName)
 
 					for nextToken := &initToken; nextToken != nil; {
 						if nextToken == &initToken {
@@ -158,7 +158,7 @@ func (suite *ecsSuite) Test00UpAndRunning() {
 							MaxResults:    pointer.Ptr(int32(100)), // Because `DescribeTasks` takes at most 100 tasks in input
 							NextToken:     nextToken,
 						})
-						if !assert.NoErrorf(c, err, "Failed to list ECS tasks for service %s", *serviceDescription.ServiceName) {
+						if !assert.NoErrorf(c, err, "%s\tFailed to list ECS tasks for service %s", time.Now(), *serviceDescription.ServiceName) {
 							break
 						}
 
@@ -168,20 +168,20 @@ func (suite *ecsSuite) Test00UpAndRunning() {
 							Cluster: &suite.ecsClusterName,
 							Tasks:   tasksList.TaskArns,
 						})
-						if !assert.NoErrorf(c, err, "Failed to describe ECS tasks %v", tasksList.TaskArns) {
+						if !assert.NoErrorf(c, err, "%s\tFailed to describe ECS tasks %v", time.Now(), tasksList.TaskArns) {
 							continue
 						}
 
 						for _, taskDescription := range tasksDescription.Tasks {
 							assert.Equalf(c, string(awsecstypes.DesiredStatusRunning), *taskDescription.LastStatus,
-								"Task %s of service %s is not running", *taskDescription.TaskArn, *serviceDescription.ServiceName)
+								"%s\tTask %s of service %s is not running", time.Now(), *taskDescription.TaskArn, *serviceDescription.ServiceName)
 							assert.NotEqualf(c, awsecstypes.HealthStatusUnhealthy, taskDescription.HealthStatus,
-								"Task %s of service %s is unhealthy", *taskDescription.TaskArn, *serviceDescription.ServiceName)
+								"%s\tTask %s of service %s is unhealthy", time.Now(), *taskDescription.TaskArn, *serviceDescription.ServiceName)
 						}
 					}
 				}
 			}
-		}, 5*time.Minute, 10*time.Second, "Not all tasks became ready in time.")
+		}, 5*time.Minute, 10*time.Second, "%s\tNot all tasks became ready in time.", time.Now())
 	})
 }
 
@@ -494,7 +494,7 @@ func (suite *ecsSuite) testTrace(taskName string) {
 	suite.EventuallyWithTf(func(c *assert.CollectT) {
 		traces, cerr := suite.Fakeintake.GetTraces()
 		// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-		if !assert.NoErrorf(c, cerr, "Failed to query fake intake") {
+		if !assert.NoErrorf(c, cerr, "%s\tFailed to query fake intake", time.Now()) {
 			return
 		}
 
@@ -527,6 +527,6 @@ func (suite *ecsSuite) testTrace(taskName string) {
 				break
 			}
 		}
-		require.NoErrorf(c, err, "Failed finding trace with proper tags")
-	}, 2*time.Minute, 10*time.Second, "Failed finding trace with proper tags")
+		require.NoErrorf(c, err, "%s\tFailed finding trace with proper tags", time.Now()) {
+		}, 2*time.Minute, 10*time.Second, "%s\tFailed finding trace with proper tags", time.Now()}
 }

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -119,7 +119,7 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 				LabelSelector: fields.OneTermEqualSelector("kubernetes.io/os", "linux").String(),
 			})
 			// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NoErrorf(c, err, "Failed to list Linux nodes") {
+			if !assert.NoErrorf(c, err, "%s\tFailed to list Linux nodes", time.Now()) {
 				return
 			}
 
@@ -127,7 +127,7 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 				LabelSelector: fields.OneTermEqualSelector("kubernetes.io/os", "windows").String(),
 			})
 			// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NoErrorf(c, err, "Failed to list Windows nodes") {
+			if !assert.NoErrorf(c, err, "%s\tFailed to list Windows nodes", time.Now()) {
 				return
 			}
 
@@ -135,7 +135,7 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 				LabelSelector: fields.OneTermEqualSelector("app", suite.AgentLinuxHelmInstallName+"-datadog").String(),
 			})
 			// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NoErrorf(c, err, "Failed to list Linux datadog agent pods") {
+			if !assert.NoErrorf(c, err, "%s\tFailed to list Linux datadog agent pods", time.Now()) {
 				return
 			}
 
@@ -143,7 +143,7 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 				LabelSelector: fields.OneTermEqualSelector("app", suite.AgentWindowsHelmInstallName+"-datadog").String(),
 			})
 			// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NoErrorf(c, err, "Failed to list Windows datadog agent pods") {
+			if !assert.NoErrorf(c, err, "%s\tFailed to list Windows datadog agent pods", time.Now()) {
 				return
 			}
 
@@ -151,7 +151,7 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 				LabelSelector: fields.OneTermEqualSelector("app", suite.AgentLinuxHelmInstallName+"-datadog-cluster-agent").String(),
 			})
 			// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NoErrorf(c, err, "Failed to list datadog cluster agent pods") {
+			if !assert.NoErrorf(c, err, "%s\tFailed to list datadog cluster agent pods", time.Now()) {
 				return
 			}
 
@@ -159,7 +159,7 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 				LabelSelector: fields.OneTermEqualSelector("app", suite.AgentLinuxHelmInstallName+"-datadog-clusterchecks").String(),
 			})
 			// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NoErrorf(c, err, "Failed to list datadog cluster checks runner pods") {
+			if !assert.NoErrorf(c, err, "%s\tFailed to list datadog cluster checks runner pods", time.Now()) {
 				return
 			}
 
@@ -167,7 +167,7 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 				LabelSelector: fields.OneTermEqualSelector("app", "dogstatsd-standalone").String(),
 			})
 			// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NoErrorf(c, err, "Failed to list dogstatsd standalone pods") {
+			if !assert.NoErrorf(c, err, "%s\tFailed to list dogstatsd standalone pods", time.Now()) {
 				return
 			}
 
@@ -180,12 +180,12 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 			for _, podList := range []*corev1.PodList{linuxPods, windowsPods, clusterAgentPods, clusterChecksPods, dogstatsdPods} {
 				for _, pod := range podList.Items {
 					for _, containerStatus := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
-						assert.Truef(c, containerStatus.Ready, "Container %s of pod %s isn’t ready", containerStatus.Name, pod.Name)
-						assert.Zerof(c, containerStatus.RestartCount, "Container %s of pod %s has restarted", containerStatus.Name, pod.Name)
+						assert.Truef(c, containerStatus.Ready, "%s\tContainer %s of pod %s isn’t ready", time.Now(), containerStatus.Name, pod.Name)
+						assert.Zerof(c, containerStatus.RestartCount, "%s\tContainer %s of pod %s has restarted", time.Now(), containerStatus.Name, pod.Name)
 					}
 				}
 			}
-		}, waitFor, 10*time.Second, "Not all agents eventually became ready in time.")
+		}, waitFor, 10*time.Second, "%s\tNot all agents eventually became ready in time.", time.Now())
 	})
 }
 
@@ -224,21 +224,21 @@ func (suite *k8sSuite) TestVersion() {
 				LabelSelector: fields.OneTermEqualSelector("app", tt.appSelector).String(),
 				Limit:         1,
 			})
-			if suite.NoError(err) && len(linuxPods.Items) >= 1 {
+			if suite.NoErrorf(err, "%s\tFailed to get one %s pod", time.Now(), tt.podType) && len(linuxPods.Items) >= 1 {
 				stdout, stderr, err := suite.podExec("datadog", linuxPods.Items[0].Name, tt.container, []string{"agent", "version"})
 				if suite.NoError(err) {
-					suite.Emptyf(stderr, "Standard error of `agent version` should be empty,")
+					suite.Emptyf(stderr, "%s\tStandard error of `agent version` should be empty,", time.Now())
 					match := versionExtractor.FindStringSubmatch(stdout)
-					if suite.Equalf(2, len(match), "'Commit' not found in the output of `agent version`.") {
-						if suite.Greaterf(len(GitCommit), 6, "Couldn’t guess the expected version of the agent.") &&
-							suite.Greaterf(len(match[1]), 6, "Couldn’t find the version of the agent.") {
+					if suite.Equalf(2, len(match), "%s\t'Commit' not found in the output of `agent version`.", time.Now()) {
+						if suite.Greaterf(len(GitCommit), 6, "%s\tCouldn’t guess the expected version of the agent.", time.Now()) &&
+							suite.Greaterf(len(match[1]), 6, "%s\tCouldn’t find the version of the agent.", time.Now()) {
 
 							size2compare := len(GitCommit)
 							if len(match[1]) < size2compare {
 								size2compare = len(match[1])
 							}
 
-							suite.Equalf(GitCommit[:size2compare], match[1][:size2compare], "Agent isn’t running the expected version")
+							suite.Equalf(GitCommit[:size2compare], match[1][:size2compare], "%s\tAgent isn’t running the expected version", time.Now())
 						}
 					}
 				}
@@ -752,15 +752,15 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 					break
 				}
 			}
-			assert.True(c, detectedLangsLabelIsSet)
-		}, 5*time.Minute, 10*time.Second, "The deployment with name %s in namespace %s does not exist or does not have the auto detected languages annotation", name, namespace)
+			assert.Truef(c, detectedLangsLabelIsSet, "%s\tFailed to witness the auto detected languages annotation on the deployment with name %s in namespace %s", time.Now(), name, namespace)
+		}, 5*time.Minute, 10*time.Second, "%s\tThe deployment with name %s in namespace %s does not exist or does not have the auto detected languages annotation", time.Now(), name, namespace)
 	}
 
 	// Delete the pod to ensure it is recreated after the admission controller is deployed
 	err := suite.K8sClient.CoreV1().Pods(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: fields.OneTermEqualSelector("app", name).String(),
 	})
-	suite.Require().NoError(err)
+	suite.Require().NoErrorf(err, "%s\tFailed to delete pods with label app=%s in namespace %s", time.Now(), name, namespace)
 
 	// Wait for the fresh pod to be created
 	var pod corev1.Pod
@@ -775,7 +775,7 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 			return
 		}
 		pod = pods.Items[0]
-	}, 2*time.Minute, 10*time.Second, "Failed to witness the creation of pod with name %s in namespace %s", name, namespace)
+	}, 2*time.Minute, 10*time.Second, "%s\tFailed to witness the creation of pod with name %s in namespace %s", time.Now(), name, namespace)
 
 	suite.Require().Len(pod.Spec.Containers, 1)
 
@@ -848,11 +848,11 @@ func (suite *k8sSuite) TestContainerImage() {
 	suite.EventuallyWithTf(func(c *assert.CollectT) {
 		images, err := suite.Fakeintake.FilterContainerImages("ghcr.io/datadog/apps-nginx-server")
 		// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-		if !assert.NoErrorf(c, err, "Failed to query fake intake") {
+		if !assert.NoErrorf(c, err, "%s\tFailed to query fake intake", time.Now()) {
 			return
 		}
 		// Can be replaced by require.NoEmptyf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-		if !assert.NotEmptyf(c, images, "No container_image yet") {
+		if !assert.NotEmptyf(c, images, "%s\tNo container_image yet", time.Now()) {
 			return
 		}
 
@@ -868,14 +868,14 @@ func (suite *k8sSuite) TestContainerImage() {
 		}
 		err = assertTags(images[len(images)-1].GetTags(), expectedTags, false)
 		assert.NoErrorf(c, err, "Tags mismatch")
-	}, 2*time.Minute, 10*time.Second, "Failed finding the container image payload")
+	}, 2*time.Minute, 10*time.Second, "%s\tFailed finding the container image payload", time.Now())
 }
 
 func (suite *k8sSuite) TestSBOM() {
 	suite.EventuallyWithTf(func(c *assert.CollectT) {
 		sbomIDs, err := suite.Fakeintake.GetSBOMIDs()
 		// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-		if !assert.NoErrorf(c, err, "Failed to query fake intake") {
+		if !assert.NoErrorf(c, err, "%s\tFailed to query fake intake", time.Now()) {
 			return
 		}
 
@@ -884,18 +884,18 @@ func (suite *k8sSuite) TestSBOM() {
 		})
 
 		// Can be replaced by require.NoEmptyf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-		if !assert.NotEmptyf(c, sbomIDs, "No SBOM for ghcr.io/datadog/apps-nginx-server yet") {
+		if !assert.NotEmptyf(c, sbomIDs, "%s\tNo SBOM for ghcr.io/datadog/apps-nginx-server yet", time.Now()) {
 			return
 		}
 
 		images := lo.FlatMap(sbomIDs, func(id string, _ int) []*aggregator.SBOMPayload {
 			images, err := suite.Fakeintake.FilterSBOMs(id)
-			assert.NoErrorf(c, err, "Failed to query fake intake")
+			assert.NoErrorf(c, err, "%s\tFailed to query fake intake", time.Now())
 			return images
 		})
 
 		// Can be replaced by require.NoEmptyf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-		if !assert.NotEmptyf(c, images, "No SBOM payload yet") {
+		if !assert.NotEmptyf(c, images, "%s\tNo SBOM payload yet", time.Now()) {
 			return
 		}
 
@@ -904,7 +904,7 @@ func (suite *k8sSuite) TestSBOM() {
 		})
 
 		// Can be replaced by require.NoEmptyf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-		if !assert.NotEmptyf(c, images, "No successful SBOM yet") {
+		if !assert.NotEmptyf(c, images, "%s\tNo successful SBOM yet", time.Now()) {
 			return
 		}
 
@@ -916,7 +916,7 @@ func (suite *k8sSuite) TestSBOM() {
 		})
 
 		// Can be replaced by require.NoEmptyf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-		if !assert.NotEmptyf(c, images, "No SBOM with complete CycloneDX") {
+		if !assert.NotEmptyf(c, images, "%s\tNo SBOM with complete CycloneDX", time.Now()) {
 			return
 		}
 
@@ -950,7 +950,7 @@ func (suite *k8sSuite) TestSBOM() {
 				assert.Contains(c, properties["aquasecurity:trivy:RepoDigest"], "ghcr.io/datadog/apps-nginx-server@sha256:")
 			}
 		}
-	}, 2*time.Minute, 10*time.Second, "Failed finding the container image payload")
+	}, 2*time.Minute, 10*time.Second, "%s\tFailed finding the container image payload", time.Now())
 }
 
 func (suite *k8sSuite) TestContainerLifecycleEvents() {
@@ -961,23 +961,23 @@ func (suite *k8sSuite) TestContainerLifecycleEvents() {
 			LabelSelector: fields.OneTermEqualSelector("app", "nginx").String(),
 		})
 		// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-		if !assert.NoErrorf(c, err, "Failed to list nginx pods") {
+		if !assert.NoErrorf(c, err, "%s\tFailed to list nginx pods", time.Now()) {
 			return
 		}
-		if !assert.NotEmptyf(c, pods, "Failed to find an nginx pod") {
+		if !assert.NotEmptyf(c, pods, "%s\tFailed to find an nginx pod", time.Now()) {
 			return
 		}
 
 		nginxPod = pods.Items[0]
-	}, 1*time.Minute, 10*time.Second, "Failed to find an nginx pod")
+	}, 1*time.Minute, 10*time.Second, "%s\tFailed to find an nginx pod", time.Now())
 
 	err := suite.K8sClient.CoreV1().Pods("workload-nginx").Delete(context.Background(), nginxPod.Name, metav1.DeleteOptions{})
-	suite.Require().NoError(err)
+	suite.Require().NoErrorf(err, "%s\tFailed to delete the nginx pod", time.Now())
 
 	suite.EventuallyWithTf(func(c *assert.CollectT) {
 		events, err := suite.Fakeintake.GetContainerLifecycleEvents()
 		// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-		if !assert.NoErrorf(c, err, "Failed to query fake intake") {
+		if !assert.NoErrorf(c, err, "%s\tFailed to query fake intake", time.Now()) {
 			return
 		}
 
@@ -992,8 +992,8 @@ func (suite *k8sSuite) TestContainerLifecycleEvents() {
 			}
 		}
 
-		assert.Truef(c, foundPodEvent, "Failed to find the pod lifecycle event")
-	}, 2*time.Minute, 10*time.Second, "Failed to find the container lifecycle events")
+		assert.Truef(c, foundPodEvent, "%s\tFailed to find the pod lifecycle event", time.Now())
+	}, 2*time.Minute, 10*time.Second, "%s\tFailed to find the container lifecycle events", time.Now())
 }
 
 func (suite *k8sSuite) testHPA(namespace, deployment string) {
@@ -1036,11 +1036,11 @@ func (suite *k8sSuite) testHPA(namespace, deployment string) {
 				}),
 			)
 			// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
-			if !assert.NoErrorf(c, err, "Failed to query fake intake") {
+			if !assert.NoErrorf(c, err, "%s\tFailed to query fake intake", time.Now()) {
 				return
 			}
-			if !assert.NotEmptyf(c, metrics, "No `kubernetes_state.deployment.replicas_available{kube_namespace:%s,kube_deployment:%s}` metrics yet", namespace, deployment) {
-				sendEvent("warning", fmt.Sprintf("No `kubernetes_state.deployment.replicas_available{kube_namespace:%s,kube_deployment:%s}` metrics yet", namespace, deployment), nil)
+			if !assert.NotEmptyf(c, metrics, "%s\tNo `kubernetes_state.deployment.replicas_available{kube_namespace:%s,kube_deployment:%s}` metrics yet", time.Now(), namespace, deployment) {
+				sendEvent("warning", fmt.Sprintf("%s\tNo `kubernetes_state.deployment.replicas_available{kube_namespace:%s,kube_deployment:%s}` metrics yet", time.Now(), namespace, deployment), nil)
 				return
 			}
 
@@ -1073,14 +1073,14 @@ func (suite *k8sSuite) testHPA(namespace, deployment string) {
 					prevValue = point.Value
 				}
 			}
-			assert.Truef(c, scaleUp, "No scale up detected")
-			assert.Truef(c, scaleDown, "No scale down detected")
+			assert.Truef(c, scaleUp, "%s\tNo scale up detected", time.Now())
+			assert.Truef(c, scaleDown, "%s\tNo scale down detected", time.Now())
 			// The deployments that have an HPA configured (nginx and redis)
 			// exhibit a traffic pattern that follows a sine wave with a
 			// 20-minute period. This is defined in the test-infra-definitions
 			// repo. For this reason, the timeout for this test needs to be a
 			// bit higher than 20 min to capture the scale down event.
-		}, 25*time.Minute, 10*time.Second, "Failed to witness scale up and scale down of %s.%s", namespace, deployment)
+		}, 25*time.Minute, 10*time.Second, "%s\tFailed to witness scale up and scale down of %s.%s", time.Now(), namespace, deployment)
 	})
 }
 
@@ -1165,6 +1165,6 @@ func (suite *k8sSuite) testTrace(kubeDeployment string) {
 				break
 			}
 		}
-		require.NoErrorf(c, err, "Failed finding trace with proper tags")
-	}, 2*time.Minute, 10*time.Second, "Failed finding trace with proper tags")
+		require.NoErrorf(c, err, "%s\tFailed finding trace with proper tags", time.Now())
+	}, 2*time.Minute, 10*time.Second, "%s\tFailed finding trace with proper tags", time.Now())
 }


### PR DESCRIPTION
### What does this PR do?

Add a timestamp to all the the e2e 

### Motivation

When a test fails, we use the dashboards ([ex](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?fromUser=false&refresh_mode=paused&tpl_var_fake_intake_task_family%5B0%5D=ci-504661319-4670-eks-cluster-fakeintake-ecs&tpl_var_kube_cluster_name%5B0%5D=ci-504661319-4670-eks-cluster&view=spans&from_ts=1714993077384&to_ts=1714993968332&live=false)) to diagnose what happens and when.

When an issue is flaky, we need to know exactly when a test ran, so that we can look, on the dashboard, what was the state of the environment at that time.

When we assert metrics or logs, it’s easy because the tests are emitting datadog events that are shown as an overlay on top of the dashboard widgets.

But for some other tests (like the ones asserting SBOM or container lifecycle events or agent readiness), we don’t have datadog events.

In such cases, having the timestamp at which a test ran would be extremely valuable.

### Additional Notes

Having to modify each call to `Errorf`/`Emptyf`/`Equalf`/etc. is really terrible.

`testify` doesn’t seem to provide a way to customize the format of errors: https://github.com/stretchr/testify/blob/8d4dcbbccbf89133a133766c53a4bd153d2f5f4a/assert/assertions.go#L1923

Forking `testify` or overriding all its `assert.*f` and `require.*f` functions seems painful.

Having GitLab put timestamp in front of all log lines is a feature requested for 4 years: https://gitlab.com/gitlab-org/gitlab/-/issues/202293.
And it wouldn’t help a lot because the testing framework (`gotestsum` ?) is buffering the errors. It doesn’t print them only when they occur, but also in a summary, at the end, once all the tests have run. In this case, the error is logged way after it has been raised. So, a timestamp put by GitLab would be misleading.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
