### PR TITLE
[CONTP-120] add kubernetes_namespace_annotations_as_tags

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -192,6 +192,7 @@ func isExternalPath(path string) bool {
 		strings.HasPrefix(path, "/api/v1/tags/pod/") && (len(strings.Split(path, "/")) == 6 || len(strings.Split(path, "/")) == 8) ||
 		strings.HasPrefix(path, "/api/v1/tags/node/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/tags/namespace/") && len(strings.Split(path, "/")) == 6 ||
+		strings.HasPrefix(path, "/api/v1/annotations/namespace/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/annotations/node/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/clusterchecks/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/endpointschecks/") && len(strings.Split(path, "/")) == 6 ||

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -189,17 +189,17 @@ func isExternalPath(path string) bool {
 	return strings.HasPrefix(path, "/api/v1/metadata/") && len(strings.Split(path, "/")) == 7 || // support for agents < 6.5.0
 		path == "/version" ||
 		path == "/api/v1/languagedetection" ||
-		strings.HasPrefix(path, "/api/v1/tags/pod/") && (len(strings.Split(path, "/")) == 6 || len(strings.Split(path, "/")) == 8) ||
-		strings.HasPrefix(path, "/api/v1/tags/node/") && len(strings.Split(path, "/")) == 6 ||
-		strings.HasPrefix(path, "/api/v1/tags/namespace/") && len(strings.Split(path, "/")) == 6 ||
-		strings.HasPrefix(path, "/api/v1/annotations/namespace/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/annotations/node/") && len(strings.Split(path, "/")) == 6 ||
-		strings.HasPrefix(path, "/api/v1/clusterchecks/") && len(strings.Split(path, "/")) == 6 ||
-		strings.HasPrefix(path, "/api/v1/endpointschecks/") && len(strings.Split(path, "/")) == 6 ||
-		strings.HasPrefix(path, "/api/v1/tags/cf/apps/") && len(strings.Split(path, "/")) == 7 ||
-		strings.HasPrefix(path, "/api/v1/cluster/id") && len(strings.Split(path, "/")) == 5 ||
 		strings.HasPrefix(path, "/api/v1/cf/apps") && len(strings.Split(path, "/")) == 5 ||
 		strings.HasPrefix(path, "/api/v1/cf/apps/") && len(strings.Split(path, "/")) == 6 ||
+		strings.HasPrefix(path, "/api/v1/cf/org_quotas") && len(strings.Split(path, "/")) == 5 ||
 		strings.HasPrefix(path, "/api/v1/cf/orgs") && len(strings.Split(path, "/")) == 5 ||
-		strings.HasPrefix(path, "/api/v1/cf/org_quotas") && len(strings.Split(path, "/")) == 5
+		strings.HasPrefix(path, "/api/v1/cluster/id") && len(strings.Split(path, "/")) == 5 ||
+		strings.HasPrefix(path, "/api/v1/clusterchecks/") && len(strings.Split(path, "/")) == 6 ||
+		strings.HasPrefix(path, "/api/v1/endpointschecks/") && len(strings.Split(path, "/")) == 6 ||
+		strings.HasPrefix(path, "/api/v1/metadata/namespace/") && len(strings.Split(path, "/")) == 6 ||
+		strings.HasPrefix(path, "/api/v1/tags/cf/apps/") && len(strings.Split(path, "/")) == 7 ||
+		strings.HasPrefix(path, "/api/v1/tags/namespace/") && len(strings.Split(path, "/")) == 6 ||
+		strings.HasPrefix(path, "/api/v1/tags/node/") && len(strings.Split(path, "/")) == 6 ||
+		strings.HasPrefix(path, "/api/v1/tags/pod/") && (len(strings.Split(path, "/")) == 6 || len(strings.Split(path, "/")) == 8)
 }

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -341,6 +341,10 @@ func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*types.Ta
 		utils.AddMetadataAsTags(name, value, c.nsLabelsAsTags, c.globNsLabels, tags)
 	}
 
