### PR TITLE
Add timestamps in e2e logs and emit datadog events where not already done

### DIFF
--- a/test/new-e2e/tests/containers/base_test.go
+++ b/test/new-e2e/tests/containers/base_test.go
@@ -50,6 +50,14 @@ func (suite *baseSuite) TearDownSuite() {
 	suite.endTime = time.Now()
 }
 
+func (suite *baseSuite) BeforeTest(suiteName, testName string) {
+	suite.T().Logf("START  %s/%s %s", suiteName, testName, time.Now())
+}
+
+func (suite *baseSuite) AfterTest(suiteName, testName string) {
+	suite.T().Logf("FINISH %s/%s %s", suiteName, testName, time.Now())
+}
+
 type testMetricArgs struct {
 	Filter testMetricFilterArgs
 	Expect testMetricExpectArgs

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -7,6 +7,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -842,7 +843,50 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 }
 
 func (suite *k8sSuite) TestContainerImage() {
-	suite.EventuallyWithTf(func(c *assert.CollectT) {
+	sendEvent := func(alertType, text string) {
+		if _, err := suite.datadogClient.PostEvent(&datadog.Event{
+			Title: pointer.Ptr(suite.T().Name()),
+			Text: pointer.Ptr(fmt.Sprintf(`%%%%%%
+`+"```"+`
+%s
+`+"```"+`
+ %%%%%%`, text)),
+			AlertType: &alertType,
+			Tags: []string{
+				"app:agent-new-e2e-tests-containers",
+				"cluster_name:" + suite.clusterName,
+				"contimage:ghcr.io/datadog/apps-nginx-server",
+				"test:" + suite.T().Name(),
+			},
+		}); err != nil {
+			suite.T().Logf("Failed to post event: %s", err)
+		}
+	}
+
+	defer func() {
+		if suite.T().Failed() {
+			sendEvent("error", "Failed finding the `ghcr.io/datadog/apps-nginx-server` container image payload with proper tags")
+		} else {
+			sendEvent("success", "All good!")
+		}
+	}()
+
+	suite.EventuallyWithTf(func(collect *assert.CollectT) {
+		c := &myCollectT{
+			CollectT: collect,
+			errors:   []error{},
+		}
+		// To enforce the use of myCollectT instead
+		collect = nil //nolint:ineffassign
+
+		defer func() {
+			if len(c.errors) == 0 {
+				sendEvent("success", "All good!")
+			} else {
+				sendEvent("warning", errors.Join(c.errors...).Error())
+			}
+		}()
+
 		images, err := suite.Fakeintake.FilterContainerImages("ghcr.io/datadog/apps-nginx-server")
 		// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
 		if !assert.NoErrorf(c, err, "Failed to query fake intake") {
@@ -869,7 +913,50 @@ func (suite *k8sSuite) TestContainerImage() {
 }
 
 func (suite *k8sSuite) TestSBOM() {
-	suite.EventuallyWithTf(func(c *assert.CollectT) {
+	sendEvent := func(alertType, text string) {
+		if _, err := suite.datadogClient.PostEvent(&datadog.Event{
+			Title: pointer.Ptr(suite.T().Name()),
+			Text: pointer.Ptr(fmt.Sprintf(`%%%%%%
+`+"```"+`
+%s
+`+"```"+`
+ %%%%%%`, text)),
+			AlertType: &alertType,
+			Tags: []string{
+				"app:agent-new-e2e-tests-containers",
+				"cluster_name:" + suite.clusterName,
+				"sbom:ghcr.io/datadog/apps-nginx-server",
+				"test:" + suite.T().Name(),
+			},
+		}); err != nil {
+			suite.T().Logf("Failed to post event: %s", err)
+		}
+	}
+
+	defer func() {
+		if suite.T().Failed() {
+			sendEvent("error", "Failed finding the `ghcr.io/datadog/apps-nginx-server` SBOM payload with proper tags")
+		} else {
+			sendEvent("success", "All good!")
+		}
+	}()
+
+	suite.EventuallyWithTf(func(collect *assert.CollectT) {
+		c := &myCollectT{
+			CollectT: collect,
+			errors:   []error{},
+		}
+		// To enforce the use of myCollectT instead
+		collect = nil //nolint:ineffassign
+
+		defer func() {
+			if len(c.errors) == 0 {
+				sendEvent("success", "All good!")
+			} else {
+				sendEvent("warning", errors.Join(c.errors...).Error())
+			}
+		}()
+
 		sbomIDs, err := suite.Fakeintake.GetSBOMIDs()
 		// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
 		if !assert.NoErrorf(c, err, "Failed to query fake intake") {
@@ -951,6 +1038,34 @@ func (suite *k8sSuite) TestSBOM() {
 }
 
 func (suite *k8sSuite) TestContainerLifecycleEvents() {
+	sendEvent := func(alertType, text string) {
+		if _, err := suite.datadogClient.PostEvent(&datadog.Event{
+			Title: pointer.Ptr(suite.T().Name()),
+			Text: pointer.Ptr(fmt.Sprintf(`%%%%%%
+`+"```"+`
+%s
+`+"```"+`
+ %%%%%%`, text)),
+			AlertType: &alertType,
+			Tags: []string{
+				"app:agent-new-e2e-tests-containers",
+				"cluster_name:" + suite.clusterName,
+				"contlcycle:ghcr.io/datadog/apps-nginx-server",
+				"test:" + suite.T().Name(),
+			},
+		}); err != nil {
+			suite.T().Logf("Failed to post event: %s", err)
+		}
+	}
+
+	defer func() {
+		if suite.T().Failed() {
+			sendEvent("error", "Failed finding the `ghcr.io/datadog/apps-nginx-server` container lifecycle event")
+		} else {
+			sendEvent("success", "All good!")
+		}
+	}()
+
 	var nginxPod corev1.Pod
 
 	suite.Require().EventuallyWithTf(func(c *assert.CollectT) {
@@ -971,7 +1086,22 @@ func (suite *k8sSuite) TestContainerLifecycleEvents() {
 	err := suite.K8sClient.CoreV1().Pods("workload-nginx").Delete(context.Background(), nginxPod.Name, metav1.DeleteOptions{})
 	suite.Require().NoError(err)
 
-	suite.EventuallyWithTf(func(c *assert.CollectT) {
+	suite.EventuallyWithTf(func(collect *assert.CollectT) {
+		c := &myCollectT{
+			CollectT: collect,
+			errors:   []error{},
+		}
+		// To enforce the use of myCollectT instead
+		collect = nil //nolint:ineffassign
+
+		defer func() {
+			if len(c.errors) == 0 {
+				sendEvent("success", "All good!")
+			} else {
+				sendEvent("warning", errors.Join(c.errors...).Error())
+			}
+		}()
+
 		events, err := suite.Fakeintake.GetContainerLifecycleEvents()
 		// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
 		if !assert.NoErrorf(c, err, "Failed to query fake intake") {
@@ -989,8 +1119,8 @@ func (suite *k8sSuite) TestContainerLifecycleEvents() {
 			}
 		}
 
-		assert.Truef(c, foundPodEvent, "Failed to find the pod lifecycle event")
-	}, 2*time.Minute, 10*time.Second, "Failed to find the container lifecycle events")
+		assert.Truef(c, foundPodEvent, "Failed to find the pod lifecycle event for pod %s/%s", nginxPod.Namespace, nginxPod.Name)
+	}, 2*time.Minute, 10*time.Second, "Failed to find the pod lifecycle event for pod %s/%s", nginxPod.Namespace, nginxPod.Name)
 }
 
 func (suite *k8sSuite) testHPA(namespace, deployment string) {


### PR DESCRIPTION
### What does this PR do?

* Log timestamps each time a test starts and stops
  ```
  === RUN   TestKindSuite
  Creating workspace for stack: lenaic-kind-cluster at /tmp/pulumi-workspace/0791493cef93fef3
  === RUN   TestKindSuite/TestContainerImage
      base_test.go:54: START  kindSuite/TestContainerImage 2024-05-15 14:15:31.785101277 +0200 CEST
      base_test.go:58: FINISH kindSuite/TestContainerImage 2024-05-15 14:15:42.807564545 +0200 CEST
  === RUN   TestKindSuite/TestContainerLifecycleEvents
      base_test.go:54: START  kindSuite/TestContainerLifecycleEvents 2024-05-15 14:15:42.807794245 +0200 CEST
      base_test.go:58: FINISH kindSuite/TestContainerLifecycleEvents 2024-05-15 14:16:23.51142582 +0200 CEST
  […]
  ```
* In case of `TestContainerLifecycleEvents` failure, log the name of the pod for which an event is expected.
* Emit events each time a test looks for a container image, a sbom or a container lifecycle event payload.
  ![image](https://github.com/DataDog/datadog-agent/assets/1437785/684f517b-f201-4ef5-a37e-703a859a7e16)

### Motivation

`TestContainerLifecycleEvents` e2e test happens to fail from time to time.
[Here is an example](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.name%3ATestEKSSuite%2FTestContainerLifecycleEvents&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=AgAAAY93ZDkmw9vLxwAAAAAAAAAYAAAAAEFZOTNaRGttQUFELVJMRXVsXy1IbWp2RAAAACQAAAAAMDE4Zjc3NjctMjZmNy00YzM1LWJkMWUtZWRlM2UyZmJlOTFh&fromUser=false&index=citest&mode=sliding&saved-view-id=2236559&testId=AgAAAY93ZDkmw9vLxwAAAAAAAAAYAAAAAEFZOTNaRGttQUFELVJMRXVsXy1IbWp2RAAAACQAAAAAMDE4Zjc3NjctMjZmNy00YzM1LWJkMWUtZWRlM2UyZmJlOTFh&trace=AgAAAY93ZDkmw9vLxwAAAAAAAAAYAAAAAEFZOTNaRGttQUFELVJMRXVsXy1IbWp2RAAAACQAAAAAMDE4Zjc3NjctMjZmNy00YzM1LWJkMWUtZWRlM2UyZmJlOTFh&start=1715171428632&end=1715776228632&paused=false).
Although we have a lot of information on `dddev`, in order to be able to investigate this issue, we miss:
* the name of the pod for which we expect a deletion event;
* the time at which the test ran.

### Additional Notes

The [dashboard](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s) has already been updated accordingly:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/ae11063a-95f7-45d9-95f1-958a23ca07b1)


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
