### PR TITLE
[ASCII-1621] Fix flake in configsync tests

### DIFF
--- a/comp/core/configsync/configsyncimpl/sync_integration_test.go
+++ b/comp/core/configsync/configsyncimpl/sync_integration_test.go
@@ -91,15 +91,17 @@ func TestRunWithChan(t *testing.T) {
 
 		for i := 1; i <= errnums; i++ {
 			ch <- time.Now()
-			time.Sleep(50 * time.Millisecond)
-			require.EqualValues(t, i, callnb.Load())
-			require.Equal(t, "not-value1", cs.Config.GetString("key1"))
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				assert.EqualValues(t, i, callnb.Load())
+				assert.Equal(t, "not-value1", cs.Config.GetString("key1"))
+			}, 100*time.Millisecond, 10*time.Millisecond)
 		}
 
 		ch <- time.Now()
-		time.Sleep(50 * time.Millisecond)
-		require.EqualValues(t, errnums+1, callnb.Load())
-		assertConfigIsSet(t, cs.Config, "key1", "value1")
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.EqualValues(t, errnums+1, callnb.Load())
+			assertConfigIsSet(t, cs.Config, "key1", "value1")
+		}, 100*time.Millisecond, 10*time.Millisecond)
 	})
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix a flake in `comp/core/configsync/configsyncimpl/sync_integration_test.go` happening on slow runners.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
We don't want any flakiness in tests.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Replaces two calls to `Sleep` with `EventuallyWithT` and increased timeout.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
