### PR TITLE
(fleet) skip re-installation of packages that have already been installed

### DIFF
--- a/pkg/fleet/internal/db/db.go
+++ b/pkg/fleet/internal/db/db.go
@@ -7,6 +7,7 @@
 package db
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -16,6 +17,19 @@ import (
 var (
 	bucketPackages = []byte("packages")
 )
+
+var (
+	// ErrPackageNotFound is returned when a package is not found
+	ErrPackageNotFound = fmt.Errorf("package not found")
+)
+
+// Package represents a package
+type Package struct {
+	Name    string
+	Version string
+
+	InstallerVersion string
+}
 
 // PackagesDB is a database that stores information about packages
 type PackagesDB struct {
@@ -66,14 +80,18 @@ func (p *PackagesDB) Close() error {
 	return p.db.Close()
 }
 
-// CreatePackage sets a package
-func (p *PackagesDB) CreatePackage(name string) error {
+// SetPackage sets a package
+func (p *PackagesDB) SetPackage(pkg Package) error {
 	err := p.db.Update(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(bucketPackages)
 		if b == nil {
 			return fmt.Errorf("bucket not found")
 		}
-		return b.Put([]byte(name), []byte{})
+		rawPkg, err := json.Marshal(&pkg)
+		if err != nil {
+			return fmt.Errorf("could not marshal package: %w", err)
+		}
+		return b.Put([]byte(pkg.Name), rawPkg)
 	})
 	if err != nil {
 		return fmt.Errorf("could not set package: %w", err)
@@ -96,16 +114,68 @@ func (p *PackagesDB) DeletePackage(name string) error {
 	return nil
 }
 
+// HasPackage checks if a package exists
+func (p *PackagesDB) HasPackage(name string) (bool, error) {
+	var hasPackage bool
+	err := p.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketPackages)
+		if b == nil {
+			return fmt.Errorf("bucket not found")
+		}
+		v := b.Get([]byte(name))
+		hasPackage = v != nil
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("could not check if package exists: %w", err)
+	}
+	return hasPackage, nil
+}
+
+// GetPackage returns a package by name
+func (p *PackagesDB) GetPackage(name string) (Package, error) {
+	var pkg Package
+	err := p.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketPackages)
+		if b == nil {
+			return fmt.Errorf("bucket not found")
+		}
+		v := b.Get([]byte(name))
+		if v == nil {
+			return ErrPackageNotFound
+		}
+		err := json.Unmarshal(v, &pkg)
+		if err != nil {
+			return fmt.Errorf("could not unmarshal package: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return Package{}, fmt.Errorf("could not get package: %w", err)
+	}
+	return pkg, nil
+}
+
 // ListPackages returns a list of all packages
-func (p *PackagesDB) ListPackages() ([]string, error) {
-	var pkgs []string
+func (p *PackagesDB) ListPackages() ([]Package, error) {
+	var pkgs []Package
 	err := p.db.View(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(bucketPackages)
 		if b == nil {
 			return fmt.Errorf("bucket not found")
 		}
 		return b.ForEach(func(k, v []byte) error {
-			pkgs = append(pkgs, string(k))
+			// support v0.0.7
+			if len(v) == 0 {
+				pkgs = append(pkgs, Package{Name: string(k)})
+				return nil
+			}
+			var pkg Package
+			err := json.Unmarshal(v, &pkg)
+			if err != nil {
+				return fmt.Errorf("could not unmarshal package: %w", err)
+			}
+			pkgs = append(pkgs, pkg)
 			return nil
 		})
 	})

--- a/pkg/fleet/internal/db/db_test.go
+++ b/pkg/fleet/internal/db/db_test.go
@@ -20,23 +20,25 @@ func newTestDB(t *testing.T) *PackagesDB {
 	return db
 }
 
-func TestCreatePackage(t *testing.T) {
+func TestSetPackage(t *testing.T) {
 	db := newTestDB(t)
 	defer db.Close()
 
-	err := db.CreatePackage("test")
+	testPackage := Package{Name: "test", Version: "1.2.3", InstallerVersion: "4.5.6"}
+	err := db.SetPackage(testPackage)
 	assert.NoError(t, err)
 	packages, err := db.ListPackages()
 	assert.NoError(t, err)
 	assert.Len(t, packages, 1)
-	assert.Equal(t, "test", packages[0])
+	assert.Equal(t, testPackage, packages[0])
 }
 
 func TestDeletePackage(t *testing.T) {
 	db := newTestDB(t)
 	defer db.Close()
 
-	err := db.CreatePackage("test")
+	testPackage := Package{Name: "test", Version: "1.2.3", InstallerVersion: "4.5.6"}
+	err := db.SetPackage(testPackage)
 	assert.NoError(t, err)
 	err = db.DeletePackage("test")
 	assert.NoError(t, err)
@@ -53,15 +55,52 @@ func TestListPackages(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, packages, 0)
 
-	err = db.CreatePackage("test1")
+	testPackage1 := Package{Name: "test1", Version: "1.2.3", InstallerVersion: "4.5.6"}
+	err = db.SetPackage(testPackage1)
 	assert.NoError(t, err)
-	err = db.CreatePackage("test2")
+	testPackage2 := Package{Name: "test2", Version: "1.2.3", InstallerVersion: "4.5.6"}
+	err = db.SetPackage(testPackage2)
 	assert.NoError(t, err)
 	packages, err = db.ListPackages()
 	assert.NoError(t, err)
 	assert.Len(t, packages, 2)
-	assert.Contains(t, packages, "test1")
-	assert.Contains(t, packages, "test2")
+	assert.Contains(t, packages, testPackage1)
+	assert.Contains(t, packages, testPackage2)
+}
+
+func TestGetPackage(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	testPackage := Package{Name: "test", Version: "1.2.3", InstallerVersion: "4.5.6"}
+	err := db.SetPackage(testPackage)
+	assert.NoError(t, err)
+	p, err := db.GetPackage("test")
+	assert.NoError(t, err)
+	assert.Equal(t, testPackage, p)
+}
+
+func TestGetPackageNotFound(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	_, err := db.GetPackage("test")
+	assert.ErrorIs(t, err, ErrPackageNotFound)
+}
+
+func TestHasPackage(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	testPackage := Package{Name: "test", Version: "1.2.3", InstallerVersion: "4.5.6"}
+	err := db.SetPackage(testPackage)
+	assert.NoError(t, err)
+	has, err := db.HasPackage("test")
+	assert.NoError(t, err)
+	assert.True(t, has)
+	has, err = db.HasPackage("test2")
+	assert.NoError(t, err)
+	assert.False(t, has)
 }
 
 func TestTimeout(t *testing.T) {

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -152,11 +152,6 @@ func (s *packageBaseSuite) SetupSuite() {
 func (s *packageBaseSuite) RunInstallScriptWithError(params ...string) error {
 	// FIXME: use the official install script
 	_, err := s.Env().RemoteHost.Execute(fmt.Sprintf(`%s bash -c "$(curl -L https://storage.googleapis.com/updater-dev/install_script_agent7.sh)"`, strings.Join(params, " ")), client.WithEnvVariables(installScriptEnv(s.arch)))
-	if err != nil {
-		return err
-	}
-	// Right now the install script can fail installing the installer silently, so we need to do this check or it will fail later in a way that is hard to debug
-	_, err = s.Env().RemoteHost.Execute("sudo datadog-installer version")
 	return err
 }
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -79,6 +79,12 @@ func (h *Host) ReadFile(path string) ([]byte, error) {
 	return h.remote.ReadFile(path)
 }
 
+// DeletePath deletes a path on the host.
+func (h *Host) DeletePath(path string) {
+	h.remote.MustExecute(fmt.Sprintf("ls %s", path))
+	h.remote.MustExecute(fmt.Sprintf("rm -rf %s", path))
+}
+
 // WaitForUnitActive waits for a systemd unit to be active
 func (h *Host) WaitForUnitActive(units ...string) {
 	for _, unit := range units {

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -81,8 +81,8 @@ func (h *Host) ReadFile(path string) ([]byte, error) {
 
 // DeletePath deletes a path on the host.
 func (h *Host) DeletePath(path string) {
-	h.remote.MustExecute(fmt.Sprintf("ls %s", path))
-	h.remote.MustExecute(fmt.Sprintf("rm -rf %s", path))
+	h.remote.MustExecute(fmt.Sprintf("sudo ls %s", path))
+	h.remote.MustExecute(fmt.Sprintf("sudo rm -rf %s", path))
 }
 
 // WaitForUnitActive waits for a systemd unit to be active

--- a/test/new-e2e/tests/installer/package_installer_test.go
+++ b/test/new-e2e/tests/installer/package_installer_test.go
@@ -78,12 +78,12 @@ func (s *packageInstallerSuite) TestReInstall() {
 	s.RunInstallScript("DD_NO_AGENT_INSTALL=true")
 	defer s.Purge()
 
-	// remove the installer directory and re-install it. Given that the installer is already installed,
+	// remove an installer directory and re-install it. Given that the installer is already installed,
 	// it should not be re-installed and the directory should not be re-created.
-	s.host.DeletePath("/opt/datadog-packages/datadog-installer")
+	s.host.DeletePath("/opt/datadog-packages/datadog-installer/stable/systemd")
 	s.RunInstallScript("DD_NO_AGENT_INSTALL=true")
 
 	state := s.host.State()
-	state.AssertPathDoesNotExist("/opt/datadog-packages/datadog-installer")
+	state.AssertPathDoesNotExist("/opt/datadog-packages/datadog-installer/stable/systemd")
 	s.host.AssertPackageInstalledByInstaller("datadog-installer")
 }

--- a/test/new-e2e/tests/installer/package_installer_test.go
+++ b/test/new-e2e/tests/installer/package_installer_test.go
@@ -73,3 +73,17 @@ func (s *packageInstallerSuite) TestUninstall() {
 	state.AssertPathDoesNotExist("/usr/bin/datadog-bootstrap")
 	state.AssertPathDoesNotExist("/usr/bin/datadog-installer")
 }
+
+func (s *packageInstallerSuite) TestReInstall() {
+	s.RunInstallScript("DD_NO_AGENT_INSTALL=true")
+	defer s.Purge()
+
+	// remove the installer directory and re-install it. Given that the installer is already installed,
+	// it should not be re-installed and the directory should not be re-created.
+	s.host.DeletePath("/opt/datadog-packages/datadog-installer")
+	s.RunInstallScript("DD_NO_AGENT_INSTALL=true")
+
+	state := s.host.State()
+	state.AssertPathDoesNotExist("/opt/datadog-packages/datadog-installer")
+	s.host.AssertPackageInstalledByInstaller("datadog-installer")
+}


### PR DESCRIPTION
This PR:
- Stores the version of installed packages in the package DB
- Checks during installation if we already have the latest version installed and skips if we do

This does not play well with "configurable" packages such as APM's injector with docker/host options but I don't think we have a good option there TBH. Our behavior is in line with APT or YUM.