### PR TITLE
[EBPF] Test correct packaging of eBPF files

### DIFF
--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -115,6 +115,9 @@ remove_sysprobe_secagent_files()
     if [ -d "$INSTALL_DIR/run" ]; then
         rmdir "$INSTALL_DIR/run" 2>/dev/null || true
     fi
+
+    # Remove any unpacked BTF files
+    find "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re/btf" -name "*.btf*" -type f -delete || true
 }
 
 remove_remote_config_db()

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -118,8 +118,8 @@ remove_sysprobe_secagent_files()
 
     # Remove any unpacked BTF files
     find "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re/btf" -name "*.btf*" -type f -delete || true
-    # And remove the directory
-    rmdir "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re/btf" 2>/dev/null || true
+    # And remove empty directories
+    find "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re" -type d -empty -delete || true
 }
 
 remove_remote_config_db()

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -118,6 +118,8 @@ remove_sysprobe_secagent_files()
 
     # Remove any unpacked BTF files
     find "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re/btf" -name "*.btf*" -type f -delete || true
+    # And remove the directory
+    rmdir "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re/btf" 2>/dev/null || true
 }
 
 remove_remote_config_db()

--- a/pkg/ebpf/c/bpf_metadata.h
+++ b/pkg/ebpf/c/bpf_metadata.h
@@ -2,11 +2,11 @@
 #define __BPF_METADATA_H__
 
 #if defined(__x86_64__) || defined(__TARGET_ARCH_x86)
-char _arch[] __attribute__((section("dd_metadata"), used)) = "<arch:amd64>";
+char __dd_metadata_arch[] __attribute__((section("dd_metadata"), used)) = "<arch:amd64>";
 #elif defined(__aarch64__) || defined(__TARGET_ARCH_arm64)
-char _arch[] __attribute__((section("dd_metadata"), used)) = "<arch:arm64>";
+char __dd_metadata_arch[] __attribute__((section("dd_metadata"), used)) = "<arch:arm64>";
 #else
-char _arch[] __attribute__((section("dd_metadata"), used)) = "<arch:unset>";
+char __dd_metadata_arch[] __attribute__((section("dd_metadata"), used)) = "<arch:unset>";
 #endif
 
 #endif

--- a/pkg/ebpf/c/bpf_metadata.h
+++ b/pkg/ebpf/c/bpf_metadata.h
@@ -1,12 +1,19 @@
+/**
+ * This header file is included in kconfig.h and ktypes.h, which should make
+ * this metadata available to all object files.
+ */
+
 #ifndef __BPF_METADATA_H__
 #define __BPF_METADATA_H__
 
+#ifndef __CGO__ // Do not include metadata in CGo builds, as it causes duplicate symbols
 #if defined(__x86_64__) || defined(__TARGET_ARCH_x86)
 char __dd_metadata_arch[] __attribute__((section("dd_metadata"), used)) = "<arch:amd64>";
 #elif defined(__aarch64__) || defined(__TARGET_ARCH_arm64)
 char __dd_metadata_arch[] __attribute__((section("dd_metadata"), used)) = "<arch:arm64>";
 #else
 char __dd_metadata_arch[] __attribute__((section("dd_metadata"), used)) = "<arch:unset>";
+#endif
 #endif
 
 #endif

--- a/pkg/ebpf/c/bpf_metadata.h
+++ b/pkg/ebpf/c/bpf_metadata.h
@@ -1,0 +1,12 @@
+#ifndef __BPF_METADATA_H__
+#define __BPF_METADATA_H__
+
+#if defined(__x86_64__) || defined(__TARGET_ARCH_x86)
+char _arch[] __attribute__((section("dd_metadata"), used)) = "<arch:amd64>";
+#elif defined(__aarch64__) || defined(__TARGET_ARCH_arm64)
+char _arch[] __attribute__((section("dd_metadata"), used)) = "<arch:arm64>";
+#else
+char _arch[] __attribute__((section("dd_metadata"), used)) = "<arch:unset>";
+#endif
+
+#endif

--- a/pkg/ebpf/c/bpf_metadata.h
+++ b/pkg/ebpf/c/bpf_metadata.h
@@ -8,7 +8,7 @@
 
 #ifndef __CGO__ // Do not include metadata in CGo builds, as it causes duplicate symbols
 #if defined(__x86_64__) || defined(__TARGET_ARCH_x86)
-char __dd_metadata_arch[] __attribute__((section("dd_metadata"), used)) = "<arch:amd64>";
+char __dd_metadata_arch[] __attribute__((section("dd_metadata"), used)) = "<arch:x86_64>";
 #elif defined(__aarch64__) || defined(__TARGET_ARCH_arm64)
 char __dd_metadata_arch[] __attribute__((section("dd_metadata"), used)) = "<arch:arm64>";
 #else

--- a/pkg/ebpf/c/kconfig.h
+++ b/pkg/ebpf/c/kconfig.h
@@ -1,6 +1,8 @@
 #ifndef __KCONFIG_H
 #define __KCONFIG_H
 
