### PR TITLE
[CWS] add back centos 7 test to kmt

### DIFF
--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -135,6 +135,7 @@ kmt_run_secagent_tests_x64:
           - "debian_10"
           - "debian_11"
           - "debian_12"
+          - "centos_7.9"
           - "oracle_8.9"
           - "oracle_9.3"
           - "rocky_8.5"


### PR DESCRIPTION
### What does this PR do?

This PR re-includes centos 7 in CWS KMT test matrix.
Needed PRs for that:
- https://github.com/DataDog/datadog-agent/pull/25789
- https://github.com/DataDog/datadog-agent/pull/25799
- https://github.com/DataDog/datadog-agent/pull/25802
- https://github.com/DataDog/datadog-agent/pull/25842

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
