### PR TITLE
[kubeapiserver/events] Support namespace labels as tags on kubernetes events

### DIFF
--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -36,7 +36,7 @@ func installKubernetesMetadataEndpoints(r *mux.Router, wmeta workloadmeta.Compon
 		"getNodeLabels",
 		func(w http.ResponseWriter, r *http.Request) { getNodeLabels(w, r, wmeta) },
 	)).Methods("GET")
-	r.HandleFunc("/tags/namespace/{ns}", api.WithTelemetryWrapper("getNamespaceLabels", getNamespaceLabels)).Methods("GET")
+	r.HandleFunc("/tags/namespace/{ns}", api.WithTelemetryWrapper("getNamespaceLabels", func(w http.ResponseWriter, r *http.Request) { getNamespaceLabels(w, r, wmeta) })).Methods("GET")
 	r.HandleFunc("/cluster/id", api.WithTelemetryWrapper("getClusterID", getClusterID)).Methods("GET")
 }
 
@@ -110,7 +110,7 @@ func getNodeAnnotations(w http.ResponseWriter, r *http.Request, wmeta workloadme
 }
 
 // getNamespaceLabels is only used when the node agent hits the DCA for the list of labels
-func getNamespaceLabels(w http.ResponseWriter, r *http.Request) {
+func getNamespaceLabels(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Component) {
 	/*
 		Input
 			localhost:5001/api/v1/tags/namespace/default
@@ -131,12 +131,13 @@ func getNamespaceLabels(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	var labelBytes []byte
 	nsName := vars["ns"]
-	nsLabels, err := as.GetNamespaceLabels(nsName)
-	if err != nil {
-		log.Errorf("Could not retrieve the namespace labels of %s: %v", nsName, err.Error()) //nolint:errcheck
+	namespace, err := wmeta.GetKubernetesNamespace(nsName)
+	if namespace == nil {
+		log.Errorf("Could not retrieve the namespace %s: %v", nsName, err.Error()) //nolint:errcheck
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	nsLabels := namespace.EntityMeta.Labels
 	labelBytes, err = json.Marshal(nsLabels)
 	if err != nil {
 		log.Errorf("Could not process the labels of the namespace %s from the informer's cache: %v", nsName, err.Error()) //nolint:errcheck

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -132,12 +132,12 @@ func getNamespaceLabels(w http.ResponseWriter, r *http.Request, wmeta workloadme
 	var labelBytes []byte
 	nsName := vars["ns"]
 	namespace, err := wmeta.GetKubernetesNamespace(nsName)
-	if namespace == nil {
+	if err != nil {
 		log.Errorf("Could not retrieve the namespace %s: %v", nsName, err.Error()) //nolint:errcheck
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	nsLabels := namespace.EntityMeta.Labels
+	nsLabels := namespace.Labels
 	labelBytes, err = json.Marshal(nsLabels)
 	if err != nil {
 		log.Errorf("Could not process the labels of the namespace %s from the informer's cache: %v", nsName, err.Error()) //nolint:errcheck

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -137,7 +137,7 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 			case workloadmeta.KindKubernetesNode:
 				tagInfos = append(tagInfos, c.handleKubeNode(ev)...)
 			case workloadmeta.KindKubernetesNamespace:
-				// tagInfos = append(tagInfos, c.handleKubeNamespace(ev)...) No tags for now
+				tagInfos = append(tagInfos, c.handleKubeNamespace(ev)...)
 			case workloadmeta.KindECSTask:
 				tagInfos = append(tagInfos, c.handleECSTask(ev)...)
 			case workloadmeta.KindContainerImageMetadata:
@@ -427,6 +427,28 @@ func (c *WorkloadMetaCollector) handleKubeNode(ev workloadmeta.Event) []*types.T
 		{
 			Source:               nodeSource,
 			Entity:               buildTaggerEntityID(node.EntityID),
+			HighCardTags:         high,
+			OrchestratorCardTags: orch,
+			LowCardTags:          low,
+			StandardTags:         standard,
+		},
+	}
+
+	return tagInfos
+}
+
+func (c *WorkloadMetaCollector) handleKubeNamespace(ev workloadmeta.Event) []*types.TagInfo {
+	namespace := ev.Entity.(*workloadmeta.KubernetesNamespace)
+
+	tags := utils.NewTagList()
+
+	// Add tags for namespace here
+
+	low, orch, high, standard := tags.Compute()
+	tagInfos := []*types.TagInfo{
+		{
+			Source:               nodeSource,
+			Entity:               buildTaggerEntityID(namespace.EntityID),
 			HighCardTags:         high,
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -442,7 +442,9 @@ func (c *WorkloadMetaCollector) handleKubeNamespace(ev workloadmeta.Event) []*ty
 
 	tags := utils.NewTagList()
 
-	// Add tags for namespace here
+	for name, value := range namespace.Labels {
+		utils.AddMetadataAsTags(name, value, c.nsLabelsAsTags, c.globNsLabels, tags)
+	}
 
 	low, orch, high, standard := tags.Compute()
 	tagInfos := []*types.TagInfo{

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -610,12 +610,12 @@ func TestHandleKubePodNoContainerName(t *testing.T) {
 func TestHandleKubeNamespace(t *testing.T) {
 	const namespace = "foobar"
 
-	namespaceEntityId := workloadmeta.EntityID{
+	namespaceEntityID := workloadmeta.EntityID{
 		Kind: workloadmeta.KindKubernetesNamespace,
 		ID:   namespace,
 	}
 
-	namespaceTaggerEntityId := fmt.Sprintf("namespace://%s", namespaceEntityId.ID)
+	namespaceTaggerEntityID := fmt.Sprintf("namespace://%s", namespaceEntityID.ID)
 
 	store := fxutil.Test[workloadmeta.Mock](t, fx.Options(
 		logimpl.MockModule(),
@@ -650,7 +650,7 @@ func TestHandleKubeNamespace(t *testing.T) {
 				"ns-ownerteam": "ns-team",
 			},
 			namespace: workloadmeta.KubernetesNamespace{
-				EntityID: namespaceEntityId,
+				EntityID: namespaceEntityID,
 				EntityMeta: workloadmeta.EntityMeta{
 					Name: namespace,
 					Labels: map[string]string{
@@ -663,12 +663,12 @@ func TestHandleKubeNamespace(t *testing.T) {
 			expected: []*types.TagInfo{
 				{
 					Source:               nodeSource,
-					Entity:               namespaceTaggerEntityId,
+					Entity:               namespaceTaggerEntityID,
 					HighCardTags:         []string{},
 					OrchestratorCardTags: []string{},
 					LowCardTags: []string{
-						fmt.Sprintf("ns_env:dev"),
-						fmt.Sprintf("ns-team:containers"),
+						"ns_env:dev",
+						"ns-team:containers",
 					},
 					StandardTags: []string{},
 				},

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"testing"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -18,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
-	"go.uber.org/fx"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -599,6 +600,94 @@ func TestHandleKubePodNoContainerName(t *testing.T) {
 			actual := collector.handleKubePod(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,
 				Entity: &tt.pod,
+			})
+
+			assertTagInfoListEqual(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestHandleKubeNamespace(t *testing.T) {
+	const namespace = "foobar"
+
+	namespaceEntityId := workloadmeta.EntityID{
+		Kind: workloadmeta.KindKubernetesNamespace,
+		ID:   namespace,
+	}
+
+	namespaceTaggerEntityId := fmt.Sprintf("namespace://%s", namespaceEntityId.ID)
+
+	store := fxutil.Test[workloadmeta.Mock](t, fx.Options(
+		logimpl.MockModule(),
+		config.MockModule(),
+		fx.Supply(workloadmeta.NewParams()),
+		fx.Supply(context.Background()),
+		workloadmeta.MockModule(),
+	))
+
+	store.Set(&workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesNamespace,
+			ID:   namespace,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name: namespace,
+		},
+	})
+
+	tests := []struct {
+		name              string
+		labelsAsTags      map[string]string
+		annotationsAsTags map[string]string
+		nsLabelsAsTags    map[string]string
+		namespace         workloadmeta.KubernetesNamespace
+		expected          []*types.TagInfo
+	}{
+		{
+			name: "fully formed namespace",
+			nsLabelsAsTags: map[string]string{
+				"ns_env":       "ns_env",
+				"ns-ownerteam": "ns-team",
+			},
+			namespace: workloadmeta.KubernetesNamespace{
+				EntityID: namespaceEntityId,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: namespace,
+					Labels: map[string]string{
+						"ns_env":       "dev",
+						"ns-ownerteam": "containers",
+						"foo":          "bar",
+					},
+				},
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:               nodeSource,
+					Entity:               namespaceTaggerEntityId,
+					HighCardTags:         []string{},
+					OrchestratorCardTags: []string{},
+					LowCardTags: []string{
+						fmt.Sprintf("ns_env:dev"),
+						fmt.Sprintf("ns-team:containers"),
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := &WorkloadMetaCollector{
+				store:    store,
+				children: make(map[string]map[string]struct{}),
+			}
+
+			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags)
+
+			actual := collector.handleKubeNamespace(workloadmeta.Event{
+				Type:   workloadmeta.EventTypeSet,
+				Entity: &tt.namespace,
 			})
 
 			assertTagInfoListEqual(t, tt.expected, actual)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
@@ -150,6 +150,8 @@ func (r *reflectorStore) Delete(obj interface{}) error {
 		uid = v.UID
 	case *appsv1.Deployment:
 		uid = v.UID
+	case *corev1.Namespace:
+		uid = v.UID
 	default:
 		return fmt.Errorf("failed to identify Kind of object: %#v", obj)
 	}

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -16,6 +16,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -25,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
-	"go.uber.org/fx"
 )
 
 const (

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -35,18 +35,17 @@ const (
 )
 
 type collector struct {
-	id                          string
-	store                       workloadmeta.Component
-	catalog                     workloadmeta.AgentType
-	seen                        map[workloadmeta.EntityID]struct{}
-	kubeUtil                    kubelet.KubeUtilInterface
-	apiClient                   *apiserver.APIClient
-	dcaClient                   clusteragent.DCAClientInterface
-	dcaEnabled                  bool
-	updateFreq                  time.Duration
-	lastUpdate                  time.Time
-	collectNamespaceLabels      bool
-	collectKubernetesNamespaces bool
+	id                     string
+	store                  workloadmeta.Component
+	catalog                workloadmeta.AgentType
+	seen                   map[workloadmeta.EntityID]struct{}
+	kubeUtil               kubelet.KubeUtilInterface
+	apiClient              *apiserver.APIClient
+	dcaClient              clusteragent.DCAClientInterface
+	dcaEnabled             bool
+	updateFreq             time.Duration
+	lastUpdate             time.Time
+	collectNamespaceLabels bool
 }
 
 // NewCollector returns a CollectorProvider to build a kubemetadata collector, and an error if any.
@@ -115,7 +114,6 @@ func (c *collector) Start(_ context.Context, store workloadmeta.Component) error
 
 	c.updateFreq = time.Duration(config.Datadog.GetInt("kubernetes_metadata_tag_update_freq")) * time.Second
 	c.collectNamespaceLabels = len(config.Datadog.GetStringMapString("kubernetes_namespace_labels_as_tags")) > 0
-	c.collectKubernetesNamespaces = config.Datadog.GetBool("kubernetes_namespace_collection_enabled")
 
 	return err
 }
@@ -293,7 +291,7 @@ func (c *collector) getMetadata(getPodMetaDataFromAPIServerFunc func(string, str
 
 // getNamespaceLabels returns the namespace labels, fast return if namespace labels as tags is disabled.
 func (c *collector) getNamespaceLabels(ns string) (map[string]string, error) {
-	if !c.collectNamespaceLabels || !c.collectKubernetesNamespaces || !c.isDCAEnabled() {
+	if !c.collectNamespaceLabels || !c.isDCAEnabled() {
 		return nil, nil
 	}
 

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events.go
@@ -8,18 +8,22 @@
 package kubernetesapiserver
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
+	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 )
 
-func newBundledTransformer(clusterName string) eventTransformer {
+func newBundledTransformer(clusterName string, taggerInstance tagger.Component) eventTransformer {
 	return &bundledTransformer{
-		clusterName: clusterName,
+		clusterName:    clusterName,
+		taggerInstance: taggerInstance,
 	}
 }
 
 type bundledTransformer struct {
-	clusterName string
+	clusterName    string
+	taggerInstance tagger.Component
 }
 
 func (c *bundledTransformer) Transform(events []*v1.Event) ([]event.Event, []error) {
@@ -60,7 +64,7 @@ func (c *bundledTransformer) Transform(events []*v1.Event) ([]event.Event, []err
 	datadogEvs := make([]event.Event, 0, len(bundlesByObject))
 
 	for id, bundle := range bundlesByObject {
-		datadogEv, err := bundle.formatEvents()
+		datadogEv, err := bundle.formatEvents(c.taggerInstance)
 		if err != nil {
 			errors = append(errors, err)
 			continue

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
@@ -68,8 +68,8 @@ func getInvolvedObjectTags(involvedObject v1.ObjectReference, taggerInstance tag
 			fmt.Sprintf("namespace:%s", involvedObject.Namespace),
 		)
 
-		namespaceEntityId := fmt.Sprintf("namespace://%s", involvedObject.Namespace)
-		namespaceEntity, err := taggerInstance.GetEntity(namespaceEntityId)
+		namespaceEntityID := fmt.Sprintf("namespace://%s", involvedObject.Namespace)
+		namespaceEntity, err := taggerInstance.GetEntity(namespaceEntityID)
 		if err == nil {
 			tags = append(tags, namespaceEntity.GetTags(types.HighCardinality)...)
 		}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
@@ -88,16 +88,14 @@ func Test_getInvolvedObjectTags(t *testing.T) {
 				"name:my-pod",
 				"kube_namespace:default",
 				"namespace:default",
-				"team:container-int",
+				"team:container-int", // this tag is coming from the namespace
 				"pod_name:my-pod",
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getInvolvedObjectTags(tt.involvedObject, taggerInstance); !reflect.DeepEqual(got, tt.tags) {
-				t.Errorf("getInvolvedObjectTags() = %v, want %v", got, tt.tags)
-			}
+			assert.ElementsMatch(t, getInvolvedObjectTags(tt.involvedObject, taggerInstance), tt.tags)
 		})
 	}
 }

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
@@ -12,9 +12,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl/local"
+	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 )
 
 func TestGetDDAlertType(t *testing.T) {
@@ -43,6 +45,64 @@ func TestGetDDAlertType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := getDDAlertType(tt.k8sType)
 			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func Test_getInvolvedObjectTags(t *testing.T) {
+	type args struct {
+		clusterName string
+		ev          *v1.Event
+	}
+
+	taggerInstance := local.NewFakeTagger()
+	taggerInstance.SetTags("namespace://default", "workloadmeta-kubernetes_node", []string{"team:container-int"}, nil, nil, nil)
+	tests := []struct {
+		name           string
+		involvedObject v1.ObjectReference
+		tags           []string
+	}{
+		{
+			name: "get pod basic tags",
+			involvedObject: v1.ObjectReference{
+				Kind:      "Pod",
+				Name:      "my-pod",
+				Namespace: "my-namespace",
+			},
+			tags: []string{
+				"kube_kind:Pod",
+				"kube_name:my-pod",
+				"kubernetes_kind:Pod",
+				"name:my-pod",
+				"kube_namespace:my-namespace",
+				"namespace:my-namespace",
+				"pod_name:my-pod",
+			},
+		},
+		{
+			name: "get pod namespace tags",
+			involvedObject: v1.ObjectReference{
+				Kind:      "Pod",
+				Name:      "my-pod",
+				Namespace: "default",
+			},
+			tags: []string{
+				"kube_kind:Pod",
+				"kube_name:my-pod",
+				"kubernetes_kind:Pod",
+				"name:my-pod",
+				"kube_namespace:default",
+				"namespace:default",
+				"team:container-int",
+				"pod_name:my-pod",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getInvolvedObjectTags(tt.involvedObject, taggerInstance); !reflect.DeepEqual(got, tt.tags) {
+				t.Errorf("getInvolvedObjectTags() = %v, want %v", got, tt.tags)
+			}
 		})
 	}
 }

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
@@ -50,11 +50,6 @@ func TestGetDDAlertType(t *testing.T) {
 }
 
 func Test_getInvolvedObjectTags(t *testing.T) {
-	type args struct {
-		clusterName string
-		ev          *v1.Event
-	}
-
 	taggerInstance := local.NewFakeTagger()
 	taggerInstance.SetTags("namespace://default", "workloadmeta-kubernetes_node", []string{"team:container-int"}, nil, nil, nil)
 	tests := []struct {

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -170,7 +170,7 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, integrationC
 		k.eventCollection.Transformer = newUnbundledTransformer(clusterName, tagger.GetTaggerInstance(), k.instance.CollectedEventTypes)
 	} else {
 		k.eventCollection.Filter = convertFilters(k.instance.FilteredEventTypes)
-		k.eventCollection.Transformer = newBundledTransformer(clusterName)
+		k.eventCollection.Transformer = newBundledTransformer(clusterName, tagger.GetTaggerInstance())
 	}
 
 	return nil

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle.go
@@ -17,6 +17,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 )
 
@@ -55,13 +56,13 @@ func (b *kubernetesEventBundle) addEvent(event *v1.Event) error {
 	return nil
 }
 
-func (b *kubernetesEventBundle) formatEvents() (event.Event, error) {
+func (b *kubernetesEventBundle) formatEvents(taggerInstance tagger.Component) (event.Event, error) {
 	if len(b.countByAction) == 0 {
 		return event.Event{}, errors.New("no event to export")
 	}
 
 	readableKey := buildReadableKey(b.involvedObject)
-	tags := getInvolvedObjectTags(b.involvedObject)
+	tags := getInvolvedObjectTags(b.involvedObject, taggerInstance)
 	tags = append(tags, fmt.Sprintf("source_component:%s", b.component))
 
 	if b.hostInfo.providerID != "" {

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl/local"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 )
 
@@ -177,7 +178,7 @@ func TestFormatEvent(t *testing.T) {
 				b.addEvent(ev)
 			}
 
-			output, err := b.formatEvents()
+			output, err := b.formatEvents(local.NewFakeTagger())
 
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expected.Text, output.Text)
@@ -239,7 +240,7 @@ func TestEventsTagging(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			bundle := newKubernetesEventBundler("", tt.k8sEvent)
 			bundle.addEvent(tt.k8sEvent)
-			got, err := bundle.formatEvents()
+			got, err := bundle.formatEvents(local.NewFakeTagger())
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tt.expectedTags, got.Tags)
 		})

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
@@ -112,8 +112,8 @@ func (c *unbundledTransformer) getTagsFromTagger(obj v1.ObjectReference, tagsAcc
 		// we can get high Cardinality because tags on events is seemless.
 		tagsAcc.Append(entity.GetTags(types.HighCardinality)...)
 
-		namespaceEntityId := fmt.Sprintf("namespace://%s", obj.Namespace)
-		namespaceEntity, err := c.taggerInstance.GetEntity(namespaceEntityId)
+		namespaceEntityID := fmt.Sprintf("namespace://%s", obj.Namespace)
+		namespaceEntity, err := c.taggerInstance.GetEntity(namespaceEntityID)
 		if err != nil {
 			return
 		}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
@@ -66,7 +66,7 @@ func (c *unbundledTransformer) Transform(events []*v1.Event) ([]event.Event, []e
 		readableKey := buildReadableKey(involvedObject)
 		tagsAccumulator := tagset.NewHashlessTagsAccumulator()
 
-		tagsAccumulator.Append(getInvolvedObjectTags(involvedObject)...)
+		tagsAccumulator.Append(getInvolvedObjectTags(involvedObject, c.taggerInstance)...)
 		tagsAccumulator.Append(
 			fmt.Sprintf("source_component:%s", ev.Source.Component),
 			fmt.Sprintf("event_reason:%s", ev.Reason))
@@ -111,6 +111,14 @@ func (c *unbundledTransformer) getTagsFromTagger(obj v1.ObjectReference, tagsAcc
 		}
 		// we can get high Cardinality because tags on events is seemless.
 		tagsAcc.Append(entity.GetTags(types.HighCardinality)...)
+
+		namespaceEntityId := fmt.Sprintf("namespace://%s", obj.Namespace)
+		namespaceEntity, err := c.taggerInstance.GetEntity(namespaceEntityId)
+		if err != nil {
+			return
+		}
+		tagsAcc.Append(namespaceEntity.GetTags(types.HighCardinality)...)
+
 	default:
 		return
 	}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl/local"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
+	"github.com/DataDog/datadog-agent/pkg/tagset"
 )
 
 func TestUnbundledEventsTransform(t *testing.T) {
@@ -103,6 +104,61 @@ func TestUnbundledEventsTransform(t *testing.T) {
 
 			assert.Empty(t, errors)
 			assert.Equal(t, tt.expected, events)
+		})
+	}
+}
+
+func TestGetTagsFromTagger(t *testing.T) {
+	taggerInstance := local.NewFakeTagger()
+	taggerInstance.SetTags("kubernetes_pod_uid://nginx", "workloadmeta-kubernetes_pod", nil, []string{"pod_name:nginx"}, nil, nil)
+	taggerInstance.SetTags("namespace://foobar", "workloadmeta-kubernetes_node", []string{"team:container-int"}, nil, nil, nil)
+
+	tests := []struct {
+		name         string
+		obj          v1.ObjectReference
+		expectedTags *tagset.HashlessTagsAccumulator
+	}{
+		{
+			name: "accumulates basic pod tags",
+			obj: v1.ObjectReference{
+				UID:       "redis",
+				Kind:      "Pod",
+				Namespace: "default",
+				Name:      "redis",
+			},
+			expectedTags: tagset.NewHashlessTagsAccumulator(),
+		},
+		{
+			name: "add tagger pod tags",
+			obj: v1.ObjectReference{
+				UID:       "nginx",
+				Kind:      "Pod",
+				Namespace: "default",
+				Name:      "nginx",
+			},
+			expectedTags: tagset.NewHashlessTagsAccumulatorFromSlice([]string{"pod_name:nginx"}),
+		},
+		{
+			name: "add tagger namespace tags",
+			obj: v1.ObjectReference{
+				UID:       "nginx",
+				Kind:      "Pod",
+				Namespace: "foobar",
+				Name:      "nginx",
+			},
+			expectedTags: tagset.NewHashlessTagsAccumulatorFromSlice([]string{"pod_name:nginx", "team:container-int"}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collectedTypes := []collectedEventType{
+				{Kind: "Pod", Reasons: []string{}},
+			}
+			transformer := newUnbundledTransformer("test-cluster", taggerInstance, collectedTypes)
+			accumulator := tagset.NewHashlessTagsAccumulator()
+			transformer.(*unbundledTransformer).getTagsFromTagger(tt.obj, accumulator)
+			assert.Equal(t, tt.expectedTags, accumulator)
 		})
 	}
 }

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
@@ -29,7 +31,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"google.golang.org/protobuf/proto"
 )
 
 /*

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -119,7 +119,6 @@ func StartControllers(ctx ControllerContext) errors.Aggregate {
 func startMetadataController(ctx ControllerContext, c chan error) {
 	metaController := NewMetadataController(
 		ctx.InformerFactory.Core().V1().Nodes(),
-		ctx.InformerFactory.Core().V1().Namespaces(),
 		ctx.InformerFactory.Core().V1().Endpoints(),
 	)
 	go metaController.Run(ctx.StopCh)

--- a/pkg/util/kubernetes/apiserver/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller_test.go
@@ -472,7 +472,6 @@ func newFakeMetadataController(client kubernetes.Interface) (*MetadataController
 
 	metaController := NewMetadataController(
 		informerFactory.Core().V1().Nodes(),
-		informerFactory.Core().V1().Namespaces(),
 		informerFactory.Core().V1().Endpoints(),
 	)
 

--- a/releasenotes-dca/notes/tag-kubernetes-events-with-namespace-labels-eb958ece9487e5ee.yaml
+++ b/releasenotes-dca/notes/tag-kubernetes-events-with-namespace-labels-eb958ece9487e5ee.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Support namespace labels as tags on kubernetes events.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add support for namespace labels as tags on kubernetes events. Use of the namespace `InformerFactory` is also removed now that namespace information is stored in `workloadmeta`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Namespace labels as tags is already supported on metrics; as we continue fleshing out the kubernetes events product, it would be good to add namespace labels as tags to emitted events.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The code path to get namespace labels when the DCA is disabled was removed in this PR. Upon testing the latest version of the agent, it was found that namespace information was not being stored by the node agent (i.e. the paths in `metadata_controller.go` were not hit). As a result, when the DCA was disabled the agent is unable to fetch namespace labels. When the DCA Is enabled, the logic was changed to fetch namespace information from `workloadmeta`, thus the informer factory for namespaces was removed altogether.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. Enable both the agent and cluster agent
2. Set `kubernetes_namespace_collection_enabled` to `true` (set to `false` by default)
3. Configure `namespaceLabelsAsTags`
e.g.
```
datadog:
  logLevel: DEBUG
  clusterName: test-ns-labels
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  collectEvents: true
  namespaceLabelsAsTags:
    "*": prefixing_%%label%%
```
4. Deploy both the agent and cluster agent
5. Add a label to a namespace you expect to see events from e.g. `kubectl label namespace default test=qa`
6. Go to the event explorer and check that you can see kubernetes events being streamed; for events tagged with the namespace you labeled above, check that you also see a tag `prefixing_test:qa`