### PR TITLE
[CWS] implement user path discarders on Windows

### DIFF
--- a/pkg/security/probe/discarders_windows.go
+++ b/pkg/security/probe/discarders_windows.go
@@ -37,6 +37,28 @@ func init() {
 		{
 			Entries: []rules.MultiDiscarderEntry{
 				{
+					Field:     "create.file.path",
+					EventType: model.CreateNewFileEventType,
+				},
+				{
+					Field:     "rename.file.path",
+					EventType: model.FileRenameEventType,
+				},
+				{
+					Field:     "delete.file.path",
+					EventType: model.DeleteFileEventType,
+				},
+				{
+					Field:     "write.file.path",
+					EventType: model.WriteFileEventType,
+				},
+			},
+			FinalField:     "create.file.path",
+			FinalEventType: model.CreateNewFileEventType,
+		},
+		{
+			Entries: []rules.MultiDiscarderEntry{
+				{
 					Field:     "create.file.name",
 					EventType: model.CreateNewFileEventType,
 				},

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -162,9 +162,14 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 	} else {
 		return nil, fmt.Errorf("unknown version %v", e.EventHeader.EventDescriptor.Version)
 	}
-	ca.userFileName = wp.mustConvertDrivePath(ca.fileName)
 
 	if _, ok := wp.discardedPaths.Get(ca.fileName); ok {
+		wp.stats.fileCreateSkippedDiscardedPaths++
+		return nil, errDiscardedPath
+	}
+
+	ca.userFileName = wp.mustConvertDrivePath(ca.fileName)
+	if _, ok := wp.discardedUserPaths.Get(ca.userFileName); ok {
 		wp.stats.fileCreateSkippedDiscardedPaths++
 		return nil, errDiscardedPath
 	}

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -82,6 +82,7 @@ type WindowsProbe struct {
 	stats stats
 	// discarders
 	discardedPaths     *lru.Cache[string, struct{}]
+	discardedUserPaths *lru.Cache[string, struct{}]
 	discardedBasenames *lru.Cache[string, struct{}]
 
 	// map of device path to volume name (i.e. c:)
@@ -868,6 +869,11 @@ func initializeWindowsProbe(config *config.Config, opts Opts) (*WindowsProbe, er
 		return nil, err
 	}
 
+	discardedUserPaths, err := lru.New[string, struct{}](1 << 10)
+	if err != nil {
+		return nil, err
+	}
+
 	discardedBasenames, err := lru.New[string, struct{}](1 << 10)
 	if err != nil {
 		return nil, err
@@ -906,6 +912,7 @@ func initializeWindowsProbe(config *config.Config, opts Opts) (*WindowsProbe, er
 		renamePreArgs: rnc,
 
 		discardedPaths:     discardedPaths,
+		discardedUserPaths: discardedUserPaths,
 		discardedBasenames: discardedBasenames,
 
 		volumeMap: make(map[string]string),
@@ -961,6 +968,7 @@ func (p *WindowsProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetRe
 // FlushDiscarders invalidates all the discarders
 func (p *WindowsProbe) FlushDiscarders() error {
 	p.discardedPaths.Purge()
+	p.discardedUserPaths.Purge()
 	p.discardedBasenames.Purge()
 	return nil
 }
@@ -975,6 +983,13 @@ func (p *WindowsProbe) OnNewDiscarder(_ *rules.RuleSet, ev *model.Event, field e
 		path := ev.CreateNewFile.File.PathnameStr
 		seclog.Debugf("new discarder for `%s` -> `%v`", field, path)
 		p.discardedPaths.Add(path, struct{}{})
+	} else if field == "create.file.path" {
+		path := ev.CreateNewFile.File.UserPathnameStr
+		if path == "" {
+			return
+		}
+		seclog.Debugf("new discarder for `%s` -> `%v`", field, path)
+		p.discardedUserPaths.Add(path, struct{}{})
 	} else if field == "create.file.name" {
 		basename := ev.CreateNewFile.File.BasenameStr
 		seclog.Debugf("new discarder for `%s` -> `%v`", field, basename)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds windows discarders on `.path` in addition to `.device_path`.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
