### PR TITLE
[cluster-agent/api/kubernetes_metadata] Use workloadmeta to get namespace labels

### DIFF
--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -36,7 +36,13 @@ func installKubernetesMetadataEndpoints(r *mux.Router, wmeta workloadmeta.Compon
 		"getNodeLabels",
 		func(w http.ResponseWriter, r *http.Request) { getNodeLabels(w, r, wmeta) },
 	)).Methods("GET")
-	r.HandleFunc("/tags/namespace/{ns}", api.WithTelemetryWrapper("getNamespaceLabels", getNamespaceLabels)).Methods("GET")
+	r.HandleFunc(
+		"/tags/namespace/{ns}",
+		api.WithTelemetryWrapper(
+			"getNamespaceLabels",
+			func(w http.ResponseWriter, r *http.Request) { getNamespaceLabels(w, r, wmeta) },
+		),
+	).Methods("GET")
 	r.HandleFunc("/cluster/id", api.WithTelemetryWrapper("getClusterID", getClusterID)).Methods("GET")
 }
 
@@ -110,7 +116,7 @@ func getNodeAnnotations(w http.ResponseWriter, r *http.Request, wmeta workloadme
 }
 
 // getNamespaceLabels is only used when the node agent hits the DCA for the list of labels
-func getNamespaceLabels(w http.ResponseWriter, r *http.Request) {
+func getNamespaceLabels(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Component) {
 	/*
 		Input
 			localhost:5001/api/v1/tags/namespace/default
@@ -131,13 +137,15 @@ func getNamespaceLabels(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	var labelBytes []byte
 	nsName := vars["ns"]
-	nsLabels, err := as.GetNamespaceLabels(nsName)
+
+	namespace, err := wmeta.GetKubernetesNamespace(nsName)
 	if err != nil {
 		log.Errorf("Could not retrieve the namespace labels of %s: %v", nsName, err.Error()) //nolint:errcheck
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	labelBytes, err = json.Marshal(nsLabels)
+
+	labelBytes, err = json.Marshal(namespace.Labels)
 	if err != nil {
 		log.Errorf("Could not process the labels of the namespace %s from the informer's cache: %v", nsName, err.Error()) //nolint:errcheck
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -119,7 +119,6 @@ func StartControllers(ctx ControllerContext) errors.Aggregate {
 func startMetadataController(ctx ControllerContext, c chan error) {
 	metaController := NewMetadataController(
 		ctx.InformerFactory.Core().V1().Nodes(),
-		ctx.InformerFactory.Core().V1().Namespaces(),
 		ctx.InformerFactory.Core().V1().Endpoints(),
 	)
 	go metaController.Run(ctx.StopCh)

--- a/pkg/util/kubernetes/apiserver/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller_test.go
@@ -472,7 +472,6 @@ func newFakeMetadataController(client kubernetes.Interface) (*MetadataController
 
 	metaController := NewMetadataController(
 		informerFactory.Core().V1().Nodes(),
-		informerFactory.Core().V1().Namespaces(),
 		informerFactory.Core().V1().Endpoints(),
 	)
 


### PR DESCRIPTION
### What does this PR do?

Changes the DCA API endpoint that returns kubernetes namespace labels to rely on workloadmeta instead of a namespaces informer.

Workloadmeta now stores namespace labels (https://github.com/DataDog/datadog-agent/pull/25279) so we can use that instead of the generic informer.

Workloadmeta doesn't store the whole namespace object, just what we need (labels for now) so this might also reduce memory usage.

### Describe how to test/QA your changes

We need to check that the "namespace labels as tags" still works. Enable kubernetes tags and namespace collection and set some namespace labels as tags. When using helm you can use a config like this one:
```yaml
datadog:
  kubelet:
    tlsVerify: false
  clusterTagger:
    collectKubernetesTags: true
  namespaceLabelsAsTags:
    testlabel: testtag
clusterAgent:
  env:
    - name: DD_KUBERNETES_NAMESPACE_COLLECTION_ENABLED (The env to configure this might have changed by the time we need to do QA, check if that's the case).
      value: "true"
```

Then add the label in `namespaceLabelsAsTags` (`testlabel` in the example) with any value to some namespace and deploy a pod there. The metrics for that pod should include the tag in `namespaceLabelsAsTags` (`testtag` in the example).