### PR TITLE
[Fleet Automation] Generate OCI package for the Windows Agent

### DIFF
--- a/.gitlab/deploy_packages/oci.yml
+++ b/.gitlab/deploy_packages/oci.yml
@@ -23,9 +23,9 @@ include:
     - ${CI_PROJECT_DIR}/tools/ci/retry.sh git clone --depth=1 https://github.com/DataDog/datadog-packages /tmp/datadog-packages
     - cd /tmp/datadog-packages/cmd/datadog-package
     - go build .
-    - ./datadog-package push registry.ddbuild.io/ci/remote-updates/${OCI_PRODUCT}:${VERSION} ${OMNIBUS_PACKAGE_DIR}/${OCI_PRODUCT}-${MAJOR_VERSION}.*.oci.tar
+    - ./datadog-package push registry.ddbuild.io/ci/remote-updates/${OCI_PRODUCT}:${VERSION} ${OMNIBUS_PACKAGE_DIR}/${OCI_PRODUCT}-${VERSION}.oci.tar
     # This is used for E2E tests. Doesn't cost more than an additional tag to the registry.
-    - ./datadog-package push registry.ddbuild.io/ci/remote-updates/${OCI_PRODUCT}:pipeline-${CI_PIPELINE_ID} ${OMNIBUS_PACKAGE_DIR}/${OCI_PRODUCT}-${MAJOR_VERSION}.*.oci.tar
+    - ./datadog-package push registry.ddbuild.io/ci/remote-updates/${OCI_PRODUCT}:pipeline-${CI_PIPELINE_ID} ${OMNIBUS_PACKAGE_DIR}/${OCI_PRODUCT}-${VERSION}.oci.tar
   variables:
     MAJOR_VERSION: 7
 

--- a/.gitlab/packaging/oci.yml
+++ b/.gitlab/packaging/oci.yml
@@ -29,7 +29,7 @@
     - ls $OMNIBUS_PACKAGE_DIR
     # Copy existing OCI (like the Windows one) to the output dir directly to be merged.
     - |
