### PR TITLE
AMLII-1804 Refactor context timestamp tracking

### DIFF
--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -180,7 +180,7 @@ func testHistogramCountSampling(t *testing.T, store *tags.Store) {
 	checkSampler.addSample(&mSample3)
 
 	checkSampler.commit(12349.0)
-	require.Len(t, checkSampler.contextResolver.expireCountByKey, 1)
+	require.Equal(t, 1, checkSampler.contextResolver.length())
 	series, _ := checkSampler.flush()
 
 	// Check that the `.count` metric returns a raw count of the samples, with no interval normalization
@@ -205,7 +205,7 @@ func testHistogramCountSampling(t *testing.T, store *tags.Store) {
 
 	assert.True(t, foundCount)
 	checkSampler.commit(12349.0)
-	require.Len(t, checkSampler.contextResolver.expireCountByKey, 0)
+	require.Equal(t, 0, checkSampler.contextResolver.length())
 }
 
 func TestHistogramCountSampling(t *testing.T) {

--- a/pkg/aggregator/context_resolver_bench_test.go
+++ b/pkg/aggregator/context_resolver_bench_test.go
@@ -30,7 +30,7 @@ func benchmarkContextResolver(numContexts int, b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		cr.trackContext(&samples[n%numContexts])
+		cr.trackContext(&samples[n%numContexts], 0)
 	}
 	b.ReportAllocs()
 }

--- a/pkg/aggregator/context_resolver_debug.go
+++ b/pkg/aggregator/context_resolver_debug.go
@@ -26,7 +26,8 @@ type ContextDebugRepr struct {
 func (cr *contextResolver) dumpContexts(dest io.Writer) error {
 	enc := json.NewEncoder(dest)
 
-	for _, c := range cr.contextsByKey {
+	for _, e := range cr.contextsByKey {
+		c := e.context
 		err := enc.Encode(ContextDebugRepr{
 			Name:       c.Name,
 			Host:       c.Host,

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -77,18 +77,18 @@ func testTrackContext(t *testing.T, store *tags.Store) {
 	contextResolver := newContextResolver(store, "test")
 
 	// Track the 2 contexts
-	contextKey1 := contextResolver.trackContext(&mSample1)
-	contextKey2 := contextResolver.trackContext(&mSample2)
-	contextKey3 := contextResolver.trackContext(&mSample3)
+	contextKey1 := contextResolver.trackContext(&mSample1, 0)
+	contextKey2 := contextResolver.trackContext(&mSample2, 0)
+	contextKey3 := contextResolver.trackContext(&mSample3, 0)
 
 	// When we look up the 2 keys, they return the correct contexts
-	context1 := contextResolver.contextsByKey[contextKey1]
+	context1 := contextResolver.contextsByKey[contextKey1].context
 	assertContext(t, context1, mSample1.Name, mSample1.Tags, "")
 
-	context2 := contextResolver.contextsByKey[contextKey2]
+	context2 := contextResolver.contextsByKey[contextKey2].context
 	assertContext(t, context2, mSample2.Name, mSample2.Tags, "")
 
-	context3 := contextResolver.contextsByKey[contextKey3]
+	context3 := contextResolver.contextsByKey[contextKey3].context
 	assertContext(t, context3, mSample3.Name, mSample3.Tags, mSample3.Host)
 
 	assert.Equal(t, uint64(2), contextResolver.countsByMtype[metrics.GaugeType])
@@ -131,94 +131,59 @@ func testExpireContexts(t *testing.T, store *tags.Store) {
 		Tags:       []string{"foo", "bar", "baz"},
 		SampleRate: 1,
 	}
-	contextResolver := newTimestampContextResolver(store, "test")
+	mSample3 := metrics.MetricSample{
+		Name:       "my.counter.name",
+		Value:      1,
+		Mtype:      metrics.CounterType,
+		Tags:       []string{"foo"},
+		SampleRate: 1,
+	}
+	contextResolver := newTimestampContextResolver(store, "test", 2, 4)
 
 	// Track the 2 contexts
-	contextKey1 := contextResolver.trackContext(&mSample1, 4)
-	contextKey2 := contextResolver.trackContext(&mSample2, 6)
+	contextKey1 := contextResolver.trackContext(&mSample1, 4) // expires after 6
+	contextKey2 := contextResolver.trackContext(&mSample2, 6) // expires after 8
+	contextKey3 := contextResolver.trackContext(&mSample3, 6) // expires after 10
 
 	// With an expireTimestap of 3, both contexts are still valid
-	contextResolver.expireContexts(3, nil)
-	_, ok1 := contextResolver.resolver.contextsByKey[contextKey1]
-	_, ok2 := contextResolver.resolver.contextsByKey[contextKey2]
-	assert.True(t, ok1)
-	assert.True(t, ok2)
+	contextResolver.expireContexts(4)
+	_, ok := contextResolver.resolver.contextsByKey[contextKey1]
+	assert.True(t, ok)
+	_, ok = contextResolver.resolver.contextsByKey[contextKey2]
+	assert.True(t, ok)
+	_, ok = contextResolver.resolver.contextsByKey[contextKey3]
+	assert.True(t, ok)
 
-	// With an expireTimestap of 5, context 1 is expired
-	contextResolver.expireContexts(5, nil)
+	// With an expireTimestap of 8, context 1 is expired
+	contextResolver.expireContexts(7)
 
 	// context 1 is not tracked anymore, but context 2 still is
-	_, ok := contextResolver.resolver.contextsByKey[contextKey1]
+	_, ok = contextResolver.resolver.contextsByKey[contextKey1]
 	assert.False(t, ok)
 	_, ok = contextResolver.resolver.contextsByKey[contextKey2]
 	assert.True(t, ok)
+	_, ok = contextResolver.resolver.contextsByKey[contextKey3]
+	assert.True(t, ok)
+
+	contextResolver.expireContexts(9)
+	_, ok = contextResolver.resolver.contextsByKey[contextKey1]
+	assert.False(t, ok)
+	_, ok = contextResolver.resolver.contextsByKey[contextKey2]
+	assert.False(t, ok)
+	_, ok = contextResolver.resolver.contextsByKey[contextKey3]
+	assert.True(t, ok)
+
+	contextResolver.expireContexts(11)
+	_, ok = contextResolver.resolver.contextsByKey[contextKey1]
+	assert.False(t, ok)
+	_, ok = contextResolver.resolver.contextsByKey[contextKey2]
+	assert.False(t, ok)
+	_, ok = contextResolver.resolver.contextsByKey[contextKey3]
+	assert.False(t, ok)
 }
 
 func TestExpireContexts(t *testing.T) {
 	testWithTagsStore(t, testExpireContexts)
-}
-
-func testExpireContextsWithKeep(t *testing.T, store *tags.Store) {
-	mSample1 := metrics.MetricSample{
-		Name:       "my.metric.name",
-		Value:      1,
-		Mtype:      metrics.GaugeType,
-		Tags:       []string{"foo", "bar"},
-		SampleRate: 1,
-	}
-	mSample2 := metrics.MetricSample{
-		Name:       "my.metric.name",
-		Value:      1,
-		Mtype:      metrics.GaugeType,
-		Tags:       []string{"foo", "bar", "baz"},
-		SampleRate: 1,
-	}
-	contextResolver := newTimestampContextResolver(store, "test")
-
-	// Track the 2 contexts
-	contextKey1 := contextResolver.trackContext(&mSample1, 4)
-	contextKey2 := contextResolver.trackContext(&mSample2, 7)
-
-	keeperCalled := 0
-	keep := true
-	keeper := func(k ckey.ContextKey) bool {
-		keeperCalled++
-		assert.Equal(t, k, contextKey1)
-		return keep
-	}
-
-	// With an expireTimestap of 3, both contexts are still valid
-	contextResolver.expireContexts(3, keeper)
-	_, ok1 := contextResolver.resolver.contextsByKey[contextKey1]
-	_, ok2 := contextResolver.resolver.contextsByKey[contextKey2]
-	assert.True(t, ok1)
-	assert.True(t, ok2)
-	assert.Equal(t, keeperCalled, 0)
-
-	// With an expireTimestap of 5, context 1 is expired, but we explicitly keep it
-	contextResolver.expireContexts(5, keeper)
-	assert.Equal(t, keeperCalled, 1)
-
-	// both contexts are still tracked
-	_, ok1 = contextResolver.resolver.contextsByKey[contextKey1]
-	_, ok2 = contextResolver.resolver.contextsByKey[contextKey2]
-	assert.True(t, ok1)
-	assert.True(t, ok2)
-
-	// With an expireTimestap of 6, context 1 is expired, and we don't keep it this time
-	keep = false
-	contextResolver.expireContexts(6, keeper)
-	assert.Equal(t, keeperCalled, 2)
-
-	// context 1 is not tracked anymore
-	_, ok1 = contextResolver.resolver.contextsByKey[contextKey1]
-	_, ok2 = contextResolver.resolver.contextsByKey[contextKey2]
-	assert.False(t, ok1)
-	assert.True(t, ok2)
-}
-
-func TestExpireContextsWithKeep(t *testing.T) {
-	testWithTagsStore(t, testExpireContextsWithKeep)
 }
 
 func testCountBasedExpireContexts(t *testing.T, store *tags.Store) {
@@ -255,10 +220,10 @@ func testTagDeduplication(t *testing.T, store *tags.Store) {
 	ckey := resolver.trackContext(&metrics.MetricSample{
 		Name: "foo",
 		Tags: []string{"bar", "bar"},
-	})
+	}, 0)
 
-	assert.Equal(t, resolver.contextsByKey[ckey].Tags().Len(), 1)
-	metrics.AssertCompositeTagsEqual(t, resolver.contextsByKey[ckey].Tags(), tagset.CompositeTagsFromSlice([]string{"bar"}))
+	assert.Equal(t, resolver.contextsByKey[ckey].context.Tags().Len(), 1)
+	metrics.AssertCompositeTagsEqual(t, resolver.contextsByKey[ckey].context.Tags(), tagset.CompositeTagsFromSlice([]string{"bar"}))
 }
 
 func TestTagDeduplication(t *testing.T) {
@@ -289,11 +254,11 @@ func (s *mockSample) GetTags(tb, mb tagset.TagsAccumulator, _ metrics.EnrichTags
 
 func TestOriginTelemetry(t *testing.T) {
 	r := newContextResolver(tags.NewStore(true, "test"), "test")
-	r.trackContext(&mockSample{"foo", []string{"foo"}, []string{"ook"}})
-	r.trackContext(&mockSample{"foo", []string{"foo"}, []string{"eek"}})
-	r.trackContext(&mockSample{"foo", []string{"bar"}, []string{"ook"}})
-	r.trackContext(&mockSample{"bar", []string{"bar"}, []string{}})
-	r.trackContext(&mockSample{"bar", []string{"baz"}, []string{}})
+	r.trackContext(&mockSample{"foo", []string{"foo"}, []string{"ook"}}, 0)
+	r.trackContext(&mockSample{"foo", []string{"foo"}, []string{"eek"}}, 0)
+	r.trackContext(&mockSample{"foo", []string{"bar"}, []string{"ook"}}, 0)
+	r.trackContext(&mockSample{"bar", []string{"bar"}, []string{}}, 0)
+	r.trackContext(&mockSample{"bar", []string{"baz"}, []string{}}, 0)
 	sink := mockSink{}
 	ts := 1672835152.0
 	r.sendOriginTelemetry(ts, &sink, "test", []string{"test"})

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -156,7 +156,6 @@ func testCounterExpirySeconds(t *testing.T, store *tags.Store) {
 		Tags:       []string{"foo", "bar"},
 		SampleRate: 1,
 	}
-	contextCounter1 := generateContextKey(sampleCounter1)
 
 	sampleCounter2 := &metrics.MetricSample{
 		Name:       "my.counter2",
@@ -165,7 +164,6 @@ func testCounterExpirySeconds(t *testing.T, store *tags.Store) {
 		Tags:       []string{"foo", "bar"},
 		SampleRate: 1,
 	}
-	contextCounter2 := generateContextKey(sampleCounter2)
 
 	sampleGauge3 := &metrics.MetricSample{
 		Name:       "my.gauge",
@@ -178,8 +176,6 @@ func testCounterExpirySeconds(t *testing.T, store *tags.Store) {
 	sampler.sample(sampleCounter1, 1004.0)
 	sampler.sample(sampleCounter2, 1002.0)
 	sampler.sample(sampleGauge3, 1003.0)
-	// counterLastSampledByContext should be populated when a sample is added
-	assert.Equal(t, 2, len(sampler.counterLastSampledByContext))
 
 	series, _ := flushSerie(sampler, 1010.0)
 
@@ -214,10 +210,7 @@ func testCounterExpirySeconds(t *testing.T, store *tags.Store) {
 	}
 	expectedSeries := metrics.Series{expectedSerie1, expectedSerie2, expectedSerie3}
 
-	require.Equal(t, 2, len(sampler.counterLastSampledByContext))
 	metrics.AssertSeriesEqual(t, expectedSeries, series)
-	assert.Equal(t, 1004.0, sampler.counterLastSampledByContext[contextCounter1])
-	assert.Equal(t, 1002.0, sampler.counterLastSampledByContext[contextCounter2])
 
 	sampleCounter1 = &metrics.MetricSample{
 		Name:       "my.counter1",
@@ -268,13 +261,11 @@ func testCounterExpirySeconds(t *testing.T, store *tags.Store) {
 	// Counter1 should have stopped reporting but the context is not expired yet
 	// Counter2 should still report
 	assert.Equal(t, 1, len(series))
-	assert.Equal(t, 1, len(sampler.counterLastSampledByContext))
-	assert.Equal(t, 1, len(sampler.contextResolver.resolver.contextsByKey))
+	assert.Equal(t, 2, len(sampler.contextResolver.resolver.contextsByKey))
 
 	series, _ = flushSerie(sampler, 1800.0)
 	// Everything stopped reporting and is expired
 	assert.Equal(t, 0, len(series))
-	assert.Equal(t, 0, len(sampler.counterLastSampledByContext))
 	assert.Equal(t, 0, len(sampler.contextResolver.resolver.contextsByKey))
 }
 func TestCounterExpirySeconds(t *testing.T) {
@@ -528,7 +519,7 @@ func testFlushMissingContext(t *testing.T, store *tags.Store) {
 	}, 1000)
 
 	// Simulate a sutation where contexts are expired prematurely.
-	sampler.contextResolver.expireContexts(10000, nil)
+	sampler.contextResolver.expireContexts(10000)
 
 	assert.Len(t, sampler.contextResolver.resolver.contextsByKey, 0)
 


### PR DESCRIPTION
### What does this PR do?

Instead of two separate maps (in addition to the contextsByKey) that store timestamps when a certain context was last seen, store the timestamp alongside the context itself.

For counters, the timestamp context resolver now directly takes into account required extra retention time.

This reduces memory footprint (we save memory by not having copies of keys three times) and simplifies code a little bit.

### Motivation

Reduce memory footprint and simplify implementation of #24605 

### Additional Notes

A profile that illustrates the impact: minus two large maps in the sampler and timestamp context resolver, but a larger allocation in trackContext:

```
  -38.25MB  5.20%  5.20%   -32.07MB  4.36%  github.com/DataDog/datadog-agent/pkg/aggregator.(*TimeSampler).sample
  -38.25MB  5.20% 10.39%   -24.25MB  3.29%  github.com/DataDog/datadog-agent/pkg/aggregator.(*timestampContextResolver).trackContext (inline)
   13.49MB  1.83%  5.47%    12.99MB  1.76%  github.com/DataDog/datadog-agent/pkg/aggregator.(*contextResolver).trackContext
```

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the agent with 
```
log_level: debug
log_payloads: true
dogstatsd_socket: /tmp/dsd.sock
```

Send a counter and a gauge to dogstatsd:
```
echo -e 'test.counter:1|c\ntest.gauge:1|g' | nc -uU /tmp/dsd.sock
```

Check via the log_payloads output that:
- the gauge is sent once.
- the counter value is sent once, and the counter continues to report 0 value for 5 mintues.

Check the telemetry output (`curl -s http://localhost:5000/telemetry | grep dogstatsd`) and make sure that:
- after 20 seconds gauge context expires
- after 320 seconds the counter context expires
