### PR TITLE
[AGENT-11522] Ignore tracefs mountpoint and make log more informative

### DIFF
--- a/pkg/gohai/filesystem/filesystem_nix.go
+++ b/pkg/gohai/filesystem/filesystem_nix.go
@@ -22,7 +22,7 @@ type fsInfoGetter func(*mountinfo.Info) (uint64, error)
 func sizeKB(mount *mountinfo.Info) (uint64, error) {
 	var statfs unix.Statfs_t
 	if err := unix.Statfs(mount.Mountpoint, &statfs); err != nil {
-		return 0, fmt.Errorf("statfs %s: %w", mount.Source, err)
+		return 0, fmt.Errorf("gohai filesystem collection: statfs %s: %w", mount.Source, err)
 	}
 
 	sizeKB := statfs.Blocks * uint64(statfs.Bsize) / 1024
@@ -150,6 +150,7 @@ func isDummyFS(fsType string) bool {
 		"squashfs":    {}, // added by a patch on ubuntu
 		"subfs":       {},
 		"sysfs":       {},
+		"tracefs":     {}, // debug/tracing was moved out of debugfs
 	}
 
 	_, found := ignoredFSTypes[fsType]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

When we cannot get filesystem info for a mountpoint we log it:
```
2024-04-22 20:23:39 PDT | CORE | INFO | (/usr/local/go/src/runtime/asm_amd64.s:1598 in goexit) | statfs tracefs: permission denied
```

But we already ignore `debugfs` from filesystem collection in gohai. `debug/trace` was moved into a separate mountpoint `tracefs` and we should also ignore it now

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
* mount tracefs with inaccessible permissions then see if the permission log no longer appears.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
