### PR TITLE
[EBPF] Retry btfhub archive clone in case of failure

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1547,7 +1547,7 @@ def process_btfhub_archive(ctx, branch="main"):
     with tempfile.TemporaryDirectory() as temp_dir:
         with ctx.cd(temp_dir):
             clone_cmd = (
-                f"git clone --depth=1 --single-branch --branch={branch} https://github.com/DataDog/btfhub-archive.git",
+                f"git clone --depth=1 --single-branch --branch={branch} https://github.com/DataDog/btfhub-archive.git"
             )
             retries = 2
             downloaded = False

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1546,9 +1546,23 @@ def process_btfhub_archive(ctx, branch="main"):
     output_dir = os.getcwd()
     with tempfile.TemporaryDirectory() as temp_dir:
         with ctx.cd(temp_dir):
-            ctx.run(
-                f"git clone --depth=1 --single-branch --branch={branch} https://github.com/DataDog/btfhub-archive.git"
+            clone_cmd = (
+                f"git clone --depth=1 --single-branch --branch={branch} https://github.com/DataDog/btfhub-archive.git",
             )
+            retries = 2
+            downloaded = False
+
+            while not downloaded and retries > 0:
+                res = ctx.run(clone_cmd, warn=True)
+                downloaded = res is not None and res.ok
+
+                if not downloaded:
+                    retries -= 1
+                    print(f"Failed to clone btfhub-archive. Remaining retries: {retries}")
+
+            if not downloaded:
+                raise Exit("Failed to clone btfhub-archive")
+
             with ctx.cd("btfhub-archive"):
                 # iterate over all top-level directories, which are platforms (amzn, ubuntu, etc.)
                 with os.scandir(ctx.cwd) as pit:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Retry the clone of `btfhub-archive` in `system-probe.process-btfhub-archive` task if it fails.

### Motivation

The `btfhub-archive` is fairly large and is more prone to failures in the clone operation due to network or upstream issues. This change should avoid those failures from breaking the pipeline.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Changes tested in CI.