### PR TITLE
[ASCII-1614] Fix race in TestGetHostname

### DIFF
--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -201,10 +201,12 @@ func TestGetHostname(t *testing.T) {
 	var responseCode int
 	var lastRequest *http.Request
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// save the last request before writing the response to avoid a race when asserting
+		lastRequest = r
+
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(responseCode)
 		io.WriteString(w, expected)
-		lastRequest = r
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Prevent a race in `TestGetHostname` by saving the last request before replying in the test server.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
There shouldn't be any race, and there should be no test flake either.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
`GetHostname` can return as long as the response has been written by the server, in this case it's after the call to `io.WriteString`.
This means that we can have a race where `GetHostname` returns, we assert on `lastRequest`, and then the server saves the new latest request.
Simply saving the request before writing the response should fix that.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
