### PR TITLE
[windows][cws][wkint-494] Backport LRU cache.

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -38,6 +38,9 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.use_secruntime_track", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.compliance_module.enabled", false)
 
+	cfg.SetDefault("runtime_security_config.windows_filename_cache_max", 16384)
+	cfg.SetDefault("runtime_security_config.windows_registry_cache_max", 4096)
+
 	// CWS - activity dump
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.cleanup_period", "30s")

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -224,6 +224,12 @@ type RuntimeSecurityConfig struct {
 
 	// Enforcement capabilities
 	EnforcementEnabled bool
+
+	//WindowsFilenameCacheSize is the max number of filenames to cache
+	WindowsFilenameCacheSize int
+
+	//WindowsRegistryCacheSize is the max number of registry paths to cache
+	WindowsRegistryCacheSize int
 }
 
 // Config defines a security config
@@ -277,8 +283,10 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 	}
 
 	rsConfig := &RuntimeSecurityConfig{
-		RuntimeEnabled: coreconfig.SystemProbe.GetBool("runtime_security_config.enabled"),
-		FIMEnabled:     coreconfig.SystemProbe.GetBool("runtime_security_config.fim_enabled"),
+		RuntimeEnabled:           coreconfig.SystemProbe.GetBool("runtime_security_config.enabled"),
+		FIMEnabled:               coreconfig.SystemProbe.GetBool("runtime_security_config.fim_enabled"),
+		WindowsFilenameCacheSize: coreconfig.SystemProbe.GetInt("runtime_security_config.windows_filename_cache_max"),
+		WindowsRegistryCacheSize: coreconfig.SystemProbe.GetInt("runtime_security_config.windows_registry_cache_max"),
 
 		SocketPath:           coreconfig.SystemProbe.GetString("runtime_security_config.socket"),
 		EventServerBurst:     coreconfig.SystemProbe.GetInt("runtime_security_config.event_server.burst"),

--- a/pkg/security/metrics/metrics_windows.go
+++ b/pkg/security/metrics/metrics_windows.go
@@ -121,4 +121,10 @@ var (
 	//MetricWindowsETWTotalNotifications is the metric for counting the total number of ETW notifications
 	//Tags: -
 	MetricWindowsETWTotalNotifications = newRuntimeMetric(".windows.etw_total_notifications")
+	//MetricWindowsFilePathEvictions is the metric for counting the number of file path evictions
+	//Tags: -
+	MetricWindowsFilePathEvictions = newRuntimeMetric(".windows.file_path_evictions")
+	//MetricWindowsRegPathEvictions is the metric for counting the number of registry path evictions
+	//Tags: -
+	MetricWindowsRegPathEvictions = newRuntimeMetric(".windows.registry_path_evictions")
 )

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -170,9 +170,8 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 		return nil, errDiscardedPath
 	}
 
-	wp.filePathResolverLock.Lock()
-	defer wp.filePathResolverLock.Unlock()
-	wp.filePathResolver[ca.fileObject] = ca.fileName
+	// lru is thread safe, has its own locking
+	wp.filePathResolver.Add(ca.fileObject, fileCache{fileName: ca.fileName})
 
 	return ca, nil
 }
@@ -267,10 +266,9 @@ func (wp *WindowsProbe) parseInformationArgs(e *etw.DDEventRecord) (*setInformat
 		return nil, fmt.Errorf("unknown version number %v", e.EventHeader.EventDescriptor.Version)
 	}
 
