### PR TITLE
Correctly report single-step agent installations on Docker

### DIFF
--- a/comp/trace/config/install_signature.go
+++ b/comp/trace/config/install_signature.go
@@ -90,9 +90,8 @@ func inferInstallTypeFromEnvironment() string {
 	if env.IsContainerized() {
 		if os.Getenv("DD_APM_ENABLED") != "" {
 			return dockerSingleStepInstallType
-		} else {
-			return defaultDockerInstallType
 		}
+		return defaultDockerInstallType
 	}
 	return defaultInstallType
 }

--- a/comp/trace/config/install_signature.go
+++ b/comp/trace/config/install_signature.go
@@ -12,12 +12,15 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/google/uuid"
 )
 
 const (
-	defaultInstallType = "manual"
+	defaultInstallType          = "manual"
+	defaultDockerInstallType    = "docker_manual"
+	dockerSingleStepInstallType = "docker_single_step"
 )
 
 func applyOrCreateInstallSignature(c *config.AgentConfig) {
@@ -77,10 +80,21 @@ func generateNewInstallSignature(s *config.InstallSignatureConfig) (err error) {
 	}
 	*s = config.InstallSignatureConfig{
 		InstallID:   installID.String(),
-		InstallType: defaultInstallType,
+		InstallType: inferInstallTypeFromEnvironment(),
 		InstallTime: time.Now().Unix(),
 	}
 	return nil
+}
+
+func inferInstallTypeFromEnvironment() string {
+	if env.IsContainerized() {
+		if os.Getenv("DD_APM_ENABLED") != "" {
+			return dockerSingleStepInstallType
+		} else {
+			return defaultDockerInstallType
+		}
+	}
+	return defaultInstallType
 }
 
 func writeInstallSignatureToDisk(path string, s *config.InstallSignatureConfig) error {

--- a/comp/trace/config/install_signature_test.go
+++ b/comp/trace/config/install_signature_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInferInstallTypeFromEnvironment(t *testing.T) {
+	t.Run("Non-dockerized agent", func(t *testing.T) {
+		assert.Equal(t, defaultInstallType, inferInstallTypeFromEnvironment())
+	})
+
+	t.Run("Dockerized manual instrumentation", func(t *testing.T) {
+		_ = os.Setenv("DOCKER_DD_AGENT", "true")
+		defer os.Unsetenv("DOCKER_DD_AGENT")
+		assert.Equal(t, defaultDockerInstallType, inferInstallTypeFromEnvironment())
+	})
+
+	t.Run("Dockerized single-step instrumentation", func(t *testing.T) {
+		_ = os.Setenv("DOCKER_DD_AGENT", "true")
+		_ = os.Setenv("DD_APM_ENABLED", "true")
+		defer os.Unsetenv("DOCKER_DD_AGENT")
+		defer os.Unsetenv("DD_APM_ENABLED")
+		assert.Equal(t, dockerSingleStepInstallType, inferInstallTypeFromEnvironment())
+	})
+
+	t.Run("Non-standard environment variable values", func(t *testing.T) {
+		_ = os.Setenv("DOCKER_DD_AGENT", "yes")
+		_ = os.Setenv("DD_APM_ENABLED", "sure")
+		defer os.Unsetenv("DOCKER_DD_AGENT")
+		defer os.Unsetenv("DD_APM_ENABLED")
+		assert.Equal(t, dockerSingleStepInstallType, inferInstallTypeFromEnvironment())
+	})
+}

--- a/comp/trace/config/install_signature_test.go
+++ b/comp/trace/config/install_signature_test.go
@@ -6,7 +6,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,23 +18,18 @@ func TestInferInstallTypeFromEnvironment(t *testing.T) {
 
 	t.Run("Dockerized manual instrumentation", func(t *testing.T) {
 		t.Setenv("DOCKER_DD_AGENT", "true")
-		defer os.Unsetenv("DOCKER_DD_AGENT")
 		assert.Equal(t, defaultDockerInstallType, inferInstallTypeFromEnvironment())
 	})
 
 	t.Run("Dockerized single-step instrumentation", func(t *testing.T) {
 		t.Setenv("DOCKER_DD_AGENT", "true")
 		t.Setenv("DD_APM_ENABLED", "true")
-		defer os.Unsetenv("DOCKER_DD_AGENT")
-		defer os.Unsetenv("DD_APM_ENABLED")
 		assert.Equal(t, dockerSingleStepInstallType, inferInstallTypeFromEnvironment())
 	})
 
 	t.Run("Non-standard environment variable values", func(t *testing.T) {
 		t.Setenv("DOCKER_DD_AGENT", "yes")
 		t.Setenv("DD_APM_ENABLED", "sure")
-		defer os.Unsetenv("DOCKER_DD_AGENT")
-		defer os.Unsetenv("DD_APM_ENABLED")
 		assert.Equal(t, dockerSingleStepInstallType, inferInstallTypeFromEnvironment())
 	})
 }

--- a/comp/trace/config/install_signature_test.go
+++ b/comp/trace/config/install_signature_test.go
@@ -18,22 +18,22 @@ func TestInferInstallTypeFromEnvironment(t *testing.T) {
 	})
 
 	t.Run("Dockerized manual instrumentation", func(t *testing.T) {
-		_ = os.Setenv("DOCKER_DD_AGENT", "true")
+		t.Setenv("DOCKER_DD_AGENT", "true")
 		defer os.Unsetenv("DOCKER_DD_AGENT")
 		assert.Equal(t, defaultDockerInstallType, inferInstallTypeFromEnvironment())
 	})
 
 	t.Run("Dockerized single-step instrumentation", func(t *testing.T) {
-		_ = os.Setenv("DOCKER_DD_AGENT", "true")
-		_ = os.Setenv("DD_APM_ENABLED", "true")
+		t.Setenv("DOCKER_DD_AGENT", "true")
+		t.Setenv("DD_APM_ENABLED", "true")
 		defer os.Unsetenv("DOCKER_DD_AGENT")
 		defer os.Unsetenv("DD_APM_ENABLED")
 		assert.Equal(t, dockerSingleStepInstallType, inferInstallTypeFromEnvironment())
 	})
 
 	t.Run("Non-standard environment variable values", func(t *testing.T) {
-		_ = os.Setenv("DOCKER_DD_AGENT", "yes")
-		_ = os.Setenv("DD_APM_ENABLED", "sure")
+		t.Setenv("DOCKER_DD_AGENT", "yes")
+		t.Setenv("DD_APM_ENABLED", "sure")
 		defer os.Unsetenv("DOCKER_DD_AGENT")
 		defer os.Unsetenv("DD_APM_ENABLED")
 		assert.Equal(t, dockerSingleStepInstallType, inferInstallTypeFromEnvironment())

--- a/comp/trace/config/install_signature_test.go
+++ b/comp/trace/config/install_signature_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 package config
 
 import (


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
TL;DR: This PR will let us collect more accurate telemetry on how often customers use single-step APM instrumentation for agent installs on Docker.

This PR addresses an issue from https://github.com/DataDog/agent-linux-install-script/pull/131 : even though the code in that PR sets the install type to `linux_single_step_dkr` for Docker agent installations, we are not actually seeing any of these values on our backend, because for Docker, the install script does not run in the same container as the agent. So any install signature that the install script might write is not going to be visible to the agent anyway. In fact, the install script does not even attempt to write the signature for Docker installs, because then [no_agent is set to true](https://github.com/DataDog/agent-linux-install-script/blob/f82603d43f9b805fff781471f16566d6a0e9e4a6/install_script.sh.template#L707) and as a result [we make no attempt to write an install signature](https://github.com/DataDog/agent-linux-install-script/blob/f82603d43f9b805fff781471f16566d6a0e9e4a6/install_script.sh.template#L1743-L1747)

After discussing with the Container Integrations team, passing special environment variables (install ID, install type and install time) from the install script into the dockerized agent is not trivial; they aren't aware of an easy way to do it. Instead in this PR I am making the agent report one of two new install types, `docker_manual` or `docker_single_step`, if it realizes from looking at the environment that it is running inside a Docker container. If the `DOCKER_DD_AGENT` env variable is set, then we are on docker. If the `DD_APM_ENABLED` environment variable is also set, then this is a single step Docker agent installation. Otherwise we report a manually instrumented Docker agent installation.
`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Jira: [Set install ID, time and type for Docker](https://datadoghq.atlassian.net/browse/AIT-10210)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
It is theoretically possible for a customer to mess with the environment variables in their Docker container, but I am hopeful that only a small minority of customers will.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Make sure all new unit tests pass.

Deploy an agent image from CI for this build on Docker, and make sure the install signature is set correctly, as follows:

- There is a CI job on this PR called `dd-gitlab/docker_build_agent7_arm64`, like [this one](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/507531474). Open the link to that job and copy the name of the Docker image that it built: `486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent:v33896657-c318ad95-7-arm64` .
- Download that Docker image locally:
```
aws-vault exec sso-build-stable-developer -- docker pull 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent:v33896657-c318ad95-7-arm64
```
- Start a Docker container using that downloaded Docker image:
```
 docker run -d --name dd-agent \
-e DD_API_KEY=your_api_key \
-e DD_SITE="datadoghq.com" \
-e DD_APM_ENABLED=true \
-e DD_APM_NON_LOCAL_TRAFFIC=true \
-e DD_APM_RECEIVER_SOCKET=/opt/datadog/apm/inject/run/apm.socket \
-e DD_DOGSTATSD_SOCKET=/opt/datadog/apm/inject/run/dsd.socket \
-v /opt/datadog/apm:/opt/datadog/apm \
-v /var/run/docker.sock:/var/run/docker.sock:ro \
-v /proc/:/host/proc/:ro \
-v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-v /var/lib/docker/containers:/var/lib/docker/containers:ro \
486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent:v33896657-c318ad95-7-arm64
```
- Exec into that container that you have just started:
```
docker exec -i -t dd-agent bash
```
Check the agent install signature:
```
root@2c6f4a3bbc5b:/# cat /etc/datadog-agent/install.json
{"install_id":"e029d97a-2223-4f35-b0a2-b6b5734f48bd","install_type":"docker_single_step","install_time":1715200376}
root@2c6f4a3bbc5b:/#
```
This confirms that the agent install signature for a single-step Agent installation on Docker now correctly sets the install type to `docker_single_step` instead of `manual`.

Stop and delete your container through the Docker UI, and then start it with the same command, but without `-e DD_APM_ENABLED=true`. Verify that the install type on the container is now set to `docker_manual`:
```
root@17005dd3d8d3:/# cat /etc/datadog-agent/install.json
{"install_id":"7db4258b-e63e-479a-ba9f-ae57a9e4a20f","install_type":"docker_manual","install_time":1715206186}
root@17005dd3d8d3:/#
```