### PR TITLE
Add compdef.In and some additional error checking

### DIFF
--- a/comp/def/type.go
+++ b/comp/def/type.go
@@ -6,5 +6,8 @@
 // Package compdef defines basic types used for components
 package compdef
 
+// In has no semantic meaning, but makes conversion a bit easier
+type In struct{}
+
 // Out can be put in a struct that represents a collection of Components
 type Out struct{}


### PR DESCRIPTION
### What does this PR do?

Additional error checking provides better errors when compdef.In and compdef.Out are used incorrectly.

compdef.In is not needed, and provides no functionality, but makes conversion from fx to compdef a little easier to do.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

During conversion of components to the new `multi-impl` layout, I ran into some issues that would have been solved via additional error checking. This PR will make future conversions a bit easier.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
