### PR TITLE
[AGNTR-186] Automatic Agent RC staging deployments - improvement

### DIFF
--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -18,9 +18,9 @@ rc_kubernetes_deploy:
   tags: ["arch:amd64"]
   variables:
     OPTION_AUTOMATIC_ROLLOUT: "true"
-    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging ${CI_COMMIT_REF_SLUG}-jmx ${CI_COMMIT_REF_SLUG}"
     SKIP_PLAN_CHECK: "true"
     EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
+    AGENT_IMAGE_TAG: $CI_COMMIT_REF_NAME
   script:
     - source /root/.bashrc
     - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $GITLAB_SCHEDULER_TOKEN_SSM_NAME)
@@ -30,9 +30,4 @@ rc_kubernetes_deploy:
       --variable EXPLICIT_WORKFLOWS
       --variable OPTION_PRE_SCRIPT
       --variable SKIP_PLAN_CHECK
-      --variable APPS
-      --variable BAZEL_TARGET
-      --variable DDR
-      --variable DDR_WORKFLOW_ID
-      --variable TARGET_ENV
-      --variable DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+      --variable AGENT_IMAGE_TAG"


### PR DESCRIPTION
### What does this PR do?

This PR is the second step required to utilise changes made in [this PR](https://github.com/DataDog/k8s-datadog-agent-ops/pull/3601).

After this change the child pipeline in `k8s-datadog-agent-ops` repository will automatically open the PR for staging deployments, which will make it easier for engineers responsible for RC deployments.

Some of the variables passed to the new pipeline where not required so I cleaned them up.

### Motivation

Automation of the Agent RC build and QA process


### Describe how to test/QA your changes

This will be tested e2e with next Agent RC build.
