### PR TITLE
Fix get_embedded_path when running in non-default path

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -125,18 +125,17 @@ def get_win_py_runtime_var(python_runtimes):
 
 
 def get_embedded_path(ctx):
-    embedded_path = ""
     base = os.path.dirname(os.path.abspath(__file__))
-    task_repo_root = os.path.abspath(os.path.join(base, ".."))
+    task_repo_root = os.path.abspath(os.path.join(base, "..", ".."))
     git_repo_root = get_root()
     gopath_root = f"{get_gopath(ctx)}/src/github.com/DataDog/datadog-agent"
 
     for root_candidate in [task_repo_root, git_repo_root, gopath_root]:
         test_embedded_path = os.path.join(root_candidate, "dev")
         if os.path.exists(test_embedded_path):
-            embedded_path = test_embedded_path
+            return test_embedded_path
 
-    return embedded_path
+    return ""
 
 
 def get_xcode_version(ctx):

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -135,7 +135,7 @@ def get_embedded_path(ctx):
         if os.path.exists(test_embedded_path):
             return test_embedded_path
 
-    return ""
+    return None
 
 
 def get_xcode_version(ctx):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix the `get_embedded_path` when running in a non-default path.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
It had several issues which resulted in using the default path (`github.com/DataDog/datadog-agent`) whenever running in a non-default path.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
It tried a list of paths (the task directory, the git root, and a default path), and kept the last one matching instead of the first one.
It also used the wrong path to get to the task directory due to the file being moved.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
