### PR TITLE
[ASCII-1790] Send metrics with number of go dependencies for each build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -509,6 +509,7 @@
 /tasks/                                 @DataDog/agent-developer-tools @DataDog/agent-ci-experience
 /tasks/msi.py                           @DataDog/windows-agent
 /tasks/agent.py                         @DataDog/agent-shared-components
+/tasks/go_deps.py                       @DataDog/agent-shared-components
 /tasks/dogstatsd.py                     @DataDog/agent-metrics-logs
 /tasks/update_go.py                     @DataDog/agent-shared-components
 /tasks/unit-tests/update_go_tests.py    @DataDog/agent-shared-components

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -13,8 +13,8 @@ security_go_generate_check           @DataDog/agent-security
 prepare_sysprobe_ebpf_functional_tests* @DataDog/ebpf-platform
 prepare_secagent_ebpf_functional_tests* @DataDog/agent-security
 
-# Golang dependency list generation (currently disabled)
-golang_deps_generate                 @DataDog/agent-shared-components
+# Send count metrics about Golang dependencies
+golang_deps_send_count_metrics       @DataDog/agent-shared-components
 # Golang dependency diff generation
 golang_deps_diff                     @DataDog/ebpf-platform
 golang_deps_commenter                @DataDog/ebpf-platform

--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -47,3 +47,18 @@ golang_deps_commenter:
         exit 0
       fi
       exit $exitcode
