### PR TITLE
[CONTINT-3877] Add admission controller webhook for autoscaling

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -405,6 +405,10 @@ func start(log log.Component,
 			return fmt.Errorf("Remote config is disabled or failed to initialize, remote config is a required dependency for autoscaling")
 		}
 
+		if !config.GetBool("admission_controller.enabled") {
+			log.Error("Admission controller is disabled, vertical autoscaling requires the admission controller to be enabled. Vertical scaling will be disabled.")
+		}
+
 		if adapter, err := workload.StartWorkloadAutoscaling(mainCtx, apiCl, rcClient); err != nil {
 			pkglog.Errorf("Error while starting workload autoscaling: %v", err)
 		} else {

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -79,6 +79,8 @@ func mutatingWebhooks(wmeta workloadmeta.Component) []MutatingWebhook {
 		config.NewWebhook(wmeta),
 		tagsfromlabels.NewWebhook(wmeta),
 		agentsidecar.NewWebhook(),
+		// TODO: initialize the autoscaling webhook when the autoscaling controller
+		// is made as a component
 	}
 
 	apm, err := autoinstrumentation.GetWebhook(wmeta)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -26,9 +26,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	agentsidecar "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/agent_sidecar"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/cwsinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/tagsfromlabels"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -39,12 +41,12 @@ type Controller interface {
 }
 
 // NewController returns the adequate implementation of the Controller interface.
