### PR TITLE
[workloadmeta/kubeapiserver] Use kube informers client

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -77,7 +77,7 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Componen
 	if err != nil {
 		return err
 	}
-	client := apiserverClient.Cl
+	client := apiserverClient.InformerCl
 
 	// TODO(components): do not use the config.Datadog reference, use a component instead
 	for _, storeBuilder := range storeGenerators(config.Datadog) {

--- a/releasenotes-dca/notes/kubeapiserver-wlmeta-informers-client-68de7f69c589480f.yaml
+++ b/releasenotes-dca/notes/kubeapiserver-wlmeta-informers-client-68de7f69c589480f.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes an issue with large clusters where the Cluster
+    Agent fails to collect all tags when
+    `cluster_agent.collect_kubernetes_tags` is enabled.


### PR DESCRIPTION
### What does this PR do?

Updates the kubeapiserver workloadmeta collector to use the kubernetes client meant to be used for informers (it has higher timeouts) instead of the normal one.

Reference:
https://github.com/DataDog/datadog-agent/blob/92c5677509b1e0c2928dea93454b20f789463495/pkg/util/kubernetes/apiserver/apiserver.go#L74

This fixes an issue that can happen in large clusters when `cluster_agent.collect_kubernetes_tags` is enabled. When the number of pods in the cluster is high, the requests sent by the pod informer might timeout if the standard client is used.

### Describe how to test/QA your changes

Already verified in the cluster where we had the issue.