### PR TITLE
Add more error types to trigger retries

### DIFF
--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -74,6 +74,16 @@ var handledErrorsLs = []handledError{
 		metric:      "ec2-timeout-state-change",
 		action:      retryStack | emitMetric,
 	},
+	{
+		errorType:   ioTimeout,
+		errorString: "i/o timeout",
+		action:      retryStack,
+	},
+	{
+		errorType:   tcp22ConnectionRefused,
+		errorString: "failed attempts: dial tcp :22: connect: connection refused",
+		action:      retryStack,
+	},
 }
 
 func errorMetric(errType string) datadogV2.MetricPayload {

--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -35,6 +35,8 @@ const (
 	insufficientCapacityError
 	aria2cMissingStatusError
 	ec2StateChangeTimeoutError
+	ioTimeout
+	tcp22ConnectionRefused
 )
 
 type handledError struct {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds a few more scenarios to trigger retries in KMT. These new error types are taken from the list of errors on which other e2e tests trigger retries: https://github.com/DataDog/datadog-agent/blob/9c7a03d420843ad02a395a817a898b4071cf0ae0/test/new-e2e/pkg/utils/infra/retriable_errors.go#L22

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
