### PR TITLE
[CWS] add another hook option for `ptrace_check_attach`

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/ptrace.h
+++ b/pkg/security/ebpf/c/include/hooks/ptrace.h
@@ -24,20 +24,33 @@ HOOK_SYSCALL_ENTRY3(ptrace, u32, request, pid_t, pid, void *, addr) {
     return 0;
 }
 
-HOOK_ENTRY("ptrace_check_attach")
-int hook_ptrace_check_attach(ctx_t *ctx) {
+int __attribute__((always_inline)) ptrace_check_attach_common(struct task_struct *child) {
+    if (!child) {
+        return 0;
+    }
+
     struct syscall_cache_t *syscall = peek_syscall(EVENT_PTRACE);
     if (!syscall) {
         return 0;
     }
 
-    struct task_struct *child = (struct task_struct *)CTX_PARM1(ctx);
-    if (!child) {
+    // we already found the pid
+    if (syscall->ptrace.pid != 0) {
         return 0;
     }
     syscall->ptrace.pid = get_root_nr_from_task_struct(child);
 
     return 0;
+}
+
+HOOK_ENTRY("ptrace_check_attach")
+int hook_ptrace_check_attach(ctx_t *ctx) {
+    return ptrace_check_attach_common((struct task_struct *)CTX_PARM1(ctx));
+}
+
+HOOK_ENTRY("arch_ptrace")
+int hook_arch_ptrace(ctx_t *ctx) {
+    return ptrace_check_attach_common((struct task_struct *)CTX_PARM1(ctx));
 }
 
 int __attribute__((always_inline)) sys_ptrace_ret(void *ctx, int retval) {

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -366,8 +366,9 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		// List of probes required to capture ptrace events
 		"ptrace": {
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "ptrace", fentry, EntryAndExit)},
-			&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				kprobeOrFentry("ptrace_check_attach"),
+				kprobeOrFentry("arch_ptrace"),
 			}},
 		},
 

--- a/pkg/security/ebpf/probes/ptrace.go
+++ b/pkg/security/ebpf/probes/ptrace.go
@@ -24,5 +24,11 @@ func getPTraceProbes(fentry bool) []*manager.Probe {
 			EBPFFuncName: "hook_ptrace_check_attach",
 		},
 	})
+	ptraceProbes = append(ptraceProbes, &manager.Probe{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFFuncName: "hook_arch_ptrace",
+		},
+	})
 	return ptraceProbes
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

On some kernel builds `ptrace_check_attach` is fully inlined and thus unavailable for hooking. This PR adds another option `arch_ptrace` that offers an alternative for the pid collection step.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix some KMT tests (rhel 8 arm64 mainly)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
