### PR TITLE
[kitchen/e2e] update amazon linux 2023 x86_64

### DIFF
--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -132,7 +132,7 @@
                 "amazonlinux2-4-14": "ami-038b3df3312ddf25d",
                 "amazonlinux2-5-10": "ami-06a0cd9728546d178",
                 "amazonlinux2022-5-15": "ami-0f0f00c2d082c52ae",
-                "amazonlinux2023": "ami-09a843efa5c250b9c"
+                "amazonlinux2023": "ami-0f01e3f9e6afe7661"
             },
             "arm64": {
                 "amazonlinux2-4-14": "ami-090230ed0c6b13c74",

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -138,7 +138,7 @@
                 "amazonlinux2-4-14": "ami-090230ed0c6b13c74",
                 "amazonlinux2-5-10": "ami-09e51988f56677f44",
                 "amazonlinux2022-5-15": "ami-0acc51c3357f26240",
-                "amazonlinux2023": "ami-08fc6fb8ad2e794bb"
+                "amazonlinux2023": "ami-0a515c154e76934f7"
             }
         }
     },

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -132,7 +132,7 @@
                 "amazonlinux2-4-14": "ami-038b3df3312ddf25d",
                 "amazonlinux2-5-10": "ami-06a0cd9728546d178",
                 "amazonlinux2022-5-15": "ami-0f0f00c2d082c52ae",
-                "amazonlinux2023": "ami-0f01e3f9e6afe7661"
+                "amazonlinux2023": "ami-064ed2d3fc01d3ec1"
             },
             "arm64": {
                 "amazonlinux2-4-14": "ami-090230ed0c6b13c74",

--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -37,7 +37,7 @@
             "amazonlinux2-4-14": "ami-038b3df3312ddf25d",
             "amazonlinux2-5-10": "ami-06a0cd9728546d178",
             "amazonlinux2022-5-15": "ami-0f0f00c2d082c52ae",
-            "amazonlinux2023": "ami-0f01e3f9e6afe7661"
+            "amazonlinux2023": "ami-064ed2d3fc01d3ec1"
         },
         "arm64": {
             "amazonlinux2-4-14": "ami-090230ed0c6b13c74",

--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -43,7 +43,7 @@
             "amazonlinux2-4-14": "ami-090230ed0c6b13c74",
             "amazonlinux2-5-10": "ami-09e51988f56677f44",
             "amazonlinux2022-5-15": "ami-0acc51c3357f26240",
-            "amazonlinux2023": "ami-08fc6fb8ad2e794bb"
+            "amazonlinux2023": "ami-0a515c154e76934f7"
         }
     },
     "centos": {

--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -37,7 +37,7 @@
             "amazonlinux2-4-14": "ami-038b3df3312ddf25d",
             "amazonlinux2-5-10": "ami-06a0cd9728546d178",
             "amazonlinux2022-5-15": "ami-0f0f00c2d082c52ae",
-            "amazonlinux2023": "ami-09a843efa5c250b9c"
+            "amazonlinux2023": "ami-0f01e3f9e6afe7661"
         },
         "arm64": {
             "amazonlinux2-4-14": "ami-090230ed0c6b13c74",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

* Update Amazon Linux 2023 x86_64 AMI for kitchen an E2E tests with a copy of AMI `ami-0bb84b8ffd87024d8`, Amazon Linux 2023 x86_64, targeting `runc-1.1.11-1.amzn2023.0.1.src.rpm`
* Update Amazon Linux 2023 arm64 AMI for kitchen and E2E tests with a copy of AMI `ami-04b395c05193adbbd` from `al2023-ami-2023.4.20240513.0-kernel-6.1-arm64` targeting `runc-1.1.11-1.amzn2023.0.1.src.rpm`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Previous hosts are affected by https://nvd.nist.gov/vuln/detail/CVE-2024-21626

Incident-27459
Incident-27490

The previous Amazon Linux 2023 x86_64 in use in our e2e tests had a security vulnerability due to the version of `runc`, installed at `docker` install within the agent security kitchen tests. 

The CVE mentions that the vulnerability is fixed in `runc 1.1.12+`, but for Amazon Linux 2023 this is fixed in `runc-1.1.11-1.amzn2023.0.1+`, as mentioned in https://alas.aws.amazon.com/AL2023/ALAS-2024-501.html

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->



### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

* cd to `~/dd/test-infra-definitions` 
* create a VM using 

```bash
inv create-vm -m ami-0a515c154e76934f7 -o amazonlinux --no-install-agent   
``` 

* ssh to the VM
* Run `yum info runc` and ensure the target package version is `runc-1.1.11-1.amzn2023.0.1.src.rpm`
* Destroy the VM with `inv destroy-vm -y`
* Create a VM using 

```bash
inv create-vm -m ami-064ed2d3fc01d3ec1 -o amazonlinux --no-install-agent   
``` 

* ssh to the VM
* Run `yum info runc` and ensure the target package version is `runc-1.1.11-1.amzn2023.0.1.src.rpm`
* Destroy the VM with `inv destroy-vm -y`