### PR TITLE
[ksm] Delete spammy debug log

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -956,7 +956,6 @@ func ownerTags(kind, name string) []string {
 
 	tagKey, found := kubernetes.KindToTagName[kind]
 	if !found {
-		log.Debugf("Unknown owner kind %q", kind)
 		return nil
 	}
 


### PR DESCRIPTION
### What does this PR do?

Deletes a spammy debug log in the KSM core check.
While investigating an issue, I set the log level to "debug" and noticed that this line appeared lots of times.


### Describe how to test/QA your changes

Skip.