+#include "bpf_metadata.h"
+
 #include <linux/kconfig.h>
 // include asm/compiler.h to fix `error: expected string literal in 'asm'` compilation error coming from mte-kasan.h
 // this was fixed in https://github.com/torvalds/linux/commit/b859ebedd1e730bbda69142fca87af4e712649a1

--- a/pkg/ebpf/c/ktypes.h
+++ b/pkg/ebpf/c/ktypes.h
@@ -1,6 +1,8 @@
 #ifndef __KTYPES_H__
 #define __KTYPES_H__
 
+#include "bpf_metadata.h"
+
 #ifdef COMPILE_CORE
 #include "vmlinux.h"
 #else

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -254,6 +254,7 @@ def get_build_flags(
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + ' -Wl,--allow-multiple-definition'
 
     extra_cgo_flags = " -Werror -Wno-deprecated-declarations"
+    extra_cgo_flags += " -D__CGO__"  # Some C files include definitions that can cause duplicate symbols if included in CGo code (bpf_metadata.h) mainly
     if rtloader_headers:
         extra_cgo_flags += f" -I{rtloader_headers}"
     if rtloader_common_headers:

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -348,6 +348,11 @@ func CheckSystemProbeBehavior(t *testing.T, client *TestClient) {
 		files := strings.Split(strings.TrimSpace(output), "\n")
 		require.Greater(tt, len(files), 0, "ebpf object files should be present")
 
+		_, err = client.Host.Execute("command -v readelf")
+		if err != nil {
+			t.Skip("readelf is not available on the host")
+		}
+
 		hostArch, err := client.Host.Execute("uname -m")
 		require.NoError(tt, err)
 		hostArch = strings.TrimSpace(hostArch)

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -351,6 +351,7 @@ func CheckSystemProbeBehavior(t *testing.T, client *TestClient) {
 		_, err = client.Host.Execute("command -v readelf")
 		if err != nil {
 			t.Skip("readelf is not available on the host")
+			return
 		}
 
 		hostArch, err := client.Host.Execute("uname -m")

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -321,6 +321,7 @@ func CheckCWSBehaviour(t *testing.T, client *TestClient) {
 	})
 }
 
+// CheckSystemProbeBehavior runs tests to check the agent behave correctly when system-probe is enabled
 func CheckSystemProbeBehavior(t *testing.T, client *TestClient) {
 	t.Run("enable system-probe and restarts", func(tt *testing.T) {
 		err := client.SetConfig(client.Helper.GetConfigFolder()+"system-probe.yaml", "system_probe_config.enabled", "true")

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -350,7 +350,7 @@ func CheckSystemProbeBehavior(t *testing.T, client *TestClient) {
 
 		_, err = client.Host.Execute("command -v readelf")
 		if err != nil {
-			t.Skip("readelf is not available on the host")
+			tt.Skip("readelf is not available on the host")
 			return
 		}
 

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -347,13 +347,19 @@ func CheckSystemProbeBehavior(t *testing.T, client *TestClient) {
 		require.NoError(tt, err)
 		files := strings.Split(strings.TrimSpace(output), "\n")
 		require.Greater(tt, len(files), 0, "ebpf object files should be present")
+
+		hostArch, err := client.Host.Execute("uname -m")
+		require.NoError(tt, err)
+		if hostArch == "aarch64" {
+			hostArch = "arm64"
+		}
+		archMetadata := fmt.Sprintf("<arch:%s>", hostArch)
+
 		for _, file := range files {
 			file = strings.TrimSpace(file)
-			fileOutput, err := client.Host.Execute(fmt.Sprintf("file %s", file))
-			require.NoError(tt, err, "cannot run file command on ebpf object file %s", file)
-
-			fileType := strings.Split(fileOutput, ":")[1]
-			require.Contains(tt, fileType, "eBPF", "ebpf object files should be valid and recognized as such")
+			ddMetadata, err := client.Host.Execute(fmt.Sprintf("readelf -p dd_metadata %s", file))
+			require.NoError(tt, err, "readelf should not error, file is %s", file)
+			require.Contains(tt, ddMetadata, archMetadata, "invalid arch metadata")
 		}
 	})
 }

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -15,10 +15,11 @@ import (
 
 	componentos "github.com/DataDog/test-infra-definitions/components/os"
 
-	agentclient "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
-	boundport "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/bound-port"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	agentclient "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
+	boundport "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/bound-port"
 )
 
 // CheckAgentBehaviour runs test to check the agent is behaving as expected
@@ -317,5 +318,40 @@ func CheckCWSBehaviour(t *testing.T, client *TestClient) {
 			time.Sleep(2 * time.Second)
 		}
 		require.True(tt, result, "system-probe and security-agent should communicate")
+	})
+}
+
+func CheckSystemProbeBehavior(t *testing.T, client *TestClient) {
+	t.Run("enable system-probe and restarts", func(tt *testing.T) {
+		err := client.SetConfig(client.Helper.GetConfigFolder()+"system-probe.yaml", "system_probe_config.enabled", "true")
+		require.NoError(tt, err)
+
+		err = client.SetConfig(client.Helper.GetConfigFolder()+"system-probe.yaml", "system_probe_config.enabled", "true")
+		require.NoError(tt, err)
+
+		_, err = client.SvcManager.Restart(client.Helper.GetServiceName())
+		require.NoError(tt, err, "datadog-agent should restart after CWS is enabled")
+	})
+
+	t.Run("system-probe is running", func(tt *testing.T) {
+		var err error
+		require.Eventually(tt, func() bool {
+			return AgentProcessIsRunning(client, "system-probe")
+		}, 1*time.Minute, 500*time.Millisecond, "system-probe should be running ", err)
+	})
+
+	t.Run("ebpf programs are unpacked and valid", func(tt *testing.T) {
+		ebpfPath := "/opt/datadog-agent/embedded/share/system-probe/ebpf"
+		output, err := client.Host.Execute(fmt.Sprintf("find %s -name '*.o'", ebpfPath))
+		require.NoError(tt, err)
+		files := strings.Split(output, "\n")
+		require.Greater(tt, len(files), 0, "ebpf object files should be present")
+		for _, file := range files {
+			fileOutput, err := client.Host.Execute(fmt.Sprintf("file %s", file))
+			require.NoError(tt, err)
+
+			fileType := strings.Split(fileOutput, ":")[1]
+			require.Contains(tt, fileType, "eBPF", "ebpf object files should be valid and recognized as such")
+		}
 	})
 }

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -345,11 +345,12 @@ func CheckSystemProbeBehavior(t *testing.T, client *TestClient) {
 		ebpfPath := "/opt/datadog-agent/embedded/share/system-probe/ebpf"
 		output, err := client.Host.Execute(fmt.Sprintf("find %s -name '*.o'", ebpfPath))
 		require.NoError(tt, err)
-		files := strings.Split(output, "\n")
+		files := strings.Split(strings.TrimSpace(output), "\n")
 		require.Greater(tt, len(files), 0, "ebpf object files should be present")
 		for _, file := range files {
+			file = strings.TrimSpace(file)
 			fileOutput, err := client.Host.Execute(fmt.Sprintf("file %s", file))
-			require.NoError(tt, err)
+			require.NoError(tt, err, "cannot run file command on ebpf object file %s", file)
 
 			fileType := strings.Split(fileOutput, ":")[1]
 			require.Contains(tt, fileType, "eBPF", "ebpf object files should be valid and recognized as such")

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -350,6 +350,7 @@ func CheckSystemProbeBehavior(t *testing.T, client *TestClient) {
 
 		hostArch, err := client.Host.Execute("uname -m")
 		require.NoError(tt, err)
+		hostArch = strings.TrimSpace(hostArch)
 		if hostArch == "aarch64" {
 			hostArch = "arm64"
 		}

--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -136,8 +136,11 @@ func (is *installScriptSuite) AgentTest(flavor string) {
 	common.CheckAgentPython(is.T(), client, common.ExpectedPythonVersion3)
 	common.CheckApmEnabled(is.T(), client)
 	common.CheckApmDisabled(is.T(), client)
-	if flavor == "datadog-agent" && is.cwsSupported {
-		common.CheckCWSBehaviour(is.T(), client)
+	if flavor == "datadog-agent" {
+		common.CheckSystemProbeBehavior(is.T(), client)
+		if is.cwsSupported {
+			common.CheckCWSBehaviour(is.T(), client)
+		}
 	}
 	common.CheckInstallationInstallScript(is.T(), client)
 	is.testUninstall(client, flavor)

--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -160,8 +160,11 @@ func (is *stepByStepSuite) CheckStepByStepAgentInstallation(VMclient *common.Tes
 	}
 	common.CheckApmEnabled(is.T(), VMclient)
 	common.CheckApmDisabled(is.T(), VMclient)
-	if *flavorName == "datadog-agent" && is.cwsSupported {
-		common.CheckCWSBehaviour(is.T(), VMclient)
+	if *flavorName == "datadog-agent" {
+		common.CheckSystemProbeBehavior(is.T(), VMclient)
+		if is.cwsSupported {
+			common.CheckCWSBehaviour(is.T(), VMclient)
+		}
 	}
 
 	is.T().Run("remove the agent", func(tt *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR changes e2e tests so that they validate that eBPF object files are correctly packaged. This means two changes:

- Add metadata to eBPF object files that helps us define the architecture they were compiled against. While eBPF assembly is architecture agnostic, offsets and structs used in them are not, which means we need some manual way to mark the architecture they were built for.
- Add code to the e2e packaging tests that ensure that system-probe is running (which means that at least one module that loaded eBPF object files was enabled) and that eBPF object files are of the correct arch.

### Motivation

Ensure that changes of the eBPF build process ([motivating PR](https://github.com/DataDog/datadog-agent/pull/25592)) have at least a basic sanity check.

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
