### PR TITLE
Add fxLifecycle to fxutil.TestRun

### DIFF
--- a/cmd/otel-agent/subcommands/run/command_test.go
+++ b/cmd/otel-agent/subcommands/run/command_test.go
@@ -12,18 +12,13 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands"
-	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 func TestFxRun(t *testing.T) {
 	fxutil.TestRun(t, func() error {
 		ctx := context.Background()
 		cliParams := &subcommands.GlobalParams{}
-		return runOTelAgentCommand(ctx, cliParams, fx.Provide(compdef.NewTestLifecycle), fx.Provide(func(lc *compdef.TestLifecycle) compdef.Lifecycle {
-			return lc
-		}),
-		)
+		return runOTelAgentCommand(ctx, cliParams)
 	})
 }

--- a/pkg/util/fxutil/test.go
+++ b/pkg/util/fxutil/test.go
@@ -118,6 +118,7 @@ func TestRun(t *testing.T, f func() error) {
 	var fxFakeAppRan bool
 	fxAppTestOverride = func(i interface{}, opts []fx.Option) error {
 		fxFakeAppRan = true
+		opts = append(opts, fx.Provide(newFxLifecycleAdapter))
 		require.NoError(t, fx.ValidateApp(opts...))
 		return nil
 	}


### PR DESCRIPTION
### What does this PR do?

Adds a constructor to our fxutil.TestRun utility so that tests using it do not need to provide their own implementation for compdef.TestLifecycle.

### Motivation


### Additional Notes



### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

