### PR TITLE
[Fast tests] Take build tags into account

### DIFF
--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from pathlib import Path
 
 from invoke import task
+from invoke.context import Context
 from invoke.exceptions import Exit
 
 from tasks.agent import integration_tests as agent_integration_tests
@@ -787,7 +788,7 @@ def get_impacted_packages(ctx, build_tags=None):
                 formatted_path = "/".join(formatted_path.split("/")[:-1])
 
     imp = find_impacted_packages(dependencies, modified_packages)
-    return format_packages(ctx, imp)
+    return format_packages(ctx, impacted_packages=imp, build_tags=build_tags)
 
 
 def create_dependencies(ctx, build_tags=None):
@@ -833,12 +834,12 @@ def find_impacted_packages(dependencies, modified_modules, cache=None):
     return impacted_modules
 
 
-def format_packages(ctx, impacted_packages):
+def format_packages(ctx: Context, impacted_packages: set[str], build_tags: list[str] = None):
     """
     Format the packages list to be used in our test function. Will take each path and create a list of modules with its targets
     """
-    # if build_tags is None:
-    build_tags = []
+    if build_tags is None:
+        build_tags = []
 
     packages = [f'{package.replace("github.com/DataDog/datadog-agent/", "./")}' for package in impacted_packages]
     modules_to_test = {}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Modifies the `--only-impacted-packages` option of the `inv test` task to take into account build tags when resolving the list of packages to be tested.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix edge cases where less packages than expected are being tested, because they only contain files with build tags.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a
