### PR TITLE
[CONTINT-3702] fix(sbom): Fix mount path retrieval from overlayfs

### DIFF
--- a/pkg/sbom/collectors/containerd/containerd.go
+++ b/pkg/sbom/collectors/containerd/containerd.go
@@ -64,8 +64,7 @@ type Collector struct {
 	containerdClient cutil.ContainerdItf
 	wmeta            optional.Option[workloadmeta.Component]
 
-	fromFileSystem bool
-	closed         bool
+	closed bool
 }
 
 // CleanCache cleans the cache
@@ -81,7 +80,6 @@ func (c *Collector) Init(cfg config.Component, wmeta optional.Option[workloadmet
 	}
 	c.wmeta = wmeta
 	c.trivyCollector = trivyCollector
-	c.fromFileSystem = cfg.GetBool("sbom.container_image.use_mount")
 	c.opts = sbom.ScanOptionsFromConfig(cfg, true)
 	return nil
 }
@@ -117,7 +115,7 @@ func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.Sca
 	}
 
 	var report sbom.Report
-	if c.fromFileSystem {
+	if c.opts.UseMount {
 		report, err = c.trivyCollector.ScanContainerdImageFromFilesystem(
 			ctx,
 			imageMeta,

--- a/pkg/sbom/collectors/containerd/containerd.go
+++ b/pkg/sbom/collectors/containerd/containerd.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/containerd/containerd"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
@@ -32,6 +34,8 @@ const resultChanSize = 1000
 type scanRequest struct {
 	imageID string
 }
+
+type scannerFunc func(ctx context.Context, imgMeta *workloadmeta.ContainerImageMetadata, img containerd.Image, client cutil.ContainerdItf, scanOptions sbom.ScanOptions) (sbom.Report, error)
 
 // NewScanRequest creates a new scan request
 func NewScanRequest(imageID string) sbom.ScanRequest {
@@ -115,23 +119,15 @@ func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.Sca
 	}
 
 	var report sbom.Report
+	var scanner scannerFunc
 	if c.opts.UseMount {
-		report, err = c.trivyCollector.ScanContainerdImageFromFilesystem(
-			ctx,
-			imageMeta,
-			image,
-			c.containerdClient,
-			c.opts,
-		)
+		scanner = c.trivyCollector.ScanContainerdImageFromFilesystem
+	} else if c.opts.OverlayFsScan {
+		scanner = c.trivyCollector.ScanContainerdImageFromSnapshotter
 	} else {
-		report, err = c.trivyCollector.ScanContainerdImage(
-			ctx,
-			imageMeta,
-			image,
-			c.containerdClient,
-			c.opts,
-		)
+		scanner = c.trivyCollector.ScanContainerdImage
 	}
+	report, err = scanner(ctx, imageMeta, image, c.containerdClient, c.opts)
 	scanResult := sbom.ScanResult{
 		Error:   err,
 		Report:  report,

--- a/pkg/sbom/collectors/docker/docker.go
+++ b/pkg/sbom/collectors/docker/docker.go
@@ -27,6 +27,8 @@ import (
 // 1000 is already a very large default value
 const resultChanSize = 1000
 
+type scannerFunc func(ctx context.Context, imgMeta *workloadmeta.ContainerImageMetadata, client client.ImageAPIClient, scanOptions sbom.ScanOptions) (sbom.Report, error)
+
 // scanRequest defines a scan request. This struct should be
 // hashable to be pushed in the work queue for processing.
 type scanRequest struct {
@@ -106,7 +108,13 @@ func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.Sca
 		return sbom.ScanResult{Error: fmt.Errorf("image metadata not found for image id %s: %s", dockerScanRequest.ID(), err)}
 	}
 
-	report, err := c.trivyCollector.ScanDockerImage(
+	var scanner scannerFunc
+	if c.opts.OverlayFsScan {
+		scanner = c.trivyCollector.ScanDockerImageFromGraphDriver
+	} else {
+		scanner = c.trivyCollector.ScanDockerImage
+	}
+	report, err := scanner(
 		ctx,
 		imageMeta,
 		c.cl,

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -36,6 +36,7 @@ type ScanOptions struct {
 	Fast             bool
 	CollectFiles     bool
 	UseMount         bool
+	OverlayFsScan    bool
 }
 
 // ScanOptionsFromConfig loads the scanning options from the configuration
@@ -47,6 +48,7 @@ func ScanOptionsFromConfig(cfg config.Component, containers bool) (scanOpts Scan
 		scanOpts.WaitAfter = time.Duration(cfg.GetInt("sbom.container_image.scan_interval")) * time.Second
 		scanOpts.Analyzers = cfg.GetStringSlice("sbom.container_image.analyzers")
 		scanOpts.UseMount = cfg.GetBool("sbom.container_image.use_mount")
+		scanOpts.OverlayFsScan = cfg.GetBool("sbom.container_image.overlayfs_direct_scan")
 	}
 
 	if len(scanOpts.Analyzers) == 0 {

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -34,7 +34,6 @@ type ScanOptions struct {
 	Timeout          time.Duration
 	WaitAfter        time.Duration
 	Fast             bool
-	NoCache          bool // Caching doesn't really provide any value when scanning filesystem as the filesystem has to be walked to compute the keys
 	CollectFiles     bool
 	UseMount         bool
 }
@@ -48,8 +47,6 @@ func ScanOptionsFromConfig(cfg config.Component, containers bool) (scanOpts Scan
 		scanOpts.WaitAfter = time.Duration(cfg.GetInt("sbom.container_image.scan_interval")) * time.Second
 		scanOpts.Analyzers = cfg.GetStringSlice("sbom.container_image.analyzers")
 		scanOpts.UseMount = cfg.GetBool("sbom.container_image.use_mount")
-	} else {
-		scanOpts.NoCache = true
 	}
 
 	if len(scanOpts.Analyzers) == 0 {

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -16,11 +16,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opencontainers/image-spec/identity"
+
 	"github.com/DataDog/datadog-agent/pkg/config"
 	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
-	"github.com/opencontainers/image-spec/identity"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/types"
@@ -70,6 +71,7 @@ type ContainerdItf interface {
 	CallWithClientContext(namespace string, f func(context.Context) error) error
 	IsSandbox(namespace string, ctn containerd.Container) (bool, error)
 	MountImage(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image, targetDir string) (func(context.Context) error, error)
+	Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, error)
 }
 
 // ContainerdUtil is the util used to interact with the Containerd api.
@@ -384,28 +386,28 @@ func (c *ContainerdUtil) IsSandbox(namespace string, ctn containerd.Container) (
 	return labels["io.cri-containerd.kind"] == "sandbox", nil
 }
 
-// MountImage mounts the given image in the targetDir specified
-func (c *ContainerdUtil) MountImage(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image, targetDir string) (func(context.Context) error, error) {
+// getMounts retrieves mounts and returns a function to clean the snapshot and release the lease. The lease is already released in error cases.
+func (c *ContainerdUtil) getMounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, func(context.Context) error, error) {
 	snapshotter := containerd.DefaultSnapshotter
 	ctx = namespaces.WithNamespace(ctx, namespace)
 
 	// Checking if image is already unpacked
 	imgUnpacked, err := img.IsUnpacked(ctx, snapshotter)
 	if err != nil {
-		return nil, fmt.Errorf("unable to check if image named: %s is unpacked, err: %w", img.Name(), err)
+		return nil, nil, fmt.Errorf("unable to check if image named: %s is unpacked, err: %w", img.Name(), err)
 	}
 	if !imgUnpacked {
-		return nil, fmt.Errorf("unable to scan image named: %s, image is not unpacked", img.Name())
+		return nil, nil, fmt.Errorf("unable to scan image named: %s, image is not unpacked", img.Name())
 	}
 
 	// Getting image id
 	imgConfig, err := img.Config(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get image config for image named: %s, err: %w", img.Name(), err)
+		return nil, nil, fmt.Errorf("unable to get image config for image named: %s, err: %w", img.Name(), err)
 	}
 	imageID := imgConfig.Digest.String()
 
-	// Adding a lease to cleanup dandling snaphots at expiration
+	// Adding a lease to cleanup dangling snapshots at expiration
 	ctx, done, err := c.cl.WithLease(ctx,
 		leases.WithID(imageID),
 		leases.WithExpiration(expiration),
@@ -414,7 +416,7 @@ func (c *ContainerdUtil) MountImage(ctx context.Context, expiration time.Duratio
 		}),
 	)
 	if err != nil && !errdefs.IsAlreadyExists(err) {
-		return nil, fmt.Errorf("unable to get a lease, err: %w", err)
+		return nil, nil, fmt.Errorf("unable to get a lease, err: %w", err)
 	}
 
 	// Getting top layer image id
@@ -423,18 +425,17 @@ func (c *ContainerdUtil) MountImage(ctx context.Context, expiration time.Duratio
 		if err := done(ctx); err != nil {
 			log.Warnf("Unable to cancel containerd lease with id: %s, err: %v", imageID, err)
 		}
-		return nil, fmt.Errorf("unable to get layers digests for image: %s, err: %w", imageID, err)
+		return nil, nil, fmt.Errorf("unable to get layers digests for image: %s, err: %w", imageID, err)
 	}
 	chainID := identity.ChainID(diffIDs).String()
-
-	// Creating snaphot for the top layer
+	// Creating snapshot for the top layer
 	s := c.cl.SnapshotService(snapshotter)
 	mounts, err := s.View(ctx, imageID, chainID)
 	if err != nil && !errdefs.IsAlreadyExists(err) {
 		if err := done(ctx); err != nil {
 			log.Warnf("Unable to cancel containerd lease with id: %s, err: %v", imageID, err)
 		}
-		return nil, fmt.Errorf("unable to build snapshot for image: %s, err: %w", imageID, err)
+		return nil, nil, fmt.Errorf("unable to build snapshot for image: %s, err: %w", imageID, err)
 	}
 	cleanSnapshot := func(ctx context.Context) error {
 		return s.Remove(ctx, imageID)
@@ -448,7 +449,7 @@ func (c *ContainerdUtil) MountImage(ctx context.Context, expiration time.Duratio
 		if err := done(ctx); err != nil {
 			log.Warnf("Unable to cancel containerd lease with id: %s, err: %v", imageID, err)
 		}
-		return nil, fmt.Errorf("No snapshots returned for image: %s, err: %w", imageID, err)
+		return nil, nil, fmt.Errorf("No snapshots returned for image: %s", imageID)
 	}
 
 	// Transforming mounts in case we're running in a container
@@ -460,32 +461,47 @@ func (c *ContainerdUtil) MountImage(ctx context.Context, expiration time.Duratio
 			}
 		}
 	}
-
-	// Mouting returned mounts
-	log.Infof("Mounting %+v to %s", mounts, targetDir)
-	if err := mount.All(mounts, targetDir); err != nil {
+	return mounts, func(ctx context.Context) error {
+		ctx = namespaces.WithNamespace(ctx, namespace)
 		if err := cleanSnapshot(ctx); err != nil {
 			log.Warnf("Unable to clean snapshot with id: %s, err: %v", imageID, err)
 		}
 		if err := done(ctx); err != nil {
 			log.Warnf("Unable to cancel containerd lease with id: %s, err: %v", imageID, err)
 		}
-		return nil, fmt.Errorf("unable to mount image %s to dir %s, err: %w", imageID, targetDir, err)
-	}
+		return nil
+	}, nil
+}
 
+// Mounts returns the mounts for an image
+func (c *ContainerdUtil) Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, error) {
+	mounts, clean, err := c.getMounts(ctx, expiration, namespace, img)
+	if err != nil {
+		return nil, err
+	}
+	if err := clean(ctx); err != nil {
+		return nil, fmt.Errorf("unable to clean snapshot, err: %w", err)
+	}
+	return mounts, nil
+}
+
+// MountImage mounts an image to a directory
+func (c *ContainerdUtil) MountImage(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image, targetDir string) (func(context.Context) error, error) {
+	mounts, clean, err := c.getMounts(ctx, expiration, namespace, img)
+	if err != nil {
+		return nil, err
+	}
+	if err := mount.All(mounts, targetDir); err != nil {
+		if err := clean(ctx); err != nil {
+			log.Warnf("Unable to clean snapshot, err: %v", err)
+		}
+		return nil, fmt.Errorf("unable to mount image %s to dir %s, err: %w", img.Name(), targetDir, err)
+	}
 	return func(ctx context.Context) error {
 		ctx = namespaces.WithNamespace(ctx, namespace)
-
 		if err := mount.UnmountAll(targetDir, 0); err != nil {
-			return fmt.Errorf("unable to unmount directory: %s for image: %s, err: %w", targetDir, imageID, err)
+			return fmt.Errorf("unable to unmount directory: %s for image: %s, err: %w", targetDir, img.Name(), err)
 		}
-		if err := cleanSnapshot(ctx); err != nil && !errdefs.IsNotFound(err) {
-			return fmt.Errorf("unable to cleanup snapshot for image: %s, err: %w", imageID, err)
-		}
-		if err := done(ctx); err != nil {
-			return fmt.Errorf("unable to cancel lease for image: %s, err: %w", imageID, err)
-		}
-
-		return nil
+		return clean(ctx)
 	}, nil
 }

--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/oci"
 
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
@@ -47,6 +48,7 @@ type MockedContainerdClient struct {
 	MockCallWithClientContext func(namespace string, f func(context.Context) error) error
 	MockIsSandbox             func(namespace string, ctn containerd.Container) (bool, error)
 	MockMountImage            func(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image, targetDir string) (func(context.Context) error, error)
+	MockMounts                func(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, error)
 }
 
 // Close is a mock method
@@ -145,9 +147,7 @@ func (client *MockedContainerdClient) GetEvents() containerd.EventService {
 }
 
 // Spec is a mock method
-//
-//nolint:revive // TODO(CINT) Fix revive linter
-func (client *MockedContainerdClient) Spec(namespace string, ctn containers.Container, maxSize int) (*oci.Spec, error) {
+func (client *MockedContainerdClient) Spec(namespace string, ctn containers.Container, _ int) (*oci.Spec, error) {
 	return client.MockSpec(namespace, ctn)
 }
 
@@ -169,4 +169,9 @@ func (client *MockedContainerdClient) IsSandbox(namespace string, ctn containerd
 // MountImage is a mock method
 func (client *MockedContainerdClient) MountImage(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image, targetDir string) (func(context.Context) error, error) {
 	return client.MockMountImage(ctx, expiration, namespace, img, targetDir)
+}
+
+// Mounts is a mock method
+func (client *MockedContainerdClient) Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, error) {
+	return client.MockMounts(ctx, expiration, namespace, img)
 }

--- a/pkg/util/trivy/image.go
+++ b/pkg/util/trivy/image.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/sbom/telemetry"
 	fimage "github.com/aquasecurity/trivy/pkg/fanal/image"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -26,6 +25,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
+
+	"github.com/DataDog/datadog-agent/pkg/sbom/telemetry"
 )
 
 var mu sync.Mutex
@@ -62,7 +63,7 @@ func imageOpener(ctx context.Context, collector, ref string, f *os.File, imageSa
 
 // image is a wrapper for github.com/google/go-containerregistry/pkg/v1/daemon.Image
 // daemon.Image loads the entire image into the memory at first,
-// but it doesn't need to load it if the information is already in the cache,
+// but it doesn't need to load it if the information is already in the persistentCache,
 // To avoid entire loading, this wrapper uses ImageInspectWithRaw and checks image ID and layer IDs.
 type image struct {
 	v1.Image

--- a/pkg/util/trivy/trivy_test.go
+++ b/pkg/util/trivy/trivy_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy
+
+// Package trivy holds the scan components
+package trivy
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExtractLayersFromOverlayFSMounts checks if the function correctly extracts layer paths from Mount options.
+func TestExtractLayersFromOverlayFSMounts(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mounts []mount.Mount
+		want   []string
+	}{
+		{
+			name:   "No mounts",
+			mounts: []mount.Mount{},
+		},
+		{
+			name:   "Single upperdir",
+			mounts: []mount.Mount{{Options: []string{"someoption=somevalue", "upperdir=/path/to/upper"}}},
+			want:   []string{"/path/to/upper"},
+		},
+		{
+			name:   "Single lowerdir",
+			mounts: []mount.Mount{{Options: []string{"someoption=somevalue", "lowerdir=/path/to/lower"}}},
+			want:   []string{"/path/to/lower"},
+		},
+		{
+			name:   "Multiple lowerdir",
+			mounts: []mount.Mount{{Options: []string{"someoption=somevalue", "lowerdir=/path/to/lower1:/path/to/lower2"}}},
+			want:   []string{"/path/to/lower1", "/path/to/lower2"},
+		},
+		{
+			name:   "Multiple options",
+			mounts: []mount.Mount{{Options: []string{"someoption=somevalue", "upperdir=/path/to/upper", "lowerdir=/path/to/lower1:/path/to/lower2"}}},
+			want:   []string{"/path/to/upper", "/path/to/lower1", "/path/to/lower2"},
+		},
+		{
+			name: "Multiple mounts",
+			mounts: []mount.Mount{
+				{Options: []string{"someoption=somevalue", "upperdir=/path/to/upper1"}},
+				{Options: []string{"someoption=somevalue", "lowerdir=/path/to/lower1:/path/to/lower2"}},
+			},
+			want: []string{"/path/to/upper1", "/path/to/lower1", "/path/to/lower2"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractLayersFromOverlayFSMounts(tt.mounts))
+		})
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR fixes mount path retrieval from overlayfs snapshotter. We also make sure to avoid scanning twice the same image if the cache should not be used

First commit: In containerd, `GraphData` is empty and cannot be used to check if the image is unpacked with the overlayfs snapshotter.
Second commit: Rename collector.cache as collector.persistentCache and add a `useCache` argument to clarify when the cache should be used. It should not be used with the new method.
Third commit: Move the `ScanFromOverlayfs` out of the default function for code clarity

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fix scanning directly from snapshotter.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent with the following env var 
```
    - name: DD_SBOM_CONTAINER_IMAGE_OVERLAYFS_DIRECT_SCAN
      value: "true"
```
And the following settings in helm:
```
  sbom:
    host:
      enabled: true
    containerImage:
      enabled: true
      uncompressedLayersSupport: false
```
The error new error should be:
```
Error: unable to marshal report to sbom format for image sha256:9806192403a17aedfbf50d1996bd3e511ba159497993ed516d1e9fa65175d31f, err: walk filesystem: walk dir error: unknown error with .: stat .: no such file or directory
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
