### PR TITLE
(fleet) add minimal e2e coverage for the installer daemon

### DIFF
--- a/pkg/config/setup/config_nix.go
+++ b/pkg/config/setup/config_nix.go
@@ -14,10 +14,13 @@ var (
 	// InstallPath is the default install path for the agent
 	// It might be overridden at build time
 	InstallPath = "/opt/datadog-agent"
+
+	// defaultRunPath is the default path for the agent's runtime files
+	// It might be overridden at build time
+	defaultRunPath = "/opt/datadog-agent/run"
 )
 
 var (
-	defaultRunPath = filepath.Join(InstallPath, "run")
 	// defaultSystemProbeAddress is the default unix socket path to be used for connecting to the system probe
 	defaultSystemProbeAddress = filepath.Join(InstallPath, "run/sysprobe.sock")
 	// defaultEventMonitorAddress is the default unix socket path to be used for connecting to the event monitor

--- a/pkg/fleet/installer/service/datadog_installer.go
+++ b/pkg/fleet/installer/service/datadog_installer.go
@@ -187,10 +187,10 @@ func startInstallerStable(ctx context.Context) (err error) {
 	}
 	// this is expected during a fresh install with the install script / asible / chef / etc...
 	// the config is populated afterwards by the install method and the agent is restarted
-	if !os.IsNotExist(err) {
-		return startUnit(ctx, installerUnit)
+	if os.IsNotExist(err) {
+		return nil
 	}
-	return nil
+	return startUnit(ctx, installerUnit)
 }
 
 // RemoveInstaller removes the installer systemd units

--- a/pkg/fleet/installer/service/datadog_installer.go
+++ b/pkg/fleet/installer/service/datadog_installer.go
@@ -181,7 +181,16 @@ func getAgentIDs() (uid, gid int, err error) {
 
 // startInstallerStable starts the stable systemd units for the installer
 func startInstallerStable(ctx context.Context) (err error) {
-	return startUnit(ctx, installerUnit)
+	_, err = os.Stat("/etc/datadog-agent/datadog.yaml")
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	// this is expected during a fresh install with the install script / asible / chef / etc...
+	// the config is populated afterwards by the install method and the agent is restarted
+	if !os.IsNotExist(err) {
+		return startUnit(ctx, installerUnit)
+	}
+	return nil
 }
 
 // RemoveInstaller removes the installer systemd units

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -486,7 +486,7 @@ func (s *State) AssertUnitsEnabled(names ...string) {
 	for _, name := range names {
 		unit, ok := s.Units[name]
 		assert.True(s.t, ok, "unit %v is not enabled", name)
-		assert.NotEqual(s.t, "unknown", unit.Enabled, "unit %v is not enabled", name)
+		assert.Equal(s.t, "enabled", unit.Enabled, "unit %v is not enabled", name)
 	}
 }
 
@@ -504,6 +504,15 @@ func (s *State) AssertUnitsNotLoaded(names ...string) {
 	for _, name := range names {
 		_, ok := s.Units[name]
 		assert.True(s.t, !ok, "unit %v is loaded", name)
+	}
+}
+
+// AssertUnitsNotEnabled asserts that a systemd unit is not enabled
+func (s *State) AssertUnitsNotEnabled(names ...string) {
+	for _, name := range names {
+		unit, ok := s.Units[name]
+		assert.True(s.t, ok, "unit %v is enabled", name)
+		assert.Equal(s.t, "disabled", unit.Enabled, "unit %v is enabled", name)
 	}
 }
 

--- a/test/new-e2e/tests/installer/package_installer_test.go
+++ b/test/new-e2e/tests/installer/package_installer_test.go
@@ -52,7 +52,7 @@ func (s *packageInstallerSuite) TestInstall() {
 }
 
 func (s *packageInstallerSuite) TestInstallWithRemoteUpdates() {
-	s.RunInstallScript("DD_NO_AGENT_INSTALL=true DD_REMOTE_UPDATES=true")
+	s.RunInstallScript("DD_REMOTE_UPDATES=true")
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-installer.service")
 

--- a/test/new-e2e/tests/installer/package_installer_test.go
+++ b/test/new-e2e/tests/installer/package_installer_test.go
@@ -51,6 +51,18 @@ func (s *packageInstallerSuite) TestInstall() {
 	state.AssertUnitsNotLoaded("datadog-installer.service", "datadog-installer-exp.service")
 }
 
+func (s *packageInstallerSuite) TestInstallWithRemoteUpdates() {
+	s.RunInstallScript("DD_NO_AGENT_INSTALL=true DD_REMOTE_UPDATES=true")
+	defer s.Purge()
+	s.host.WaitForUnitActive("datadog-installer.service")
+
+	state := s.host.State()
+	state.AssertUnitsLoaded("datadog-installer.service", "datadog-installer-exp.service")
+	state.AssertUnitsEnabled("datadog-installer.service")
+	state.AssertUnitsNotEnabled("datadog-installer-exp.service")
+	state.AssertUnitsRunning("datadog-installer.service")
+}
+
 func (s *packageInstallerSuite) TestUninstall() {
 	s.RunInstallScript("DD_NO_AGENT_INSTALL=true")
 	s.Purge()


### PR DESCRIPTION
This PR:
- fixes 2 remaining bugs preventing the installer daemon from starting without manual help
- adds an e2e to ensure that behavior
