### PR TITLE
Modify the indents of conf.yaml.example in oracle.d

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -32,275 +32,275 @@ instances:
   ## If you use Oracle names resolution via tnsnamas.ora or ldap.ora,
   ## you must specify 'tns_alias' instead of 'server' and 'service_name'.
   #
-- server: <HOST> or server: <HOST>:<PORT>
+  - server: <HOST> or server: <HOST>:<PORT>
 
-  ## @param port - string - optional
-  ## The port of your Oracle database. It overrides the port specified in 'server'
-  #
-  # port: <PORT>
-
-  ## @param service_name - string - optional
-  ## The Oracle CDB service name. To view the services available on your server,
-  ## run the following query: `SELECT value FROM v$parameter WHERE name='service_names'`
-  #
-  # service_name: <SERVICE_NAME>
-
-  ## @param tns_alias - string - optional
-  ## The alias for the database connect string (stored in tnsnames.ora or in LDAP) to a CDB.
-  ## It's an alternative to specifying 'server' and 'service_name'. 'tns_alias' requires
-  ## an Oracle software installation.
-  #
-  # tns_alias: <TNS_ALIAS>
-
-  ## @param tns_admin - string - optional
-  ## The location of the Oracle client configuration files (sqlnet.ora, tnsnames.ora, ldap.ora).
-  ## This configuration is required only when using Oracle instant client. Oracle instant client
-  ## is reuquired when the 'tns_alias' is set. Alternatively, you can set the environment variable
-  ## TNS_ADMIN before starting the Datadog agent.
-  #
-  # tns_admin: <TNS_ADMIN_DIR>
-
-  ## @param protocol - string - optional - default: true
-  ## The protocol to connect to the Oracle Database Server. Valid protocols include TCP and TCPS.
-  #
-  # protocol: TCP
-
-  ## @param protocol - string - optional
-  ## The directory containing Oracle wallet. Oracle wallet is used with TCPS protocol.
-  #
-  # wallet: <WALLET_DIR>>
-
-  ## @param instant_client - boolean - optional
-  ## DEPRECATED, use oracle_client instead
-  ## Force using instant_client even when 'tns_alias' isn't used. This might be necessary
-  ## for using some advanced Oracle SQLNet features which aren't supported by the
-  ## Oracle driver for Go. If you specify 'tns_admin' the agent will automatically try
-  ## to use instant client.
-  #
-  # instant_client: false
-
-  ## @param oracle_client - boolean - optional
-  ## Force using an external Oracle client even when `tns_alias` isn't set. This might be necessary
-  ## for using some advanced Oracle SQLNet features which aren't supported by the
-  ## Oracle driver for Go. If you specify 'tns_admin', the agent will automatically try
-  ## to use an external client. For Linux, if you are using instant client, set
-  ## the environment variable `LD_LIBRARY_PATH` for the Agent process. If you are using
-  ## a client or server Oracle home, additionally set `ORACLE_HOME`.
-  #
-  # oracle_client: false
-
-  ## @param username - string - required
-  ## Username for the Datadog-Oracle server check user. The user has to exist in CDB.
-  #
-  # username: <USERNAME>
-
-  ## @param password - string - required
-  ## Password for the Datadog-Oracle check user.
-  #
-  # password: <PASSWORD>
-
-  ## @param reported_hostname - string - optional
-  ## Set the reported hostname for this instance. This value overrides the hostname detected by the Agent
-  #
-  # reported_hostname: <REPORTED_HOSTNAME>
-
-  ## @param dbm - boolean - optional - default: false
-  ## Set to `true` to enable Database Monitoring.
-  #
-  # dbm: false
-
-  ## @param tags - list of strings - optional
-  ## A list of tags to attach to every metric and service check emitted by this instance.
-  ##
-  ## Learn more about tagging at https://docs.datadoghq.com/tagging
-  #
-  # tags:
-  #   - <KEY_1>:<VALUE_1>
-  #   - <KEY_2>:<VALUE_2>
-
-  ## @param service - string - optional
-  ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
-  ##
-  ## Overrides any `service` defined in the `init_config` section.
-  #
-  # service: <SERVICE>
-
-  ## Configure collection of query samples
-  #
-  # query_samples:
-
-    ## @param enabled - boolean - optional - default: true
-    ## Enable collection of query samples. Requires `dbm: true`.
+    ## @param port - string - optional
+    ## The port of your Oracle database. It overrides the port specified in 'server'
     #
