### PR TITLE
Fix flaky TestContainerLifecycleEvents e2e test

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -1071,6 +1071,8 @@ func (suite *k8sSuite) TestContainerLifecycleEvents() {
 	suite.Require().EventuallyWithTf(func(c *assert.CollectT) {
 		pods, err := suite.K8sClient.CoreV1().Pods("workload-nginx").List(context.Background(), metav1.ListOptions{
 			LabelSelector: fields.OneTermEqualSelector("app", "nginx").String(),
+			FieldSelector: fields.OneTermEqualSelector("status.phase", "Running").String(),
+			Limit:         1,
 		})
 		// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
 		if !assert.NoErrorf(c, err, "Failed to list nginx pods") {


### PR DESCRIPTION
### What does this PR do?

In the `TestContainerLifecycleEvents` e2e test, consider only Nginx pods which are in `Running` phase.

### Motivation

[`TestContainerLifecycleEvents` is currently a bit flaky](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%28%40test.name%3ATestEKSSuite%2FTestContainerLifecycleEvents%20OR%20%40test.name%3ATestKindSuite%2FTestContainerLifecycleEvents%29&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=AgAAAY-Gr2JeWFtskgAAAAAAAAAYAAAAAEFZLUdyMkplQUFDcG9Lems5VHFPVG9NTQAAACQAAAAAMDE4Zjg2YjEtMDVlNi00MTI0LWJiYzEtZGEwOGZhMjcyMDEy&fromUser=false&index=citest&mode=sliding&saved-view-id=2236559&testId=AgAAAY-Gr2JeWFtskgAAAAAAAAAYAAAAAEFZLUdyMkplQUFDcG9Lems5VHFPVG9NTQAAACQAAAAAMDE4Zjg2YjEtMDVlNi00MTI0LWJiYzEtZGEwOGZhMjcyMDEy&trace=AgAAAY-Gr2JeWFtskgAAAAAAAAAYAAAAAEFZLUdyMkplQUFDcG9Lems5VHFPVG9NTQAAACQAAAAAMDE4Zjg2YjEtMDVlNi00MTI0LWJiYzEtZGEwOGZhMjcyMDEy&start=1715360415845&end=1715965215845&paused=false).

The investigation showed that the Nginx pod considered for the test, that has been deleted and for which a lifecycle event is expected, has never been seen by the agent:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/748a1df0-bfce-42bc-8a8f-b949c3f2621b)
We cannot find any data for it.
The agent didn’t see this pod. So, it couldn’t notice its deletion either.

Given the fact that the Nginx pods are constantly created and deleted by an HPA, my hypothesis is that the test choose a pod which was freshly created and not already running.

In order for the test to reliably pass, it needs to chose only a running pod that the agent has noticed.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

[Check if `TestContainerLifecycleEvents` is still flaky](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%28%40test.name%3ATestEKSSuite%2FTestContainerLifecycleEvents%20OR%20%40test.name%3ATestKindSuite%2FTestContainerLifecycleEvents%29&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=&fromUser=false&index=citest&mode=sliding&saved-view-id=2236559&start=1715361255842&end=1715966055842&paused=false).
