### PR TITLE
[CWS] `TestProcessContext/tty` switch to slow cat

### DIFF
--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -637,6 +637,26 @@ int test_sleep(int argc, char **argv) {
     return EXIT_SUCCESS;
 }
 
+int test_slow_cat(int argc, char **argv) {
+    if (argc != 3) {
+        fprintf(stderr, "%s: Please pass a duration in seconds, and a path.\n", __FUNCTION__);
+        return EXIT_FAILURE;
+    }
+
+    int duration = atoi(argv[1]);
+    int fd = open(argv[2], O_RDONLY);
+
+    if (duration <= 0) {
+        fprintf(stderr, "Please specify at a valid sleep duration\n");
+    }
+    for (int i = 0; i < duration; i++)
+        sleep(1);
+
+    close(fd);
+
+    return EXIT_SUCCESS;
+}
+
 int test_memfd_create(int argc, char **argv) {
     if (argc < 2) {
         fprintf(stderr, "Please specify at least a file name \n");
@@ -761,6 +781,8 @@ int main(int argc, char **argv) {
             exit_code = test_memfd_create(sub_argc, sub_argv);
         } else if (strcmp(cmd, "new_netns_exec") == 0) {
             exit_code = test_new_netns_exec(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "slow-cat") == 0) {
+            exit_code = test_slow_cat(sub_argc, sub_argv);
         } else {
             fprintf(stderr, "Unknown command `%s`\n", cmd);
             exit_code = EXIT_FAILURE;


### PR DESCRIPTION
### What does this PR do?

`TestProcessContext/tty` was using a very complex way of ensuring a tty is attached to the process opening the file, and that the process is not too short-lived. This PR simplifies the whole process by using `slow-cat` in syscall tester that opens the file, sleeps and then close the file. This allows the `script` process to terminates on its own, which was an issue in centos 7 tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
