### PR TITLE
[CWS] windows: fix nil process context on process resolution failure

### DIFF
--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -473,9 +473,7 @@ func (p *WindowsProbe) Start() error {
 					continue
 				}
 			case notif := <-p.onETWNotification:
-				if !p.handleETWNotification(ev, notif) {
-					continue
-				}
+				p.handleETWNotification(ev, notif)
 			}
 
 			p.DispatchEvent(ev)
@@ -556,7 +554,7 @@ func (p *WindowsProbe) handleProcessStop(ev *model.Event, stop *procmon.ProcessS
 	return true
 }
 
-func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotification) bool {
+func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotification) {
 	// handle incoming events here
 	// each event will come in as a different type
 	// parse it with
@@ -654,7 +652,6 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 			log.Debugf("%v", errRes)
 		}
 	}
-	return true
 }
 
 func (p *WindowsProbe) setProcessContext(pid uint32, event *model.Event) error {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR fixes a panic in the rule evaluation of windows events. 
This occurred when the process resolution failed and caused the process context of an event to be nil.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