-    # enabled: true
+    # port: <PORT>
 
-  ## Configure collection of query metrics
-  #
-  # query_metrics:
-
-    ## @param enabled - boolean - optional - default: true
-    ## Enable collection of query metrics. Requires enabled query samples.
+    ## @param service_name - string - optional
+    ## The Oracle CDB service name. To view the services available on your server,
+    ## run the following query: `SELECT value FROM v$parameter WHERE name='service_names'`
     #
-    # enabled: true
+    # service_name: <SERVICE_NAME>
 
-  ## Configure collection of execution plans
-  #
-  # execution_plans:
-
-    ## @param enabled - boolean - optional - default: true
-    ## Enable collection of execution plans. Requires query metrics.
+    ## @param tns_alias - string - optional
+    ## The alias for the database connect string (stored in tnsnames.ora or in LDAP) to a CDB.
+    ## It's an alternative to specifying 'server' and 'service_name'. 'tns_alias' requires
+    ## an Oracle software installation.
     #
-    # enabled: true
+    # tns_alias: <TNS_ALIAS>
 
-  ## Configure collection of shared memory usage
-  #
-  # shared_memory:
-
-    ## @param enabled - boolean - optional - default: true. Requires `dbm: true`.
-    ## Enable collection of database shared memory usages
+    ## @param tns_admin - string - optional
+    ## The location of the Oracle client configuration files (sqlnet.ora, tnsnames.ora, ldap.ora).
+    ## This configuration is required only when using Oracle instant client. Oracle instant client
+    ## is reuquired when the 'tns_alias' is set. Alternatively, you can set the environment variable
+    ## TNS_ADMIN before starting the Datadog agent.
     #
-    # enabled: true
+    # tns_admin: <TNS_ADMIN_DIR>
 
-  ## Configure collection of database sysmetrics
-  #
-  # sysmetrics:
-
-    ## @param enabled - boolean - optional - default: true
-    ## Enable collection of database sysmetrics
+    ## @param protocol - string - optional - default: true
+    ## The protocol to connect to the Oracle Database Server. Valid protocols include TCP and TCPS.
     #
-    # enabled: true
+    # protocol: TCP
 
-  ## Configure collection of tablespace usage
-  #
-  # tablespaces:
-
-    ## @param enabled - boolean - optional - default: true
-    ## Enable collection of tablespace usage
+    ## @param protocol - string - optional
+    ## The directory containing Oracle wallet. Oracle wallet is used with TCPS protocol.
     #
-    # enabled: true
+    # wallet: <WALLET_DIR>>
 
-  ## Configure collection of process memory usage
-  #
-  # processes:
-
-    ## @param enabled - boolean - optional - default: true
-    ## Enable collection of process memory usage
+    ## @param instant_client - boolean - optional
+    ## DEPRECATED, use oracle_client instead
+    ## Force using instant_client even when 'tns_alias' isn't used. This might be necessary
+    ## for using some advanced Oracle SQLNet features which aren't supported by the
+    ## Oracle driver for Go. If you specify 'tns_admin' the agent will automatically try
+    ## to use instant client.
     #
-    # enabled: true
+    # instant_client: false
 
