### PR TITLE
add linux compatibility for diagnose port-conflict

### DIFF
--- a/pkg/diagnose/runner.go
+++ b/pkg/diagnose/runner.go
@@ -449,7 +449,7 @@ func getSuites(diagCfg diagnosis.Config, deps SuitesDeps) []diagnosis.Suite {
 	catalog.Register("connectivity-datadog-autodiscovery", connectivity.DiagnoseMetadataAutodiscoveryConnectivity)
 	catalog.Register("connectivity-datadog-event-platform", eventplatformimpl.Diagnose)
 	// port-conflict suite available in darwin only for now
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
 		catalog.Register("port-conflict", func() []diagnosis.Diagnosis { return ports.DiagnosePortSuite() })
 	}
 

--- a/pkg/util/port/portlist/netstat_test.go
+++ b/pkg/util/port/portlist/netstat_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2014-present Datadog, Inc.
 
-//go:build darwin && !ios
-// +build darwin,!ios
+//go:build darwin
+// +build darwin
 
 package portlist
 

--- a/pkg/util/port/portlist/poller_linux.go
+++ b/pkg/util/port/portlist/poller_linux.go
@@ -1,0 +1,458 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2014-present Datadog, Inc.
+
+//go:build linux
+
+package portlist
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"go4.org/mem"
+	"golang.org/x/sys/unix"
+)
+
+func (p *Poller) init() {
+	p.os = newLinuxImpl(p.IncludeLocalhost)
+}
+
+type linuxImpl struct {
+	procNetFiles    []*os.File // seeked to start & reused between calls
+	readlinkPathBuf []byte
+
+	known            map[string]*portMeta // inode string => metadata
+	br               *bufio.Reader
+	includeLocalhost bool
+}
+
+type portMeta struct {
+	port          Port
+	pid           int
+	keep          bool
+	needsProcName bool
+}
+
+var eofReader = bytes.NewReader(nil)
+
+func newLinuxImplBase(includeLocalhost bool) *linuxImpl {
+	return &linuxImpl{
+		br:               bufio.NewReader(eofReader),
+		known:            map[string]*portMeta{},
+		includeLocalhost: includeLocalhost,
+	}
+}
+
+func newLinuxImpl(includeLocalhost bool) osImpl {
+	li := newLinuxImplBase(includeLocalhost)
+	for _, name := range []string{
+		"/proc/net/tcp",
+		"/proc/net/tcp6",
+		"/proc/net/udp",
+		"/proc/net/udp6",
+	} {
+		f, err := os.Open(name)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			log.Printf("portlist warning; ignoring: %v", err)
+			continue
+		}
+		li.procNetFiles = append(li.procNetFiles, f)
+	}
+	return li
+}
+
+func (li *linuxImpl) Close() error {
+	for _, f := range li.procNetFiles {
+		f.Close()
+	}
+	li.procNetFiles = nil
+	return nil
+}
+
+const (
+	v6Localhost = "00000000000000000000000001000000:"
+	v6Any       = "00000000000000000000000000000000:0000"
+	v4Localhost = "0100007F:"
+	v4Any       = "00000000:0000"
+)
+
+func (li *linuxImpl) AppendListeningPorts(base []Port) ([]Port, error) {
+
+	br := li.br
+	defer br.Reset(eofReader)
+
+	// Start by marking all previous known ports as gone. If this mark
+	// bit is still false later, we'll remove them.
+	for _, pm := range li.known {
+		pm.keep = false
+	}
+
+	for _, f := range li.procNetFiles {
+		name := f.Name()
+		_, err := f.Seek(0, io.SeekStart)
+		if err != nil {
+			return nil, err
+		}
+		br.Reset(f)
+		err = li.parseProcNetFile(br, filepath.Base(name))
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q: %w", name, err)
+		}
+	}
+
+	// Delete ports that aren't open any longer.
+	// And see if there are any process names we need to look for.
+	needProc := make(map[string]*portMeta)
+	for inode, pm := range li.known {
+		if !pm.keep {
+			delete(li.known, inode)
+			continue
+		}
+		if pm.needsProcName {
+			needProc[inode] = pm
+		}
+	}
+	err := li.findProcessNames(needProc)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := base
+	for _, pm := range li.known {
+		ret = append(ret, pm.port)
+	}
+	return sortAndDedup(ret), nil
+}
+
+func (li *linuxImpl) parseProcNetFile(r *bufio.Reader, fileBase string) error {
+	proto := strings.TrimSuffix(fileBase, "6")
+
+	// skip header row
+	_, err := r.ReadSlice('\n')
+	if err != nil {
+		return err
+	}
+
+	fields := make([]mem.RO, 0, 20) // 17 current fields + some future slop
+
+	wantRemote := mem.S(v4Any)
+	if strings.HasSuffix(fileBase, "6") {
+		wantRemote = mem.S(v6Any)
+	}
+
+	// remoteIndex is the index within a line to the remote address field.
+	// -1 means not yet found.
+	remoteIndex := -1
+
+	// Add an upper bound on how many rows we'll attempt to read just
+	// to make sure this doesn't consume too much of their CPU.
+	// TODO(bradfitz,crawshaw): adaptively adjust polling interval as function
+	// of open sockets.
+	const maxRows = 1e6
+	rows := 0
+
+	// Scratch buffer for making inode strings.
+	inoBuf := make([]byte, 0, 50)
+
+	for {
+		line, err := r.ReadSlice('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		rows++
+		if rows >= maxRows {
+			break
+		}
+		if len(line) == 0 {
+			continue
+		}
+
+		// On the first row of output, find the index of the 3rd field (index 2),
+		// the remote address. All the rows are aligned, at least until 4 billion open
+		// TCP connections, per the Linux get_tcp4_sock's "%4d: " on an int i.
+		if remoteIndex == -1 {
+			remoteIndex = fieldIndex(line, 2)
+			if remoteIndex == -1 {
+				break
+			}
+		}
+
+		if len(line) < remoteIndex || !mem.HasPrefix(mem.B(line).SliceFrom(remoteIndex), wantRemote) {
+			// Fast path for not being a listener port.
+			continue
+		}
+
+		// sl local rem ... inode
+		fields = mem.AppendFields(fields[:0], mem.B(line))
+		local := fields[1]
+		rem := fields[2]
+		inode := fields[9]
+
+		if !rem.Equal(wantRemote) {
+			// not a "listener" port
+			continue
+		}
+
+		// If a port is bound to localhost, ignore it.
+		// TODO: localhost is bigger than 1 IP, we need to ignore
+		// more things.
+		if !li.includeLocalhost && (mem.HasPrefix(local, mem.S(v4Localhost)) || mem.HasPrefix(local, mem.S(v6Localhost))) {
+			continue
+		}
+
+		// Don't use strings.Split here, because it causes
+		// allocations significant enough to show up in profiles.
+		i := mem.IndexByte(local, ':')
+		if i == -1 {
+			return fmt.Errorf("%q unexpectedly didn't have a colon", local.StringCopy())
+		}
+		portv, err := mem.ParseUint(local.SliceFrom(i+1), 16, 16)
+		if err != nil {
+			return fmt.Errorf("%#v: %s", local.SliceFrom(9).StringCopy(), err)
+		}
+		inoBuf = append(inoBuf[:0], "socket:["...)
+		inoBuf = mem.Append(inoBuf, inode)
+		inoBuf = append(inoBuf, ']')
+
+		if pm, ok := li.known[string(inoBuf)]; ok {
+			pm.keep = true
+			// Rest should be unchanged.
+		} else {
+			li.known[string(inoBuf)] = &portMeta{
+				needsProcName: true,
+				keep:          true,
+				port: Port{
+					Proto: proto,
+					Port:  uint16(portv),
+				},
+			}
+		}
+	}
+
+	return nil
+}
+
+// errDone is an internal sentinel error that we found everything we were looking for.
+var errDone = errors.New("done")
+
+// need is keyed by inode string.
+func (li *linuxImpl) findProcessNames(need map[string]*portMeta) error {
+	if len(need) == 0 {
+		return nil
+	}
+	defer func() {
+		// Anything we didn't find, give up on and don't try to look for it later.
+		for _, pm := range need {
+			pm.needsProcName = false
+		}
+	}()
+
+	err := foreachPID(func(pid mem.RO) error {
+		var procBuf [128]byte
+		fdPath := mem.Append(procBuf[:0], mem.S("/proc/"))
+		fdPath = mem.Append(fdPath, pid)
+		fdPath = mem.Append(fdPath, mem.S("/fd"))
+
+		// Android logs a bunch of audit violations in logcat
+		// if we try to open things we don't have access
+		// to. So on Android only, ask if we have permission
+		// rather than just trying it to determine whether we
+		// have permission.
+		if runtime.GOOS == "android" && syscall.Access(string(fdPath), unix.R_OK) != nil {
+			return nil
+		}
+		_ = walkShallow(mem.B(fdPath), func(fd mem.RO, de fs.DirEntry) error {
+			targetBuf := make([]byte, 64) // plenty big for "socket:[165614651]"
+
+			linkPath := li.readlinkPathBuf[:0]
+			linkPath = fmt.Appendf(linkPath, "/proc/")
+			linkPath = mem.Append(linkPath, pid)
+			linkPath = append(linkPath, "/fd/"...)
+			linkPath = mem.Append(linkPath, fd)
+			linkPath = append(linkPath, 0) // terminating NUL
+			li.readlinkPathBuf = linkPath  // to reuse its buffer next time
+			n, ok := readlink(linkPath, targetBuf)
+			if !ok {
+				// Not a symlink or no permission.
+				// Skip it.
+				return nil
+			}
+
+			pe := need[string(targetBuf[:n])] // m[string([]byte)] avoids alloc
+			if pe == nil {
+				return nil
+			}
+			bs, err := os.ReadFile(fmt.Sprintf("/proc/%s/cmdline", pid.StringCopy()))
+			if err != nil {
+				// Usually shouldn't happen. One possibility is
+				// the process has gone away, so let's skip it.
+				return nil
+			}
+
+			argv := strings.Split(strings.TrimSuffix(string(bs), "\x00"), "\x00")
+			if p, err := mem.ParseInt(pid, 10, 0); err == nil {
+				pe.pid = int(p)
+			}
+			pe.port.Process = argvSubject(argv...)
+			pid64, _ := mem.ParseInt(pid, 10, 0)
+			pe.port.Pid = int(pid64)
+			pe.needsProcName = false
+			delete(need, string(targetBuf[:n]))
+			if len(need) == 0 {
+				return errDone
+			}
+			return nil
+		})
+		return nil
+	})
+	if err == errDone {
+		return nil
+	}
+	return err
+}
+
+func foreachPID(fn func(pidStr mem.RO) error) error {
+	err := walkShallow(mem.S("/proc"), func(name mem.RO, de fs.DirEntry) error {
+		if !isNumeric(name) {
+			return nil
+		}
+		return fn(name)
+	})
+	if os.IsNotExist(err) {
+		// This can happen if the directory we're
+		// reading disappears during the run. No big
+		// deal.
+		return nil
+	}
+	return err
+}
+
+func isNumeric(s mem.RO) bool {
+	for i, n := 0, s.Len(); i < n; i++ {
+		b := s.At(i)
+		if b < '0' || b > '9' {
+			return false
+		}
+	}
+	return s.Len() > 0
+}
+
+// fieldIndex returns the offset in line where the Nth field (0-based) begins, or -1
+// if there aren't that many fields. Fields are separated by 1 or more spaces.
+func fieldIndex(line []byte, n int) int {
+	skip := 0
+	for i := 0; i <= n; i++ {
+		// Skip spaces.
+		for skip < len(line) && line[skip] == ' ' {
+			skip++
+		}
+		if skip == len(line) {
+			return -1
+		}
+		if i == n {
+			break
+		}
+		// Skip non-space.
+		for skip < len(line) && line[skip] != ' ' {
+			skip++
+		}
+	}
+	return skip
+}
+
+// path must be null terminated.
+func readlink(path, buf []byte) (n int, ok bool) {
+	if len(buf) == 0 || len(path) < 2 || path[len(path)-1] != 0 {
+		return 0, false
+	}
+	var dirfd int = unix.AT_FDCWD
+	r0, _, e1 := unix.Syscall6(unix.SYS_READLINKAT,
+		uintptr(dirfd),
+		uintptr(unsafe.Pointer(&path[0])),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+		0, 0)
+	n = int(r0)
+	if e1 != 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// argvSubject takes a command and its flags, and returns the
+// short/pretty name for the process. This is usually the basename of
+// the binary being executed, but can sometimes vary (e.g. so that we
+// don't report all Java programs as "java").
+func argvSubject(argv ...string) string {
+	if len(argv) == 0 {
+		return ""
+	}
+	ret := filepath.Base(argv[0])
+
+	// Handle special cases.
+	switch {
+	case ret == "mono" && len(argv) >= 2:
+		// .Net programs execute as `mono actualProgram.exe`.
+		ret = filepath.Base(argv[1])
+	}
+
+	// Handle space separated argv
+	ret, _, _ = strings.Cut(ret, " ")
+
+	// Remove common noise.
+	ret = strings.TrimSpace(ret)
+	ret = strings.TrimSuffix(ret, ".exe")
+
+	return ret
+}
+
+// walkFunc is the callback type used with walkShallow.
+//
+// The name and de are only valid for the duration of func's call
+// and should not be retained.
+type walkFunc func(name mem.RO, de fs.DirEntry) error
+
+// walkShallow reads the entries in the named directory and calls fn for each.
+// It does not recurse into subdirectories.
+//
+// If fn returns an error, iteration stops and walkShallow returns that value.
+func walkShallow(dirName mem.RO, fn walkFunc) error {
+	of, err := os.Open(dirName.StringCopy())
+	if err != nil {
+		return err
+	}
+	defer of.Close()
+	for {
+		fis, err := of.ReadDir(100)
+		for _, de := range fis {
+			if err := fn(mem.S(de.Name()), de); err != nil {
+				return err
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
+}

--- a/pkg/util/port/portlist/poller_linux_macos.go
+++ b/pkg/util/port/portlist/poller_linux_macos.go
@@ -1,0 +1,38 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2014-present Datadog, Inc.
+
+//go:build darwin || linux
+
+package portlist
+
+import "sort"
+
+func (a *Port) lessThan(b *Port) bool {
+	if a.Port != b.Port {
+		return a.Port < b.Port
+	}
+	if a.Proto != b.Proto {
+		return a.Proto < b.Proto
+	}
+	return a.Process < b.Process
+}
+
+// sortAndDedup sorts ps in place (by Port.LessThan) and then returns
+// a subset of it with duplicate (Proto, Port) removed.
+func sortAndDedup(ps List) List {
+	sort.Slice(ps, func(i, j int) bool {
+		return (&ps[i]).lessThan(&ps[j])
+	})
+	out := ps[:0]
+	var last Port
+	for _, p := range ps {
+		if last.Proto == p.Proto && last.Port == p.Port {
+			continue
+		}
+		out = append(out, p)
+		last = p
+	}
+	return out
+}

--- a/pkg/util/port/portlist/poller_linux_test.go
+++ b/pkg/util/port/portlist/poller_linux_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2014-present Datadog, Inc.
+
+package portlist
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFieldIndex(t *testing.T) {
+	tests := []struct {
+		in    string
+		field int
+		want  int
+	}{
+		{"foo", 0, 0},
+		{"  foo", 0, 2},
+		{"foo  bar", 1, 5},
+		{" foo  bar", 1, 6},
+		{" foo  bar", 2, -1},
+		{" foo  bar ", 2, -1},
+		{" foo  bar x", 2, 10},
+		{"  1: 00000000:0016 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 34062 1 0000000000000000 100 0 0 10 0",
+			2, 19},
+	}
+	for _, tt := range tests {
+		if got := fieldIndex([]byte(tt.in), tt.field); got != tt.want {
+			t.Errorf("fieldIndex(%q, %v) = %v; want %v", tt.in, tt.field, got, tt.want)
+		}
+	}
+}
+
+func TestParsePorts(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		file string
+		want map[string]*portMeta
+	}{
+		{
+			name: "empty",
+			in:   "header line (ignored)\n",
+			want: map[string]*portMeta{},
+		},
+		{
+			name: "ipv4",
+			file: "tcp",
+			in: `header line
+  0: 0100007F:0277 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 22303 1 0000000000000000 100 0 0 10 0
+  1: 00000000:0016 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 34062 1 0000000000000000 100 0 0 10 0
+  2: 5501A8C0:ADD4 B25E9536:01BB 01 00000000:00000000 02:00000B2B 00000000  1000        0 155276677 2 0000000000000000 22 4 30 10 -1
+`,
+			want: map[string]*portMeta{
+				"socket:[34062]": {
+					port: Port{Proto: "tcp", Port: 22},
+				},
+			},
+		},
+		{
+			name: "ipv6",
+			file: "tcp6",
+			in: `  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000001000000:0277 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 35720 1 0000000000000000 100 0 0 10 0
+   1: 00000000000000000000000000000000:1F91 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 142240557 1 0000000000000000 100 0 0 10 0
+   2: 00000000000000000000000000000000:0016 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 34064 1 0000000000000000 100 0 0 10 0
+   3: 69050120005716BC64906EBE009ECD4D:D506 0047062600000000000000006E171268:01BB 01 00000000:00000000 02:0000009E 00000000  1000        0 151042856 2 0000000000000000 21 4 28 10 -1
+`,
+			want: map[string]*portMeta{
+				"socket:[142240557]": {
+					port: Port{Proto: "tcp", Port: 8081},
+				},
+				"socket:[34064]": {
+					port: Port{Proto: "tcp", Port: 22},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := bytes.NewBufferString(tt.in)
+			r := bufio.NewReader(buf)
+			file := "tcp"
+			if tt.file != "" {
+				file = tt.file
+			}
+			li := newLinuxImplBase(false)
+			err := li.parseProcNetFile(r, file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, pm := range tt.want {
+				pm.keep = true
+				pm.needsProcName = true
+			}
+			if diff := cmp.Diff(li.known, tt.want, cmp.AllowUnexported(Port{}), cmp.AllowUnexported(portMeta{})); diff != "" {
+				t.Errorf("unexpected parsed ports (-got+want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkParsePorts(b *testing.B) {
+	b.ReportAllocs()
+
+	var contents bytes.Buffer
+	contents.WriteString(`  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000001000000:0277 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 35720 1 0000000000000000 100 0 0 10 0
+   1: 00000000000000000000000000000000:1F91 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 142240557 1 0000000000000000 100 0 0 10 0
+   2: 00000000000000000000000000000000:0016 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 34064 1 0000000000000000 100 0 0 10 0
+`)
+	for i := 0; i < 50000; i++ {
+		contents.WriteString("   3: 69050120005716BC64906EBE009ECD4D:D506 0047062600000000000000006E171268:01BB 01 00000000:00000000 02:0000009E 00000000  1000        0 151042856 2 0000000000000000 21 4 28 10 -1\n")
+	}
+
+	li := newLinuxImplBase(false)
+
+	r := bytes.NewReader(contents.Bytes())
+	br := bufio.NewReader(&contents)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.Seek(0, io.SeekStart)
+		br.Reset(r)
+		err := li.parseProcNetFile(br, "tcp6")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(li.known) != 2 {
+			b.Fatalf("wrong results; want 2 parsed got %d", len(li.known))
+		}
+	}
+}
+
+func BenchmarkFindProcessNames(b *testing.B) {
+	b.ReportAllocs()
+	li := &linuxImpl{}
+	need := map[string]*portMeta{
+		"something-we'll-never-find": new(portMeta),
+	}
+	for i := 0; i < b.N; i++ {
+		if err := li.findProcessNames(need); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/util/port/portlist/poller_macos.go
+++ b/pkg/util/port/portlist/poller_macos.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
-	"sort"
 	"strings"
 
 	"go.uber.org/atomic"
@@ -229,16 +228,6 @@ func lsofProtoLower(p []byte) string {
 	return strings.ToLower(string(p))
 }
 
-func (a *Port) lessThan(b *Port) bool {
-	if a.Port != b.Port {
-		return a.Port < b.Port
-	}
-	if a.Proto != b.Proto {
-		return a.Proto < b.Proto
-	}
-	return a.Process < b.Process
-}
-
 func (a List) String() string {
 	var sb strings.Builder
 	for _, v := range a {
@@ -246,22 +235,4 @@ func (a List) String() string {
 			v.Proto, v.Port, v.Process)
 	}
 	return strings.TrimRight(sb.String(), "\n")
-}
-
-// sortAndDedup sorts ps in place (by Port.LessThan) and then returns
-// a subset of it with duplicate (Proto, Port) removed.
-func sortAndDedup(ps List) List {
-	sort.Slice(ps, func(i, j int) bool {
-		return (&ps[i]).lessThan(&ps[j])
-	})
-	out := ps[:0]
-	var last Port
-	for _, p := range ps {
-		if last.Proto == p.Proto && last.Port == p.Port {
-			continue
-		}
-		out = append(out, p)
-		last = p
-	}
-	return out
 }

--- a/pkg/util/port/portlist/poller_other.go
+++ b/pkg/util/port/portlist/poller_other.go
@@ -3,11 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !darwin
+//go:build !darwin && !linux
 
 package portlist
 
-import "errors"
+import (
+	"errors"
+)
 
 // ErrNotImplemented is the "not implemented" error given by `gopsutil` when an
 // OS doesn't support and API. Unfortunately it's in an internal package so


### PR DESCRIPTION
### What does this PR do?

Add linux compatibility for the diagnose port conflict suite. This builds on [PR#25209](https://github.com/DataDog/datadog-agent/pull/25209).

### Motivation

Making this feature available for Linux is make it much more useful since our customers are much more likely to be on Linux compared to MacOS.

### Possible Drawbacks / Trade-offs

This PR will make this feature available for MacOS and Linux. Windows will come after.

### Describe how to test/QA your changes

Check that the diagnose suite works properly for Linux and Darwin:
- when the agent isn't running and there is no port issue
- when the agent is running and there is no port issue (the agent is detected as being the agent, so no issue is raised)
- when some port is used by another process, it is reported
You can use `netcat` to bind to a port:
```
netcat -nvlp 6062
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.