### PR TITLE
Remove unnecessary argument in CommonConfigure calls

### DIFF
--- a/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
+++ b/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
@@ -105,7 +105,7 @@ func (c *WinCrashConfig) Parse(data []byte) error {
 
 // Configure accepts the configuration
 func (wcd *AgentCrashDetect) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	err := wcd.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := wcd.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
+++ b/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
@@ -104,7 +104,7 @@ func (c *WinCrashConfig) Parse(data []byte) error {
 }
 
 // Configure accepts the configuration
-func (wcd *AgentCrashDetect) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (wcd *AgentCrashDetect) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	err := wcd.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err

--- a/comp/checks/windowseventlog/windowseventlogimpl/check/check.go
+++ b/comp/checks/windowseventlog/windowseventlogimpl/check/check.go
@@ -166,7 +166,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	// common CoreCheck requirements
 	// This check supports multiple instances, BuildID must be called before CommonConfigure
 	c.BuildID(integrationConfigDigest, data, initConfig)
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return fmt.Errorf("configuration error: %w", err)
 	}

--- a/comp/checks/winregistry/impl/winregistryimpl.go
+++ b/comp/checks/winregistry/impl/winregistryimpl.go
@@ -131,7 +131,7 @@ func createSchema() ([]byte, error) {
 func (c *WindowsRegistryCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
 	c.senderManager = senderManager
 	c.BuildID(integrationConfigDigest, data, initConfig)
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -96,8 +96,6 @@ func (c *CheckBase) Configure(senderManager sender.SenderManager, _ uint64, data
 
 // CommonConfigure is called when checks implement their own Configure method,
 // in order to setup common options (run interval, empty hostname)
-//
-//nolint:revive // TODO(AML) Fix revive linter
 func (c *CheckBase) CommonConfigure(senderManager sender.SenderManager, initConfig, instanceConfig integration.Data, source string) error {
 	c.senderManager = senderManager
 	handleConf := func(conf integration.Data, c *CheckBase) error {

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -78,7 +78,7 @@ func (c *CheckBase) BuildID(integrationConfigDigest uint64, instance, initConfig
 // the call to CommonConfigure must be preserved.
 func (c *CheckBase) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
 	c.senderManager = senderManager
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (c *CheckBase) Configure(senderManager sender.SenderManager, integrationCon
 // in order to setup common options (run interval, empty hostname)
 //
 //nolint:revive // TODO(AML) Fix revive linter
-func (c *CheckBase) CommonConfigure(senderManager sender.SenderManager, integrationConfigDigest uint64, initConfig, instanceConfig integration.Data, source string) error {
+func (c *CheckBase) CommonConfigure(senderManager sender.SenderManager, initConfig, instanceConfig integration.Data, source string) error {
 	c.senderManager = senderManager
 	handleConf := func(conf integration.Data, c *CheckBase) error {
 		commonOptions := integration.CommonInstanceConfig{}

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -76,7 +76,7 @@ func (c *CheckBase) BuildID(integrationConfigDigest uint64, instance, initConfig
 
 // Configure is provided for checks that require no config. If overridden,
 // the call to CommonConfigure must be preserved.
-func (c *CheckBase) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (c *CheckBase) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	c.senderManager = senderManager
 	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {

--- a/pkg/collector/corechecks/checkbase_test.go
+++ b/pkg/collector/corechecks/checkbase_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 )
@@ -38,13 +37,13 @@ func TestCommonConfigure(t *testing.T) {
 	}
 	mockSender := mocksender.NewMockSender(mycheck.ID())
 
-	err := mycheck.CommonConfigure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, []byte(defaultsInstance), "test")
+	err := mycheck.CommonConfigure(mockSender.GetSenderManager(), nil, []byte(defaultsInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, defaults.DefaultCheckInterval, mycheck.Interval())
 	mockSender.AssertNumberOfCalls(t, "DisableDefaultHostname", 0)
 
 	mockSender.On("DisableDefaultHostname", true).Return().Once()
-	err = mycheck.CommonConfigure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, []byte(customInstance), "test")
+	err = mycheck.CommonConfigure(mockSender.GetSenderManager(), nil, []byte(customInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 60*time.Second, mycheck.Interval())
 	mycheck.BuildID(1, []byte(customInstance), []byte(initConfig))
@@ -62,7 +61,7 @@ func TestCommonConfigureCustomID(t *testing.T) {
 	mockSender := mocksender.NewMockSender(mycheck.ID())
 
 	mockSender.On("DisableDefaultHostname", true).Return().Once()
-	err := mycheck.CommonConfigure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, []byte(customInstance), "test")
+	err := mycheck.CommonConfigure(mockSender.GetSenderManager(), nil, []byte(customInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 60*time.Second, mycheck.Interval())
 	mycheck.BuildID(1, []byte(customInstance), []byte(initConfig))

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -104,7 +104,7 @@ func newCheck() check.Check {
 func (hc *HelmCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
 	hc.BuildID(integrationConfigDigest, config, initConfig)
 
-	err := hc.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source)
+	err := hc.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -278,7 +278,7 @@ func TestRun(t *testing.T) {
 			// are not necessarily emitted in the first run. It depends on
 			// whether the check had time to process the events.
 
-			err := check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
+			err := check.CommonConfigure(mockedSender.GetSenderManager(), nil, nil, "")
 			require.NoError(t, err)
 
 			err = check.Run()
@@ -333,7 +333,7 @@ func TestRun_withCollectEvents(t *testing.T) {
 	mockedSender.SetupAcceptAll()
 
 	// First run to set up the informers.
-	err = check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
+	err = check.CommonConfigure(mockedSender.GetSenderManager(), nil, nil, "")
 	require.NoError(t, err)
 
 	err = check.Run()
@@ -425,7 +425,7 @@ func TestRun_skipEventForExistingRelease(t *testing.T) {
 	// Create a new release and check that we never send an event for it
 	_, err = k8sClient.CoreV1().Secrets("default").Create(context.TODO(), secret, metav1.CreateOptions{})
 	require.NoError(t, err)
-	err = check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
+	err = check.CommonConfigure(mockedSender.GetSenderManager(), nil, nil, "")
 	require.NoError(t, err)
 	err = check.Run()
 	require.NoError(t, err)
@@ -560,7 +560,7 @@ func TestRun_ServiceCheck(t *testing.T) {
 
 			k8sClient := fake.NewSimpleClientset()
 			check.informerFactory = informers.NewSharedInformerFactory(k8sClient, time.Minute)
-			err := check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
+			err := check.CommonConfigure(mockedSender.GetSenderManager(), nil, nil, "")
 			require.NoError(t, err)
 			err = check.Run()
 			require.NoError(t, err)

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -204,7 +204,7 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 	k.BuildID(integrationConfigDigest, config, initConfig)
 	k.agentConfig = ddconfig.Datadog
 
-	err := k.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source)
+	err := k.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -143,7 +143,7 @@ func newCheck() check.Check {
 }
 
 // Configure parses the check configuration and init the check.
-func (k *KubeASCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	err := k.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -144,7 +144,7 @@ func newCheck() check.Check {
 
 // Configure parses the check configuration and init the check.
 func (k *KubeASCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
-	err := k.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source)
+	err := k.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -114,7 +114,7 @@ func (o *OrchestratorCheck) Interval() time.Duration {
 func (o *OrchestratorCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
 	o.BuildID(integrationConfigDigest, config, initConfig)
 
-	err := o.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source)
+	err := o.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containerimage/check.go
+++ b/pkg/collector/corechecks/containerimage/check.go
@@ -110,7 +110,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 		return errors.New("collection of container images is disabled")
 	}
 
-	if err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source); err != nil {
+	if err := c.CommonConfigure(senderManager, initConfig, config, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/containerimage/check.go
+++ b/pkg/collector/corechecks/containerimage/check.go
@@ -105,7 +105,7 @@ func Factory(store workloadmeta.Component) optional.Option[func() check.Check] {
 }
 
 // Configure parses the check configuration and initializes the container_image check
-func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	if !ddConfig.Datadog.GetBool("container_image.enabled") {
 		return errors.New("collection of container images is disabled")
 	}

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -58,7 +58,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 
 	var err error
 
-	err = c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source)
+	err = c.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -51,7 +51,7 @@ type Check struct {
 }
 
 // Configure parses the check configuration and initializes the container_lifecycle check
-func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	if !ddConfig.Datadog.GetBool("container_lifecycle.enabled") {
 		return errors.New("collection of container lifecycle events is disabled")
 	}

--- a/pkg/collector/corechecks/containers/containerd/check.go
+++ b/pkg/collector/corechecks/containers/containerd/check.go
@@ -80,7 +80,7 @@ func (co *ContainerdConfig) Parse(data []byte) error {
 // Configure parses the check configuration and init the check
 func (c *ContainerdCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
 	var err error
-	if err = c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source); err != nil {
+	if err = c.CommonConfigure(senderManager, initConfig, config, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/containers/containerd/check.go
+++ b/pkg/collector/corechecks/containers/containerd/check.go
@@ -78,7 +78,7 @@ func (co *ContainerdConfig) Parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check
-func (c *ContainerdCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (c *ContainerdCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	var err error
 	if err = c.CommonConfigure(senderManager, initConfig, config, source); err != nil {
 		return err

--- a/pkg/collector/corechecks/containers/cri/check.go
+++ b/pkg/collector/corechecks/containers/cri/check.go
@@ -66,7 +66,7 @@ func (c *CRIConfig) Parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check
-func (c *CRICheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (c *CRICheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	var err error
 	if err = c.CommonConfigure(senderManager, initConfig, config, source); err != nil {
 		return err

--- a/pkg/collector/corechecks/containers/cri/check.go
+++ b/pkg/collector/corechecks/containers/cri/check.go
@@ -68,7 +68,7 @@ func (c *CRIConfig) Parse(data []byte) error {
 // Configure parses the check configuration and init the check
 func (c *CRICheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
 	var err error
-	if err = c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source); err != nil {
+	if err = c.CommonConfigure(senderManager, initConfig, config, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -78,7 +78,7 @@ func Factory(store workloadmeta.Component) optional.Option[func() check.Check] {
 
 // Configure parses the check configuration and init the check
 func (d *DockerCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
-	err := d.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source)
+	err := d.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -77,7 +77,7 @@ func Factory(store workloadmeta.Component) optional.Option[func() check.Check] {
 }
 
 // Configure parses the check configuration and init the check
-func (d *DockerCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (d *DockerCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	err := d.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/containers/generic/check.go
+++ b/pkg/collector/corechecks/containers/generic/check.go
@@ -56,7 +56,7 @@ func Factory(store workloadmeta.Component) optional.Option[func() check.Check] {
 
 // Configure parses the check configuration and init the check
 func (c *ContainerCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source)
+	err := c.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/generic/check.go
+++ b/pkg/collector/corechecks/containers/generic/check.go
@@ -55,7 +55,7 @@ func Factory(store workloadmeta.Component) optional.Option[func() check.Check] {
 }
 
 // Configure parses the check configuration and init the check
-func (c *ContainerCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (c *ContainerCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	err := c.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/containers/kubelet/kubelet.go
+++ b/pkg/collector/corechecks/containers/kubelet/kubelet.go
@@ -107,7 +107,7 @@ func Factory(store workloadmeta.Component) optional.Option[func() check.Check] {
 
 // Configure configures the check
 func (k *KubeletCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
-	err := k.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source)
+	err := k.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/kubelet/kubelet.go
+++ b/pkg/collector/corechecks/containers/kubelet/kubelet.go
@@ -106,7 +106,7 @@ func Factory(store workloadmeta.Component) optional.Option[func() check.Check] {
 }
 
 // Configure configures the check
-func (k *KubeletCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (k *KubeletCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	err := k.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/ebpf/ebpf.go
+++ b/pkg/collector/corechecks/ebpf/ebpf.go
@@ -62,7 +62,7 @@ func (c *EBPFCheckConfig) Parse(data []byte) error {
 
 // Configure parses the check configuration and init the check
 func (m *EBPFCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
-	if err := m.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source); err != nil {
+	if err := m.CommonConfigure(senderManager, initConfig, config, source); err != nil {
 		return err
 	}
 	if err := m.config.Parse(config); err != nil {

--- a/pkg/collector/corechecks/ebpf/ebpf.go
+++ b/pkg/collector/corechecks/ebpf/ebpf.go
@@ -61,7 +61,7 @@ func (c *EBPFCheckConfig) Parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check
-func (m *EBPFCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (m *EBPFCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	if err := m.CommonConfigure(senderManager, initConfig, config, source); err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
@@ -71,7 +71,7 @@ func (c *OOMKillConfig) Parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check
-func (m *OOMKillCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (m *OOMKillCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	err := m.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
@@ -72,7 +72,7 @@ func (c *OOMKillConfig) Parse(data []byte) error {
 
 // Configure parses the check configuration and init the check
 func (m *OOMKillCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
-	err := m.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source)
+	err := m.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/ebpf/tcpqueuelength/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcpqueuelength/tcp_queue_length.go
@@ -68,7 +68,7 @@ func (t *TCPQueueLengthConfig) Parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check
-func (t *TCPQueueLengthCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (t *TCPQueueLengthCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	err := t.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/ebpf/tcpqueuelength/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcpqueuelength/tcp_queue_length.go
@@ -69,7 +69,7 @@ func (t *TCPQueueLengthConfig) Parse(data []byte) error {
 
 // Configure parses the check configuration and init the check
 func (t *TCPQueueLengthCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
-	err := t.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source)
+	err := t.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/embed/process/process_agent.go
+++ b/pkg/collector/corechecks/embed/process/process_agent.go
@@ -155,7 +155,7 @@ func (c *ProcessAgentCheck) run() error {
 // Configure the ProcessAgentCheck
 //
 //nolint:revive // TODO(PROC) Fix revive linter
-func (c *ProcessAgentCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (c *ProcessAgentCheck) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	// only log whether process check is enabled or not but don't return early, because we still need to initialize "binPath", "source" and
 	// start up process-agent. Ultimately it's up to process-agent to decide whether to run or not based on the config
 	if enabled := config.Datadog.GetBool("process_config.process_collection.enabled"); !enabled {

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -24,7 +24,7 @@ type TestCheck struct {
 }
 
 //nolint:revive // TODO(AML) Fix revive linter
-func (c *TestCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initData integration.Data, source string) error {
+func (c *TestCheck) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initData integration.Data, source string) error {
 	if string(data) == "err" {
 		return fmt.Errorf("testError")
 	}

--- a/pkg/collector/corechecks/net/network/network.go
+++ b/pkg/collector/corechecks/net/network/network.go
@@ -281,7 +281,7 @@ func netstatTCPExtCounters() (map[string]int64, error) {
 }
 
 // Configure configures the network checks
-func (c *NetworkCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
+func (c *NetworkCheck) Configure(senderManager sender.SenderManager, _ uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
 	err := c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/net/network/network.go
+++ b/pkg/collector/corechecks/net/network/network.go
@@ -282,7 +282,7 @@ func netstatTCPExtCounters() (map[string]int64, error) {
 
 // Configure configures the network checks
 func (c *NetworkCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, rawInitConfig, rawInstance, source)
+	err := c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/net/ntp/ntp.go
+++ b/pkg/collector/corechecks/net/ntp/ntp.go
@@ -155,7 +155,7 @@ func (c *NTPCheck) Configure(senderManager sender.SenderManager, integrationConf
 	c.BuildID(integrationConfigDigest, data, initConfig)
 	c.cfg = cfg
 
-	err = c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err = c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
@@ -148,7 +148,7 @@ func (c *CiscoSdwanCheck) Configure(senderManager sender.SenderManager, integrat
 	// Must be called before c.CommonConfigure
 	c.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)
 
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, rawInitConfig, rawInstance, source)
+	err := c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/networkpath/networkpath.go
+++ b/pkg/collector/corechecks/networkpath/networkpath.go
@@ -113,7 +113,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	// Must be called before c.CommonConfigure
 	c.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)
 
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, rawInitConfig, rawInstance, source)
+	err := c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source)
 	if err != nil {
 		return fmt.Errorf("common configure failed: %s", err)
 	}

--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -155,7 +155,7 @@ func (c *JetsonCheck) Run() error {
 }
 
 // Configure the GPU check
-func (c *JetsonCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (c *JetsonCheck) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -156,7 +156,7 @@ func (c *JetsonCheck) Run() error {
 
 // Configure the GPU check
 func (c *JetsonCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -366,7 +366,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	// Must be called before c.CommonConfigure because this integration supports multiple instances
 	c.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)
 
-	if err := c.CommonConfigure(senderManager, integrationConfigDigest, rawInitConfig, rawInstance, source); err != nil {
+	if err := c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source); err != nil {
 		return fmt.Errorf("common configure failed: %s", err)
 	}
 

--- a/pkg/collector/corechecks/orchestrator/ecs/ecs.go
+++ b/pkg/collector/corechecks/orchestrator/ecs/ecs.go
@@ -77,7 +77,7 @@ func (c *Check) Configure(
 ) error {
 	c.BuildID(integrationConfigDigest, data, initConfig)
 
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/orchestrator/pod/pod.go
+++ b/pkg/collector/corechecks/orchestrator/pod/pod.go
@@ -72,7 +72,7 @@ func (c *Check) Configure(
 ) error {
 	c.BuildID(integrationConfigDigest, data, initConfig)
 
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -128,7 +128,7 @@ func Factory(store workloadmeta.Component, cfg config.Component) optional.Option
 }
 
 // Configure parses the check configuration and initializes the sbom check
-func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	if !c.cfg.GetBool("sbom.enabled") {
 		return errors.New("collection of SBOM is disabled")
 	}

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -133,7 +133,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 		return errors.New("collection of SBOM is disabled")
 	}
 
-	if err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, config, source); err != nil {
+	if err := c.CommonConfigure(senderManager, initConfig, config, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -149,7 +149,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	// Must be called before c.CommonConfigure
 	c.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)
 
-	err = c.CommonConfigure(senderManager, integrationConfigDigest, rawInitConfig, rawInstance, source)
+	err = c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source)
 	if err != nil {
 		return fmt.Errorf("common configure failed: %s", err)
 	}

--- a/pkg/collector/corechecks/system/cpu/cpu/cpu.go
+++ b/pkg/collector/corechecks/system/cpu/cpu/cpu.go
@@ -93,7 +93,7 @@ func (c *Check) Run() error {
 }
 
 // Configure the CPU check
-func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/system/cpu/cpu/cpu.go
+++ b/pkg/collector/corechecks/system/cpu/cpu/cpu.go
@@ -94,7 +94,7 @@ func (c *Check) Run() error {
 
 // Configure the CPU check
 func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/cpu/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu/cpu_windows.go
@@ -145,7 +145,7 @@ func addProcessorPdhCounter(query *pdhutil.PdhQuery, counterName string) pdhutil
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	if err := c.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/cpu/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu/cpu_windows.go
@@ -146,7 +146,7 @@ func addProcessorPdhCounter(query *pdhutil.PdhQuery, counterName string) pdhutil
 
 // Configure the CPU check doesn't need configuration
 func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	if err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source); err != nil {
+	if err := c.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/cpu/load/load.go
+++ b/pkg/collector/corechecks/system/cpu/load/load.go
@@ -63,7 +63,7 @@ func (c *LoadCheck) Run() error {
 
 // Configure the CPU check
 func (c *LoadCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/cpu/load/load.go
+++ b/pkg/collector/corechecks/system/cpu/load/load.go
@@ -62,7 +62,7 @@ func (c *LoadCheck) Run() error {
 }
 
 // Configure the CPU check
-func (c *LoadCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (c *LoadCheck) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/system/disk/disk/disk_nix.go
+++ b/pkg/collector/corechecks/system/disk/disk/disk_nix.go
@@ -144,7 +144,7 @@ func (c *Check) sendDiskMetrics(sender sender.Sender, ioCounter disk.IOCountersS
 
 // Configure the disk check
 func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/disk/disk/disk_nix.go
+++ b/pkg/collector/corechecks/system/disk/disk/disk_nix.go
@@ -143,7 +143,7 @@ func (c *Check) sendDiskMetrics(sender sender.Sender, ioCounter disk.IOCountersS
 }
 
 // Configure the disk check
-func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/system/disk/io/iostats.go
+++ b/pkg/collector/corechecks/system/disk/io/iostats.go
@@ -27,7 +27,7 @@ const (
 )
 
 // Configure the IOstats check
-func (c *IOCheck) commonConfigure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (c *IOCheck) commonConfigure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	if err := c.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/disk/io/iostats.go
+++ b/pkg/collector/corechecks/system/disk/io/iostats.go
@@ -28,7 +28,7 @@ const (
 
 // Configure the IOstats check
 func (c *IOCheck) commonConfigure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	if err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source); err != nil {
+	if err := c.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/disk/io/iostats.go
+++ b/pkg/collector/corechecks/system/disk/io/iostats.go
@@ -27,7 +27,7 @@ const (
 )
 
 // Configure the IOstats check
-func (c *IOCheck) commonConfigure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (c *IOCheck) commonConfigure(senderManager sender.SenderManager, data integration.Data, initConfig integration.Data, source string) error {
 	if err := c.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/disk/io/iostats_nix.go
+++ b/pkg/collector/corechecks/system/disk/io/iostats_nix.go
@@ -41,8 +41,8 @@ type IOCheck struct {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	err := c.commonConfigure(senderManager, integrationConfigDigest, data, initConfig, source)
+func (c *IOCheck) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
+	err := c.commonConfigure(senderManager, data, initConfig, source)
 	return err
 }
 

--- a/pkg/collector/corechecks/system/disk/io/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/disk/io/iostats_pdh_windows.go
@@ -77,8 +77,8 @@ func isDrive(instance string) bool {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	err := c.commonConfigure(senderManager, integrationConfigDigest, data, initConfig, source)
+func (c *IOCheck) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
+	err := c.commonConfigure(senderManager, data, initConfig, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/filehandles/file_handles_bsd.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_bsd.go
@@ -54,7 +54,7 @@ func (c *fhCheck) Run() error {
 }
 
 // The check doesn't need configuration
-func (c *fhCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
+func (c *fhCheck) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
 	if err := c.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/filehandles/file_handles_bsd.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_bsd.go
@@ -55,7 +55,7 @@ func (c *fhCheck) Run() error {
 
 // The check doesn't need configuration
 func (c *fhCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
-	if err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source); err != nil {
+	if err := c.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
@@ -56,7 +56,7 @@ func (c *fhCheck) Run() error {
 
 // The check doesn't need configuration
 func (c *fhCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
-	if err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source); err != nil {
+	if err := c.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
@@ -55,7 +55,7 @@ func (c *fhCheck) Run() error {
 }
 
 // The check doesn't need configuration
-func (c *fhCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
+func (c *fhCheck) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
 	if err := c.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/memory/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows.go
@@ -35,7 +35,7 @@ const mbSize float64 = 1024 * 1024
 
 // Configure handles initial configuration/initialization of the check
 func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
-	if err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source); err != nil {
+	if err := c.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/memory/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows.go
@@ -34,7 +34,7 @@ type Check struct {
 const mbSize float64 = 1024 * 1024
 
 // Configure handles initial configuration/initialization of the check
-func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
 	if err := c.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect.go
@@ -71,7 +71,7 @@ func (c *WinCrashConfig) Parse(data []byte) error {
 }
 
 // Configure accepts configuration
-func (wcd *WinCrashDetect) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (wcd *WinCrashDetect) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	err := wcd.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect.go
@@ -72,7 +72,7 @@ func (c *WinCrashConfig) Parse(data []byte) error {
 
 // Configure accepts configuration
 func (wcd *WinCrashDetect) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	err := wcd.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := wcd.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/winkmem/winkmem.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem.go
@@ -93,7 +93,7 @@ func (w *KMemCheck) Configure(senderManager sender.SenderManager, integrationCon
 		return err
 	}
 
-	if err := w.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source); err != nil {
+	if err := w.CommonConfigure(senderManager, initConfig, data, source); err != nil {
 		return err
 	}
 	cf := Config{

--- a/pkg/collector/corechecks/system/winkmem/winkmem.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem.go
@@ -83,7 +83,7 @@ init_config:
 */
 
 // Configure is called to configure the object prior to the first run
-func (w *KMemCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (w *KMemCheck) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	// check to make sure the function is actually there, so we can fail gracefully
 	// if it's not
 	if err := modntdll.Load(); err != nil {

--- a/pkg/collector/corechecks/system/winproc/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc/winproc_windows.go
@@ -56,7 +56,7 @@ func (c *processChk) Run() error {
 	return nil
 }
 
-func (c *processChk) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+func (c *processChk) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string) error {
 	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/system/winproc/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc/winproc_windows.go
@@ -57,7 +57,7 @@ func (c *processChk) Run() error {
 }
 
 func (c *processChk) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, initConfig, data, source)
+	err := c.CommonConfigure(senderManager, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -534,7 +534,7 @@ func (c *SystemdCheck) Configure(senderManager sender.SenderManager, integration
 	// Must be called before CommonConfigure that uses checkID
 	c.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)
 
-	err := c.CommonConfigure(senderManager, integrationConfigDigest, rawInitConfig, rawInstance, source)
+	err := c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Remove unnecessary argument in `CommonConfigure` calls
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
 **Dead code** code smell
In the context of a method argument, if an argument is declared but not used within the method body, it indicates potential dead code. This can clutter the codebase and may lead to confusion for other developers, so it's generally considered good practice to remove such unused arguments to keep the code clean and maintainable.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
It does not require new tests as it is a code smell refactor. No new functionality is added.
The condition is that the tests existing until now continue to work in the same way.
