### PR TITLE
[Invoke Monitoring] Detect tasks run in Unit Tests

### DIFF
--- a/tasks/custom_task/custom_task.py
+++ b/tasks/custom_task/custom_task.py
@@ -31,6 +31,21 @@ def get_dd_invoke_logs_path() -> str:
     return os.path.join(temp_folder, DD_INVOKE_LOGS_FILE)
 
 
+def get_running_mode() -> str:
+    """
+    Get the running mode of the task.
+    If the task is run via pre-commit, the running mode is set to "pre_commit".
+    If the task is run via unittest, the running mode is set to "invoke_unit_tests".
+    Otherwise, it is set to "manual".
+    """
+    output = "manual"
+    if os.environ.get("PRE_COMMIT", 0) == "1":
+        output = "pre_commit"
+    elif os.environ.get("INVOKE_UNIT_TESTS", 0) == "1" or 'unittest' in sys.modules:
+        output = "invoke_unit_tests"
+    return output
+
+
 def log_invoke_task(
     log_path: str, name: str, module: str, task_datetime: str, duration: float, task_result: str
 ) -> None:
@@ -47,7 +62,7 @@ def log_invoke_task(
     """
     logging.basicConfig(filename=log_path, level=logging.INFO, format='%(message)s')
     user = getuser()
-    running_mode = "pre_commit" if os.environ.get("PRE_COMMIT", 0) == "1" else "manual"
+    running_mode = get_running_mode()
     task_info = {
         "name": name,
         "module": module,

--- a/tasks/custom_task/custom_task.py
+++ b/tasks/custom_task/custom_task.py
@@ -72,7 +72,7 @@ def log_invoke_task(
     task_info = {
         "name": name,
         "module": module,
-        "running_mode": running_modes,
+        "running_modes": running_modes,
         "datetime": task_datetime,
         "duration": duration,
         "user": user,

--- a/tasks/custom_task/custom_task.py
+++ b/tasks/custom_task/custom_task.py
@@ -32,7 +32,7 @@ def get_dd_invoke_logs_path() -> str:
     return os.path.join(temp_folder, DD_INVOKE_LOGS_FILE)
 
 
-def get_running_modes() -> dict[str, bool]:
+def get_running_modes() -> list[str]:
     """
     List the running modes of the task.
     If the task is run via pre-commit -> "pre_commit"

--- a/tasks/custom_task/custom_task.py
+++ b/tasks/custom_task/custom_task.py
@@ -40,9 +40,12 @@ def get_running_modes() -> dict[str, bool]:
     If the task is run in the ci      -> "ci"
     Neither pre-commit nor ci         -> "manual"
     """
+    # This will catch when devs are running the unit tests with the unittest module directly.
+    # When running the unit tests with the invoke command, the INVOKE_UNIT_TESTS env variable is set.
+    is_running_ut = "unittest" in " ".join(sys.argv)
     running_modes = {
         "pre_commit": os.environ.get("PRE_COMMIT", 0) == "1",
-        "invoke_unit_tests": os.environ.get("INVOKE_UNIT_TESTS", 0) == "1",
+        "invoke_unit_tests": is_running_ut or os.environ.get("INVOKE_UNIT_TESTS", 0) == "1",
         "ci": running_in_ci(),
     }
     running_modes["manual"] = not (running_modes["pre_commit"] or running_modes["ci"])

--- a/tasks/custom_task/custom_task.py
+++ b/tasks/custom_task/custom_task.py
@@ -46,7 +46,7 @@ def get_running_modes() -> dict[str, bool]:
         "ci": running_in_ci(),
     }
     running_modes["manual"] = not (running_modes["pre_commit"] or running_modes["ci"])
-    return running_modes
+    return [mode for mode, is_running in running_modes.items() if is_running]
 
 
 def log_invoke_task(

--- a/tasks/custom_task/custom_task.py
+++ b/tasks/custom_task/custom_task.py
@@ -42,7 +42,7 @@ def get_running_modes() -> dict[str, bool]:
     """
     running_modes = {
         "pre_commit": os.environ.get("PRE_COMMIT", 0) == "1",
-        "invoke_unit_tests": os.environ.get("INVOKE_UNIT_TESTS", 0) == "1" or 'unittest' in sys.modules,
+        "invoke_unit_tests": os.environ.get("INVOKE_UNIT_TESTS", 0) == "1",
         "ci": running_in_ci(),
     }
     running_modes["manual"] = not (running_modes["pre_commit"] or running_modes["ci"])

--- a/tasks/unit_tests.py
+++ b/tasks/unit_tests.py
@@ -8,4 +8,7 @@ def invoke_unit_tests(ctx):
     """
     Run the unit tests on the invoke tasks
     """
-    ctx.run(f"'{sys.executable}' -m unittest discover -s tasks -p '*_tests.py'", env={"GITLAB_TOKEN": "fake_token"})
+    ctx.run(
+        f"'{sys.executable}' -m unittest discover -s tasks -p '*_tests.py'",
+        env={"GITLAB_TOKEN": "fake_token", "INVOKE_UNIT_TESTS": "1"},
+    )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds the `invoke_unit_tests` running_mode for tasks run in the Unit Tests.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We noticed some `omnibus.build` tasks with a <1s duration in the logs which is abnormally short. It came from the Unit Tests when the task was mocked. To avoid confusion, I'm adding the `invoke_unit_tests` running_mode to flag this.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
