### PR TITLE
[AGNTR-161] Add task to collect Agent release metrics

### DIFF
--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -34,13 +34,6 @@ class GithubAPI:
 
         return self._repository
 
-    def raw_request(self, url):
-        """
-        Perform a raw request to the Github API.
-        """
-
-        return self._github._Github__requester.requestJsonAndCheck("GET", url)
-
     def get_branch(self, branch_name):
         """
         Gets info on a given branch in the given Github repository.

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -34,6 +34,13 @@ class GithubAPI:
 
         return self._repository
 
+    def raw_request(self, url):
+        """
+        Perform a raw request to the Github API.
+        """
+
+        return self._github._Github__requester.requestJsonAndCheck("GET", url)
+
     def get_branch(self, branch_name):
         """
         Gets info on a given branch in the given Github repository.

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -30,6 +30,7 @@ from tasks.libs.common.utils import (
 from tasks.libs.types.version import Version
 from tasks.modules import DEFAULT_MODULES
 from tasks.pipeline import edit_schedule, run
+from tasks.release_metrics.metrics import get_prs_metrics, get_release_lead_time
 
 # Generic version regex. Aims to match:
 # - X.Y.Z
@@ -1762,3 +1763,38 @@ def get_active_release_branch(_ctx):
         print(f"{release_branch.name}")
     else:
         print("main")
+
+
+@task
+def generate_release_metrics(ctx, milestone, freeze_date, release_date):
+    """
+    Task to run after the release is done to generate release metrics.
+
+    milestone - github milestone number for the release. Expected format like '7.54.0'
+    freeze_date - date when the code freeze was started. Expected format YYYY-MM-DD, like '2022-02-01'
+    release_date - date when the release was done. Expected format YYYY-MM-DD, like '2022-09-15'
+
+    Results are formatted in a way that can be easily copied to https://docs.google.com/spreadsheets/d/1r39CtyuvoznIDx1JhhLHQeAzmJB182n7ln8nToiWQ8s/edit#gid=1490566519
+    Copy paste numbers to the respective sheets and select 'Split text to columns'.
+    """
+
+    # Step 1: Lead Time for Changes data
+    lead_time = get_release_lead_time(freeze_date, release_date)
+    print("Lead Time for Changes data")
+    print("--------------------------")
+    print(lead_time)
+
+    # Step 2: Agent stability data
+    prs = get_prs_metrics(milestone, freeze_date)
+    print("Agent stability data")
+    print("--------------------")
+    print(f"{prs['total']}, {prs['before_freeze']}, {prs['on_freeze']}, {prs['after_freeze']}")
+
+    # Step 2: Code changes
+    code_stats = ctx.run(
+        f"git log --shortstat {milestone}-devel..{milestone} | grep \"files changed\" | awk '{{files+=$1; inserted+=$4; deleted+=$6}} END {{print files,\",\", inserted,\",\", deleted}}'",
+        hide=True,
+    ).stdout.strip()
+    print("Code changes")
+    print("------------")
+    print(code_stats)

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1786,15 +1786,17 @@ def generate_release_metrics(ctx, milestone, freeze_date, release_date):
 
     # Step 2: Agent stability data
     prs = get_prs_metrics(milestone, freeze_date)
+    print("\n")
     print("Agent stability data")
     print("--------------------")
     print(f"{prs['total']}, {prs['before_freeze']}, {prs['on_freeze']}, {prs['after_freeze']}")
 
-    # Step 2: Code changes
+    # Step 3: Code changes
     code_stats = ctx.run(
         f"git log --shortstat {milestone}-devel..{milestone} | grep \"files changed\" | awk '{{files+=$1; inserted+=$4; deleted+=$6}} END {{print files,\",\", inserted,\",\", deleted}}'",
         hide=True,
     ).stdout.strip()
+    print("\n")
     print("Code changes")
     print("------------")
     print(code_stats)

--- a/tasks/release_metrics/metrics.py
+++ b/tasks/release_metrics/metrics.py
@@ -1,0 +1,36 @@
+"""
+Agent release metrics collection scripts
+"""
+
+from datetime import datetime
+
+from tasks.libs.ciproviders.github_api import GithubAPI
+from tasks.libs.common.utils import (
+    GITHUB_REPO_NAME,
+)
+
+QUERY_URLS = {
+    "before_freeze": "https://api.github.com/search/issues?q=repo:datadog/datadog-agent+type:pr+milestone:{}+merged:<{}",
+    "on_freeze": "https://api.github.com/search/issues?q=repo:datadog/datadog-agent+type:pr+milestone:{}+merged:{}",
+    "after_freeze": "https://api.github.com/search/issues?q=repo:datadog/datadog-agent+type:pr+milestone:{}+merged:>{}",
+}
+
+
+def get_release_lead_time(freeze_date, release_date):
+    release_date = datetime.strptime(release_date, "%Y-%m-%d")
+    freeze_date = datetime.strptime(freeze_date, "%Y-%m-%d")
+
+    return (release_date - freeze_date).days
+
+
+def get_prs_metrics(milestone, freeze_date):
+    github = GithubAPI(repository=GITHUB_REPO_NAME)
+
+    pr_counts = {"total": 0}
+
+    for key, url in QUERY_URLS.items():
+        _, prs = github.raw_request(url.format(milestone, freeze_date))
+        pr_counts[key] = prs["total_count"]
+        pr_counts["total"] += pr_counts[key]
+
+    return pr_counts


### PR DESCRIPTION
### What does this PR do?

This PR adds new task to the release group which generates basic set of the release metrics. It requires milestone, freeze date and release date to pass and produces set of numbers which are meant to be copied to [Agent release metrics](https://docs.google.com/spreadsheets/d/1r39CtyuvoznIDx1JhhLHQeAzmJB182n7ln8nToiWQ8s/edit#gid=1490566519).

There used to be scripts collecting those numbers but to simplify the usage I reviewed and moved the most important parts to the new invoke task.

This task is meant to be run once per release, so every 5 weeks.

### Motivation

Agent release process automation.

### Additional Notes

The most tricky part is the `get_prs_metrics` and why it was written this way. 
PyGithub which we use for all GH related activities is usually good enough but does not provide straight solution for this case when we need just the total number of PRs without getting details about them. If I use [get_pulls](https://github.com/DataDog/datadog-agent/blob/main/tasks/libs/ciproviders/github_api.py#L99) I hit the GH limit very often as there is almost no filter and we need to get information about 700-900 PRs, each one in the separate request. 
By making direct request to the GH endpoint and reading just a single field, whole procedure is quick and does not burden the server. I still used the PyGithub objects to reuse authentication approach.

### Describe how to test/QA your changes

Run the task and compare to the actual release metrics. [Agent release metrics](https://docs.google.com/spreadsheets/d/1r39CtyuvoznIDx1JhhLHQeAzmJB182n7ln8nToiWQ8s/edit#gid=1490566519.) can be used as a reference.