### PR TITLE
[CWS] fix btrfs root mount parsing

### DIFF
--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -43,6 +43,22 @@ type redemptionEntry struct {
 
 // newMountFromMountInfo - Creates a new Mount from parsed MountInfo data
 func newMountFromMountInfo(mnt *mountinfo.Info) *model.Mount {
+	root := mnt.Root
+
+	if mnt.FSType == "btrfs" {
+		var subvol string
+		for _, opt := range strings.Split(mnt.VFSOptions, ",") {
+			name, val, ok := strings.Cut(opt, "=")
+			if ok && name == "subvol" {
+				subvol = val
+			}
+		}
+
+		if subvol != "" {
+			root = strings.TrimPrefix(root, subvol)
+		}
+	}
+
 	// create a Mount out of the parsed MountInfo
 	return &model.Mount{
 		MountID: uint32(mnt.ID),
@@ -53,7 +69,7 @@ func newMountFromMountInfo(mnt *mountinfo.Info) *model.Mount {
 		FSType:        mnt.FSType,
 		MountPointStr: mnt.Mountpoint,
 		Path:          mnt.Mountpoint,
-		RootStr:       mnt.Root,
+		RootStr:       root,
 	}
 }
 

--- a/pkg/security/resolvers/path/resolver.go
+++ b/pkg/security/resolvers/path/resolver.go
@@ -65,8 +65,8 @@ func (r *Resolver) ResolveFileFieldsPath(e *model.FileFields, pidCtx *model.PIDC
 	}
 
 	// This aims to handle bind mounts
-	if strings.HasPrefix(pathStr, rootPath) && rootPath != "/" {
-		pathStr = strings.Replace(pathStr, rootPath, "", 1)
+	if rootPath != "/" {
+		pathStr = strings.TrimPrefix(pathStr, rootPath)
 	}
 
 	if mountPath != "/" {


### PR DESCRIPTION
### What does this PR do?

BTRFS is a filesystem that works a bit differently than other filesystems. It introduces the concept of volumes that confuses our current implementation of the mount resolver. To improve this (and fix some tests), this PR parses the subvolume id from mount info file, and uses this to trim the root path of the mount, matching the expected result path.

### Motivation

Fix some tests on opensuse (which uses btrfs by default in our tests).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
