### PR TITLE
USM: add AMQP classification on top of TLS

### DIFF
--- a/pkg/network/protocols/amqp/client.go
+++ b/pkg/network/protocols/amqp/client.go
@@ -55,6 +55,10 @@ func NewClient(opts Options) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = publishCh.Confirm(false)
+	if err != nil {
+		return nil, err
+	}
 	consumeConn, err := newAMQPConnection(opts)
 	if err != nil {
 		return nil, err

--- a/pkg/network/protocols/amqp/server.go
+++ b/pkg/network/protocols/amqp/server.go
@@ -7,10 +7,14 @@ package amqp
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+	"github.com/stretchr/testify/require"
+
+	httpUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 )
 
@@ -19,18 +23,74 @@ const (
 	User = "guest"
 	// Pass is the password to use for authentication
 	Pass = "guest"
+
+	// Plaintext is a flag to indicate that the server should be started with plaintext
+	Plaintext = false
+	// TLS is a flag to indicate that the server should be started with TLS
+	TLS = true
 )
 
-// RunServer runs an amqp server in a docker container
-func RunServer(t testing.TB, serverAddr, serverPort string) error {
-	env := []string{
+type encryptionPoliciesMap map[bool]string
+type regexGeneratorsMap map[bool]func(testing.TB, string) *regexp.Regexp
+
+var (
+	encryptionPolicies      = encryptionPoliciesMap{Plaintext: "plaintext", TLS: "tls"}
+	startupRegexpGenerators = regexGeneratorsMap{
+		Plaintext: getPlaintextRegexp,
+		TLS:       getTLSRegexp,
+	}
+)
+
+// RunServer runs an AMQP server in a docker container.
+func RunServer(t testing.TB, serverAddr, serverPort string, withTLS bool) error {
+	t.Helper()
+
+	env := getServerEnv(t, serverAddr, serverPort, withTLS)
+	startupRegexp := startupRegexpGenerators[withTLS](t, serverPort)
+
+	dir, _ := httpUtils.CurDir()
+	return protocolsUtils.RunDockerServer(t, "amqp", dir+"/testdata/docker-compose.yml", env, startupRegexp, protocolsUtils.DefaultTimeout, 3)
+}
+
+// getServerEnv returns the environment to configure the amqp server
+func getServerEnv(t testing.TB, serverAddr, serverPort string, withTLS bool) []string {
+	t.Helper()
+
+	cert, _, err := httpUtils.GetCertsPaths()
+	require.NoError(t, err)
+	certsDir := filepath.Dir(cert)
+
+	// The certificates are bind-mounted in the container. They
+	// inherit permissions from the host, so we ensure the permissions
+	// allow RabbitMQ to read the certificate/key pair.
+	curDir, _ := httpUtils.CurDir()
+	require.NoError(t, os.Chmod(curDir+"/testdata/tls.conf", 0644))
+	require.NoError(t, os.Chmod(curDir+"/testdata/plaintext.conf", 0644))
+	require.NoError(t, os.Chmod(certsDir+"/server.key", 0644))
+	require.NoError(t, os.Chmod(certsDir+"/cert.pem.0", 0644))
+
+	return []string{
 		"AMQP_ADDR=" + serverAddr,
 		"AMQP_PORT=" + serverPort,
 		"USER=" + User,
 		"PASS=" + Pass,
+		"CERTS_PATH=" + certsDir,
+		"ENCRYPTION_POLICY=" + encryptionPolicies[withTLS],
 	}
+}
 
+// getPlaintextRegexp the startup regexp to check for proper
+// initialization of the plaintext AMQP server.
+func getPlaintextRegexp(t testing.TB, serverPort string) *regexp.Regexp {
 	t.Helper()
-	dir, _ := testutil.CurDir()
-	return protocolsUtils.RunDockerServer(t, "amqp", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(fmt.Sprintf(".*started TCP listener on .*%s.*", serverPort)), protocolsUtils.DefaultTimeout, 3)
+
+	return regexp.MustCompile(fmt.Sprintf(".*started TCP listener on .*%s.*", serverPort))
+}
+
+// getTLSRegexp returns the startup regexp to check for proper
+// initialization of the TLS-enabled AMQP server.
+func getTLSRegexp(t testing.TB, serverPort string) *regexp.Regexp {
+	t.Helper()
+
+	return regexp.MustCompile(fmt.Sprintf(".*started TLS \\(SSL\\) listener on .*%s.*", serverPort))
 }

--- a/pkg/network/protocols/amqp/testdata/docker-compose.yml
+++ b/pkg/network/protocols/amqp/testdata/docker-compose.yml
@@ -4,8 +4,16 @@ services:
   rabbitmq:
     image: rabbitmq:3-management-alpine
     ports:
-      - ${AMQP_ADDR:-127.0.0.1}:${AMQP_PORT:-5672}:5672
+      - ${AMQP_ADDR:-127.0.0.1}:${AMQP_PORT:-5672}:${AMQP_PORT:-5672}
       - ${AMQP_ADDR:-127.0.0.1}:15672:15672
+      - ${AMQP_ADDR:-127.0.0.1}:15671:15671
     environment:
       - "RABBITMQ_DEFAULT_PASS=${PASS:-guest}"
       - "RABBITMQ_DEFAULT_USER=${USER:-guest}"
+    volumes:
+      - type: bind
+        source: ${CERTS_PATH}
+        target: /certs
+      - type: bind
+        source: ./${ENCRYPTION_POLICY}.conf
+        target: /etc/rabbitmq/rabbitmq.conf

--- a/pkg/network/protocols/amqp/testdata/plaintext.conf
+++ b/pkg/network/protocols/amqp/testdata/plaintext.conf
@@ -1,0 +1,1 @@
+ssl_options = none

--- a/pkg/network/protocols/amqp/testdata/tls.conf
+++ b/pkg/network/protocols/amqp/testdata/tls.conf
@@ -1,0 +1,4 @@
+listeners.ssl.1 = 5671
+ssl_options.certfile = /certs/cert.pem.0
+ssl_options.keyfile = /certs/server.key
+ssl_options.verify = verify_none

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -1690,7 +1690,7 @@ func testAMQPProtocolClassification(t *testing.T, tr *Tracer, clientHost, target
 	// Setting one instance of amqp server for all tests.
 	serverAddress := net.JoinHostPort(serverHost, amqpPort)
 	targetAddress := net.JoinHostPort(targetHost, amqpPort)
-	require.NoError(t, amqp.RunServer(t, serverHost, amqpPort))
+	require.NoError(t, amqp.RunServer(t, serverHost, amqpPort, amqp.Plaintext))
 
 	tests := []protocolClassificationAttributes{
 		{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds AMQP classification to USM's TLS classifier. It reuses the classification code used in plaintext, and is expected to behave in the same way, as is verified by the included tests.

I recommend reviewing it commit by commit

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Part of the process of matching our TLS classifier with our plaintext classifier.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The change is tested by the provided unit tests.