+	for name, value := range pod.NamespaceAnnotations {
+		utils.AddMetadataAsTags(name, value, c.nsAnnotationsAsTags, c.globNsAnnotations, tags)
+	}
+
 	kubeServiceDisabled := false
 	for _, disabledTag := range config.Datadog.GetStringSlice("kubernetes_ad_tags_disabled") {
 		if disabledTag == "kube_service" {
@@ -444,6 +448,10 @@ func (c *WorkloadMetaCollector) handleKubeNamespace(ev workloadmeta.Event) []*ty
 
 	for name, value := range namespace.Labels {
 		utils.AddMetadataAsTags(name, value, c.nsLabelsAsTags, c.globNsLabels, tags)
+	}
+
+	for name, value := range namespace.Annotations {
+		utils.AddMetadataAsTags(name, value, c.nsAnnotationsAsTags, c.globNsAnnotations, tags)
 	}
 
 	low, orch, high, standard := tags.Compute()

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_main.go
@@ -58,9 +58,11 @@ type WorkloadMetaCollector struct {
 	labelsAsTags           map[string]string
 	annotationsAsTags      map[string]string
 	nsLabelsAsTags         map[string]string
+	nsAnnotationsAsTags    map[string]string
 	globLabels             map[string]glob.Glob
 	globAnnotations        map[string]glob.Glob
 	globNsLabels           map[string]glob.Glob
+	globNsAnnotations      map[string]glob.Glob
 	globContainerLabels    map[string]glob.Glob
 	globContainerEnvLabels map[string]glob.Glob
 
@@ -72,10 +74,11 @@ func (c *WorkloadMetaCollector) initContainerMetaAsTags(labelsAsTags, envAsTags 
 	c.containerEnvAsTags, c.globContainerEnvLabels = utils.InitMetadataAsTags(envAsTags)
 }
 
-func (c *WorkloadMetaCollector) initPodMetaAsTags(labelsAsTags, annotationsAsTags, nsLabelsAsTags map[string]string) {
+func (c *WorkloadMetaCollector) initPodMetaAsTags(labelsAsTags, annotationsAsTags, nsLabelsAsTags, nsAnnotationsAsTags map[string]string) {
 	c.labelsAsTags, c.globLabels = utils.InitMetadataAsTags(labelsAsTags)
 	c.annotationsAsTags, c.globAnnotations = utils.InitMetadataAsTags(annotationsAsTags)
 	c.nsLabelsAsTags, c.globNsLabels = utils.InitMetadataAsTags(nsLabelsAsTags)
+	c.nsAnnotationsAsTags, c.globNsAnnotations = utils.InitMetadataAsTags(nsAnnotationsAsTags)
 }
 
 // Run runs the continuous event watching loop and sends new tags to the
@@ -175,7 +178,8 @@ func NewWorkloadMetaCollector(_ context.Context, store workloadmeta.Component, p
 	labelsAsTags := config.Datadog.GetStringMapString("kubernetes_pod_labels_as_tags")
 	annotationsAsTags := config.Datadog.GetStringMapString("kubernetes_pod_annotations_as_tags")
 	nsLabelsAsTags := config.Datadog.GetStringMapString("kubernetes_namespace_labels_as_tags")
-	c.initPodMetaAsTags(labelsAsTags, annotationsAsTags, nsLabelsAsTags)
+	nsAnnotationsAsTags := config.Datadog.GetStringMapString("kubernetes_namespace_annotations_as_tags")
+	c.initPodMetaAsTags(labelsAsTags, annotationsAsTags, nsLabelsAsTags, nsAnnotationsAsTags)
 
 	return c
 }

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -119,8 +119,8 @@ func TestHandleKubePod(t *testing.T) {
 				"ns-ownerteam": "ns-team",
 			},
 			nsAnnotationsAsTags: map[string]string{
-				"ns_tier":     "ns_tier",
-				"ns_security": "ns_security",
+				"ns_tier":            "ns_tier",
+				"namespace_security": "ns_security",
 			},
 			pod: workloadmeta.KubernetesPod{
 				EntityID: podEntityID,
@@ -166,8 +166,8 @@ func TestHandleKubePod(t *testing.T) {
 
 				// NS annotations as tags
 				NamespaceAnnotations: map[string]string{
-					"ns_tier":     "some_tier",
-					"ns_security": "critical",
+					"ns_tier":            "some_tier",
+					"namespace_security": "critical",
 				},
 
 				// kube_service tags
@@ -665,8 +665,8 @@ func TestHandleKubeNamespace(t *testing.T) {
 				"ns-ownerteam": "ns-team",
 			},
 			nsAnnotationsAsTags: map[string]string{
-				"ns_tier":     "ns_tier",
-				"ns_security": "ns_security",
+				"ns_tier":            "ns_tier",
+				"namespace_security": "ns_security",
 			},
 			namespace: workloadmeta.KubernetesNamespace{
 				EntityID: namespaceEntityID,
@@ -678,8 +678,8 @@ func TestHandleKubeNamespace(t *testing.T) {
 						"foo":          "bar",
 					},
 					Annotations: map[string]string{
-						"ns_tier":     "some_tier",
-						"ns_security": "critical",
+						"ns_tier":            "some_tier",
+						"namespace_security": "critical",
 					},
 				},
 			},

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -95,13 +95,14 @@ func TestHandleKubePod(t *testing.T) {
 	})
 
 	tests := []struct {
-		name              string
-		staticTags        map[string]string
-		labelsAsTags      map[string]string
-		annotationsAsTags map[string]string
-		nsLabelsAsTags    map[string]string
-		pod               workloadmeta.KubernetesPod
-		expected          []*types.TagInfo
+		name                string
+		staticTags          map[string]string
+		labelsAsTags        map[string]string
+		annotationsAsTags   map[string]string
+		nsLabelsAsTags      map[string]string
+		nsAnnotationsAsTags map[string]string
+		pod                 workloadmeta.KubernetesPod
+		expected            []*types.TagInfo
 	}{
 		{
 			name: "fully formed pod (no containers)",
@@ -116,6 +117,10 @@ func TestHandleKubePod(t *testing.T) {
 			nsLabelsAsTags: map[string]string{
 				"ns_env":       "ns_env",
 				"ns-ownerteam": "ns-team",
+			},
+			nsAnnotationsAsTags: map[string]string{
+				"ns_tier":     "ns_tier",
+				"ns_security": "ns_security",
 			},
 			pod: workloadmeta.KubernetesPod{
 				EntityID: podEntityID,
@@ -157,6 +162,12 @@ func TestHandleKubePod(t *testing.T) {
 					"ns_env":       "dev",
 					"ns-ownerteam": "containers",
 					"foo":          "bar",
+				},
+
+				// NS annotations as tags
+				NamespaceAnnotations: map[string]string{
+					"ns_tier":     "some_tier",
+					"ns_security": "critical",
 				},
 
 				// kube_service tags
@@ -206,6 +217,8 @@ func TestHandleKubePod(t *testing.T) {
 						"kube_qos:guaranteed",
 						"ns-team:containers",
 						"ns_env:dev",
+						"ns_tier:some_tier",
+						"ns_security:critical",
 						"pod_phase:running",
 						"pod_template_version:1.0.0",
 						"team:container-integrations",
@@ -445,7 +458,7 @@ func TestHandleKubePod(t *testing.T) {
 				staticTags: tt.staticTags,
 			}
 
-			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags)
+			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags, tt.nsAnnotationsAsTags)
 
 			actual := collector.handleKubePod(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,
@@ -526,13 +539,14 @@ func TestHandleKubePodNoContainerName(t *testing.T) {
 	})
 
 	tests := []struct {
-		name              string
-		staticTags        map[string]string
-		labelsAsTags      map[string]string
-		annotationsAsTags map[string]string
-		nsLabelsAsTags    map[string]string
-		pod               workloadmeta.KubernetesPod
-		expected          []*types.TagInfo
+		name                string
+		staticTags          map[string]string
+		labelsAsTags        map[string]string
+		annotationsAsTags   map[string]string
+		nsLabelsAsTags      map[string]string
+		nsAnnotationsAsTags map[string]string
+		pod                 workloadmeta.KubernetesPod
+		expected            []*types.TagInfo
 	}{
 		{
 			name: "pod with no container name",
@@ -595,7 +609,7 @@ func TestHandleKubePodNoContainerName(t *testing.T) {
 				staticTags: tt.staticTags,
 			}
 
-			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags)
+			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags, tt.annotationsAsTags)
 
 			actual := collector.handleKubePod(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,
@@ -636,18 +650,23 @@ func TestHandleKubeNamespace(t *testing.T) {
 	})
 
 	tests := []struct {
-		name              string
-		labelsAsTags      map[string]string
-		annotationsAsTags map[string]string
-		nsLabelsAsTags    map[string]string
-		namespace         workloadmeta.KubernetesNamespace
-		expected          []*types.TagInfo
+		name                string
+		labelsAsTags        map[string]string
+		annotationsAsTags   map[string]string
+		nsLabelsAsTags      map[string]string
+		nsAnnotationsAsTags map[string]string
+		namespace           workloadmeta.KubernetesNamespace
+		expected            []*types.TagInfo
 	}{
 		{
 			name: "fully formed namespace",
 			nsLabelsAsTags: map[string]string{
 				"ns_env":       "ns_env",
 				"ns-ownerteam": "ns-team",
+			},
+			nsAnnotationsAsTags: map[string]string{
+				"ns_tier":     "ns_tier",
+				"ns_security": "ns_security",
 			},
 			namespace: workloadmeta.KubernetesNamespace{
 				EntityID: namespaceEntityID,
@@ -657,6 +676,10 @@ func TestHandleKubeNamespace(t *testing.T) {
 						"ns_env":       "dev",
 						"ns-ownerteam": "containers",
 						"foo":          "bar",
+					},
+					Annotations: map[string]string{
+						"ns_tier":     "some_tier",
+						"ns_security": "critical",
 					},
 				},
 			},
@@ -669,6 +692,8 @@ func TestHandleKubeNamespace(t *testing.T) {
 					LowCardTags: []string{
 						"ns_env:dev",
 						"ns-team:containers",
+						"ns_tier:some_tier",
+						"ns_security:critical",
 					},
 					StandardTags: []string{},
 				},
@@ -683,7 +708,7 @@ func TestHandleKubeNamespace(t *testing.T) {
 				children: make(map[string]map[string]struct{}),
 			}
 
-			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags)
+			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags, tt.nsAnnotationsAsTags)
 
 			actual := collector.handleKubeNamespace(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,

--- a/comp/core/tagger/utils/k8s_metadata.go
+++ b/comp/core/tagger/utils/k8s_metadata.go
@@ -15,14 +15,14 @@ import (
 )
 
 // InitMetadataAsTags prepares labels and annotations as tags
-// - It lower-case all the labels in metadataAsTags
+// - It lower-case all the keys in metadataAsTags
 // - It compiles all the patterns and stores them in a map of glob.Glob objects
 func InitMetadataAsTags(metadataAsTags map[string]string) (map[string]string, map[string]glob.Glob) {
 	// We lower-case the values collected by viper as well as the ones from inspecting the pod labels/annotations.
 	globMap := map[string]glob.Glob{}
-	for label, value := range metadataAsTags {
-		delete(metadataAsTags, label)
-		pattern := strings.ToLower(label)
+	for metadataKey, value := range metadataAsTags {
+		delete(metadataAsTags, metadataKey)
+		pattern := strings.ToLower(metadataKey)
 		metadataAsTags[pattern] = value
 		if strings.Contains(pattern, "*") {
 			g, err := glob.Compile(pattern)

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
@@ -20,6 +20,7 @@ import (
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -171,7 +172,7 @@ func (f *FakeDCAClient) GetNamespaceLabels(_ string) (map[string]string, error) 
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) GetNamespaceAnnotations(_ string) (map[string]string, error) {
+func (f *FakeDCAClient) GetNamespaceMetadata(_ string) (*clusteragent.Metadata, error) {
 	panic("implement me")
 }
 

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
@@ -211,6 +211,10 @@ func (f *FakeDCAClient) PostLanguageMetadata(_ context.Context, _ *pbgo.ParentLa
 	panic("implement me")
 }
 
+func (f *FakeDCAClient) SupportsNamespaceMetadataCollection() bool {
+	panic("implement me")
+}
+
 func TestStartError(t *testing.T) {
 	fakeGardenUtil := FakeGardenUtil{}
 

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
@@ -171,6 +171,10 @@ func (f *FakeDCAClient) GetNamespaceLabels(_ string) (map[string]string, error) 
 	panic("implement me")
 }
 
+func (f *FakeDCAClient) GetNamespaceAnnotations(_ string) (map[string]string, error) {
+	panic("implement me")
+}
+
 func (f *FakeDCAClient) GetPodsMetadataForNode(_ string) (apiv1.NamespacesPodsStringsSet, error) {
 	panic("implement me")
 }

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -233,7 +233,7 @@ func (c *collector) parsePods(
 
 		var nsLabels, nsAnnotations map[string]string
 
-		if c.dcaClient.Version().Major >= 7 && c.dcaClient.Version().Minor >= 55 {
+		if c.dcaClient.SupportsNamespaceMetadataCollection() {
 			// Cluster agent with version 7.55+
 			var nsMetadata *clusteragent.Metadata
 			nsMetadata, err = c.getNamespaceMetadata(pod.Metadata.Namespace)

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -127,6 +127,10 @@ func (f *FakeDCAClient) PostLanguageMetadata(_ context.Context, _ *pbgo.ParentLa
 	panic("implement me")
 }
 
+func (f *FakeDCAClient) SupportsNamespaceMetadataCollection() bool {
+	return f.LocalVersion.Major >= 7 && f.LocalVersion.Minor >= 55
+}
+
 func TestKubeMetadataCollector_getMetadata(t *testing.T) {
 	type fields struct {
 		dcaClient           clusteragent.DCAClientInterface

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -45,8 +45,8 @@ type FakeDCAClient struct {
 	NamespaceLabels    map[string]string
 	NamespaceLabelsErr error
 
-	NamespaceAnnotations    map[string]string
-	NamespaceAnnotationsErr error
+	NamespaceMetadata    clusteragent.Metadata
+	NamespaceMetadataErr error
 
 	PodMetadataForNode    apiv1.NamespacesPodsStringsSet
 	PodMetadataForNodeErr error
@@ -91,8 +91,8 @@ func (f *FakeDCAClient) GetNamespaceLabels(_ string) (map[string]string, error) 
 	return f.NamespaceLabels, f.NamespaceLabelsErr
 }
 
-func (f *FakeDCAClient) GetNamespaceAnnotations(_ string) (map[string]string, error) {
-	return f.NamespaceAnnotations, f.NamespaceAnnotationsErr
+func (f *FakeDCAClient) GetNamespaceMetadata(_ string) (*clusteragent.Metadata, error) {
+	return &f.NamespaceMetadata, f.NamespaceMetadataErr
 }
 
 func (f *FakeDCAClient) GetPodsMetadataForNode(_ string) (apiv1.NamespacesPodsStringsSet, error) {
@@ -298,85 +298,7 @@ func TestKubeMetadataCollector_getMetadata(t *testing.T) {
 	}
 }
 
-func TestKubeMetadataCollector_getNamespaceLabels(t *testing.T) {
-	type fields struct {
-		dcaClient           clusteragent.DCAClientInterface
-		clusterAgentEnabled bool
-	}
-
-	tests := []struct {
-		name                  string
-		fields                fields
-		namespaceLabelsAsTags map[string]string
-		want                  map[string]string
-		wantErr               bool
-	}{
-		{
-			name:    "no namespace labels as tags",
-			want:    nil,
-			wantErr: false,
-		},
-		{
-			name: "cluster agent not enabled",
-			fields: fields{
-				clusterAgentEnabled: false,
-				dcaClient:           &FakeDCAClient{},
-			},
-			namespaceLabelsAsTags: map[string]string{
-				"label": "tag",
-			},
-			want:    nil,
-			wantErr: false,
-		},
-		{
-			name: "cluster agent enabled",
-			fields: fields{
-				clusterAgentEnabled: true,
-				dcaClient: &FakeDCAClient{
-					LocalVersion: version.Version{Major: 1, Minor: 12},
-					NamespaceLabels: map[string]string{
-						"label": "value",
-					},
-				},
-			},
-			namespaceLabelsAsTags: map[string]string{
-				"label": "tag",
-			},
-			want:    map[string]string{"label": "tag"},
-			wantErr: false,
-		},
-		{
-			name: "cluster agent enabled and failed to get namespace labels",
-			fields: fields{
-				clusterAgentEnabled: true,
-				dcaClient: &FakeDCAClient{
-					LocalVersion:       version.Version{Major: 1, Minor: 12},
-					NamespaceLabelsErr: errors.New("failed to get namespace labels"),
-				},
-			},
-			namespaceLabelsAsTags: map[string]string{
-				"label": "tag",
-			},
-			want:    nil,
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &collector{
-				dcaClient:              tt.fields.dcaClient,
-				dcaEnabled:             tt.fields.clusterAgentEnabled,
-				collectNamespaceLabels: len(tt.namespaceLabelsAsTags) > 0,
-			}
-
-			labels, err := c.getNamespaceLabels("foo")
-			assert.True(t, (err != nil) == tt.wantErr)
-			assert.EqualValues(&testing.T{}, tt.want, labels)
-		})
-	}
-}
-
-func TestKubeMetadataCollector_getNamespaceAnnotations(t *testing.T) {
+func TestKubeMetadataCollector_getNamespaceMetadata(t *testing.T) {
 	type fields struct {
 		dcaClient           clusteragent.DCAClientInterface
 		clusterAgentEnabled bool
@@ -386,11 +308,12 @@ func TestKubeMetadataCollector_getNamespaceAnnotations(t *testing.T) {
 		name                       string
 		fields                     fields
 		namespaceAnnotationsAsTags map[string]string
-		want                       map[string]string
+		namespaceLabelsAsTags      map[string]string
+		want                       *workloadmeta.EntityMeta
 		wantErr                    bool
 	}{
 		{
-			name:    "no namespace annotations as tags",
+			name:    "no namespace annotations as tags and no namespace labels as tags",
 			want:    nil,
 			wantErr: false,
 		},
@@ -401,10 +324,13 @@ func TestKubeMetadataCollector_getNamespaceAnnotations(t *testing.T) {
 				dcaClient:           &FakeDCAClient{},
 			},
 			namespaceAnnotationsAsTags: map[string]string{
-				"key": "tag",
+				"annot-key": "annot-tag",
+			},
+			namespaceLabelsAsTags: map[string]string{
+				"label-key": "label-tag",
 			},
 			want:    nil,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "cluster agent enabled",
@@ -412,27 +338,41 @@ func TestKubeMetadataCollector_getNamespaceAnnotations(t *testing.T) {
 				clusterAgentEnabled: true,
 				dcaClient: &FakeDCAClient{
 					LocalVersion: version.Version{Major: 1, Minor: 12},
-					NamespaceAnnotations: map[string]string{
-						"key": "value",
+					NamespaceMetadata: clusteragent.Metadata{
+						Annotations: map[string]string{
+							"annot-key": "value",
+						},
+						Labels: map[string]string{
+							"label-key": "value",
+						},
 					},
+				},
+			},
+			namespaceAnnotationsAsTags: map[string]string{
+				"annot-key": "annot-tag",
+			},
+			namespaceLabelsAsTags: map[string]string{
+				"label-key": "label-tag",
+			},
+			want: &workloadmeta.EntityMeta{
+				Labels:      map[string]string{"label-key": "value"},
+				Annotations: map[string]string{"annot-key": "value"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "cluster agent enabled and failed to get namespace metadata",
+			fields: fields{
+				clusterAgentEnabled: true,
+				dcaClient: &FakeDCAClient{
+					LocalVersion:         version.Version{Major: 1, Minor: 12},
+					NamespaceMetadataErr: errors.New("failed to get namespace metadata"),
 				},
 			},
 			namespaceAnnotationsAsTags: map[string]string{
 				"key": "tag",
 			},
-			want:    map[string]string{"key": "tag"},
-			wantErr: false,
-		},
-		{
-			name: "cluster agent enabled and failed to get namespace annotations",
-			fields: fields{
-				clusterAgentEnabled: true,
-				dcaClient: &FakeDCAClient{
-					LocalVersion:            version.Version{Major: 1, Minor: 12},
-					NamespaceAnnotationsErr: errors.New("failed to get namespace annotations"),
-				},
-			},
-			namespaceAnnotationsAsTags: map[string]string{
+			namespaceLabelsAsTags: map[string]string{
 				"key": "tag",
 			},
 			want:    nil,
@@ -446,11 +386,12 @@ func TestKubeMetadataCollector_getNamespaceAnnotations(t *testing.T) {
 				dcaClient:                   tt.fields.dcaClient,
 				dcaEnabled:                  tt.fields.clusterAgentEnabled,
 				collectNamespaceAnnotations: len(tt.namespaceAnnotationsAsTags) > 0,
+				collectNamespaceLabels:      len(tt.namespaceLabelsAsTags) > 0,
 			}
 
-			annotations, err := c.getNamespaceAnnotations("foo")
+			metadata, err := c.getNamespaceMetadata("foo")
 			assert.True(t, (err != nil) == tt.wantErr)
-			assert.EqualValues(&testing.T{}, tt.want, annotations)
+			assert.EqualValues(&testing.T{}, tt.want, metadata)
 		})
 	}
 }
@@ -482,24 +423,26 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 	kubeUtilFake := &kubelet.KubeUtil{}
 
 	type fields struct {
-		kubeUtil               *kubelet.KubeUtil
-		apiClient              *apiserver.APIClient
-		dcaClient              clusteragent.DCAClientInterface
-		lastUpdate             time.Time
-		updateFreq             time.Duration
-		dcaEnabled             bool
-		collectNamespaceLabels bool
+		kubeUtil                    *kubelet.KubeUtil
+		apiClient                   *apiserver.APIClient
+		dcaClient                   clusteragent.DCAClientInterface
+		lastUpdate                  time.Time
+		updateFreq                  time.Duration
+		dcaEnabled                  bool
+		collectNamespaceLabels      bool
+		collectNamespaceAnnotations bool
 	}
 	type args struct {
 		pods []*kubelet.Pod
 	}
 	tests := []struct {
-		name                  string
-		fields                fields
-		args                  args
-		namespaceLabelsAsTags map[string]string
-		want                  []workloadmeta.CollectorEvent
-		wantErr               bool
+		name                       string
+		fields                     fields
+		args                       args
+		namespaceLabelsAsTags      map[string]string
+		namespaceAnnotationsAsTags map[string]string
+		want                       []workloadmeta.CollectorEvent
+		wantErr                    bool
 	}{
 		{
 			name: "clusterAgentEnabled enabled, cluster-agent 1.3.x >=",
@@ -520,6 +463,163 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 			},
 			namespaceLabelsAsTags: map[string]string{
 				"label": "tag",
+			},
+			want: []workloadmeta.CollectorEvent{
+				{
+					Type:   workloadmeta.EventTypeSet,
+					Source: workloadmeta.SourceClusterOrchestrator,
+					Entity: &workloadmeta.KubernetesPod{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindKubernetesPod,
+							ID:   "foouid",
+						},
+						EntityMeta: workloadmeta.EntityMeta{
+							Name:      "foo",
+							Namespace: "default",
+						},
+						KubeServices: []string{"svc1", "svc2"},
+						NamespaceLabels: map[string]string{
+							"label": "value",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "clusterAgentEnabled enabled, cluster-agent version < 7.55, ns labels enabled, ns annotations enabled",
+			args: args{
+				pods: pods,
+			},
+			fields: fields{
+				kubeUtil:                    kubeUtilFake,
+				dcaEnabled:                  true,
+				collectNamespaceLabels:      true,
+				collectNamespaceAnnotations: true,
+				dcaClient: &FakeDCAClient{
+					LocalVersion:            version.Version{Major: 1, Minor: 3},
+					KubernetesMetadataNames: []string{"svc1", "svc2"},
+					NamespaceLabels: map[string]string{
+						"label": "value",
+					},
+				},
+			},
+			namespaceLabelsAsTags: map[string]string{
+				"label": "tag",
+			},
+			namespaceAnnotationsAsTags: map[string]string{
+				"annotation": "tag",
+			},
+			want: []workloadmeta.CollectorEvent{
+				{
+					Type:   workloadmeta.EventTypeSet,
+					Source: workloadmeta.SourceClusterOrchestrator,
+					Entity: &workloadmeta.KubernetesPod{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindKubernetesPod,
+							ID:   "foouid",
+						},
+						EntityMeta: workloadmeta.EntityMeta{
+							Name:      "foo",
+							Namespace: "default",
+						},
+						KubeServices: []string{"svc1", "svc2"},
+						NamespaceLabels: map[string]string{
+							"label": "value",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "clusterAgentEnabled enabled, cluster-agent version >= 7.55, ns labels collection enabled, ns annotations collection enabled",
+			args: args{
+				pods: pods,
+			},
+			fields: fields{
+				kubeUtil:                    kubeUtilFake,
+				dcaEnabled:                  true,
+				collectNamespaceLabels:      true,
+				collectNamespaceAnnotations: true,
+				dcaClient: &FakeDCAClient{
+					LocalVersion:            version.Version{Major: 7, Minor: 55},
+					KubernetesMetadataNames: []string{"svc1", "svc2"},
+					NamespaceLabels: map[string]string{
+						"label": "value",
+					},
+					NamespaceMetadata: clusteragent.Metadata{
+						Labels: map[string]string{
+							"label": "value",
+						},
+						Annotations: map[string]string{
+							"annotation": "value",
+						},
+					},
+				},
+			},
+			namespaceLabelsAsTags: map[string]string{
+				"label": "label-tag",
+			},
+			namespaceAnnotationsAsTags: map[string]string{
+				"annotation": "annotation-tag",
+			},
+			want: []workloadmeta.CollectorEvent{
+				{
+					Type:   workloadmeta.EventTypeSet,
+					Source: workloadmeta.SourceClusterOrchestrator,
+					Entity: &workloadmeta.KubernetesPod{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindKubernetesPod,
+							ID:   "foouid",
+						},
+						EntityMeta: workloadmeta.EntityMeta{
+							Name:      "foo",
+							Namespace: "default",
+						},
+						KubeServices: []string{"svc1", "svc2"},
+						NamespaceLabels: map[string]string{
+							"label": "value",
+						},
+						NamespaceAnnotations: map[string]string{
+							"annotation": "value",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "clusterAgentEnabled enabled, cluster-agent version >= 7.55, ns labels collection enabled, ns annotations collection disabled",
+			args: args{
+				pods: pods,
+			},
+			fields: fields{
+				kubeUtil:                    kubeUtilFake,
+				dcaEnabled:                  true,
+				collectNamespaceLabels:      true,
+				collectNamespaceAnnotations: false,
+				dcaClient: &FakeDCAClient{
+					LocalVersion:            version.Version{Major: 7, Minor: 55},
+					KubernetesMetadataNames: []string{"svc1", "svc2"},
+					NamespaceLabels: map[string]string{
+						"label": "value",
+					},
+					NamespaceMetadata: clusteragent.Metadata{
+						Labels: map[string]string{
+							"label": "value",
+						},
+						Annotations: map[string]string{
+							"annotation": "value",
+						},
+					},
+				},
+			},
+			namespaceLabelsAsTags: map[string]string{
+				"label": "label-tag",
+			},
+			namespaceAnnotationsAsTags: map[string]string{
+				"annotation": "annotation-tag",
 			},
 			want: []workloadmeta.CollectorEvent{
 				{
@@ -615,14 +715,15 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &collector{
-				kubeUtil:               tt.fields.kubeUtil,
-				apiClient:              tt.fields.apiClient,
-				dcaClient:              tt.fields.dcaClient,
-				lastUpdate:             tt.fields.lastUpdate,
-				updateFreq:             tt.fields.updateFreq,
-				dcaEnabled:             tt.fields.dcaEnabled,
-				collectNamespaceLabels: tt.fields.collectNamespaceLabels,
-				seen:                   make(map[workloadmeta.EntityID]struct{}),
+				kubeUtil:                    tt.fields.kubeUtil,
+				apiClient:                   tt.fields.apiClient,
+				dcaClient:                   tt.fields.dcaClient,
+				lastUpdate:                  tt.fields.lastUpdate,
+				updateFreq:                  tt.fields.updateFreq,
+				dcaEnabled:                  tt.fields.dcaEnabled,
+				collectNamespaceLabels:      tt.fields.collectNamespaceLabels,
+				collectNamespaceAnnotations: tt.fields.collectNamespaceAnnotations,
+				seen:                        make(map[workloadmeta.EntityID]struct{}),
 			}
 
 			got, err := c.parsePods(context.TODO(), tt.args.pods, make(map[workloadmeta.EntityID]struct{}))

--- a/comp/core/workloadmeta/types.go
+++ b/comp/core/workloadmeta/types.go
@@ -671,6 +671,7 @@ type KubernetesPod struct {
 	QOSClass                   string
 	KubeServices               []string
 	NamespaceLabels            map[string]string
+	NamespaceAnnotations       map[string]string
 	FinishedAt                 time.Time
 	SecurityContext            *PodSecurityContext
 }
@@ -737,6 +738,7 @@ func (p KubernetesPod) String(verbose bool) string {
 		_, _ = fmt.Fprintln(&sb, "PVCs:", sliceToString(p.PersistentVolumeClaimNames))
 		_, _ = fmt.Fprintln(&sb, "Kube Services:", sliceToString(p.KubeServices))
 		_, _ = fmt.Fprintln(&sb, "Namespace Labels:", mapToString(p.NamespaceLabels))
+		_, _ = fmt.Fprintln(&sb, "Namespace Annotations:", mapToString(p.NamespaceAnnotations))
 		if !p.FinishedAt.IsZero() {
 			_, _ = fmt.Fprintln(&sb, "Finished At:", p.FinishedAt)
 		}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -329,6 +329,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("kubernetes_node_annotations_as_host_aliases", []string{"cluster.k8s.io/machine"})
 	config.BindEnvAndSetDefault("kubernetes_node_label_as_cluster_name", "")
 	config.BindEnvAndSetDefault("kubernetes_namespace_labels_as_tags", map[string]string{})
+	config.BindEnvAndSetDefault("kubernetes_namespace_annotations_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_cgroup_prefix", "")
 	config.BindEnvAndSetDefault("kubernetes_namespace_collection_enabled", false) // Enables collection of kubernetes namespace information
 

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -76,6 +76,7 @@ type DCAClientInterface interface {
 	GetKubernetesClusterID() (string, error)
 
 	PostLanguageMetadata(ctx context.Context, data *pbgo.ParentLanguageAnnotationRequest) error
+	SupportsNamespaceMetadataCollection() bool
 }
 
 // DCAClient is required to query the API of Datadog cluster agent
@@ -493,4 +494,9 @@ func (c *DCAClient) PostLanguageMetadata(ctx context.Context, data *pbgo.ParentL
 	// query https://host:port/api/v1/languagedetection without expecting a response
 	_, err = c.doQuery(ctx, languageDetectionPath, "POST", bytes.NewBuffer(queryBody), false, false)
 	return err
+}
+
+// SupportsNamespaceMetadataCollection returns true only if the cluster agent supports collecting namespace metadata
+func (c *DCAClient) SupportsNamespaceMetadataCollection() bool {
+	return c.Version().Major >= 7 && c.Version().Minor >= 55
 }

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -48,6 +48,14 @@ var globalClusterAgentClient *DCAClient
 
 type metadataNames []string
 
+// Metadata represents the metadata of a kubernetes resource including its name, namespace, annotations and labels
+type Metadata struct {
+	Name        string
+	Namespace   string
+	Annotations map[string]string
+	Labels      map[string]string
+}
+
 // DCAClientInterface  is required to query the API of Datadog cluster agent
 type DCAClientInterface interface {
 	Version() version.Version
@@ -57,7 +65,7 @@ type DCAClientInterface interface {
 	GetNodeLabels(nodeName string) (map[string]string, error)
 	GetNodeAnnotations(nodeName string) (map[string]string, error)
 	GetNamespaceLabels(nsName string) (map[string]string, error)
-	GetNamespaceAnnotations(nsName string) (map[string]string, error)
+	GetNamespaceMetadata(nsName string) (*Metadata, error)
 	GetPodsMetadataForNode(nodeName string) (apiv1.NamespacesPodsStringsSet, error)
 	GetKubernetesMetadataNames(nodeName, ns, podName string) ([]string, error)
 	GetCFAppsMetadataForNode(nodename string) (map[string][]string, error)
@@ -396,11 +404,11 @@ func (c *DCAClient) GetNamespaceLabels(nsName string) (map[string]string, error)
 	return result, err
 }
 
-// GetNamespaceAnnotations returns the namespace annotations from the Cluster Agent.
-func (c *DCAClient) GetNamespaceAnnotations(nsName string) (map[string]string, error) {
-	var result map[string]string
-	err := c.doJSONQuery(context.TODO(), "api/v1/annotations/namespace/"+nsName, "GET", nil, &result, false)
-	return result, err
+// GetNamespaceMetadata returns the namespace metadata from the Cluster Agent.
+func (c *DCAClient) GetNamespaceMetadata(nsName string) (*Metadata, error) {
+	var result Metadata
+	err := c.doJSONQuery(context.TODO(), "api/v1/metadata/namespace/"+nsName, "GET", nil, &result, false)
+	return &result, err
 }
 
 // GetNodeAnnotations returns the node annotations from the Cluster Agent.

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -57,6 +57,7 @@ type DCAClientInterface interface {
 	GetNodeLabels(nodeName string) (map[string]string, error)
 	GetNodeAnnotations(nodeName string) (map[string]string, error)
 	GetNamespaceLabels(nsName string) (map[string]string, error)
+	GetNamespaceAnnotations(nsName string) (map[string]string, error)
 	GetPodsMetadataForNode(nodeName string) (apiv1.NamespacesPodsStringsSet, error)
 	GetKubernetesMetadataNames(nodeName, ns, podName string) ([]string, error)
 	GetCFAppsMetadataForNode(nodename string) (map[string][]string, error)
@@ -392,6 +393,13 @@ func (c *DCAClient) GetNodeLabels(nodeName string) (map[string]string, error) {
 func (c *DCAClient) GetNamespaceLabels(nsName string) (map[string]string, error) {
 	var result map[string]string
 	err := c.doJSONQuery(context.TODO(), "api/v1/tags/namespace/"+nsName, "GET", nil, &result, false)
+	return result, err
+}
+
+// GetNamespaceAnnotations returns the namespace annotations from the Cluster Agent.
+func (c *DCAClient) GetNamespaceAnnotations(nsName string) (map[string]string, error) {
+	var result map[string]string
+	err := c.doJSONQuery(context.TODO(), "api/v1/annotations/namespace/"+nsName, "GET", nil, &result, false)
 	return result, err
 }
 

--- a/releasenotes-dca/notes/support_ns_annots_as_tags-7dcd19109a7d3f9e.yaml
+++ b/releasenotes-dca/notes/support_ns_annots_as_tags-7dcd19109a7d3f9e.yaml
@@ -9,3 +9,6 @@
 features:
   - |
     Add support for `kubernetes_namespace_annotations_as_tags`.
+    This new option is equivalent to the existing `kubernetes_namespace_labels_as_tags`, 
+    but it considers namespace annotations instead of namespace labels.
+    With this new option, users can enrich tagging based on namespace annotations.

--- a/releasenotes-dca/notes/support_ns_annots_as_tags-7dcd19109a7d3f9e.yaml
+++ b/releasenotes-dca/notes/support_ns_annots_as_tags-7dcd19109a7d3f9e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support for `kubernetes_namespace_annotations_as_tags`.

--- a/releasenotes/notes/support_ns_annots_as_tags-76aab85969e9a985.yaml
+++ b/releasenotes/notes/support_ns_annots_as_tags-76aab85969e9a985.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support for `kubernetes_namespace_annotations_as_tags`.

--- a/releasenotes/notes/support_ns_annots_as_tags-76aab85969e9a985.yaml
+++ b/releasenotes/notes/support_ns_annots_as_tags-76aab85969e9a985.yaml
@@ -9,3 +9,6 @@
 features:
   - |
     Add support for `kubernetes_namespace_annotations_as_tags`.
+    This new option is equivalent to the existing `kubernetes_namespace_labels_as_tags`, 
+    but it considers namespace annotations instead of namespace labels.
+    With this new option, users can enrich tagging based namespace annotations.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds support to configure `kubernetes_namespace_annotations_as_tags` option.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Currently, users can set `kubernetes_namespace_labels_as_tags` in order to automatically assign namespace labels as tags on pod entities in the tagger. 

This PR implements a similar feature that allows users to automatically assign namespace annotations as tags on pod entities in the tagger. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Currently, the node agent has a kube metadata collector that queries namespace labels for each pod by sending an API request to the DCA. 

Here are some of the endpoints exposed by the cluster agent:

- `api/v1/tags/node/{nodeName}` => returns the list of labels of the node
- `api/v1/annotations/node/{nodeName}` => returns the list of annotations of the node
- `api/v1/tags/namespace/{nsName}` => returns the list of labels of the namespace

If we add  `api/v1/annotations/namespace/{nsName]` endpoint, it means that we will have to send 2 API requests per pod to the cluster agent in order to get labels and annotations of the namespace.

A better approach was to add `api/v1/metadata/namespace/{nsName}` endpoint which returns the EntityMeta of the namespace from workloadmeta, which includes the following information about the namespace:
- Name
- Namespace
- Annotations
- Labels


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
- Thanks to the [work done](https://github.com/DataDog/datadog-agent/pull/25279) by @jennchenn to collect namespace metadata in workloadmeta store of the cluster agent, we improved the implementation of label as tags too in this PR by looking up the labels of the namespace from workloadmeta instead of sending an API request to the kube api server or using a shared informer.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
ATTENTION: The QA should be done for two cases:
- DCA version < 7.55
   - namespace annotations as tags are skipped, but namespace labels as tags are applied.
   - there should be an error saying that namespace annotations collection requires version 7.55+ of the cluster agent
- DCA version >= 7.55
  - both namespace annotations as tags and namespace labels as tags should be work fine


Deploy the agent cluster agent and ensure that:
- `kubernetes_namespace_labels_as_tags` is still working as expected
- `kubernetes_namespace_annotations_as_tags` is supported.

Note: you should enable namespace collection in the cluster agent (see env var override below)

Example:

- Deploying the agents
```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
  kubeStateMetricsCore:
    enabled: true

  namespaceLabelsAsTags:
    related_team: team

agents:
  telemetry: enabled
  containers:
    agent:
      env:
        - name: DD_KUBERNETES_NAMESPACE_ANNOTATIONS_AS_TAGS
          value: '{"related_email":"email"}'
clusterAgent:
  enabled: true
  env:
    - name: DD_KUBERNETES_NAMESPACE_COLLECTION_ENABLED
      value: true
    - name: DD_KUBERNETES_NAMESPACE_ANNOTATIONS_AS_TAGS
      value: '{"related_email":"email"}'

```

- Creating a namespace with some annotations and labels:
```
apiVersion: v1
kind: Namespace
metadata:
  name: annotated-namespace
  labels:
    injectSidecarNs: "true"
    related_team: "contp"
  annotations:
    related_email: "express@sunday"
```

- Creating a pod in the annotated namespace
```
apiVersion: v1
kind: Pod
metadata:
  name: sample-pod
  namespace: annotated-namespace
spec:
  containers:
    - name: nginx
      image: nginx:1.14.2
      ports:
        - containerPort: 80
```

- Wait for some time, and then run `agent tagger-list` on the node agent, and verify that the labels and annotations are set on the pod tagger entity
```
=== Entity kubernetes_pod_uid://59d404b3-86f1-4ef1-9f40-57e5ed766693 ===
== Source workloadmeta-kubernetes_pod =
=Tags: [email:express@sunday kube_namespace:annotated-namespace kube_qos:BestEffort pod_name:sample-pod pod_phase:running team:contp]
===
```

- Run `agent tagger-list` on the cluster agent, and verify that the labels and annotations are set on the namespace tagger entity
```
=== Entity namespace://annotated-namespace ===
== Source workloadmeta-kubernetes_node =
=Tags: [email:express@sunday team:contp]
===
```

Repeat the same process with an older version of the cluster agent and verify that:
- namespace labels as tags is still working
- namespace annotations as tags doesn't work
- an error is emitted to indicate that a newer version of the cluster agent is required in order to support namespace annotations as tags 

Example:
```
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod annotated-namespace/sample-pod: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod kube-system/kube-apiserver-kind-control-plane: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod kube-system/kube-controller-manager-kind-control-plane: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod kube-system/kube-proxy-zf8th: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod local-path-storage/local-path-provisioner-6bc4bddd6b-bt9b8: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod kube-system/coredns-5d78c9869d-x964d: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod default/datadog-agent-68qww: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod default/datadog-agent-cluster-agent-6b448bf64f-c57l7: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod kube-system/etcd-kind-control-plane: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod kube-system/kube-scheduler-kind-control-plane: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod kube-system/kindnet-bq5sg: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod kube-system/coredns-5d78c9869d-sx9kn: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
2024-05-17 09:45:00 UTC | CORE | ERROR | (comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:261 in parsePods) | Could not fetch namespace annotations for pod default/hello-28589158-f46lw: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent
```
