### PR TITLE
[NPM-3413][networkpath] Fix flakly test Test_NpCollector_StartAndStop

### DIFF
--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -232,7 +232,6 @@ func runTraceroute(cfg traceroute.Config) (payload.NetworkPath, error) {
 
 func (s *npCollectorImpl) flushLoop() {
 	s.logger.Debugf("Starting flush loop")
-	defer s.logger.Debugf("Stopped flush loop")
 
 	flushTicker := time.NewTicker(s.flushInterval)
 
@@ -241,7 +240,7 @@ func (s *npCollectorImpl) flushLoop() {
 		select {
 		// stop sequence
 		case <-s.stopChan:
-			s.logger.Info("Stop flush loop")
+			s.logger.Info("Stopped flush loop")
 			s.flushLoopDone <- struct{}{}
 			flushTicker.Stop()
 			return


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

[networkpath] Fix flakly test Test_NpCollector_StartAndStop

Instead of assert the log in `defer`, we assert the log just before `s.flushLoopDone <- struct{}{}`

In `Test_NpCollector_StartAndStop` we assert based on logs after calling `NpCollector.stop()`, the change in this PR will ensure that the log `Stopped flush loop` will be present.

The log in defer might happen some time after `NpCollector.stop()` is called.



<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