-      if [ $($OMNIBUS_PACKAGE_DIR/*.oci.tar 2> /dev/null | wc -l) -ge 1 ]; then
+      if [ $(ls $OMNIBUS_PACKAGE_DIR/*.oci.tar 2> /dev/null | wc -l) -ge 1 ]; then
         echo "Copying already built images to output dir"
         cp $OMNIBUS_PACKAGE_DIR/*.oci.tar ${OUTPUT_DIR}
       fi

--- a/.gitlab/packaging/oci.yml
+++ b/.gitlab/packaging/oci.yml
@@ -28,11 +28,7 @@
     - mkdir -p ${OUTPUT_DIR}
     - ls $OMNIBUS_PACKAGE_DIR
     # Copy existing OCI (like the Windows one) to the output dir directly to be merged.
-    - |
-      ls $OMNIBUS_PACKAGE_DIR/*.oci.tar 2> /dev/null
-      if [ $? -eq 0 ]; then
-        cp $OMNIBUS_PACKAGE_DIR/*.oci.tar ${OUTPUT_DIR}
-      fi
+    - if [ $($OMNIBUS_PACKAGE_DIR/*.oci.tar 2> /dev/null | wc -l) -ge 1 ]; then cp $OMNIBUS_PACKAGE_DIR/*.oci.tar ${OUTPUT_DIR}; fi
     - |
       for ARCH in "amd64" "arm64"; do
         INPUT_FILE="$OMNIBUS_PACKAGE_DIR/${OCI_PRODUCT}-*${ARCH}.tar.xz"

--- a/.gitlab/packaging/oci.yml
+++ b/.gitlab/packaging/oci.yml
@@ -28,7 +28,11 @@
     - mkdir -p ${OUTPUT_DIR}
     - ls $OMNIBUS_PACKAGE_DIR
     # Copy existing OCI (like the Windows one) to the output dir directly to be merged.
-    - cp $OMNIBUS_PACKAGE_DIR/*.oci.tar ${OUTPUT_DIR} 2>/dev/null
+    - |
+      ls $OMNIBUS_PACKAGE_DIR/*.oci.tar 2> /dev/null
+      if [ $? -eq 0 ]; then
+        cp $OMNIBUS_PACKAGE_DIR/*.oci.tar ${OUTPUT_DIR}
+      fi
     - |
       for ARCH in "amd64" "arm64"; do
         INPUT_FILE="$OMNIBUS_PACKAGE_DIR/${OCI_PRODUCT}-*${ARCH}.tar.xz"

--- a/.gitlab/packaging/oci.yml
+++ b/.gitlab/packaging/oci.yml
@@ -26,6 +26,9 @@
     - go build .
     - OUTPUT_DIR="/tmp/oci_output"
     - mkdir -p ${OUTPUT_DIR}
+    - ls $OMNIBUS_PACKAGE_DIR
+    # Copy existing OCI (like the Windows one) to the output dir directly to be merged.
+    - cp $OMNIBUS_PACKAGE_DIR/*.oci.tar ${OUTPUT_DIR} 2>/dev/null
     - |
       for ARCH in "amd64" "arm64"; do
         INPUT_FILE="$OMNIBUS_PACKAGE_DIR/${OCI_PRODUCT}-*${ARCH}.tar.xz"
@@ -64,7 +67,7 @@
 
 agent_oci:
   extends: .package_oci
-  needs: ["datadog-agent-oci-x64-a7", "datadog-agent-oci-arm64-a7"]
+  needs: ["datadog-agent-oci-x64-a7", "datadog-agent-oci-arm64-a7", "windows_msi_and_bosh_zip_x64-a7"]
   variables:
     OCI_PRODUCT: "datadog-agent"
 

--- a/.gitlab/packaging/oci.yml
+++ b/.gitlab/packaging/oci.yml
@@ -28,7 +28,11 @@
     - mkdir -p ${OUTPUT_DIR}
     - ls $OMNIBUS_PACKAGE_DIR
     # Copy existing OCI (like the Windows one) to the output dir directly to be merged.
-    - if [ $($OMNIBUS_PACKAGE_DIR/*.oci.tar 2> /dev/null | wc -l) -ge 1 ]; then cp $OMNIBUS_PACKAGE_DIR/*.oci.tar ${OUTPUT_DIR}; fi
+    - |
+      if [ $($OMNIBUS_PACKAGE_DIR/*.oci.tar 2> /dev/null | wc -l) -ge 1 ]; then
+        echo "Copying already built images to output dir"
+        cp $OMNIBUS_PACKAGE_DIR/*.oci.tar ${OUTPUT_DIR}
+      fi
     - |
       for ARCH in "amd64" "arm64"; do
         INPUT_FILE="$OMNIBUS_PACKAGE_DIR/${OCI_PRODUCT}-*${ARCH}.tar.xz"

--- a/tasks/winbuildscripts/Generate-OCIPackage.ps1
+++ b/tasks/winbuildscripts/Generate-OCIPackage.ps1
@@ -1,0 +1,24 @@
+$omnibusOutput = "c:\buildroot\datadog-agent\omnibus\pkg\"
+
+if (-not (Test-Path C:\tools\datadog-package.exe)) {
+    Write-Host "Downloading datadog-package.exe"
+    (New-Object System.Net.WebClient).DownloadFile("https://dd-agent-omnibus.s3.amazonaws.com/datadog-package.exe", "C:\\tools\\datadog-package.exe")
+}
+$rawAgentVersion = "{0}-1" -f (inv agent.version --url-safe --major-version 7)
+Write-Host "Detected agent version ${rawAgentVersion}"
+
+$packageName = "datadog-agent-${rawAgentVersion}-windows-amd64.oci.tar"
+
+if (Test-Path $omnibusOutput\$packageName) {
+    Remove-Item $omnibusOutput\$packageName
+}
+
+# datadog-package takes a folder as input and will package everything in that, so copy the msi to its own folder
+Remove-Item -Recurse -Force C:\oci-pkg -ErrorAction SilentlyContinue
+New-Item -ItemType Directory C:\oci-pkg
+Copy-Item (Get-ChildItem $omnibusOutput\datadog-agent-${rawAgentVersion}-x86_64.msi).FullName -Destination C:\oci-pkg\datadog-agent-${rawAgentVersion}-x86_64.msi
+
+# The argument --archive-path ".\omnibus\pkg\datadog-agent-${version}.tar.gz" is currently broken and has no effects
+& C:\tools\datadog-package.exe create --package datadog-agent --os windows --arch amd64 --archive --version $rawAgentVersion C:\oci-pkg
+
+Move-Item datadog-agent-${rawAgentVersion}-windows-amd64.tar $omnibusOutput\$packageName

--- a/tasks/winbuildscripts/dobuild.bat
+++ b/tasks/winbuildscripts/dobuild.bat
@@ -59,4 +59,10 @@ if "%OMNIBUS_TARGET%" == "main" (
     @echo "inv -e msi.build --major-version %MAJOR_VERSION% --python-runtimes "%PY_RUNTIMES%" --release-version %RELEASE_VERSION%
     inv -e msi.build --major-version %MAJOR_VERSION% --python-runtimes "%PY_RUNTIMES%" --release-version %RELEASE_VERSION% || exit /b 106
 )
+
+REM Build the OCI package for the Agent 7 only.
+if %MAJOR_VERSION% == 7 (
+    Powershell -C "./tasks/winbuildscripts/Generate-OCIPackage.ps1"
+)
+
 popd


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds a script that will generate the OCI image for the Windows Agent and it modifies the CI to merge the resulting OCI image with the Linux one.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://datadoghq.atlassian.net/browse/WINA-754

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Follow-up task: https://datadoghq.atlassian.net/browse/WINA-806
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Currently the `datadog-package` is hosted in S3. In a follow up PR, we'll need to either add it to the build image, or build it on the fly.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
