### PR TITLE
fix(ci): Review extends rule to ensure upload of junit xml in system probe context

### DIFF
--- a/.gitlab/functional_test/common.yml
+++ b/.gitlab/functional_test/common.yml
@@ -7,7 +7,7 @@
 
 .kitchen_test_system_probe:
   extends:
-    - .kitchen_common
+    - .kitchen_common_with_junit
     - .kitchen_datadog_agent_flavor
   rules:
     !reference [.on_system_probe_or_e2e_changes_or_manual]

--- a/.gitlab/functional_test/system_probe_windows.yml
+++ b/.gitlab/functional_test/system_probe_windows.yml
@@ -8,10 +8,8 @@
 
 kitchen_test_system_probe_windows_x64:
   extends:
-    - .kitchen_agent_a7
-    - .kitchen_os_windows
     - .kitchen_test_system_probe
-    - .kitchen_azure_x64
+    - .kitchen_os_windows
     - .kitchen_azure_location_north_central_us
   stage: functional_test
   needs: [ "tests_windows_sysprobe_x64" ]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Change the extends condition of the `kitchen_test_system_probe_windows_x64` job.
I also removed a duplicated extends (`kitchen_azure_x64` is already included in `kitchen_os_windows`) 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
junit artefacts are not uploaded in such [job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/510880441) whereas we could expect it to be there, especially to understand why the test were not forwarded to the correct team in this case

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