+
+golang_deps_send_count_metrics:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  rules:
+    - when: on_success
+  needs: ["go_deps"]
+  before_script:
+    - source /root/.bashrc
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    # Get API key to send metrics
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_ORG2_SSM_NAME)
+    - inv -e go-deps.send-count-metrics --git-sha "${CI_COMMIT_SHA}" --git-ref "${CI_COMMIT_REF_NAME}"

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -23,6 +23,7 @@ from tasks import (
     epforwarder,
     fakeintake,
     github_tasks,
+    go_deps,
     installer,
     kmt,
     linter,
@@ -142,6 +143,7 @@ ns.add_collection(dogstatsd)
 ns.add_collection(ebpf)
 ns.add_collection(emacs)
 ns.add_collection(epforwarder)
+ns.add_collection(go_deps)
 ns.add_collection(linter)
 ns.add_collection(msi)
 ns.add_collection(github_tasks, "github")

--- a/tasks/diff.py
+++ b/tasks/diff.py
@@ -15,6 +15,57 @@ from tasks.libs.common.color import color_message
 from tasks.libs.common.utils import check_uncommitted_changes
 from tasks.release import _get_release_json_value
 
+BINARIES = {
+    "agent": {
+        "entrypoint": "cmd/agent",
+        "platforms": ["linux/x64", "linux/arm64", "win32/x64", "darwin/x64", "darwin/arm64"],
+    },
+    "iot-agent": {
+        "build": "agent",
+        "entrypoint": "cmd/agent",
+        "flavor": AgentFlavor.iot,
+        "platforms": ["linux/x64", "linux/arm64"],
+    },
+    "heroku-agent": {
+        "build": "agent",
+        "entrypoint": "cmd/agent",
+        "flavor": AgentFlavor.heroku,
+        "platforms": ["linux/x64"],
+    },
+    "cluster-agent": {"entrypoint": "cmd/cluster-agent", "platforms": ["linux/x64", "linux/arm64"]},
+    "cluster-agent-cloudfoundry": {
+        "entrypoint": "cmd/cluster-agent-cloudfoundry",
+        "platforms": ["linux/x64", "linux/arm64"],
+    },
+    "dogstatsd": {"entrypoint": "cmd/dogstatsd", "platforms": ["linux/x64", "linux/arm64"]},
+    "process-agent": {
+        "entrypoint": "cmd/process-agent",
+        "platforms": ["linux/x64", "linux/arm64", "win32/x64", "darwin/x64", "darwin/arm64"],
+    },
+    "heroku-process-agent": {
+        "build": "process-agent",
+        "entrypoint": "cmd/process-agent",
+        "flavor": AgentFlavor.heroku,
+        "platforms": ["linux/x64"],
+    },
+    "security-agent": {
+        "entrypoint": "cmd/security-agent",
+        "platforms": ["linux/x64", "linux/arm64"],
+    },
+    "serverless": {"entrypoint": "cmd/serverless", "platforms": ["linux/x64", "linux/arm64"]},
+    "system-probe": {"entrypoint": "cmd/system-probe", "platforms": ["linux/x64", "linux/arm64", "win32/x64"]},
+    "trace-agent": {
+        "entrypoint": "cmd/trace-agent",
+        "platforms": ["linux/x64", "linux/arm64", "win32/x64", "darwin/x64", "darwin/arm64"],
+    },
+    "heroku-trace-agent": {
+        "build": "trace-agent",
+        "entrypoint": "cmd/trace-agent",
+        "flavor": AgentFlavor.heroku,
+        "platforms": ["linux/x64"],
+    },
+}
+
 
 @task
 def go_deps(ctx, baseline_ref=None, report_file=None):
@@ -35,57 +86,6 @@ def go_deps(ctx, baseline_ref=None, report_file=None):
         base_branch = _get_release_json_value("base_branch")
         baseline_ref = ctx.run(f"git merge-base {commit_sha} origin/{base_branch}", hide=True).stdout.strip()
 
-    # platforms are the agent task recognized os/platform and arch values, not Go-specific values
-    binaries = {
-        "agent": {
-            "entrypoint": "cmd/agent",
-            "platforms": ["linux/x64", "linux/arm64", "win32/x64", "darwin/x64", "darwin/arm64"],
-        },
-        "iot-agent": {
-            "build": "agent",
-            "entrypoint": "cmd/agent",
-            "flavor": AgentFlavor.iot,
-            "platforms": ["linux/x64", "linux/arm64"],
-        },
-        "heroku-agent": {
-            "build": "agent",
-            "entrypoint": "cmd/agent",
-            "flavor": AgentFlavor.heroku,
-            "platforms": ["linux/x64"],
-        },
-        "cluster-agent": {"entrypoint": "cmd/cluster-agent", "platforms": ["linux/x64", "linux/arm64"]},
-        "cluster-agent-cloudfoundry": {
-            "entrypoint": "cmd/cluster-agent-cloudfoundry",
-            "platforms": ["linux/x64", "linux/arm64"],
-        },
-        "dogstatsd": {"entrypoint": "cmd/dogstatsd", "platforms": ["linux/x64", "linux/arm64"]},
-        "process-agent": {
-            "entrypoint": "cmd/process-agent",
-            "platforms": ["linux/x64", "linux/arm64", "win32/x64", "darwin/x64", "darwin/arm64"],
-        },
-        "heroku-process-agent": {
-            "build": "process-agent",
-            "entrypoint": "cmd/process-agent",
-            "flavor": AgentFlavor.heroku,
-            "platforms": ["linux/x64"],
-        },
-        "security-agent": {
-            "entrypoint": "cmd/security-agent",
-            "platforms": ["linux/x64", "linux/arm64"],
-        },
-        "serverless": {"entrypoint": "cmd/serverless", "platforms": ["linux/x64", "linux/arm64"]},
-        "system-probe": {"entrypoint": "cmd/system-probe", "platforms": ["linux/x64", "linux/arm64", "win32/x64"]},
-        "trace-agent": {
-            "entrypoint": "cmd/trace-agent",
-            "platforms": ["linux/x64", "linux/arm64", "win32/x64", "darwin/x64", "darwin/arm64"],
-        },
-        "heroku-trace-agent": {
-            "build": "trace-agent",
-            "entrypoint": "cmd/trace-agent",
-            "flavor": AgentFlavor.heroku,
-            "platforms": ["linux/x64"],
-        },
-    }
     diffs = {}
     dep_cmd = "go list -f '{{ range .Deps }}{{ printf \"%s\\n\" . }}{{end}}'"
 
@@ -97,7 +97,7 @@ def go_deps(ctx, baseline_ref=None, report_file=None):
                 if branch_ref:
                     ctx.run(f"git checkout -q {branch_ref}")
 
-                for binary, details in binaries.items():
+                for binary, details in BINARIES.items():
                     with ctx.cd(details.get("entrypoint")):
                         for combo in details.get("platforms"):
                             platform, arch = combo.split("/")
@@ -114,7 +114,7 @@ def go_deps(ctx, baseline_ref=None, report_file=None):
             ctx.run(f"git checkout -q {current_branch}")
 
         # compute diffs for each target
-        for binary, details in binaries.items():
+        for binary, details in BINARIES.items():
             for combo in details.get("platforms"):
                 platform, arch = combo.split("/")
                 goos, goarch = GOOS_MAPPING.get(platform), GOARCH_MAPPING.get(arch)
@@ -135,7 +135,7 @@ def go_deps(ctx, baseline_ref=None, report_file=None):
                 f"Comparison: {commit_sha}\n",
                 "<table><thead><tr><th>binary</th><th>os</th><th>arch</th><th>change</th></tr></thead><tbody>",
             ]
