### PR TITLE
Revert "Remove guessing for sport offset (#21771)"

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -99,11 +99,13 @@ static __always_inline int guess_offsets(tracer_status_t* status, char* subject)
         new_status.offset_family = aligned_offset(subject, status->offset_family, SIZEOF_FAMILY);
         bpf_probe_read_kernel(&new_status.family, sizeof(new_status.family), subject + new_status.offset_family);
         break;
+    case GUESS_SPORT:
+        new_status.offset_sport = aligned_offset(subject, status->offset_sport, SIZEOF_SPORT);
+        bpf_probe_read_kernel(&new_status.sport, sizeof(new_status.sport), subject + new_status.offset_sport);
+        break;
     case GUESS_DPORT:
         new_status.offset_dport = aligned_offset(subject, status->offset_dport, SIZEOF_DPORT);
-        new_status.offset_sport = aligned_offset(subject, status->offset_dport+SIZEOF_DPORT, SIZEOF_SPORT);
         bpf_probe_read_kernel(&new_status.dport, sizeof(new_status.dport), subject + new_status.offset_dport);
-        bpf_probe_read_kernel(&new_status.sport, sizeof(new_status.sport), subject + new_status.offset_sport);
         break;
     case GUESS_SADDR_FL4:
         new_status.offset_saddr_fl4 = aligned_offset(subject, status->offset_saddr_fl4, SIZEOF_SADDR_FL4);

--- a/pkg/network/ebpf/c/runtime/offsetguess-test.c
+++ b/pkg/network/ebpf/c/runtime/offsetguess-test.c
@@ -64,7 +64,7 @@ int kprobe__tcp_getsockopt(struct pt_regs* ctx) {
     bpf_map_update_elem(&offsets, &o, &offset, BPF_ANY);
 
     o = OFFSET_SPORT;
-    offset = offsetof(struct sock, sk_num);
+    offset = offsetof(struct inet_sock, inet_sport);
     bpf_map_update_elem(&offsets, &o, &offset, BPF_ANY);
 
     o = OFFSET_DPORT;

--- a/pkg/network/ebpf/c/sock.h
+++ b/pkg/network/ebpf/c/sock.h
@@ -87,7 +87,12 @@ static __always_inline u16 read_sport(struct sock* skp) {
     // try skc_num, then inet_sport
     u16 sport = 0;
 #ifdef COMPILE_PREBUILT
-    bpf_probe_read_kernel_with_telemetry(&sport, sizeof(sport), ((char*)skp) + offset_sport());
+    // try skc_num, then inet_sport
+    bpf_probe_read_kernel_with_telemetry(&sport, sizeof(sport), ((char*)skp) + offset_dport() + sizeof(sport));
+    if (sport == 0) {
+        bpf_probe_read_kernel_with_telemetry(&sport, sizeof(sport), ((char*)skp) + offset_sport());
+        sport = bpf_ntohs(sport);
+    }
 #elif defined(COMPILE_CORE) || defined(COMPILE_RUNTIME)
     BPF_CORE_READ_INTO(&sport, skp, sk_num);
     if (sport == 0) {

--- a/pkg/network/tracer/offsetguess_test.go
+++ b/pkg/network/tracer/offsetguess_test.go
@@ -304,6 +304,7 @@ func testOffsetGuess(t *testing.T) {
 		var name offsetT = o
 		require.NoError(t, mp.Lookup(&name, &offset))
 		assert.Equal(t, offset, consts[o], "unexpected offset for %s", o)
+		t.Logf("offset %s expected: %d guessed: %d", o, offset, consts[o])
 	}
 }
 

--- a/pkg/network/tracer/offsetguess_test.go
+++ b/pkg/network/tracer/offsetguess_test.go
@@ -304,7 +304,6 @@ func testOffsetGuess(t *testing.T) {
 		var name offsetT = o
 		require.NoError(t, mp.Lookup(&name, &offset))
 		assert.Equal(t, offset, consts[o], "unexpected offset for %s", o)
-		t.Logf("offset %s expected: %d guessed: %d", o, offset, consts[o])
 	}
 }
 


### PR DESCRIPTION
This reverts commit 26b4d50702cb643ba5fd7a1a0bee2930aafdc0e5.

This was originally done to stabilize some tests but results in missing data for TCP connection failures. The CI for this revert commit is green, the plan is to see how this looks in CI after a week or two.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
