### PR TITLE
Setup for end to end tests for TCP and UDP listeners

### DIFF
--- a/test/new-e2e/pkg/components/remotehost_docker.go
+++ b/test/new-e2e/pkg/components/remotehost_docker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/test-infra-definitions/components/docker"
+	dclient "github.com/docker/docker/client"
 )
 
 // RemoteHostDocker represents an Agent running directly on a Host
@@ -24,4 +25,9 @@ var _ e2e.Initializable = (*RemoteHostDocker)(nil)
 func (d *RemoteHostDocker) Init(ctx e2e.Context) (err error) {
 	d.Client, err = client.NewDocker(ctx.T(), d.ManagerOutput)
 	return err
+}
+
+// GetClient returns the Docker client for the host
+func (d *RemoteHostDocker) GetClient() *dclient.Client {
+	return d.Client.GetClient()
 }

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/file-tailing/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/file-tailing/file_tailing_test.go
@@ -122,7 +122,7 @@ func (s *LinuxFakeintakeSuite) testLogCollection() {
 		fmt.Sprintf("dirname:%s", utils.LinuxLogsFolderPath),
 	}
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-world", expectedTags)
+	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "hello", "hello-world", expectedTags)
 }
 
 func (s *LinuxFakeintakeSuite) testLogNoPermission() {
@@ -146,7 +146,7 @@ func (s *LinuxFakeintakeSuite) testLogNoPermission() {
 			// Generate log
 			utils.AppendLog(s, logFileName, "access-denied", 1)
 			// Check intake for new logs
-			utils.CheckLogsNotExpected(s, "hello", "access-denied")
+			utils.CheckLogsNotExpected(s.T(), s.Env().FakeIntake, "hello", "access-denied")
 		}
 	}, 2*time.Minute, 5*time.Second)
 }
@@ -165,7 +165,7 @@ func (s *LinuxFakeintakeSuite) testLogCollectionAfterPermission() {
 	t.Logf("Permissions granted for log file.")
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-after-permission-world", []string{})
+	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "hello", "hello-after-permission-world", []string{})
 }
 
 func (s *LinuxFakeintakeSuite) testLogCollectionBeforePermission() {
@@ -189,7 +189,7 @@ func (s *LinuxFakeintakeSuite) testLogCollectionBeforePermission() {
 	utils.AppendLog(s, logFileName, "access-granted", 1)
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "access-granted", []string{})
+	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "hello", "access-granted", []string{})
 }
 
 func (s *LinuxFakeintakeSuite) testLogRecreateRotation() {
@@ -213,5 +213,5 @@ func (s *LinuxFakeintakeSuite) testLogRecreateRotation() {
 	utils.AppendLog(s, logFileName, "hello-world-new-content", 1)
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-world-new-content", []string{})
+	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "hello", "hello-world-new-content", []string{})
 }

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/journald/journald_tailing_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/journald/journald_tailing_test.go
@@ -95,7 +95,7 @@ func (s *LinuxJournaldFakeintakeSuite) journaldLogCollection() {
 	appendJournaldLog(s, "hello-world", 1)
 
 	// Check that the generated log is collected
-	utils.CheckLogsExpected(s, "hello", "hello-world", []string{})
+	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "hello", "hello-world", []string{})
 }
 
 func (s *LinuxJournaldFakeintakeSuite) journaldIncludeServiceLogCollection() {
@@ -141,7 +141,7 @@ func (s *LinuxJournaldFakeintakeSuite) journaldIncludeServiceLogCollection() {
 		agentReady := s.Env().Agent.Client.IsReady()
 		if assert.Truef(c, agentReady, "Agent is not ready after restart") {
 			// Check that the agent service log is collected
-			utils.CheckLogsExpected(s, "random-logger", "less important", []string{})
+			utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "random-logger", "less important", []string{})
 		}
 	}, 1*time.Minute, 5*time.Second)
 
