### PR TITLE
AMLII-1647 Added duration to Flare's stream-logs

### DIFF
--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -287,15 +287,12 @@ func makeFlare(flareComp flare.Component,
 	}
 
 	// Set default duration to 60 seconds if not provided by the user
-	streamLogDuration := 60 * time.Second // default duration
+	const defaultStreamLogDuration = 60 * time.Second
 	if streamLogParams.Duration <= 0 {
-		streamLogParams.Duration = streamLogDuration
+		streamLogParams.Duration = defaultStreamLogDuration
 	}
-
 	// If Duration is set, automatically enable withStreamLogs.
-	if streamLogParams.Duration > 0 {
-		cliParams.withStreamLogs = true
-	}
+	cliParams.withStreamLogs = streamLogParams.Duration > 0
 
 	fmt.Fprintln(color.Output, color.BlueString("NEW: You can now generate a flare from the comfort of your Datadog UI!"))
 	fmt.Fprintln(color.Output, color.BlueString("See https://docs.datadoghq.com/agent/troubleshooting/send_a_flare/?tab=agentv6v7#send-a-flare-from-the-datadog-site for more info."))

--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -152,7 +152,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	flareCmd.Flags().IntVarP(&cliParams.profileMutexFraction, "profile-mutex-fraction", "", 100, "Set the fraction of mutex contention events that are reported in the mutex profile")
 	flareCmd.Flags().BoolVarP(&cliParams.profileBlocking, "profile-blocking", "B", false, "Add gorouting blocking profile to the performance data in the flare")
 	flareCmd.Flags().IntVarP(&cliParams.profileBlockingRate, "profile-blocking-rate", "", 10000, "Set the fraction of goroutine blocking events that are reported in the blocking profile")
-	flareCmd.Flags().DurationVarP(&cliParams.withStreamLogs, "with-stream-logs", "L", -1*time.Second, "Add stream-logs data to the flare. It will collect logs for the amount of seconds passed to the flag")
+	flareCmd.Flags().DurationVarP(&cliParams.withStreamLogs, "with-stream-logs", "L", 0*time.Second, "Add stream-logs data to the flare. It will collect logs for the amount of seconds passed to the flag")
 	flareCmd.SetArgs([]string{"caseID"})
 
 	return []*cobra.Command{flareCmd}
@@ -284,11 +284,8 @@ func makeFlare(flareComp flare.Component,
 		Quiet:    true,
 	}
 
-	// Set default duration to 60 seconds if not provided by the user
-	const defaultStreamLogDuration = 60 * time.Second
-	if streamLogParams.Duration <= 0 {
-		fmt.Fprintln(color.Output, color.YellowString("Invalid duration provided for streaming logs, defaulting to 60 seconds."))
-		streamLogParams.Duration = defaultStreamLogDuration
+	if streamLogParams.Duration < 0 {
+		fmt.Fprintln(color.Output, color.YellowString("Invalid duration provided for streaming logs, please provide a positive value"))
 	}
 
 	fmt.Fprintln(color.Output, color.BlueString("NEW: You can now generate a flare from the comfort of your Datadog UI!"))

--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -74,8 +74,7 @@ type cliParams struct {
 	profileMutexFraction int
 	profileBlocking      bool
 	profileBlockingRate  int
-	withStreamLogs       bool
-	streamLogsDuration   time.Duration
+	withStreamLogs       time.Duration
 }
 
 // Commands returns a slice of subcommands for the 'agent' command.
@@ -153,8 +152,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	flareCmd.Flags().IntVarP(&cliParams.profileMutexFraction, "profile-mutex-fraction", "", 100, "Set the fraction of mutex contention events that are reported in the mutex profile")
 	flareCmd.Flags().BoolVarP(&cliParams.profileBlocking, "profile-blocking", "B", false, "Add gorouting blocking profile to the performance data in the flare")
 	flareCmd.Flags().IntVarP(&cliParams.profileBlockingRate, "profile-blocking-rate", "", 10000, "Set the fraction of goroutine blocking events that are reported in the blocking profile")
-	flareCmd.Flags().BoolVarP(&cliParams.withStreamLogs, "with-stream-logs", "L", false, "60s default; use --stream-logs-duration flag to change")
-	flareCmd.Flags().DurationVarP(&cliParams.streamLogsDuration, "stream-logs-duration", "D", 0*time.Second, "To be used with --with-stream-logs flag. Duration of the attached log stream")
+	flareCmd.Flags().DurationVarP(&cliParams.withStreamLogs, "with-stream-logs", "L", -1*time.Second, "Add stream-logs data to the flare. It will collect logs for the amount of seconds passed to the flag")
 	flareCmd.SetArgs([]string{"caseID"})
 
 	return []*cobra.Command{flareCmd}
@@ -282,17 +280,16 @@ func makeFlare(flareComp flare.Component,
 
 	streamLogParams := streamlogs.CliParams{
 		FilePath: commonpath.DefaultStreamlogsLogFile,
-		Duration: cliParams.streamLogsDuration,
+		Duration: cliParams.withStreamLogs,
 		Quiet:    true,
 	}
 
 	// Set default duration to 60 seconds if not provided by the user
 	const defaultStreamLogDuration = 60 * time.Second
 	if streamLogParams.Duration <= 0 {
+		fmt.Fprintln(color.Output, color.YellowString("Invalid duration provided for streaming logs, defaulting to 60 seconds."))
 		streamLogParams.Duration = defaultStreamLogDuration
 	}
-	// If Duration is set, automatically enable withStreamLogs.
-	cliParams.withStreamLogs = streamLogParams.Duration > 0
 
 	fmt.Fprintln(color.Output, color.BlueString("NEW: You can now generate a flare from the comfort of your Datadog UI!"))
 	fmt.Fprintln(color.Output, color.BlueString("See https://docs.datadoghq.com/agent/troubleshooting/send_a_flare/?tab=agentv6v7#send-a-flare-from-the-datadog-site for more info."))
@@ -358,7 +355,7 @@ func makeFlare(flareComp flare.Component,
 		return err
 	}
 
-	if cliParams.withStreamLogs {
+	if streamLogParams.Duration > 0 {
 		fmt.Fprintln(color.Output, color.GreenString((fmt.Sprintf("Asking the agent to stream logs for %s", streamLogParams.Duration))))
 		err := streamlogs.StreamLogs(lc, config, &streamLogParams)
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?
This PR adjusts the --with-stream-logs flag from a bool to duration so that it would accept a duration and attach a stream-logs for that duration to the flare 

### Motivation
The motivation behind this change is to provide users with more flexibility when using the flare command. By allowing users to adjust the duration of the the stream log output, they can easily save troubleshoot or send it to our support for troubleshooting

### Additional Notes

### Describe how to test/QA your changes
- Run:
```
datad-agent flare -L 10s 
```
or
```
datad-agent flare --with-stream-logs 10s
```
Check to see if negative number also throw errors:
```
datad-agent flare -L -10s 
```


Logs should be output in the same [agent log directory
](https://docs.datadoghq.com/agent/configuration/agent-log-files/?tab=agentv6v7)
and attached to the flare 