### PR TITLE
[github/codeowners] Add container-platform as owner of /pkg/proto/datadog/workloadmeta

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -384,6 +384,7 @@
 /pkg/proto/datadog/languagedetection    @DataDog/processes
 /pkg/proto/datadog/process              @DataDog/processes
 /pkg/proto/datadog/trace                @DataDog/agent-apm
+/pkg/proto/datadog/workloadmeta         @DataDog/container-platform
 /pkg/remoteconfig/                      @DataDog/remote-config
 /pkg/runtime/                           @DataDog/agent-shared-components
 /pkg/serializer/                        @DataDog/agent-processing-and-routing


### PR DESCRIPTION
### What does this PR do?

Adds container-platform as owner of `/pkg/proto/datadog/workloadmeta`.


### Describe how to test/QA your changes

Skip.
