### PR TITLE
fix(installer): Set up sockets at injector install

### DIFF
--- a/pkg/fleet/installer/default_packages_test.go
+++ b/pkg/fleet/installer/default_packages_test.go
@@ -94,6 +94,12 @@ func TestDefaultPackages(t *testing.T) {
 			env:      &env.Env{DefaultPackagesInstallOverride: map[string]bool{"datadog-agent": true}, DefaultPackagesVersionOverride: map[string]string{"datadog-agent": "1.2.3"}},
 			expected: []pkg{{n: "datadog-agent", v: "1.2.3"}},
 		},
+		{
+			name:     "APM inject before agent",
+			packages: []defaultPackage{{name: "datadog-apm-inject", released: true}, {name: "datadog-agent", released: true}},
+			env:      &env.Env{},
+			expected: []pkg{{n: "datadog-apm-inject", v: "latest"}, {n: "datadog-agent", v: "latest"}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/fleet/installer/service/apm_inject.go
+++ b/pkg/fleet/installer/service/apm_inject.go
@@ -99,6 +99,24 @@ func (a *apmInjectorInstaller) Setup(ctx context.Context) (err error) {
 	if err := a.verifyDockerRuntime(); err != nil {
 		return err
 	}
+
+	// Set up defaults for agent sockets
+	if err = configureSocketsEnv(); err != nil {
+		return
+	}
+	if err = addSystemDEnvOverrides(agentUnit); err != nil {
+		return
+	}
+	if err = addSystemDEnvOverrides(agentExp); err != nil {
+		return
+	}
+	if err = addSystemDEnvOverrides(traceAgentUnit); err != nil {
+		return
+	}
+	if err = addSystemDEnvOverrides(traceAgentExp); err != nil {
+		return
+	}
+
 	return nil
 }
 

--- a/pkg/fleet/installer/service/datadog_installer.go
+++ b/pkg/fleet/installer/service/datadog_installer.go
@@ -109,23 +109,6 @@ func SetupInstaller(ctx context.Context) (err error) {
 		return fmt.Errorf("error creating symlink to /usr/bin/datadog-installer: %w", err)
 	}
 
-	// Set up defaults for packages interacting with each other
-	if err = configureSocketsEnv(); err != nil {
-		return
-	}
-	if err = addSystemDEnvOverrides(agentUnit); err != nil {
-		return
-	}
-	if err = addSystemDEnvOverrides(agentExp); err != nil {
-		return
-	}
-	if err = addSystemDEnvOverrides(traceAgentUnit); err != nil {
-		return
-	}
-	if err = addSystemDEnvOverrides(traceAgentExp); err != nil {
-		return
-	}
-
 	// FIXME(Arthur): enable the daemon unit by default and use the same strategy as the system probe
 	if os.Getenv("DD_REMOTE_UPDATES") != "true" {
 		return nil

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -38,6 +38,7 @@ func (s *packageApmInjectSuite) TestInstall() {
 	s.host.AssertPackageInstalledByInstaller("datadog-agent", "datadog-apm-inject", "datadog-apm-library-python")
 	s.host.AssertPackageNotInstalledByPackageManager("datadog-agent", "datadog-apm-inject", "datadog-apm-library-python")
 	state := s.host.State()
+	state.AssertFileExists("/var/run/datadog/installer/environment", 0644, "root", "root")
 	state.AssertFileExists("/etc/ld.so.preload", 0644, "root", "root")
 	s.assertLDPreloadInstrumented()
 	s.assertDockerdInstrumented()

--- a/test/new-e2e/tests/installer/package_installer_test.go
+++ b/test/new-e2e/tests/installer/package_installer_test.go
@@ -39,7 +39,6 @@ func (s *packageInstallerSuite) TestInstall() {
 	state.AssertDirExists("/var/run/datadog", 0755, "dd-agent", "dd-agent")
 	state.AssertDirExists("/var/run/datadog/installer", 0755, "dd-agent", "dd-agent")
 	state.AssertDirExists("/var/run/datadog/installer/locks", 0777, "root", "root")
-	state.AssertFileExists("/var/run/datadog/installer/environment", 0644, "root", "root")
 
 	state.AssertDirExists("/opt/datadog-installer", 0755, "root", "root")
 	state.AssertDirExists("/opt/datadog-packages", 0755, "root", "root")


### PR DESCRIPTION
### What does this PR do?
Moves the socket install from installer postinstall to injector postinstall as we now have guarantees that it'll be installed before the agent

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