-	wp.filePathResolverLock.Lock()
-	defer wp.filePathResolverLock.Unlock()
-	if s, ok := wp.filePathResolver[fileObjectPointer(sia.fileObject)]; ok {
-		sia.fileName = s
+	// lru is thread safe, has its own locking
+	if s, ok := wp.filePathResolver.Get(fileObjectPointer(sia.fileObject)); ok {
+		sia.fileName = s.fileName
 	}
 
 	return sia, nil
@@ -402,10 +400,9 @@ func (wp *WindowsProbe) parseCleanupArgs(e *etw.DDEventRecord) (*cleanupArgs, er
 		return nil, fmt.Errorf("unknown version number %v", e.EventHeader.EventDescriptor.Version)
 	}
 
-	wp.filePathResolverLock.Lock()
-	defer wp.filePathResolverLock.Unlock()
-	if s, ok := wp.filePathResolver[ca.fileObject]; ok {
-		ca.fileName = s
+	// lru is thread safe, has its own locking
+	if s, ok := wp.filePathResolver.Get(fileObjectPointer(ca.fileObject)); ok {
+		ca.fileName = s.fileName
 	}
 
 	return ca, nil
@@ -495,10 +492,9 @@ func (wp *WindowsProbe) parseReadArgs(e *etw.DDEventRecord) (*readArgs, error) {
 	} else {
 		return nil, fmt.Errorf("unknown version number %v", e.EventHeader.EventDescriptor.Version)
 	}
-	wp.filePathResolverLock.Lock()
-	defer wp.filePathResolverLock.Unlock()
-	if s, ok := wp.filePathResolver[fileObjectPointer(ra.fileObject)]; ok {
-		ra.fileName = s
+	// lru is thread safe, has its own locking
+	if s, ok := wp.filePathResolver.Get(fileObjectPointer(ra.fileObject)); ok {
+		ra.fileName = s.fileName
 	}
 	return ra, nil
 }
@@ -594,10 +590,9 @@ func (wp *WindowsProbe) parseDeletePathArgs(e *etw.DDEventRecord) (*deletePathAr
 		dpa.filePath, _, _, _ = data.ParseUnicodeString(40)
 	}
 
-	wp.filePathResolverLock.Lock()
-	defer wp.filePathResolverLock.Unlock()
-	if s, ok := wp.filePathResolver[fileObjectPointer(dpa.fileObject)]; ok {
-		dpa.oldPath = s
+	// lru is thread safe, has its own locking
+	if s, ok := wp.filePathResolver.Get(fileObjectPointer(dpa.fileObject)); ok {
+		dpa.oldPath = s.fileName
 		// question, should we reset the filePathResolver here?
 	}
 	return dpa, nil

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -171,7 +171,9 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 	}
 
 	// lru is thread safe, has its own locking
-	wp.filePathResolver.Add(ca.fileObject, fileCache{fileName: ca.fileName})
+	if wp.filePathResolver.Add(ca.fileObject, fileCache{fileName: ca.fileName}) {
+		wp.stats.fileNameCacheEvictions++
+	}
 
 	return ca, nil
 }

--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -46,14 +46,22 @@ func createTestProbe() (*WindowsProbe, error) {
 	if err != nil {
 		return nil, err
 	}
+	fc, err := lru.New[fileObjectPointer, fileCache](1024)
+	if err != nil {
+		return nil, err
+	}
+	rc, err := lru.New[regObjectPointer, string](1024)
+	if err != nil {
+		return nil, err
+	}
 
 	// probe and config are provided as null.  During the tests, it is assumed
 	// that we will not access those values.
 	wp := &WindowsProbe{
 		opts:               opts,
 		config:             cfg,
-		filePathResolver:   make(map[fileObjectPointer]string, 0),
-		regPathResolver:    make(map[regObjectPointer]string, 0),
+		filePathResolver:   fc,
+		regPathResolver:    rc,
 		discardedPaths:     discardedPaths,
 		discardedBasenames: discardedBasenames,
 	}

--- a/pkg/security/probe/probe_kernel_reg_windows.go
+++ b/pkg/security/probe/probe_kernel_reg_windows.go
@@ -161,7 +161,9 @@ func (wp *WindowsProbe) computeFullPath(cka *createKeyArgs) {
 	if strings.HasPrefix(cka.relativeName, regprefix) {
 		cka.translateBasePaths()
 		cka.computedFullPath = cka.relativeName
-		wp.regPathResolver.Add(cka.keyObject, cka.relativeName)
+		if wp.regPathResolver.Add(cka.keyObject, cka.relativeName) {
+			wp.stats.registryCacheEvictions++
+		}
 		return
 	}
 	if s, ok := wp.regPathResolver.Get(cka.keyObject); ok {
@@ -181,7 +183,9 @@ func (wp *WindowsProbe) computeFullPath(cka *createKeyArgs) {
 			outstr = cka.relativeName
 		}
 	}
-	wp.regPathResolver.Add(cka.keyObject, outstr)
+	if wp.regPathResolver.Add(cka.keyObject, outstr) {
+		wp.stats.registryCacheEvictions++
+	}
 	cka.computedFullPath = outstr
 
 }

--- a/pkg/security/probe/probe_kernel_reg_windows.go
+++ b/pkg/security/probe/probe_kernel_reg_windows.go
@@ -161,10 +161,10 @@ func (wp *WindowsProbe) computeFullPath(cka *createKeyArgs) {
 	if strings.HasPrefix(cka.relativeName, regprefix) {
 		cka.translateBasePaths()
 		cka.computedFullPath = cka.relativeName
-		wp.regPathResolver[cka.keyObject] = cka.relativeName
+		wp.regPathResolver.Add(cka.keyObject, cka.relativeName)
 		return
 	}
-	if s, ok := wp.regPathResolver[cka.keyObject]; ok {
+	if s, ok := wp.regPathResolver.Get(cka.keyObject); ok {
 		cka.computedFullPath = s
 	}
 	var outstr string
@@ -175,14 +175,15 @@ func (wp *WindowsProbe) computeFullPath(cka *createKeyArgs) {
 		outstr += cka.relativeName
 	} else {
 
-		if s, ok := wp.regPathResolver[cka.baseObject]; ok {
+		if s, ok := wp.regPathResolver.Get(cka.baseObject); ok {
 			outstr = s + "\\" + cka.relativeName
 		} else {
 			outstr = cka.relativeName
 		}
 	}
-	wp.regPathResolver[cka.keyObject] = outstr
+	wp.regPathResolver.Add(cka.keyObject, outstr)
 	cka.computedFullPath = outstr
+
 }
 func (cka *createKeyArgs) String() string {
 
@@ -213,7 +214,7 @@ func (wp *WindowsProbe) parseDeleteRegistryKey(e *etw.DDEventRecord) (*deleteKey
 	dka.keyObject = regObjectPointer(data.GetUint64(0))
 	dka.status = data.GetUint32(8)
 	dka.keyName, _, _, _ = data.ParseUnicodeString(12)
-	if s, ok := wp.regPathResolver[dka.keyObject]; ok {
+	if s, ok := wp.regPathResolver.Get(dka.keyObject); ok {
 		dka.computedFullPath = s
 	}
 
@@ -329,7 +330,7 @@ func (wp *WindowsProbe) parseSetValueKey(e *etw.DDEventRecord) (*setValueKeyArgs
 
 	sv.previousData = data.Bytes(nextOffset, int(sv.previousDataSize))
 
-	if s, ok := wp.regPathResolver[sv.keyObject]; ok {
+	if s, ok := wp.regPathResolver.Get(sv.keyObject); ok {
 		sv.computedFullPath = s
 	}
 

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -137,6 +137,9 @@ type stats struct {
 	fileCreateSkippedDiscardedPaths     uint64
 	fileCreateSkippedDiscardedBasenames uint64
 
+	fileNameCacheEvictions uint64
+	registryCacheEvictions uint64
+
 	// currently not used, reserved for future use
 	etwChannelBlocked uint64
 
@@ -771,6 +774,12 @@ func (p *WindowsProbe) SendStats() error {
 		return err
 	}
 	if err := p.statsdClient.Gauge(metrics.MetricWindowsFileCreateSkippedDiscardedBasenames, float64(p.stats.fileCreateSkippedDiscardedBasenames), nil, 1); err != nil {
+		return err
+	}
+	if err := p.statsdClient.Gauge(metrics.MetricWindowsFilePathEvictions, float64(p.stats.fileNameCacheEvictions), nil, 1); err != nil {
+		return err
+	}
+	if err := p.statsdClient.Gauge(metrics.MetricWindowsRegPathEvictions, float64(p.stats.registryCacheEvictions), nil, 1); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Backport using LRU cache to store file & registry path names.
    Limits the amount of memory consumed when notifications are missed.

    Also adds, in addition to original PR, stats to count when this occurs.

    Original PR: #25493


### Describe how to test/QA your changes

Test in long-running load environment to see that system-probe memory usage doesn't grow