### PR TITLE
[2024 GPG KEY ROTATION] Rotate GPG key used to build the agent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -205,8 +205,8 @@ variables:
   CHANGELOG_COMMIT_SHA_SSM_NAME: ci.datadog-agent.gitlab_changelog_commit_sha  # agent-ci-experience
   CHOCOLATEY_API_KEY_SSM_NAME: ci.datadog-agent.chocolatey_api_key  # windows-agent
   CODECOV_TOKEN_SSM_NAME: ci.datadog-agent.codecov_token  # agent-ci-experience
-  DEB_GPG_KEY_SSM_NAME: ci.datadog-agent.deb_signing_private_key_v2_${DEB_GPG_KEY_ID}  # agent-build-and-releases
-  DEB_SIGNING_PASSPHRASE_SSM_NAME: ci.datadog-agent.deb_signing_key_passphrase_v2_${DEB_GPG_KEY_ID}  # agent-build-and-releases
+  DEB_GPG_KEY_SSM_NAME: ci.datadog-agent.deb_signing_private_key_${DEB_GPG_KEY_ID}  # agent-build-and-releases
+  DEB_SIGNING_PASSPHRASE_SSM_NAME: ci.datadog-agent.deb_signing_key_passphrase_${DEB_GPG_KEY_ID}  # agent-build-and-releases
   DOCKER_REGISTRY_LOGIN_SSM_KEY: ci.datadog-agent.docker_hub_login  # agent-ci-experience
   DOCKER_REGISTRY_PWD_SSM_KEY: ci.datadog-agent.docker_hub_pwd  # agent-ci-experience
   E2E_TESTS_API_KEY_SSM_NAME: ci.datadog-agent.e2e_tests_api_key  # agent-developer-tools
@@ -227,8 +227,8 @@ variables:
   MACOS_GITHUB_APP_ID_2_SSM_NAME: ci.datadog-agent.macos_github_app_id_2  # agent-ci-experience
   MACOS_GITHUB_INSTALLATION_ID_2_SSM_NAME: ci.datadog-agent.macos_github_installation_id_2  # agent-ci-experience
   MACOS_GITHUB_KEY_2_SSM_NAME: ci.datadog-agent.macos_github_key_b64_2  # agent-ci-experience
-  RPM_GPG_KEY_SSM_NAME: ci.datadog-agent.rpm_signing_private_key_v2_${RPM_GPG_KEY_ID}  # agent-build-and-releases
-  RPM_SIGNING_PASSPHRASE_SSM_NAME: ci.datadog-agent.rpm_signing_key_passphrase_v2_${RPM_GPG_KEY_ID}  # agent-build-and-releases
+  RPM_GPG_KEY_SSM_NAME: ci.datadog-agent.rpm_signing_private_key_${RPM_GPG_KEY_ID}  # agent-build-and-releases
+  RPM_SIGNING_PASSPHRASE_SSM_NAME: ci.datadog-agent.rpm_signing_key_passphrase_${RPM_GPG_KEY_ID}  # agent-build-and-releases
   SMP_ACCOUNT_ID_SSM_NAME: ci.datadog-agent.single-machine-performance-account-id  # single-machine-performance
   SMP_AGENT_TEAM_ID_SSM_NAME: ci.datadog-agent.single-machine-performance-agent-team-id  # single-machine-performance
   SMP_API_SSM_NAME: ci.datadog-agent.single-machine-performance-api  # single-machine-performance

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,9 +175,9 @@ variables:
   DATADOG_AGENT_BTF_GEN_BUILDIMAGES: v34562478-ec7ead93
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded
-  DEB_GPG_KEY_ID: ad9589b7
-  DEB_GPG_KEY_NAME: "Datadog, Inc. Master key"
-  RPM_GPG_KEY_ID: fd4bf915
+  DEB_GPG_KEY_ID: c0962c7d
+  DEB_GPG_KEY_NAME: "Datadog, Inc. APT key"
+  RPM_GPG_KEY_ID: b01082d3
   RPM_GPG_KEY_NAME: "Datadog, Inc. RPM key"
   DOCKER_REGISTRY_URL: docker.io
   KITCHEN_INFRASTRUCTURE_FLAKES_RETRY: 2

--- a/releasenotes/notes/2024-gpg-key-rotation-0aceffce7a9771fa.yaml
+++ b/releasenotes/notes/2024-gpg-key-rotation-0aceffce7a9771fa.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+    Rotated RPM and APT GPG keys used to sign the agent package.
+

--- a/releasenotes/notes/2024-gpg-key-rotation-0aceffce7a9771fa.yaml
+++ b/releasenotes/notes/2024-gpg-key-rotation-0aceffce7a9771fa.yaml
@@ -8,6 +8,6 @@
 ---
 security:
   - |
-    Current GPG keys used to sign new release of the agent are about to expire.
-    Following our 2024 GPG Key rotation plan, we rotated RPM and APT GPG keys used to sign the agent package.
+    Current GPG keys that are used to sign new releases of the Agent package are about to expire.
+    Following our 2024 GPG key rotation plan, we rotated RPM and APT GPG keys.
 

--- a/releasenotes/notes/2024-gpg-key-rotation-0aceffce7a9771fa.yaml
+++ b/releasenotes/notes/2024-gpg-key-rotation-0aceffce7a9771fa.yaml
@@ -8,5 +8,6 @@
 ---
 security:
   - |
-    Rotated RPM and APT GPG keys used to sign the agent package.
+    Current GPG keys used to sign new release of the agent are about to expire.
+    Following our 2024 GPG Key rotation plan, we rotated RPM and APT GPG keys used to sign the agent package.
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Rotate the keys used to build the agent.
RPM keys are rotating from `fd4bf915` to `b01082d3`
APT keys are rotating from `ad9589b7` to `c0962c7d`
see the [Agent Signing Key Document](https://datadoghq.atlassian.net/wiki/spaces/BARX/pages/2971370900/Agent+signing+keys+history) to verify that we're replacing current keys by future keys

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Renamed `DEB_GPG_KEY_NAME` because we aren't using subkeys with the new APT key.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
For every RPM packages
  - `rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public`
  - `rpm --checksig <package>` -> We expect `digests signatures OK`

For every DEB packages
  - TBD

