### PR TITLE
[CWS] limit process tree depth when serializing events

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -1083,6 +1083,10 @@ CSM Threats logs have the following JSON schema:
                 "variables": {
                     "$ref": "#/$defs/Variables",
                     "description": "Variables values"
+                },
+                "truncated_ancestors": {
+                    "type": "boolean",
+                    "description": "True if the ancestors list was truncated because it was too big"
                 }
             },
             "additionalProperties": false,
@@ -3024,6 +3028,10 @@ CSM Threats logs have the following JSON schema:
         "variables": {
             "$ref": "#/$defs/Variables",
             "description": "Variables values"
+        },
+        "truncated_ancestors": {
+            "type": "boolean",
+            "description": "True if the ancestors list was truncated because it was too big"
         }
     },
     "additionalProperties": false,
@@ -3070,6 +3078,7 @@ CSM Threats logs have the following JSON schema:
 | `parent` | Parent process |
 | `ancestors` | Ancestor processes |
 | `variables` | Variables values |
+| `truncated_ancestors` | True if the ancestors list was truncated because it was too big |
 
 | References |
 | ---------- |

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -1067,6 +1067,10 @@
         "variables": {
           "$ref": "#/$defs/Variables",
           "description": "Variables values"
+        },
+        "truncated_ancestors": {
+          "type": "boolean",
+          "description": "True if the ancestors list was truncated because it was too big"
         }
       },
       "additionalProperties": false,

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -73,6 +73,8 @@ type ProcessContextSerializer struct {
 	Ancestors []*ProcessSerializer `json:"ancestors,omitempty"`
 	// Variables values
 	Variables Variables `json:"variables,omitempty"`
+	// True if the ancestors list was truncated because it was too big
+	TruncatedAncestors bool `json:"truncated_ancestors,omitempty"`
 }
 
 // IPPortSerializer is used to serialize an IP and Port context to JSON

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -146,6 +146,8 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers1(i
 			}
 		case "variables":
 			(out.Variables).UnmarshalEasyJSON(in)
+		case "truncated_ancestors":
+			out.TruncatedAncestors = bool(in.Bool())
 		case "pid":
 			out.Pid = uint32(in.Uint32())
 		case "ppid":
@@ -403,6 +405,16 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers1(o
 			out.RawString(prefix)
 		}
 		(in.Variables).MarshalEasyJSON(out)
+	}
+	if in.TruncatedAncestors {
+		const prefix string = ",\"truncated_ancestors\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.TruncatedAncestors))
 	}
 	if in.Pid != 0 {
 		const prefix string = ",\"pid\":"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds a limit on the depth of the process tree when serializing events.
The current limit is arbitrarily set to 200 processes. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
