### PR TITLE
[CWS] remove some defunct process from tests

### DIFF
--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -53,6 +53,10 @@ func TestContainerCreatedAt(t *testing.T) {
 		t.Skip("Skipping created time in containers tests: Docker not available")
 		return
 	}
+
+	if _, err := dockerWrapper.start(); err != nil {
+		t.Fatal(err)
+	}
 	defer dockerWrapper.stop()
 
 	dockerWrapper.Run(t, "container-created-at", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1398,16 +1398,16 @@ func TestProcessMetadata(t *testing.T) {
 
 	t.Run("credentials", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			attr := &syscall.ProcAttr{
-				Sys: &syscall.SysProcAttr{
-					Credential: &syscall.Credential{
-						Uid: 1001,
-						Gid: 2001,
-					},
+			attr := &syscall.SysProcAttr{
+				Credential: &syscall.Credential{
+					Uid: 1001,
+					Gid: 2001,
 				},
 			}
-			_, err := syscall.ForkExec(testFile, []string{}, attr)
-			return err
+
+			cmd := exec.Command(testFile)
+			cmd.SysProcAttr = attr
+			return cmd.Run()
 		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
 			assert.Equal(t, 1001, int(event.Exec.Credentials.UID), "wrong uid")

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2195,14 +2195,12 @@ func TestProcessResolution(t *testing.T) {
 	var cmd *exec.Cmd
 	var stdin io.WriteCloser
 	defer func() {
-		if cmd != nil {
-			if stdin != nil {
-				stdin.Close()
-			}
+		if stdin != nil {
+			stdin.Close()
+		}
 
-			if err := cmd.Wait(); err != nil {
-				t.Fatal(err)
-			}
+		if err := cmd.Wait(); err != nil {
+			t.Fatal(err)
 		}
 	}()
 
@@ -2213,7 +2211,7 @@ func TestProcessResolution(t *testing.T) {
 			"getchar", ";",
 			"open", "/tmp/test-process-resolution"}
 
-		cmd := exec.Command(syscallTester, args...)
+		cmd = exec.Command(syscallTester, args...)
 		stdin, err = cmd.StdinPipe()
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR is a collection of fixes for tests that were creating some defunct processes:
- `TestProcessMetadata/credentials` was fork/exec-ing but never called wait
- `TestContainerCreatedAt` was never starting the docker wrapper causing some issues with previous containers
- `TestProcessResolution` was never waiting the correct cmd because of function variable shadowing (yeah..)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
