### PR TITLE
[CWS] fix mmap and open flags approver for 0 cases

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/approvers.h
+++ b/pkg/security/ebpf/c/include/helpers/approvers.h
@@ -137,8 +137,13 @@ int __attribute__((always_inline)) mprotect_approvers(struct syscall_cache_t *sy
 
 int __attribute__((always_inline)) approve_by_flags(struct syscall_cache_t *syscall) {
     u32 key = 0;
-    u32 *flags = bpf_map_lookup_elem(&open_flags_approvers, &key);
-    if (flags != NULL && (syscall->open.flags & *flags) > 0) {
+    u32 *flags_ptr = bpf_map_lookup_elem(&open_flags_approvers, &key);
+    if (flags_ptr == NULL) {
+        return 0;
+    }
+
+    u32 flags = *flags_ptr;
+    if ((flags == 0 && syscall->open.flags == 0) || ((syscall->open.flags & flags) > 0)) {
         monitor_event_approved(syscall->type, FLAG_APPROVER_TYPE);
 #ifdef DEBUG
         bpf_printk("open flags %d approved", syscall->open.flags);

--- a/pkg/security/probe/kfilters/kfilters_bpf.go
+++ b/pkg/security/probe/kfilters/kfilters_bpf.go
@@ -25,7 +25,9 @@ type activeKFilters map[interface{}]activeKFilter
 func newActiveKFilters(kfilters ...activeKFilter) (ak activeKFilters) {
 	ak = make(map[interface{}]activeKFilter)
 	for _, kfilter := range kfilters {
-		ak.Add(kfilter)
+		if kfilter != nil {
+			ak.Add(kfilter)
+		}
 	}
 	return
 }

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -82,7 +82,7 @@ func TestMMapApproverZero(t *testing.T) {
 	defer test.Close()
 
 	test.WaitSignal(t, func() error {
-		data, err := unix.Mmap(0, 0, os.Getpagesize(), unix.PROT_READ, unix.MAP_SHARED|unix.MAP_ANON)
+		data, err := unix.Mmap(0, 0, os.Getpagesize(), unix.PROT_NONE, unix.MAP_SHARED|unix.MAP_ANON)
 		if err != nil {
 			return fmt.Errorf("couldn't memory segment: %w", err)
 		}
@@ -93,7 +93,7 @@ func TestMMapApproverZero(t *testing.T) {
 		return nil
 	}, func(event *model.Event, r *rules.Rule) {
 		assert.Equal(t, "mmap", event.GetType(), "wrong event type")
-		assert.Equal(t, uint64(unix.PROT_READ), event.MMap.Protection&(unix.PROT_READ), fmt.Sprintf("wrong protection: %s", model.Protection(event.MMap.Protection)))
+		assert.Equal(t, uint64(unix.PROT_NONE), event.MMap.Protection&(unix.PROT_NONE), fmt.Sprintf("wrong protection: %s", model.Protection(event.MMap.Protection)))
 
 		value, _ := event.GetFieldValue("event.async")
 		assert.Equal(t, value.(bool), false)

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -64,3 +64,46 @@ func TestMMapEvent(t *testing.T) {
 		})
 	})
 }
+
+func TestMMapApproverZero(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_mmap",
+			Expression: `mmap.protection == 0 && process.file.name == "testsuite"`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	test.WaitSignal(t, func() error {
+		data, err := unix.Mmap(0, 0, os.Getpagesize(), unix.PROT_READ, unix.MAP_SHARED|unix.MAP_ANON)
+		if err != nil {
+			return fmt.Errorf("couldn't memory segment: %w", err)
+		}
+
+		if err := unix.Munmap(data); err != nil {
+			return fmt.Errorf("couldn't unmap memory segment: %w", err)
+		}
+		return nil
+	}, func(event *model.Event, r *rules.Rule) {
+		assert.Equal(t, "mmap", event.GetType(), "wrong event type")
+		assert.Equal(t, uint64(unix.PROT_READ), event.MMap.Protection&(unix.PROT_READ), fmt.Sprintf("wrong protection: %s", model.Protection(event.MMap.Protection)))
+
+		value, _ := event.GetFieldValue("event.async")
+		assert.Equal(t, value.(bool), false)
+
+		executable, err := os.Executable()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertFieldEqual(t, event, "process.file.path", executable)
+
+		test.validateMMapSchema(t, event)
+	})
+}

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -455,6 +455,9 @@ func TestOpenApproverZero(t *testing.T) {
 
 		fd, _, errno := syscall.Syscall6(unix.SYS_OPENAT2, 0, uintptr(testFilePtr), uintptr(unsafe.Pointer(&openHow)), unix.SizeofOpenHow, 0, 0)
 		if errno != 0 {
+			if errno == unix.ENOSYS {
+				return ErrSkipTest{"openat2 is not supported"}
+			}
 			return error(errno)
 		}
 		return syscall.Close(int(fd))

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -421,6 +421,52 @@ func TestOpenDiscarded(t *testing.T) {
 	})
 }
 
+func TestOpenApproverZero(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	rule := &rules.RuleDefinition{
+		ID:         "test_rule",
+		Expression: `open.flags == 0 && process.file.name == "testsuite"`,
+	}
+
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	testFile, testFilePtr, err := test.Path("test-open")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(testFile)
+
+	tf, err := os.Create(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tf.Close()
+
+	test.WaitSignal(t, func() error {
+		openHow := unix.OpenHow{
+			Flags: unix.O_RDONLY,
+			Mode:  0,
+		}
+
+		fd, _, errno := syscall.Syscall6(unix.SYS_OPENAT2, 0, uintptr(testFilePtr), uintptr(unsafe.Pointer(&openHow)), unix.SizeofOpenHow, 0, 0)
+		if errno != 0 {
+			return error(errno)
+		}
+		return syscall.Close(int(fd))
+	}, func(event *model.Event, r *rules.Rule) {
+		assert.Equal(t, "open", event.GetType(), "wrong event type")
+		assert.Equal(t, 0, int(event.Open.Flags), "wrong flags")
+		value, _ := event.GetFieldValue("event.async")
+		assert.Equal(t, value.(bool), false)
+		assertInode(t, event.Open.File.Inode, getInode(t, testFile))
+	})
+}
+
 func openMountByID(mountID int) (f *os.File, err error) {
 	mi, err := os.Open("/proc/self/mountinfo")
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the handling of approvers when confronted to flags with 0 value, especially:
- `O_RDONLY` for open.flags
- `PROT_NONE` for mmap.protection

The bug fixed by this was a crash userspace when loading the approver, and a bug kernelspace where the approver evaluation was wrong. This PR adds 2 tests to check for those.

This PR also fixes an issue with ebpfless where the mode returned is not correct (mode of the file, instead of the mode passed in the syscall).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
