### PR TITLE
pkg/trace: fix serialized writing

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -177,15 +177,16 @@ func (a *Agent) Run() {
 
 	go a.StatsWriter.Run()
 
-	// Having GOMAXPROCS/2 processor threads is
-	// enough to keep the downstream writer busy.
+	// Having GOMAXPROCS processor threads is
+	// enough to keep the agent busy.
 	// Having more processor threads would not speed
 	// up processing, but just expand memory.
-	workers := runtime.GOMAXPROCS(0) / 2
+	workers := runtime.GOMAXPROCS(0)
 	if workers < 1 {
 		workers = 1
 	}
 
+	log.Infof("Processing Pipeline configured with %d workers", workers)
 	for i := 0; i < workers; i++ {
 		go a.work()
 	}

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -237,14 +237,14 @@ func (w *TraceWriter) flush() {
 // w does not need to be locked during flushPayloads.
 func (w *TraceWriter) flushPayloads(payloads []*pb.TracerPayload) {
 	w.flushTicker.Reset(w.tick) // reset the flush timer whenever we flush
-	if len(w.tracerPayloads) == 0 {
+	if len(payloads) == 0 {
 		// nothing to do
 		return
 	}
 
 	defer w.timing.Since("datadog.trace_agent.trace_writer.encode_ms", time.Now())
 
-	log.Debugf("Serializing %d tracer payloads.", len(w.tracerPayloads))
+	log.Debugf("Serializing %d tracer payloads.", len(payloads))
 	p := pb.AgentPayload{
 		AgentVersion:       w.agentVersion,
 		HostName:           w.hostname,

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -188,24 +188,37 @@ func (w *TraceWriter) FlushSync() error {
 	return nil
 }
 
-// WriteChunks writes and serializes the provided chunks
-func (w *TraceWriter) WriteChunks(pkg *SampledChunks) {
-	w.stats.Spans.Add(pkg.SpanCount)
-	w.stats.Traces.Add(int64(len(pkg.TracerPayload.Chunks)))
-	w.stats.Events.Add(pkg.EventCount)
-
+// appendChunks adds sampled chunks to the current payload, and in the case the payload
+// is full, returns a finished payload which needs to be written out.
+func (w *TraceWriter) appendChunks(pkg *SampledChunks) []*pb.TracerPayload {
+	var toflush []*pb.TracerPayload
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	size := pkg.Size
 	if size+w.bufferedSize > MaxPayloadSize {
 		// reached maximum allowed buffered size
-		w.flush()
+		// reset the buffer so we can add our payload and defer a flush.
+		toflush = w.tracerPayloads
+		w.resetBuffer()
 	}
 	if len(pkg.TracerPayload.Chunks) > 0 {
 		log.Tracef("Writer: handling new tracer payload with %d spans: %v", pkg.SpanCount, pkg.TracerPayload)
 		w.tracerPayloads = append(w.tracerPayloads, pkg.TracerPayload)
 	}
 	w.bufferedSize += size
+	return toflush
+}
+
+// WriteChunks writes and serializes the provided chunks
+func (w *TraceWriter) WriteChunks(pkg *SampledChunks) {
+	w.stats.Spans.Add(pkg.SpanCount)
+	w.stats.Traces.Add(int64(len(pkg.TracerPayload.Chunks)))
+	w.stats.Events.Add(pkg.EventCount)
+
+	toflush := w.appendChunks(pkg)
+	if toflush != nil {
+		w.flushPayloads(toflush)
+	}
 }
 
 func (w *TraceWriter) resetBuffer() {
@@ -215,7 +228,14 @@ func (w *TraceWriter) resetBuffer() {
 
 const headerLanguages = "X-Datadog-Reported-Languages"
 
+// w must be locked for a flush.
 func (w *TraceWriter) flush() {
+	defer w.resetBuffer()
+	w.flushPayloads(w.tracerPayloads)
+}
+
+// w does not need to be locked during flushPayloads.
+func (w *TraceWriter) flushPayloads(payloads []*pb.TracerPayload) {
 	w.flushTicker.Reset(w.tick) // reset the flush timer whenever we flush
 	if len(w.tracerPayloads) == 0 {
 		// nothing to do
@@ -223,7 +243,6 @@ func (w *TraceWriter) flush() {
 	}
 
 	defer w.timing.Since("datadog.trace_agent.trace_writer.encode_ms", time.Now())
-	defer w.resetBuffer()
 
 	log.Debugf("Serializing %d tracer payloads.", len(w.tracerPayloads))
 	p := pb.AgentPayload{
@@ -233,7 +252,7 @@ func (w *TraceWriter) flush() {
 		TargetTPS:          w.prioritySampler.GetTargetTPS(),
 		ErrorTPS:           w.errorsSampler.GetTargetTPS(),
 		RareSamplerEnabled: w.rareSampler.IsEnabled(),
-		TracerPayloads:     w.tracerPayloads,
+		TracerPayloads:     payloads,
 	}
 	log.Debugf("Reported agent rates: target_tps=%v errors_tps=%v rare_sampling=%v", p.TargetTPS, p.ErrorTPS, p.RareSamplerEnabled)
 

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -171,6 +171,8 @@ func (w *TraceWriter) Stop() {
 	// Wait for encoding/compression to complete on each payload,
 	// and submission to senders
 	w.wg.Wait()
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.flush()
 	stopSenders(w.senders)
 }


### PR DESCRIPTION
When removing the old worker pool from the writer, we accidentally caused all marshalling of the outgoing payloads to be serialized due to a lock. This fixes that issue, and also increases the number of processing workers to recover throughput that was lost due to lack of workers.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
