### PR TITLE
tracer: tests: move HTTPS tests to a TLS subtest

### DIFF
--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -97,7 +97,7 @@ func (s *USMSuite) TestProtocolClassification() {
 		// SetupDNAT sets up a NAT translation from 2.2.2.2 to 1.1.1.1
 		netlink.SetupDNAT(t)
 		testProtocolClassification(t, tr, "localhost", "2.2.2.2", "1.1.1.1")
-		testHTTPSClassification(t, tr, "localhost", "2.2.2.2", "1.1.1.1")
+		testTLSClassification(t, tr, "localhost", "2.2.2.2", "1.1.1.1")
 		testProtocolConnectionProtocolMapCleanup(t, tr, "localhost", "2.2.2.2", "1.1.1.1:0")
 	})
 
@@ -105,13 +105,13 @@ func (s *USMSuite) TestProtocolClassification() {
 		// SetupDNAT sets up a NAT translation from 6.6.6.6 to 7.7.7.7
 		netlink.SetupSNAT(t)
 		testProtocolClassification(t, tr, "6.6.6.6", "127.0.0.1", "127.0.0.1")
-		testHTTPSClassification(t, tr, "6.6.6.6", "127.0.0.1", "127.0.0.1")
+		testTLSClassification(t, tr, "6.6.6.6", "127.0.0.1", "127.0.0.1")
 		testProtocolConnectionProtocolMapCleanup(t, tr, "6.6.6.6", "127.0.0.1", "127.0.0.1:0")
 	})
 
 	t.Run("without nat", func(t *testing.T) {
 		testProtocolClassification(t, tr, "localhost", "127.0.0.1", "127.0.0.1")
-		testHTTPSClassification(t, tr, "localhost", "127.0.0.1", "127.0.0.1")
+		testTLSClassification(t, tr, "localhost", "127.0.0.1", "127.0.0.1")
 		testProtocolConnectionProtocolMapCleanup(t, tr, "localhost", "127.0.0.1", "127.0.0.1:0")
 	})
 }
@@ -344,6 +344,23 @@ func skipIfHTTPSNotSupported(t *testing.T, _ testContext) {
 	if !httpsSupported() {
 		t.Skip("https is not supported")
 	}
+}
+
+func testTLSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, serverHost string) {
+	t.Run("TLS", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   func(t *testing.T, tr *Tracer, clientHost, targetHost, serverHost string)
+		}{
+			{"HTTP", testHTTPSClassification},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tt.fn(t, tr, clientHost, targetHost, serverHost)
+			})
+		}
+	})
 }
 
 func testHTTPSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, serverHost string) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Renames and restructure HTTPS classification tests into TLS classification test.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Allow parallel work on adding classification on top of TLS

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
