### PR TITLE
Sort routes from endpoint providers in api component

### DIFF
--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"sort"
 	"time"
 
 	"github.com/DataDog/zstd"
@@ -74,6 +75,7 @@ func SetupHandlers(
 ) *mux.Router {
 
 	// Register the handlers from the component providers
+	sort.Slice(providers, func(i, j int) bool { return providers[i].Route < providers[j].Route })
 	for _, p := range providers {
 		r.HandleFunc(p.Route, p.HandlerFunc).Methods(p.Methods...)
 	}

--- a/test/new-e2e/tests/agent-subcommands/config/config_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/config/config_common_test.go
@@ -82,7 +82,6 @@ func (v *baseConfigSuite) TestNonDefaultConfig() {
 }
 
 func (v *baseConfigSuite) TestConfigListRuntime() {
-	v.T().Skip("Skipping list-runtime test temporarily to troubleshoot flakiness")
 	output := v.Env().Agent.Client.Config(agentclient.WithArgs([]string{"list-runtime"}))
 	for _, config := range visibleConfigs {
 		assert.Contains(v.T(), output, config)

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_common_test.go
@@ -64,7 +64,6 @@ func (v *baseFlareSuite) TestLocalFlareDefaultFiles() {
 }
 
 func (v *baseFlareSuite) TestFlareProfiling() {
-	v.T().Skip("Skipping list-runtime test temporarily to troubleshoot flakiness")
 	args := agentclient.WithArgs([]string{"--email", "e2e@test.com", "--send", "--profile", "31",
 		"--profile-blocking", "--profile-blocking-rate", "5000", "--profile-mutex", "--profile-mutex-fraction", "200"})
 	flare, logs := requestAgentFlareAndFetchFromFakeIntake(v, args)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

follow up to https://github.com/DataDog/datadog-agent/pull/25831

[fx Value Groups are randomized order](https://github.com/uber-go/fx/discussions/886#discussioncomment-2838642) so when we have two routes `/config/list-runtime` and `/config/{setting}` where the order matters (we want to register list-runtime before the variable route) we don't have a guarantee without sorting these by route

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
