### PR TITLE
Add retry loop around public images publication

### DIFF
--- a/.gitlab/common/container_publish_job_templates.yml
+++ b/.gitlab/common/container_publish_job_templates.yml
@@ -23,6 +23,8 @@
       fi
     - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
+    - RETRY_DELAY=120
+    - RETRY_COUNT=3
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/public-images --git-ref main
       --variable IMG_VARIABLES
       --variable IMG_REGISTRIES
@@ -35,3 +37,5 @@
       --variable DDR_WORKFLOW_ID
       --variable TARGET_ENV
       --variable DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+      --variable RETRY_DELAY
+      --variable RETRY_COUNT


### PR DESCRIPTION
### What does this PR do?

Configure the [retry loop](https://github.com/DataDog/public-images/blob/661092f2e62e0acc51e60fd120ad890b93807065/run.sh#L3-L11) around public images publication.

### Motivation

Avoid [pipeline failures](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/510880307) like:
```
2024/05/14 06:11:00 Publishing to registry id: dockerhub at path: docker.io/datadog/agent-dev:nightly-09b8d387-py3-jmx-win-servercore
2024/05/14 06:11:00 Resolving authentication for registry: index.docker.io
2024/05/14 06:11:00 Failed to publish image, err: publish failed for registry id: dockerhub, err: GET https://index.docker.io/v2/: unexpected status code 429 Too Many Requests: Too Many Requests (HAP429).
Attempt 0 failed - retrying in 0
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
