### PR TITLE
pkg/trace/agent: improve perf of CC Obfuscator

### DIFF
--- a/pkg/obfuscate/credit_cards.go
+++ b/pkg/obfuscate/credit_cards.go
@@ -54,7 +54,7 @@ func (o *Obfuscator) ObfuscateCreditCardNumber(key, val string) string {
 		// these tags are known to not be credit card numbers
 		return val
 	}
-	if strings.HasPrefix(key, "_dd") {
+	if strings.HasPrefix(key, "_") {
 		return val
 	}
 	if o.ccObfuscator.IsCardNumber(val) {

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -29,7 +29,10 @@ func (a *Agent) obfuscateSpan(span *pb.Span) {
 
 	if a.conf.Obfuscation != nil && a.conf.Obfuscation.CreditCards.Enabled {
 		for k, v := range span.Meta {
-			span.Meta[k] = o.ObfuscateCreditCardNumber(k, v)
+			newV := o.ObfuscateCreditCardNumber(k, v)
+			if v != newV {
+				span.Meta[k] = newV
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Improves the performance of our usage of the credit card obfuscator. The new refactored version was marginally slower, this change reduces the CPU cost by avoiding writing to the meta map when the obfuscator didn't change anything - (which is most cases). I also altered the prefix check to look for any tags starting with `_` since all those tags are hidden and therefore won't be set by customers.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
benchstat shows a decent improvement in CPU usage here
```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/trace/agent
                 │  oldCC.out   │              newCC.out              │
                 │    sec/op    │    sec/op     vs base               │
CCObfuscation-10   379.2n ± ∞ ¹   338.9n ± ∞ ¹  -10.63% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

                 │  oldCC.out  │           newCC.out            │
                 │    B/op     │    B/op      vs base           │
CCObfuscation-10   336.0 ± ∞ ¹   336.0 ± ∞ ¹  ~ (p=1.000 n=5) ²
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

                 │  oldCC.out  │           newCC.out            │
                 │  allocs/op  │  allocs/op   vs base           │
CCObfuscation-10   2.000 ± ∞ ¹   2.000 ± ∞ ¹  ~ (p=1.000 n=5) ²
```
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
covered with tests!
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
