### PR TITLE
chore: include variant in ng installer error reporting

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Flare/FlareUnitTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Flare/FlareUnitTests.cs
@@ -42,7 +42,8 @@ namespace CustomActions.Tests.Flare
                 { "version", CiInfo.PackageVersion },
                 { "log", string.Empty },
                 { "email", email },
-                { "apikey", apiKey }
+                { "apikey", apiKey },
+                { "variant", "windows_installer" }
             };
             httpClientMock.Verify(c => c.Post(
                 $"https://api.{site}/agent_stats/report_failure",
@@ -82,7 +83,8 @@ namespace CustomActions.Tests.Flare
                 { "version", CiInfo.PackageVersion },
                 { "log", string.Empty },
                 { "email", email },
-                { "apikey", apiKey }
+                { "apikey", apiKey },
+                { "variant", "windows_installer" }
             };
             httpClientMock.Verify(c => c.Post(
                 $"https://api.{site}/agent_stats/report_failure",
@@ -131,7 +133,8 @@ namespace CustomActions.Tests.Flare
                 { "version", CiInfo.PackageVersion },
                 { "log", log },
                 { "email", email },
-                { "apikey", apiKey }
+                { "apikey", apiKey },
+                { "variant", "windows_installer" }
             };
             httpClientMock.Verify(c => c.Post(
                 $"https://api.{site}/agent_stats/report_failure",

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Flare.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Flare.cs
@@ -68,7 +68,8 @@ namespace Datadog.CustomActions
                 { "version", agentVersion },
                 { "log", log },
                 { "email", email },
-                { "apikey", apikey }
+                { "apikey", apikey },
+                { "variant", "ng_windows_installer" }
             };
 
             _client.Post(uri, payload, new Dictionary<string, string>());

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Flare.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Flare.cs
@@ -69,7 +69,7 @@ namespace Datadog.CustomActions
                 { "log", log },
                 { "email", email },
                 { "apikey", apikey },
-                { "variant", "ng_windows_installer" }
+                { "variant", "windows_installer" }
             };
 
             _client.Post(uri, payload, new Dictionary<string, string>());


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add a "variant" field to the NG windows installer error report payload.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Install scripts for linux include a variant to differentiate between the "type" of the installer. The NG installer uses the same endpoint and we end up with a reasonably high percentage of `n/a` values for variant. This change aims to reduce the unknown values so our visibility into installer failures can be more accurate and useful.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