-            for binary, details in binaries.items():
+            for binary, details in BINARIES.items():
                 for combo in details.get("platforms"):
                     platform, arch = combo.split("/")
                     goos, goarch = GOOS_MAPPING.get(platform), GOARCH_MAPPING.get(arch)

--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -1,0 +1,117 @@
+import datetime
+import os
+from collections.abc import Iterable
+
+from invoke.context import Context
+from invoke.exceptions import Exit
+from invoke.tasks import task
+
+from tasks.build_tags import get_default_build_tags
+from tasks.diff import BINARIES
+from tasks.flavor import AgentFlavor
+from tasks.go import GOARCH_MAPPING, GOOS_MAPPING
+from tasks.libs.common.color import color_message
+from tasks.libs.common.datadog_api import create_gauge, send_metrics
+
+
+def compute_count_metric(
+    ctx: Context,
+    build: str,
+    flavor: AgentFlavor,
+    platform: str,
+    arch: str,
+    entrypoint: str,
+    timestamp: int | None = None,
+    extra_tags: Iterable[str] = (),
+):
+    """
+    Compute a metric representing the number of Go dependencies of the given build/flavor/platform/arch,
+    and one with only dependencies outside of the agent repository.
+    """
+
+    if not timestamp:
+        timestamp = int(datetime.datetime.now(datetime.UTC).timestamp())
+
+    goos, goarch = GOOS_MAPPING[platform], GOARCH_MAPPING[arch]
+    tags = [
+        f"build:{build}",
+        f"flavor:{flavor.name}",
+        f"os:{goos}",
+        f"arch:{goarch}",
+    ]
+    tags.extend(extra_tags)
+
+    build_tags = get_default_build_tags(build=build, flavor=flavor, platform=platform)
+
+    env = {"GOOS": goos, "GOARCH": goarch}
+    cmd = "go list -f '{{ join .Deps \"\\n\"}}'"
+    with ctx.cd(entrypoint):
+        res = ctx.run(
+            f"{cmd} -tags {','.join(build_tags)}",
+            env=env,
+            hide='out',  # don't hide errors
+        )
+        assert res
+
+    deps = res.stdout.strip().split("\n")
+    count = len(deps)
+    external = sum(1 for dep in deps if not dep.startswith("github.com/DataDog/datadog-agent/"))
+
+    metric_count = create_gauge("datadog.agent.go_dependencies.all", timestamp, count, tags=tags)
+    metric_external = create_gauge("datadog.agent.go_dependencies.external", timestamp, external, tags=tags)
+    return metric_count, metric_external
+
+
+def compute_all_count_metrics(ctx: Context, extra_tags: Iterable[str] = ()):
+    """
+    Compute metrics representing the number of Go dependencies of every build/flavor/platform/arch.
+    """
+
+    timestamp = int(datetime.datetime.now(datetime.UTC).timestamp())
+
+    series = []
+    for binary, details in BINARIES.items():
+        for combo in details["platforms"]:
+            platform, arch = combo.split("/")
+            flavor = details.get("flavor", AgentFlavor.base)
+            build = details.get("build", binary)
+            entrypoint = details["entrypoint"]
+
+            metric_count, metric_external = compute_count_metric(
+                ctx, build, flavor, platform, arch, entrypoint, timestamp, extra_tags=extra_tags
+            )
+            series.append(metric_count)
+            series.append(metric_external)
+
+    return series
+
+
+@task
+def send_count_metrics(
+    ctx: Context,
+    git_sha: str,
+    git_ref: str | None = None,
+    send_series: bool = True,
+):
+    if send_series and not os.environ.get("DD_API_KEY"):
+        raise Exit(
+            code=1,
+            message=color_message(
+                "DD_API_KEY environment variable not set, cannot send pipeline metrics to the backend", "red"
+            ),
+        )
+
+    extra_tags = [
+        f"git_sha:{git_sha}",
+    ]
+    if git_ref:
+        extra_tags.append(f"git_ref:{git_ref}")
+
+    series = compute_all_count_metrics(ctx, extra_tags=extra_tags)
+    print(color_message("Data collected:", "blue"))
+    print(series)
+
+    if send_series:
+        print(color_message("Sending metrics to Datadog", "blue"))
+        send_metrics(series=series)
+        print(color_message("Done", "green"))

