### PR TITLE
[gitlab] Do not run single-machine-performance-regression_detector on main or release branches

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -1,7 +1,7 @@
 single-machine-performance-regression_detector:
   stage: functional_test
   rules:
-    - !reference [.except_mergequeue]
+    - !reference [.except_main_or_release_branch]
     - when: on_success
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker"]


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Prevents the `single-machine-performance-regression_detector` job from running on `main` and release branches.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

When run on `main` and release branches, the job compares a given commit to itself, which doesn't give any meaningful information ([example on main](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/510856513), [example on 7.54.x](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/512040040)).
Removing them saves pipeline time and money.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The `single_machine_performance-amd64-a7` job still needs to run on `main` and release branches, otherwise we don't have images to compare PRs against anymore.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Verify that `main` pipelines are still correctly generated, and do not have the `single-machine-performance-regression_detector` job. 
