### PR TITLE
[CWS] add `/workload-list` api routes and associated subcommands to security agent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -363,6 +363,7 @@
 /pkg/config/setup/system_probe_cws.go           @DataDog/agent-security
 /pkg/config/setup/system_probe_cws_notwin.go    @DataDog/agent-security
 /pkg/config/setup/system_probe_cws_windows.go   @DataDog/windows-kernel-integrations
+/pkg/config/setup/security_agent.go             @DataDog/agent-security
 /pkg/config/remote/                     @DataDog/remote-config
 /pkg/config/remote/meta/                @DataDog/remote-config @DataDog/software-integrity-and-trust
 /pkg/containerlifecycle/                @Datadog/container-integrations

--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -54,11 +54,9 @@ func (a *Agent) SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/config/list-runtime", a.settings.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", a.settings.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", a.settings.SetValue).Methods("POST")
-	r.HandleFunc("/workload-list/short", func(w http.ResponseWriter, r *http.Request) {
-		workloadList(w, false, a.wmeta)
-	}).Methods("GET")
-	r.HandleFunc("/workload-list/verbose", func(w http.ResponseWriter, r *http.Request) {
-		workloadList(w, true, a.wmeta)
+	r.HandleFunc("/workload-list", func(w http.ResponseWriter, r *http.Request) {
+		verbose := r.URL.Query().Get("verbose") == "true"
+		workloadList(w, verbose, a.wmeta)
 	}).Methods("GET")
 }
 

--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
 	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -29,13 +30,15 @@ import (
 type Agent struct {
 	statusComponent status.Component
 	settings        settings.Component
+	wmeta           workloadmeta.Component
 }
 
 // NewAgent returns a new Agent
-func NewAgent(statusComponent status.Component, settings settings.Component) *Agent {
+func NewAgent(statusComponent status.Component, settings settings.Component, wmeta workloadmeta.Component) *Agent {
 	return &Agent{
 		statusComponent: statusComponent,
 		settings:        settings,
+		wmeta:           wmeta,
 	}
 }
 
@@ -51,6 +54,26 @@ func (a *Agent) SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/config/list-runtime", a.settings.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", a.settings.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", a.settings.SetValue).Methods("POST")
+	r.HandleFunc("/workload-list/short", func(w http.ResponseWriter, r *http.Request) {
+		workloadList(w, false, a.wmeta)
+	}).Methods("GET")
+	r.HandleFunc("/workload-list/verbose", func(w http.ResponseWriter, r *http.Request) {
+		workloadList(w, true, a.wmeta)
+	}).Methods("GET")
+}
+
+func workloadList(w http.ResponseWriter, verbose bool, wmeta workloadmeta.Component) {
+	response := wmeta.Dump(verbose)
+	jsonDump, err := json.Marshal(response)
+	if err != nil {
+		err := log.Errorf("Unable to marshal workload list response: %v", err)
+		w.Header().Set("Content-Type", "application/json")
+		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(body), 500)
+		return
+	}
+
+	w.Write(jsonDump)
 }
 
 func (a *Agent) stopAgent(w http.ResponseWriter, _ *http.Request) {

--- a/cmd/security-agent/api/server.go
+++ b/cmd/security-agent/api/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/api/agent"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
 	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -38,14 +39,14 @@ type Server struct {
 }
 
 // NewServer creates a new Server instance
-func NewServer(statusComponent status.Component, settings settings.Component) (*Server, error) {
+func NewServer(statusComponent status.Component, settings settings.Component, wmeta workloadmeta.Component) (*Server, error) {
 	listener, err := newListener()
 	if err != nil {
 		return nil, err
 	}
 	return &Server{
 		listener: listener,
-		agent:    agent.NewAgent(statusComponent, settings),
+		agent:    agent.NewAgent(statusComponent, settings, wmeta),
 	}, nil
 }
 

--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -89,10 +89,10 @@ func (s *service) Run(svcctx context.Context) error {
 	params := &cliParams{}
 	err := fxutil.OneShot(
 		func(log log.Component, config config.Component, _ secrets.Component, statsd statsd.Component, sysprobeconfig sysprobeconfig.Component,
-			telemetry telemetry.Component, _ workloadmeta.Component, params *cliParams, statusComponent status.Component, _ autoexit.Component, settings settings.Component) error {
+			telemetry telemetry.Component, _ workloadmeta.Component, params *cliParams, statusComponent status.Component, _ autoexit.Component, settings settings.Component, wmeta workloadmeta.Component) error {
 			defer start.StopAgent(log)
 
-			err := start.RunAgent(log, config, telemetry, statusComponent, settings)
+			err := start.RunAgent(log, config, telemetry, statusComponent, settings, wmeta)
 			if err != nil {
 				return err
 			}

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -203,10 +203,10 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 // TODO(components): note how workloadmeta is passed anonymously, it is still required as it is used
 // as a global. This should eventually be fixed and all workloadmeta interactions should be via the
 // injected instance.
-func start(log log.Component, config config.Component, _ secrets.Component, _ statsd.Component, _ sysprobeconfig.Component, telemetry telemetry.Component, statusComponent status.Component, _ pid.Component, _ autoexit.Component, settings settings.Component) error {
+func start(log log.Component, config config.Component, _ secrets.Component, _ statsd.Component, _ sysprobeconfig.Component, telemetry telemetry.Component, statusComponent status.Component, _ pid.Component, _ autoexit.Component, settings settings.Component, wmeta workloadmeta.Component) error {
 	defer StopAgent(log)
 
-	err := RunAgent(log, config, telemetry, statusComponent, settings)
+	err := RunAgent(log, config, telemetry, statusComponent, settings, wmeta)
 	if errors.Is(err, errAllComponentsDisabled) || errors.Is(err, errNoAPIKeyConfigured) {
 		return nil
 	}
@@ -257,7 +257,7 @@ var errAllComponentsDisabled = errors.New("all security-agent component are disa
 var errNoAPIKeyConfigured = errors.New("no API key configured")
 
 // RunAgent initialized resources and starts API server
-func RunAgent(log log.Component, config config.Component, telemetry telemetry.Component, statusComponent status.Component, settings settings.Component) (err error) {
+func RunAgent(log log.Component, config config.Component, telemetry telemetry.Component, statusComponent status.Component, settings settings.Component, wmeta workloadmeta.Component) (err error) {
 	if err := util.SetupCoreDump(config); err != nil {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
@@ -300,7 +300,7 @@ func RunAgent(log log.Component, config config.Component, telemetry telemetry.Co
 		}
 	}()
 
-	srv, err = api.NewServer(statusComponent, settings)
+	srv, err = api.NewServer(statusComponent, settings, wmeta)
 	if err != nil {
 		return log.Errorf("Error while creating api server, exiting: %v", err)
 	}

--- a/cmd/security-agent/subcommands/subcommands.go
+++ b/cmd/security-agent/subcommands/subcommands.go
@@ -16,6 +16,7 @@ import (
 	cmdstart "github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/start"
 	cmdstatus "github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/status"
 	cmdversion "github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/version"
+	cmdworkloadlist "github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/workloadlist"
 )
 
 // SecurityAgentSubcommands returns SubcommandFactories for the subcommands supported
@@ -33,5 +34,6 @@ func SecurityAgentSubcommands() []command.SubcommandFactory {
 		cmdstart.Commands,
 		cmdstatus.Commands,
 		cmdversion.Commands,
+		cmdworkloadlist.Commands,
 	}
 }

--- a/cmd/security-agent/subcommands/workloadlist/command.go
+++ b/cmd/security-agent/subcommands/workloadlist/command.go
@@ -21,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -64,7 +64,7 @@ func workloadList(_ log.Component, config config.Component, cliParams *cliParams
 		return err
 	}
 
-	url, err := workloadURL(cliParams.verboseList)
+	url, err := workloadURL(config, cliParams.verboseList)
 	if err != nil {
 		return err
 	}
@@ -90,8 +90,8 @@ func workloadList(_ log.Component, config config.Component, cliParams *cliParams
 	return nil
 }
 
-func workloadURL(verbose bool) (string, error) {
-	addressPort, err := ddconfig.GetSecurityAgentAPIAddressPort()
+func workloadURL(config config.Component, verbose bool) (string, error) {
+	addressPort, err := pkgconfigsetup.GetSecurityAgentAPIAddressPort(config)
 	if err != nil {
 		return "", fmt.Errorf("config error: %s", err.Error())
 	}

--- a/cmd/security-agent/subcommands/workloadlist/command.go
+++ b/cmd/security-agent/subcommands/workloadlist/command.go
@@ -99,8 +99,8 @@ func workloadURL(config config.Component, verbose bool) (string, error) {
 	url := fmt.Sprintf("https://%s/agent/workload-list", addressPort)
 
 	if verbose {
-		return url + "/verbose", nil
+		return url + "?verbose=true", nil
 	}
 
-	return url + "/short", nil
+	return url, nil
 }

--- a/cmd/security-agent/subcommands/workloadlist/command.go
+++ b/cmd/security-agent/subcommands/workloadlist/command.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//nolint:revive // TODO(PROC) Fix revive linter
+package workloadlist
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+type cliParams struct {
+	*command.GlobalParams
+	verboseList bool
+}
+
+// Commands returns a slice of subcommands for the `workload-list` command in the Process Agent
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
+	workloadListCommand := &cobra.Command{
+		Use:   "workload-list",
+		Short: "Print the workload content of a running agent",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fxutil.OneShot(workloadList,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    logimpl.ForOneShot(command.LoggerName, "off", true),
+				}),
+				core.Bundle(),
+			)
+		},
+	}
+	workloadListCommand.Flags().BoolVarP(&cliParams.verboseList, "verbose", "", false, "print out a full dump of the workload store")
+
+	return []*cobra.Command{workloadListCommand}
+}
+
+func workloadList(_ log.Component, config config.Component, cliParams *cliParams) error {
+	c := util.GetClient(false)
+
+	// Set session token
+	err := util.SetAuthToken(config)
+	if err != nil {
+		return err
+	}
+
+	url, err := workloadURL(cliParams.verboseList)
+	if err != nil {
+		return err
+	}
+
+	r, err := util.DoGet(c, url, util.LeaveConnectionOpen)
+	if err != nil {
+		if r != nil && string(r) != "" {
+			fmt.Fprintf(color.Output, "The agent ran into an error while getting the workload store information: %s\n", string(r))
+		} else {
+			fmt.Fprintf(color.Output, "Failed to query the agent (running?): %s\n", err)
+		}
+		return err
+	}
+
+	workload := workloadmeta.WorkloadDumpResponse{}
+	err = json.Unmarshal(r, &workload)
+	if err != nil {
+		return err
+	}
+
+	workload.Write(color.Output)
+
+	return nil
+}
+
+func workloadURL(verbose bool) (string, error) {
+	addressPort, err := ddconfig.GetSecurityAgentAPIAddressPort()
+	if err != nil {
+		return "", fmt.Errorf("config error: %s", err.Error())
+	}
+
+	url := fmt.Sprintf("https://%s/agent/workload-list", addressPort)
+
+	if verbose {
+		return url + "/verbose", nil
+	}
+
+	return url + "/short", nil
+}

--- a/cmd/security-agent/subcommands/workloadlist/command_test.go
+++ b/cmd/security-agent/subcommands/workloadlist/command_test.go
@@ -9,7 +9,10 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
 )
 
 func TestWorkloadListCommand(t *testing.T) {
@@ -19,4 +22,29 @@ func TestWorkloadListCommand(t *testing.T) {
 		workloadList,
 		func() {},
 	)
+}
+
+func TestWorkloadURL(t *testing.T) {
+	cfg := fxutil.Test[config.Component](t, fx.Options(
+		config.MockModule(),
+		// fx.Replace(config.MockParams{Overrides: overrides}),
+	))
+
+	expected := "https://localhost:5010/agent/workload-list?verbose=true"
+	got, err := workloadURL(cfg, true)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+
+	cfg = fxutil.Test[config.Component](t, fx.Options(
+		config.MockModule(),
+		fx.Replace(config.MockParams{Overrides: map[string]interface{}{
+			"security_agent.cmd_port": 1234,
+			"cmd_host":                "127.0.0.1",
+		}}),
+	))
+
+	expected = "https://127.0.0.1:1234/agent/workload-list"
+	got, err = workloadURL(cfg, false)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
 }

--- a/cmd/security-agent/subcommands/workloadlist/command_test.go
+++ b/cmd/security-agent/subcommands/workloadlist/command_test.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workloadlist
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestWorkloadListCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"workload-list"},
+		workloadList,
+		func() {},
+	)
+}

--- a/pkg/config/aliases.go
+++ b/pkg/config/aliases.go
@@ -263,8 +263,3 @@ func LoadWithoutSecret() (*model.Warnings, error) {
 func GetProcessAPIAddressPort() (string, error) {
 	return pkgconfigsetup.GetProcessAPIAddressPort(Datadog)
 }
-
-// GetSecurityAgentAPIAddressPort Alias using Datadog config
-func GetSecurityAgentAPIAddressPort() (string, error) {
-	return pkgconfigsetup.GetSecurityAgentAPIAddressPort(Datadog)
-}

--- a/pkg/config/aliases.go
+++ b/pkg/config/aliases.go
@@ -263,3 +263,8 @@ func LoadWithoutSecret() (*model.Warnings, error) {
 func GetProcessAPIAddressPort() (string, error) {
 	return pkgconfigsetup.GetProcessAPIAddressPort(Datadog)
 }
+
+// GetSecurityAgentAPIAddressPort Alias using Datadog config
+func GetSecurityAgentAPIAddressPort() (string, error) {
+	return pkgconfigsetup.GetSecurityAgentAPIAddressPort(Datadog)
+}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -789,7 +789,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("inventories_first_run_delay", 60)
 
 	// Datadog security agent (common)
-	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)
+	config.BindEnvAndSetDefault("security_agent.cmd_port", DefaultSecurityAgentCmdPort)
 	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)
 	config.BindEnvAndSetDefault("security_agent.log_file", DefaultSecurityAgentLogFile)
 	config.BindEnvAndSetDefault("security_agent.remote_tagger", true)

--- a/pkg/config/setup/security_agent.go
+++ b/pkg/config/setup/security_agent.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package setup
+
+import (
+	"net"
+	"strconv"
+
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// DefaultSecurityAgentCmdPort is the default port used by security-agent to run a runtime settings server
+const DefaultSecurityAgentCmdPort = 5010
+
+// GetSecurityAgentAPIAddressPort returns the API endpoint of the security agent
+func GetSecurityAgentAPIAddressPort(config pkgconfigmodel.Reader) (string, error) {
+	address, err := GetIPCAddress(config)
+	if err != nil {
+		return "", err
+	}
+
+	port := config.GetInt("security_agent.cmd_port")
+	if port <= 0 {
+		log.Warnf("Invalid security.cmd_port -- %d, using default port %d", port, DefaultSecurityAgentCmdPort)
+		port = DefaultProcessCmdPort
+	}
+
+	addrPort := net.JoinHostPort(address, strconv.Itoa(port))
+	return addrPort, nil
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds the `/agent/workload-list` routes to the security agent, copying the way it's done for the process agent. This PR also adds the matching subcommands allowing to call those routes using the cmd line.

The end goal of this PR is to allow easier debugging of the workload meta store in the security agent.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
