### PR TITLE
[pkg/trace] Fix log level of warn message

### DIFF
--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -128,7 +128,7 @@ func NewTraceWriter(
 		tw.tick = time.Duration(s*1000) * time.Millisecond
 	}
 	qsize := 1
-	log.Warnf("Trace writer initialized (climit=%d qsize=%d)", climit, qsize)
+	log.Infof("Trace writer initialized (climit=%d qsize=%d)", climit, qsize)
 	tw.senders = newSenders(cfg, tw, pathTraces, climit, qsize, telemetryCollector, statsd)
 	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
 		tw.wg.Add(1)

--- a/releasenotes/notes/change-log-level-a7a89906417c9999.yaml
+++ b/releasenotes/notes/change-log-level-a7a89906417c9999.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Correct log level of trace writer log message


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Changes log level from warn to info

 
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fixes open-telemetry/opentelemetry-collector-contrib/issues/33053

