### PR TITLE
(fleet) add logs to the e2e tests when the installer fails to install

### DIFF
--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -165,6 +165,9 @@ func (s *packageBaseSuite) RunInstallScript() {
 	require.NoError(s.T(), err)
 	s.Env().RemoteHost.MustExecute("sudo mkdir -p /etc/datadog-agent")
 	s.Env().RemoteHost.MustExecute(fmt.Sprintf("echo '%s' | sudo tee /etc/datadog-agent/datadog.yaml", string(rawDatadogConfig)))
+	_, err = s.Env().RemoteHost.Execute("sudo datadog-installer version")
+	// Right now the install script can fail installing the installer silently, so we need to do this check or it will fail later in a way that is hard to debug
+	require.NoErrorf(s.T(), err, "installer not properly installed. logs: \n%s\n%s", s.Env().RemoteHost.MustExecute("/tmp/datadog-installer-stdout.log"), s.Env().RemoteHost.MustExecute("/tmp/datadog-installer-stderr.log"))
 	s.Env().RemoteHost.MustExecute("sudo chown -R dd-agent:dd-agent /etc/datadog-agent")
 }
 

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -167,7 +167,7 @@ func (s *packageBaseSuite) RunInstallScript() {
 	s.Env().RemoteHost.MustExecute(fmt.Sprintf("echo '%s' | sudo tee /etc/datadog-agent/datadog.yaml", string(rawDatadogConfig)))
 	_, err = s.Env().RemoteHost.Execute("sudo datadog-installer version")
 	// Right now the install script can fail installing the installer silently, so we need to do this check or it will fail later in a way that is hard to debug
-	require.NoErrorf(s.T(), err, "installer not properly installed. logs: \n%s\n%s", s.Env().RemoteHost.MustExecute("/tmp/datadog-installer-stdout.log"), s.Env().RemoteHost.MustExecute("/tmp/datadog-installer-stderr.log"))
+	require.NoErrorf(s.T(), err, "installer not properly installed. logs: \n%s\n%s", s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stdout.log"), s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stderr.log"))
 	s.Env().RemoteHost.MustExecute("sudo chown -R dd-agent:dd-agent /etc/datadog-agent")
 }
 


### PR DESCRIPTION
We had one flake where I suspect the installer to have failed to install for some reason. This PR should catch this and make it debuggable.
