### PR TITLE
[CWS] add option to force manager reload in tests and use it for `TestMountPropagated`

### DIFF
--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -653,7 +653,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		}
 		return testMod, nil
 
-	} else if testMod != nil && opts.staticOpts.Equal(testMod.opts.staticOpts) {
+	} else if !opts.forceReload && testMod != nil && opts.staticOpts.Equal(testMod.opts.staticOpts) {
 		testMod.st = st
 		testMod.cmdWrapper = cmdWrapper
 		testMod.t = t

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -165,7 +165,7 @@ func TestMountPropagated(t *testing.T) {
 		Expression: `chmod.file.path == "{{.Root}}/dir1-bind-mounted/test-drive/test-file"`,
 	}}
 
-	test, err := newTestModule(t, nil, ruleDefs)
+	test, err := newTestModule(t, nil, ruleDefs, withForceReload())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -67,6 +67,7 @@ type dynamicTestOpts struct {
 type tmOpts struct {
 	staticOpts  testOpts
 	dynamicOpts dynamicTestOpts
+	forceReload bool
 }
 
 type optFunc = func(opts *tmOpts)
@@ -82,6 +83,13 @@ func withDynamicOpts(opts dynamicTestOpts) optFunc {
 		tmo.dynamicOpts = opts
 	}
 }
+
+func withForceReload() optFunc {
+	return func(tmo *tmOpts) {
+		tmo.forceReload = true
+	}
+}
+
 func (to testOpts) Equal(opts testOpts) bool {
 	return to.disableApprovers == opts.disableApprovers &&
 		to.enableActivityDump == opts.enableActivityDump &&


### PR DESCRIPTION

### What does this PR do?

`TestMountPropagated ` is currently our most flaky test, but it nearly always passes on retry. We know the mount tracking is very difficult and we are not doing the best job, which is why when we retry it we start from a fresh manager with a freshly parsed mountinfo and it succeeds. To limit the amount of flakyness until we improve the tracking this PR adds a new option to force the reloading of the manager and uses it for this test. This is basically a way to directly start in the "retry" state.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
