### PR TITLE
Fix duplicate otelcollector pipeline start

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -593,7 +593,7 @@ func startAgent(
 	// start dependent services
 	go startDependentServices()
 
-	return otelcollector.Start()
+	return nil
 }
 
 // StopAgentWithDefaults is a temporary way for other packages to use stopAgent.

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -479,7 +479,7 @@ func startAgent(
 	_ processAgent.Component,
 	_ defaultforwarder.Component,
 	_ serializer.MetricSerializer,
-	otelcollector otelcollector.Component,
+	_ otelcollector.Component,
 	demultiplexer demultiplexer.Component,
 	agentAPI internalAPI.Component,
 	invChecks inventorychecks.Component,

--- a/comp/otelcol/collector/component.go
+++ b/comp/otelcol/collector/component.go
@@ -17,17 +17,8 @@ import (
 
 // team: opentelemetry
 
-// TODO: This component can't use the fx lifecycle hooks for starting and stopping
-// because it depends on the logs agent component's log channel which isn't ready at
-// that time and can't be obtained. This needs to be addressed as an improvement
-// of the logs agent component.
-
 // Component specifies the interface implemented by the collector module.
-type Component interface {
-	collectordef.Component
-	Start() error
-	Stop()
-}
+type Component = collectordef.Component
 
 // Module specifies the Collector module bundle.
 func Module() fxutil.Module {

--- a/comp/otelcol/collector/pipeline.go
+++ b/comp/otelcol/collector/pipeline.go
@@ -65,7 +65,7 @@ type collector struct {
 	col  *otlp.Pipeline
 }
 
-func (c *collector) start(ctx context.Context) error {
+func (c *collector) start(context.Context) error {
 	deps := c.deps
 	on := otlp.IsEnabled(deps.Config)
 	deps.InventoryAgent.Set(otlpEnabled, on)
@@ -88,6 +88,7 @@ func (c *collector) start(ctx context.Context) error {
 	c.col = col
 	// the context passed to this function has a startup deadline which
 	// will shutdown the collector prematurely
+	ctx := context.Background()
 	go func() {
 		if err := col.Run(ctx); err != nil {
 			deps.Log.Errorf("Error running the OTLP ingest pipeline: %v", err)

--- a/comp/otelcol/collector/pipeline.go
+++ b/comp/otelcol/collector/pipeline.go
@@ -65,7 +65,7 @@ type collector struct {
 	col  *otlp.Pipeline
 }
 
-func (c *collector) Start() error {
+func (c *collector) start(ctx context.Context) error {
 	deps := c.deps
 	on := otlp.IsEnabled(deps.Config)
 	deps.InventoryAgent.Set(otlpEnabled, on)
@@ -88,7 +88,6 @@ func (c *collector) Start() error {
 	c.col = col
 	// the context passed to this function has a startup deadline which
 	// will shutdown the collector prematurely
-	ctx := context.Background()
 	go func() {
 		if err := col.Run(ctx); err != nil {
 			deps.Log.Errorf("Error running the OTLP ingest pipeline: %v", err)
@@ -97,19 +96,11 @@ func (c *collector) Start() error {
 	return nil
 }
 
-func (c *collector) Stop() {
+func (c *collector) stop(context.Context) error {
 	if c.col != nil {
 		c.col.Stop()
 	}
-}
-
-func (c *collector) stop(context.Context) error {
-	c.Stop()
 	return nil
-}
-
-func (c *collector) start(context.Context) error {
-	return c.Start()
 }
 
 // Status returns the status of the collector.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Found a bug during QA where the otelcollector pipeline Start method was being called twice:
1. In a lifecycle hook that was added for otel-agent: https://github.com/DataDog/datadog-agent/blob/a1ef7edf5b86951839fe8139a88ef9acbc844c03/comp/otelcol/collector/pipeline.go#L126-L129
2. In the core agent run command: https://github.com/DataDog/datadog-agent/blob/ee5579b58a6e434ae4589f80dcc9bb979f6916c4/cmd/agent/subcommands/run/command.go#L596

This PR removes the second call so that both the core agent and otel agent depend on the pipeline lifecycle hook.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Verified that the following error did not appear with the fix:
```
2024-05-08 12:47:22 EDT | CORE | INFO | (otlpreceiver@v0.98.0/otlp.go:102 in startGRPCServer) | kind:receiver,name:otlp,data_type:traces,endpoint:0.0.0.0:4317 | Starting GRPC server
2024-05-08 12:47:22 EDT | CORE | INFO | (service@v0.99.0/service.go:229 in Shutdown) | Starting shutdown...
2024-05-08 12:47:22 EDT | CORE | INFO | (service@v0.99.0/extensions/extensions.go:59 in Shutdown) | Stopping extensions...
2024-05-08 12:47:22 EDT | CORE | INFO | (service@v0.99.0/service.go:243 in Shutdown) | Shutdown complete.
2024-05-08 12:47:22 EDT | CORE | ERROR | (comp/otelcol/collector/pipeline.go:94 in func1) | Error running the OTLP ingest pipeline: cannot start pipelines: listen tcp 0.0.0.0:4317: bind: address already in use
```
