### PR TITLE
Improve error handling by using errors.Is

### DIFF
--- a/comp/core/tagger/taggerimpl/remote/tagger.go
+++ b/comp/core/tagger/taggerimpl/remote/tagger.go
@@ -151,7 +151,7 @@ func (t *Tagger) Start(ctx context.Context) error {
 	err = t.startTaggerStream(timeout)
 	if err != nil {
 		// tagger stopped before being connected
-		if err == errTaggerStreamNotStarted {
+		if errors.Is(err, errTaggerStreamNotStarted) {
 			return nil
 		}
 		return err

--- a/comp/core/workloadmeta/collectors/internal/docker/docker.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker.go
@@ -382,7 +382,7 @@ func extractImage(ctx context.Context, container types.ContainerJSON, resolve re
 			log.Debugf("cannot split image name %q for container %q: %s", resolvedImageSpec, container.ID, err)
 
 			// fallback and try to parse the original imageSpec anyway
-			if err == containers.ErrImageIsSha256 {
+			if errors.Is(err, containers.ErrImageIsSha256) {
 				name, registry, shortName, tag, err = containers.SplitImageName(imageSpec)
 				if err != nil {
 					log.Debugf("cannot split image name %q for container %q: %s", imageSpec, container.ID, err)

--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -10,6 +10,7 @@ package kubelet
 
 import (
 	"context"
+	stdErrors "errors"
 	"strings"
 	"time"
 
@@ -217,7 +218,7 @@ func (c *collector) parsePodContainers(
 
 		image, err := workloadmeta.NewContainerImage(imageID, container.Image)
 		if err != nil {
-			if err == containers.ErrImageIsSha256 {
+			if stdErrors.Is(err, containers.ErrImageIsSha256) {
 				// try the resolved image ID if the image name in the container
 				// status is a SHA256. this seems to happen sometimes when
 				// pinning the image to a SHA256

--- a/pkg/collector/corechecks/containers/kubelet/common/testing/utils.go
+++ b/pkg/collector/corechecks/containers/kubelet/common/testing/utils.go
@@ -10,6 +10,7 @@ package testing
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -185,7 +186,7 @@ func StorePopulatedFromFile(store workloadmeta.Mock, filename string, podUtils *
 
 			image, err := workloadmeta.NewContainerImage(container.ImageID, container.Image)
 			if err != nil {
-				if err == containers.ErrImageIsSha256 {
+				if errors.Is(err, containers.ErrImageIsSha256) {
 					// try the resolved image ID if the image name in the container
 					// status is a SHA256. this seems to happen sometimes when
 					// pinning the image to a SHA256


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Replace  '==' with errors.Is in error comparison in tagger, workloadmeta and autodiscovery component

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Inspired by this [PR](https://github.com/DataDog/datadog-agent/pull/25653/), it is now the [best practice](https://go.dev/wiki/ErrorValueFAQ) to use errors.Is instead of "=="


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
