### PR TITLE
[Backport 7.54.x][CWS] windows: fix nil process context on process resolution failure

### DIFF
--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -14,6 +14,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/cenkalti/backoff/v4"
+	lru "github.com/hashicorp/golang-lru/v2"
+
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/comp/etw"
 	etwimpl "github.com/DataDog/datadog-agent/comp/etw/impl"
@@ -30,9 +34,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/windowsdriver/procmon"
-	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/cenkalti/backoff/v4"
-	lru "github.com/hashicorp/golang-lru/v2"
 
 	"golang.org/x/sys/windows"
 )
@@ -470,9 +471,7 @@ func (p *WindowsProbe) Start() error {
 					continue
 				}
 			case notif := <-p.onETWNotification:
-				if !p.handleETWNotification(ev, notif) {
-					continue
-				}
+				p.handleETWNotification(ev, notif)
 			}
 
 			p.DispatchEvent(ev)
@@ -546,7 +545,7 @@ func (p *WindowsProbe) handleProcessStop(ev *model.Event, stop *procmon.ProcessS
 	return true
 }
 
-func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotification) bool {
+func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotification) {
 	// handle incoming events here
 	// each event will come in as a different type
 	// parse it with
@@ -644,20 +643,29 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 			log.Debugf("%v", errRes)
 		}
 	}
-	return true
 }
 
 func (p *WindowsProbe) setProcessContext(pid uint32, event *model.Event) error {
+	event.PIDContext.Pid = pid
 	err := backoff.Retry(func() error {
-		pce := p.Resolvers.ProcessResolver.GetEntry(pid)
-		if pce == nil {
-			return fmt.Errorf("Could not resolve process for Process: %v", pid)
+		entry, isResolved := p.fieldHandlers.ResolveProcessCacheEntry(event)
+		event.ProcessCacheEntry = entry
+		// use ProcessCacheEntry process context as process context
+		event.ProcessContext = &event.ProcessCacheEntry.ProcessContext
+		if !isResolved {
+			return fmt.Errorf("could not resolve process for Process: %v", pid)
 		}
-		event.ProcessCacheEntry = pce
-		event.ProcessContext = &pce.ProcessContext
 		return nil
-
 	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(50*time.Millisecond), 5))
+
+	if event.ProcessCacheEntry == nil {
+		panic("should always return a process cache entry")
+	}
+
+	if event.ProcessContext == nil {
+		panic("should always return a process context")
+	}
+
 	return err
 }
 


### PR DESCRIPTION
Backport https://github.com/DataDog/datadog-agent/commit/1d5c52e7eb1a951e9b9986cde5bfbd72f51b9b68 from https://github.com/DataDog/datadog-agent/pull/25617.

----

### What does this PR do?

This PR fixes a panic in the rule evaluation of windows events. 
This occurred when the process resolution failed and caused the process context of an event to be nil.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This bug was causing the system-probe process to crash on Windows.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Run the agent on a Windows host.
- Create a rule that uses a process context field
- Verify the system-probe process doesn't crash

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
