### PR TITLE
[CONTP-61] remove global variables in tagger

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_mock.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_mock.go
@@ -14,6 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/api/api"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -32,8 +34,9 @@ func (ac *AutoConfig) mockHandleRequest(w http.ResponseWriter, _ *http.Request) 
 
 type mockdependencies struct {
 	fx.In
-	WMeta  optional.Option[workloadmeta.Component]
-	Params MockParams
+	WMeta      optional.Option[workloadmeta.Component]
+	Params     MockParams
+	TaggerComp tagger.Mock
 }
 
 type mockprovides struct {
@@ -44,7 +47,7 @@ type mockprovides struct {
 }
 
 func newMockAutoConfig(deps mockdependencies) mockprovides {
-	ac := createNewAutoConfig(deps.Params.Scheduler, nil, deps.WMeta)
+	ac := createNewAutoConfig(deps.Params.Scheduler, nil, deps.WMeta, deps.TaggerComp)
 	return mockprovides{
 		Comp:     ac,
 		Endpoint: api.NewAgentEndpointProvider(ac.mockHandleRequest, "/config-check", "GET"),
@@ -62,5 +65,6 @@ func MockModule() fxutil.Module {
 func CreateMockAutoConfig(t *testing.T, scheduler *scheduler.MetaScheduler) autodiscovery.Mock {
 	return fxutil.Test[autodiscovery.Mock](t, fx.Options(
 		fx.Supply(MockParams{Scheduler: scheduler}),
+		taggerimpl.MockModule(),
 		MockModule()))
 }

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -524,5 +524,5 @@ type Deps struct {
 }
 
 func createDeps(t *testing.T) Deps {
-	return fxutil.Test[Deps](t, core.MockBundle(), workloadmeta.MockModule(), fx.Supply(workloadmeta.NewParams()), taggerimpl.MockModule())
+	return fxutil.Test[Deps](t, core.MockBundle(), workloadmeta.MockModule(), fx.Supply(workloadmeta.NewParams()), fx.Supply(tagger.NewFakeTaggerParams()), taggerimpl.Module())
 }

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -168,15 +170,15 @@ func (suite *AutoConfigTestSuite) SetupTest() {
 	suite.deps = createDeps(suite.T())
 }
 
-func getAutoConfig(scheduler *scheduler.MetaScheduler, secretResolver secrets.Component, wmeta optional.Option[workloadmeta.Component]) *AutoConfig {
-	ac := createNewAutoConfig(scheduler, secretResolver, wmeta)
+func getAutoConfig(scheduler *scheduler.MetaScheduler, secretResolver secrets.Component, wmeta optional.Option[workloadmeta.Component], taggerComp tagger.Component) *AutoConfig {
+	ac := createNewAutoConfig(scheduler, secretResolver, wmeta, taggerComp)
 	go ac.serviceListening()
 	return ac
 }
 
 func (suite *AutoConfigTestSuite) TestAddConfigProvider() {
 	mockResolver := MockSecretResolver{suite.T(), nil}
-	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, suite.deps.WMeta)
+	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp)
 	assert.Len(suite.T(), ac.configPollers, 0)
 	mp := &MockProvider{}
 	ac.AddConfigProvider(mp, false, 0)
@@ -193,7 +195,7 @@ func (suite *AutoConfigTestSuite) TestAddConfigProvider() {
 
 func (suite *AutoConfigTestSuite) TestAddListener() {
 	mockResolver := MockSecretResolver{suite.T(), nil}
-	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, suite.deps.WMeta)
+	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp)
 	assert.Len(suite.T(), ac.listeners, 0)
 
 	ml := &MockListener{}
@@ -231,7 +233,7 @@ func (suite *AutoConfigTestSuite) TestDiffConfigs() {
 
 func (suite *AutoConfigTestSuite) TestStop() {
 	mockResolver := MockSecretResolver{suite.T(), nil}
-	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, suite.deps.WMeta)
+	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp)
 
 	ml := &MockListener{}
 	listeners.Register("mock", ml.fakeFactory, ac.serviceListenerFactories)
@@ -244,7 +246,7 @@ func (suite *AutoConfigTestSuite) TestStop() {
 
 func (suite *AutoConfigTestSuite) TestListenerRetry() {
 	mockResolver := MockSecretResolver{suite.T(), nil}
-	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, suite.deps.WMeta)
+	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp)
 
 	// Hack the retry delay to shorten the test run time
 	initialListenerCandidateIntl := listenerCandidateIntl
@@ -352,7 +354,7 @@ func TestResolveTemplate(t *testing.T) {
 	msch.Register("mock", sch, false)
 
 	mockResolver := MockSecretResolver{t, nil}
-	ac := getAutoConfig(msch, &mockResolver, deps.WMeta)
+	ac := getAutoConfig(msch, &mockResolver, deps.WMeta, deps.TaggerComp)
 	tpl := integration.Config{
 		Name:          "cpu",
 		ADIdentifiers: []string{"redis"},
@@ -388,7 +390,7 @@ func TestRemoveTemplate(t *testing.T) {
 
 	mockResolver := MockSecretResolver{t, nil}
 
-	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, deps.WMeta)
+	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, deps.WMeta, deps.TaggerComp)
 	// Add static config
 	c := integration.Config{
 		Name: "memory",
@@ -441,7 +443,7 @@ func TestDecryptConfig(t *testing.T) {
 		},
 	}}
 
-	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, deps.WMeta)
+	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, deps.WMeta, deps.TaggerComp)
 	ac.processNewService(ctx, &dummyService{ID: "abcd", ADIdentifiers: []string{"redis"}})
 
 	tpl := integration.Config{
@@ -485,7 +487,7 @@ func TestProcessClusterCheckConfigWithSecrets(t *testing.T) {
 			returnedError:  nil,
 		},
 	}}
-	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, deps.WMeta)
+	ac := getAutoConfig(scheduler.NewMetaScheduler(), &mockResolver, deps.WMeta, deps.TaggerComp)
 
 	tpl := integration.Config{
 		Provider:     names.ClusterChecks,
@@ -517,9 +519,10 @@ func TestProcessClusterCheckConfigWithSecrets(t *testing.T) {
 
 type Deps struct {
 	fx.In
-	WMeta optional.Option[workloadmeta.Component]
+	WMeta      optional.Option[workloadmeta.Component]
+	TaggerComp tagger.Component
 }
 
 func createDeps(t *testing.T) Deps {
-	return fxutil.Test[Deps](t, core.MockBundle(), workloadmeta.MockModule(), fx.Supply(workloadmeta.NewParams()))
+	return fxutil.Test[Deps](t, core.MockBundle(), workloadmeta.MockModule(), fx.Supply(workloadmeta.NewParams()), taggerimpl.MockModule())
 }

--- a/comp/core/autodiscovery/listeners/service.go
+++ b/comp/core/autodiscovery/listeners/service.go
@@ -83,7 +83,7 @@ func (s *service) GetPorts(_ context.Context) ([]ContainerPort, error) {
 
 // GetTags returns the tags associated with the service.
 func (s *service) GetTags() ([]string, error) {
-	return tagger.Tag(s.GetTaggerEntity(), tagger.ChecksCardinality)
+	return tagger.Tag(s.GetTaggerEntity(), tagger.ChecksCardinality())
 }
 
 // GetPid returns the process ID of the service.

--- a/comp/core/tagger/component.go
+++ b/comp/core/tagger/component.go
@@ -40,4 +40,6 @@ type Component interface {
 	SetNewCaptureTagger(newCaptureTagger Component)
 	ResetCaptureTagger()
 	EnrichTags(tb tagset.TagsAccumulator, originInfo taggertypes.OriginInfo)
+	ChecksCardinality() types.TagCardinality
+	DogstatsdCardinality() types.TagCardinality
 }

--- a/comp/core/tagger/global.go
+++ b/comp/core/tagger/global.go
@@ -22,14 +22,6 @@ var (
 	// initOnce ensures that the global tagger is only initialized once.  It is reset every
 	// time the default tagger is set.
 	initOnce sync.Once
-
-	// ChecksCardinality defines the cardinality of tags we should send for check metrics
-	// this can still be overridden when calling get_tags in python checks.
-	ChecksCardinality types.TagCardinality
-
-	// DogstatsdCardinality defines the cardinality of tags we should send for metrics from
-	// dogstatsd.
-	DogstatsdCardinality types.TagCardinality
 )
 
 // SetGlobalTaggerClient sets the global taggerClient instance
@@ -132,4 +124,20 @@ func EnrichTags(tb tagset.TagsAccumulator, originInfo taggertypes.OriginInfo) {
 	if globalTagger != nil {
 		globalTagger.EnrichTags(tb, originInfo)
 	}
+}
+
+// ChecksCardinality is an interface function that queries taggerclient singleton
+func ChecksCardinality() types.TagCardinality {
+	if globalTagger != nil {
+		return globalTagger.ChecksCardinality()
+	}
+	return types.LowCardinality
+}
+
+// DogstatsdCardinality is an interface function that queries taggerclient singleton
+func DogstatsdCardinality() types.TagCardinality {
+	if globalTagger != nil {
+		return globalTagger.DogstatsdCardinality()
+	}
+	return types.LowCardinality
 }

--- a/comp/core/tagger/taggerimpl/empty/empty.go
+++ b/comp/core/tagger/taggerimpl/empty/empty.go
@@ -42,3 +42,14 @@ func (t *Tagger) ResetCaptureTagger() {}
 
 // EnrichTags extends a tag list with origin detection tags
 func (t *Tagger) EnrichTags(tagset.TagsAccumulator, taggertypes.OriginInfo) {}
+
+// ChecksCardinality defines the cardinality of tags we should send for check metrics
+func (t *Tagger) ChecksCardinality() types.TagCardinality {
+	return types.LowCardinality
+}
+
+// DogstatsdCardinality defines the cardinality of tags we should send for metrics from
+// dogstatsd.
+func (t *Tagger) DogstatsdCardinality() types.TagCardinality {
+	return types.LowCardinality
+}

--- a/comp/core/tagger/taggerimpl/tagger.go
+++ b/comp/core/tagger/taggerimpl/tagger.go
@@ -367,7 +367,7 @@ func (t *TaggerClient) ResetCaptureTagger() {
 // enrichment, the metric and its tags is sent to the context key generator, which
 // is taking care of deduping the tags while generating the context key.
 func (t *TaggerClient) EnrichTags(tb tagset.TagsAccumulator, originInfo taggertypes.OriginInfo) {
-	cardinality := t.taggerCardinality(originInfo.Cardinality)
+	cardinality := taggerCardinality(originInfo.Cardinality, t.dogstatsdCardinality)
 
 	productOrigin := originInfo.ProductOrigin
 	// If origin_detection_unified is disabled, we use DogStatsD's Legacy Origin Detection.
@@ -502,16 +502,17 @@ func (t *TaggerClient) DogstatsdCardinality() types.TagCardinality {
 }
 
 // taggerCardinality converts tagger cardinality string to types.TagCardinality
-// It defaults to DogstatsdCardinality if the string is empty or unknown
-func (t *TaggerClient) taggerCardinality(cardinality string) types.TagCardinality {
+// It should be defaulted to DogstatsdCardinality if the string is empty or unknown
+func taggerCardinality(cardinality string,
+	defaultCardinality types.TagCardinality) types.TagCardinality {
 	if cardinality == "" {
-		return t.dogstatsdCardinality
+		return defaultCardinality
 	}
 
 	taggerCardinality, err := types.StringToTagCardinality(cardinality)
 	if err != nil {
 		log.Tracef("Couldn't convert cardinality tag: %v", err)
-		return t.dogstatsdCardinality
+		return defaultCardinality
 	}
 
 	return taggerCardinality

--- a/comp/core/tagger/taggerimpl/tagger.go
+++ b/comp/core/tagger/taggerimpl/tagger.go
@@ -90,6 +90,9 @@ type TaggerClient struct {
 
 	wmeta         workloadmeta.Component
 	datadogConfig datadogConfig
+
+	checksCardinality    types.TagCardinality
+	dogstatsdCardinality types.TagCardinality
 }
 
 // we use to pull tagger metrics in dogstatsd. Pulling it later in the
@@ -160,16 +163,16 @@ func newTaggerClient(deps dependencies) provides {
 		var err error
 		checkCard := deps.Config.GetString("checks_tag_cardinality")
 		dsdCard := deps.Config.GetString("dogstatsd_tag_cardinality")
-		taggerComp.ChecksCardinality, err = types.StringToTagCardinality(checkCard)
+		taggerClient.checksCardinality, err = types.StringToTagCardinality(checkCard)
 		if err != nil {
 			deps.Log.Warnf("failed to parse check tag cardinality, defaulting to low. Error: %s", err)
-			taggerComp.ChecksCardinality = types.LowCardinality
+			taggerClient.checksCardinality = types.LowCardinality
 		}
 
-		taggerComp.DogstatsdCardinality, err = types.StringToTagCardinality(dsdCard)
+		taggerClient.dogstatsdCardinality, err = types.StringToTagCardinality(dsdCard)
 		if err != nil {
 			deps.Log.Warnf("failed to parse dogstatsd tag cardinality, defaulting to low. Error: %s", err)
-			taggerComp.DogstatsdCardinality = types.LowCardinality
+			taggerClient.dogstatsdCardinality = types.LowCardinality
 		}
 		// Main context passed to components, consistent with the one used in the workloadmeta component
 		mainCtx, _ := common.GetMainCtxCancel()
@@ -364,7 +367,7 @@ func (t *TaggerClient) ResetCaptureTagger() {
 // enrichment, the metric and its tags is sent to the context key generator, which
 // is taking care of deduping the tags while generating the context key.
 func (t *TaggerClient) EnrichTags(tb tagset.TagsAccumulator, originInfo taggertypes.OriginInfo) {
-	cardinality := taggerCardinality(originInfo.Cardinality)
+	cardinality := t.taggerCardinality(originInfo.Cardinality)
 
 	productOrigin := originInfo.ProductOrigin
 	// If origin_detection_unified is disabled, we use DogStatsD's Legacy Origin Detection.
@@ -486,17 +489,29 @@ func (t *TaggerClient) parseEntityID(entityID string, metricsProvider provider.C
 	return containers.BuildTaggerEntityName(cid)
 }
 
+// ChecksCardinality defines the cardinality of tags we should send for check metrics
+// this can still be overridden when calling get_tags in python checks.
+func (t *TaggerClient) ChecksCardinality() types.TagCardinality {
+	return t.checksCardinality
+}
+
+// DogstatsdCardinality defines the cardinality of tags we should send for metrics from
+// dogstatsd.
+func (t *TaggerClient) DogstatsdCardinality() types.TagCardinality {
+	return t.dogstatsdCardinality
+}
+
 // taggerCardinality converts tagger cardinality string to types.TagCardinality
 // It defaults to DogstatsdCardinality if the string is empty or unknown
-func taggerCardinality(cardinality string) types.TagCardinality {
+func (t *TaggerClient) taggerCardinality(cardinality string) types.TagCardinality {
 	if cardinality == "" {
-		return taggerComp.DogstatsdCardinality
+		return t.dogstatsdCardinality
 	}
 
 	taggerCardinality, err := types.StringToTagCardinality(cardinality)
 	if err != nil {
 		log.Tracef("Couldn't convert cardinality tag: %v", err)
-		return taggerComp.DogstatsdCardinality
+		return t.dogstatsdCardinality
 	}
 
 	return taggerCardinality

--- a/comp/core/tagger/taggerimpl/tagger_test.go
+++ b/comp/core/tagger/taggerimpl/tagger_test.go
@@ -52,17 +52,17 @@ func Test_taggerCardinality(t *testing.T) {
 		{
 			name:        "empty",
 			cardinality: "",
-			want:        tagger.DogstatsdCardinality,
+			want:        tagger.DogstatsdCardinality(),
 		},
 		{
 			name:        "unknown",
 			cardinality: "foo",
-			want:        tagger.DogstatsdCardinality,
+			want:        tagger.DogstatsdCardinality(),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, taggerCardinality(tt.cardinality))
+			assert.Equal(t, tt.want, taggerCardinality(tt.cardinality, tagger.DogstatsdCardinality()))
 		})
 	}
 }

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -812,13 +812,13 @@ func (agg *BufferedAggregator) tags(withVersion bool) []string {
 	var tags []string
 
 	var err error
-	tags, err = agg.globalTags(tagger.ChecksCardinality)
+	tags, err = agg.globalTags(tagger.ChecksCardinality())
 	if err != nil {
 		log.Debugf("Couldn't get Global tags: %v", err)
 	}
 
 	if agg.tlmContainerTagsEnabled {
-		agentTags, err := agg.agentTags(tagger.ChecksCardinality)
+		agentTags, err := agg.agentTags(tagger.ChecksCardinality())
 		if err == nil {
 			if tags == nil {
 				tags = agentTags

--- a/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
@@ -118,7 +118,7 @@ func (m *OOMKillCheck) Run() error {
 		entityID := containers.BuildTaggerEntityName(containerID)
 		var tags []string
 		if entityID != "" {
-			tags, err = tagger.Tag(entityID, tagger.ChecksCardinality)
+			tags, err = tagger.Tag(entityID, tagger.ChecksCardinality())
 			if err != nil {
 				log.Errorf("Error collecting tags for container %s: %s", containerID, err)
 			}

--- a/pkg/logs/internal/util/adlistener/ad_test.go
+++ b/pkg/logs/internal/util/adlistener/ad_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"go.uber.org/fx"
@@ -26,7 +28,10 @@ func TestListenersGetScheduleCalls(t *testing.T) {
 		autodiscoveryimpl.MockModule(),
 		workloadmeta.MockModule(),
 		fx.Supply(workloadmeta.NewParams()),
-		core.MockBundle())
+		core.MockBundle(),
+		fx.Provide(taggerimpl.NewMock),
+		fx.Supply(tagger.NewFakeTaggerParams()),
+	)
 
 	got1 := make(chan struct{}, 1)
 	l1 := NewADListener("l1", ac, func(configs []integration.Config) {

--- a/pkg/logs/schedulers/cca/scheduler_test.go
+++ b/pkg/logs/schedulers/cca/scheduler_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	logsConfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -28,7 +30,10 @@ func setup(t *testing.T) (scheduler *Scheduler, ac autodiscovery.Component, spy 
 		autodiscoveryimpl.MockModule(),
 		workloadmeta.MockModule(),
 		fx.Supply(workloadmeta.NewParams()),
-		core.MockBundle())
+		core.MockBundle(),
+		fx.Supply(tagger.NewFakeTaggerParams()),
+		fx.Provide(taggerimpl.NewMock),
+	)
 	scheduler = New(ac).(*Scheduler)
 	spy = &schedulers.MockSourceManager{}
 	return


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
[CONTP-61](https://datadoghq.atlassian.net/browse/CONTP-61)

1. Remove global variables ChecksCardinality and DogstatsdCardinality 
2. Add member functions to tagger component
3. If tagger component is passed into the caller or injected by fx, call taggerComp.ChecksCardinality()
4. If component not passed in, call ChecksCardinality() which is a wrapper function to query singleton of tagger.

Note [CONTP-59](https://datadoghq.atlassian.net/browse/CONTP-59)  will remove tagger singleton and all functions in global.go

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
No change is expected. Generic QA and e2e test should cover it. 


[CONTP-61]: https://datadoghq.atlassian.net/browse/CONTP-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CONTP-59]: https://datadoghq.atlassian.net/browse/CONTP-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