### PR TITLE
remote workload meta client: fix handling of `io.EOF` errors

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -210,7 +210,7 @@ func (c *GenericCollector) Run() {
 		}
 		if err != nil {
 			// at the end of stream, but its OK
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				continue
 			}
 


### PR DESCRIPTION
### What does this PR do?

I'm investigating some strange spikes generated from the remote workloadmeta client. [Profile displaying the issue](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Asecurity-agent%20host%3Aeu1-staging-dog-lagaffe-k8s-8a09ddfb64636a53-6m4q.c.datadog-staging.internal&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&group_by=line&my_code=disabled&selected_tf=1715835580696.7175%2C1715838901628.158&viz=flame_graph&start=1715832940115&end=1715847340115&paused=true). During this investigation I found a lot of the following logs:
```
2024-05-16 12:22:51 UTC | SECURITY | WARN | (comp/core/workloadmeta/collectors/internal/remote/generic.go:228 in Run) | error received from remote workloadmeta: rpc error: code = Unavailable desc = error reading from server: EOF
```
which indicates that we are not handling EOF correctly when `Recv`-ing from the entity stream.

This PR fixes this by using `errors.Is` correctly handling wrapped EOF errors (if `io.EOF` is returned directly it continues to work).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Deploy the agent with at least one remote workloadmeta client (for example CWS enabled, and `security_agent.remote_workloadmeta` set to true)
- Ensure the workloadmeta is working as expected (for example you can `ListContainers` from the remote client)
One good way of doing that is checking that the metric `datadog.security_agent.runtime.containers_running` is reporting a value > 0, and close to `kubernetes.containers.running` (a delta is expected, for internal reasons, but > 0 should be good enough to ensure this PR is working as expected).