-  ## Configure collection of resource manager statistics
-  #
-  # resource_manager:
-
-    ## @param enabled - boolean - optional - default: true
-    ## Enable collection of resource manager statistics
+    ## @param oracle_client - boolean - optional
+    ## Force using an external Oracle client even when `tns_alias` isn't set. This might be necessary
+    ## for using some advanced Oracle SQLNet features which aren't supported by the
+    ## Oracle driver for Go. If you specify 'tns_admin', the agent will automatically try
+    ## to use an external client. For Linux, if you are using instant client, set
+    ## the environment variable `LD_LIBRARY_PATH` for the Agent process. If you are using
+    ## a client or server Oracle home, additionally set `ORACLE_HOME`.
     #
-    # enabled: true
+    # oracle_client: false
 
-  ## Configure how the SQL obfuscator behaves.
-  ## Note: This option only applies when `dbm` is enabled.
-  #
-  # obfuscator_options:
-
-    ## @param replace_digits - boolean - optional - default: false
-    ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
-    ## Note: This option also applies to extracted tables using `collect_tables`.
+    ## @param username - string - required
+    ## Username for the Datadog-Oracle server check user. The user has to exist in CDB.
     #
-    # replace_digits: false
+    # username: <USERNAME>
 
-    ## @param collect_metadata - boolean - optional - default: true
-    ## Set to `false` to disable the collection of metadata in your SQL statements.
-    ## Metadata includes things such as tables, commands, and comments.
+    ## @param password - string - required
+    ## Password for the Datadog-Oracle check user.
     #
-    # collect_metadata: true
+    # password: <PASSWORD>
 
-    ## @param collect_tables - boolean - optional - default: true
-    ## Set to `false` to disable the collection of tables in your SQL statements.
-    ## Requires `collect_metadata: true`.
+    ## @param reported_hostname - string - optional
+    ## Set the reported hostname for this instance. This value overrides the hostname detected by the Agent
     #
-    # collect_tables: true
+    # reported_hostname: <REPORTED_HOSTNAME>
 
-    ## @param collect_commands - boolean - optional - default: true
-    ## Set to `false` to disable the collection of commands in your SQL statements.
-    ## Requires `collect_metadata: true`.
+    ## @param dbm - boolean - optional - default: false
+    ## Set to `true` to enable Database Monitoring.
+    #
+    # dbm: false
+
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
     ##
-    ## Examples: SELECT, UPDATE, DELETE, etc.
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
     #
-    # collect_commands: true
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
 
-    ## @param collect_comments - boolean - optional - default: true
-    ## Set to `false` to disable the collection of comments in your SQL statements.
-    ## Requires `collect_metadata: true`.
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Overrides any `service` defined in the `init_config` section.
     #
-    # collect_comments: true
+    # service: <SERVICE>
 
-  ## @param use_global_custom_queries - string - optional - default: 'true'
-  ## How `global_custom_queries` should be used for this instance. There are 3 options:
-  ##
-  ## 1. true - `global_custom_queries` override `custom_queries`.
-  ## 2. false - `custom_queries` override `global_custom_queries`.
-  ## 3. extend - `global_custom_queries` are used in addition to any `custom_queries`.
-  #
-  # use_global_custom_queries: 'true'
-
-  ## @param custom_queries - list of mappings - optional
-  ## Each query must have 2 fields, and can have a third optional field:
-  ##
-  ## 1. metric_prefix - Each metric starts with the chosen prefix. The default is `oracle`.
-  ## 2. query - The SQL to execute. It can be a simple statement or a multi-line script.
-  ##            Use the pipe `|` if you require a multi-line script.
-  ## 3. columns - The list representing each column, ordered sequentially from left to right.
-  ##              The number of columns must equal the number of columns returned in the query.
-  ##              There are 2 required pieces of data:
-  ##                a. name - The suffix to append to `metric_prefix` to form
-  ##                          the full metric name. If `type` is `tag`, this column is
-  ##                          considered a tag and applied to every
-  ##                          metric collected by this particular query.
-  ##                b. type - The submission method (gauge, monotonic_count, etc.).
-  ##                          This can also be set to `tag` to tag each metric in the row
-  ##                          with the name and value of the item in this column. You can
-  ##                          use the `count` type to perform aggregation for queries that
-  ##                          return multiple rows with the same or no tags.
-  ##              Columns without a name are ignored. To skip a column, enter:
-  ##                - {}
-  ## 4. tags (optional) - A list of tags to apply to each metric.
-  #
-  ## WARNING: Running custom queries may result in additional costs or fees assessed by Oracle.
-  #
-  # custom_queries:
-  #   - metric_prefix: oracle
-  #     query: SELECT 'foo', 11 FROM dual
-  #     columns:
-  #     - name: foo
-  #       type: tag
-  #     - name: event.total
-  #       type: gauge
-  #     tags:
-  #     - test:tag_value_1
-  #     pdb: <MYPDB>
-
-  ## Start an SQL trace for Agent queries. This feature is only meant for Agent troubleshooting, and
-  ## should normally be switched off.
-  ## Requires execute the execute privilege on `dbms_monitor` to datadog user
-  #
-  # agent_sql_trace:
-
-    ## @param enabled - boolean - optional - default: false
-    ## Enable SQL trace
+    ## Configure collection of query samples
     #
