### PR TITLE
(fleet) cleanup installer config entries names

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -886,10 +886,10 @@ func InitConfig(config pkgconfigmodel.Config) {
 
 	setupProcesses(config)
 
-	// Updater configuration
-	config.BindEnvAndSetDefault("updater.remote_updates", false)
-	config.BindEnv("updater.registry")
-	config.BindEnvAndSetDefault("updater.registry_auth", "")
+	// Installer configuration
+	config.BindEnvAndSetDefault("remote_updates", false)
+	config.BindEnvAndSetDefault("installer.registry.url", "")
+	config.BindEnvAndSetDefault("installer.registry.auth", "")
 }
 
 func agent(config pkgconfigmodel.Config) {

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -61,8 +61,8 @@ type daemonImpl struct {
 	requestsWG    sync.WaitGroup
 }
 
-func newInstaller(config config.Reader, installerBin string) installer.Installer {
-	return exec.NewInstallerExec(env.FromConfig(config), installerBin)
+func newInstaller(env *env.Env, installerBin string) installer.Installer {
+	return exec.NewInstallerExec(env, installerBin)
 }
 
 // NewDaemon returns a new daemon.
@@ -79,9 +79,9 @@ func NewDaemon(rcFetcher client.ConfigFetcher, config config.Reader) (Daemon, er
 	if err != nil {
 		return nil, fmt.Errorf("could not create remote config client: %w", err)
 	}
-	installer := newInstaller(config, installerBin)
-	remoteUpdates := config.GetBool("updater.remote_updates")
-	return newDaemon(rc, installer, remoteUpdates), nil
+	env := env.FromConfig(config)
+	installer := newInstaller(env, installerBin)
+	return newDaemon(rc, installer, env.RemoteUpdates), nil
 }
 
 func newDaemon(rc *remoteConfig, installer installer.Installer, remoteUpdates bool) *daemonImpl {

--- a/pkg/fleet/env/env.go
+++ b/pkg/fleet/env/env.go
@@ -18,6 +18,7 @@ import (
 const (
 	envAPIKey                = "DD_API_KEY"
 	envSite                  = "DD_SITE"
+	envRemoteUpdates         = "DD_REMOTE_UPDATES"
 	envRegistryURL           = "DD_INSTALLER_REGISTRY_URL"
 	envRegistryAuth          = "DD_INSTALLER_REGISTRY_AUTH"
 	envDefaultPackageVersion = "DD_INSTALLER_DEFAULT_PKG_VERSION"
@@ -25,8 +26,9 @@ const (
 )
 
 var defaultEnv = Env{
-	APIKey: "",
-	Site:   "datadoghq.com",
+	APIKey:        "",
+	Site:          "datadoghq.com",
+	RemoteUpdates: false,
 
 	RegistryOverride:            "",
 	RegistryAuthOverride:        "",
@@ -43,8 +45,9 @@ var defaultEnv = Env{
 
 // Env contains the configuration for the installer.
 type Env struct {
-	APIKey string
-	Site   string
+	APIKey        string
+	Site          string
+	RemoteUpdates bool
 
 	RegistryOverride            string
 	RegistryAuthOverride        string
@@ -60,8 +63,9 @@ type Env struct {
 // FromEnv returns an Env struct with values from the environment.
 func FromEnv() *Env {
 	return &Env{
-		APIKey: getEnvOrDefault(envAPIKey, defaultEnv.APIKey),
-		Site:   getEnvOrDefault(envSite, defaultEnv.Site),
+		APIKey:        getEnvOrDefault(envAPIKey, defaultEnv.APIKey),
+		Site:          getEnvOrDefault(envSite, defaultEnv.Site),
+		RemoteUpdates: os.Getenv(envRemoteUpdates) == "true",
 
 		RegistryOverride:            getEnvOrDefault(envRegistryURL, defaultEnv.RegistryOverride),
 		RegistryAuthOverride:        getEnvOrDefault(envRegistryAuth, defaultEnv.RegistryAuthOverride),
@@ -80,8 +84,9 @@ func FromConfig(config config.Reader) *Env {
 	return &Env{
 		APIKey:               utils.SanitizeAPIKey(config.GetString("api_key")),
 		Site:                 config.GetString("site"),
-		RegistryOverride:     config.GetString("updater.registry"),
-		RegistryAuthOverride: config.GetString("updater.registry_auth"),
+		RemoteUpdates:        config.GetBool("remote_updates"),
+		RegistryOverride:     config.GetString("installer.registry.url"),
+		RegistryAuthOverride: config.GetString("installer.registry.auth"),
 	}
 }
 
@@ -93,6 +98,9 @@ func (e *Env) ToEnv() []string {
 	}
 	if e.Site != "" {
 		env = append(env, envSite+"="+e.Site)
+	}
+	if e.RemoteUpdates {
+		env = append(env, envRemoteUpdates+"=true")
 	}
 	if e.RegistryOverride != "" {
 		env = append(env, envRegistryURL+"="+e.RegistryOverride)

--- a/pkg/fleet/env/env_test.go
+++ b/pkg/fleet/env/env_test.go
@@ -18,14 +18,8 @@ func TestFromEnv(t *testing.T) {
 		expected *Env
 	}{
 		{
-			name: "Empty environment variables",
-			envVars: map[string]string{
-				envAPIKey:                "",
-				envSite:                  "",
-				envRegistryURL:           "",
-				envRegistryAuth:          "",
-				envDefaultPackageVersion: "",
-			},
+			name:    "Empty environment variables",
+			envVars: map[string]string{},
 			expected: &Env{
 				APIKey:                         "",
 				Site:                           "datadoghq.com",
@@ -42,6 +36,7 @@ func TestFromEnv(t *testing.T) {
 			envVars: map[string]string{
 				envAPIKey:                                     "123456",
 				envSite:                                       "datadoghq.eu",
+				envRemoteUpdates:                              "true",
 				envRegistryURL:                                "registry.example.com",
 				envRegistryAuth:                               "auth",
 				envRegistryURL + "_IMAGE":                     "another.registry.example.com",
@@ -56,6 +51,7 @@ func TestFromEnv(t *testing.T) {
 			expected: &Env{
 				APIKey:               "123456",
 				Site:                 "datadoghq.eu",
+				RemoteUpdates:        true,
 				RegistryOverride:     "registry.example.com",
 				RegistryAuthOverride: "auth",
 				RegistryOverrideByImage: map[string]string{
@@ -106,6 +102,7 @@ func TestToEnv(t *testing.T) {
 			env: &Env{
 				APIKey:               "123456",
 				Site:                 "datadoghq.eu",
+				RemoteUpdates:        true,
 				RegistryOverride:     "registry.example.com",
 				RegistryAuthOverride: "auth",
 				RegistryOverrideByImage: map[string]string{
@@ -128,6 +125,7 @@ func TestToEnv(t *testing.T) {
 			expected: []string{
 				"DD_API_KEY=123456",
 				"DD_SITE=datadoghq.eu",
+				"DD_REMOTE_UPDATES=true",
 				"DD_INSTALLER_REGISTRY_URL=registry.example.com",
 				"DD_INSTALLER_REGISTRY_AUTH=auth",
 				"DD_INSTALLER_REGISTRY_URL_IMAGE=another.registry.example.com",


### PR DESCRIPTION
This PR aligns the install script env variable (DD_REMOTE_UPDATES, DD_INSTALLER_REGISTRY*) with the entries in datadog.yaml.
