### PR TITLE
Attach `kube_service` tag to pods with `hostNetwork: true`

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -212,9 +212,8 @@ func (c *collector) parsePods(
 		}
 
 		// Skip `kube_service` label for pods that are not ready (since their endpoint will be disabled from the service)
-		// Skip pods with hostNetwork because we cannot use their IP to match endpoints.
 		services := []string{}
-		if !pod.Spec.HostNetwork && kubelet.IsPodReady(pod) {
+		if kubelet.IsPodReady(pod) {
 			for _, data := range metadata {
 				d := strings.Split(data, ":")
 				switch len(d) {

--- a/releasenotes/notes/kube_service_host_network-bd8bc188c9e200ef.yaml
+++ b/releasenotes/notes/kube_service_host_network-bd8bc188c9e200ef.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Also add `kube_service` tag to pods that run with `hostNetwork: true`.


### PR DESCRIPTION
### What does this PR do?

Lift the old technical limitation that was preventing `kube_service` tag to be attached to pods running with `hostNetwork: true`.

### Motivation

The potential issue with pods having `hostNetwork: true` is that all those pods share the same IP (the node IP).
But this isn’t an issue as long as we match pods by their name in service endpoints: https://github.com/DataDog/datadog-agent/blob/213682e97e1b6a265c00b46e6f66874d939d434a/pkg/util/kubernetes/apiserver/metadata_controller.go#L227

I validated that there was no confusion by creating two pods with `hostNetwork: true` on the same node and by querying the `/api/v1/tags/pod` DCA endpoint.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

* Create 3 pods on the same k8s node. Two with `hostNetwork: true`, one with the default `hostNetwork: false`.
* Attach a service to each of those pods.
* Check that, without this fix, only the pod with the default `hostNetwork: false` is tagged with `kube_service`.
* Chcek that, with this fix, all 3 pods are tagged with `kube_service`.
* Check that pods are tagged only with the relevant `kube_service`. (No confusion between all the pods sharing the same IP)