### PR TITLE
fix(CI): Remove i7 jobs and use a7 repository for the installer

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -642,9 +642,7 @@ workflow:
   - <<: *if_installer_tests
     when: always
 
-.on_all_new_e2e_tests:
-  - <<: *if_not_run_all_builds
-    when: never
+.on_all_install_script_tests:
   - <<: *if_installer_tests
 
 # Default kitchen tests are also run on dev branches

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -302,12 +302,12 @@ new-e2e-installer:
   rules:
     !reference [.on_installer_or_e2e_changes_or_manual]
   needs:
-    - deploy_deb_testing-i7_arm64
-    - deploy_deb_testing-i7_amd64
-    - deploy_rpm_testing-i7_arm64
-    - deploy_rpm_testing-i7_x64
-    - deploy_suse_rpm_testing-i7_arm64
-    - deploy_suse_rpm_testing-i7_x64
+    - deploy_deb_testing-a7_arm64
+    - deploy_deb_testing-a7_x64
+    - deploy_rpm_testing-a7_arm64
+    - deploy_rpm_testing-a7_x64
+    - deploy_suse_rpm_testing_arm64-a7
+    - deploy_suse_rpm_testing_x64-a7
     - qa_installer_oci
     - qa_agent_oci
   variables:

--- a/.gitlab/kitchen_deploy/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy/kitchen_deploy.yml
@@ -117,9 +117,8 @@ deploy_deb_testing-a7_x64:
 
 deploy_deb_testing-a7_arm64:
   rules:
-    - !reference [.except_no_tests_no_deploy]
-    - !reference [.except_mergequeue]
-    - when: on_success
+    - !reference [.on_installer_or_e2e_changes_or_manual]
+    - !reference [.on_all_new_e2e_tests]
   extends:
     - .deploy_deb_testing-a7
   needs: ["installer_deb-arm64", "agent_deb-arm64-a7", "lint_linux-arm64"]
@@ -202,9 +201,8 @@ deploy_rpm_testing-a7_x64:
 
 deploy_rpm_testing-a7_arm64:
   rules:
-    - !reference [.except_no_tests_no_deploy]
-    - !reference [.except_mergequeue]
-    - when: on_success
+    - !reference [.on_installer_or_e2e_changes_or_manual]
+    - !reference [.on_all_new_e2e_tests]
   extends:
     - .deploy_rpm_testing-a7
   needs: ["installer_rpm-arm64", "agent_rpm-arm64-a7", "lint_linux-arm64"]
@@ -261,9 +259,8 @@ deploy_suse_rpm_testing_x64-a7:
 
 deploy_suse_rpm_testing_arm64-a7:
   rules:
-    - !reference [.except_no_tests_no_deploy]
-    - !reference [.except_mergequeue]
-    - when: on_success
+    - !reference [.on_kitchen_tests]
+    - !reference [.on_installer_or_e2e_changes_or_manual]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/kitchen_deploy/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy/kitchen_deploy.yml
@@ -43,16 +43,6 @@
     - source /root/.bashrc
     - ls $OMNIBUS_PACKAGE_DIR
 
-.deploy_deb_testing-i7:
-  stage: kitchen_deploy
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  variables:
-    DD_PIPELINE_ID: $CI_PIPELINE_ID-i7
-  before_script:
-    - source /root/.bashrc
-    - ls $OMNIBUS_PACKAGE_DIR
-
 deploy_deb_testing-a6_x64:
   rules: !reference [.on_kitchen_tests]
   extends:
