### PR TITLE
[CWS] increase test timeout to account for host tags delays

### DIFF
--- a/test/new-e2e/tests/cws/ec2_test.go
+++ b/test/new-e2e/tests/cws/ec2_test.go
@@ -214,7 +214,7 @@ func (a *agentSuite) Test03OpenSignal() {
 			assert.Contains(c, e.Tags, "tag1", "missing event tag")
 			assert.Contains(c, e.Tags, "tag2", "missing event tag")
 		})
-	}, 4*time.Minute, 20*time.Second)
+	}, 10*time.Minute, 30*time.Second)
 
 	// Check app signal
 	assert.EventuallyWithT(a.T(), func(c *assert.CollectT) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

It can take up to 10 minutes for CWS events to be enriched with host tags. In most cases the actual delay is way lower, but in some rare cases it exceeds the corresponding test timeout, causing it to fail. 
This PR then increases the test timeout to 10 minutes with the aim of making it more stable.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
