### PR TITLE
[CONS-6250] Add a simple shell script to replace S6

### DIFF
--- a/Dockerfiles/agent/entrypoint.d/process-agent
+++ b/Dockerfiles/agent/entrypoint.d/process-agent
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-exec /opt/datadog-agent/embedded/bin/process-agent -config=/etc/datadog-agent/datadog.yaml -sysprobe-config=/etc/datadog-agent/system-probe.yaml
+exec /opt/datadog-agent/embedded/bin/process-agent --cfgpath=/etc/datadog-agent/datadog.yaml

--- a/Dockerfiles/agent/entrypoint.d/simple-all-in-one
+++ b/Dockerfiles/agent/entrypoint.d/simple-all-in-one
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# agent_pid is an associative array that maps agent PIDs to their names
+declare -A agent_pid
+
+# stop_everybody is a function that stops all agents and sets the stopping flag to true
+stopping=false
+function stop_everybody() {
+    if [[ $stopping == true ]]; then
+        return
+    fi
+    stopping=true
+
+    for pid in "${!agent_pid[@]}"; do
+        printf "===== STOPPING %s =====\n" "${agent_pid[$pid]}"
+        kill -TERM "$pid" ||:
+    done
+}
+
+trap stop_everybody TERM
+
+# Run all init scripts
+for init in /etc/cont-init.d/*.sh; do
+    if [[ -e $init ]]; then
+        printf "===== RUNNING %s =====\n" "$init"
+        $BASH "$init"
+    fi
+done
+
+# Start all agents in the background
+for agent in agent process-agent security-agent system-probe trace-agent; do
+    (
+        printf "===== STARTING %s =====\n" "$agent"
+        exec "$DIR/$agent"
+    ) &
+    agent_pid[$!]=$agent
+done
+
+global_exit_code=0
+
+# Wait for all agents to exit
+while [[ "${#agent_pid[@]}" -gt 0 ]]; do
+    set +e
+    wait -n -p pid "${!agent_pid[@]}"
+    exit_code=$?
+    set -e
+
+    if [[ -z ${pid+x} ]]; then
+        break
+    fi
+
+    printf "===== EXITED %s WITH CODE %d =====\n" "${agent_pid[$pid]}" $exit_code
+    unset "agent_pid[$pid]"
+
+    if [[ $exit_code -ne 0 && $stopping != true ]]; then
+        printf "===== EXITING DUE TO FAILURE =====\n"
+        global_exit_code=$exit_code
+        stop_everybody
+    fi
+done
+
+exit $global_exit_code


### PR DESCRIPTION
### What does this PR do?

Propose a simple replacement for S6 for cases where we absolutely want to have several agents running in the same container.

### Motivation

We received several bug reports related to bad S6 behavior that we haven’t been able to reproduce and, hence, to fix.
* [CONS-5869](https://datadoghq.atlassian.net/browse/CONS-5869)
* [CONS-6051](https://datadoghq.atlassian.net/browse/CONS-6051)
* [CONS-6250](https://datadoghq.atlassian.net/browse/CONS-6250)

### Additional Notes

The default behavior of the agent container remains unchanged: without any explicit command, the container will start S6 as before.
In order to use the simplest script as a replacement of S6, the `ENTRYPOINT` environment variable needs to be set to `simple-all-in-one`.

### Possible Drawbacks / Trade-offs

There’s a small difference between the S6 behavior and this simpler script one.

|      | S6 | with `ENTRYPOINT=simple-all-in-one` |
| --- | --- | --- |
| When the core `agent` crashes | The container stops. All other agents are killed. | The container stops. All other agents are killed. |
| When any other agent crashes (`process-agent`, `trace-agent`, etc.) | The agent is restarted by S6. The container runtime doesn’t notice anything. | The container stops. All other agents are killed. |

### Describe how to test/QA your changes

Run the containerized agent with `ENTRYPOINT` environment variable set to `simple-all-in-one`.

Ex.:
```
docker run -d --name dd-agent -e DD_API_KEY=$DD_API_KEY -e DD_LOGS_ENABLED=true -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -v /var/lib/docker/containers:/var/lib/docker/containers:ro -e ENTRYPOINT=simple-all-in-one gcr.io/datadoghq/agent:7.55.0
```

Validate that:
* “Disabled agents” (`security-agent`, `system-probe` and `trace-agent` are not enabled by default for ex.) start, exit cleanly and the container eventually remains up and running with only the “enabled agents” (`agent` and `process-agent` for ex.). That’s also the current S6 behavior.
* When the container is stopped, all agents are properly cleanly stopped. (`TERM` signal is properly propagated)
* When any agent crashes (can be simulated by manually sending it a signal), it makes the whole container exit.

[CONS-6250]: https://datadoghq.atlassian.net/browse/CONS-6250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CONS-5869]: https://datadoghq.atlassian.net/browse/CONS-5869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CONS-6051]: https://datadoghq.atlassian.net/browse/CONS-6051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