@@ -162,7 +162,7 @@ func (s *LinuxJournaldFakeintakeSuite) journaldExcludeServiceCollection() {
 		agentReady := s.Env().Agent.Client.IsReady()
 		if assert.Truef(c, agentReady, "Agent is not ready after restart") {
 			// Check that the datadog-agent.service log is not collected, specifically logs from the check runners
-			utils.CheckLogsNotExpected(s, "no-datadog", "running check")
+			utils.CheckLogsNotExpected(s.T(), s.Env().FakeIntake, "no-datadog", "running check")
 		}
 	}, 1*time.Minute, 5*time.Second)
 }

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/listener/tcp_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/listener/tcp_test.go
@@ -1,0 +1,112 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package listener
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-metric-logs/log-agent/utils"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awsdocker "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/docker"
+
+	appslogger "github.com/DataDog/test-infra-definitions/components/datadog/apps/logger"
+	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
+
+	"github.com/docker/docker/api/types"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/tcp-compose.yaml
+var tcpCompose string
+
+type dockerSuite struct {
+	e2e.BaseSuite[environments.DockerHost]
+}
+
+func TestTCPListener(t *testing.T) {
+	t.Skip("Skipping as don't currently support using labels to spin up TCP/UDP listener")
+	e2e.Run(t, &dockerSuite{}, e2e.WithProvisioner(
+		awsdocker.Provisioner(
+			awsdocker.WithAgentOptions(
+				dockeragentparams.WithExtraComposeManifest("logger", appslogger.DockerComposeManifest.Content),
+				dockeragentparams.WithExtraComposeManifest("logger-tcp", pulumi.String(tcpCompose)),
+			))))
+}
+
+func (d *dockerSuite) TestLogsReceived() {
+	d.EventuallyWithT(func(c *assert.CollectT) {
+		agentReady := d.Env().Agent.Client.IsReady()
+		assert.True(c, agentReady)
+	}, 1*time.Minute, 5*time.Second, "Agent was not ready")
+	agentVersion := d.Env().Agent.Client.Version()
+	d.T().Logf("Testing Agent Version '%v'\n", agentVersion)
+	statusOutput := d.Env().Agent.Client.Status().Content
+	d.T().Logf("Agent status:\n %v", statusOutput)
+	containerID, err := d.getLoggerContainerID()
+	require.NoError(d.T(), err)
+	assert.NotEmpty(d.T(), containerID)
+
+	dc := d.Env().Docker.GetClient()
+
+	// Command to execute inside the container
+	cmd := []string{
+		"curl", "-v",
+		"--header", "\"Content-Type: application/json\"",
+		"--request", "POST",
+		"--data", "'{\"message\":\"bob\"}'",
+		"localhost:3333/",
+	}
+
+	// Prepare the execution configuration
+	execConfig := types.ExecConfig{
+		AttachStdout: true,
+		AttachStderr: true,
+		Cmd:          cmd,
+	}
+
+	// Create the execution request
+	execResponse, err := dc.ContainerExecCreate(context.Background(), containerID, execConfig)
+	require.NoError(d.T(), err)
+
+	// Run the command in the container
+	execID := execResponse.ID
+	execStartCheck := types.ExecStartCheck{}
+	respID, err := dc.ContainerExecAttach(context.Background(), execID, execStartCheck)
+	require.NoError(d.T(), err)
+
+	// Wait for command execution to complete
+	_, err = dc.ContainerExecInspect(context.Background(), execID)
+	assert.NoError(d.T(), err)
+
+	all, err := io.ReadAll(respID.Reader)
+	require.NoError(d.T(), err)
+	d.T().Log(string(all))
+	utils.CheckLogsExpected(d.T(), d.Env().FakeIntake, "test-app", "bob", []string{})
+}
+
+// getLoggerContainerID returns the container ID of the logger app container
+func (d *dockerSuite) getLoggerContainerID() (string, error) {
+	containers, err := d.Env().Docker.GetClient().ContainerList(context.Background(), types.ContainerListOptions{})
+	if err != nil {
+		return "", err
+	}
+	for _, ctr := range containers {
+		d.T().Logf("Got container: %s %s | %v\n", ctr.ID, ctr.Image, ctr.Names)
+		if ctr.Image == "ghcr.io/datadog/apps-logger:main" {
+			return ctr.ID, nil
+		}
+	}
+	return "", errors.New("could not find logger app container")
+}

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/listener/testdata/agent-logs-tcp-conf.yaml
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/listener/testdata/agent-logs-tcp-conf.yaml
@@ -1,0 +1,7 @@
+---
+
+logs:
+  - type: tcp
+    port: 10518
+    service: "test-app"
+    source: "logger"

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/listener/testdata/agent-logs-udp-conf.yaml
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/listener/testdata/agent-logs-udp-conf.yaml
@@ -1,0 +1,7 @@
+---
+
+logs:
+  - type: udp
+    port: 10518
+    service: "test-app"
+    source: "logger"

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/listener/testdata/tcp-compose.yaml
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/listener/testdata/tcp-compose.yaml
@@ -1,0 +1,23 @@
+---
+services:
+
+  logger-app:
+    environment:
+      TCP: true
+      TARGET: "agent:10518"
+    labels:
+      com.datadoghq.ad.logs: |
+        [
+          {
+            "type": "tcp",
+            "port": 10518,
+            "source": "logger",
+            "service": "test-app"
+          }
+        ]
+
+  agent:
+    environment:
+      DD_LOGS_ENABLED: true
+      DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: false
+      DD_LOG_LEVEL: info

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/listener/testdata/udp-compose.yaml
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/listener/testdata/udp-compose.yaml
@@ -1,0 +1,23 @@
+---
+services:
+
+  logger-app:
+    environment:
+      TCP: true
+      TARGET: "agent:10518"
+    labels:
+      com.datadoghq.ad.logs: |
+        [
+          {
+            "type": "udp",
+            "port": 10518,
+            "source": "logger",
+            "service": "test-app"
+          }
+        ]
+
+  agent:
+    environment:
+      DD_LOGS_ENABLED: true
+      DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: false
+      DD_LOG_LEVEL: info

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/utils/file_tailing_utils.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/utils/file_tailing_utils.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -114,10 +116,9 @@ func CheckLogFilePresence(ls LogsTestSuite, logFileName string) {
 	}
 }
 
