### PR TITLE
[ASCII-1616] Remove `EventuallyWithT` in secret command e2e test to avoid timeout

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/secret/secret_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/secret/secret_win_test.go
@@ -8,15 +8,14 @@ package secret
 import (
 	_ "embed"
 	"testing"
-	"time"
-
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 )
 
 type windowsSecretSuite struct {
@@ -30,25 +29,21 @@ func TestWindowsSecretSuite(t *testing.T) {
 func (v *windowsSecretSuite) TestAgentSecretExecDoesNotExist() {
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)), awshost.WithAgentOptions(agentparams.WithAgentConfig("secret_backend_command: /does/not/exist"))))
 
-	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		output := v.Env().Agent.Client.Secret()
-		assert.Contains(t, output, "=== Checking executable permissions ===")
-		assert.Contains(t, output, "Executable path: /does/not/exist")
-		assert.Contains(t, output, "Executable permissions: error: secretBackendCommand '/does/not/exist' does not exist")
-		assert.Regexp(t, "Number of secrets .+: 0", output)
-	}, 30*time.Second, 3*time.Second)
+	output := v.Env().Agent.Client.Secret()
+	assert.Contains(v.T(), output, "=== Checking executable permissions ===")
+	assert.Contains(v.T(), output, "Executable path: /does/not/exist")
+	assert.Contains(v.T(), output, "Executable permissions: error: secretBackendCommand '/does/not/exist' does not exist")
+	assert.Regexp(v.T(), "Number of secrets .+: 0", output)
 }
 
 func (v *windowsSecretSuite) TestAgentSecretChecksExecutablePermissions() {
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)), awshost.WithAgentOptions(agentparams.WithAgentConfig("secret_backend_command: C:\\Windows\\system32\\cmd.exe"))))
 
-	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		output := v.Env().Agent.Client.Secret()
-		assert.Contains(t, output, "=== Checking executable permissions ===")
-		assert.Contains(t, output, "Executable path: C:\\Windows\\system32\\cmd.exe")
-		assert.Regexp(t, "Executable permissions: error: invalid executable 'C:\\\\Windows\\\\system32\\\\cmd.exe': other users/groups than LOCAL_SYSTEM, .+ have rights on it", output)
-		assert.Regexp(t, "Number of secrets .+: 0", output)
-	}, 30*time.Second, 3*time.Second)
+	output := v.Env().Agent.Client.Secret()
+	assert.Contains(v.T(), output, "=== Checking executable permissions ===")
+	assert.Contains(v.T(), output, "Executable path: C:\\Windows\\system32\\cmd.exe")
+	assert.Regexp(v.T(), "Executable permissions: error: invalid executable 'C:\\\\Windows\\\\system32\\\\cmd.exe': other users/groups than LOCAL_SYSTEM, .+ have rights on it", output)
+	assert.Regexp(v.T(), "Number of secrets .+: 0", output)
 }
 
 //go:embed fixtures/setup_secret.ps1
@@ -77,17 +72,15 @@ host_aliases:
 			awshost.WithAgentOptions(agentparams.WithAgentConfig(config))),
 	)
 
-	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		output := v.Env().Agent.Client.Secret()
-		assert.Contains(t, output, "=== Checking executable permissions ===")
-		assert.Contains(t, output, "Executable path: C:\\TestFolder\\secret.bat")
-		assert.Contains(t, output, "Executable permissions: OK, the executable has the correct permissions")
+	output := v.Env().Agent.Client.Secret()
+	assert.Contains(v.T(), output, "=== Checking executable permissions ===")
+	assert.Contains(v.T(), output, "Executable path: C:\\TestFolder\\secret.bat")
+	assert.Contains(v.T(), output, "Executable permissions: OK, the executable has the correct permissions")
 
-		ddagentRegex := `Access : .+\\ddagentuser Allow  ReadAndExecute`
-		assert.Regexp(t, ddagentRegex, output)
-		assert.Regexp(t, "Number of secrets .+: 1", output)
-		assert.Contains(t, output, "- 'alias_secret':\r\n\tused in 'datadog.yaml' configuration in entry 'host_aliases")
-		// assert we don't output the resolved secret
-		assert.NotContains(t, output, "a_super_secret_string")
-	}, 30*time.Second, 3*time.Second)
+	ddagentRegex := `Access : .+\\ddagentuser Allow  ReadAndExecute`
+	assert.Regexp(v.T(), ddagentRegex, output)
+	assert.Regexp(v.T(), "Number of secrets .+: 1", output)
+	assert.Contains(v.T(), output, "- 'alias_secret':\r\n\tused in 'datadog.yaml' configuration in entry 'host_aliases")
+	// assert we don't output the resolved secret
+	assert.NotContains(v.T(), output, "a_super_secret_string")
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Remove uses of `EventuallyWithT` in the secret subcommand Windows e2e tests to avoid timeout errors.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
`EventuallyWithT` was added on Windows when we had issues with this test and we thought it was an issue in the agent.
The real cause was infrastructure (fixed since), so the `EventuallyWithT` are actually useless.

We used `EventuallyWithT` with a total timeout of 30 seconds, which results in the following not super explicit error when the `secret` command takes more than 30 seconds:
``` 
    secret_win_test.go:33: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-subcommands/secret/secret_win_test.go:33
        	Error:      	Condition never satisfied
        	Test:       	TestWindowsSecretSuite/TestAgentSecretExecDoesNotExist
    --- FAIL: TestWindowsSecretSuite/TestAgentSecretExecDoesNotExist (205.51s)
```

Removing the uses of `EventuallyWithT` will avoid errors when the command takes too long.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