-    # enabled: false
+    # query_samples:
 
-    ## @param enabled - boolean - optional - default: false
-    ## include bind variables in trace
-    #
-    # binds: false
+      ## @param enabled - boolean - optional - default: true
+      ## Enable collection of query samples. Requires `dbm: true`.
+      #
+      # enabled: true
 
-    ## @param enabled - boolean - optional - default: false
-    ## include wait events in trace
+    ## Configure collection of query metrics
     #
-    # waits: false
+    # query_metrics:
 
-    ## @param enabled - int - optional - default: 10
-    ## Limit the number of traced check executions to avoid filling the file system.
+      ## @param enabled - boolean - optional - default: true
+      ## Enable collection of query metrics. Requires enabled query samples.
+      #
+      # enabled: true
+
+    ## Configure collection of execution plans
     #
-    # traced_runs: 10
+    # execution_plans:
+
+      ## @param enabled - boolean - optional - default: true
+      ## Enable collection of execution plans. Requires query metrics.
+      #
+      # enabled: true
+
+    ## Configure collection of shared memory usage
+    #
+    # shared_memory:
+
+      ## @param enabled - boolean - optional - default: true. Requires `dbm: true`.
+      ## Enable collection of database shared memory usages
+      #
+      # enabled: true
+
+    ## Configure collection of database sysmetrics
+    #
+    # sysmetrics:
+
+      ## @param enabled - boolean - optional - default: true
+      ## Enable collection of database sysmetrics
+      #
+      # enabled: true
+
+    ## Configure collection of tablespace usage
+    #
+    # tablespaces:
+
+      ## @param enabled - boolean - optional - default: true
+      ## Enable collection of tablespace usage
+      #
+      # enabled: true
+
+    ## Configure collection of process memory usage
+    #
+    # processes:
+
+      ## @param enabled - boolean - optional - default: true
+      ## Enable collection of process memory usage
+      #
+      # enabled: true
+
+    ## Configure collection of resource manager statistics
+    #
+    # resource_manager:
+
+      ## @param enabled - boolean - optional - default: true
+      ## Enable collection of resource manager statistics
+      #
+      # enabled: true
+
+    ## Configure how the SQL obfuscator behaves.
+    ## Note: This option only applies when `dbm` is enabled.
+    #
+    # obfuscator_options:
+
+      ## @param replace_digits - boolean - optional - default: false
+      ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
+      ## Note: This option also applies to extracted tables using `collect_tables`.
+      #
+      # replace_digits: false
+
+      ## @param collect_metadata - boolean - optional - default: true
+      ## Set to `false` to disable the collection of metadata in your SQL statements.
+      ## Metadata includes things such as tables, commands, and comments.
+      #
+      # collect_metadata: true
+
+      ## @param collect_tables - boolean - optional - default: true
+      ## Set to `false` to disable the collection of tables in your SQL statements.
+      ## Requires `collect_metadata: true`.
+      #
+      # collect_tables: true
+
+      ## @param collect_commands - boolean - optional - default: true
+      ## Set to `false` to disable the collection of commands in your SQL statements.
+      ## Requires `collect_metadata: true`.
+      ##
+      ## Examples: SELECT, UPDATE, DELETE, etc.
+      #
+      # collect_commands: true
+
+      ## @param collect_comments - boolean - optional - default: true
+      ## Set to `false` to disable the collection of comments in your SQL statements.
+      ## Requires `collect_metadata: true`.
+      #
+      # collect_comments: true
+
+    ## @param use_global_custom_queries - string - optional - default: 'true'
+    ## How `global_custom_queries` should be used for this instance. There are 3 options:
+    ##
+    ## 1. true - `global_custom_queries` override `custom_queries`.
+    ## 2. false - `custom_queries` override `global_custom_queries`.
+    ## 3. extend - `global_custom_queries` are used in addition to any `custom_queries`.
+    #
+    # use_global_custom_queries: 'true'
+
+    ## @param custom_queries - list of mappings - optional
+    ## Each query must have 2 fields, and can have a third optional field:
+    ##
+    ## 1. metric_prefix - Each metric starts with the chosen prefix. The default is `oracle`.
+    ## 2. query - The SQL to execute. It can be a simple statement or a multi-line script.
+    ##            Use the pipe `|` if you require a multi-line script.
+    ## 3. columns - The list representing each column, ordered sequentially from left to right.
+    ##              The number of columns must equal the number of columns returned in the query.
+    ##              There are 2 required pieces of data:
+    ##                a. name - The suffix to append to `metric_prefix` to form
+    ##                          the full metric name. If `type` is `tag`, this column is
+    ##                          considered a tag and applied to every
+    ##                          metric collected by this particular query.
+    ##                b. type - The submission method (gauge, monotonic_count, etc.).
+    ##                          This can also be set to `tag` to tag each metric in the row
+    ##                          with the name and value of the item in this column. You can
+    ##                          use the `count` type to perform aggregation for queries that
+    ##                          return multiple rows with the same or no tags.
+    ##              Columns without a name are ignored. To skip a column, enter:
+    ##                - {}
+    ## 4. tags (optional) - A list of tags to apply to each metric.
+    #
+    ## WARNING: Running custom queries may result in additional costs or fees assessed by Oracle.
+    #
+    # custom_queries:
+    #   - metric_prefix: oracle
+    #     query: SELECT 'foo', 11 FROM dual
+    #     columns:
+    #     - name: foo
+    #       type: tag
+    #     - name: event.total
+    #       type: gauge
+    #     tags:
+    #     - test:tag_value_1
+    #     pdb: <MYPDB>
+
+    ## Start an SQL trace for Agent queries. This feature is only meant for Agent troubleshooting, and
+    ## should normally be switched off.
+    ## Requires execute the execute privilege on `dbms_monitor` to datadog user
+    #
+    # agent_sql_trace:
+
+      ## @param enabled - boolean - optional - default: false
+      ## Enable SQL trace
+      #
+      # enabled: false
+
+      ## @param enabled - boolean - optional - default: false
+      ## include bind variables in trace
+      #
+      # binds: false
+
+      ## @param enabled - boolean - optional - default: false
+      ## include wait events in trace
+      #
+      # waits: false
+
+      ## @param enabled - int - optional - default: 10
+      ## Limit the number of traced check executions to avoid filling the file system.
+      #
+      # traced_runs: 10


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR modifies the indents of `oracle.d/conf.yaml`.


before
```
instances:
- server: <HOST> or server: <HOST>:<PORT>
```

↓

after
```
instances:
  - server: <HOST> or server: <HOST>:<PORT>
```


put two-space indents to all the lines after L35

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
To improve visibility
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
