### PR TITLE
APM: do not replace tags on special dd tags

### DIFF
--- a/pkg/trace/filters/replacer.go
+++ b/pkg/trace/filters/replacer.go
@@ -8,6 +8,7 @@ package filters
 import (
 	"regexp"
 	"strconv"
+	"strings"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -24,6 +25,8 @@ func NewReplacer(rules []*config.ReplaceRule) *Replacer {
 	return &Replacer{rules: rules}
 }
 
+const ddTagPrefix = "_dd."
+
 // Replace replaces all tags matching the Replacer's rules.
 func (f Replacer) Replace(trace pb.Trace) {
 	for _, rule := range f.rules {
@@ -32,10 +35,14 @@ func (f Replacer) Replace(trace pb.Trace) {
 			switch key {
 			case "*":
 				for k := range s.Meta {
-					s.Meta[k] = re.ReplaceAllString(s.Meta[k], str)
+					if !strings.HasPrefix(k, ddTagPrefix) {
+						s.Meta[k] = re.ReplaceAllString(s.Meta[k], str)
+					}
 				}
 				for k := range s.Metrics {
-					f.replaceNumericTag(re, s, k, str)
+					if !strings.HasPrefix(k, ddTagPrefix) {
+						f.replaceNumericTag(re, s, k, str)
+					}
 				}
 				s.Resource = re.ReplaceAllString(s.Resource, str)
 			case "resource.name":

--- a/pkg/trace/filters/replacer.go
+++ b/pkg/trace/filters/replacer.go
@@ -25,7 +25,7 @@ func NewReplacer(rules []*config.ReplaceRule) *Replacer {
 	return &Replacer{rules: rules}
 }
 
-const ddTagPrefix = "_dd."
+const hiddenTagPrefix = "_"
 
 // Replace replaces all tags matching the Replacer's rules.
 func (f Replacer) Replace(trace pb.Trace) {
@@ -35,12 +35,12 @@ func (f Replacer) Replace(trace pb.Trace) {
 			switch key {
 			case "*":
 				for k := range s.Meta {
-					if !strings.HasPrefix(k, ddTagPrefix) {
+					if !strings.HasPrefix(k, hiddenTagPrefix) {
 						s.Meta[k] = re.ReplaceAllString(s.Meta[k], str)
 					}
 				}
 				for k := range s.Metrics {
-					if !strings.HasPrefix(k, ddTagPrefix) {
+					if !strings.HasPrefix(k, hiddenTagPrefix) {
 						f.replaceNumericTag(re, s, k, str)
 					}
 				}

--- a/pkg/trace/filters/replacer_test.go
+++ b/pkg/trace/filters/replacer_test.go
@@ -52,12 +52,14 @@ func TestReplacer(t *testing.T) {
 					"http.url":      "some/[REDACTED]/token/abcdef/abc",
 					"other.url":     "some/guid/token/abcdef/abc",
 					"custom.tag":    "/foo/bar/foo",
+					"_dd.special":   "this should not be changed",
 				},
 				want: map[string]string{
 					"resource.name": "that is stage",
 					"http.url":      "some/[REDACTED]/token/?/abc",
 					"other.url":     "some/guid/token/?/abc",
 					"custom.tag":    "/foo/bar/extra",
+					"_dd.special":   "this should not be changed",
 				},
 			},
 		} {

--- a/pkg/trace/filters/replacer_test.go
+++ b/pkg/trace/filters/replacer_test.go
@@ -52,14 +52,14 @@ func TestReplacer(t *testing.T) {
 					"http.url":      "some/[REDACTED]/token/abcdef/abc",
 					"other.url":     "some/guid/token/abcdef/abc",
 					"custom.tag":    "/foo/bar/foo",
-					"_dd.special":   "this should not be changed",
+					"_special":      "this should not be changed",
 				},
 				want: map[string]string{
 					"resource.name": "that is stage",
 					"http.url":      "some/[REDACTED]/token/?/abc",
 					"other.url":     "some/guid/token/?/abc",
 					"custom.tag":    "/foo/bar/extra",
-					"_dd.special":   "this should not be changed",
+					"_special":      "this should not be changed",
 				},
 			},
 		} {

--- a/releasenotes/notes/noReplaceDD-5ea756d06f438f23.yaml
+++ b/releasenotes/notes/noReplaceDD-5ea756d06f438f23.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fixes issue where match-all replace tags rules could inadvertantly affect required datadog tags. It is still possible to redact specific datadog tags by targetting them explicitly.

--- a/releasenotes/notes/noReplaceDD-5ea756d06f438f23.yaml
+++ b/releasenotes/notes/noReplaceDD-5ea756d06f438f23.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    APM: Fixes issue where match-all replace tags rules could inadvertantly affect required datadog tags. It is still possible to redact specific datadog tags by targetting them explicitly.
+    APM: Fixes issue where match-all replace tags rules could inadvertently affect required datadog tags. It is still possible to redact specific Datadog tags by targeting them explicitly.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Alters the behavior of "match all" rules for replace_tags config such that they no longer affect internal datadog tags. (ie. those that start with "_."). Note that it is still possible to use replace tags on specific hidden tags if that's required (this should not ever be required, but is left as an option "just in case"), just target the specific tag directly with a replace tags rule.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We rely on hidden tags for various product features within APM, some customers with very strict replace tags rules experienced broken APM features when these rules unexpectedly replaced important datadog tags.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
It's _possible_ someone is relying on the ability to redact data even within internal datadog tags, but this really should NOT be the case, and if they absolutely must do so then they are able to redact specific tags explicitly still. (But if you're reading this because you want to replace all _dd. tags please let us know via support so we can help support your exact use case!)
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
New unit tests change covers this change well!
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
