### PR TITLE
Allow checks to cache their senders to reduce blocking operations

### DIFF
--- a/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go
+++ b/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go
@@ -60,6 +60,7 @@ func (c *CheckWrapper) destroySender() {
 	c.runM.Lock()
 	defer c.runM.Unlock()
 	c.done = true
+	c.inner.InvalidateSender()
 	c.senderManager.DestroySender(c.ID())
 }
 
@@ -99,6 +100,11 @@ func (c *CheckWrapper) GetWarnings() []error {
 // GetSenderStats implements Check#GetSenderStats
 func (c *CheckWrapper) GetSenderStats() (stats.SenderStats, error) {
 	return c.inner.GetSenderStats()
+}
+
+// InvalidateSender implements Check#InvalidateSender
+func (c *CheckWrapper) InvalidateSender() {
+	c.inner.InvalidateSender()
 }
 
 // Version implements Check#Version

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -27,6 +27,8 @@ type Check interface {
 	// - unlike Stop, it is called even if the check is not running when it's unscheduled
 	// - if the check is running, Cancel is called after Stop and may be called before the call to Stop completes
 	Cancel()
+	// InvalidateSender clears any cached sender state
+	InvalidateSender()
 	// String provides a printable version of the check name
 	String() string
 	// Configure configures the check

--- a/pkg/collector/check/stub/stub.go
+++ b/pkg/collector/check/stub/stub.go
@@ -67,3 +67,6 @@ func (c *StubCheck) InstanceConfig() string { return "" }
 
 // GetDiagnoses returns the diagnoses of the check
 func (c *StubCheck) GetDiagnoses() ([]diagnosis.Diagnosis, error) { return nil, nil }
+
+// InvalidateSender removes the cached sender
+func (c *StubCheck) InvalidateSender() {}

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -51,6 +51,7 @@ type CheckBase struct {
 	telemetry      bool
 	initConfig     string
 	instanceConfig string
+	sender         sender.Sender
 }
 
 // NewCheckBase returns a check base struct with a given check name
@@ -265,7 +266,14 @@ func (c *CheckBase) GetSender() (sender.Sender, error) {
 
 // GetRawSender is similar to GetSender, but does not provide the safety wrapper.
 func (c *CheckBase) GetRawSender() (sender.Sender, error) {
-	return c.senderManager.GetSender(c.ID())
+	if c.sender == nil {
+		s, err := c.senderManager.GetSender(c.ID())
+		if err != nil {
+			return nil, err
+		}
+		c.sender = s
+	}
+	return c.sender, nil
 }
 
 // GetSenderStats returns the stats from the last run of the check.
@@ -280,4 +288,9 @@ func (c *CheckBase) GetSenderStats() (stats.SenderStats, error) {
 // GetDiagnoses returns the diagnoses cached in last run or diagnose explicitly
 func (c *CheckBase) GetDiagnoses() ([]diagnosis.Diagnosis, error) {
 	return nil, nil
+}
+
+// InvalidateSender clears the cached sender
+func (c *CheckBase) InvalidateSender() {
+	c.sender = nil
 }

--- a/pkg/collector/corechecks/embed/apm/apm.go
+++ b/pkg/collector/corechecks/embed/apm/apm.go
@@ -232,6 +232,9 @@ func (c *APMCheck) GetSenderStats() (stats.SenderStats, error) {
 	return stats.NewSenderStats(), nil
 }
 
+// InvalidateSender does nothing
+func (c *APMCheck) InvalidateSender() {}
+
 // InitConfig returns the initConfig for the APM check
 func (c *APMCheck) InitConfig() string {
 	return c.initConfig

--- a/pkg/collector/corechecks/embed/process/process_agent.go
+++ b/pkg/collector/corechecks/embed/process/process_agent.go
@@ -236,6 +236,9 @@ func (c *ProcessAgentCheck) GetSenderStats() (stats.SenderStats, error) {
 	return stats.NewSenderStats(), nil
 }
 
+// InvalidateSender does nothing
+func (c *ProcessAgentCheck) InvalidateSender() {}
+
 // GetDiagnoses returns the diagnoses of the check
 func (c *ProcessAgentCheck) GetDiagnoses() ([]diagnosis.Diagnosis, error) {
 	return nil, nil

--- a/pkg/collector/corechecks/longrunning_test.go
+++ b/pkg/collector/corechecks/longrunning_test.go
@@ -121,6 +121,10 @@ func (m *mockLongRunningCheck) Cancel() {
 	}
 }
 
+func (m *mockLongRunningCheck) InvalidateSender() {
+	m.Called()
+}
+
 func (m *mockLongRunningCheck) waitUntilRun() {
 	<-m.runningCh
 }

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -107,6 +107,7 @@ tags:
 
 	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
+	chk.InvalidateSender()
 
 	sender := mocksender.NewMockSenderWithSenderManager(chk.ID(), senderManager)
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
@@ -586,6 +587,7 @@ profiles:
 
 	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, rawInitConfig, "test")
 	assert.NoError(t, err)
+	chk.InvalidateSender()
 
 	sender := mocksender.NewMockSenderWithSenderManager(chk.ID(), senderManager)
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
@@ -1315,6 +1317,7 @@ tags:
 
 	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, rawInitConfig, "test")
 	assert.Nil(t, err)
+	chk.InvalidateSender()
 
 	sender := mocksender.NewMockSenderWithSenderManager(chk.ID(), senderManager)
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
@@ -1622,6 +1625,7 @@ tags:
 
 	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, rawInitConfig, "test")
 	assert.Nil(t, err)
+	chk.InvalidateSender()
 
 	sender := mocksender.NewMockSenderWithSenderManager(chk.ID(), senderManager)
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Allow checks to cache their senders. 

[`GetSender`](https://github.com/DataDog/datadog-agent/blob/cecc1bbf039c0a003ed3eeea2d51327966e22653/pkg/aggregator/demultiplexer_agent.go#L569) and [`flushToSerializer`](https://github.com/DataDog/datadog-agent/blob/cecc1bbf039c0a003ed3eeea2d51327966e22653/pkg/aggregator/demultiplexer_agent.go#L397) both hold the same lock. So if a flush takes a very long time, it could prevent checks from starting since today checks will always call `GetSender` when they start. This PR allows checks to re-use their sender so they don't have acquire the senders more than once in the lifetime.

#### Additional context 
This PR is one part of a solution to a bigger problem: Some checks that send an extremely high volume of metrics can cause other checks to block due to very long flushes. The flush mechanism several parts, but I am most interested in the aggregator check sampler flush. As a whole, these operations are blocking and prevent checks from starting until a flush finishes but with this change, we can scope the blocking behavior down to just the check sampler instead of "everything". 

This PR removes the need for checks to block on the demultiplexer. On top of this, all of the interactions between the sender and check sampler are buffered - so we can tune them with various existing agent settings reducing the impact of blocking on the [check sampler's channel operations ](https://github.com/DataDog/datadog-agent/blob/cecc1bbf039c0a003ed3eeea2d51327966e22653/pkg/aggregator/aggregator.go#L750)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

This has already been deployed to a large cluster so testing should be done. 
Manual steps: ensure checks still work correctly (lifecycle, and metrics) 
