### PR TITLE
[CWS] improve netns resolver close operations

### DIFF
--- a/pkg/security/resolvers/netns/resolver.go
+++ b/pkg/security/resolvers/netns/resolver.go
@@ -547,6 +547,15 @@ func (nr *Resolver) SendStats() error {
 	return nil
 }
 
+// Close closes this resolver and frees all the resources
+func (nr *Resolver) Close() {
+	if nr.networkNamespaces != nil {
+		nr.Lock()
+		nr.networkNamespaces.Purge()
+		nr.Unlock()
+	}
+}
+
 func newTmpFile(prefix string) (*os.File, error) {
 	f, err := os.CreateTemp("/tmp", prefix)
 	if err != nil {

--- a/pkg/security/resolvers/netns/resolver.go
+++ b/pkg/security/resolvers/netns/resolver.go
@@ -413,6 +413,17 @@ func (nr *Resolver) Start(ctx context.Context) error {
 	return nil
 }
 
+func (nr *Resolver) manualFlushNamespaces() {
+	probesCount := nr.tcResolver.FlushInactiveProbes(nr.manager, nr.IsLazyDeletionInterface)
+
+	// There is a possible race condition if we lose all network device creations but do notice the new network
+	// namespace: we will create a handle that will never be flushed by `nr.probe.flushInactiveNamespaces()`.
+	// To detect this race, compute the list of namespaces that are in cache, but for which we do not have any
+	// device. Defer a snapshot process for each of those namespaces, and delete them if the snapshot yields
+	// no new device.
+	nr.preventNetworkNamespaceDrift(probesCount)
+}
+
 func (nr *Resolver) flushNamespaces(ctx context.Context) {
 	ticker := time.NewTicker(flushNamespacesPeriod)
 	defer ticker.Stop()
@@ -422,14 +433,7 @@ func (nr *Resolver) flushNamespaces(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			probesCount := nr.tcResolver.FlushInactiveProbes(nr.manager, nr.IsLazyDeletionInterface)
-
-			// There is a possible race condition if we lose all network device creations but do notice the new network
-			// namespace: we will create a handle that will never be flushed by `nr.probe.flushInactiveNamespaces()`.
-			// To detect this race, compute the list of namespaces that are in cache, but for which we do not have any
-			// device. Defer a snapshot process for each of those namespaces, and delete them if the snapshot yields
-			// no new device.
-			nr.preventNetworkNamespaceDrift(probesCount)
+			nr.manualFlushNamespaces()
 		}
 	}
 }
@@ -554,6 +558,7 @@ func (nr *Resolver) Close() {
 		nr.networkNamespaces.Purge()
 		nr.Unlock()
 	}
+	nr.manualFlushNamespaces()
 }
 
 func newTmpFile(prefix string) (*os.File, error) {

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -285,6 +285,14 @@ func (r *EBPFResolvers) snapshot() error {
 
 // Close cleans up any underlying resolver that requires a cleanup
 func (r *EBPFResolvers) Close() error {
+	// clean up the handles in netns resolver
+	r.NamespaceResolver.Close()
+
 	// clean up the dentry resolver eRPC segment
-	return r.DentryResolver.Close()
+	if err := r.DentryResolver.Close(); err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds a new `Close` function for the network namespace resolver allowing it to purge in-flight namespaces and associated resources.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
