### PR TITLE
Add Go execution traces to Agent Flare

### DIFF
--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -202,6 +202,11 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 					name: service + "-block.pprof",
 					path: "/block",
 				},
+				{
+					// Trace
+					name: service + ".trace",
+					path: fmt.Sprintf("/trace?seconds=%d", seconds),
+				},
 			} {
 				b, err := get(prof.path)
 				if err != nil {

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -40,6 +40,8 @@ func getPprofTestServer(t *testing.T) (tcpServer *httptest.Server, unixServer *h
 			w.Write([]byte("block"))
 		case "/debug/stats": // only for system-probe
 			w.WriteHeader(200)
+		case "/debug/pprof/trace":
+			w.Write([]byte("trace"))
 		default:
 			w.WriteHeader(500)
 		}
@@ -95,21 +97,25 @@ func TestReadProfileData(t *testing.T) {
 		"core-block.pprof":              []byte("block"),
 		"core-cpu.pprof":                []byte("10_sec_cpu_pprof"),
 		"core-mutex.pprof":              []byte("mutex"),
+		"core.trace":                    []byte("trace"),
 		"process-1st-heap.pprof":        []byte("heap_profile"),
 		"process-2nd-heap.pprof":        []byte("heap_profile"),
 		"process-block.pprof":           []byte("block"),
 		"process-cpu.pprof":             []byte("10_sec_cpu_pprof"),
 		"process-mutex.pprof":           []byte("mutex"),
+		"process.trace":                 []byte("trace"),
 		"security-agent-1st-heap.pprof": []byte("heap_profile"),
 		"security-agent-2nd-heap.pprof": []byte("heap_profile"),
 		"security-agent-block.pprof":    []byte("block"),
 		"security-agent-cpu.pprof":      []byte("10_sec_cpu_pprof"),
 		"security-agent-mutex.pprof":    []byte("mutex"),
+		"security-agent.trace":          []byte("trace"),
 		"trace-1st-heap.pprof":          []byte("heap_profile"),
 		"trace-2nd-heap.pprof":          []byte("heap_profile"),
 		"trace-block.pprof":             []byte("block"),
 		"trace-cpu.pprof":               []byte("10_sec_cpu_pprof"),
 		"trace-mutex.pprof":             []byte("mutex"),
+		"trace.trace":                   []byte("trace"),
 	}
 	if runtime.GOOS != "darwin" {
 		maps.Copy(expected, flare.ProfileData{
@@ -118,6 +124,7 @@ func TestReadProfileData(t *testing.T) {
 			"system-probe-block.pprof":    []byte("block"),
 			"system-probe-cpu.pprof":      []byte("10_sec_cpu_pprof"),
 			"system-probe-mutex.pprof":    []byte("mutex"),
+			"system-probe.trace":          []byte("trace"),
 		})
 	}
 
@@ -164,16 +171,19 @@ func TestReadProfileDataNoTraceAgent(t *testing.T) {
 		"core-block.pprof":              []byte("block"),
 		"core-cpu.pprof":                []byte("10_sec_cpu_pprof"),
 		"core-mutex.pprof":              []byte("mutex"),
+		"core.trace":                    []byte("trace"),
 		"process-1st-heap.pprof":        []byte("heap_profile"),
 		"process-2nd-heap.pprof":        []byte("heap_profile"),
 		"process-block.pprof":           []byte("block"),
 		"process-cpu.pprof":             []byte("10_sec_cpu_pprof"),
 		"process-mutex.pprof":           []byte("mutex"),
+		"process.trace":                 []byte("trace"),
 		"security-agent-1st-heap.pprof": []byte("heap_profile"),
 		"security-agent-2nd-heap.pprof": []byte("heap_profile"),
 		"security-agent-block.pprof":    []byte("block"),
 		"security-agent-cpu.pprof":      []byte("10_sec_cpu_pprof"),
 		"security-agent-mutex.pprof":    []byte("mutex"),
+		"security-agent.trace":          []byte("trace"),
 	}
 	if runtime.GOOS != "darwin" {
 		maps.Copy(expected, flare.ProfileData{
@@ -182,6 +192,7 @@ func TestReadProfileDataNoTraceAgent(t *testing.T) {
 			"system-probe-block.pprof":    []byte("block"),
 			"system-probe-cpu.pprof":      []byte("10_sec_cpu_pprof"),
 			"system-probe-mutex.pprof":    []byte("mutex"),
+			"system-probe.trace":          []byte("trace"),
 		})
 	}
 

--- a/releasenotes/notes/add-trace-to-flare-9cdf89d813966b38.yaml
+++ b/releasenotes/notes/add-trace-to-flare-9cdf89d813966b38.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add Go execution traces to Agent Flare.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add [powerful Go execution traces](https://go.dev/blog/execution-traces-2024) to a flare.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

For troubleshooting perf issues.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

```
kubectl exec datadog-agent-pvzzw -c agent -- agent flare --profile 30
kubectl cp -c agent datadog-agent-pvzzw:/tmp/datadog-agent-2024-05-16T01-16-19Z-off.zip /tmp/flare.zip
unzip -d /tmp /tmp/flare.zip

# There are *.trace files.
find /tmp/i-09df1e4674d40f561/profiles/ -name '*.trace'
/tmp/i-09df1e4674d40f561/profiles/core.trace
/tmp/i-09df1e4674d40f561/profiles/process.trace
/tmp/i-09df1e4674d40f561/profiles/system-probe.trace
/tmp/i-09df1e4674d40f561/profiles/trace.trace
```

```
go tool trace ~/Downloads/i-09df1e4674d40f561/profiles/core.trace
2024/05/16 10:43:24 Parsing trace...
2024/05/16 10:43:27 Splitting trace...
2024/05/16 10:43:32 Opening browser. Trace viewer is listening on http://127.0.0.1:58545
```

<img width="920" alt="2024-05-16_10-48-43" src="https://github.com/DataDog/datadog-agent/assets/41987730/94d2b3fe-b8f3-4851-b964-a98e7e9de5c7">


