### PR TITLE
[CWS] add support for fchdir (in addition to the already supported chdir event)

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/chdir.h
+++ b/pkg/security/ebpf/c/include/hooks/chdir.h
@@ -29,6 +29,11 @@ HOOK_SYSCALL_ENTRY1(chdir, const char*, path)
     return trace__sys_chdir();
 }
 
+HOOK_SYSCALL_ENTRY1(fchdir, unsigned int, fd)
+{
+    return trace__sys_chdir();
+}
+
 HOOK_ENTRY("set_fs_pwd")
 int hook_set_fs_pwd(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_CHDIR);
@@ -88,6 +93,11 @@ int __attribute__((always_inline)) sys_chdir_ret(void *ctx, int retval, int dr_t
 }
 
 HOOK_SYSCALL_EXIT(chdir) {
+    int retval = SYSCALL_PARMRET(ctx);
+    return sys_chdir_ret(ctx, retval, DR_KPROBE_OR_FENTRY);
+}
+
+HOOK_SYSCALL_EXIT(fchdir) {
     int retval = SYSCALL_PARMRET(ctx);
     return sys_chdir_ret(ctx, retval, DR_KPROBE_OR_FENTRY);
 }

--- a/pkg/security/ebpf/probes/chdir.go
+++ b/pkg/security/ebpf/probes/chdir.go
@@ -26,5 +26,11 @@ func getChdirProbes(fentry bool) []*manager.Probe {
 		},
 		SyscallFuncName: "chdir",
 	}, fentry, EntryAndExit)...)
+	chdirProbes = append(chdirProbes, ExpandSyscallProbes(&manager.Probe{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
+		SyscallFuncName: "fchdir",
+	}, fentry, EntryAndExit)...)
 	return chdirProbes
 }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -448,7 +448,9 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				kprobeOrFentry("set_fs_pwd"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chdir", fentry, EntryAndExit)}},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chdir", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchdir", fentry, EntryAndExit)},
+		},
 	}
 
 	// add probes depending on loaded modules

--- a/pkg/security/tests/chdir_test.go
+++ b/pkg/security/tests/chdir_test.go
@@ -47,4 +47,18 @@ func TestChdir(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_chdir_rule")
 		})
 	})
+
+	t.Run("fchdir", func(t *testing.T) {
+		test.WaitSignal(t, func() error {
+			f, err := os.Open(testFolder)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			return f.Chdir()
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_chdir_rule")
+		})
+	})
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds support for hooking the fchdir syscall in addition to the regular chdir one. The rest is basically the exact same as the current chdir event.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
