### PR TITLE
[autodiscovery] Delete misplaced comment

### DIFF
--- a/comp/core/autodiscovery/component.go
+++ b/comp/core/autodiscovery/component.go
@@ -3,11 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package tagger implements the Tagger component. The Tagger is the central
-// source of truth for client-side entity tagging. It runs Collectors that
-// detect entities and collect their tags. Tags are then stored in memory (by
-// the TagStore) and can be queried by the tagger.Tag() method.
-
 // Package autodiscovery provides the autodiscovery component for the Datadog Agent
 package autodiscovery
 


### PR DESCRIPTION
### What does this PR do?

Small cleanup. Removes a misplaced comment in the autodiscovery package.
The comment was pasted from the tagger component by mistake.

### Describe how to test/QA your changes

Skip.
