### PR TITLE
usm: postgres: Add first latency of aggregation if we have multiple entries

### DIFF
--- a/pkg/network/protocols/postgres/statskeeper.go
+++ b/pkg/network/protocols/postgres/statskeeper.go
@@ -57,6 +57,9 @@ func (s *StatKeeper) Process(tx *EventWrapper) {
 		if err := requestStats.initSketch(); err != nil {
 			return
 		}
+		if err := requestStats.Latencies.Add(requestStats.FirstLatencySample); err != nil {
+			return
+		}
 	}
 	if err := requestStats.Latencies.Add(tx.RequestLatency()); err != nil {
 		log.Debugf("could not add request latency to ddsketch: %v", err)

--- a/pkg/network/protocols/postgres/statskeeper_test.go
+++ b/pkg/network/protocols/postgres/statskeeper_test.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package postgres
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestStatKeeperProcessValidateSketches(t *testing.T) {
+	cfg := config.New()
+	cfg.MaxPostgresStatsBuffered = 100
+	s := NewStatkeeper(cfg)
+	for i := 0; i < 20; i++ {
+		s.Process(&EventWrapper{
+			EbpfEvent: &EbpfEvent{
+				Tx: EbpfTx{
+					Request_started:    1,
+					Response_last_seen: 10,
+				},
+			},
+			operationSet: true,
+			operation:    SelectOP,
+			tableNameSet: true,
+			tableName:    "dummy",
+		})
+	}
+
+	require.Equal(t, 1, len(s.stats))
+	for k, stat := range s.stats {
+		require.Equal(t, "dummy", k.TableName)
+		require.Equal(t, SelectOP, k.Operation)
+		require.Equal(t, 20, stat.Count)
+		require.Equal(t, float64(20), stat.Latencies.GetCount())
+	}
+}

--- a/pkg/network/protocols/postgres/statskeeper_test.go
+++ b/pkg/network/protocols/postgres/statskeeper_test.go
@@ -8,12 +8,14 @@
 package postgres
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/network/config"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
 
-func TestStatKeeperProcessValidateSketches(t *testing.T) {
+func TestStatKeeperProcess(t *testing.T) {
 	cfg := config.New()
 	cfg.MaxPostgresStatsBuffered = 100
 	s := NewStatkeeper(cfg)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adds first entry latency to the new general latency sketch object, in case we have more than one entry.

As a performance improvement we added FirstLatency field to store the latency of the first entry in the aggregation.
In case we have more than one entry, we generate new sketch object to store the latencies in it. However, we didn't add the first latency to the sketch object, and by that we had more hits in the aggregation than latencies (off by one). That generated a warning in the backend.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixing mismatch between total number of hits to total number of sketches.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
