### PR TITLE
[CWS] do not send cpu in `kevent_t`

### DIFF
--- a/pkg/security/ebpf/c/include/structs/events_context.h
+++ b/pkg/security/ebpf/c/include/structs/events_context.h
@@ -5,7 +5,6 @@
 #include "dentry_resolver.h"
 
 struct kevent_t {
-    u64 cpu;
     u64 timestamp;
     u32 type;
     u32 flags;

--- a/pkg/security/probe/eventstream/reorderer/perfmap.go
+++ b/pkg/security/probe/eventstream/reorderer/perfmap.go
@@ -91,13 +91,13 @@ func (m *OrderedPerfMap) Resume() error {
 
 // ExtractEventInfo extracts cpu and timestamp from the raw data event
 func ExtractEventInfo(record *perf.Record) (QuickInfo, error) {
-	if len(record.RawSample) < 16 {
+	if len(record.RawSample) < 8 {
 		return QuickInfo{}, model.ErrNotEnoughData
 	}
 
 	return QuickInfo{
-		CPU:       binary.NativeEndian.Uint64(record.RawSample[0:8]),
-		Timestamp: binary.NativeEndian.Uint64(record.RawSample[8:16]),
+		CPU:       uint64(record.CPU),
+		Timestamp: binary.NativeEndian.Uint64(record.RawSample[0:8]),
 	}, nil
 }
 

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -75,15 +75,15 @@ func (e *ChownEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *Event) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 24 {
+	if len(data) < 16 {
 		return 0, ErrNotEnoughData
 	}
 
-	e.TimestampRaw = binary.NativeEndian.Uint64(data[8:16])
-	e.Type = binary.NativeEndian.Uint32(data[16:20])
-	e.Flags = binary.NativeEndian.Uint32(data[20:24])
+	e.TimestampRaw = binary.NativeEndian.Uint64(data[0:8])
+	e.Type = binary.NativeEndian.Uint32(data[8:12])
+	e.Flags = binary.NativeEndian.Uint32(data[12:16])
 
-	return 24, nil
+	return 16, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself


### PR DESCRIPTION
### What does this PR do?

The CPU is not unmarshaled except for perf ring quick info (sorting purposes). This PR removes it since the CPU is already accessible through other ways, winning 8 bytes in every events going in the ring buffer.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
