### PR TITLE
(fleet) fix the installer PID file

### DIFF
--- a/omnibus/config/templates/installer/datadog-installer-exp.service.erb
+++ b/omnibus/config/templates/installer/datadog-installer-exp.service.erb
@@ -7,11 +7,11 @@ JobTimeoutSec=3000 #50 minutes
 
 [Service]
 Type=oneshot
-PIDFile=<%= installer_dir %>/run/installer.pid
+PIDFile=/var/run/datadog/installer/installer.pid
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= installer_dir %>/bin/installer/installer run -p <%= installer_dir %>/run/installer.pid
-ExecStart=<%= installer_dir %>/bin/installer/installer run -p <%= installer_dir %>/run/installer.pid
-ExecStart=<%= installer_dir %>/bin/installer/installer run -p <%= installer_dir %>/run/installer.pid
+ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog/installer/installer.pid
+ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog/installer/installer.pid
+ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog/installer/installer.pid
 ExecStart=/bin/false
 ExecStop=/bin/false
 

--- a/omnibus/config/templates/installer/datadog-installer.service.erb
+++ b/omnibus/config/templates/installer/datadog-installer.service.erb
@@ -5,10 +5,10 @@ Conflicts=datadog-installer-exp.service
 
 [Service]
 Type=simple
-PIDFile=<%= installer_dir %>/run/installer.pid
+PIDFile=/var/run/datadog/installer/installer.pid
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= installer_dir %>/bin/installer/installer run -p <%= installer_dir %>/run/installer.pid
+ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog/installer/installer.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10


### PR DESCRIPTION
A recent PR moved the run dir to `/var/run/datadog/installer` for the installer. We forgot to also move the PID file.