### PR TITLE
[CONTP-55] generic k8s metadata collection

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -4262,6 +4262,7 @@ core,k8s.io/client-go/listers/storage/v1,Apache-2.0,Copyright 2014 The Kubernete
 core,k8s.io/client-go/listers/storage/v1alpha1,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/client-go/listers/storage/v1beta1,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/client-go/metadata,Apache-2.0,Copyright 2014 The Kubernetes Authors.
+core,k8s.io/client-go/metadata/fake,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/client-go/openapi,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/client-go/openapi/cached,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/client-go/pkg/apis/clientauthentication,Apache-2.0,Copyright 2014 The Kubernetes Authors.

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -35,9 +34,6 @@ const (
 
 // storeGenerator returns a new store specific to a given resource
 type storeGenerator func(context.Context, workloadmeta.Component, kubernetes.Interface) (*cache.Reflector, *reflectorStore)
-
-// metadataStoreGenerator returns a new kubernetes metadata store for a specific GVR
-type metadataStoreGenerator func(context.Context, workloadmeta.Component, metadata.Interface, schema.GroupVersionResource) (*cache.Reflector, *reflectorStore)
 
 func storeGenerators(cfg config.Reader) []storeGenerator {
 	generators := []storeGenerator{newNodeStore}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -351,26 +352,9 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			fakeDiscoveryClient.Resources = test.apiServerResourceList
 
 			discoveredGVRs, err := metadataCollectionGVRs(cfg, fakeDiscoveryClient)
-			assert.NoErrorf(t, err, "Function should not have returned an error")
+			require.NoErrorf(t, err, "Function should not have returned an error")
 
 			assert.Truef(t, reflect.DeepEqual(discoveredGVRs, test.expectedGVRs), "Expected %v but got %v.", test.expectedGVRs, discoveredGVRs)
 		})
 	}
 }
