### PR TITLE
[ASCII-1622] Prevent deadlock for status and flare command 

### DIFF
--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -8,7 +8,6 @@ package fetcher
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -30,7 +29,7 @@ func SecurityAgentConfig(config config.Reader) (string, error) {
 	}
 
 	c := util.GetClient(false)
-	c.Timeout = time.Second * 30
+	c.Timeout = config.GetDuration("subagent_config_fetch_timeout")
 
 	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", port)
 	client := settingshttp.NewClient(c, apiConfigURL, "security-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
@@ -50,7 +49,7 @@ func TraceAgentConfig(config config.Reader) (string, error) {
 	}
 
 	c := util.GetClient(false)
-	c.Timeout = time.Second * 30
+	c.Timeout = config.GetDuration("subagent_config_fetch_timeout")
 
 	ipcAddressWithPort := fmt.Sprintf("http://127.0.0.1:%d/config", port)
 
@@ -81,7 +80,7 @@ func ProcessAgentConfig(config config.Reader, getEntireConfig bool) (string, err
 	}
 
 	c := util.GetClient(false)
-	c.Timeout = time.Second * 30
+	c.Timeout = config.GetDuration("subagent_config_fetch_timeout")
 
 	client := settingshttp.NewClient(c, ipcAddressWithPort, "process-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
 

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -8,6 +8,7 @@ package fetcher
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -29,7 +30,7 @@ func SecurityAgentConfig(config config.Reader) (string, error) {
 	}
 
 	c := util.GetClient(false)
-	c.Timeout = config.GetDuration("server_timeout")
+	c.Timeout = config.GetDuration("server_timeout") * time.Second
 
 	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", port)
 	client := settingshttp.NewClient(c, apiConfigURL, "security-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
@@ -49,7 +50,7 @@ func TraceAgentConfig(config config.Reader) (string, error) {
 	}
 
 	c := util.GetClient(false)
-	c.Timeout = config.GetDuration("server_timeout")
+	c.Timeout = config.GetDuration("server_timeout") * time.Second
 
 	ipcAddressWithPort := fmt.Sprintf("http://127.0.0.1:%d/config", port)
 
@@ -80,7 +81,7 @@ func ProcessAgentConfig(config config.Reader, getEntireConfig bool) (string, err
 	}
 
 	c := util.GetClient(false)
-	c.Timeout = config.GetDuration("server_timeout")
+	c.Timeout = config.GetDuration("server_timeout") * time.Second
 
 	client := settingshttp.NewClient(c, ipcAddressWithPort, "process-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
 

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -29,7 +29,7 @@ func SecurityAgentConfig(config config.Reader) (string, error) {
 	}
 
 	c := util.GetClient(false)
-	c.Timeout = config.GetDuration("subagent_config_fetch_timeout")
+	c.Timeout = config.GetDuration("server_timeout")
 
 	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", port)
 	client := settingshttp.NewClient(c, apiConfigURL, "security-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
@@ -49,7 +49,7 @@ func TraceAgentConfig(config config.Reader) (string, error) {
 	}
 
 	c := util.GetClient(false)
-	c.Timeout = config.GetDuration("subagent_config_fetch_timeout")
+	c.Timeout = config.GetDuration("server_timeout")
 
 	ipcAddressWithPort := fmt.Sprintf("http://127.0.0.1:%d/config", port)
 
@@ -80,7 +80,7 @@ func ProcessAgentConfig(config config.Reader, getEntireConfig bool) (string, err
 	}
 
 	c := util.GetClient(false)
-	c.Timeout = config.GetDuration("subagent_config_fetch_timeout")
+	c.Timeout = config.GetDuration("server_timeout")
 
 	client := settingshttp.NewClient(c, ipcAddressWithPort, "process-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
 

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -8,6 +8,7 @@ package fetcher
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -23,9 +24,15 @@ func SecurityAgentConfig(config config.Reader) (string, error) {
 		return "", err
 	}
 
-	c := util.GetClient(false)
+	port := config.GetInt("security_agent.cmd_port")
+	if port <= 0 {
+		return "", fmt.Errorf("invalid security_agent.cmd_port -- %d", port)
+	}
 
-	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", config.GetInt("security_agent.cmd_port"))
+	c := util.GetClient(false)
+	c.Timeout = time.Second * 30
+
+	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", port)
 	client := settingshttp.NewClient(c, apiConfigURL, "security-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
 	return client.FullConfig()
 }
@@ -37,12 +44,13 @@ func TraceAgentConfig(config config.Reader) (string, error) {
 		return "", err
 	}
 
-	c := util.GetClient(false)
-
 	port := config.GetInt("apm_config.debug.port")
 	if port <= 0 {
 		return "", fmt.Errorf("invalid apm_config.debug.port -- %d", port)
 	}
+
+	c := util.GetClient(false)
+	c.Timeout = time.Second * 30
 
 	ipcAddressWithPort := fmt.Sprintf("http://127.0.0.1:%d/config", port)
 
@@ -56,8 +64,6 @@ func ProcessAgentConfig(config config.Reader, getEntireConfig bool) (string, err
 	if err != nil {
 		return "", err
 	}
-
-	c := util.GetClient(false)
 
 	ipcAddress, err := setup.GetIPCAddress(config)
 	if err != nil {
@@ -73,6 +79,9 @@ func ProcessAgentConfig(config config.Reader, getEntireConfig bool) (string, err
 	if getEntireConfig {
 		ipcAddressWithPort += "/all"
 	}
+
+	c := util.GetClient(false)
+	c.Timeout = time.Second * 30
 
 	client := settingshttp.NewClient(c, ipcAddressWithPort, "process-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -973,9 +973,6 @@ func agent(config pkgconfigmodel.Config) {
 	config.SetKnown("proxy.http")
 	config.SetKnown("proxy.https")
 	config.SetKnown("proxy.no_proxy")
-
-	// Define the duration after which subagent configuration fetch will timeout
-	config.BindEnvAndSetDefault("subagent_config_fetch_timeout", "30s")
 }
 
 func fips(config pkgconfigmodel.Config) {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -973,6 +973,9 @@ func agent(config pkgconfigmodel.Config) {
 	config.SetKnown("proxy.http")
 	config.SetKnown("proxy.https")
 	config.SetKnown("proxy.no_proxy")
+
+	// Define the duration after which subagent configuration fetch will timeout
+	config.BindEnvAndSetDefault("subagent_config_fetch_timeout", "30s")
 }
 
 func fips(config pkgconfigmodel.Config) {

--- a/releasenotes/notes/fix-flare-genereation-deadlock-b40fca3c82469d40.yaml
+++ b/releasenotes/notes/fix-flare-genereation-deadlock-b40fca3c82469d40.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue where the datadog-agent status and datadog-agent flare commands would hang if a non-core Agent's port was occupied by a process that caused incoming connections to hang.

--- a/releasenotes/notes/fix-flare-genereation-deadlock-b40fca3c82469d40.yaml
+++ b/releasenotes/notes/fix-flare-genereation-deadlock-b40fca3c82469d40.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixed an issue where the datadog-agent status and datadog-agent flare commands would hang if a non-core Agent's port was occupied by a process that caused incoming connections to hang.
+    Fixed an issue where the ``datadog-agent status`` and ``datadog-agent flare`` commands could hang while trying to reach other agent processes.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR add timeout to IPC connection between core Agent and other Agents (security-agent, trace-agent) 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
In the current Agent state, when the port of an non-core Agent is taken by a process that hang incoming connections on it, any `datadog-agent status` or `datadog-agent flare` will stay block.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. build the Agent
2. listen on the default port of the security-agent with netcat command: `nc -l 5010`
3. run the core Agent with `./bin/agent/agent run -c ./bin/agent/dist/datadog.yaml`
4. wait until a connection arrived to netcat
5. try to run the command `./bin/agent/agent status -c ./bin/agent/dist/datadog.yaml`
    a. before this PR the command must block
    b. with this fix the command must work (with at most 30 seconds of delay)