### PR TITLE
[FA] Add default log source to file logs

### DIFF
--- a/comp/core/autodiscovery/common/utils/annotations.go
+++ b/comp/core/autodiscovery/common/utils/annotations.go
@@ -37,12 +37,7 @@ func ExtractTemplatesFromMap(key string, input map[string]string, prefix string)
 	}
 	configs = append(configs, checksConfigs...)
 
-	logCheckName := ""
-	if len(configs) >= 1 {
-		// Consider the first check name as the log check name, even if it's empty
-		logCheckName = configs[0].Name
-	}
-	logsConfigs, err := extractLogsTemplatesFromMap(logCheckName, key, input, prefix)
+	logsConfigs, err := extractLogsTemplatesFromMap(configs, key, input, prefix)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("could not extract logs config: %v", err))
 	}
@@ -86,11 +81,17 @@ func extractCheckTemplatesFromMap(key string, input map[string]string, prefix st
 
 // extractLogsTemplatesFromMap returns the logs configuration from a given map,
 // if none are found return an empty list.
-func extractLogsTemplatesFromMap(logCheckName string, key string, input map[string]string, prefix string) ([]integration.Config, error) {
+func extractLogsTemplatesFromMap(configs []integration.Config, key string, input map[string]string, prefix string) ([]integration.Config, error) {
 	value, found := input[prefix+logsConfigPath]
 	if !found {
 		return []integration.Config{}, nil
 	}
+	logCheckName := ""
+	if len(configs) >= 1 {
+		// Consider the first check name as the log check name, even if it's empty
+		logCheckName = configs[0].Name
+	}
+
 	var data interface{}
 	err := json.Unmarshal([]byte(value), &data)
 	if err != nil {
@@ -292,13 +293,7 @@ func extractTemplatesFromMapWithV2(entityName string, annotations map[string]str
 	}
 
 	if actualPrefix != "" {
-		logCheckName := ""
-		if len(configs) >= 1 {
-			// Consider the first check name as the log check name, even if it's empty
-			logCheckName = configs[0].Name
-		}
-
-		c, err := extractLogsTemplatesFromMap(logCheckName, entityName, annotations, actualPrefix)
+		c, err := extractLogsTemplatesFromMap(configs, entityName, annotations, actualPrefix)
 
 		if err != nil {
 			errors = append(errors, fmt.Errorf("could not extract logs config: %v", err))

--- a/comp/core/autodiscovery/common/utils/annotations.go
+++ b/comp/core/autodiscovery/common/utils/annotations.go
@@ -89,6 +89,9 @@ func extractLogsTemplatesFromMap(configs []integration.Config, key string, input
 	logCheckName := ""
 	if len(configs) >= 1 {
 		// Consider the first check name as the log check name, even if it's empty
+		// It's possible to have different names in different configs, and it would mean that one attached multiple integrations
+		// to a single container (e.g. redis + nginx). We expect we won't encounter this most of the time,
+		// but if it happens it means we're tagging the wrong integration name.
 		logCheckName = configs[0].Name
 	}
 

--- a/comp/core/autodiscovery/common/utils/annotations.go
+++ b/comp/core/autodiscovery/common/utils/annotations.go
@@ -37,7 +37,12 @@ func ExtractTemplatesFromMap(key string, input map[string]string, prefix string)
 	}
 	configs = append(configs, checksConfigs...)
 
-	logsConfigs, err := extractLogsTemplatesFromMap(key, input, prefix)
+	logCheckName := ""
+	if len(configs) >= 1 {
+		// Consider the first check name as the log check name, even if it's empty
+		logCheckName = configs[0].Name
+	}
+	logsConfigs, err := extractLogsTemplatesFromMap(logCheckName, key, input, prefix)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("could not extract logs config: %v", err))
 	}
@@ -81,7 +86,7 @@ func extractCheckTemplatesFromMap(key string, input map[string]string, prefix st
 
 // extractLogsTemplatesFromMap returns the logs configuration from a given map,
 // if none are found return an empty list.
-func extractLogsTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, error) {
+func extractLogsTemplatesFromMap(logCheckName string, key string, input map[string]string, prefix string) ([]integration.Config, error) {
 	value, found := input[prefix+logsConfigPath]
 	if !found {
 		return []integration.Config{}, nil
@@ -94,7 +99,7 @@ func extractLogsTemplatesFromMap(key string, input map[string]string, prefix str
 	switch data.(type) {
 	case []interface{}:
 		logsConfig, _ := json.Marshal(data)
-		return []integration.Config{{LogsConfig: logsConfig, ADIdentifiers: []string{key}}}, nil
+		return []integration.Config{{Name: logCheckName, LogsConfig: logsConfig, ADIdentifiers: []string{key}}}, nil
 	default:
 		return []integration.Config{}, fmt.Errorf("invalid format, expected an array, got: '%v'", data)
 	}
@@ -287,7 +292,14 @@ func extractTemplatesFromMapWithV2(entityName string, annotations map[string]str
 	}
 
 	if actualPrefix != "" {
-		c, err := extractLogsTemplatesFromMap(entityName, annotations, actualPrefix)
+		logCheckName := ""
+		if len(configs) >= 1 {
+			// Consider the first check name as the log check name, even if it's empty
+			logCheckName = configs[0].Name
+		}
+
+		c, err := extractLogsTemplatesFromMap(logCheckName, entityName, annotations, actualPrefix)
+
 		if err != nil {
 			errors = append(errors, fmt.Errorf("could not extract logs config: %v", err))
 		} else {

--- a/comp/core/autodiscovery/common/utils/annotations_test.go
+++ b/comp/core/autodiscovery/common/utils/annotations_test.go
@@ -101,6 +101,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 					ADIdentifiers: []string{"id"},
 				},
 				{
+					Name:          "apache",
 					LogsConfig:    integration.Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 					ADIdentifiers: []string{"id"},
 				},

--- a/comp/core/autodiscovery/common/utils/pod_annotations_test.go
+++ b/comp/core/autodiscovery/common/utils/pod_annotations_test.go
@@ -187,6 +187,7 @@ func TestExtractTemplatesFromAnnotations(t *testing.T) {
 					ADIdentifiers: []string{adID},
 				},
 				{
+					Name:          "apache",
 					LogsConfig:    integration.Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 					ADIdentifiers: []string{adID},
 				},
@@ -421,6 +422,7 @@ func TestExtractTemplatesFromAnnotations(t *testing.T) {
 					ADIdentifiers: []string{adID},
 				},
 				{
+					Name:          "apache",
 					LogsConfig:    integration.Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 					ADIdentifiers: []string{adID},
 				},

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -38,6 +38,8 @@ const (
 type LogsConfig struct {
 	Type string
 
+	IntegrationName string
+
 	Port        int    // Network
 	IdleTimeout string `mapstructure:"idle_timeout" json:"idle_timeout"` // Network
 	Path        string // File, Journald

--- a/comp/metadata/inventorychecks/README.md
+++ b/comp/metadata/inventorychecks/README.md
@@ -38,6 +38,9 @@ The payload is a JSON dict with the following fields
       - `status` - **string**: one of `pending`, `error` or `success`.
       - `error` - **string**: the error description if any.
     - `integration_name` - **string**: the name of the integration, can be empty.
+    - `service` - **string**: the service name of the log source.
+    - `source` - **string**: the log source name.
+    - `tags` - **list of string**: a list of tags attached to the log source.
 
 ("scrubbed" indicates that secrets are removed from the field value just as they are in logs)
 
@@ -117,6 +120,7 @@ Here an example of an inventory payload:
         "redisdb": [
             {
                 "config": "{\"path\":\"/var/log/redis_6379.log\",\"service\":\"myredis2\",\"source\":\"redis\",\"type\":\"file\",\"tags\":[\"env:prod\"]}",
+                "integration_name": "redis",
                 "service": "awesome_cache",
                 "source": "source1",
                 "state": {
@@ -129,6 +133,7 @@ Here an example of an inventory payload:
         "nginx": [
             {
                 "config": "{\"path\":\"/var/log/nginx/access.log\",\"service\":\"nginx\",\"source\":\"nginx\",\"type\":\"file\"}",
+                "integration_name": "nginx",
                 "service": "nginx",
                 "source": "source2",
                 "state": {

--- a/comp/metadata/inventorychecks/README.md
+++ b/comp/metadata/inventorychecks/README.md
@@ -33,11 +33,11 @@ The payload is a JSON dict with the following fields
 - `logs_metadata` - **dict of string to list**: dictionary with the log source names as keys; values are a list of the metadata
   for each instance of that log source.
   Each instance is composed of:
-    - `detected_integration` - **string**: the name of the integration, can be empty.
     - `config` - **string**: the canonical JSON of the log source configuration.
     - `state` - **dict of string**: the current state of the log source.
       - `status` - **string**: one of `pending`, `error` or `success`.
       - `error` - **string**: the error description if any.
+    - `integration_name` - **string**: the name of the integration, can be empty.
 
 ("scrubbed" indicates that secrets are removed from the field value just as they are in logs)
 

--- a/comp/metadata/inventorychecks/README.md
+++ b/comp/metadata/inventorychecks/README.md
@@ -33,6 +33,7 @@ The payload is a JSON dict with the following fields
 - `logs_metadata` - **dict of string to list**: dictionary with the log source names as keys; values are a list of the metadata
   for each instance of that log source.
   Each instance is composed of:
+    - `detected_integration` - **string**: the name of the integration, can be empty.
     - `config` - **string**: the canonical JSON of the log source configuration.
     - `state` - **dict of string**: the current state of the log source.
       - `status` - **string**: one of `pending`, `error` or `success`.

--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
@@ -238,10 +238,10 @@ func (ic *inventorychecksImpl) getPayload() marshaler.JSONMarshaler {
 						"error":  logSource.Status.GetError(),
 						"status": logSource.Status.String(),
 					},
-					"service":              logSource.Config.Service,
-					"source":               logSource.Config.Source,
-					"detected_integration": logSource.DetectedIntegration,
-					"tags":                 tags,
+					"service":          logSource.Config.Service,
+					"source":           logSource.Config.Source,
+					"integration_name": logSource.Config.IntegrationName,
+					"tags":             tags,
 				})
 			}
 		}

--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
@@ -238,9 +238,10 @@ func (ic *inventorychecksImpl) getPayload() marshaler.JSONMarshaler {
 						"error":  logSource.Status.GetError(),
 						"status": logSource.Status.String(),
 					},
-					"service": logSource.Config.Service,
-					"source":  logSource.Config.Source,
-					"tags":    tags,
+					"service":              logSource.Config.Service,
+					"source":               logSource.Config.Source,
+					"detected_integration": logSource.DetectedIntegration,
+					"tags":                 tags,
 				})
 			}
 		}

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -211,10 +211,10 @@ func (s *Scheduler) createSources(config integration.Config) ([]*sourcesPkg.LogS
 
 		source := sourcesPkg.NewLogSource(configName, cfg)
 		if source.Config.IntegrationName == "" {
-			// If the log source comes from a config file it does not specify a log source
-			// We try to match it with the config name that is most likely the integration name
+			// If the log integration comes from a config file, we try to match it with the config name
+			// that is most likely the integration name.
 			// If it comes from a container environment, the name was computed based on the `check_names`
-			// Running next to it.
+			// labels attached to the same container.
 			source.Config.IntegrationName = configName
 		}
 		sources = append(sources, source)

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -210,9 +210,11 @@ func (s *Scheduler) createSources(config integration.Config) ([]*sourcesPkg.LogS
 		}
 
 		source := sourcesPkg.NewLogSource(configName, cfg)
-		if config.Provider == names.File {
+		if source.Config.IntegrationName == "" {
 			// If the log source comes from a config file it does not specify a log source
 			// We try to match it with the config name that is most likely the integration name
+			// If it comes from a container environment, the name was computed based on the `check_names`
+			// Running next to it.
 			source.Config.IntegrationName = configName
 		}
 		sources = append(sources, source)

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -213,7 +213,7 @@ func (s *Scheduler) createSources(config integration.Config) ([]*sourcesPkg.LogS
 		if config.Provider == names.File {
 			// If the log source comes from a config file it does not specify a log source
 			// We try to match it with the config name that is most likely the integration name
-			source.DetectedIntegration = configName
+			source.Config.IntegrationName = configName
 		}
 		sources = append(sources, source)
 		if err := cfg.Validate(); err != nil {

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -210,6 +210,11 @@ func (s *Scheduler) createSources(config integration.Config) ([]*sourcesPkg.LogS
 		}
 
 		source := sourcesPkg.NewLogSource(configName, cfg)
+		if config.Provider == names.File {
+			// If the log source comes from a config file it does not specify a log source
+			// We try to match it with the config name that is most likely the integration name
+			source.DetectedIntegration = configName
+		}
 		sources = append(sources, source)
 		if err := cfg.Validate(); err != nil {
 			log.Warnf("Invalid logs configuration: %v", err)

--- a/pkg/logs/sources/source.go
+++ b/pkg/logs/sources/source.go
@@ -46,11 +46,9 @@ type LogSource struct {
 	ParentSource *LogSource
 	// LatencyStats tracks internal stats on the time spent by messages from this source in a processing pipeline, i.e.
 	// the duration between when a message is decoded by the tailer/listener/decoder and when the message is handled by a sender
-	LatencyStats *statstracker.Tracker
-	BytesRead    *status.CountInfo
-	// DetectedIntegration is the integration name that was detected from the source
-	DetectedIntegration string
-	hiddenFromStatus    bool
+	LatencyStats     *statstracker.Tracker
+	BytesRead        *status.CountInfo
+	hiddenFromStatus bool
 }
 
 // NewLogSource creates a new log source.

--- a/pkg/logs/sources/source.go
+++ b/pkg/logs/sources/source.go
@@ -46,9 +46,11 @@ type LogSource struct {
 	ParentSource *LogSource
 	// LatencyStats tracks internal stats on the time spent by messages from this source in a processing pipeline, i.e.
 	// the duration between when a message is decoded by the tailer/listener/decoder and when the message is handled by a sender
-	LatencyStats     *statstracker.Tracker
-	BytesRead        *status.CountInfo
-	hiddenFromStatus bool
+	LatencyStats *statstracker.Tracker
+	BytesRead    *status.CountInfo
+	// DetectedIntegration is the integration name that was detected from the source
+	DetectedIntegration string
+	hiddenFromStatus    bool
 }
 
 // NewLogSource creates a new log source.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add a default log source == config name provider if it comes from an integration file.
In that case, it should be the integration name https://github.com/DataDog/datadog-agent/blob/442605d09ba348e17c4cc417775fb782a005f0fa/comp/core/autodiscovery/providers/config_reader.go#L272
So fleet automation can map the log section with the correct integration

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

* Create a log section in an integration file without a `source`
* Check that the log source was set in the metadata payload