### PR TITLE
Fix cobra command error handling

### DIFF
--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -229,10 +229,10 @@ func installCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
 			i, err := newInstallerCmd("install")
-			defer func() { i.Stop(err) }()
 			if err != nil {
 				return err
 			}
+			defer func() { i.Stop(err) }()
 			i.span.SetTag("params.url", args[0])
 			return i.Install(i.ctx, args[0])
 		},
@@ -248,10 +248,10 @@ func removeCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
 			i, err := newInstallerCmd("remove")
-			defer func() { i.Stop(err) }()
 			if err != nil {
 				return err
 			}
+			defer func() { i.Stop(err) }()
 			i.span.SetTag("params.package", args[0])
 			return i.Remove(i.ctx, args[0])
 		},
@@ -267,10 +267,10 @@ func purgeCommand() *cobra.Command {
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
 			i, err := newInstallerCmd("purge")
-			defer func() { i.Stop(err) }()
 			if err != nil {
 				return err
 			}
+			defer func() { i.Stop(err) }()
 			i.Purge(i.ctx)
 			return nil
 		},
@@ -286,10 +286,10 @@ func installExperimentCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
 			i, err := newInstallerCmd("install_experiment")
-			defer func() { i.Stop(err) }()
 			if err != nil {
 				return err
 			}
+			defer func() { i.Stop(err) }()
 			i.span.SetTag("params.url", args[0])
 			return i.InstallExperiment(i.ctx, args[0])
 		},
@@ -305,10 +305,10 @@ func removeExperimentCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
 			i, err := newInstallerCmd("remove_experiment")
-			defer func() { i.Stop(err) }()
 			if err != nil {
 				return err
 			}
+			defer func() { i.Stop(err) }()
 			i.span.SetTag("params.package", args[0])
 			return i.RemoveExperiment(i.ctx, args[0])
 		},
@@ -324,10 +324,10 @@ func promoteExperimentCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
 			i, err := newInstallerCmd("promote_experiment")
-			defer func() { i.Stop(err) }()
 			if err != nil {
 				return err
 			}
+			defer func() { i.Stop(err) }()
 			i.span.SetTag("params.package", args[0])
 			return i.PromoteExperiment(i.ctx, args[0])
 		},
@@ -343,10 +343,10 @@ func garbageCollectCommand() *cobra.Command {
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
 			i, err := newInstallerCmd("garbage_collect")
-			defer func() { i.Stop(err) }()
 			if err != nil {
 				return err
 			}
+			defer func() { i.Stop(err) }()
 			return i.GarbageCollect(i.ctx)
 		},
 	}
@@ -366,10 +366,10 @@ func isInstalledCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
 			i, err := newInstallerCmd("is_installed")
-			defer func() { i.Stop(err) }()
 			if err != nil {
 				return err
 			}
+			defer func() { i.Stop(err) }()
 			installed, err := i.IsInstalled(i.ctx, args[0])
 			if err != nil {
 				return err

--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -96,8 +96,13 @@ type installerCmd struct {
 	installer.Installer
 }
 
-func newInstallerCmd(operation string) (*installerCmd, error) {
+func newInstallerCmd(operation string) (_ *installerCmd, err error) {
 	cmd := newCmd(operation)
+	defer func() {
+		if err != nil {
+			cmd.Stop(err)
+		}
+	}()
 	var opts []installer.Option
 	if cmd.registry != "" {
 		opts = append(opts, installer.WithRegistry(cmd.registry))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR moves the `defer` call in the cobra commands after checking for `err`.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
If `err != nil` then the `defer` code would dereference a `nil` pointer:
```
PS C:\dev\datadog-agent> .\bin\installer\installer.exe install oci://registry.ddbuild.io/ci/remote-updates/datadog-agent:7.55.0-devel.git.189.384c096.pipeline.34365942-1
telemetry disabled: missing DD_API_KEY
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x7ff66a5cc8f6]

goroutine 1 [running]:
github.com/DataDog/datadog-agent/cmd/installer/subcommands/installer.installCommand.func1.1()
        C:/dev/datadog-agent/cmd/installer/subcommands/installer/command.go:187 +0x16
```
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run the `install` command as an un-privileged user, it should print an error:
```
PS C:\dev\datadog-agent> (New-Object System.Security.Principal.WindowsPrincipal([System.Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
False
PS C:\dev\datadog-agent> .\bin\installer\installer.exe install oci://registry.ddbuild.io/ci/remote-updates/datadog-agent:7.55.0-devel.git.189.384c096.pipeline.34365942-1
telemetry disabled: missing DD_API_KEY
Error: could not create packages db: could not open database: open C:\ProgramData\Datadog Installer\packages.db: Access is denied.
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
