### PR TITLE
Replace the `which` command so the `setup` task works on Windows

### DIFF
--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -142,7 +142,7 @@ def update_dependencies(ctx) -> Iterable[SetupResult]:
 def enable_pre_commit(ctx) -> SetupResult:
     print(color_message("Enabling pre-commit...", "blue"))
 
-    if not ctx.run("which pre-commit", hide=True, warn=True).ok:
+    if not ctx.run("pre-commit --version", hide=True, warn=True).ok:
         return SetupResult(
             "Enable pre-commit", Status.FAIL, "Please install pre-commit first: https://pre-commit.com/#installation."
         )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Replace the `which` command so the `setup` task works on Windows

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`which` does not work on Windows 🤦 . Instead of playing with the os and `which`/`where`, let's just runn `pre-commit --version` which should always work if pre-commit is installed to determine if `pre-commit` is there

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
