### PR TITLE
Move context keys in a new package to remove imports

### DIFF
--- a/comp/api/api/utils/common.go
+++ b/comp/api/api/utils/common.go
@@ -11,7 +11,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/DataDog/datadog-agent/pkg/util/grpc/context"
+	grpccontext "github.com/DataDog/datadog-agent/pkg/util/grpc/context"
 )
 
 // SetJSONError writes a server error as JSON with the correct http error code
@@ -23,5 +23,5 @@ func SetJSONError(w http.ResponseWriter, err error, errorCode int) {
 
 // GetConnection returns the connection for the request
 func GetConnection(r *http.Request) net.Conn {
-	return r.Context().Value(context.ConnContextKey).(net.Conn)
+	return r.Context().Value(grpccontext.ConnContextKey).(net.Conn)
 }

--- a/comp/api/api/utils/common.go
+++ b/comp/api/api/utils/common.go
@@ -11,7 +11,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/DataDog/datadog-agent/pkg/util/grpc"
+	"github.com/DataDog/datadog-agent/pkg/util/grpc/context"
 )
 
 // SetJSONError writes a server error as JSON with the correct http error code
@@ -23,5 +23,5 @@ func SetJSONError(w http.ResponseWriter, err error, errorCode int) {
 
 // GetConnection returns the connection for the request
 func GetConnection(r *http.Request) net.Conn {
-	return r.Context().Value(grpc.ConnContextKey).(net.Conn)
+	return r.Context().Value(context.ConnContextKey).(net.Conn)
 }

--- a/pkg/util/grpc/auth.go
+++ b/pkg/util/grpc/auth.go
@@ -11,9 +11,9 @@ import (
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-)
 
-var contextKeyTokenInfoID = &contextKey{"token-info-id"}
+	grpccontext "github.com/DataDog/datadog-agent/pkg/util/grpc/context"
+)
 
 // verifierFunc receives the token passed in the request headers, and returns
 // arbitrary information about the token to be stored in the request context,
@@ -34,6 +34,6 @@ func AuthInterceptor(verifier verifierFunc) grpc_auth.AuthFunc {
 			return nil, status.Errorf(codes.Unauthenticated, "invalid auth token: %v", err)
 		}
 
-		return context.WithValue(ctx, contextKeyTokenInfoID, tokenInfo), nil
+		return context.WithValue(ctx, grpccontext.ContextKeyTokenInfoID, tokenInfo), nil
 	}
 }

--- a/pkg/util/grpc/context/types.go
+++ b/pkg/util/grpc/context/types.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package context provides some constant contexts
+package context
+
+type contextKey struct {
+	key string
+}
+
+// ConnContextKey is a contextKey with http-connection key
+var ConnContextKey = &contextKey{"http-connection"}
+
+// ContextKeyTokenInfoID is a contextKey with token-info-id key
+var ContextKeyTokenInfoID = &contextKey{"token-info-id"}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Move grpc context keys from `pkg/util/grpc` to a separate package to avoid importing the whole package (and its dependencies) in `comp/api/api/utils`. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This is indirectly used by the serverless agent and prevents removing some grpc dependencies from it.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