--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -13,6 +13,9 @@ from tasks.go import GOARCH_MAPPING, GOOS_MAPPING
 from tasks.libs.common.color import color_message
 from tasks.libs.common.datadog_api import create_gauge, send_metrics
 
+METRIC_GO_DEPS_ALL_NAME = "datadog.agent.go_dependencies.all"
+METRIC_GO_DEPS_EXTERNAL_NAME = "datadog.agent.go_dependencies.external"
+
 
 def compute_count_metric(
     ctx: Context,
@@ -35,6 +38,7 @@ def compute_count_metric(
     goos, goarch = GOOS_MAPPING[platform], GOARCH_MAPPING[arch]
     build_tags = get_default_build_tags(build=build, flavor=flavor, platform=platform)
 
+    # need to explicitly enable CGO to also include CGO-only deps when checking different platforms
     env = {"GOOS": goos, "GOARCH": goarch, "CGO_ENABLED": "1"}
     cmd = "go list -f '{{ join .Deps \"\\n\"}}'"
     with ctx.cd(entrypoint):
@@ -57,8 +61,8 @@ def compute_count_metric(
     ]
     tags.extend(extra_tags)
 
-    metric_count = create_gauge("datadog.agent.go_dependencies.all", timestamp, count, tags=tags)
-    metric_external = create_gauge("datadog.agent.go_dependencies.external", timestamp, external, tags=tags)
+    metric_count = create_gauge(METRIC_GO_DEPS_ALL_NAME, timestamp, count, tags=tags)
+    metric_external = create_gauge(METRIC_GO_DEPS_EXTERNAL_NAME, timestamp, external, tags=tags)
     return metric_count, metric_external
 
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Send metrics for each binary (build/flavor/os/arch) with the total number of Go dependencies, and number of external Go dependencies. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
- Being able to visualize evolution of the number of dependencies over time (over PRs really).
- Being able to track back easily which PR added or removed dependencies.
- Possibly add monitors/notifications when too many dependencies are added at once.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This is currently enabled on all pipelines, but could be restricted to only main + release branches if branch info is deemed not valuable. The main thing I want is having this information on main.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
