### PR TITLE
[EBPF] Download KMT buildimage instead of building in-place

### DIFF
--- a/tasks/kernel_matrix_testing/compiler.py
+++ b/tasks/kernel_matrix_testing/compiler.py
@@ -87,7 +87,7 @@ class CompilerImage:
 
         if uid == 0:
             # If we're starting the compiler as root, we won't be able to create the compiler user
-            # and we will get weird failures later on
+            # and we will get weird failures later on, as the user 'compiler' won't exist in the container
             raise ValueError("Cannot start compiler as root, we need to run as a non-root user")
 
         # Now create the compiler user with same UID and GID as the current user

--- a/tasks/kernel_matrix_testing/compiler.py
+++ b/tasks/kernel_matrix_testing/compiler.py
@@ -101,7 +101,8 @@ class CompilerImage:
 
         self.exec("chmod a+rx /root", user="root")  # Some binaries will be in /root and need to be readable
         self.exec("apt install sudo", user="root")
-        self.exec("echo conda activate ddpy3 >> ~/.bashrc")
+        self.exec("usermod -aG sudo compiler && echo 'compiler ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers", user="root")
+        self.exec("echo conda activate ddpy3 >> /home/compiler/.bashrc", user="compiler")
         self.exec(f"install -d -m 0777 -o {uid} -g {uid} /go", user="root")
 
 

--- a/tasks/kernel_matrix_testing/compiler.py
+++ b/tasks/kernel_matrix_testing/compiler.py
@@ -4,17 +4,28 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+import yaml
 from invoke.context import Context
 from invoke.runners import Result
 
 from tasks.kernel_matrix_testing.tool import full_arch, info, warn
 from tasks.kernel_matrix_testing.vars import arch_mapping
+from tasks.pipeline import GitlabYamlLoader
 
 if TYPE_CHECKING:
     from tasks.kernel_matrix_testing.types import Arch, ArchOrLocal, PathOrStr
 
 
 CONTAINER_AGENT_PATH = "/tmp/datadog-agent"
+
+
+def get_build_image_suffix_and_version() -> tuple[str, str]:
+    gitlab_ci_file = Path(__file__).parent.parent.parent / ".gitlab-ci.yml"
+    with open(gitlab_ci_file) as f:
+        ci_config = yaml.load(f, Loader=GitlabYamlLoader())
+
+    ci_vars = ci_config['variables']
+    return ci_vars['DATADOG_AGENT_BUILDIMAGES_SUFFIX'], ci_vars['DATADOG_AGENT_BUILDIMAGES']
 
 
 class CompilerImage:
@@ -28,17 +39,11 @@ class CompilerImage:
 
     @property
     def image(self):
-        return f"kmt:compile-{self.arch}"
+        suffix, version = get_build_image_suffix_and_version()
+        image_base = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe"
+        image_arch = "x64" if self.arch == "x86_64" else "arm64"
 
-    @property
-    def is_built(self):
-        res = self.ctx.run(f"docker images {self.image} | grep -v REPOSITORY | grep kmt", warn=True)
-        return res is not None and res.ok
-
-    def ensure_built(self):
-        if not self.is_built:
-            info(f"[*] Compiler image for {self.arch} not built, building it...")
-            self.build()
+        return f"{image_base}_{image_arch}{suffix}:{version}"
 
     @property
     def is_running(self):
@@ -63,45 +68,11 @@ class CompilerImage:
         self.ensure_running()
         return self.ctx.run(f"docker exec -u {user} -i {self.name} bash -c \"{cmd}\"", hide=(not verbose))
 
-    def build(self) -> Result:
-        self.ctx.run(f"docker rm -f $(docker ps -aqf \"name={self.name}\")", warn=True, hide=True)
-        self.ctx.run(f"docker image rm {self.image}", warn=True, hide=True)
-
-        if self.arch == "x86_64":
-            docker_platform = "linux/amd64"
-            buildimages_arch = "x64"
-        else:
-            docker_platform = "linux/arm64"
-            buildimages_arch = "arm64"
-
-        docker_build_args = ["--platform", docker_platform]
-
-        agent_path = Path(__file__).parent.parent.parent
-        buildimages_path = (agent_path.parent / "datadog-agent-buildimages").resolve()
-
-        if not buildimages_path.is_dir():
-            raise FileNotFoundError(
-                f"datadog-agent-buildimages not found at {buildimages_path}. Please clone the repository there to access compiler images"
-            )
-
-        # Add build arguments (such as go version) from go.env
-        with open(buildimages_path / "go.env") as f:
-            for line in f:
-                docker_build_args += ["--build-arg", line.strip()]
-
-        docker_build_args_s = " ".join(docker_build_args)
-        res = self.ctx.run(
-            f"cd {buildimages_path} && docker build {docker_build_args_s} -f system-probe_{buildimages_arch}/Dockerfile -t {self.image} ."
-        )
-        return cast('Result', res)  # Avoid mypy error about res being None
-
     def stop(self) -> Result:
         res = self.ctx.run(f"docker rm -f $(docker ps -aqf \"name={self.name}\")")
         return cast('Result', res)  # Avoid mypy error about res being None
 
     def start(self) -> None:
-        self.ensure_built()
-
         if self.is_running:
             self.stop()
 
@@ -111,8 +82,6 @@ class CompilerImage:
 
         uid = cast('Result', self.ctx.run("id -u")).stdout.rstrip()
         gid = cast('Result', self.ctx.run("id -g")).stdout.rstrip()
-        self.exec(f"getent group {gid} || groupadd -f -g {gid} compiler", user="root")
-        self.exec(f"getent passwd {uid} || useradd -m -u {uid} -g {gid} compiler", user="root")
 
         if sys.platform != "darwin":  # No need to change permissions in MacOS
             self.exec(
@@ -121,8 +90,7 @@ class CompilerImage:
 
         self.exec("chmod a+rx /root", user="root")  # Some binaries will be in /root and need to be readable
         self.exec("apt install sudo", user="root")
-        self.exec("usermod -aG sudo compiler && echo 'compiler ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers", user="root")
-        self.exec("echo conda activate ddpy3 >> /home/compiler/.bashrc", user="compiler")
+        self.exec("echo conda activate ddpy3 >> ~/.bashrc")
         self.exec(f"install -d -m 0777 -o {uid} -g {uid} /go", user="root")
 
 

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -357,14 +357,9 @@ def update_resources(
 
 
 @task
-def build_compiler(ctx: Context):
-    for cc in all_compilers(ctx):
-        cc.build()
-
-
-@task
 def start_compiler(ctx: Context):
     for cc in all_compilers(ctx):
+        info(f"[+] Starting compiler {cc.name}")
         cc.start()
 
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Uses the build image from `datadog-agent-buildimages` directly using the version specified in `.gitlab-ci.yml`, without building it from the local repository.

### Motivation

No need to download the buildimages repo and keep it up to date, more consistent behavior.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
