### PR TITLE
Increase the time-out e2e tests are waiting for the ECS tasks

### DIFF
--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -181,7 +181,7 @@ func (suite *ecsSuite) Test00UpAndRunning() {
 					}
 				}
 			}
-		}, 5*time.Minute, 10*time.Second, "Not all tasks became ready in time.")
+		}, 10*time.Minute, 10*time.Second, "Not all tasks became ready in time.")
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

Increase the time-out the `TestECSSuite/Test00UpAndRunning/ECS_tasks_are_ready` e2e test is waiting for the ECS tasks to become ready.

### Motivation

We had [a failure where the Nginx task for Fargate wasn’t ready in time](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/511239193):
```
=== RUN   TestECSSuite/Test00UpAndRunning/ECS_tasks_are_ready
    ecs_test.go:119: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/ecs_test.go:176
        	            				/usr/local/go/src/runtime/asm_amd64.s:1650
        	Error:      	Not equal: 
        	            	expected: "RUNNING"
        	            	actual  : "PROVISIONING"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-RUNNING
        	            	+PROVISIONING
        	Messages:   	Task arn:aws:ecs:us-east-1:669783387624:task/ci-511239193-4670-ecs-cluster-ecs/ba54b09efb0c4252bab62ff6b088bd88 of service ci-511239193-4670-ecs-cluster-nginx-fg is not running
    ecs_test.go:119: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/ecs_test.go:119
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:115
        	Error:      	Condition never satisfied
        	Test:       	TestECSSuite/Test00UpAndRunning/ECS_tasks_are_ready
        	Messages:   	Not all tasks became ready in time.
```

### Additional Notes

We have [evidences that the task eventually became ready later](https://dddev.datadoghq.com/dashboard/mnw-tdr-jd8/e2e-tests-containers-ecs?refresh_mode=paused&tpl_var_ecs_cluster_name%5B0%5D=ci-511239193-4670-ecs-cluster-ecs&tpl_var_fake_intake_task_family%5B0%5D=ci-511239193-4670-ecs-cluster-fakeintake-ecs&from_ts=1715691243678&to_ts=1715691711647&live=false).
So, we have a proof having waited longer would have helped in this case.
![image](https://github.com/DataDog/datadog-agent/assets/1437785/3f6fb5c8-7598-4de0-869c-e6d034942bec)

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check if the above mentioned e2e failure happen again.
