### PR TITLE
fix(junit): Upload junit for kitchen secagent and tweak the filepath for correct ownership assignation in kitchen testing

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -174,9 +174,8 @@ kitchen_stress_security_agent:
 
 kitchen_test_security_agent_windows_x64:
   extends:
-    - .kitchen_os_windows
     - .kitchen_test_security_agent
-    - .kitchen_azure_x64
+    - .kitchen_os_windows
     - .kitchen_azure_location_north_central_us
   rules:
     !reference [.on_security_agent_changes_or_manual]

--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -155,8 +155,11 @@ def split_junitxml(xml_path, codeowners, output_dir, flaky_tests):
         # don't, so for determining ownership we append "/" temporarily.
         owners = codeowners.of(path + "/")
         if not owners:
+            # In kitchen testing the test name might not be a file path, so we check the file attribute instead
             filepath = next(tree.iter("testcase")).attrib.get("file", None)
             if filepath:
+                if filepath.startswith("./"):  # Leading "./" is not handled by codeowners
+                    filepath = filepath[2:]
                 owners = codeowners.of(filepath)
                 main_owner = owners[0][1][len(CODEOWNERS_ORG_PREFIX) :]
             else:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
There was a difference between definition of kitchen tests for system probe and security agent. The secagent part was missing junit upload.
Besides, the file path in kitchen situation starts with a leading './' not handled by codeowners leading to a wrong failed test assignation

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Housekeeping

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
