### PR TITLE
Retry KMT tests jobs on timeout

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -160,6 +160,17 @@
 
 # -- Test runners
 .kmt_run_tests:
+  retry:
+    max: 2
+    when:
+      - job_execution_timeout
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+      - api_failure
+      - scheduler_failure
+      - stale_schedule
+      - data_integrity_failure
   variables:
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
     RETRY: 2

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -117,9 +117,20 @@ kmt_run_secagent_tests_x64:
     - kmt_setup_env_secagent_x64
     - upload_dependencies_secagent_x64
     - upload_secagent_tests_x64
-  timeout: 3h
+  timeout: 1h 30m
   variables:
     ARCH: "x86_64"
+  retry:
+    max: 3
+    when:
+      - job_execution_timeout
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+      - api_failure
+      - scheduler_failure
+      - stale_schedule
+      - data_integrity_failure
   parallel:
     matrix:
       - TAG:
@@ -157,7 +168,18 @@ kmt_run_secagent_tests_arm64:
     - kmt_setup_env_secagent_arm64
     - upload_dependencies_secagent_arm64
     - upload_secagent_tests_arm64
-  timeout: 3h
+  timeout: 1h 30m
+  retry:
+    max: 3
+    when:
+      - job_execution_timeout
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+      - api_failure
+      - scheduler_failure
+      - stale_schedule
+      - data_integrity_failure
   variables:
     ARCH: "arm64"
   parallel:

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -105,6 +105,18 @@ upload_secagent_tests_arm64:
   allow_failure: true
   stage: kernel_matrix_testing_security_agent
   rules: !reference [.on_security_agent_changes_or_manual]
+  timeout: 1h 30m
+  retry:
+    max: 3
+    when:
+      - job_execution_timeout
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+      - api_failure
+      - scheduler_failure
+      - stale_schedule
+      - data_integrity_failure
   variables:
     TEST_COMPONENT: security-agent
 
@@ -117,20 +129,8 @@ kmt_run_secagent_tests_x64:
     - kmt_setup_env_secagent_x64
     - upload_dependencies_secagent_x64
     - upload_secagent_tests_x64
-  timeout: 1h 30m
   variables:
     ARCH: "x86_64"
-  retry:
-    max: 3
-    when:
-      - job_execution_timeout
-      - runner_system_failure
-      - stuck_or_timeout_failure
-      - unknown_failure
-      - api_failure
-      - scheduler_failure
-      - stale_schedule
-      - data_integrity_failure
   parallel:
     matrix:
       - TAG:
@@ -168,18 +168,6 @@ kmt_run_secagent_tests_arm64:
     - kmt_setup_env_secagent_arm64
     - upload_dependencies_secagent_arm64
     - upload_secagent_tests_arm64
-  timeout: 1h 30m
-  retry:
-    max: 3
-    when:
-      - job_execution_timeout
-      - runner_system_failure
-      - stuck_or_timeout_failure
-      - unknown_failure
-      - api_failure
-      - scheduler_failure
-      - stale_schedule
-      - data_integrity_failure
   variables:
     ARCH: "arm64"
   parallel:

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -106,17 +106,6 @@ upload_secagent_tests_arm64:
   stage: kernel_matrix_testing_security_agent
   rules: !reference [.on_security_agent_changes_or_manual]
   timeout: 1h 30m
-  retry:
-    max: 3
-    when:
-      - job_execution_timeout
-      - runner_system_failure
-      - stuck_or_timeout_failure
-      - unknown_failure
-      - api_failure
-      - scheduler_failure
-      - stale_schedule
-      - data_integrity_failure
   variables:
     TEST_COMPONENT: security-agent
 

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -186,6 +186,18 @@ upload_sysprobe_tests_arm64:
   extends: .kmt_run_tests
   stage: kernel_matrix_testing_system_probe
   rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
+  timeout: 1h 30m
+  retry:
+    max: 3
+    when:
+      - job_execution_timeout
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+      - api_failure
+      - scheduler_failure
+      - stale_schedule
+      - data_integrity_failure
   variables:
     TEST_COMPONENT: system-probe
 
@@ -199,18 +211,6 @@ kmt_run_sysprobe_tests_x64:
     - upload_dependencies_sysprobe_x64
     - upload_sysprobe_tests_x64
     - upload_minimized_btfs_sysprobe_x64
-  timeout: 1h 30m
-  retry:
-    max: 3
-    when:
-      - job_execution_timeout
-      - runner_system_failure
-      - stuck_or_timeout_failure
-      - unknown_failure
-      - api_failure
-      - scheduler_failure
-      - stale_schedule
-      - data_integrity_failure
   variables:
     ARCH: "x86_64"
   parallel:
@@ -247,18 +247,6 @@ kmt_run_sysprobe_tests_arm64:
     - upload_dependencies_sysprobe_arm64
     - upload_sysprobe_tests_arm64
     - upload_minimized_btfs_sysprobe_arm64
-  timeout: 1h 30m
-  retry:
-    max: 3
-    when:
-      - job_execution_timeout
-      - runner_system_failure
-      - stuck_or_timeout_failure
-      - unknown_failure
-      - api_failure
-      - scheduler_failure
-      - stale_schedule
-      - data_integrity_failure
   variables:
     ARCH: "arm64"
   parallel:

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -187,17 +187,6 @@ upload_sysprobe_tests_arm64:
   stage: kernel_matrix_testing_system_probe
   rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   timeout: 1h 30m
-  retry:
-    max: 3
-    when:
-      - job_execution_timeout
-      - runner_system_failure
-      - stuck_or_timeout_failure
-      - unknown_failure
-      - api_failure
-      - scheduler_failure
-      - stale_schedule
-      - data_integrity_failure
   variables:
     TEST_COMPONENT: system-probe
 

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -199,7 +199,18 @@ kmt_run_sysprobe_tests_x64:
     - upload_dependencies_sysprobe_x64
     - upload_sysprobe_tests_x64
     - upload_minimized_btfs_sysprobe_x64
-  timeout: 3h
+  timeout: 1h 30m
+  retry:
+    max: 3
+    when:
+      - job_execution_timeout
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+      - api_failure
+      - scheduler_failure
+      - stale_schedule
+      - data_integrity_failure
   variables:
     ARCH: "x86_64"
   parallel:
@@ -236,7 +247,18 @@ kmt_run_sysprobe_tests_arm64:
     - upload_dependencies_sysprobe_arm64
     - upload_sysprobe_tests_arm64
     - upload_minimized_btfs_sysprobe_arm64
-  timeout: 3h
+  timeout: 1h 30m
+  retry:
+    max: 3
+    when:
+      - job_execution_timeout
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+      - api_failure
+      - scheduler_failure
+      - stale_schedule
+      - data_integrity_failure
   variables:
     ARCH: "arm64"
   parallel:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR retries KMT test jobs on timeout. This is to solve retry issues where a job takes too long to acquire a runner.
The job timeout has been set to 1h30m.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
