### PR TITLE
[E2E] Don't fail registry key creation to disable Windows Defender

### DIFF
--- a/test/new-e2e/tests/windows/common/powershell/command_builder.go
+++ b/test/new-e2e/tests/windows/common/powershell/command_builder.go
@@ -166,7 +166,7 @@ if ((Get-MpComputerStatus).IsTamperProtected) {
 ) | ForEach-Object { Set-MpPreference @_ }`)
 	// Even though Microsoft claims to have deprecated this option as of Platform Version 4.18.2108.4,
 	// it still works for me on Platform Version 4.18.23110.3 after a reboot, so set it anywawy.
-	ps.cmds = append(ps.cmds, `mkdir -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows NewDefender"`)
+	ps.cmds = append(ps.cmds, `mkdir -Force -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows NewDefender"`)
 	ps.cmds = append(ps.cmds, `Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows NewDefender" -Name DisableAntiSpyware -Value 1`)
 	return ps
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds a `-Force` flag to ignore any error if the registry key to disable Windows Defender already exists.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Sometimes the command gets interrupted and when Pulumi retries it, it fails because the key already exists.
https://datadoghq.atlassian.net/browse/WINA-794
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
This doesn't address the root cause of why the script gets interrupted in the first place.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
E2E test will take care of that.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
