### PR TITLE
[pkg/util] Improve NTP server detection message

### DIFF
--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -86,7 +86,7 @@ func GetCloudProviderNTPHosts(ctx context.Context) []string {
 
 	for _, cloudNTPDetector := range detectors {
 		if cloudNTPServers := cloudNTPDetector.callback(ctx); cloudNTPServers != nil {
-			log.Infof("Using NTP servers from %s cloud provider: %+q", cloudNTPDetector.name, cloudNTPServers)
+			log.Infof("Detected %s cloud provider environment with NTP server(s) at %+q", cloudNTPDetector.name, cloudNTPServers)
 			return cloudNTPServers
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

This commit improves the NTP server detection message by ensuring that the log entry language does not imply that the NTP server(s) detected will be the exact one used by the NTP check since they can be overridden by a local config.

Old message:
```
... | Using NTP servers from GCP cloud provider: [metadata.google.internal]
```

New message:
```
... | Detected GCP cloud provider environment with NTP server(s) at [metadata.google.internal]
```

### Motivation

The original log line implied that the cloud provider NTP servers will be used for the NTP check but that is not the case when they are overridden by a local NTP config.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

N/A
