### PR TITLE
increase systemd test coverage

### DIFF
--- a/omnibus/config/templates/installer/datadog-agent-sysprobe-exp.service.erb
+++ b/omnibus/config/templates/installer/datadog-agent-sysprobe-exp.service.erb
@@ -1,7 +1,6 @@
 [Unit]
 Description=Datadog System Probe Experiment
 Requires=sys-kernel-debug.mount
-Before=datadog-agent.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
 ConditionPathExists=<%= etc_dir %>/system-probe.yaml

--- a/test/new-e2e/tests/installer/host/fixtures.go
+++ b/test/new-e2e/tests/installer/host/fixtures.go
@@ -102,8 +102,8 @@ func (h *Host) RemoveBrokenDockerConfig() {
 	h.remote.MustExecute("sudo rm /etc/docker/daemon.json")
 }
 
-// SetupFakeAgentXP sets up a fake Agent XP with configurable options.
-func (h *Host) SetupFakeAgentXP() FakeAgent {
+// SetupFakeAgentExp sets up a fake Agent experiment with configurable options.
+func (h *Host) SetupFakeAgentExp() FakeAgent {
 	vBroken := "/opt/datadog-packages/datadog-agent/vbroken"
 	h.remote.MustExecute(fmt.Sprintf("sudo mkdir -p %s/embedded/bin", vBroken))
 	h.remote.MustExecute(fmt.Sprintf("sudo mkdir -p %s/bin/agent", vBroken))

--- a/test/new-e2e/tests/installer/host/fixtures.go
+++ b/test/new-e2e/tests/installer/host/fixtures.go
@@ -33,6 +33,13 @@ func (h *Host) uploadFixtures() {
 	h.remote.MustExecute("sudo mkdir -p /opt/fixtures")
 	h.remote.MustExecute("sudo chmod 777 /opt/fixtures")
 	err = h.remote.CopyFolder(tmpDir, "/opt/fixtures")
+	for _, fixture := range fixtures {
+		if filepath.Ext(fixture.Name()) == ".sh" {
+			fixturePath := filepath.Join("/opt/fixtures", fixture.Name())
+			h.remote.MustExecute(fmt.Sprintf("chmod +x %s", fixturePath))
+		}
+	}
+
 	require.NoError(h.t, err)
 }
 
@@ -43,7 +50,7 @@ func (h *Host) StartExamplePythonApp() {
 		"DD_ENV":     "e2e-installer",
 		"DD_VERSION": "1.0",
 	}
-	h.remote.MustExecute(`sudo chmod +x /opt/fixtures/run_http_server.sh && sudo -E /opt/fixtures/run_http_server.sh`, client.WithEnvVariables(env))
+	h.remote.MustExecute(`sudo -E /opt/fixtures/run_http_server.sh`, client.WithEnvVariables(env))
 }
 
 // StopExamplePythonApp stops the example Python app
@@ -93,4 +100,70 @@ func (h *Host) SetBrokenDockerConfigAdditionalFields() {
 // RemoveBrokenDockerConfig removes the broken configuration from the Docker daemon
 func (h *Host) RemoveBrokenDockerConfig() {
 	h.remote.MustExecute("sudo rm /etc/docker/daemon.json")
+}
+
+// SetupFakeAgentXP sets up a fake Agent XP with configurable options.
+func (h *Host) SetupFakeAgentXP() FakeAgent {
+	vBroken := "/opt/datadog-packages/datadog-agent/vbroken"
+	h.remote.MustExecute(fmt.Sprintf("sudo mkdir -p %s/embedded/bin", vBroken))
+	h.remote.MustExecute(fmt.Sprintf("sudo mkdir -p %s/bin/agent", vBroken))
+
+	h.remote.MustExecute(fmt.Sprintf("sudo ln -sf %s /opt/datadog-packages/datadog-agent/experiment", vBroken))
+	f := FakeAgent{
+		h:    h,
+		path: vBroken,
+	}
+
+	// default with sigterm
+	f.SetStopWithSigterm("trace-agent")
+	f.SetStopWithSigterm("core-agent")
+	f.SetStopWithSigterm("process-agent")
+
+	return f
+}
+
+// FakeAgent represents a fake Agent.
+type FakeAgent struct {
+	h    *Host
+	path string
+}
+
+func (f FakeAgent) setBinary(fixtureBinary, agent string) {
+	pathToFixture := filepath.Join("/opt/fixtures", fixtureBinary)
+	var pathToAgent string
+	switch agent {
+	case "trace-agent":
+		pathToAgent = filepath.Join(f.path, "embedded/bin/trace-agent")
+	case "process-agent":
+		pathToAgent = filepath.Join(f.path, "embedded/bin/process-agent")
+	case "core-agent":
+		pathToAgent = filepath.Join(f.path, "bin/agent/agent")
+	default:
+		panic("unimplemented agent")
+	}
+	f.h.remote.MustExecute(fmt.Sprintf("sudo ln -sf %s %s", pathToFixture, pathToAgent))
+}
+
+// SetExit0 sets the fake Agent to exit with code 0.
+func (f FakeAgent) SetExit0(agent string) FakeAgent {
+	f.setBinary("exit0.sh", agent)
+	return f
+}
+
+// SetExit1 sets the fake Agent to exit with code 1.
+func (f FakeAgent) SetExit1(agent string) FakeAgent {
+	f.setBinary("exit1.sh", agent)
+	return f
+}
+
+// SetStopWithSigkill sets the fake Agent to stop with SIGKILL.
+func (f FakeAgent) SetStopWithSigkill(agent string) FakeAgent {
+	f.setBinary("stop_with_sigkill.sh", agent)
+	return f
+}
+
+// SetStopWithSigterm sets the fake Agent to stop with SIGTERM.
+func (f FakeAgent) SetStopWithSigterm(agent string) FakeAgent {
+	f.setBinary("stop_with_sigterm.sh", agent)
+	return f
 }

--- a/test/new-e2e/tests/installer/host/fixtures/exit0.sh
+++ b/test/new-e2e/tests/installer/host/fixtures/exit0.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sleep 1
+exit 0

--- a/test/new-e2e/tests/installer/host/fixtures/exit1.sh
+++ b/test/new-e2e/tests/installer/host/fixtures/exit1.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sleep 3
+exit 1

--- a/test/new-e2e/tests/installer/host/fixtures/stop_with_sigkill.sh
+++ b/test/new-e2e/tests/installer/host/fixtures/stop_with_sigkill.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+trap '' SIGINT SIGHUP SIGQUIT SIGTERM
+
+while true; do
+  sleep 1
+done

--- a/test/new-e2e/tests/installer/host/fixtures/stop_with_sigterm.sh
+++ b/test/new-e2e/tests/installer/host/fixtures/stop_with_sigterm.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+while true; do
+  sleep 1
+done
+

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -21,14 +21,16 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Host is a remote host environment.
 type Host struct {
-	t      *testing.T
-	remote *components.RemoteHost
-	os     e2eos.Descriptor
-	arch   e2eos.Architecture
+	t              *testing.T
+	remote         *components.RemoteHost
+	os             e2eos.Descriptor
+	arch           e2eos.Architecture
+	systemdVersion int
 }
 
 // Option is an option to configure a Host.
@@ -46,7 +48,16 @@ func New(t *testing.T, remote *components.RemoteHost, os e2eos.Descriptor, arch 
 		opt(t, host)
 	}
 	host.uploadFixtures()
+	host.setSystemdVersion()
 	return host
+}
+
+func (h *Host) setSystemdVersion() {
+	strVersion := strings.TrimSpace(h.remote.MustExecute("systemctl --version | head -n1 | awk '{print $2}'"))
+	version, err := strconv.Atoi(strVersion)
+	require.NoError(h.t, err)
+	h.t.Log("Systemd version:", version)
+	h.systemdVersion = version
 }
 
 // InstallDocker installs Docker on the host.

--- a/test/new-e2e/tests/installer/host/systemd.go
+++ b/test/new-e2e/tests/installer/host/systemd.go
@@ -7,6 +7,8 @@ package host
 
 import (
 	"encoding/json"
+	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -33,39 +35,94 @@ func (h *Host) LastJournaldTimestamp() JournaldTimestamp {
 	return JournaldTimestamp(log.MonotonicTimestamp)
 }
 
+// AssertUnitProperty asserts that the given systemd unit has the given property
+func (h *Host) AssertUnitProperty(unit, property, value string) {
+	res, err := h.remote.Execute(fmt.Sprintf("sudo systemctl show -p %s %s", property, unit))
+	require.NoError(h.t, err)
+	require.Equal(h.t, fmt.Sprintf("%s=%s\n", property, value), res)
+}
+
+func popIfMatches(searchedEvents []SystemdEvent, log journaldLog) []SystemdEvent {
+	for i, event := range searchedEvents {
+		if eventMatches(log, event) {
+			newEvents := make([]SystemdEvent, 0, len(searchedEvents)-1)
+			newEvents = append(newEvents, searchedEvents[:i]...)
+			newEvents = append(newEvents, searchedEvents[i+1:]...)
+			return newEvents
+		}
+	}
+	return searchedEvents
+}
+
+func eventMatches(log journaldLog, event SystemdEvent) bool {
+	if log.Unit != event.Unit {
+		return false
+	}
+	match, _ := regexp.MatchString(event.Pattern, log.Message)
+	return match
+}
+
+func (h *Host) stripSystemd244(events []SystemdEvent) []SystemdEvent {
+	if h.systemdVersion >= 244 {
+		return events
+	}
+	newEvents := make([]SystemdEvent, 0, len(events))
+	map244Units := map[string]struct{}{
+		"datadog-agent-sysprobe.service":     {},
+		"datadog-agent-security.service":     {},
+		"datadog-agent-sysprobe-exp.service": {},
+		"datadog-agent-security-exp.service": {},
+	}
+	for _, e := range events {
+		if _, ok := map244Units[e.Unit]; ok {
+			continue
+		}
+		newEvents = append(newEvents, e)
+	}
+	return newEvents
+}
+
 // AssertSystemdEvents asserts that the systemd events have been logged since the given timestamp
 func (h *Host) AssertSystemdEvents(since JournaldTimestamp, events SystemdEventSequence) {
+	var lastSearchedEvents []SystemdEvent
 	success := assert.Eventually(h.t, func() bool {
 		logs := h.journaldLogsSince(since)
 		if len(logs) < len(events.Events) {
 			return false
 		}
-		i := 0
-		j := 0
+		i, j := 0, 0
+		var searchedEvents []SystemdEvent
 		for i < len(logs) && j < len(events.Events) {
-			if logs[i].Unit == events.Events[j].Unit && strings.HasPrefix(logs[i].Message, events.Events[j].MessagePrefix) {
+			if len(searchedEvents) == 0 {
+				searchedEvents = events.Events[j]
 				j++
 			}
+			searchedEvents = h.stripSystemd244(searchedEvents)
+			searchedEvents = popIfMatches(searchedEvents, logs[i])
 			i++
 		}
+		lastSearchedEvents = searchedEvents
 		return j == len(events.Events)
 	}, 30*time.Second, 1*time.Second)
+
 	if !success {
 		logs := h.journaldLogsSince(since)
+		h.t.Logf("Blocked on validating: %v", lastSearchedEvents)
 		h.t.Logf("Expected events: %v", events.Events)
 		h.t.Logf("Actual events: %v", logs)
+		require.True(h.t, success)
 	}
 }
 
 // SystemdEvent represents a systemd event
 type SystemdEvent struct {
-	Unit          string
-	MessagePrefix string
+	Unit    string
+	Pattern string
 }
 
 // SystemdEventSequence represents a sequence of systemd events
 type SystemdEventSequence struct {
-	Events []SystemdEvent
+	Events [][]SystemdEvent
 }
 
 // SystemdEvents returns a new SystemdEventSequence
@@ -75,31 +132,65 @@ func SystemdEvents() SystemdEventSequence {
 
 // Starting adds a "Starting" event to the sequence
 func (s SystemdEventSequence) Starting(unit string) SystemdEventSequence {
-	s.Events = append(s.Events, SystemdEvent{Unit: unit, MessagePrefix: "Starting"})
+	s.Events = append(s.Events, []SystemdEvent{{Unit: unit, Pattern: "Starting.*"}})
 	return s
 }
 
 // Started adds a "Started" event to the sequence
 func (s SystemdEventSequence) Started(unit string) SystemdEventSequence {
-	s.Events = append(s.Events, SystemdEvent{Unit: unit, MessagePrefix: "Started"})
+	s.Events = append(s.Events, []SystemdEvent{{Unit: unit, Pattern: "Started.*"}})
 	return s
 }
 
 // Stopping adds a "Stopping" event to the sequence
 func (s SystemdEventSequence) Stopping(unit string) SystemdEventSequence {
-	s.Events = append(s.Events, SystemdEvent{Unit: unit, MessagePrefix: "Stopping"})
+	s.Events = append(s.Events, []SystemdEvent{{Unit: unit, Pattern: "Stopping.*"}})
 	return s
 }
 
 // Stopped adds a "Stopped" event to the sequence
 func (s SystemdEventSequence) Stopped(unit string) SystemdEventSequence {
-	s.Events = append(s.Events, SystemdEvent{Unit: unit, MessagePrefix: "Stopped"})
+	s.Events = append(s.Events, []SystemdEvent{{Unit: unit, Pattern: "Stopped.*"}})
 	return s
 }
 
 // Failed adds a "Failed" event to the sequence
 func (s SystemdEventSequence) Failed(unit string) SystemdEventSequence {
-	s.Events = append(s.Events, SystemdEvent{Unit: unit, MessagePrefix: "Failed"})
+	s.Events = append(s.Events, []SystemdEvent{{Unit: unit, Pattern: "Failed.*"}})
+	return s
+}
+
+// Timed adds a "Timed" event to the sequence
+func (s SystemdEventSequence) Timed(unit string) SystemdEventSequence {
+	s.Events = append(s.Events, []SystemdEvent{{Unit: unit, Pattern: "Timed.*"}})
+	return s
+}
+
+// Skipped adds a "Skipped" event to the sequence
+func (s SystemdEventSequence) Skipped(unit string) SystemdEventSequence {
+	s.Events = append(s.Events, []SystemdEvent{{Unit: unit, Pattern: ".*skipped.*"}})
+	return s
+}
+
+// SigtermTimed adds a "SigtermTimed" event to the sequence
+func (s SystemdEventSequence) SigtermTimed(unit string) SystemdEventSequence {
+	s.Events = append(s.Events, []SystemdEvent{{Unit: unit, Pattern: ".*stop-sigterm.*timed out.*"}})
+	return s
+}
+
+// Sigkill adds a "Sigkill" event to the sequence
+func (s SystemdEventSequence) Sigkill(unit string) SystemdEventSequence {
+	s.Events = append(s.Events, []SystemdEvent{{Unit: unit, Pattern: ".*status=9/KILL.*"}})
+	return s
+}
+
+// Unordered adds an unordered sequence of events to the sequence
+func (s SystemdEventSequence) Unordered(events SystemdEventSequence) SystemdEventSequence {
+	flatten := []SystemdEvent{}
+	for _, e := range events.Events {
+		flatten = append(flatten, e...)
+	}
+	s.Events = append(s.Events, flatten)
 	return s
 }
 

--- a/test/new-e2e/tests/installer/host/systemd.go
+++ b/test/new-e2e/tests/installer/host/systemd.go
@@ -110,7 +110,6 @@ func (h *Host) AssertSystemdEvents(since JournaldTimestamp, events SystemdEventS
 		h.t.Logf("Blocked on validating: %v", lastSearchedEvents)
 		h.t.Logf("Expected events: %v", events.Events)
 		h.t.Logf("Actual events: %v", logs)
-		require.True(h.t, success)
 	}
 }
 

--- a/test/new-e2e/tests/installer/host/systemd.go
+++ b/test/new-e2e/tests/installer/host/systemd.go
@@ -62,6 +62,9 @@ func eventMatches(log journaldLog, event SystemdEvent) bool {
 	return match
 }
 
+// stripSystemd244 removes the events that are not present for systemd versions
+// before 244: 'ConditionPathExists' is added in 244 and used by
+// system-probe and security-agent
 func (h *Host) stripSystemd244(events []SystemdEvent) []SystemdEvent {
 	if h.systemdVersion >= 244 {
 		return events

--- a/test/new-e2e/tests/installer/package_agent_test.go
+++ b/test/new-e2e/tests/installer/package_agent_test.go
@@ -53,7 +53,7 @@ func (s *packageAgentSuite) TestInstall() {
 	// state.AssertFileExists("/etc/datadog-agent/install.json", 0644, "dd-agent", "dd-agent")
 }
 
-func (s *packageAgentSuite) TestTimeout() {
+func (s *packageAgentSuite) TestExperimentTimeout() {
 	s.RunInstallScript(envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
@@ -112,7 +112,7 @@ func (s *packageAgentSuite) TestTimeout() {
 	)
 }
 
-func (s *packageAgentSuite) TestSigkill() {
+func (s *packageAgentSuite) TestExperimentIgnoringSigterm() {
 	s.RunInstallScript(envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
@@ -183,7 +183,7 @@ func (s *packageAgentSuite) TestSigkill() {
 	)
 }
 
-func (s *packageAgentSuite) TestAgentExitCodes() {
+func (s *packageAgentSuite) TestExperimentExits() {
 	s.RunInstallScript(envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")

--- a/test/new-e2e/tests/installer/package_agent_test.go
+++ b/test/new-e2e/tests/installer/package_agent_test.go
@@ -58,7 +58,7 @@ func (s *packageAgentSuite) TestExperimentTimeout() {
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
 
-	s.host.SetupFakeAgentXP()
+	s.host.SetupFakeAgentExp()
 
 	// assert timeout is already set
 	s.host.AssertUnitProperty("datadog-agent-exp.service", "JobTimeoutUSec", "50min")
@@ -117,12 +117,13 @@ func (s *packageAgentSuite) TestExperimentIgnoringSigterm() {
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
 
-	s.host.SetupFakeAgentXP().
+	s.host.SetupFakeAgentExp().
 		SetStopWithSigkill("core-agent").
 		SetStopWithSigkill("process-agent").
 		SetStopWithSigkill("trace-agent")
 
 	for _, unit := range []string{traceUnitXP, processUnitXP, agentUnitXP} {
+		s.T().Logf("Testing timeoutStop of unit %s", traceUnitXP)
 		s.host.AssertUnitProperty(unit, "TimeoutStopUSec", "1min 30s")
 		s.host.Run(fmt.Sprintf("sudo mkdir -p /etc/systemd/system/%s.d/", unit))
 		defer s.host.Run(fmt.Sprintf("sudo rm -rf /etc/systemd/system/%s.d/", unit))
@@ -188,7 +189,7 @@ func (s *packageAgentSuite) TestExperimentExits() {
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
 
-	xpAgent := s.host.SetupFakeAgentXP()
+	xpAgent := s.host.SetupFakeAgentExp()
 
 	for _, exitProgram := range []string{"exit0", "exit1"} {
 		s.T().Logf("Testing exit code of %s", exitProgram)
@@ -244,7 +245,7 @@ func (s *packageAgentSuite) TestExperimentStopped() {
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
 
-	s.host.SetupFakeAgentXP()
+	s.host.SetupFakeAgentExp()
 
 	for _, stopCommand := range []string{"start datadog-agent", "stop datadog-agent-exp"} {
 		s.T().Logf("Testing stop experiment command %s", stopCommand)

--- a/test/new-e2e/tests/installer/package_agent_test.go
+++ b/test/new-e2e/tests/installer/package_agent_test.go
@@ -6,9 +6,24 @@
 package installer
 
 import (
+	"fmt"
+
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
+)
+
+const (
+	agentUnit      = "datadog-agent.service"
+	agentUnitXP    = "datadog-agent-exp.service"
+	traceUnit      = "datadog-agent-trace.service"
+	traceUnitXP    = "datadog-agent-trace-exp.service"
+	processUnit    = "datadog-agent-process.service"
+	processUnitXP  = "datadog-agent-process-exp.service"
+	probeUnit      = "datadog-agent-sysprobe.service"
+	probeUnitXP    = "datadog-agent-sysprobe-exp.service"
+	securityUnit   = "datadog-agent-security.service"
+	securityUnitXP = "datadog-agent-security-exp.service"
 )
 
 type packageAgentSuite struct {
@@ -38,19 +53,247 @@ func (s *packageAgentSuite) TestInstall() {
 	// state.AssertFileExists("/etc/datadog-agent/install.json", 0644, "dd-agent", "dd-agent")
 }
 
-func (s *packageAgentSuite) TestExperimentStartedButNotInstalled() {
+func (s *packageAgentSuite) TestTimeout() {
 	s.RunInstallScript(envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
 
+	s.host.SetupFakeAgentXP()
+
+	// assert timeout is already set
+	s.host.AssertUnitProperty("datadog-agent-exp.service", "JobTimeoutUSec", "50min")
+
+	// shorten timeout for tests
+	s.host.Run("sudo mkdir -p /etc/systemd/system/datadog-agent-exp.service.d/")
+	defer s.host.Run("sudo rm -rf /etc/systemd/system/datadog-agent-exp.service.d/")
+	s.host.Run(`echo -e "[Unit]\nJobTimeoutSec=5" | sudo tee /etc/systemd/system/datadog-agent-exp.service.d/override.conf > /dev/null`)
+	s.host.Run(`sudo systemctl daemon-reload`)
+
+	s.host.AssertUnitProperty("datadog-agent-exp.service", "JobTimeoutUSec", "5s")
+
 	timestamp := s.host.LastJournaldTimestamp()
-	// Start the experiment while it's not installed. This should immediately revert to the stable version.
 	s.host.Run(`sudo systemctl start datadog-agent-exp --no-block`)
+
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
-		Stopping("datadog-agent.service").
-		Stopped("datadog-agent.service").
-		Starting("datadog-agent-exp.service").
-		Failed("datadog-agent-exp.service").
-		Started("datadog-agent.service"),
+		// first stop agent dependency
+		Unordered(host.SystemdEvents().
+			Stopped(traceUnit).
+			Stopped(processUnit),
+		).
+		// then agent
+		Stopping(agentUnit).
+		Stopped(agentUnit).
+
+		// start experiment dependency
+		Unordered(host.SystemdEvents().
+			Starting(agentUnitXP).
+			Started(processUnitXP).
+			Started(traceUnitXP).
+			Skipped(probeUnitXP).
+			Skipped(securityUnitXP),
+		).
+
+		// timeout
+		Timed(agentUnitXP).
+		Unordered(host.SystemdEvents().
+			Stopped(agentUnitXP).
+			Stopped(processUnitXP).
+			Stopped(traceUnitXP),
+		).
+
+		// start stable agents
+		Started(agentUnit).
+		Unordered(host.SystemdEvents().
+			Started(traceUnit).
+			Started(processUnit).
+			Skipped(probeUnit).
+			Skipped(securityUnit),
+		),
 	)
+}
+
+func (s *packageAgentSuite) TestSigkill() {
+	s.RunInstallScript(envForceInstall("datadog-agent"))
+	defer s.Purge()
+	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
+
+	s.host.SetupFakeAgentXP().
+		SetStopWithSigkill("core-agent").
+		SetStopWithSigkill("process-agent").
+		SetStopWithSigkill("trace-agent")
+
+	for _, unit := range []string{traceUnitXP, processUnitXP, agentUnitXP} {
+		s.host.AssertUnitProperty(unit, "TimeoutStopUSec", "1min 30s")
+		s.host.Run(fmt.Sprintf("sudo mkdir -p /etc/systemd/system/%s.d/", unit))
+		defer s.host.Run(fmt.Sprintf("sudo rm -rf /etc/systemd/system/%s.d/", unit))
+		if unit != agentUnitXP {
+			s.host.Run(fmt.Sprintf(`echo -e "[Service]\nTimeoutStopSec=1" | sudo tee /etc/systemd/system/%s.d/override.conf > /dev/null`, unit))
+		} else {
+			// using timeout on core agent to trigger the kill
+			s.host.Run(`echo -e "[Unit]\nJobTimeoutSec=5\n[Service]\nTimeoutStopSec=1" | sudo tee /etc/systemd/system/datadog-agent-exp.service.d/override.conf > /dev/null`)
+		}
+		s.host.Run(`sudo systemctl daemon-reload`)
+		s.host.AssertUnitProperty(unit, "TimeoutStopUSec", "1s")
+	}
+
+	timestamp := s.host.LastJournaldTimestamp()
+	s.host.Run(`sudo systemctl start datadog-agent-exp --no-block`)
+
+	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
+		// first stop agent dependency
+		Unordered(host.SystemdEvents().
+			Stopped(traceUnit).
+			Stopped(processUnit),
+		).
+		// then agent
+		Stopping(agentUnit).
+		Stopped(agentUnit).
+
+		// start experiment dependency
+		Unordered(host.SystemdEvents().
+			Starting(agentUnitXP).
+			Started(processUnitXP).
+			Started(traceUnitXP).
+			Skipped(probeUnitXP).
+			Skipped(securityUnitXP),
+		).
+
+		// timeout
+		Timed(agentUnitXP).
+		Unordered(host.SystemdEvents().
+			SigtermTimed(agentUnitXP).
+			SigtermTimed(processUnitXP).
+			SigtermTimed(traceUnitXP).
+			Sigkill(agentUnitXP).
+			Sigkill(processUnitXP).
+			Sigkill(traceUnitXP).
+			Stopped(agentUnitXP).
+			Stopped(processUnitXP).
+			Stopped(traceUnitXP),
+		).
+
+		// start stable agents
+		Started(agentUnit).
+		Unordered(host.SystemdEvents().
+			Started(traceUnit).
+			Started(processUnit).
+			Skipped(probeUnit).
+			Skipped(securityUnit),
+		),
+	)
+}
+
+func (s *packageAgentSuite) TestAgentExitCodes() {
+	s.RunInstallScript(envForceInstall("datadog-agent"))
+	defer s.Purge()
+	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
+
+	xpAgent := s.host.SetupFakeAgentXP()
+
+	for _, exitProgram := range []string{"exit0", "exit1"} {
+		s.T().Logf("Testing exit code of %s", exitProgram)
+		if exitProgram == "exit0" {
+			xpAgent.SetExit0("core-agent")
+		} else {
+			xpAgent.SetExit1("core-agent")
+		}
+
+		timestamp := s.host.LastJournaldTimestamp()
+		s.host.Run(`sudo systemctl start datadog-agent-exp --no-block`)
+
+		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
+			// first stop agent dependency
+			Unordered(host.SystemdEvents().
+				Stopped(traceUnit).
+				Stopped(processUnit),
+			).
+			// then agent
+			Stopping(agentUnit).
+			Stopped(agentUnit).
+
+			// start experiment dependency
+			Unordered(host.SystemdEvents().
+				Starting(agentUnitXP).
+				Started(processUnitXP).
+				Started(traceUnitXP).
+				Skipped(probeUnitXP).
+				Skipped(securityUnitXP),
+			).
+
+			// failed agent XP unit
+			Failed(agentUnitXP).
+			Unordered(host.SystemdEvents().
+				Stopped(processUnitXP).
+				Stopped(traceUnitXP),
+			).
+
+			// start stable agents
+			Started(agentUnit).
+			Unordered(host.SystemdEvents().
+				Started(traceUnit).
+				Started(processUnit).
+				Skipped(probeUnit).
+				Skipped(securityUnit),
+			),
+		)
+	}
+}
+
+func (s *packageAgentSuite) TestExperimentStopped() {
+	s.RunInstallScript(envForceInstall("datadog-agent"))
+	defer s.Purge()
+	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
+
+	s.host.SetupFakeAgentXP()
+
+	for _, stopCommand := range []string{"start datadog-agent", "stop datadog-agent-exp"} {
+		s.T().Logf("Testing stop experiment command %s", stopCommand)
+		timestamp := s.host.LastJournaldTimestamp()
+		s.host.Run(`sudo systemctl start datadog-agent-exp --no-block`)
+
+		// ensure experiment is running
+		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().Started(traceUnitXP))
+		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().Started(processUnitXP))
+		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().Skipped(securityUnitXP))
+		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().Skipped(probeUnitXP))
+
+		// stop experiment
+		s.host.Run(fmt.Sprintf(`sudo systemctl %s`, stopCommand))
+
+		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
+			// first stop agent dependency
+			Unordered(host.SystemdEvents().
+				Stopped(traceUnit).
+				Stopped(processUnit),
+			).
+			// then agent
+			Stopping(agentUnit).
+			Stopped(agentUnit).
+
+			// start experiment dependency
+			Unordered(host.SystemdEvents().
+				Starting(agentUnitXP).
+				Started(processUnitXP).
+				Started(traceUnitXP).
+				Skipped(probeUnitXP).
+				Skipped(securityUnitXP),
+			).
+
+			// stop order
+			Unordered(host.SystemdEvents().
+				Stopped(agentUnitXP).
+				Stopped(processUnitXP).
+				Stopped(traceUnitXP),
+			).
+
+			// start stable agents
+			Started(agentUnit).
+			Unordered(host.SystemdEvents().
+				Started(traceUnit).
+				Started(processUnit).
+				Skipped(probeUnit).
+				Skipped(securityUnit),
+			),
+		)
+	}
 }


### PR DESCRIPTION
**Fix**
- a mistake on sysprobe-exp unit creating a cyclic dependency

**New test coverage**
- ordering of experiment/stable units start/stop
- timeout works on the experiment, and triggers a Sigterm on all experiment units
- sigkill is eventually called on each experiment unit 
- `start datadog-agent` & `stop datadog-agent-exp` have the same behaviour and launch back the stable
- exit 0 & exit 1 of the experiment core-agent
- system-probe/security-agent skip conditions work

**What's missing?**
- coverage of system-probe and security-agent when they are enabled

**Nota bene**
system-probe & security-agent only work on systemd 244+, while centos7+ amazonlinux are on 219. I added a special check on systemd version for tests to pass
This is what the unit looks like on old systemd versions
```
[centos@ip-10-1-58-6 ~]$ sudo systemctl status datadog-agent-sysprobe.service
● datadog-agent-sysprobe.service - Datadog System Probe
   Loaded: loaded (/usr/lib/systemd/system/datadog-agent-sysprobe.service; enabled; vendor preset: disabled)
   Active: inactive (dead)
Condition: start condition failed at mer. 2024-05-22 15:55:00 UTC; 21s ago
           ConditionPathExists=/etc/datadog-agent/system-probe.yaml was not met
```