### PR TITLE
[CWS] `TestProcessContext/tty` use sigterm instead

### DIFF
--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -771,13 +771,17 @@ func TestProcessContext(t *testing.T) {
 				time.Sleep(2 * time.Second)
 				cmd := exec.Command("script", "/dev/null", "-c", executable+" -f "+testFile)
 				if err := cmd.Start(); err != nil {
-					errChan <- err
+					errChan <- fmt.Errorf("failed to start the process: %w", err)
 					return
 				}
 				time.Sleep(2 * time.Second)
 
-				cmd.Process.Kill()
-				cmd.Wait()
+				if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+					errChan <- fmt.Errorf("failed to SIGTERM the process: %w", err)
+				}
+				if err := cmd.Wait(); err != nil {
+					errChan <- fmt.Errorf("failed to wait the process: %w", err)
+				}
 			}()
 
 			wg.Wait()


### PR DESCRIPTION
### What does this PR do?

This PR makes `TestProcessContext/tty` use SIGTERM instead of direct kill allowing a clean shutdown of the `script` process and the wait to succeed. This should allow for a better clean up of process resources.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
