### PR TITLE
[CWS] fix KMT tests for suse 12 x64 tests

### DIFF
--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -568,7 +568,11 @@ func getSizeOfUpid(kv *kernel.Version) uint64 {
 	case kv.IsRH8Kernel():
 		sizeOfUpid = 16
 	case kv.IsSuse12Kernel():
-		sizeOfUpid = 16
+		if kv.IsInRangeCloseOpen(kernel.Kernel4_12, kernel.Kernel4_13) && kv.Code.Patch() >= 14 {
+			sizeOfUpid = 32
+		} else {
+			sizeOfUpid = 16
+		}
 	case kv.IsSuse15Kernel():
 		if kv.IsInRangeCloseOpen(kernel.Kernel5_3, kernel.Kernel5_4) {
 			sizeOfUpid = 16

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -180,7 +180,11 @@ func getSizeOfStructInode(kv *kernel.Version) uint64 {
 	case kv.IsRH8Kernel() || kv.IsRH9Kernel():
 		sizeOf = 648
 	case kv.IsSuse12Kernel():
-		sizeOf = 560
+		if kv.IsInRangeCloseOpen(kernel.Kernel4_12, kernel.Kernel4_13) && kv.Code.Patch() >= 14 {
+			sizeOf = 592
+		} else {
+			sizeOf = 560
+		}
 	case kv.IsSuse15Kernel():
 		sizeOf = 592
 	case kv.IsOracleUEKKernel():

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -738,6 +738,8 @@ func getNetNSOffset(kv *kernel.Version) uint64 {
 	// and is part of master since 5.1
 	case kv.IsRH8Kernel():
 		fallthrough
+	case kv.IsSuse12Kernel():
+		fallthrough
 	case (kv.IsInRangeCloseOpen(kernel.Kernel4_9, kernel.Kernel4_10) && kv.Code.Patch() >= 168) ||
 		(kv.IsInRangeCloseOpen(kernel.Kernel4_14, kernel.Kernel4_15) && kv.Code.Patch() >= 111) ||
 		kv.Code >= kernel.Kernel5_1:

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -29,7 +29,7 @@ func TestSetXAttr(t *testing.T) {
 		Expression: `((setxattr.file.path == "{{.Root}}/test-setxattr" && setxattr.file.uid == 98 && setxattr.file.gid == 99) || setxattr.file.path == "{{.Root}}/test-setxattr-link") && setxattr.file.destination.namespace == "user" && setxattr.file.destination.name == "user.test_xattr"`,
 	}
 
-	testDrive, err := newTestDrive(t, "ext4", []string{"user_xattr"}, "")
+	testDrive, err := newTestDrive(t, "xfs", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestRemoveXAttr(t *testing.T) {
 		},
 	}
 
-	testDrive, err := newTestDrive(t, "ext4", []string{"user_xattr"}, "")
+	testDrive, err := newTestDrive(t, "xfs", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### What does this PR do?

This PR fixes the KMT tests sec agent suse 12 on x64. It simply fixes a few wrong offsets, and run the xattr tests using an xfs drive instead of ext4 (which is not there on the suse 12 images)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