@@ -107,6 +97,7 @@ deploy_deb_testing-a7_x64:
     - .deploy_deb_testing-a7
   needs:
     [
+      "installer_deb-amd64",
       "agent_deb-x64-a7",
       "agent_heroku_deb-x64-a7",
       "iot_agent_deb-x64",
@@ -125,10 +116,13 @@ deploy_deb_testing-a7_x64:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 7 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 deploy_deb_testing-a7_arm64:
-  rules: !reference [.on_all_new_e2e_tests]
+  rules:
+    - !reference [.except_no_tests_no_deploy]
+    - !reference [.except_mergequeue]
+    - when: on_success
   extends:
     - .deploy_deb_testing-a7
-  needs: ["agent_deb-arm64-a7", "lint_linux-arm64"]
+  needs: ["installer_deb-arm64", "agent_deb-arm64-a7", "lint_linux-arm64"]
   script:
     - *setup_apt_signing_key
     - set +x # make sure we don't output the creds to the build log
@@ -136,40 +130,6 @@ deploy_deb_testing-a7_arm64:
     - *setup_signing_keys_package
 
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-arm64" -m 7 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-*_7*arm64.deb
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-arm64" -m 7 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
-
-deploy_deb_testing-i7_amd64:
-  rules:
-    - !reference [.except_no_tests_no_deploy]
-    - !reference [.except_mergequeue]
-    - when: on_success
-  extends:
-    - .deploy_deb_testing-i7
-  needs: ["installer_deb-amd64", "lint_linux-x64"]
-  script:
-    - *setup_apt_signing_key
-    - set +x # make sure we don't output the creds to the build log
-
-    - *setup_signing_keys_package
-
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 7 -b $DEB_TESTING_S3_BUCKET -a amd64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-installer*amd64.deb
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 7 -b $DEB_TESTING_S3_BUCKET -a amd64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
-
-deploy_deb_testing-i7_arm64:
-  rules:
-    - !reference [.except_no_tests_no_deploy]
-    - !reference [.except_mergequeue]
-    - when: on_success
-  extends:
-    - .deploy_deb_testing-i7
-  needs: ["installer_deb-arm64", "lint_linux-arm64"]
-  script:
-    - *setup_apt_signing_key
-    - set +x # make sure we don't output the creds to the build log
-
-    - *setup_signing_keys_package
-
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-arm64" -m 7 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-installer*arm64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-arm64" -m 7 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 .deploy_rpm_testing-a6:
@@ -229,6 +189,7 @@ deploy_rpm_testing-a7_x64:
     - .deploy_rpm_testing-a7
   needs:
     [
+      "installer_rpm-amd64",
       "agent_rpm-x64-a7",
       "iot_agent_rpm-x64",
       "dogstatsd_rpm-x64",
@@ -240,64 +201,17 @@ deploy_rpm_testing-a7_x64:
     - echo "$RPM_SIGNING_PASSPHRASE" | python2 /opt/rpm-s3/bin/rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-7.*x86_64.rpm
 
 deploy_rpm_testing-a7_arm64:
-  rules: !reference [.on_all_new_e2e_tests]
-  extends:
-    - .deploy_rpm_testing-a7
-  needs: ["agent_rpm-arm64-a7", "lint_linux-arm64"]
-  script:
-    - *setup_rpm_signing_key
-    - set +x
-    - echo "$RPM_SIGNING_PASSPHRASE" | python2 /opt/rpm-s3/bin/rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/7/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-7.*aarch64.rpm
-
-.deploy_rpm_testing-i7:
-  stage: kitchen_deploy
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
   rules:
     - !reference [.except_no_tests_no_deploy]
     - !reference [.except_mergequeue]
     - when: on_success
-  variables:
-    DD_PIPELINE_ID: $CI_PIPELINE_ID-i7
-  before_script:
-    - source /root/.bashrc
-    - ls $OMNIBUS_PACKAGE_DIR
-
-deploy_rpm_testing-i7_arm64:
   extends:
-    - .deploy_rpm_testing-i7
-  needs: ["installer_rpm-arm64", "lint_linux-arm64"]
+    - .deploy_rpm_testing-a7
+  needs: ["installer_rpm-arm64", "agent_rpm-arm64-a7", "lint_linux-arm64"]
   script:
     - *setup_rpm_signing_key
-    - set +x # make sure we don't output the creds to the build log
+    - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | python2 /opt/rpm-s3/bin/rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/7/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-7.*aarch64.rpm
-
-deploy_rpm_testing-i7_x64:
-  extends:
-    - .deploy_rpm_testing-i7
-  needs: ["installer_rpm-amd64", "lint_linux-x64"]
-  script:
-    - *setup_rpm_signing_key
-    - set +x # make sure we don't output the creds to the build log
-    - echo "$RPM_SIGNING_PASSPHRASE" | python2 /opt/rpm-s3/bin/rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-7.*x86_64.rpm
-
-deploy_suse_rpm_testing-i7_arm64:
-  extends:
-    - .deploy_rpm_testing-i7
-  needs: ["installer_suse_rpm-arm64", "lint_linux-arm64"]
-  script:
-    - *setup_rpm_signing_key
-    - set +x # make sure we don't output the creds to the build log
-    - echo "$RPM_SIGNING_PASSPHRASE" | python2 /opt/rpm-s3/bin/rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/testing/pipeline-$DD_PIPELINE_ID/7/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-7.*aarch64.rpm
-
-deploy_suse_rpm_testing-i7_x64:
-  extends:
-    - .deploy_rpm_testing-i7
-  needs: ["installer_suse_rpm-amd64", "lint_linux-x64"]
-  script:
-    - *setup_rpm_signing_key
-    - set +x # make sure we don't output the creds to the build log
-    - echo "$RPM_SIGNING_PASSPHRASE" | python2 /opt/rpm-s3/bin/rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/testing/pipeline-$DD_PIPELINE_ID/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-7.*x86_64.rpm
 
 deploy_suse_rpm_testing_x64-a6:
   rules: !reference [.on_kitchen_tests]
@@ -329,6 +243,7 @@ deploy_suse_rpm_testing_x64-a7:
   tags: ["arch:amd64"]
   needs:
     [
+      "installer_suse_rpm-amd64",
       "agent_suse-x64-a7",
       "iot_agent_suse-x64",
       "dogstatsd_suse-x64",
@@ -345,11 +260,14 @@ deploy_suse_rpm_testing_x64-a7:
     - echo "$RPM_SIGNING_PASSPHRASE" | python2 /opt/rpm-s3/bin/rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/testing/pipeline-$DD_PIPELINE_ID/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/datadog-*-7.*x86_64.rpm
 
 deploy_suse_rpm_testing_arm64-a7:
-  rules: !reference [.on_kitchen_tests]
+  rules:
+    - !reference [.except_no_tests_no_deploy]
+    - !reference [.except_mergequeue]
+    - when: on_success
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["agent_suse-arm64-a7", "lint_linux-arm64"]
+  needs: ["installer_suse_rpm-arm64", "agent_suse-arm64-a7", "lint_linux-arm64"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:

--- a/.gitlab/kitchen_deploy/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy/kitchen_deploy.yml
@@ -65,7 +65,7 @@ deploy_deb_testing-a6_x64:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 6 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 deploy_deb_testing-a6_arm64:
-  rules: !reference [.on_all_new_e2e_tests]
+  rules: !reference [.on_all_install_script_tests]
   extends:
     - .deploy_deb_testing-a6
   needs: ["agent_deb-arm64-a6"]
@@ -117,8 +117,8 @@ deploy_deb_testing-a7_x64:
 
 deploy_deb_testing-a7_arm64:
   rules:
+    - !reference [.on_all_install_script_tests]
     - !reference [.on_installer_or_e2e_changes_or_manual]
-    - !reference [.on_all_new_e2e_tests]
   extends:
     - .deploy_deb_testing-a7
   needs: ["installer_deb-arm64", "agent_deb-arm64-a7", "lint_linux-arm64"]
@@ -156,7 +156,7 @@ deploy_rpm_testing-a6_x64:
     - echo "$RPM_SIGNING_PASSPHRASE" | python2 /opt/rpm-s3/bin/rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/6/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-6.*x86_64.rpm
 
 deploy_rpm_testing-a6_arm64:
-  rules: !reference [.on_all_new_e2e_tests]
+  rules: !reference [.on_all_install_script_tests]
   extends:
     - .deploy_rpm_testing-a6
   needs:
@@ -201,8 +201,8 @@ deploy_rpm_testing-a7_x64:
 
 deploy_rpm_testing-a7_arm64:
   rules:
+    - !reference [.on_all_install_script_tests]
     - !reference [.on_installer_or_e2e_changes_or_manual]
-    - !reference [.on_all_new_e2e_tests]
   extends:
     - .deploy_rpm_testing-a7
   needs: ["installer_rpm-arm64", "agent_rpm-arm64-a7", "lint_linux-arm64"]

--- a/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
@@ -76,7 +76,7 @@ new-e2e-agent-platform-install-script-amazonlinux-a7-arm64:
     - .new-e2e_os_amazonlinux
     - .new-e2e_amazonlinux_a7_arm64
     - .new-e2e_agent_a7
-  rules: !reference [.on_all_new_e2e_tests]
+  rules: !reference [.on_all_install_script_tests]
   variables:
     FLAVOR: datadog-agent
 

--- a/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
@@ -76,7 +76,7 @@ new-e2e-agent-platform-install-script-debian-a7-arm64:
     - .new-e2e_os_debian
     - .new-e2e_debian_a7_arm64
     - .new-e2e_agent_a7
-  rules: !reference [.on_all_new_e2e_tests]
+  rules: !reference [.on_all_install_script_tests]
   variables:
     FLAVOR: datadog-agent
 

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -63,7 +63,7 @@ new-e2e-agent-platform-install-script-suse-a7-arm64:
     - .new-e2e_os_suse
     - .new-e2e_suse_a7_arm64
     - .new-e2e_agent_a7
-  rules: !reference [.on_all_new_e2e_tests]
+  rules: !reference [.on_all_install_script_tests]
   variables:
     FLAVOR: datadog-agent
 

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -91,7 +91,7 @@ new-e2e-agent-platform-install-script-ubuntu-a7-arm64:
     - .new-e2e_ubuntu_a7_arm64
     - .new-e2e_agent_a7
   rules:
-    !reference [.on_all_new_e2e_tests]
+    !reference [.on_all_install_script_tests]
   variables:
     FLAVOR: datadog-agent
 

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -114,8 +114,10 @@ agent_rpm-arm64-a6:
 agent_rpm-arm64-a7:
   extends: .agent_build_common_rpm
   rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
+    - !reference [.on_all_builds]
+    - !reference [.on_packaging_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_installer_or_e2e_changes_or_manual]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -114,9 +114,8 @@ agent_rpm-arm64-a6:
 agent_rpm-arm64-a7:
   extends: .agent_build_common_rpm
   rules:
-    - !reference [.on_all_builds]
-    - !reference [.on_packaging_change]
-    - !reference [.on_go-version_change]
+    - !reference [.except_mergequeue]
+    - when: on_success
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -92,9 +92,8 @@ agent_suse-x64-a7:
 agent_suse-arm64-a7:
   extends: .agent_build_common_suse_rpm
   rules:
-    - !reference [.on_all_builds]
-    - !reference [.on_packaging_change]
-    - !reference [.on_go-version_change]
+    - !reference [.except_mergequeue]
+    - when: on_success
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -92,8 +92,10 @@ agent_suse-x64-a7:
 agent_suse-arm64-a7:
   extends: .agent_build_common_suse_rpm
   rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
+    - !reference [.on_all_builds]
+    - !reference [.on_packaging_change]
+    - !reference [.on_go-version_change]
+    - !reference [.on_installer_or_e2e_changes_or_manual]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -211,9 +211,9 @@ func installScriptEnv(arch e2eos.Architecture) map[string]string {
 		"DD_INSTALLER":             "true",
 		"TESTING_KEYS_URL":         "keys.datadoghq.com",
 		"TESTING_APT_URL":          "apttesting.datad0g.com",
-		"TESTING_APT_REPO_VERSION": fmt.Sprintf("pipeline-%s-i7-%s 7", os.Getenv("CI_PIPELINE_ID"), arch),
+		"TESTING_APT_REPO_VERSION": fmt.Sprintf("pipeline-%s-a7-%s 7", os.Getenv("CI_PIPELINE_ID"), arch),
 		"TESTING_YUM_URL":          "yumtesting.datad0g.com",
-		"TESTING_YUM_VERSION_PATH": fmt.Sprintf("testing/pipeline-%s-i7/7", os.Getenv("CI_PIPELINE_ID")),
+		"TESTING_YUM_VERSION_PATH": fmt.Sprintf("testing/pipeline-%s-a7/7", os.Getenv("CI_PIPELINE_ID")),
 	}
 	for _, pkg := range packagesConfig {
 		name := strings.ToUpper(strings.ReplaceAll(pkg.name, "-", "_"))


### PR DESCRIPTION
### What does this PR do?
Removes `i7` deb/rpm repositories use for the installer, make it use `a7` like the agent.

This has the nice side effect of removing a bunch of jobs, making the CI cost less 👍 

### Motivation
We can only override the repository once for all packages in the install script, so to test end to end the override of the agent & the installer debs/rpms we need them to be in the same repository

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
N/A