-func NewController(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, admissionInterface admissionregistration.Interface, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config, wmeta workloadmeta.Component) Controller {
+func NewController(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, admissionInterface admissionregistration.Interface, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pa workload.PatcherAdapter) Controller {
 	if config.useAdmissionV1() {
-		return NewControllerV1(client, secretInformer, admissionInterface.V1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta)
+		return NewControllerV1(client, secretInformer, admissionInterface.V1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
 	}
 
-	return NewControllerV1beta1(client, secretInformer, admissionInterface.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta)
+	return NewControllerV1beta1(client, secretInformer, admissionInterface.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
 }
 
 // MutatingWebhook represents a mutating webhook
@@ -74,13 +76,12 @@ type MutatingWebhook interface {
 // the config one. The reason is that the volume mount for the APM socket added
 // by the config webhook doesn't always work on Fargate (one of the envs where
 // we use an agent sidecar), and the agent sidecar webhook needs to remove it.
-func mutatingWebhooks(wmeta workloadmeta.Component) []MutatingWebhook {
+func mutatingWebhooks(wmeta workloadmeta.Component, pa workload.PatcherAdapter) []MutatingWebhook {
 	webhooks := []MutatingWebhook{
 		config.NewWebhook(wmeta),
 		tagsfromlabels.NewWebhook(wmeta),
 		agentsidecar.NewWebhook(),
-		// TODO: initialize the autoscaling webhook when the autoscaling controller
-		// is made as a component
+		autoscaling.NewWebhook(pa),
 	}
 
 	apm, err := autoinstrumentation.GetWebhook(wmeta)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -41,7 +41,16 @@ type Controller interface {
 }
 
 // NewController returns the adequate implementation of the Controller interface.
-func NewController(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, admissionInterface admissionregistration.Interface, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pa workload.PatcherAdapter) Controller {
+func NewController(
+	client kubernetes.Interface,
+	secretInformer coreinformers.SecretInformer,
+	admissionInterface admissionregistration.Interface,
+	isLeaderFunc func() bool,
+	isLeaderNotif <-chan struct{},
+	config Config,
+	wmeta workloadmeta.Component,
+	pa workload.PatcherAdapter,
+) Controller {
 	if config.useAdmissionV1() {
 		return NewControllerV1(client, secretInformer, admissionInterface.V1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
 	}

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
@@ -34,6 +34,7 @@ func TestNewController(t *testing.T) {
 		make(chan struct{}),
 		v1Cfg,
 		wmeta,
+		nil,
 	)
 
 	assert.IsType(t, &ControllerV1{}, controller)
@@ -47,6 +48,7 @@ func TestNewController(t *testing.T) {
 		make(chan struct{}),
 		v1beta1Cfg,
 		wmeta,
+		nil,
 	)
 
 	assert.IsType(t, &ControllerV1beta1{}, controller)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -39,7 +40,7 @@ type ControllerV1 struct {
 }
 
 // NewControllerV1 returns a new Webhook Controller using admissionregistration/v1.
-func NewControllerV1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config, wmeta workloadmeta.Component) *ControllerV1 {
+func NewControllerV1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pa workload.PatcherAdapter) *ControllerV1 {
 	controller := &ControllerV1{}
 	controller.clientSet = client
 	controller.config = config
@@ -50,7 +51,7 @@ func NewControllerV1(client kubernetes.Interface, secretInformer coreinformers.S
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
 	controller.isLeaderNotif = isLeaderNotif
-	controller.mutatingWebhooks = mutatingWebhooks(wmeta)
+	controller.mutatingWebhooks = mutatingWebhooks(wmeta, pa)
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -40,7 +40,16 @@ type ControllerV1 struct {
 }
 
 // NewControllerV1 returns a new Webhook Controller using admissionregistration/v1.
-func NewControllerV1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pa workload.PatcherAdapter) *ControllerV1 {
+func NewControllerV1(
+	client kubernetes.Interface,
+	secretInformer coreinformers.SecretInformer,
+	webhookInformer admissioninformers.MutatingWebhookConfigurationInformer,
+	isLeaderFunc func() bool,
+	isLeaderNotif <-chan struct{},
+	config Config,
+	wmeta workloadmeta.Component,
+	pa workload.PatcherAdapter,
+) *ControllerV1 {
 	controller := &ControllerV1{}
 	controller.clientSet = client
 	controller.config = config

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -34,8 +34,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 )
 
-const waitFor = 10 * time.Second
-const tick = 50 * time.Millisecond
+const (
+	waitFor = 10 * time.Second
+	tick    = 50 * time.Millisecond
+)
 
 var v1Cfg = NewConfig(true, false)
 
@@ -952,7 +954,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 
 			c := &ControllerV1{}
 			c.config = tt.configFunc()
-			c.mutatingWebhooks = mutatingWebhooks(wmeta)
+			c.mutatingWebhooks = mutatingWebhooks(wmeta, nil)
 			c.generateTemplates()
 
 			assert.EqualValues(t, tt.want(), c.webhookTemplates)
@@ -1087,6 +1089,7 @@ func (f *fixtureV1) createController() (*ControllerV1, informers.SharedInformerF
 		make(chan struct{}),
 		v1Cfg,
 		wmeta,
+		nil,
 	), factory
 }
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -39,7 +40,7 @@ type ControllerV1beta1 struct {
 }
 
 // NewControllerV1beta1 returns a new Webhook Controller using admissionregistration/v1beta1.
-func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config, wmeta workloadmeta.Component) *ControllerV1beta1 {
+func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pa workload.PatcherAdapter) *ControllerV1beta1 {
 	controller := &ControllerV1beta1{}
 	controller.clientSet = client
 	controller.config = config
@@ -50,7 +51,7 @@ func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinform
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
 	controller.isLeaderNotif = isLeaderNotif
-	controller.mutatingWebhooks = mutatingWebhooks(wmeta)
+	controller.mutatingWebhooks = mutatingWebhooks(wmeta, pa)
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -947,7 +947,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 
 			c := &ControllerV1beta1{}
 			c.config = tt.configFunc()
-			c.mutatingWebhooks = mutatingWebhooks(wmeta)
+			c.mutatingWebhooks = mutatingWebhooks(wmeta, nil)
 			c.generateTemplates()
 
 			assert.EqualValues(t, tt.want(), c.webhookTemplates)
@@ -1082,6 +1082,7 @@ func (f *fixtureV1beta1) createController() (*ControllerV1beta1, informers.Share
 		make(chan struct{}),
 		v1beta1Cfg,
 		wmeta,
+		nil,
 	), factory
 }
 

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
@@ -111,6 +111,12 @@ func (w *wh) updateResources(pod *corev1.Pod, _ string, _ dynamic.Interface) (bo
 			if cont.Name != reco.Name {
 				continue
 			}
+			if cont.Resources.Limits == nil {
+				cont.Resources.Limits = corev1.ResourceList{}
+			}
+			if cont.Resources.Requests == nil {
+				cont.Resources.Requests = corev1.ResourceList{}
+			}
 			for resource, limit := range reco.Limits {
 				if limit != cont.Resources.Limits[resource] {
 					cont.Resources.Limits[resource] = limit

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
@@ -110,7 +110,7 @@ func (w *Webhook) updateResources(pod *corev1.Pod, ns string, _ dynamic.Interfac
 		return false, fmt.Errorf("no owner found for pod %s", pod.Name)
 	}
 
-	recommendations, err := w.recommender.GetRecommendations(pod.Namespace, ownerRef)
+	_, recommendations, err := w.recommender.GetRecommendations(pod.Namespace, ownerRef)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package autoscaling implements the webhook that vertically scales applications
+package autoscaling
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+
+	admiv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	webhookName = "autoscaling"
+)
+
+type wh struct {
+	name        string
+	isEnabled   bool
+	endpoint    string
+	resources   []string
+	operations  []admiv1.OperationType
+	recommender workload.PatcherAdapter
+}
+
+// NewWebhook returns a new Webhook
+func NewWebhook(recommender workload.PatcherAdapter) webhook.MutatingWebhook {
+	return &wh{
+		name:        webhookName,
+		isEnabled:   config.Datadog.GetBool("admission_controller.autoscaling.enabled"),
+		endpoint:    config.Datadog.GetString("admission_controller.autoscaling.endpoint"),
+		resources:   []string{"pods"},
+		operations:  []admiv1.OperationType{admiv1.Create},
+		recommender: recommender,
+	}
+}
+
+// Name returns the name of the webhook
+func (w *wh) Name() string {
+	return w.name
+}
+
+// IsEnabled returns whether the webhook is enabled
+func (w *wh) IsEnabled() bool {
+	return w.isEnabled
+}
+
+// Endpoint returns the endpoint of the webhook
+func (w *wh) Endpoint() string {
+	return w.endpoint
+}
+
+// Resources returns the kubernetes resources for which the webhook should
+// be invoked
+func (w *wh) Resources() []string {
+	return w.resources
+}
+
+// Operations returns the operations on the resources specified for which
+// the webhook should be invoked
+func (w *wh) Operations() []admiv1.OperationType {
+	return w.operations
+}
+
+// LabelSelectors returns the label selectors that specify when the webhook
+// should be invoked
+func (w *wh) LabelSelectors(useNamespaceSelector bool) (namespaceSelector *metav1.LabelSelector, objectSelector *metav1.LabelSelector) {
+	return common.DefaultLabelSelectors(useNamespaceSelector)
+}
+
+// MutateFunc returns the function that mutates the resources
+func (w *wh) MutateFunc() admission.WebhookFunc {
+	return w.mutate
+}
+
+// mutate adds the DD_AGENT_HOST and DD_ENTITY_ID env vars to the pod template if they don't exist
+func (w *wh) mutate(request *admission.MutateRequest) ([]byte, error) {
+	return common.Mutate(request.Raw, request.Namespace, w.Name(), w.updateResources, request.DynamicClient)
+}
+
+// updateResource finds the owner of a pod, calls the recommender to retrieve the recommended CPU and Memory
+// requests
+func (w *wh) updateResources(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
+	ownerRef := pod.OwnerReferences[0]
+	if ownerRef.Kind == kubernetes.ReplicaSetKind {
+		ownerRef.Kind = kubernetes.DeploymentKind
+		ownerRef.Name = kubernetes.ParseDeploymentForReplicaSet(ownerRef.Name)
+	}
+
+	recommendations, err := w.recommender.GetRecommendations(pod.Namespace, ownerRef)
+	if err != nil {
+		return false, err
+	}
+
+	injected := false
+	for _, reco := range recommendations {
+		for i := range pod.Spec.Containers {
+			cont := &pod.Spec.Containers[i]
+			if cont.Name != reco.Name {
+				continue
+			}
+			for resource, limit := range reco.Limits {
+				if limit != cont.Resources.Limits[resource] {
+					cont.Resources.Limits[resource] = limit
+					injected = true
+				}
+			}
+			for resource, request := range reco.Requests {
+				if request != cont.Resources.Requests[resource] {
+					cont.Resources.Requests[resource] = request
+					injected = true
+				}
+			}
+			break
+		}
+	}
+
+	return injected, nil
+}

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling_test.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling_test.go
@@ -37,7 +37,7 @@ func (f *fakeRecommender) GetRecommendations(_ string, ownerRef metav1.OwnerRefe
 func TestUpdateResources(t *testing.T) {
 	tests := []struct {
 		name         string
-		wh           *wh
+		wh           *Webhook
 		pod          corev1.Pod
 		wantInjected bool
 		wantErr      bool
@@ -45,7 +45,7 @@ func TestUpdateResources(t *testing.T) {
 	}{
 		{
 			name: "update resources when recommendations differ",
-			wh: &wh{
+			wh: &Webhook{
 				recommender: &fakeRecommender{
 					recommendations: map[string][]datadoghq.DatadogPodAutoscalerContainerResources{
 						"test-deployment": {
@@ -88,7 +88,7 @@ func TestUpdateResources(t *testing.T) {
 		},
 		{
 			name: "update resources when there are none",
-			wh: &wh{
+			wh: &Webhook{
 				recommender: &fakeRecommender{
 					recommendations: map[string][]datadoghq.DatadogPodAutoscalerContainerResources{
 						"test-deployment": {
@@ -127,7 +127,7 @@ func TestUpdateResources(t *testing.T) {
 		},
 		{
 			name: "no update when recommendations match",
-			wh: &wh{
+			wh: &Webhook{
 				recommender: &fakeRecommender{
 					recommendations: map[string][]datadoghq.DatadogPodAutoscalerContainerResources{
 						"test-deployment": {
@@ -169,7 +169,7 @@ func TestUpdateResources(t *testing.T) {
 		},
 		{
 			name: "no update when pod has no owner",
-			wh:   &wh{},
+			wh:   &Webhook{},
 			pod: corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
@@ -196,7 +196,7 @@ func TestUpdateResources(t *testing.T) {
 		},
 		{
 			name: "no update when deployment can't be parsed",
-			wh:   &wh{},
+			wh:   &Webhook{},
 			pod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
 					Kind: "ReplicaSet",
@@ -231,7 +231,7 @@ func TestUpdateResources(t *testing.T) {
 		},
 		{
 			name: "no update on errors",
-			wh: &wh{
+			wh: &Webhook{
 				recommender: &fakeRecommender{
 					err: fmt.Errorf("error"),
 				},

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling_test.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling_test.go
@@ -87,6 +87,45 @@ func TestUpdateResources(t *testing.T) {
 			},
 		},
 		{
+			name: "update resources when there are none",
+			wh: &wh{
+				recommender: &fakeRecommender{
+					recommendations: map[string][]datadoghq.DatadogPodAutoscalerContainerResources{
+						"test-deployment": {
+							{Name: "container1", Limits: corev1.ResourceList{"cpu": resource.MustParse("500m")}, Requests: corev1.ResourceList{"memory": resource.MustParse("256Mi")}},
+						},
+					},
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					Kind: "ReplicaSet",
+					Name: "test-deployment-968f49d86",
+				}}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+					}},
+				},
+			},
+			wantInjected: true,
+			wantPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					Kind: "ReplicaSet",
+					Name: "test-deployment-968f49d86",
+				}}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("500m")},
+							Requests: corev1.ResourceList{"memory": resource.MustParse("256Mi")},
+						},
+					}},
+				},
+			},
+		},
+		{
 			name: "no update when recommendations match",
 			wh: &wh{
 				recommender: &fakeRecommender{

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling_test.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling_test.go
@@ -168,6 +168,68 @@ func TestUpdateResources(t *testing.T) {
 			},
 		},
 		{
+			name: "no update when pod has no owner",
+			wh:   &wh{},
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("200m")},
+							Requests: corev1.ResourceList{"memory": resource.MustParse("128Mi")},
+						},
+					}},
+				},
+			},
+			wantPod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("200m")},
+							Requests: corev1.ResourceList{"memory": resource.MustParse("128Mi")},
+						},
+					}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no update when deployment can't be parsed",
+			wh:   &wh{},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					Kind: "ReplicaSet",
+					Name: "test-deployment-notahash",
+				}}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("200m")},
+							Requests: corev1.ResourceList{"memory": resource.MustParse("128Mi")},
+						},
+					}},
+				},
+			},
+			wantPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					Kind: "ReplicaSet",
+					Name: "test-deployment-notahash",
+				}}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("200m")},
+							Requests: corev1.ResourceList{"memory": resource.MustParse("128Mi")},
+						},
+					}},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "no update on errors",
 			wh: &wh{
 				recommender: &fakeRecommender{

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling_test.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling_test.go
@@ -1,0 +1,185 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test && kubeapiserver
+
+package autoscaling
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	datadoghq "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+type fakeRecommender struct {
+	recommendations map[string][]datadoghq.DatadogPodAutoscalerContainerResources
+	err             error
+}
+
+// GetRecommendations returns recommendations
+func (f *fakeRecommender) GetRecommendations(_ string, ownerRef metav1.OwnerReference) ([]datadoghq.DatadogPodAutoscalerContainerResources, error) {
+	if recs, ok := f.recommendations[ownerRef.Name]; ok {
+		return recs, nil
+	}
+	return nil, f.err
+}
+
+func TestUpdateResources(t *testing.T) {
+	tests := []struct {
+		name         string
+		wh           *wh
+		pod          corev1.Pod
+		wantInjected bool
+		wantErr      bool
+		wantPod      corev1.Pod
+	}{
+		{
+			name: "update resources when recommendations differ",
+			wh: &wh{
+				recommender: &fakeRecommender{
+					recommendations: map[string][]datadoghq.DatadogPodAutoscalerContainerResources{
+						"test-deployment": {
+							{Name: "container1", Limits: corev1.ResourceList{"cpu": resource.MustParse("500m")}, Requests: corev1.ResourceList{"memory": resource.MustParse("256Mi")}},
+						},
+					},
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					Kind: "ReplicaSet",
+					Name: "test-deployment-968f49d86",
+				}}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("200m")},
+							Requests: corev1.ResourceList{"memory": resource.MustParse("128Mi")},
+						},
+					}},
+				},
+			},
+			wantInjected: true,
+			wantPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					Kind: "ReplicaSet",
+					Name: "test-deployment-968f49d86",
+				}}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("500m")},
+							Requests: corev1.ResourceList{"memory": resource.MustParse("256Mi")},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "no update when recommendations match",
+			wh: &wh{
+				recommender: &fakeRecommender{
+					recommendations: map[string][]datadoghq.DatadogPodAutoscalerContainerResources{
+						"test-deployment": {
+							{Name: "container1", Limits: corev1.ResourceList{"cpu": resource.MustParse("200m")}, Requests: corev1.ResourceList{"memory": resource.MustParse("128Mi")}},
+						},
+					},
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					Kind: "ReplicaSet",
+					Name: "test-deployment-968f49d86",
+				}}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("200m")},
+							Requests: corev1.ResourceList{"memory": resource.MustParse("128Mi")},
+						},
+					}},
+				},
+			},
+			wantPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					Kind: "ReplicaSet",
+					Name: "test-deployment-968f49d86",
+				}}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("200m")},
+							Requests: corev1.ResourceList{"memory": resource.MustParse("128Mi")},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "no update on errors",
+			wh: &wh{
+				recommender: &fakeRecommender{
+					err: fmt.Errorf("error"),
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					Kind: "ReplicaSet",
+					Name: "test-deployment-968f49d86",
+				}}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("200m")},
+							Requests: corev1.ResourceList{"memory": resource.MustParse("128Mi")},
+						},
+					}},
+				},
+			},
+			wantErr: true,
+			wantPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					Kind: "ReplicaSet",
+					Name: "test-deployment-968f49d86",
+				}}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("200m")},
+							Requests: corev1.ResourceList{"memory": resource.MustParse("128Mi")},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			injected, err := tt.wh.updateResources(&tt.pod, tt.pod.Namespace, dynamic.Interface(nil))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("updateResources() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.wantInjected, injected)
+			if !reflect.DeepEqual(tt.pod, tt.wantPod) {
+				t.Errorf("updateResources() pod = %v, wantPod %v", tt.pod, tt.wantPod)
+			}
+		})
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoscaling/telemetry.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/telemetry.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package autoscaling
+
+import "github.com/DataDog/datadog-agent/pkg/telemetry"
+
+const subsystem = "autoscaling_webhook"
+
+var (
+	commonOpts = telemetry.Options{NoDoubleUnderscoreSep: true}
+)
+
+var (
+	injections = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"resource_injection",
+		[]string{
+			"resource", // CPU / Memory
+			"namespace",
+			"owner",     // Kube deployment / statefulset
+			"container", // Container name
+			"type",      // Request / Limit
+		},
+		"The injections performed on a specific workload",
+		commonOpts,
+	)
+)

