### PR TITLE
Set higher memory for OTel-agent build and go-mod-tidy

### DIFF
--- a/.gitlab/binary_build/otel_agent.yml
+++ b/.gitlab/binary_build/otel_agent.yml
@@ -9,6 +9,9 @@
     - !reference [.retrieve_linux_go_deps]
     - inv -e otel-agent.build
   needs: ["go_deps"]
+  variables:
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "8Gi"
   artifacts:
     expire_in: 1 day
     paths:

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -238,6 +238,9 @@ go_mod_tidy_check:
   script:
     - inv -e check-mod-tidy
     - inv -e check-go-mod-replaces
+  variables:
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "8Gi"
 
 
 new-e2e-unit-tests:


### PR DESCRIPTION

### What does this PR do?

Set the otel-agent and go-mod-tidy memory limits to be 8Gb. The default is only 6Gb.

### Motivation

Jobs are currently failing with OOM:
- https://github.com/DataDog/datadog-agent/pull/25402
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/511482231
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/511482202


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
