### PR TITLE
Add logs in e2e tests when running agent commands

### DIFF
--- a/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
@@ -58,6 +58,7 @@ func (agent *agentCommandRunner) executeCommandWithError(command string, command
 
 	arguments := []string{command}
 	arguments = append(arguments, args.Args...)
+	agent.t.Logf("Running agent command: %+q", arguments)
 	output, err := agent.executor.execute(arguments)
 	return output, err
 }
@@ -172,6 +173,7 @@ func (agent *agentCommandRunner) StatusWithError(commandArgs ...agentclient.Agen
 func (agent *agentCommandRunner) waitForReadyTimeout(timeout time.Duration) error {
 	interval := 100 * time.Millisecond
 	maxRetries := timeout.Milliseconds() / interval.Milliseconds()
+	agent.t.Log("Waiting for the agent to be ready")
 	err := backoff.Retry(func() error {
 		_, err := agent.executor.execute([]string{"status"})
 		if err != nil {

--- a/test/new-e2e/pkg/utils/e2e/client/ec2_metadata.go
+++ b/test/new-e2e/pkg/utils/e2e/client/ec2_metadata.go
@@ -36,6 +36,7 @@ func NewEC2Metadata(t *testing.T, h *Host, osFamily os.Family) *EC2Metadata {
 		panic(fmt.Sprintf("unsupported OS family: %v", osFamily))
 	}
 
+	t.Log("Getting EC2 metadata token")
 	output := h.MustExecute(cmd)
 	return &EC2Metadata{osFamily: osFamily, token: output, host: h, t: t}
 }
@@ -53,5 +54,6 @@ func (m *EC2Metadata) Get(name string) string {
 		panic(fmt.Sprintf("unsupported OS family: %v", m.osFamily))
 	}
 
+	m.t.Log("Getting EC2 metadata for", name)
 	return strings.TrimRight(m.host.MustExecute(cmd), "\r\n")
 }

--- a/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_win_test.go
@@ -8,13 +8,14 @@ package hostname
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 )
 
 type windowsHostnameSuite struct {
@@ -29,7 +30,9 @@ func TestWindowsHostnameSuite(t *testing.T) {
 func (v *windowsHostnameSuite) TestAgentConfigHostnameFileOverride() {
 	// Using MustExecute instead of agentparams.WithFile because encoding (utf16 and utf8) contains invisible characters
 	// that makes the hostname not RFC1123 compliant and then rejected by the Agent.
+	v.T().Log("Setting hostname in file")
 	v.Env().RemoteHost.MustExecute(`"hostname.from.file" | Out-File -FilePath "C:/ProgramData/Datadog/hostname.txt" -Encoding ascii`)
+	v.T().Log("Testing hostname with hostname_file")
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(v.GetOs(), awshost.WithAgentOptions(agentparams.WithAgentConfig("hostname_file: C:/ProgramData/Datadog/hostname.txt"))))
 
 	hostname := v.Env().Agent.Client.Hostname()
@@ -40,6 +43,7 @@ func (v *windowsHostnameSuite) TestAgentConfigPreferImdsv2() {
 	config := `ec2_prefer_imdsv2: true
 ec2_use_windows_prefix_detection: true`
 
+	v.T().Log("Testing hostname with ec2_prefer_imdsv2 and ec2_use_windows_prefix_detection")
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(v.GetOs(), awshost.WithAgentOptions(agentparams.WithAgentConfig(config))))
 	// e2e metadata provider already uses IMDSv2
 	metadata := client.NewEC2Metadata(v.T(), v.Env().RemoteHost.Host, v.Env().RemoteHost.OSFamily)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add logs in e2e tests, in the hostname subcommand tests, and in general when running agent commands.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
We had a test last 1h40m without any logs (and it succeeded eventually !), so we don't even know where it was blocked.

Pulumi logs have recently been removed, resulting in not really knowing what's happening unless adding a lot of logs in the test. Adding these logs should help understand what's going on.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