--- a/pkg/clusteragent/admission/mutate/autoscaling/telemetry.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/telemetry.go
@@ -3,28 +3,27 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
+//go:build kubeapiserver
+
 package autoscaling
 
 import "github.com/DataDog/datadog-agent/pkg/telemetry"
 
 const subsystem = "autoscaling_webhook"
 
-var (
-	commonOpts = telemetry.Options{NoDoubleUnderscoreSep: true}
-)
+var commonOpts = telemetry.Options{NoDoubleUnderscoreSep: true}
 
-var (
-	injections = telemetry.NewGaugeWithOpts(
-		subsystem,
-		"resource_injection",
-		[]string{
-			"resource", // CPU / Memory
-			"namespace",
-			"owner",     // Kube deployment / statefulset
-			"container", // Container name
-			"type",      // Request / Limit
-		},
-		"The injections performed on a specific workload",
-		commonOpts,
-	)
+var injections = telemetry.NewGaugeWithOpts(
+	subsystem,
+	"resource_injection",
+	[]string{
+		"resource", // CPU / Memory
+		"namespace",
+		"owner",     // Kube deployment / statefulset
+		"container", // Container name
+		"type",      // Request / Limit
+		"rec_id",    // Hash of the recommendations
+	},
+	"The injections performed on a specific workload",
+	commonOpts,
 )

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -24,7 +24,7 @@ import (
 )
 
 // MutationFunc is a function that mutates a pod
-type MutationFunc func(*corev1.Pod, string, dynamic.Interface) (bool, error)
+type MutationFunc func(pod *corev1.Pod, ns string, cl dynamic.Interface) (bool, error)
 
 // Mutate handles mutating pods and encoding and decoding admission
 // requests and responses for the public mutate functions

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/secret"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
@@ -35,7 +36,7 @@ type ControllerContext struct {
 }
 
 // StartControllers starts the secret and webhook controllers
-func StartControllers(ctx ControllerContext, wmeta workloadmeta.Component) ([]webhook.MutatingWebhook, error) {
+func StartControllers(ctx ControllerContext, wmeta workloadmeta.Component, pa workload.PatcherAdapter) ([]webhook.MutatingWebhook, error) {
 	if !config.Datadog.GetBool("admission_controller.enabled") {
 		log.Info("Admission controller is disabled")
 		return nil, nil
@@ -76,6 +77,7 @@ func StartControllers(ctx ControllerContext, wmeta workloadmeta.Component) ([]we
 		ctx.LeaderSubscribeFunc(),
 		webhookConfig,
 		wmeta,
+		pa,
 	)
 
 	go secretController.Run(ctx.StopCh)

--- a/pkg/clusteragent/autoscaling/workload/patcher.go
+++ b/pkg/clusteragent/autoscaling/workload/patcher.go
@@ -10,8 +10,9 @@ package workload
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	datadoghq "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -28,6 +29,10 @@ type patcherAdapter struct {
 }
 
 var _ PatcherAdapter = patcherAdapter{}
+
+func newPatcherAdapter(store *store) PatcherAdapter {
+	return patcherAdapter{store: store}
+}
 
 // GetPodAutoscalerFromOwnerRef searches for a PodAutoscalerInternal object associated with the given owner reference
 // If no PodAutoscalerInternal is found or no vertical recommendation, it returns ("", nil, nil)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -648,6 +648,8 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("admission_controller.certificate.expiration_threshold", 30*24)        // how long before its expiration a certificate should be refreshed (in hours, default 1 month)
 	config.BindEnvAndSetDefault("admission_controller.certificate.secret_name", "webhook-certificate") // name of the Secret object containing the webhook certificate
 	config.BindEnvAndSetDefault("admission_controller.webhook_name", "datadog-webhook")
+	config.BindEnvAndSetDefault("admission_controller.autoscaling.enabled", false)
+	config.BindEnvAndSetDefault("admission_controller.autoscaling.endpoint", "/autoscale")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.inject_config.endpoint", "/injectconfig")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.inject_container_name", false)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -648,8 +648,6 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("admission_controller.certificate.expiration_threshold", 30*24)        // how long before its expiration a certificate should be refreshed (in hours, default 1 month)
 	config.BindEnvAndSetDefault("admission_controller.certificate.secret_name", "webhook-certificate") // name of the Secret object containing the webhook certificate
 	config.BindEnvAndSetDefault("admission_controller.webhook_name", "datadog-webhook")
-	config.BindEnvAndSetDefault("admission_controller.autoscaling.enabled", false)
-	config.BindEnvAndSetDefault("admission_controller.autoscaling.endpoint", "/autoscale")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.inject_config.endpoint", "/injectconfig")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.inject_container_name", false)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds the admission controller webhook for autoscaling which applies vertical recommendations.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We would like to apply vertical recommendations to new pods.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy a dummy application. Create a Datadog Autoscaling Custom resource with vertical scaling recommendations. Deploy it and delete a pod. The new pod should have the resource requests/limits defined in the custom resource.

I tested it with a custom build using a fake recommender:
```
	if ns == "testnamespace" {
		return []datadoghq.DatadogPodAutoscalerContainerResources{
			{
				Name:     "container1",
				Limits:   corev1.ResourceList{"cpu": resource.MustParse("500m")},
				Requests: corev1.ResourceList{"memory": resource.MustParse("256Mi")},
			},
		}, nil
	}
```

And we can see the recommendations applied to a resource-less pod:
```
    name: container1
    resources:
      limits:
        cpu: 500m
      requests:
        cpu: 500m
        memory: 256Mi
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->