-
-/*
-type MockFailingDiscoveryClient struct {
-	fakediscovery.FakeDiscovery
-}
-
-func (m *MockFailingDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
-	return nil, nil, fmt.Errorf("timeout error")
-}
-
-func Test_metadataCollectionGVRs_WithDiscoveryFailure(t *testing.T) {
-	discoveryClient := &MockFailingDiscoveryClient{}
-	discoveredGVRs, err := discoverGVRs(discoveryClient, []string{})
-	assert.Errorf(t, err, "Function should have returned an error")
-	assert.Nilf(t, discoveredGVRs, "Discovered GVRs should be nil")
-}
-*/

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeapiserver
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+)
+
+func newMetadataStore(ctx context.Context, wlmetaStore workloadmeta.Component, metadataclient metadata.Interface, gvr schema.GroupVersionResource) (*cache.Reflector, *reflectorStore) {
+	metadataListerWatcher := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return metadataclient.Resource(gvr).List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return metadataclient.Resource(gvr).Watch(ctx, options)
+		},
+	}
+
+	metadataStore := &reflectorStore{
+		wlmetaStore: wlmetaStore,
+		seen:        make(map[string]workloadmeta.EntityID),
+		parser:      newMetadataParser(gvr),
+		filter:      nil,
+	}
+	metadataReflector := cache.NewNamedReflector(
+		componentName,
+		metadataListerWatcher,
+		&v1.PartialObjectMetadata{},
+		metadataStore,
+		noResync,
+	)
+	return metadataReflector, metadataStore
+}
+
+type metadataParser struct {
+	gvr schema.GroupVersionResource
+}
+
+func newMetadataParser(gvr schema.GroupVersionResource) objectParser {
+	return metadataParser{gvr}
+}
+
+func (p metadataParser) Parse(obj interface{}) workloadmeta.Entity {
+	partialObjectMetadata := obj.(*v1.PartialObjectMetadata)
+	id := fmt.Sprintf("%s/%s/%s", p.gvr.Resource, partialObjectMetadata.Namespace, partialObjectMetadata.Name)
+
+	return &workloadmeta.KubernetesMetadata{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesMetadata,
+			ID:   id,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:        partialObjectMetadata.Name,
+			Namespace:   partialObjectMetadata.Namespace,
+			Labels:      partialObjectMetadata.Labels,
+			Annotations: partialObjectMetadata.Annotations,
+		},
+		GVR: p.gvr,
+	}
+}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -41,7 +40,7 @@ func newMetadataStore(ctx context.Context, wlmetaStore workloadmeta.Component, m
 	metadataReflector := cache.NewNamedReflector(
 		componentName,
 		metadataListerWatcher,
-		&v1.PartialObjectMetadata{},
+		&metav1.PartialObjectMetadata{},
 		metadataStore,
 		noResync,
 	)
@@ -57,7 +56,7 @@ func newMetadataParser(gvr schema.GroupVersionResource) objectParser {
 }
 
 func (p metadataParser) Parse(obj interface{}) workloadmeta.Entity {
-	partialObjectMetadata := obj.(*v1.PartialObjectMetadata)
+	partialObjectMetadata := obj.(*metav1.PartialObjectMetadata)
 	id := fmt.Sprintf("%s/%s/%s", p.gvr.Resource, partialObjectMetadata.Namespace, partialObjectMetadata.Name)
 
 	return &workloadmeta.KubernetesMetadata{

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
@@ -55,9 +55,16 @@ func newMetadataParser(gvr schema.GroupVersionResource) objectParser {
 	return metadataParser{gvr}
 }
 
+// generateEntityID generates and returns a unique entity id for KubernetesMetadata entity
+// for namespaced objects, the id will have the format {resourceType}/{namespace}/{name} (e.g. deployments/default/app )
+// for cluster scoped objects, the id will have the format {resourceType}//{name} (e.g. node//master-node)
+func (p metadataParser) generateEntityID(resource, namespace, name string) string {
+	return fmt.Sprintf("%s/%s/%s", resource, namespace, name)
+}
+
 func (p metadataParser) Parse(obj interface{}) workloadmeta.Entity {
 	partialObjectMetadata := obj.(*metav1.PartialObjectMetadata)
-	id := fmt.Sprintf("%s/%s/%s", p.gvr.Resource, partialObjectMetadata.Namespace, partialObjectMetadata.Name)
+	id := p.generateEntityID(p.gvr.Resource, partialObjectMetadata.Namespace, partialObjectMetadata.Name)
 
 	return &workloadmeta.KubernetesMetadata{
 		EntityID: workloadmeta.EntityID{

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
@@ -10,16 +10,14 @@ package kubeapiserver
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 )
 
 func TestParse_ParsePartialObjectMetadata(t *testing.T) {

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
@@ -1,0 +1,157 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && test
+
+package kubeapiserver
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+)
+
+func TestParse_ParsePartialObjectMetadata(t *testing.T) {
+
+	testcases := []struct {
+		name                  string
+		gvr                   schema.GroupVersionResource
+		partialObjectMetadata *v1.PartialObjectMetadata
+		expected              *workloadmeta.KubernetesMetadata
+	}{
+		{
+			name: "deployments [namespace scoped]",
+			gvr: schema.GroupVersionResource{
+				Group:    "apps",
+				Version:  "v1",
+				Resource: "deployments",
+			},
+			partialObjectMetadata: &v1.PartialObjectMetadata{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "test-app",
+					Namespace:   "default",
+					Labels:      map[string]string{"l1": "v1", "l2": "v2", "l3": "v3"},
+					Annotations: map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"},
+				},
+			},
+			expected: &workloadmeta.KubernetesMetadata{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindKubernetesMetadata,
+					ID:   "deployments/default/test-app",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:        "test-app",
+					Namespace:   "default",
+					Labels:      map[string]string{"l1": "v1", "l2": "v2", "l3": "v3"},
+					Annotations: map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"},
+				},
+				GVR: schema.GroupVersionResource{
+					Group:    "apps",
+					Version:  "v1",
+					Resource: "deployments",
+				},
+			},
+		},
+		{
+			name: "namespaces [cluster scoped]",
+			gvr: schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "namespaces",
+			},
+			partialObjectMetadata: &v1.PartialObjectMetadata{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "test-namespace",
+					Namespace:   "",
+					Labels:      map[string]string{"l1": "v1", "l2": "v2", "l3": "v3"},
+					Annotations: map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"},
+				},
+			},
+			expected: &workloadmeta.KubernetesMetadata{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindKubernetesMetadata,
+					ID:   "namespaces//test-namespace",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:        "test-namespace",
+					Namespace:   "",
+					Labels:      map[string]string{"l1": "v1", "l2": "v2", "l3": "v3"},
+					Annotations: map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"},
+				},
+				GVR: schema.GroupVersionResource{
+					Group:    "",
+					Version:  "v1",
+					Resource: "namespaces",
+				},
+			},
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(tt *testing.T) {
+			parser := newMetadataParser(test.gvr)
+			entity := parser.Parse(test.partialObjectMetadata)
+			storedMetadata, ok := entity.(*workloadmeta.KubernetesMetadata)
+			require.True(t, ok)
+			assert.Equal(t, test.expected, storedMetadata)
+		})
+	}
+}
+
+func Test_MetadataFakeClient(t *testing.T) {
+	ns := "default"
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	objectMeta := metav1.ObjectMeta{
+		Name:        "test-app",
+		Namespace:   ns,
+		Labels:      map[string]string{"test-label": "test-value"},
+		Annotations: map[string]string{"k": "v"},
+	}
+
+	createObjects := func() []runtime.Object {
+		return []runtime.Object{
+			&metav1.PartialObjectMetadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       kubernetes.DeploymentKind,
+				},
+				ObjectMeta: objectMeta,
+			},
+		}
+	}
+
+	expected := workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.KubernetesMetadata{
+					EntityID: workloadmeta.EntityID{
+						ID:   "deployments/default/test-app",
+						Kind: workloadmeta.KindKubernetesMetadata,
+					},
+					EntityMeta: workloadmeta.EntityMeta{
+						Name:        objectMeta.Name,
+						Namespace:   "default",
+						Labels:      objectMeta.Labels,
+						Annotations: objectMeta.Annotations,
+					},
+					GVR: gvr,
+				},
+			},
+		},
+	}
+
+	testCollectMetadataEvent(t, createObjects, gvr, expected)
+}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
@@ -28,7 +27,7 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 	testcases := []struct {
 		name                  string
 		gvr                   schema.GroupVersionResource
-		partialObjectMetadata *v1.PartialObjectMetadata
+		partialObjectMetadata *metav1.PartialObjectMetadata
 		expected              *workloadmeta.KubernetesMetadata
 	}{
 		{
@@ -38,8 +37,8 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 				Version:  "v1",
 				Resource: "deployments",
 			},
-			partialObjectMetadata: &v1.PartialObjectMetadata{
-				ObjectMeta: v1.ObjectMeta{
+			partialObjectMetadata: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test-app",
 					Namespace:   "default",
 					Labels:      map[string]string{"l1": "v1", "l2": "v2", "l3": "v3"},
@@ -71,8 +70,8 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 				Version:  "v1",
 				Resource: "namespaces",
 			},
-			partialObjectMetadata: &v1.PartialObjectMetadata{
-				ObjectMeta: v1.ObjectMeta{
+			partialObjectMetadata: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test-namespace",
 					Namespace:   "",
 					Labels:      map[string]string{"l1": "v1", "l2": "v2", "l3": "v3"},

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -13,19 +13,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	metafake "k8s.io/client-go/metadata/fake"
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/fx"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/fake"
-	metafake "k8s.io/client-go/metadata/fake"
 )
 
 const dummySubscriber = "dummy-subscriber"

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -9,6 +9,9 @@ package kubeapiserver
 
 import (
 	"context"
+	"fmt"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"testing"
 	"time"
 
@@ -19,7 +22,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
+	metafake "k8s.io/client-go/metadata/fake"
 )
 
 const dummySubscriber = "dummy-subscriber"
@@ -48,6 +53,76 @@ func testCollectEvent(t *testing.T, createResource func(*fake.Clientset) error, 
 	ctx := context.TODO()
 
 	store, _ := newStore(ctx, wlm, client)
+	stopStore := make(chan struct{})
+	go store.Run(stopStore)
+
+	// Subscribe to the kubeapiserver events. Two cases are possible:
+	// - The reflector has already populated wlm with the resource, in that case the first call to <-ch will contain the event
+	// - The reflector is still initializing. In that case the second call to <-ch will contain the event
+
+	time.Sleep(5 * time.Second)
+
+	ch := wlm.Subscribe(dummySubscriber, workloadmeta.NormalPriority, nil)
+	var bundle workloadmeta.EventBundle
+	read := assert.Eventually(t, func() bool {
+		select {
+		case bundle = <-ch:
+			bundle.Acknowledge()
+			if len(bundle.Events) == 0 {
+				return false
+			}
+			// If bundle finally has an event, we can return from this
+			return true
+
+		default:
+			return false
+		}
+	}, 30*time.Second, 500*time.Millisecond)
+
+	// Retrieving the resource in an event bundle
+	if !read {
+		bundle = <-ch
+		bundle.Acknowledge()
+	}
+
+	// nil the bundle's Ch so we can
+	// deep-equal just the events later
+	bundle.Ch = nil
+	actual := bundle
+	assert.Equal(t, expected, actual)
+	close(stopStore)
+	wlm.Unsubscribe(ch)
+}
+
+func testCollectMetadataEvent(t *testing.T, createObjects func() []runtime.Object, gvr schema.GroupVersionResource, expected workloadmeta.EventBundle) {
+
+	// Create a resource before starting the reflector store or workloadmeta so that if the reflector calls `List()` then
+	// this resource can't be skipped
+
+	// Create test scheme
+	testScheme := runtime.NewScheme()
+	// Register Metadata objects types to the test scheme
+	v1.AddMetaToScheme(testScheme)
+
+	objects := createObjects()
+
+	metadataclient := metafake.NewSimpleMetadataClient(testScheme, objects...)
+
+	wlm := fxutil.Test[workloadmeta.Mock](t, fx.Options(
+		core.MockBundle(),
+		fx.Supply(context.Background()),
+		fx.Supply(workloadmeta.NewParams()),
+		workloadmeta.MockModuleV2(),
+	))
+	ctx := context.TODO()
+
+	// Create a fake metadata client to mock API calls.
+
+	response, err := metadataclient.Resource(gvr).List(ctx, v1.ListOptions{})
+	assert.NoError(t, err)
+	fmt.Println("metadata client listing: ", response.String())
+	store, _ := newMetadataStore(ctx, wlm, metadataclient, gvr)
+
 	stopStore := make(chan struct{})
 	go store.Run(stopStore)
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -10,10 +10,11 @@ package kubeapiserver
 import (
 	"context"
 	"fmt"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"testing"
 	"time"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -102,7 +103,8 @@ func testCollectMetadataEvent(t *testing.T, createObjects func() []runtime.Objec
 	// Create test scheme
 	testScheme := runtime.NewScheme()
 	// Register Metadata objects types to the test scheme
-	v1.AddMetaToScheme(testScheme)
+	err := v1.AddMetaToScheme(testScheme)
+	assert.NoError(t, err)
 
 	objects := createObjects()
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
@@ -66,7 +66,6 @@ func discoverGVRs(discoveryClient discovery.DiscoveryInterface, resources []stri
 	gvrs := make([]schema.GroupVersionResource, 0, len(resources))
 	for _, resource := range resources {
 		gv, found := discoveredResources[resource]
-		fmt.Println("Looking for resource ", resource, " and result is: ", found)
 		if found {
 			gvrs = append(gvrs, schema.GroupVersionResource{Group: gv.Group, Version: gv.Version, Resource: resource})
 		} else {
@@ -99,8 +98,6 @@ func discoverResources(discoveryClient discovery.DiscoveryInterface) (map[string
 			}
 		}
 	}
-
-	fmt.Println("Checkpoint 2: ", discoveredResources)
 
 	return discoveredResources, nil
 }

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils_test.go
@@ -8,6 +8,12 @@
 package kubeapiserver
 
 import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"reflect"
 	"testing"
 
@@ -78,4 +84,18 @@ func copyMap(in map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
+}
+
+func Test_discoverGVRs(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset()
+	fakeDiscoveryClient, ok := client.Discovery().(*fakediscovery.FakeDiscovery)
+	assert.Truef(t, ok, "Failed to initialise fake discovery client")
+
+	ctx := context.Background()
+
+	client.AppsV1().Deployments("default").Create(ctx, nil, metav1.CreateOptions{})
+
+	result, err := discoverGVRs(fakeDiscoveryClient, []string{"deployments"})
+	assert.NoError(t, err)
+	fmt.Println("Checkpoint Here: ", result)
 }

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils_test.go
@@ -8,12 +8,6 @@
 package kubeapiserver
 
 import (
-	"context"
-	"fmt"
-	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	fakediscovery "k8s.io/client-go/discovery/fake"
-	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"reflect"
 	"testing"
 
@@ -84,18 +78,4 @@ func copyMap(in map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
-}
-
-func Test_discoverGVRs(t *testing.T) {
-	client := fakeclientset.NewSimpleClientset()
-	fakeDiscoveryClient, ok := client.Discovery().(*fakediscovery.FakeDiscovery)
-	assert.Truef(t, ok, "Failed to initialise fake discovery client")
-
-	ctx := context.Background()
-
-	client.AppsV1().Deployments("default").Create(ctx, nil, metav1.CreateOptions{})
-
-	result, err := discoverGVRs(fakeDiscoveryClient, []string{"deployments"})
-	assert.NoError(t, err)
-	fmt.Println("Checkpoint Here: ", result)
 }

--- a/comp/core/workloadmeta/component.go
+++ b/comp/core/workloadmeta/component.go
@@ -82,6 +82,10 @@ type Component interface {
 	// the entity with kind KindKubernetesNamespace and the given ID.
 	GetKubernetesNamespace(id string) (*KubernetesNamespace, error)
 
+	// GetKubernetesMetadata returns metadata about a Kubernetes resource. It fetches
+	// the entity with kind KubernetesMetadata and the given ID.
+	GetKubernetesMetadata(id string) (*KubernetesMetadata, error)
+
 	// ListECSTasks returns metadata about all ECS tasks, equivalent to all
 	// entities with kind KindECSTask.
 	ListECSTasks() []*ECSTask

--- a/comp/core/workloadmeta/dump.go
+++ b/comp/core/workloadmeta/dump.go
@@ -65,6 +65,8 @@ func (w *workloadmeta) Dump(verbose bool) WorkloadDumpResponse {
 			info = e.String(verbose)
 		case *KubernetesNamespace:
 			info = e.String(verbose)
+		case *KubernetesMetadata:
+			info = e.String(verbose)
 		default:
 			return "", fmt.Errorf("unsupported type %T", e)
 		}

--- a/comp/core/workloadmeta/store.go
+++ b/comp/core/workloadmeta/store.go
@@ -406,6 +406,16 @@ func (w *workloadmeta) GetImage(id string) (*ContainerImageMetadata, error) {
 	return entity.(*ContainerImageMetadata), nil
 }
 
+// GetKubernetesMetadata implements Store#GetKubernetesMetadata.
+func (w *workloadmeta) GetKubernetesMetadata(id string) (*KubernetesMetadata, error) {
+	entity, err := w.getEntityByKind(KindKubernetesMetadata, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.(*KubernetesMetadata), nil
+}
+
 // Notify implements Store#Notify
 func (w *workloadmeta) Notify(events []CollectorEvent) {
 	if len(events) > 0 {

--- a/comp/core/workloadmeta/store_test.go
+++ b/comp/core/workloadmeta/store_test.go
@@ -1420,6 +1420,49 @@ func TestResetProcesses(t *testing.T) {
 
 }
 
+func TestGetKubernetesMetadata(t *testing.T) {
+	deps := fxutil.Test[dependencies](t, fx.Options(
+		logimpl.MockModule(),
+		config.MockModule(),
+		fx.Supply(NewParams()),
+	))
+
+	s := newWorkloadmetaObject(deps)
+
+	kubemetadata := &KubernetesMetadata{
+		EntityID: EntityID{
+			Kind: KindKubernetesMetadata,
+			ID:   "deployments/default/app",
+		},
+	}
+
+	s.handleEvents([]CollectorEvent{
+		{
+			Type:   EventTypeSet,
+			Source: fooSource,
+			Entity: kubemetadata,
+		},
+	})
+
+	retrievedMetadata, err := s.GetKubernetesMetadata("deployments/default/app")
+	tassert.NoError(t, err)
+
+	if !reflect.DeepEqual(kubemetadata, retrievedMetadata) {
+		t.Errorf("expected metadata %q to match the one in the store", retrievedMetadata.ID)
+	}
+
+	s.handleEvents([]CollectorEvent{
+		{
+			Type:   EventTypeUnset,
+			Source: fooSource,
+			Entity: kubemetadata,
+		},
+	})
+
+	_, err = s.GetKubernetesMetadata("deployments/default/app")
+	tassert.True(t, errors.IsNotFound(err))
+}
+
 func TestReset(t *testing.T) {
 	fooContainer := &Container{
 		EntityID: EntityID{

--- a/comp/core/workloadmeta/types.go
+++ b/comp/core/workloadmeta/types.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	langUtil "github.com/DataDog/datadog-agent/pkg/languagedetection/util"
 
 	"github.com/CycloneDX/cyclonedx-go"
@@ -41,6 +43,7 @@ const (
 	KindContainer              Kind = "container"
 	KindKubernetesPod          Kind = "kubernetes_pod"
 	KindKubernetesNode         Kind = "kubernetes_node"
+	KindKubernetesMetadata     Kind = "kubernetes_metadata"
 	KindKubernetesDeployment   Kind = "kubernetes_deployment"
 	KindKubernetesNamespace    Kind = "kubernetes_namespace"
 	KindECSTask                Kind = "ecs_task"
@@ -784,6 +787,51 @@ func (o KubernetesPodOwner) String(verbose bool) string {
 
 	return sb.String()
 }
+
+// KubernetesMetadata is an Entity representing kubernetes resource metadata
+type KubernetesMetadata struct {
+	EntityID
+	EntityMeta
+	GVR schema.GroupVersionResource
+}
+
+func (m *KubernetesMetadata) GetID() EntityID {
+	return m.EntityID
+}
+
+func (m *KubernetesMetadata) Merge(e Entity) error {
+	mm, ok := e.(*KubernetesMetadata)
+	if !ok {
+		return fmt.Errorf("cannot merge KubernetesMetadata with different kind %T", e)
+	}
+
+	return merge(m, mm)
+}
+
+// DeepCopy implements Entity#DeepCopy.
+func (m KubernetesMetadata) DeepCopy() Entity {
+	cm := deepcopy.Copy(m).(KubernetesMetadata)
+	return &cm
+}
+
+// String implements Entity#String
+func (m *KubernetesMetadata) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
+	_, _ = fmt.Fprintln(&sb, m.EntityID.String(verbose))
+
+	_, _ = fmt.Fprintln(&sb, "----------- Entity Meta -----------")
+	_, _ = fmt.Fprint(&sb, m.EntityMeta.String(verbose))
+
+	if verbose {
+		_, _ = fmt.Fprintln(&sb, "----------- Resource -----------")
+		_, _ = fmt.Fprint(&sb, m.GVR.String())
+	}
+
+	return sb.String()
+}
+
+var _ Entity = &KubernetesMetadata{}
 
 // KubernetesNode is an Entity representing a Kubernetes Node.
 type KubernetesNode struct {

--- a/comp/core/workloadmeta/types.go
+++ b/comp/core/workloadmeta/types.go
@@ -795,10 +795,12 @@ type KubernetesMetadata struct {
 	GVR schema.GroupVersionResource
 }
 
+// GetID implements Entity#GetID.
 func (m *KubernetesMetadata) GetID() EntityID {
 	return m.EntityID
 }
 
+// Merge implements Entity#Merge.
 func (m *KubernetesMetadata) Merge(e Entity) error {
 	mm, ok := e.(*KubernetesMetadata)
 	if !ok {

--- a/comp/core/workloadmeta/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/workloadmeta_mock.go
@@ -57,6 +57,16 @@ func (w *workloadMetaMock) GetContainer(id string) (*Container, error) {
 	return entity.(*Container), nil
 }
 
+// GetKubernetesMetadata implements workloadMetaMock#GetKubernetesMetadata.
+func (w *workloadMetaMock) GetKubernetesMetadata(id string) (*KubernetesMetadata, error) {
+	entity, err := w.getEntityByKind(KindKubernetesMetadata, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.(*KubernetesMetadata), nil
+}
+
 // ListContainers returns metadata about all known containers.
 func (w *workloadMetaMock) ListContainers() []*Container {
 	entities := w.listEntitiesByKind(KindContainer)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -470,6 +470,8 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("cluster_agent.language_detection.cleanup.language_ttl", "30m")
 	// language annotation cleanup period
 	config.BindEnvAndSetDefault("cluster_agent.language_detection.cleanup.period", "10m")
+	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.enabled", false)
+	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.resources", []string{})
 
 	// Metadata endpoints
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -27,10 +27,12 @@ import (
 	vpa "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
+
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/scale"
@@ -658,6 +660,21 @@ func (c *APIClient) RESTClient(apiPath string, groupVersion *schema.GroupVersion
 	clientConfig.NegotiatedSerializer = negotiatedSerializer
 
 	return rest.RESTClientFor(clientConfig)
+}
+
+// MetadataClient returns a new kubernetes metadata client
+func (c *APIClient) MetadataClient() (metadata.Interface, error) {
+	clientConfig, err := getClientConfig(c.defaultInformerTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	metaclient := metadata.NewForConfigOrDie(clientConfig)
+	return metaclient, nil
+}
+
+func (c *APIClient) DiscoveryClient() discovery.DiscoveryInterface {
+	return c.Cl.Discovery()
 }
 
 // NewSPDYExecutor returns a new SPDY executor for the provided method and URL

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -673,10 +673,6 @@ func (c *APIClient) MetadataClient() (metadata.Interface, error) {
 	return metaclient, nil
 }
 
-func (c *APIClient) DiscoveryClient() discovery.DiscoveryInterface {
-	return c.Cl.Discovery()
-}
-
 // NewSPDYExecutor returns a new SPDY executor for the provided method and URL
 func (c *APIClient) NewSPDYExecutor(apiPath string, groupVersion *schema.GroupVersion, negotiatedSerializer runtime.NegotiatedSerializer, method string, url *url.URL) (remotecommand.Executor, error) {
 	clientConfig, err := getClientConfig(c.defaultClientTimeout)


### PR DESCRIPTION
## [ATTENTION] THIS PR IS BETTER REVIEWED COMMIT BY COMMIT
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds the capability to collect metadata (Name, Namespace, Labels, Annotations) of kubernetes resources in a generic way. It allows collecting this for any kubernetes resource type (even for CRDs). 

It will be possible to collect metadata of resources by setting the following two configuration options:
- `cluster_agent.kube_metadata_collection.enabled`: specifies if collection of metadata is enabled or not.
- `cluster_agent.kube_metadata_collection.resources`: list of resource types for which metadata is to be collected.

Collected metadata are stored in workloadmeta in a new entity called `KubernetesMetadata`. It includes a GVR field so that it is possible in the future to filter entities by GVR.

### Motivation
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
- Allow other features to easily get kubernetes resource metadata without having to repeatedly make API calls to the kubernetes API server. An example of this is the `kubernetes_namespace_labels_as_tags`. Having namespace metadata in workloadmeta, we can get the labels and annotations of the namespace directly in memory in the cluster agent without having to do an API call to the kubernetes API server each time.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
- Currently, we store in workloadmeta metadata obtained by parsing all received events, even if the entity doesn't contain any labels or annotations. For now, this should be okay, as most kubernetes resources will have at least one label or at least one annotations. In addition, the memory consumed due to this collection should remain minor compared to other collection processes (such as pod collection).
- A possible improvement that can be done is to allow users to define some regex for each resource type to define what annotations, labels, or related objects should be collected.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Deploy the agent and cluster agent with the following env vars set on the cluster agent:
- DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_ENABLED (set this to true)
- DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES (set this to the list of resources for which you want to test metadata collection)

Example of helm file:
```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
clusterAgent:
  enabled: true
  env:
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_ENABLED
      value: "true"
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES
      value: "deployments daemonsets"
```

Create some deployments and daemonsets and verify that metadata are collected correctly and strictly for daemonsets and deployments:

```
=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: daemonsets/default/datadog-agent ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: daemonsets/default/datadog-agent

----------- Entity Meta -----------
Name: datadog-agent
Namespace: default
Annotations: meta.helm.sh/release-namespace:default meta.helm.sh/release-name:datadog-agent 
Labels: app.kubernetes.io/name:datadog-agent app.kubernetes.io/version:7 helm.sh/chart:datadog-3.59.5 app.kubernetes.io/component:agent app.kubernetes.io/instance:datadog-agent app.kubernetes.io/managed-by:Helm 
----------- Resource -----------
apps/v1, Resource=daemonsets===

=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: daemonsets/kube-system/kindnet ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: daemonsets/kube-system/kindnet

----------- Entity Meta -----------
Name: kindnet
Namespace: kube-system
Annotations: 
Labels: app:kindnet k8s-app:kindnet tier:node 
----------- Resource -----------
apps/v1, Resource=daemonsets===

=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: daemonsets/kube-system/kube-proxy ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: daemonsets/kube-system/kube-proxy

----------- Entity Meta -----------
Name: kube-proxy
Namespace: kube-system
Annotations: 
Labels: k8s-app:kube-proxy 
----------- Resource -----------
apps/v1, Resource=daemonsets===

=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: deployments/default/datadog-agent-cluster-agent ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: deployments/default/datadog-agent-cluster-agent

----------- Entity Meta -----------
Name: datadog-agent-cluster-agent
Namespace: default
Annotations: deployment.kubernetes.io/revision:1 meta.helm.sh/release-name:datadog-agent meta.helm.sh/release-namespace:default 
Labels: app.kubernetes.io/managed-by:Helm app.kubernetes.io/name:datadog-agent app.kubernetes.io/version:7 helm.sh/chart:datadog-3.59.5 app.kubernetes.io/component:cluster-agent app.kubernetes.io/instance:datadog-agent 
----------- Resource -----------
apps/v1, Resource=deployments===

=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: deployments/kube-system/coredns ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: deployments/kube-system/coredns

----------- Entity Meta -----------
Name: coredns
Namespace: kube-system
Annotations: deployment.kubernetes.io/revision:1 
Labels: k8s-app:kube-dns 
----------- Resource -----------
apps/v1, Resource=deployments===

=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: deployments/local-path-storage/local-path-provisioner ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: deployments/local-path-storage/local-path-provisioner

----------- Entity Meta -----------
Name: local-path-provisioner
Namespace: local-path-storage
Annotations: deployment.kubernetes.io/revision:1 kubectl.kubernetes.io/last-applied-configuration:{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"name":"local-path-provisioner","namespace":"local-path-storage"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"local-path-provisioner"}},"template":{"metadata":{"labels":{"app":"local-path-provisioner"}},"spec":{"containers":[{"command":["local-path-provisioner","--debug","start","--helper-image","docker.io/kindest/local-path-helper:v20230510-486859a6","--config","/etc/config/config.json"],"env":[{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}],"image":"docker.io/kindest/local-path-provisioner:v20230511-dc714da8","imagePullPolicy":"IfNotPresent","name":"local-path-provisioner","volumeMounts":[{"mountPath":"/etc/config/","name":"config-volume"}]}],"nodeSelector":{"kubernetes.io/os":"linux"},"serviceAccountName":"local-path-provisioner-service-account","tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Equal"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Equal"}],"volumes":[{"configMap":{"name":"local-path-config"},"name":"config-volume"}]}}}} 
Labels: 
----------- Resource -----------
apps/v1, Resource=deployments===
```