-// FetchAndFilterLogs fetches and filters logs based on the service.
-func FetchAndFilterLogs(ls LogsTestSuite, service, content string) ([]*aggregator.Log, error) {
-	client := ls.Env().FakeIntake.Client()
-	t := ls.T()
+// FetchAndFilterLogs fetches logs from the fake intake server and filters them by service and content.
+func FetchAndFilterLogs(t *testing.T, fakeIntake *components.FakeIntake, service, content string) ([]*aggregator.Log, error) {
+	client := fakeIntake.Client()
 	t.Helper()
 
 	names, err := client.GetLogServiceNames()
@@ -137,12 +138,11 @@ func FetchAndFilterLogs(ls LogsTestSuite, service, content string) ([]*aggregato
 }
 
 // CheckLogsExpected verifies the presence of expected logs.
-func CheckLogsExpected(ls LogsTestSuite, service, content string, expectedTags ddtags) {
-	t := ls.T()
+func CheckLogsExpected(t *testing.T, fakeIntake *components.FakeIntake, service, content string, expectedTags ddtags) {
 	t.Helper()
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		logs, err := FetchAndFilterLogs(ls, service, content)
+		logs, err := FetchAndFilterLogs(t, fakeIntake, service, content)
 		if assert.NoErrorf(c, err, "Error fetching logs: %s", err) {
 			intakeLog := logsToString(logs)
 			if assert.NotEmpty(c, logs, "Expected logs with content: '%s' not found. Instead, found: %s", content, intakeLog) {
@@ -157,12 +157,11 @@ func CheckLogsExpected(ls LogsTestSuite, service, content string, expectedTags d
 }
 
 // CheckLogsNotExpected verifies the absence of unexpected logs.
-func CheckLogsNotExpected(ls LogsTestSuite, service, content string) {
-	t := ls.T()
+func CheckLogsNotExpected(t *testing.T, fakeIntake *components.FakeIntake, service, content string) {
 	t.Helper()
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		logs, err := FetchAndFilterLogs(ls, service, content)
+		logs, err := FetchAndFilterLogs(t, fakeIntake, service, content)
 		intakeLog := logsToString(logs)
 		if assert.NoErrorf(c, err, "Error fetching logs: %s", err) {
 			if assert.Empty(c, logs, "Unexpected logs with content: '%s' found. Instead, found: %s", content, intakeLog) {

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/windows-log/file-tailing/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/windows-log/file-tailing/file_tailing_test.go
@@ -130,7 +130,7 @@ func (s *WindowsFakeintakeSuite) testLogCollection() {
 		fmt.Sprintf("dirname:%s", utils.WindowsLogsFolderPath),
 	}
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-world", expectedTags)
+	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "hello", "hello-world", expectedTags)
 
 }
 
@@ -150,7 +150,7 @@ func (s *WindowsFakeintakeSuite) testLogNoPermission() {
 			// Generate log
 			utils.AppendLog(s, logFileName, "access-denied", 1)
 			// Check intake for new logs
-			utils.CheckLogsNotExpected(s, "hello", "access-denied")
+			utils.CheckLogsNotExpected(s.T(), s.Env().FakeIntake, "hello", "access-denied")
 		}
 	}, 2*time.Minute, 5*time.Second)
 
@@ -169,7 +169,7 @@ func (s *WindowsFakeintakeSuite) testLogCollectionAfterPermission() {
 	t.Logf("Permissions granted for log file.")
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-after-permission-world", []string{})
+	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "hello", "hello-after-permission-world", []string{})
 }
 
 func (s *WindowsFakeintakeSuite) testLogCollectionBeforePermission() {
@@ -192,7 +192,7 @@ func (s *WindowsFakeintakeSuite) testLogCollectionBeforePermission() {
 	utils.AppendLog(s, logFileName, "access-granted", 1)
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "access-granted", []string{})
+	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "hello", "access-granted", []string{})
 }
 
 func (s *WindowsFakeintakeSuite) testLogRecreateRotation() {
@@ -217,6 +217,6 @@ func (s *WindowsFakeintakeSuite) testLogRecreateRotation() {
 	utils.AppendLog(s, logFileName, "hello-world-new-content", 1)
 
 	// Check intake for new logs
-	utils.CheckLogsExpected(s, "hello", "hello-world-new-content", []string{})
+	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "hello", "hello-world-new-content", []string{})
 
 }


### PR DESCRIPTION
### What does this PR do?

This adds a basic test for our TCP and UDP listeners using docker. Currently those tests are disabled/skipped as we don't support these listeners in a container world.

### Motivation

I'd like to get these tests in before doing the work to add support for TCP and UDP containers as the branch was getting stale very quickly.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
