### PR TITLE
[CWS] sync naming between `fileName` and `filePath`

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -233,25 +233,25 @@ func testSimpleCreate(t *testing.T, et *etwTester, testfilename string) {
 	assert.Equal(t, 4, len(et.notifications), "expected 4 notifications, got %d", len(et.notifications))
 
 	if c, ok := et.notifications[0].(*createHandleArgs); ok {
-		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
+		assert.True(t, isSameFile(testfilename, c.filePath), "expected %s, got %s", testfilename, c.filePath)
 	} else {
 		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
 	}
 
 	if cf, ok := et.notifications[1].(*createNewFileArgs); ok {
-		assert.True(t, isSameFile(testfilename, cf.fileName), "expected %s, got %s", testfilename, cf.fileName)
+		assert.True(t, isSameFile(testfilename, cf.filePath), "expected %s, got %s", testfilename, cf.filePath)
 	} else {
 		t.Errorf("expected createNewFileArgs, got %T", et.notifications[1])
 	}
 
 	if cu, ok := et.notifications[2].(*cleanupArgs); ok {
-		assert.True(t, isSameFile(testfilename, cu.fileName), "expected %s, got %s", testfilename, cu.fileName)
+		assert.True(t, isSameFile(testfilename, cu.filePath), "expected %s, got %s", testfilename, cu.filePath)
 	} else {
 		t.Errorf("expected cleanupArgs, got %T", et.notifications[2])
 	}
 
 	if cl, ok := et.notifications[3].(*closeArgs); ok {
-		assert.True(t, isSameFile(testfilename, cl.fileName), "expected %s, got %s", testfilename, cl.fileName)
+		assert.True(t, isSameFile(testfilename, cl.filePath), "expected %s, got %s", testfilename, cl.filePath)
 	} else {
 		t.Errorf("expected closeArgs, got %T", et.notifications[3])
 	}
@@ -313,20 +313,20 @@ func testSimpleFileWrite(t *testing.T, et *etwTester, testfilename string) {
 	assert.Equal(t, 3, len(et.notifications), "expected 3 notifications, got %d", len(et.notifications))
 
 	if c, ok := et.notifications[0].(*createHandleArgs); ok {
-		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
+		assert.True(t, isSameFile(testfilename, c.filePath), "expected %s, got %s", testfilename, c.filePath)
 	} else {
 		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
 	}
 
 	if wa, ok := et.notifications[1].(*writeArgs); ok {
-		assert.True(t, isSameFile(testfilename, wa.fileName), "expected %s, got %s", testfilename, wa.fileName)
+		assert.True(t, isSameFile(testfilename, wa.filePath), "expected %s, got %s", testfilename, wa.filePath)
 		assert.Equal(t, uint32(5), wa.IOSize, "expected 5, got %d", wa.IOSize)
 	} else {
 		t.Errorf("expected writeArgs, got %T", et.notifications[1])
 	}
 
 	if cl, ok := et.notifications[2].(*cleanupArgs); ok {
-		assert.True(t, isSameFile(testfilename, cl.fileName), "expected %s, got %s", testfilename, cl.fileName)
+		assert.True(t, isSameFile(testfilename, cl.filePath), "expected %s, got %s", testfilename, cl.filePath)
 	} else {
 		t.Errorf("expected cleanup, got %T", et.notifications[2])
 	}
@@ -377,20 +377,20 @@ func testSimpleFileDelete(t *testing.T, et *etwTester, testfilename string) {
 		}
 	*/
 	if c, ok := et.notifications[0].(*createHandleArgs); ok {
-		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
+		assert.True(t, isSameFile(testfilename, c.filePath), "expected %s, got %s", testfilename, c.filePath)
 	} else {
 		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
 	}
 
 	if wa, ok := et.notifications[1].(*setDeleteArgs); ok {
-		assert.True(t, isSameFile(testfilename, wa.fileName), "expected %s, got %s", testfilename, wa.fileName)
+		assert.True(t, isSameFile(testfilename, wa.filePath), "expected %s, got %s", testfilename, wa.filePath)
 	} else {
 		t.Errorf("expected setDelete, got %T", et.notifications[1])
 	}
 
 	/*
 		if cl, ok := et.notifications[2].(*cleanupArgs); ok {
-			assert.True(t, isSameFile(testfilename, cl.fileName), "expected %s, got %s", testfilename, cl.fileName)
+			assert.True(t, isSameFile(testfilename, cl.filePath), "expected %s, got %s", testfilename, cl.filePath)
 		} else {
 			t.Errorf("expected cleanup, got %T", et.notifications[2])
 		}
@@ -435,7 +435,7 @@ func testSimpleFileRename(t *testing.T, et *etwTester, testfilename, testfileren
 	//assert.Equal(t, 4, len(et.notifications), "expected 4 notifications, got %d", len(et.notifications))
 
 	if c, ok := et.notifications[0].(*createHandleArgs); ok {
-		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
+		assert.True(t, isSameFile(testfilename, c.filePath), "expected %s, got %s", testfilename, c.filePath)
 	} else {
 		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
 	}
@@ -446,7 +446,7 @@ func testSimpleFileRename(t *testing.T, et *etwTester, testfilename, testfileren
 	var ndx int
 	for ndx = 1; ndx < len(et.notifications); ndx++ {
 		if ra, ok := et.notifications[ndx].(*renameArgs); ok {
-			assert.True(t, isSameFile(testfilename, ra.fileName), "expected %s, got %s", testfilename, ra.fileName)
+			assert.True(t, isSameFile(testfilename, ra.filePath), "expected %s, got %s", testfilename, ra.filePath)
 			break
 		}
 	}
@@ -505,7 +505,7 @@ func testFileOpen(t *testing.T, et *etwTester, testfilename string) {
 	assert.Equal(t, 3, len(et.notifications), "expected 3 notifications, got %d", len(et.notifications))
 
 	if c, ok := et.notifications[0].(*createHandleArgs); ok {
-		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
+		assert.True(t, isSameFile(testfilename, c.filePath), "expected %s, got %s", testfilename, c.filePath)
 		// this should be same as sharing argument to Createfile
 		assert.Equal(t, uint32(windows.FILE_SHARE_READ), c.shareAccess, "Sharing mode did not match")
 		assert.Equal(t, expectedCreateOptions, c.createOptions, "Create options did not match")
@@ -515,13 +515,13 @@ func testFileOpen(t *testing.T, et *etwTester, testfilename string) {
 	}
 
 	if cu, ok := et.notifications[1].(*cleanupArgs); ok {
-		assert.True(t, isSameFile(testfilename, cu.fileName), "expected %s, got %s", testfilename, cu.fileName)
+		assert.True(t, isSameFile(testfilename, cu.filePath), "expected %s, got %s", testfilename, cu.filePath)
 	} else {
 		t.Errorf("expected cleanupArgs, got %T", et.notifications[2])
 	}
 
 	if cl, ok := et.notifications[2].(*closeArgs); ok {
-		assert.True(t, isSameFile(testfilename, cl.fileName), "expected %s, got %s", testfilename, cl.fileName)
+		assert.True(t, isSameFile(testfilename, cl.filePath), "expected %s, got %s", testfilename, cl.filePath)
 	} else {
 		t.Errorf("expected closeArgs, got %T", et.notifications[3])
 	}

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -100,8 +100,8 @@ type WindowsProbe struct {
 // filecache currently only has a filename.  But this is going to expand really soon.  so go ahead
 // and have the wrapper struct even though right now it doesn't add anything.
 type fileCache struct {
-	fileName     string
-	userFileName string
+	filePath     string
+	userFilePath string
 }
 
 type etwNotification struct {
@@ -595,21 +595,21 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 		ev.CreateNewFile = model.CreateNewFileEvent{
 			File: model.FimFileEvent{
 				FileObject:      uint64(arg.fileObject),
-				PathnameStr:     arg.fileName,
-				UserPathnameStr: arg.userFileName,
-				BasenameStr:     filepath.Base(arg.fileName),
+				PathnameStr:     arg.filePath,
+				UserPathnameStr: arg.userFilePath,
+				BasenameStr:     filepath.Base(arg.filePath),
 			},
 		}
 	case *renameArgs:
 		fc := fileCache{
-			fileName:     arg.fileName,
-			userFileName: arg.userFileName,
+			filePath:     arg.filePath,
+			userFilePath: arg.userFilePath,
 		}
 		p.renamePreArgs.Add(uint64(arg.fileObject), fc)
 	case *rename29Args:
 		fc := fileCache{
-			fileName:     arg.fileName,
-			userFileName: arg.userFileName,
+			filePath:     arg.filePath,
+			userFilePath: arg.userFilePath,
 		}
 		p.renamePreArgs.Add(uint64(arg.fileObject), fc)
 	case *renamePath:
@@ -622,9 +622,9 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 		ev.RenameFile = model.RenameFileEvent{
 			Old: model.FimFileEvent{
 				FileObject:      uint64(arg.fileObject),
-				PathnameStr:     fileCache.fileName,
-				UserPathnameStr: fileCache.userFileName,
-				BasenameStr:     filepath.Base(fileCache.fileName),
+				PathnameStr:     fileCache.filePath,
+				UserPathnameStr: fileCache.userFilePath,
+				BasenameStr:     filepath.Base(fileCache.filePath),
 			},
 			New: model.FimFileEvent{
 				FileObject:      uint64(arg.fileObject),
@@ -639,9 +639,9 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 		ev.DeleteFile = model.DeleteFileEvent{
 			File: model.FimFileEvent{
 				FileObject:      uint64(arg.fileObject),
-				PathnameStr:     arg.fileName,
-				UserPathnameStr: arg.userFileName,
-				BasenameStr:     filepath.Base(arg.fileName),
+				PathnameStr:     arg.filePath,
+				UserPathnameStr: arg.userFilePath,
+				BasenameStr:     filepath.Base(arg.filePath),
 			},
 		}
 	case *writeArgs:
@@ -649,9 +649,9 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 		ev.WriteFile = model.WriteFileEvent{
 			File: model.FimFileEvent{
 				FileObject:      uint64(arg.fileObject),
-				PathnameStr:     arg.fileName,
-				UserPathnameStr: arg.userFileName,
-				BasenameStr:     filepath.Base(arg.fileName),
+				PathnameStr:     arg.filePath,
+				UserPathnameStr: arg.userFilePath,
+				BasenameStr:     filepath.Base(arg.filePath),
 			},
 		}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Windows is currently mixing file names and file paths to speak about the same thing. This PR syncs everything on paths.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
