### PR TITLE
[CWS] improve size of `args_envs_event_t` by making it dynamic

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -460,7 +460,11 @@ void __attribute__((always_inline)) parse_args_envs(void *ctx, struct args_envs_
                     offset += bytes_read + 1; // count trailing 0
                 }
 
-                send_event(ctx, EVENT_ARGS_ENVS, event);
+                u64 size = offsetof(struct args_envs_event_t, value) + event.size;
+                if (size > sizeof(struct args_envs_event_t)) {
+                    size = sizeof(struct args_envs_event_t);
+                }
+                send_event_with_size_ptr(ctx, EVENT_ARGS_ENVS, &event, size);
                 event.size = 0;
             } else {
                 event.size += data_length;

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -304,7 +304,7 @@ func (e *InvalidateDentryEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *ArgsEnvsEvent) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < MaxArgEnvSize+8 {
+	if len(data) < 8 {
 		return 0, ErrNotEnoughData
 	}
 
@@ -313,9 +313,20 @@ func (e *ArgsEnvsEvent) UnmarshalBinary(data []byte) (int, error) {
 	if e.Size > MaxArgEnvSize {
 		e.Size = MaxArgEnvSize
 	}
-	SliceToArray(data[8:MaxArgEnvSize+8], e.ValuesRaw[:])
 
-	return MaxArgEnvSize + 8, nil
+	argsEnvSize := int(e.Size)
+	data = data[8:]
+	if len(data) < argsEnvSize {
+		return 8, ErrNotEnoughData
+	}
+
+	for i := range e.ValuesRaw {
+		e.ValuesRaw[i] = 0
+	}
+
+	SliceToArray(data[:argsEnvSize], e.ValuesRaw[:argsEnvSize])
+
+	return 8 + argsEnvSize, nil
 }
 
 // UnmarshalBinary unmarshals the given content


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR makes the `args_envs_event_t` dynamic my sending only what is required and not the trailing 0s if possible, in a similar way than what is done with DNS events.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
