### PR TITLE
[PROCS-3955] Address `TestLanguageDetectionSuite/TestPythonDetection` flakiness

### DIFF
--- a/test/new-e2e/tests/language-detection/language_detection_test.go
+++ b/test/new-e2e/tests/language-detection/language_detection_test.go
@@ -71,7 +71,7 @@ func (s *languageDetectionSuite) checkDetectedLanguage(command string, language 
 		fmt.Sprintf("language match not found, pid = %s, expected = %s, actual = %s, err = %v",
 			pid, language, actualLanguage, err),
 	)
-	
+
 	s.Env().RemoteHost.MustExecute(fmt.Sprintf("kill -SIGTERM %s", pid))
 }
 

--- a/test/new-e2e/tests/language-detection/language_detection_test.go
+++ b/test/new-e2e/tests/language-detection/language_detection_test.go
@@ -56,7 +56,7 @@ func (s *languageDetectionSuite) checkDetectedLanguage(command string, language 
 			pid = s.getPidForCommand(command)
 			return len(pid) > 0
 		},
-		1*time.Second, 10*time.Millisecond,
+		10*time.Second, 10*time.Millisecond,
 		fmt.Sprintf("pid not found for command %s", command),
 	)
 
@@ -71,7 +71,7 @@ func (s *languageDetectionSuite) checkDetectedLanguage(command string, language 
 		fmt.Sprintf("language match not found, pid = %s, expected = %s, actual = %s, err = %v",
 			pid, language, actualLanguage, err),
 	)
-
+	
 	s.Env().RemoteHost.MustExecute(fmt.Sprintf("kill -SIGTERM %s", pid))
 }
 
@@ -80,7 +80,10 @@ func (s *languageDetectionSuite) getPidForCommand(command string) string {
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(pid)
+	pid = strings.TrimSpace(pid)
+	// special handling in case multiple commands match
+	pids := strings.Split(pid, "\n")
+	return pids[0]
 }
 
 func (s *languageDetectionSuite) getLanguageForPid(pid string) (string, error) {

--- a/test/new-e2e/tests/language-detection/python_test.go
+++ b/test/new-e2e/tests/language-detection/python_test.go
@@ -18,10 +18,9 @@ func (s *languageDetectionSuite) installPython() {
 }
 
 func (s *languageDetectionSuite) TestPythonDetection() {
-	s.T().Skip("skipping due to flakiness")
 	s.installPython()
 
-	s.Env().RemoteHost.MustExecute("echo 'import time\ntime.sleep(30)' > prog.py")
+	s.Env().RemoteHost.MustExecute("echo -e 'import time\ntime.sleep(60)' > prog.py")
 	s.Env().RemoteHost.MustExecute("nohup python3 prog.py >myscript.log 2>&1 </dev/null &")
 
 	s.checkDetectedLanguage("python3", "python")


### PR DESCRIPTION
### What does this PR do?

Based on the test flake history there are two different errors that can occur:
1. Two commands can match `ps -C python3 -o pid=` resulting in a pid string such as `pid1 \n pid2` thus both the `kill` and language check can fail as it only expects 1 pid.
2. The language check fails due to timeout. 

To address these issues handling was added for multiple pids and the python script now stays alive for longer. The `-e` flag was also added to the `echo` command to ensure proper escaping of `import time\ntime.sleep(60)`.

### Motivation

Flaky test

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

e2e test passes:
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/507440397 