### PR TITLE
[windows][etw] add ability to filter etw messages by ID

### DIFF
--- a/comp/etw/component.go
+++ b/comp/etw/component.go
@@ -155,6 +155,17 @@ type ProviderConfiguration struct {
 
 	// PIDs allow filtering by PIDs if non-empty
 	PIDs []uint32
+
+	// The EnabledIDs and DisabledIDs fields are mutually exclusive; the API allows you to send one or the other but not both.
+	//
+	// Setting the list of EnabledIDs will enable only listed events.
+	// Setting the list of DisabledIDs will disable only listed events, and allow all others
+
+	// EventIDs for enableTrace = TRUE
+	EnabledIDs []uint16
+
+	// eventIds for enabletrace = FALSE
+	DisabledIDs []uint16
 }
 
 // ProviderConfigurationFunc is a function used to configure a provider

--- a/comp/etw/impl/etwSession.go
+++ b/comp/etw/impl/etwSession.go
@@ -63,7 +63,7 @@ func (e *etwSession) EnableProvider(providerGUID windows.GUID) error {
 	}
 	/*
 	 * the enabled list and disabled list are mutually exclusive; the API
-	 * allows you to send one or the other but not both. 
+	 * allows you to send one or the other but not both.
 	 */
 	if len(cfg.EnabledIDs) > 0 && len(cfg.DisabledIDs) > 0 {
 		return fmt.Errorf("cannot enable and disable the same provider at the same time")

--- a/comp/etw/impl/etwSession.go
+++ b/comp/etw/impl/etwSession.go
@@ -61,6 +61,28 @@ func (e *etwSession) EnableProvider(providerGUID windows.GUID) error {
 		pids = (*C.ULONG)(unsafe.SliceData(cfg.PIDs))
 		pidCount = C.ULONG(len(cfg.PIDs))
 	}
+	/*
+	 * the enabled list and disabled list are mutually exclusive; the API
+	 * allows you to send one or the other but not both. 
+	 */
+	if len(cfg.EnabledIDs) > 0 && len(cfg.DisabledIDs) > 0 {
+		return fmt.Errorf("cannot enable and disable the same provider at the same time")
+	}
+	var enabledFilters *C.USHORT
+	var enabledFilterCount C.ULONG
+
+	if len(cfg.EnabledIDs) > 0 {
+		enabledFilters = (*C.USHORT)(unsafe.SliceData(cfg.EnabledIDs))
+		enabledFilterCount = C.ULONG(len(cfg.EnabledIDs))
+	}
+
+	var disabledFilters *C.USHORT
+	var disabledFilterCount C.ULONG
+
+	if len(cfg.DisabledIDs) > 0 {
+		disabledFilters = (*C.USHORT)(unsafe.SliceData(cfg.DisabledIDs))
+		disabledFilterCount = C.ULONG(len(cfg.DisabledIDs))
+	}
 
 	ret := windows.Errno(C.DDEnableTrace(
 		e.hSession,
@@ -75,6 +97,10 @@ func (e *etwSession) EnableProvider(providerGUID windows.GUID) error {
 		// and re-assemble them in C-land using our helper DDEnableTrace.
 		pids,
 		pidCount,
+		enabledFilters,
+		enabledFilterCount,
+		disabledFilters,
+		disabledFilterCount,
 	))
 
 	if ret != windows.ERROR_SUCCESS {

--- a/comp/etw/impl/session.c
+++ b/comp/etw/impl/session.c
@@ -46,8 +46,8 @@ ULONG DDEnableTrace(
     int eventFilterDescriptorIndex = 0;
     ULONG ret = 0;
 
-    EVENT_FILTER_EVENT_ID * enabledFilters = NULL;
-    EVENT_FILTER_EVENT_ID * disabledFilters = NULL;
+    PEVENT_FILTER_EVENT_ID  enabledFilters = NULL;
+    PEVENT_FILTER_EVENT_ID  disabledFilters = NULL;
     if (PIDCount > 0)
     {
         eventFilterDescriptors[eventFilterDescriptorIndex].Ptr  = (ULONGLONG)PIDs;
@@ -60,7 +60,7 @@ ULONG DDEnableTrace(
 
     if (enableFilterIDCount > 0)
     {
-        ULONG size = sizeof(EVENT_FILTER_EVENT_ID) + (sizeof(USHORT) * enableFilterIDCount);
+        ULONG size = sizeof(EVENT_FILTER_EVENT_ID) + (sizeof(enableFilterIDs[0]) * enableFilterIDCount);
         enabledFilters = (EVENT_FILTER_EVENT_ID*)malloc(size);
 
         enabledFilters->FilterIn = TRUE;
@@ -79,7 +79,7 @@ ULONG DDEnableTrace(
 
     if (disableFilterIDCount > 0)
     {
-        ULONG size = sizeof(EVENT_FILTER_EVENT_ID) + (sizeof(USHORT) * disableFilterIDCount);
+        ULONG size = sizeof(EVENT_FILTER_EVENT_ID) + (sizeof(enableFilterIDs[0]) * disableFilterIDCount);
         disabledFilters = (EVENT_FILTER_EVENT_ID*)malloc(size);
 
         disabledFilters->FilterIn = FALSE;

--- a/comp/etw/impl/session.c
+++ b/comp/etw/impl/session.c
@@ -1,7 +1,7 @@
 #include "session.h"
 
 // This constant defines the maximum number of filter types supported.
-#define MAX_FILTER_SUPPORTED                2
+#define MAX_FILTER_SUPPORTED                4
 
 extern void ddEtwCallbackC(PEVENT_RECORD);
 
@@ -30,7 +30,11 @@ ULONG DDEnableTrace(
     ULONGLONG   MatchAllKeyword,
     ULONG       Timeout,
     ULONG*      PIDs,
-    ULONG       PIDCount
+    ULONG       PIDCount,
+    USHORT*     enableFilterIDs,
+    ULONG       enableFilterIDCount,
+    USHORT*     disableFilterIDs,
+    ULONG       disableFilterIDCount
 )
 {
     EVENT_FILTER_DESCRIPTOR eventFilterDescriptors[MAX_FILTER_SUPPORTED];
@@ -39,17 +43,60 @@ ULONG DDEnableTrace(
     enableParameters.Version = ENABLE_TRACE_PARAMETERS_VERSION_2;
     enableParameters.EnableFilterDesc = &eventFilterDescriptors[0];
     enableParameters.FilterDescCount = 0;
+    int eventFilterDescriptorIndex = 0;
+    ULONG ret = 0;
 
+    EVENT_FILTER_EVENT_ID * enabledFilters = NULL;
+    EVENT_FILTER_EVENT_ID * disabledFilters = NULL;
     if (PIDCount > 0)
     {
-        eventFilterDescriptors[0].Ptr  = (ULONGLONG)PIDs;
-        eventFilterDescriptors[0].Size = (ULONG)(sizeof(PIDs[0]) * PIDCount);
-        eventFilterDescriptors[0].Type = EVENT_FILTER_TYPE_PID;
+        eventFilterDescriptors[eventFilterDescriptorIndex].Ptr  = (ULONGLONG)PIDs;
+        eventFilterDescriptors[eventFilterDescriptorIndex].Size = (ULONG)(sizeof(PIDs[0]) * PIDCount);
+        eventFilterDescriptors[eventFilterDescriptorIndex].Type = EVENT_FILTER_TYPE_PID;
 
         enableParameters.FilterDescCount++;
+        eventFilterDescriptorIndex++;
     }
 
-    return EnableTraceEx2(
+    if (enableFilterIDCount > 0)
+    {
+        ULONG size = sizeof(EVENT_FILTER_EVENT_ID) + (sizeof(USHORT) * enableFilterIDCount);
+        enabledFilters = (EVENT_FILTER_EVENT_ID*)malloc(size);
+
+        enabledFilters->FilterIn = TRUE;
+        enabledFilters->Count = enableFilterIDCount;
+        for (int i =0; i < enableFilterIDCount; i++)
+        {
+            enabledFilters->Events[i] = enableFilterIDs[i];
+        }
+        eventFilterDescriptors[eventFilterDescriptorIndex].Ptr  = (ULONGLONG)enabledFilters;
+        eventFilterDescriptors[eventFilterDescriptorIndex].Size = size;
+        eventFilterDescriptors[eventFilterDescriptorIndex].Type = EVENT_FILTER_TYPE_EVENT_ID;
+
+        enableParameters.FilterDescCount++;
+        eventFilterDescriptorIndex++;
+    }
+
+    if (disableFilterIDCount > 0)
+    {
+        ULONG size = sizeof(EVENT_FILTER_EVENT_ID) + (sizeof(USHORT) * disableFilterIDCount);
+        disabledFilters = (EVENT_FILTER_EVENT_ID*)malloc(size);
+
+        disabledFilters->FilterIn = FALSE;
+        disabledFilters->Count = disableFilterIDCount;
+        for (int i =0; i < disableFilterIDCount; i++)
+        {
+            disabledFilters->Events[i] = disableFilterIDs[i];
+        }
+        eventFilterDescriptors[eventFilterDescriptorIndex].Ptr  = (ULONGLONG)disabledFilters;
+        eventFilterDescriptors[eventFilterDescriptorIndex].Size = size;
+        eventFilterDescriptors[eventFilterDescriptorIndex].Type = EVENT_FILTER_TYPE_EVENT_ID;
+
+        enableParameters.FilterDescCount++;
+        eventFilterDescriptorIndex++;
+    }
+
+    ret = EnableTraceEx2(
         TraceHandle,
         ProviderId,
         ControlCode,
@@ -59,4 +106,14 @@ ULONG DDEnableTrace(
         Timeout,
         &enableParameters
     );
+
+    if (enabledFilters != NULL)
+    {
+        free(enabledFilters);
+    }
+    if (disabledFilters != NULL)
+    {
+        free(disabledFilters);
+    }
+    return ret;
 }

--- a/comp/etw/impl/session.h
+++ b/comp/etw/impl/session.h
@@ -12,6 +12,19 @@
 #define EVENT_FILTER_TYPE_EVENT_ID          (0x80000200)
 #define EVENT_FILTER_TYPE_PID               (0x80000004)
 
+/* taken from windows evntprov.h because the msys version doesn't include it*/
+#define ANYSIZE_ARRAY 1
+/*
+EVENT_FILTER_EVENT_ID is used to pass EventId filter for
+stack walk filters.
+*/
+typedef struct _EVENT_FILTER_EVENT_ID {
+    BOOLEAN FilterIn;
+    UCHAR Reserved;
+    USHORT Count;
+    USHORT Events[];
+} EVENT_FILTER_EVENT_ID, *PEVENT_FILTER_EVENT_ID;
+
 ULONG DDEnableTrace(
     TRACEHANDLE TraceHandle,
     LPCGUID     ProviderId,
@@ -21,7 +34,11 @@ ULONG DDEnableTrace(
     ULONGLONG   MatchAllKeyword,
     ULONG       Timeout,
     ULONG*      PIDs,
-    ULONG       PIDCount
+    ULONG       PIDCount,
+    USHORT*     enableFilterIDs,
+    ULONG       enableFilterIDCount,
+    USHORT*     disableFilterIDs,
+    ULONG       disableFilterIDCount
 );
 TRACEHANDLE DDStartTracing(LPWSTR name, uintptr_t context);
 


### PR DESCRIPTION
### What does this PR do?

In order to make etw processing more efficient, take advantage of the API which allows you to
filter messages by id.

Provide flexible API to allow use of either the inclusion list or exclusion list

### Motivation

Make ETW processing more efficient

### Additional Notes


### Describe how to test/QA your changes

This PR provides new capabilities; testing provided in consumer PR